### PR TITLE
Scatter routed endpoints from visible dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@
 - TypeScript strict mode
 - We end lines with semicolons
 - Single quotes
-- First-party source files with `SPDX-License-Identifier` must also declare each actual copyright holder using `SPDX-FileCopyrightText`.
+- Every first-party source file with `SPDX-License-Identifier`, including tests and examples, must also declare each actual copyright holder using `SPDX-FileCopyrightText` (for example, `// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors`).
 - Preserve existing license expressions and upstream attribution; do not infer MIT licensing or ownership for generated, vendored, or third-party files.
 - Never abbreviate variables, always type out the full name in camelCase (variables, functions, fields), PascalCase (types), CAPITAL_CASE (constant)
 - Prefer verbNoun structure for function and method names.

--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -67,7 +67,6 @@ import {
 import {
   getBatchVisibilityShader,
   getCandidateDensityShader,
-  getCandidateDependencyEndpointScatterShader,
   getCandidateDependencyVisibilityShader,
   getCandidatePassDispatchShader,
   getCandidatePickShader,
@@ -83,6 +82,7 @@ import {
   getFocusFrontierSeedShader,
   getPickClearShader,
   getTraceDrawCommandsShader,
+  getVisibleDependencyEndpointScatterShader,
   TRACE_DENSITY_RENDER_SHADER,
   TRACE_DEPENDENCY_RENDER_SHADER,
   TRACE_RENDER_SHADER
@@ -1235,6 +1235,9 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         dependencyCount: resources.dependencyCount,
         spanChunks: resources.spanChunks
       };
+      const visibleDependencyCountWordOffset =
+        resources.drawCommands.getInstanceCountByteOffset(resources.dependencyDrawCommandIndex) /
+        UINT32_BYTE_LENGTH;
       const dependencyEndpointJobs = graph.createTransientBuffer({
         id: 'trace-dependency-endpoint-jobs',
         byteLength: resources.dependencyCount * 2 * UINT32_BYTE_LENGTH,
@@ -1248,6 +1251,11 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       const dependencyEndpointDispatchCommands = graph.createTransientBuffer({
         id: 'trace-dependency-endpoint-dispatch-commands',
         byteLength: resources.spanChunks.length * 3 * UINT32_BYTE_LENGTH,
+        usage: Buffer.STORAGE | Buffer.INDIRECT
+      });
+      const dependencyEndpointScatterDispatchCommands = graph.createTransientBuffer({
+        id: 'trace-dependency-endpoint-scatter-dispatch-commands',
+        byteLength: 3 * UINT32_BYTE_LENGTH,
         usage: Buffer.STORAGE | Buffer.INDIRECT
       });
       const candidateDependencyBatchFlags = graph.createTransientBuffer({
@@ -1308,46 +1316,6 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         ],
         dispatchBuffer: handles.candidateDependencyDispatchCommands
       });
-      addTraceComputePass(graph, {
-        id: 'trace-publish-dependency-endpoint-routes',
-        source: getDependencyEndpointDispatchShader(resources.spanChunks.length),
-        bindings: [
-          storageWrite('endpointChunkState', dependencyEndpointChunkState),
-          storageWrite('endpointDispatchCommands', dependencyEndpointDispatchCommands)
-        ],
-        length: 1,
-        workgroupSize: 1
-      });
-      addTraceIndirectComputePass(graph, {
-        id: 'trace-scatter-dependency-endpoint-routes',
-        source: getCandidateDependencyEndpointScatterShader(endpointRoutingProps),
-        bindings: [
-          storageRead('dependencyBatches', handles.dependencyBatchIndex),
-          storageRead('candidateBatchIds', handles.candidateDependencyBatchIds),
-          storageRead('dependencyResults', handles.dependencyResults),
-          storageWrite('endpointChunkState', dependencyEndpointChunkState),
-          storageWrite('endpointJobs', dependencyEndpointJobs)
-        ],
-        dispatchBuffer: handles.candidateDependencyDispatchCommands
-      });
-      for (const chunk of handles.spanChunks) {
-        addTraceIndirectComputePass(graph, {
-          id: `trace-resolve-routed-dependency-endpoints-${chunk.chunkIndex}`,
-          source: getDependencyEndpointResolveShader(endpointRoutingProps, chunk.chunkIndex),
-          bindings: [
-            storageRead('spans', chunk.spans),
-            storageRead('endpointJobs', dependencyEndpointJobs),
-            storageRead('endpointChunkState', dependencyEndpointChunkState),
-            storageRead('dependencyResults', handles.dependencyResults),
-            storageRead('processStates', handles.processStates),
-            storageRead('threadStates', handles.threadStates),
-            storageRead('threadOffsets', handles.threadOffsets),
-            storageWrite('dependencyEndpointPositions', handles.dependencyEndpointPositions)
-          ],
-          dispatchBuffer: dependencyEndpointDispatchCommands,
-          dispatchByteOffset: chunk.chunkIndex * 3 * UINT32_BYTE_LENGTH
-        });
-      }
       new GPUIndexedRangeCompaction({
         id: 'trace-visible-dependencies',
         flags: graph.createDataView(handles.dependencyResults, {
@@ -1373,11 +1341,57 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         count: graph.createDataView(handles.drawCommands, {
           format: 'uint32',
           length: 1,
-          byteOffset: resources.drawCommands.getInstanceCountByteOffset(
-            resources.dependencyDrawCommandIndex
-          )
+          byteOffset: visibleDependencyCountWordOffset * UINT32_BYTE_LENGTH
         })
       }).addToGraph(graph);
+      addTraceComputePass(graph, {
+        id: 'trace-publish-dependency-endpoint-routes',
+        source: getDependencyEndpointDispatchShader(
+          resources.spanChunks.length,
+          visibleDependencyCountWordOffset
+        ),
+        bindings: [
+          storageWrite('endpointChunkState', dependencyEndpointChunkState),
+          storageWrite('endpointDispatchCommands', dependencyEndpointDispatchCommands),
+          storageRead('dependencyDrawCommands', handles.drawCommands),
+          storageWrite('endpointScatterDispatchCommand', dependencyEndpointScatterDispatchCommands)
+        ],
+        length: 1,
+        workgroupSize: 1
+      });
+      addTraceIndirectComputePass(graph, {
+        id: 'trace-scatter-dependency-endpoint-routes',
+        source: getVisibleDependencyEndpointScatterShader(
+          endpointRoutingProps,
+          visibleDependencyCountWordOffset
+        ),
+        bindings: [
+          storageRead('visibleDependencyIds', handles.visibleDependencyIds),
+          storageRead('dependencyResults', handles.dependencyResults),
+          storageRead('dependencyDrawCommands', handles.drawCommands),
+          storageWrite('endpointChunkState', dependencyEndpointChunkState),
+          storageWrite('endpointJobs', dependencyEndpointJobs)
+        ],
+        dispatchBuffer: dependencyEndpointScatterDispatchCommands
+      });
+      for (const chunk of handles.spanChunks) {
+        addTraceIndirectComputePass(graph, {
+          id: `trace-resolve-routed-dependency-endpoints-${chunk.chunkIndex}`,
+          source: getDependencyEndpointResolveShader(endpointRoutingProps, chunk.chunkIndex),
+          bindings: [
+            storageRead('spans', chunk.spans),
+            storageRead('endpointJobs', dependencyEndpointJobs),
+            storageRead('endpointChunkState', dependencyEndpointChunkState),
+            storageRead('dependencyResults', handles.dependencyResults),
+            storageRead('processStates', handles.processStates),
+            storageRead('threadStates', handles.threadStates),
+            storageRead('threadOffsets', handles.threadOffsets),
+            storageWrite('dependencyEndpointPositions', handles.dependencyEndpointPositions)
+          ],
+          dispatchBuffer: dependencyEndpointDispatchCommands,
+          dispatchByteOffset: chunk.chunkIndex * 3 * UINT32_BYTE_LENGTH
+        });
+      }
     }
     renderResources.push({buffer: handles.visibleDependencyIds, usage: 'storage-read'});
 

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -907,7 +907,10 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
 }
 
 /** Publishes chunk offsets, scatter cursors, and indirect endpoint dispatches. */
-export function getDependencyEndpointDispatchShader(chunkCount: number): string {
+export function getDependencyEndpointDispatchShader(
+  chunkCount: number,
+  visibleDependencyCountWordOffset: number
+): string {
   return /* wgsl */ `
 const CHUNK_COUNT: u32 = ${chunkCount}u;
 const ENDPOINT_WORKGROUP_SIZE: u32 = ${TRACE_WORKGROUP_SIZE}u;
@@ -915,6 +918,8 @@ const OFFSET_BASE: u32 = ${chunkCount}u;
 const CURSOR_BASE: u32 = ${chunkCount * 2}u;
 @group(0) @binding(0) var<storage, read_write> endpointChunkState: array<atomic<u32>>;
 @group(0) @binding(1) var<storage, read_write> endpointDispatchCommands: array<u32>;
+@group(0) @binding(2) var<storage, read> dependencyDrawCommands: array<u32>;
+@group(0) @binding(3) var<storage, read_write> endpointScatterDispatchCommand: array<u32>;
 
 @compute @workgroup_size(1)
 fn main() {
@@ -929,38 +934,36 @@ fn main() {
     endpointDispatchCommands[chunkIndex * 3u + 2u] = 1u;
     offset += count;
   }
+  let visibleDependencyCount = dependencyDrawCommands[${visibleDependencyCountWordOffset}u];
+  endpointScatterDispatchCommand[0] =
+    (visibleDependencyCount + ENDPOINT_WORKGROUP_SIZE - 1u) / ENDPOINT_WORKGROUP_SIZE;
+  endpointScatterDispatchCommand[1] = 1u;
+  endpointScatterDispatchCommand[2] = 1u;
 }`;
 }
 
 /** Scatters visible endpoint jobs into the chunk ranges published by the count pass. */
-export function getCandidateDependencyEndpointScatterShader(
-  props: TraceDependencyEndpointRoutingShaderProps
+export function getVisibleDependencyEndpointScatterShader(
+  props: TraceDependencyEndpointRoutingShaderProps,
+  visibleDependencyCountWordOffset: number
 ): string {
   return /* wgsl */ `
 ${getDependencyEndpointRoutingDeclarations(props)}
 const CURSOR_BASE: u32 = ${props.spanChunks.length * 2}u;
-struct DependencyBatch {
-  firstIndex: u32,
-  count: u32,
-  timeMin: f32,
-  timeMax: f32,
-  familyMask: u32,
-  batchIndex: u32,
-};
-@group(0) @binding(0) var<storage, read> dependencyBatches: array<DependencyBatch>;
-@group(0) @binding(1) var<storage, read> candidateBatchIds: array<u32>;
-@group(0) @binding(2) var<storage, read> dependencyResults: array<u32>;
+@group(0) @binding(0) var<storage, read> visibleDependencyIds: array<u32>;
+@group(0) @binding(1) var<storage, read> dependencyResults: array<u32>;
+@group(0) @binding(2) var<storage, read> dependencyDrawCommands: array<u32>;
 @group(0) @binding(3) var<storage, read_write> endpointChunkState: array<atomic<u32>>;
 @group(0) @binding(4) var<storage, read_write> endpointJobs: array<u32>;
 var<workgroup> localChunkCounts: array<atomic<u32>, ${props.spanChunks.length}>;
 var<workgroup> chunkOutputBases: array<u32, ${props.spanChunks.length}>;
 
-@compute @workgroup_size(${TRACE_DEPENDENCY_BATCH_CAPACITY})
+@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
 fn main(
-  @builtin(local_invocation_id) localId: vec3<u32>,
-  @builtin(workgroup_id) workgroupId: vec3<u32>
+  @builtin(global_invocation_id) globalId: vec3<u32>,
+  @builtin(local_invocation_id) localId: vec3<u32>
 ) {
-  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_DEPENDENCY_BATCH_CAPACITY}u) {
+  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_WORKGROUP_SIZE}u) {
     atomicStore(&localChunkCounts[chunkIndex], 0u);
   }
   workgroupBarrier();
@@ -968,23 +971,21 @@ fn main(
   var endpointChunks = array<u32, 2>(INVALID_CHUNK_INDEX, INVALID_CHUNK_INDEX);
   var endpointLocalOffsets = array<u32, 2>(0u, 0u);
   var dependencyIndex = 0u;
-  let batch = dependencyBatches[candidateBatchIds[workgroupId.y]];
-  if (localId.x < batch.count) {
-    dependencyIndex = batch.firstIndex + localId.x;
-    if (dependencyResults[dependencyIndex] != 0u) {
-      let endpointResultOffset = DEPENDENCY_COUNT + dependencyIndex * 2u;
-      for (var endpointIndex = 0u; endpointIndex < 2u; endpointIndex++) {
-        let chunkIndex = getSpanChunkIndex(dependencyResults[endpointResultOffset + endpointIndex]);
-        endpointChunks[endpointIndex] = chunkIndex;
-        if (chunkIndex != INVALID_CHUNK_INDEX) {
-          endpointLocalOffsets[endpointIndex] = atomicAdd(&localChunkCounts[chunkIndex], 1u);
-        }
+  let visibleDependencyCount = dependencyDrawCommands[${visibleDependencyCountWordOffset}u];
+  if (globalId.x < visibleDependencyCount) {
+    dependencyIndex = visibleDependencyIds[globalId.x];
+    let endpointResultOffset = DEPENDENCY_COUNT + dependencyIndex * 2u;
+    for (var endpointIndex = 0u; endpointIndex < 2u; endpointIndex++) {
+      let chunkIndex = getSpanChunkIndex(dependencyResults[endpointResultOffset + endpointIndex]);
+      endpointChunks[endpointIndex] = chunkIndex;
+      if (chunkIndex != INVALID_CHUNK_INDEX) {
+        endpointLocalOffsets[endpointIndex] = atomicAdd(&localChunkCounts[chunkIndex], 1u);
       }
     }
   }
   workgroupBarrier();
 
-  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_DEPENDENCY_BATCH_CAPACITY}u) {
+  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_WORKGROUP_SIZE}u) {
     chunkOutputBases[chunkIndex] = atomicAdd(
       &endpointChunkState[CURSOR_BASE + chunkIndex],
       atomicLoad(&localChunkCounts[chunkIndex])

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -39,7 +39,6 @@ import {
 import {
   getBatchVisibilityShader,
   getCandidateDensityShader,
-  getCandidateDependencyEndpointScatterShader,
   getCandidateDependencyVisibilityShader,
   getCandidatePassDispatchShader,
   getCandidatePickShader,
@@ -55,6 +54,7 @@ import {
   getFocusFrontierSeedShader,
   getPickClearShader,
   getTraceDrawCommandsShader,
+  getVisibleDependencyEndpointScatterShader,
   TRACE_DENSITY_RENDER_SHADER,
   TRACE_DEPENDENCY_RENDER_SHADER,
   TRACE_RENDER_SHADER
@@ -293,8 +293,8 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
     ]),
     getDependencyBatchVisibilityShader(3),
     getDependencyEndpointRouteClearShader(endpointRouting.spanChunks.length),
-    getDependencyEndpointDispatchShader(endpointRouting.spanChunks.length),
-    getCandidateDependencyEndpointScatterShader(endpointRouting),
+    getDependencyEndpointDispatchShader(endpointRouting.spanChunks.length, 1),
+    getVisibleDependencyEndpointScatterShader(endpointRouting, 1),
     getDependencyEndpointResolveShader(endpointRouting, 0),
     getDependencyEndpointResolveShader(endpointRouting, 1),
     getCandidateDependencyVisibilityShader(endpointRouting),


### PR DESCRIPTION
## What changed

- drive endpoint scatter from the compacted visible dependency ID list
- publish the visible dependency count as a one-dimensional indirect scatter dispatch
- reuse the existing endpoint-route publication pass for that dispatch
- remove candidate batch/index reads from the endpoint scatter shader
- preserve per-chunk endpoint counts, workgroup aggregation, indirect resolution, and rendering semantics

## Why

After #3026 fused dependency classification with endpoint counting, scatter still traversed every row in every candidate dependency batch and discarded non-visible rows. The range compaction already produces the exact visible dependency IDs and count, so endpoint scatter can scale with visible edges instead of candidate edges.

The new dispatch stays GPU-resident and adds no graph node.

## Validation

- focused GPU trace viewer node/WGSL suite: 14/14 passed
- Biome check/write on the three changed files: passed
- hardware WebGPU: 10,000,000 spans across 5 chunks with zero application/WebGPU errors
- exact-mode exercise: 307 candidate dependency batches compacted to 2,439 visible edges and rendered successfully
- `git diff --check`: passed
- `yarn lint fix`, `yarn build`, and `yarn test`: attempted; unavailable because the shared local dependency install predates the current `@vis.gl/dev-tools` command wiring (`ocular-*` commands not found)

CI will run the full gates from a clean install.

## Stack

- base includes merged PR #3026
- this PR contains only the visible-only endpoint scatter commit
