### PR TITLE
feat(splats): scale Gaussian rendering, picking, and residency

### DIFF
--- a/docs/api-reference/splats/README.md
+++ b/docs/api-reference/splats/README.md
@@ -1,7 +1,8 @@
 # @luma.gl/splats
 
 `@luma.gl/splats` provides experimental GPU-native Gaussian splat rendering. It owns prepared
-splat data, covariance projection, depth ordering, and render models without depending on Apache
+splat data, directional spherical harmonics, semantic filtering, GPU picking, bounded residency,
+covariance projection, depth ordering, and render models without depending on Apache
 Arrow, loaders.gl, or deck.gl.
 
 The module is currently a private, unpublished luma.gl workspace. Install dependencies from the
@@ -89,7 +90,10 @@ Provide both expected counts when source metadata is available. For example, a 7
 capture streamed in twelve Arrow record batches can reuse one compiled graph throughout its entire
 download. Omit either hint when the corresponding dimension is unknown. The renderer always uses
 stable global GPU depth ordering and requires a WebGPU device; use `SplatRenderer` for WebGL2,
-source ordering, or tile ordering.
+source ordering, tile ordering, higher-order spherical harmonics, semantic filtering and picking,
+or mixed mesh rendering. The graph renderer consumes spherical-harmonic DC colors only; pass
+`{maxSphericalHarmonicsDegree: 0}` when converting graph-bound Arrow sources to avoid allocating
+unused higher-order coefficient buffers.
 
 ### Progressive graph lifecycle
 
@@ -130,8 +134,9 @@ tone mapping remain valid from the first streamed frame.
 
 `encode()` returns a `GPUCommandGraphEncoding` when it records work, or `undefined` when the source
 is empty, the renderer is destroyed, or neither its data nor its camera/style properties changed.
-Calling `setProps(...)` or `appendData(...)` marks the next frame dirty; a stationary, unchanged
-scene is not repeatedly projected or sorted.
+Calling `setProps(...)`, `appendData(...)`, or `updateRows(...)` on a retained source batch marks
+the next frame dirty; a stationary, unchanged scene is not repeatedly projected or sorted. Source
+row updates reuse the existing compiled graph and caller-owned GPU buffers.
 
 ### Reserved capacity and unknown-size streams
 
@@ -209,16 +214,149 @@ zero, until rendering. Prepared GPU columns use the `float32x3`, `float32x4`, `u
 `SplatRenderer` supports `none`, `global`, and `tile` depth-ordering modes alongside camera matrix,
 viewport, radius, opacity, and visibility controls; `GPUSplatGraphRenderer` always uses global
 GPU ordering. WebGPU uses GPU-ready splat buffers and WGSL; WebGL2 uses an attribute-backed GLSL
-fallback. Higher-order spherical harmonics and dedicated WebGPU picking are not part of the initial
-API. When globally sorted source batches are densely interleaved, `SplatRenderer` bounds draw-call
-growth by grouping the rows into depth-ordered batch runs without changing or repacking their
-source buffers.
+fallback. `SplatRenderer` additionally supports higher-order directional radiance, semantic
+filtering, dedicated GPU picking, and mixed mesh composition. When globally sorted source batches
+are densely interleaved, `SplatRenderer` bounds draw-call growth by grouping rows into
+depth-ordered batch runs without changing or repacking their source buffers.
 
 The `exposure` property scales linear color before display mapping. Floating-point source colors
 automatically enable Reinhard highlight compression on standard dynamic range targets; set
 `toneMapping` to `'none'` or `'reinhard'` to override the automatic choice. On a WebGPU canvas
 configured with `rgba16float` and extended tone mapping, the renderer preserves unclamped positive
 radiance for the presentation target instead of applying SDR highlight compression.
+
+## Higher-order spherical harmonics
+
+Supply `sphericalHarmonics` as a row-major `Float32Array` containing non-DC coefficients in
+basis-major RGB triplets. Degrees one, two, and three require 9, 24, and 45 scalar coefficients
+per source row. Set `sphericalHarmonicsDegree` explicitly or let preparation infer it from the
+coefficient count. The existing color column contains the already reconstructed DC radiance.
+
+```ts
+const prepared = makeGPUSplatData(device, {
+  positions,
+  scales,
+  rotations,
+  colors,
+  opacities,
+  sphericalHarmonics: new Float32Array(rowCount * 24),
+  sphericalHarmonicsDegree: 2
+});
+
+const renderer = new SplatRenderer(device, {
+  data: prepared,
+  cameraPosition: [cameraX, cameraY, cameraZ],
+  sphericalHarmonicsDegree: 2
+});
+```
+
+WebGPU evaluates the directional coefficients directly from a source-owned storage buffer. The
+WebGL2 fallback evaluates directional radiance into a renderer-owned color buffer without changing
+the original source colors. Changing `cameraPosition` refreshes directional colors independently
+from depth sorting.
+
+## Semantic filtering and dynamic updates
+
+Provide `semanticIds: Uint32Array` with one compact class identifier per source row. Configure
+`semanticFilter` with included or excluded IDs, an `includeUnlabeled` policy, or a predicate that
+receives the stable global row and source-batch identity. Arrow semantic columns must not contain
+null values; omit the column entirely for an unlabeled source batch.
+
+```ts
+renderer.setProps({
+  semanticFilter: {
+    include: [3, 7],
+    exclude: [11],
+    predicate: (semanticId, rowIndex, sourceBatchIndex) => rowIndex !== hiddenRow
+  }
+});
+
+prepared.updateRows(12, {
+  positions: new Float32Array([nextX, nextY, nextZ]),
+  semanticIds: new Uint32Array([7]),
+  opacities: new Float32Array([0.9])
+});
+```
+
+Updates preserve buffer identities, source-batch boundaries, and stable row indices. Borrowing
+renderers detect the prepared batch's `revision` and refresh visibility, sorting, semantic masks,
+or directional colors as needed.
+
+## GPU picking
+
+`SplatPicker` renders a dedicated semantic-aware picking pass while borrowing the renderer's
+existing source batches, visibility state, and sorted GPU draw runs:
+
+```ts
+import {SplatPicker} from '@luma.gl/splats';
+
+const picker = new SplatPicker(renderer, {
+  mode: 'auto',
+  onPick: info => {
+    console.log(info.rowIndex, info.batchIndex, info.batchRowIndex, info.semanticId);
+  }
+});
+
+const pickedSplat = await picker.pick([pointerX, pointerY]);
+await picker.pick([pointerX, pointerY], {force: true});
+
+picker.destroy();
+```
+
+WebGPU and compatible WebGL devices use integer picking attachments; other WebGL devices fall
+back to RGBA color picking. Results report the original source batch, stable global row,
+batch-local row, and optional semantic identifier. Stable global rows range from zero through
+2,147,483,647; WebGL color picking internally remaps larger-than-24-bit row identities without
+changing the original source indices. Destroy the picker before destroying the borrowing renderer
+or its caller-owned source batches.
+
+## Mixed mesh and splat scenes
+
+Use an existing render pass to draw opaque meshes, depth-tested Gaussian splats, and transparent
+mesh overlays against the same depth attachment:
+
+```ts
+renderer.drawMixed(renderPass, {
+  opaqueMeshes: [terrainModel, buildingModel],
+  transparentMeshes: [selectionOverlay]
+});
+```
+
+Opaque meshes are drawn first, splats are composited in their selected depth order, and transparent
+meshes are drawn last. Set `depthCompare` for reversed-depth scenes and enable `depthWriteEnabled`
+only when the application explicitly needs splat depth writes.
+
+## Scalable residency
+
+`SplatResidencyManager` limits GPU bytes, logical splat rows, or independently retained source
+chunks. It preserves each original prepared batch and never repacks or concatenates GPU buffers.
+
+```ts
+const residency = new SplatResidencyManager({
+  maxGpuBytes: 256 * 1024 * 1024,
+  maxResidentSplats: 2_000_000,
+  maxResidentChunks: 128,
+  onResidencyChange: batches => renderer.setProps({data: batches})
+});
+
+residency.add(preparedTile, {id: tile.id, priority: tile.priority});
+residency.pin(tile.id);
+residency.touch(tile.id);
+await residency.load(nextTile.id, () => loadPreparedTile(nextTile), {
+  priority: nextTile.priority,
+  estimatedGpuBytes: nextTile.gpuByteLength,
+  estimatedSplatCount: nextTile.rowCount,
+  ownsData: true
+});
+```
+
+Higher-priority chunks displace lower-priority chunks; equally prioritized chunks use
+least-recently-used eviction. Pinned chunks remain resident until explicitly removed. The manager
+destroys a batch only when `ownsData` transfers ownership explicitly. Renderer residency callbacks
+run before manager-owned evicted buffers are destroyed, allowing borrowing renderers to detach
+their batches safely. Supply `estimatedGpuBytes` and `estimatedSplatCount` when loading so eligible
+resident chunks are evicted before a new batch allocates GPU memory; without estimates, budgets
+bound retained resident allocations but cannot prevent a temporary upload spike.
 
 ## Apache Arrow conversion
 
@@ -235,11 +373,14 @@ for await (const batch of makeGPUSplatDataFromArrowStream(device, arrowBatchStre
 ```
 
 Arrow conversion recognizes GraphDECO-style `POSITION`, `scale_0` through `scale_2`, `rot_0`
-through `rot_3`, `opacity`, and optional `f_dc_0` through `f_dc_2` columns. Field metadata selects
+through `rot_3`, `opacity`, optional `f_dc_0` through `f_dc_2` columns, higher-order `f_rest_*`
+coefficients, and common semantic-class columns. Set `maxSphericalHarmonicsDegree` to cap decoded
+bands or `semanticColumn` to select an explicit semantic field. Field metadata selects
 linear versus logarithmic scales and linear versus logit opacity. SH DC colors remain unclamped
 linear `float32x4` radiance rather than being prematurely quantized into bytes. Each Arrow record
 batch becomes one independently owned `GPUSplatData` object with stable source batch and row
-identities.
+identities. Streamed tables prepare and yield one record batch at a time, keeping transient GPU
+allocations compatible with residency budgets and releasing no caller-owned yielded buffers.
 Arrow sources are recognized structurally, so loaders.gl 5 alpha can use a different installed
 Apache Arrow version from luma.gl without breaking record-batch detection or source identity.
 
@@ -265,6 +406,8 @@ Use `?loaders=local&scene=fixture` for the lightweight 1,000-splat parser fixtur
 are streamed through their original Arrow record batches, and the showcase reports download,
 batch, and splat progress while retaining independently owned GPU buffers. The loader remains an
 application-level dependency; `@luma.gl/splats` continues to own only GPU data and rendering.
+The default WebGPU graph decodes DC colors without allocating unused higher-order coefficients;
+add `&renderer=cpu` to evaluate and inspect camera-dependent spherical harmonics instead.
 
 GraphDECO captures do not embed a universal world-up direction. The showcase applies known
 scene-specific up vectors and, for Truck, its published initial camera; unfamiliar custom sources

--- a/docs/capabilities.mdx
+++ b/docs/capabilities.mdx
@@ -457,8 +457,12 @@ Explore the [ANARI Playground](/examples/experimental/anari-playground).
 | Indirect splat drawing | Experimental | WebGPU | `@luma.gl/splats` | Generate one bounded indirect draw from the visible GPU-resident set. |
 | HDR spherical-harmonic DC | Experimental | WebGPU | `@luma.gl/splats` | Preserve supported floating-point source radiance on compatible presentation targets. |
 | Standard-dynamic-range fallback | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Apply supported display mapping when extended HDR output is unavailable. |
-| View-dependent harmonics | Opportunity | WebGPU | `@luma.gl/splats` | Higher-order spherical harmonics are not part of the current rendering API. |
-| Dedicated splat picking | Opportunity | WebGPU | `@luma.gl/splats` | GPU-native interaction and semantic selection remain future work. |
+| View-dependent harmonics | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Evaluate degree-one through degree-three spherical harmonics against the current camera. |
+| Dedicated splat picking | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Resolve stable streamed batch, global row, and semantic identity with integer or color GPU picking. |
+| Semantic splat filtering | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Include, exclude, or predicate-filter numeric source classes without repacking batches. |
+| Dynamic splat updates | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Update prepared source rows in place while preserving GPU buffers and reusable command graphs. |
+| Mixed mesh and splat rendering | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Composite depth-tested Gaussian splats between caller-owned opaque and transparent meshes. |
+| Bounded splat residency | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Reserve upload capacity and evict prioritized, unpinned source tiles within byte, row, and chunk budgets. |
 
 View captured scenes in the [Gaussian Splat Viewer](/examples/showcase/gaussian-splat-viewer).
 
@@ -500,7 +504,7 @@ commitments to release dates.
 | Scalable GPU-native annotations | Opportunity | WebGPU + WebGL2 | `@luma.gl/text` and `@luma.gl/arrow` | Advance streamed labels, dictionary reuse, collision-aware placement, and exact row selection. |
 | Scientific volume rendering | Opportunity | WebGPU | `@luma.gl/anari` and `@luma.gl/experimental` | Visualize streamed three-dimensional fields with transfer functions, clipping, and isosurfaces. |
 | Massive geometry visualization | Opportunity | WebGPU | `@luma.gl/experimental` | Extend procedural virtual geometry toward imported mesh clusters and occlusion-aware residency. |
-| Interactive captured-scene analytics | Opportunity | WebGPU | `@luma.gl/splats` | Add splat picking, semantic filtering, view-dependent appearance, and bounded scene streaming. |
+| Hierarchical captured-scene analytics | Opportunity | WebGPU | `@luma.gl/splats` | Extend existing interaction and bounded residency with hierarchy-driven LoD, compressed page decoding, and GPU-native out-of-core scheduling. |
 | Production-ready module boundaries | Opportunity | WebGPU + WebGL2 | `@luma.gl/engine`, `@luma.gl/tables`, and `@luma.gl/gpgpu` | Graduate reusable scheduling, data adapters, and algorithms into their natural published packages. |
 
 `@luma.gl/experimental`, `@luma.gl/anari`, `@luma.gl/splats`, `@luma.gl/arrow`,

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -141,6 +141,10 @@ Target Release Date: Q3, 2026
 
 - **Gaussian splat rendering** - `SplatRenderer` draws caller-owned prepared GPU splat batches through reusable luma.gl rendering models on WebGPU and WebGL2.
 - **HDR Gaussian colors** - Float32 color columns preserve spherical-harmonic DC radiance above the display range without premature clamping or quantization.
+- **Higher-order spherical harmonics** - Degree-one through degree-three coefficients provide camera-dependent Gaussian radiance on WebGPU and WebGL2.
+- **Semantic filtering and GPU picking** - Filter prepared semantic classes and pick stable source batch, global row, and semantic identities through dedicated GPU passes.
+- **Dynamic splats and mixed scenes** - Update existing GPU source rows in place and composite depth-tested Gaussian splats between opaque and transparent mesh draws.
+- **Bounded splat residency** - Prioritized, pinned, least-recently-used source batches remain within configurable GPU byte, row, and chunk budgets.
 - **Incremental splat streaming** - New prepared batches append without concatenating source data, rebuilding previous batches, or transferring ownership to the renderer.
 - **Layered adapters** - File parsing stays in loaders.gl, Apache Arrow conversion stays in `@luma.gl/arrow`, and deck.gl integration stays in downstream applications.
 

--- a/examples/showcase/gaussian-splats/app.ts
+++ b/examples/showcase/gaussian-splats/app.ts
@@ -3,7 +3,10 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {PanelSelect, type PanelSelectOption} from '@deck.gl-community/panels';
-import {makeGPUSplatDataFromArrowStream} from '@luma.gl/arrow';
+import {
+  makeGPUSplatDataFromArrowStream,
+  type MakeGPUSplatDataFromArrowOptions
+} from '@luma.gl/arrow';
 import type {Device} from '@luma.gl/core';
 import {AnimationLoopTemplate, OrbitControls, type AnimationProps} from '@luma.gl/engine';
 import {GPUCommandGraphInspector, type GPUCommandGraphInspectorGraph} from '@luma.gl/experimental';
@@ -172,6 +175,7 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
   private hasManualCameraInteraction = false;
   private needsRedraw = true;
   private previousCameraState: GaussianSplatCameraState | undefined;
+  private readonly renderedBatchRevisions: number[] = [];
   private expectedSplatCount = GAUSSIAN_SPLAT_BATCH_COUNT * GAUSSIAN_SPLATS_PER_BATCH;
   private expectedBatchCount = GAUSSIAN_SPLAT_BATCH_COUNT;
   private loadedSplatCount = 0;
@@ -343,7 +347,10 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
       this.requestRedraw();
     }
 
-    if (!this.needsRedraw && !this.autoOrbit) {
+    const hasUpdatedBatches = this.batches.some(
+      (batch, batchIndex) => batch.revision !== this.renderedBatchRevisions[batchIndex]
+    );
+    if (!this.needsRedraw && !this.autoOrbit && !hasUpdatedBatches) {
       return;
     }
 
@@ -376,6 +383,10 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
       renderPass.end();
     }
     this.needsRedraw = false;
+    this.renderedBatchRevisions.length = this.batches.length;
+    for (let batchIndex = 0; batchIndex < this.batches.length; batchIndex++) {
+      this.renderedBatchRevisions[batchIndex] = this.batches[batchIndex].revision;
+    }
 
     this.frameIndex++;
     if (graphChanged || this.frameIndex % 20 === 0) {
@@ -422,7 +433,9 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
       }
     });
 
-    for await (const batch of makeGPUSplatDataFromArrowStream(this.device, source)) {
+    const sourceOptions: MakeGPUSplatDataFromArrowOptions | undefined =
+      this.executionMode === 'graph' ? {maxSphericalHarmonicsDegree: 0} : undefined;
+    for await (const batch of makeGPUSplatDataFromArrowStream(this.device, source, sourceOptions)) {
       if (this.isFinalized || this.loadAbortController.signal.aborted) {
         batch.destroy();
         break;
@@ -518,10 +531,15 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
       up: this.cameraFrame.up
     });
     const modelViewProjectionMatrix = new Matrix4(projectionMatrix).multiplyRight(viewMatrix);
-    this.renderer.setProps({
+    const cameraProps: Pick<SplatRendererProps, 'modelViewProjectionMatrix' | 'viewportSize'> = {
       modelViewProjectionMatrix,
       viewportSize: [cameraState.viewportWidth, cameraState.viewportHeight]
-    });
+    };
+    if (this.renderer instanceof SplatRenderer) {
+      this.renderer.setProps({...cameraProps, cameraPosition});
+    } else {
+      this.renderer.setProps(cameraProps);
+    }
   }
 
   private fitCameraToBatches(): void {

--- a/modules/arrow/src/arrow/gpu/arrow-gpu-analytics-adapters.ts
+++ b/modules/arrow/src/arrow/gpu/arrow-gpu-analytics-adapters.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Buffer, type Device} from '@luma.gl/core';
 import {

--- a/modules/arrow/src/arrow/renderers/splats/conversion/make-gpu-splat-data-from-arrow.ts
+++ b/modules/arrow/src/arrow/renderers/splats/conversion/make-gpu-splat-data-from-arrow.ts
@@ -3,7 +3,14 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {Device} from '@luma.gl/core';
-import {makeGPUSplatData, type GPUSplatData, type SplatSource} from '@luma.gl/splats';
+import {
+  getSplatSphericalHarmonicCoefficientCount,
+  getSplatSphericalHarmonicsDegree,
+  makeGPUSplatData,
+  type GPUSplatData,
+  type SplatSource,
+  type SplatSphericalHarmonicsDegree
+} from '@luma.gl/splats';
 import {
   DataType,
   type Data,
@@ -64,6 +71,10 @@ export type MakeGPUSplatDataFromArrowOptions = {
   sourceBatchIndex?: number;
   /** Global source-row index assigned to the first nonempty Arrow record batch. */
   rowIndexBase?: number;
+  /** Highest non-DC spherical-harmonic degree uploaded from GraphDECO `f_rest_*` columns. */
+  maxSphericalHarmonicsDegree?: SplatSphericalHarmonicsDegree;
+  /** Explicit source column containing numeric semantic class identifiers. */
+  semanticColumn?: string;
 };
 
 type GPUSplatArrowSourceOffsets = {
@@ -99,15 +110,25 @@ export async function* makeGPUSplatDataFromArrowStream(
   source: AsyncIterable<GPUSplatArrowSource> | Iterable<GPUSplatArrowSource>,
   options: MakeGPUSplatDataFromArrowOptions = {}
 ): AsyncIterable<GPUSplatData> {
-  let offsets: GPUSplatArrowSourceOffsets = {
-    sourceBatchIndex: options.sourceBatchIndex ?? 0,
-    rowIndexBase: options.rowIndexBase ?? 0
-  };
+  let sourceBatchIndex = options.sourceBatchIndex ?? 0;
+  let rowIndexBase = options.rowIndexBase ?? 0;
 
   for await (const arrowSource of source) {
-    const prepared = prepareArrowSplatSource(device, arrowSource, options, offsets);
-    offsets = prepared.nextOffsets;
-    for (const data of prepared.data) {
+    const columnSource = isArrowSplatColumnSource(arrowSource) ? arrowSource : arrowSource.data;
+    const recordBatches = isArrowSplatTable(columnSource) ? columnSource.batches : [columnSource];
+    for (const recordBatch of recordBatches) {
+      if (recordBatch.numRows === 0) {
+        sourceBatchIndex++;
+        continue;
+      }
+
+      const splatSource = makeSplatSourceFromArrowRecordBatch(recordBatch, options, {
+        sourceBatchIndex,
+        rowIndexBase
+      });
+      const data = makeGPUSplatData(device, splatSource);
+      rowIndexBase += data.rowCount;
+      sourceBatchIndex++;
       yield data;
     }
   }
@@ -185,6 +206,11 @@ function makeSplatSourceFromArrowRecordBatch(
   ];
   const hasSphericalHarmonicColors = sphericalHarmonicColumns.every(Boolean);
   const opacityColumn = getOptionalArrowSplatColumn(recordBatch, 'opacity');
+  const semanticColumn = getArrowSplatSemanticColumn(recordBatch, options.semanticColumn);
+  const higherOrderSphericalHarmonics = getArrowSplatSphericalHarmonics(
+    recordBatch,
+    options.maxSphericalHarmonicsDegree
+  );
   const scaleEncodings = scaleColumns.map((_, componentIndex) =>
     getArrowSplatFieldEncoding(recordBatch, `scale_${componentIndex}`)
   );
@@ -193,6 +219,7 @@ function makeSplatSourceFromArrowRecordBatch(
   const rotations = new Float32Array(rowCount * 4);
   const colors = new Float32Array(rowCount * 4);
   const opacities = new Float32Array(rowCount);
+  const semanticIds = semanticColumn ? new Uint32Array(rowCount) : undefined;
 
   for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
     for (let componentIndex = 0; componentIndex < 3; componentIndex++) {
@@ -223,9 +250,94 @@ function makeSplatSourceFromArrowRecordBatch(
       : encodedOpacity;
     // Opacity has its own GPU column; copying it into color alpha would apply it twice.
     colors[rowIndex * 4 + 3] = normalizeSplatColorByte(fallbackColor[3] ?? DEFAULT_SPLAT_COLOR[3]);
+    if (semanticColumn && semanticIds) {
+      const semanticId = semanticColumn.get(rowIndex);
+      if (semanticId === null || semanticId === undefined) {
+        throw new Error('Gaussian splat semantic identifiers cannot be null');
+      }
+      semanticIds[rowIndex] = Number(semanticId);
+    }
   }
 
-  return {positions, scales, rotations, colors, opacities, ...offsets};
+  return {
+    positions,
+    scales,
+    rotations,
+    colors,
+    opacities,
+    ...(semanticIds ? {semanticIds} : {}),
+    ...(higherOrderSphericalHarmonics
+      ? {
+          sphericalHarmonics: higherOrderSphericalHarmonics.coefficients,
+          sphericalHarmonicsDegree: higherOrderSphericalHarmonics.degree
+        }
+      : {}),
+    ...offsets
+  };
+}
+
+/** Reorders GraphDECO's channel-major `f_rest_*` fields into row-major RGB basis triplets. */
+function getArrowSplatSphericalHarmonics(
+  recordBatch: GPUSplatArrowRecordBatchLike,
+  maximumDegree: SplatSphericalHarmonicsDegree = 3
+): {coefficients: Float32Array; degree: SplatSphericalHarmonicsDegree} | undefined {
+  if (maximumDegree === 0) {
+    return undefined;
+  }
+
+  const fieldCount = recordBatch.schema.fields.filter(field =>
+    /^f_rest_\d+$/.test(field.name)
+  ).length;
+  if (fieldCount === 0) {
+    return undefined;
+  }
+  const sourceDegree = getSplatSphericalHarmonicsDegree(fieldCount);
+  const degree = sourceDegree < maximumDegree ? sourceDegree : maximumDegree;
+  const sourceCoefficientsPerColor = fieldCount / 3;
+  const targetCoefficientCount = getSplatSphericalHarmonicCoefficientCount(degree);
+  const targetCoefficientsPerColor = targetCoefficientCount / 3;
+  const coefficients = new Float32Array(recordBatch.numRows * targetCoefficientCount);
+
+  for (let colorComponentIndex = 0; colorComponentIndex < 3; colorComponentIndex++) {
+    for (
+      let coefficientIndex = 0;
+      coefficientIndex < targetCoefficientsPerColor;
+      coefficientIndex++
+    ) {
+      const sourceCoefficientIndex =
+        colorComponentIndex * sourceCoefficientsPerColor + coefficientIndex;
+      const column = getRequiredArrowSplatColumn(recordBatch, `f_rest_${sourceCoefficientIndex}`);
+      for (let rowIndex = 0; rowIndex < recordBatch.numRows; rowIndex++) {
+        const coefficientOffset = rowIndex * targetCoefficientCount + coefficientIndex * 3;
+        coefficients[coefficientOffset + colorComponentIndex] = Number(column.get(rowIndex) ?? 0);
+      }
+    }
+  }
+
+  return {coefficients, degree};
+}
+
+function getArrowSplatSemanticColumn(
+  recordBatch: GPUSplatArrowRecordBatchLike,
+  semanticColumnName: string | undefined
+): Vector | null {
+  if (semanticColumnName) {
+    return getRequiredArrowSplatColumn(recordBatch, semanticColumnName);
+  }
+  for (const columnName of [
+    'semantic_id',
+    'semanticId',
+    'class_id',
+    'classId',
+    'label',
+    'semantic'
+  ]) {
+    const column = getOptionalArrowSplatColumn(recordBatch, columnName);
+    if (column) {
+      return column;
+    }
+  }
+  return null;
 }
 
 function getArrowSplatPositions(recordBatch: GPUSplatArrowRecordBatchLike): Float32Array {

--- a/modules/arrow/test/arrow/arrow-gpu-analytics-adapters.node.spec.ts
+++ b/modules/arrow/test/arrow/arrow-gpu-analytics-adapters.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {readFileSync} from 'node:fs';
 

--- a/modules/arrow/test/arrow/arrow-gpu-analytics-adapters.spec.ts
+++ b/modules/arrow/test/arrow/arrow-gpu-analytics-adapters.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {makeGPUAnalyticsTableFromArrowTable} from '@luma.gl/arrow';
 import {Buffer} from '@luma.gl/core';

--- a/modules/arrow/test/arrow/arrow-splats.node.spec.ts
+++ b/modules/arrow/test/arrow/arrow-splats.node.spec.ts
@@ -25,6 +25,9 @@ type SplatRecordBatchOptions = {
   opacities?: readonly number[];
   colors?: readonly number[];
   sphericalHarmonicCoefficients?: readonly number[];
+  higherOrderSphericalHarmonicCoefficients?: readonly number[];
+  semanticIds?: readonly number[];
+  semanticColumnName?: string;
   scaleEncoding?: 'linear' | 'log';
   scaleEncodings?: readonly ('linear' | 'log' | undefined)[];
   opacityEncoding?: 'linear' | 'logit';
@@ -115,6 +118,116 @@ test('makeGPUSplatDataFromArrow preserves real GraphDECO Train HDR and negative 
   );
 
   batch.destroy();
+  t.end();
+});
+
+test('makeGPUSplatDataFromArrow preserves higher spherical harmonics and semantic source rows', async t => {
+  const device = new NullDevice({});
+  const recordBatch = makeSplatRecordBatch({
+    positions: [0, 0, 0, 1, 1, 1],
+    higherOrderSphericalHarmonicCoefficients: [
+      1, 2, 3, 10, 20, 30, 100, 200, 300, -1, -2, -3, -10, -20, -30, -100, -200, -300
+    ],
+    semanticIds: [7, 42]
+  });
+  const prepared = makeGPUSplatDataFromArrow(device, recordBatch)[0]!;
+  const expectedCoefficients = [
+    1, 10, 100, 2, 20, 200, 3, 30, 300, -1, -10, -100, -2, -20, -200, -3, -30, -300
+  ];
+
+  t.equal(prepared.sphericalHarmonicsDegree, 1, 'infers complete first-order spherical harmonics');
+  t.equal(
+    prepared.sphericalHarmonics?.format,
+    'float32',
+    'retains independently owned coefficients'
+  );
+  t.deepEqual(
+    Array.from(prepared.source.sphericalHarmonics ?? []),
+    expectedCoefficients,
+    'reorders channel-major GraphDECO columns into basis-major RGB source rows'
+  );
+  t.deepEqual(
+    Array.from(prepared.source.semanticIds ?? []),
+    [7, 42],
+    'preserves compact semantic class identifiers'
+  );
+  const coefficientBytes = await prepared.sphericalHarmonics?.data[0].buffer.readAsync();
+  if (coefficientBytes) {
+    t.deepEqual(
+      Array.from(
+        new Float32Array(
+          coefficientBytes.buffer,
+          coefficientBytes.byteOffset,
+          coefficientBytes.byteLength / Float32Array.BYTES_PER_ELEMENT
+        )
+      ),
+      expectedCoefficients,
+      'uploads directional radiance without collapsing Arrow source boundaries'
+    );
+  }
+
+  prepared.destroy();
+  t.end();
+});
+
+test('makeGPUSplatDataFromArrow caps higher-order bands and honors explicit semantic columns', t => {
+  const device = new NullDevice({});
+  const recordBatch = makeSplatRecordBatch({
+    positions: [0, 0, 0],
+    higherOrderSphericalHarmonicCoefficients: Array.from(
+      {length: 24},
+      (_, coefficientIndex) => coefficientIndex + 1
+    ),
+    semanticIds: [13],
+    semanticColumnName: 'custom_category'
+  });
+  const prepared = makeGPUSplatDataFromArrow(device, recordBatch, {
+    maxSphericalHarmonicsDegree: 1,
+    semanticColumn: 'custom_category'
+  })[0]!;
+
+  t.equal(prepared.sphericalHarmonicsDegree, 1, 'caps second-order source coefficients on upload');
+  t.deepEqual(
+    Array.from(prepared.source.sphericalHarmonics ?? []),
+    [1, 9, 17, 2, 10, 18, 3, 11, 19],
+    'retains first-order RGB basis triples from each original channel block'
+  );
+  t.deepEqual(
+    Array.from(prepared.source.semanticIds ?? []),
+    [13],
+    'reads an explicitly named semantic class column'
+  );
+
+  const dcOnly = makeGPUSplatDataFromArrow(device, recordBatch, {
+    maxSphericalHarmonicsDegree: 0
+  })[0]!;
+  t.equal(dcOnly.sphericalHarmonicsDegree, 0, 'supports an explicit DC-only memory budget');
+  t.notOk(dcOnly.sphericalHarmonics, 'avoids allocating excluded higher-order coefficients');
+
+  prepared.destroy();
+  dcOnly.destroy();
+  t.end();
+});
+
+test('makeGPUSplatDataFromArrow rejects nullable semantic identifiers', t => {
+  const device = new NullDevice({});
+  const source = makeSplatRecordBatch({
+    positions: [0, 0, 0, 1, 1, 1],
+    semanticIds: [7, 0]
+  });
+  const semanticIds = arrow.vectorFromArray([7, null], new arrow.Uint32());
+  const recordBatch: GPUSplatArrowRecordBatchLike = {
+    numRows: source.numRows,
+    schema: source.schema,
+    getChild: columnName =>
+      columnName === 'semantic_id' ? semanticIds : source.getChild(columnName)
+  };
+
+  t.throws(
+    () => makeGPUSplatDataFromArrow(device, recordBatch),
+    /semantic identifiers cannot be null/,
+    'never fabricates class zero for an unlabeled Arrow source row'
+  );
   t.end();
 });
 
@@ -369,6 +482,53 @@ test('makeGPUSplatDataFromArrowStream preserves mixed sources and progressive so
   t.end();
 });
 
+test('makeGPUSplatDataFromArrowStream allocates record batches lazily and honors early cancellation', async t => {
+  const device = new NullDevice({});
+  const allocatedBuffers: Array<ReturnType<typeof device.createBuffer>> = [];
+  const createBuffer = device.createBuffer.bind(device);
+  device.createBuffer = properties => {
+    const buffer = createBuffer(properties);
+    allocatedBuffers.push(buffer);
+    return buffer;
+  };
+  const firstRecordBatch = makeSplatRecordBatch({
+    positions: [0, 0, 0],
+    scaleEncoding: 'linear'
+  });
+  const secondRecordBatch = makeSplatRecordBatch({
+    positions: [1, 1, 1, 2, 2, 2],
+    scaleEncoding: 'linear'
+  });
+  const source = new arrow.Table([firstRecordBatch, secondRecordBatch]);
+  const yieldedBatches: GPUSplatData[] = [];
+
+  for await (const batch of makeGPUSplatDataFromArrowStream(device, [source], {
+    sourceBatchIndex: 6,
+    rowIndexBase: 12
+  })) {
+    yieldedBatches.push(batch);
+    break;
+  }
+
+  t.equal(yieldedBatches.length, 1, 'cancels the stream after transferring one caller-owned batch');
+  t.deepEqual(
+    [yieldedBatches[0]?.sourceBatchIndex, yieldedBatches[0]?.rowIndexBase],
+    [6, 12],
+    'preserves source identity before the consumer cancels'
+  );
+  t.equal(
+    allocatedBuffers.length,
+    Object.keys(yieldedBatches[0]?.table.batches[0].gpuData ?? {}).length,
+    'does not allocate unrequested record-batch GPU buffers before yielding'
+  );
+  yieldedBatches[0]?.destroy();
+  t.ok(
+    allocatedBuffers.every(buffer => buffer.destroyed),
+    'early cancellation leaves no inaccessible or leaked prepared-batch allocations'
+  );
+  t.end();
+});
+
 test('makeGPUSplatDataFromArrowStream preserves structural cross-realm Arrow batch boundaries', async t => {
   const device = new NullDevice({});
   const firstRecordBatch = makeSplatRecordBatch({
@@ -489,7 +649,24 @@ function makeSplatRecordBatch(options: SplatRecordBatchOptions): arrow.RecordBat
   for (let componentIndex = 0; componentIndex < 4; componentIndex++) {
     addColumn(`rot_${componentIndex}`, makeScalarVector(rotations, componentIndex, 4, rowCount));
   }
+  const higherOrderCoefficients = options.higherOrderSphericalHarmonicCoefficients;
+  if (higherOrderCoefficients) {
+    const coefficientCount = higherOrderCoefficients.length / rowCount;
+    for (let coefficientIndex = 0; coefficientIndex < coefficientCount; coefficientIndex++) {
+      addColumn(
+        `f_rest_${coefficientIndex}`,
+        makeScalarVector(higherOrderCoefficients, coefficientIndex, coefficientCount, rowCount),
+        'coefficient'
+      );
+    }
+  }
   addColumn('opacity', arrow.makeVector(Float32Array.from(opacities)), options.opacityEncoding);
+  if (options.semanticIds) {
+    addColumn(
+      options.semanticColumnName ?? 'semantic_id',
+      arrow.makeVector(Uint32Array.from(options.semanticIds))
+    );
+  }
 
   const recordBatch = new arrow.Table(new arrow.Schema(fields), columns).batches[0];
   if (!recordBatch) {

--- a/modules/splats/README.md
+++ b/modules/splats/README.md
@@ -7,6 +7,11 @@ loaders.gl, or deck.gl.
 `GPUSplatGraphRenderer` progressively streams preserved batches through reusable WebGPU command
 graphs, global GPU sorting, and one indirect draw.
 
+Prepared batches support degree-one through degree-three spherical harmonics, semantic class IDs,
+and in-place row updates. `SplatRenderer` evaluates view-dependent radiance, filters semantic
+classes, composes splats with depth-tested meshes, and works with `SplatPicker`. Use
+`SplatResidencyManager` to bound independently owned streamed batches by GPU bytes, rows, or chunks.
+
 Use optional `expectedSplatCount` and `expectedBatchCount` hints to reserve graph capacity.
 Renderers borrow source batches, preserve HDR colors, and must be destroyed before their data.
 

--- a/modules/splats/src/gpu-splat-graph-renderer.ts
+++ b/modules/splats/src/gpu-splat-graph-renderer.ts
@@ -29,7 +29,14 @@ import type {SplatRendererProps, SplatRendererStats} from './splat-renderer';
 import type {SplatSortMode} from './splat-sort';
 
 /** Camera, styling, borrowed data, and canvas clearing for graph-native Gaussian rendering. */
-export type GPUSplatGraphRendererProps = SplatRendererProps & {
+export type GPUSplatGraphRendererProps = Omit<
+  SplatRendererProps,
+  | 'cameraPosition'
+  | 'sphericalHarmonicsDegree'
+  | 'semanticFilter'
+  | 'depthCompare'
+  | 'depthWriteEnabled'
+> & {
   /** Color used when the graph opens its single default-framebuffer render pass. */
   clearColor?: [number, number, number, number];
   /** Optional final row count used to reserve one persistent progressively populated graph. */
@@ -115,6 +122,7 @@ export class GPUSplatGraphRenderer {
   private readonly expectedBatchCount?: number;
   private readonly ownedBuffers: Buffer[] = [];
   private readonly batchUniforms: Buffer[] = [];
+  private readonly cachedBatchRevisions: number[] = [];
   private model?: Model;
   private sortedValuesBuffer?: Buffer;
   private requiresGraphRebuild = true;
@@ -199,6 +207,7 @@ export class GPUSplatGraphRenderer {
       throw new Error('GPUSplatGraphRenderer requires live data prepared on its own device');
     }
     this.batches.push(batch);
+    this.cachedBatchRevisions.push(batch.revision);
     if (
       !this.hasExplicitToneMapping &&
       batch.colors.format === 'float32x4' &&
@@ -217,7 +226,7 @@ export class GPUSplatGraphRenderer {
   }
 
   /** Updates camera or styling uniforms in O(batch count), never O(splat count). */
-  setProps(props: Partial<SplatRendererProps>): void {
+  setProps(props: Partial<GPUSplatGraphRendererProps>): void {
     if (props.data !== undefined) {
       const replacementBatches = normalizeSplatGraphBatches(props.data);
       const matchesRetainedBatches =
@@ -226,6 +235,7 @@ export class GPUSplatGraphRenderer {
       if (!matchesRetainedBatches) {
         this.releaseCompiledGraph();
         this.batches.length = 0;
+        this.cachedBatchRevisions.length = 0;
         for (const batch of replacementBatches) {
           this.appendData(batch);
         }
@@ -289,7 +299,17 @@ export class GPUSplatGraphRenderer {
    * `undefined`, ensuring a stationary camera never repeatedly projects or sorts every source row.
    */
   encode(commandEncoder: CommandEncoder): GPUCommandGraphEncoding | undefined {
-    if (this.isDestroyed || !this.requiresEncoding || this.getRowCount() === 0) {
+    if (this.isDestroyed || this.getRowCount() === 0) {
+      return undefined;
+    }
+    for (let batchIndex = 0; batchIndex < this.batches.length; batchIndex++) {
+      const revision = this.batches[batchIndex].revision;
+      if (revision !== this.cachedBatchRevisions[batchIndex]) {
+        this.cachedBatchRevisions[batchIndex] = revision;
+        this.requiresEncoding = true;
+      }
+    }
+    if (!this.requiresEncoding) {
       return undefined;
     }
     if (this.requiresGraphRebuild) {
@@ -347,6 +367,7 @@ export class GPUSplatGraphRenderer {
     }
     this.releaseCompiledGraph();
     this.drawCommands.destroy();
+    this.cachedBatchRevisions.length = 0;
     this.isDestroyed = true;
   }
 

--- a/modules/splats/src/index.ts
+++ b/modules/splats/src/index.ts
@@ -5,10 +5,43 @@
 export {
   GPUSplatData,
   makeGPUSplatData,
+  type SplatDataUpdate,
   type GPUSplatTypeMap,
   type GPUSplatVectors,
   type SplatSource
 } from './splat-data';
+export {
+  evaluateSplatSphericalHarmonics,
+  getSplatSphericalHarmonicCoefficientCount,
+  getSplatSphericalHarmonicsDegree,
+  type SplatSphericalHarmonicsDegree
+} from './splat-spherical-harmonics';
+export {
+  acceptsSplatSemantic,
+  type SplatSemanticFilter,
+  type SplatSemanticSelection
+} from './splat-filter';
+export {
+  SplatPicker,
+  resolveSplatPickInfo,
+  SPLAT_COLOR_PICKING_FS_GLSL,
+  SPLAT_PICKING_ATTRIBUTE_WGSL_SHADER,
+  SPLAT_PICKING_FS_GLSL,
+  SPLAT_PICKING_STORAGE_WGSL_SHADER,
+  type SplatPickingInfo,
+  type SplatPickingProps
+} from './splat-picking';
+export {
+  SplatResidencyManager,
+  type SplatResidencyBounds,
+  type SplatResidencyBudget,
+  type SplatResidencyCallbacks,
+  type SplatResidencyChunk,
+  type SplatResidencyChunkOptions,
+  type SplatResidencyEvictionReason,
+  type SplatResidencyManagerProps,
+  type SplatResidencyStats
+} from './splat-residency';
 export {
   getCovarianceEllipseAxes,
   getQuaternionScaledAxes,
@@ -30,6 +63,9 @@ export {
 export {
   SplatRenderer,
   SPLAT_STORAGE_GPU_INPUT_SCHEMA,
+  type SplatDrawRun,
+  type SplatMeshRenderable,
+  type SplatMixedRenderOptions,
   type SplatRendererProps,
   type SplatRendererStats
 } from './splat-renderer';

--- a/modules/splats/src/splat-data.ts
+++ b/modules/splats/src/splat-data.ts
@@ -4,6 +4,11 @@
 
 import {Buffer, type Device} from '@luma.gl/core';
 import {GPUTable, GPUVector, type GPURecordBatchSourceInfo} from '@luma.gl/tables';
+import {
+  getSplatSphericalHarmonicCoefficientCount,
+  getSplatSphericalHarmonicsDegree,
+  type SplatSphericalHarmonicsDegree
+} from './splat-spherical-harmonics';
 
 /** Framework-independent, decoded Gaussian splat columns for one source batch. */
 export type SplatSource = {
@@ -17,6 +22,12 @@ export type SplatSource = {
   colors: Uint8Array | Float32Array;
   /** Decoded linear opacity values, without source-format logit encoding. */
   opacities: Float32Array;
+  /** Optional compact semantic class identifier for each source row. */
+  semanticIds?: Uint32Array;
+  /** Row-major non-DC spherical-harmonic coefficients packed as basis-major RGB triplets. */
+  sphericalHarmonics?: Float32Array;
+  /** Highest non-DC spherical-harmonic band; inferred from the coefficient count when omitted. */
+  sphericalHarmonicsDegree?: SplatSphericalHarmonicsDegree;
   /** Zero-based source batch index retained for streamed row identity. */
   sourceBatchIndex?: number;
   /** Zero-based global row index of the first source row. */
@@ -31,6 +42,35 @@ export type GPUSplatVectors = {
   colors: GPUVector<'unorm8x4' | 'float32x4'>;
   opacities: GPUVector<'float32'>;
   rowIndices: GPUVector<'uint32'>;
+  semanticIds?: GPUVector<'uint32'>;
+  sphericalHarmonics?: GPUVector<'float32'>;
+};
+
+/** In-place replacement of complete rows within one existing prepared source batch. */
+export type SplatDataUpdate = {
+  /** Zero-based batch-local row receiving the first supplied replacement values. */
+  rowOffset?: number;
+  /** Replacement packed XYZ center positions. */
+  positions?: Float32Array;
+  /** Replacement packed XYZ one-sigma scales. */
+  scales?: Float32Array;
+  /** Replacement packed WXYZ quaternion rotations. */
+  rotations?: Float32Array;
+  /** Replacement RGBA colors using the prepared source's original typed-array format. */
+  colors?: Uint8Array | Float32Array;
+  /** Replacement decoded linear opacity values. */
+  opacities?: Float32Array;
+  /** Replacement semantic identifiers when the prepared source includes semantic metadata. */
+  semanticIds?: Uint32Array;
+  /** Replacement packed non-DC spherical-harmonic coefficients for complete source rows. */
+  sphericalHarmonics?: Float32Array;
+};
+
+type SplatDataColumnUpdate = {
+  source: Float32Array | Uint8Array | Uint32Array;
+  values: Float32Array | Uint8Array | Uint32Array;
+  vector: GPUVector;
+  scalarStride: number;
 };
 
 /** Canonical stored memory formats for every prepared Gaussian splat column. */
@@ -65,19 +105,35 @@ export class GPUSplatData {
   readonly opacities: GPUVector<'float32'>;
   /** Stable global source-row indices. */
   readonly rowIndices: GPUVector<'uint32'>;
+  /** Optional independently owned compact semantic identifiers. */
+  readonly semanticIds?: GPUVector<'uint32'>;
+  /** Optional independently owned flattened non-DC spherical-harmonic coefficients. */
+  readonly sphericalHarmonics?: GPUVector<'float32'>;
+  /** Highest spherical-harmonic band represented by the prepared source. */
+  readonly sphericalHarmonicsDegree: SplatSphericalHarmonicsDegree;
   /** Stable source batch and global row identity. */
   readonly sourceInfo: GPURecordBatchSourceInfo;
   private isDestroyed = false;
+  private currentRevision = 0;
 
   /** Uploads one already-decoded source batch into separately owned typed GPU columns. */
   constructor(device: Device, source: SplatSource) {
     const length = getSplatSourceLength(source);
+    const rowIndexBase = source.rowIndexBase ?? 0;
+    if (
+      !Number.isSafeInteger(rowIndexBase) ||
+      rowIndexBase < 0 ||
+      rowIndexBase + Math.max(length - 1, 0) > 0x7fff_ffff
+    ) {
+      throw new RangeError('Gaussian splat source rows must fit signed 32-bit GPU indices');
+    }
     this.device = device;
     this.source = source;
     this.length = length;
+    this.sphericalHarmonicsDegree = getSplatSourceSphericalHarmonicsDegree(source, length);
     this.sourceInfo = {
       sourceBatchIndex: source.sourceBatchIndex ?? 0,
-      sourceRowIndexOffset: source.rowIndexBase ?? 0,
+      sourceRowIndexOffset: rowIndexBase,
       sourceRowCount: length
     };
 
@@ -105,6 +161,24 @@ export class GPUSplatData {
     this.colors = createSplatGPUVector(device, 'colors', source.colors, colorFormat, length);
     this.opacities = createSplatGPUVector(device, 'opacities', source.opacities, 'float32', length);
     this.rowIndices = createSplatGPUVector(device, 'rowIndices', rowIndices, 'uint32', length);
+    if (source.semanticIds) {
+      this.semanticIds = createSplatGPUVector(
+        device,
+        'semanticIds',
+        source.semanticIds,
+        'uint32',
+        length
+      );
+    }
+    if (source.sphericalHarmonics) {
+      this.sphericalHarmonics = createSplatGPUVector(
+        device,
+        'sphericalHarmonics',
+        source.sphericalHarmonics,
+        'float32',
+        source.sphericalHarmonics.length
+      );
+    }
     this.table = new GPUTable({
       vectors: {
         positions: this.positions,
@@ -135,10 +209,20 @@ export class GPUSplatData {
 
   /** Number of bytes allocated for all caller-owned splat columns. */
   get byteLength(): number {
-    return Object.values(this.table.batches[0]?.gpuData ?? {}).reduce(
+    const tableByteLength = Object.values(this.table.batches[0]?.gpuData ?? {}).reduce(
       (totalByteLength, data) => totalByteLength + data.buffer.byteLength,
       0
     );
+    return (
+      tableByteLength +
+      (this.semanticIds?.data[0]?.buffer.byteLength ?? 0) +
+      (this.sphericalHarmonics?.data[0]?.buffer.byteLength ?? 0)
+    );
+  }
+
+  /** Monotonic revision incremented whenever existing source rows are updated in place. */
+  get revision(): number {
+    return this.currentRevision;
   }
 
   /** Prepared-batch row, source identity, and GPU allocation diagnostics. */
@@ -163,13 +247,110 @@ export class GPUSplatData {
     return this.isDestroyed;
   }
 
+  /** Updates complete source rows without reallocating owned GPU buffers or changing row identity. */
+  update(update: SplatDataUpdate): void {
+    if (this.isDestroyed) {
+      throw new Error('Cannot update destroyed Gaussian splat data');
+    }
+
+    const rowOffset = update.rowOffset ?? 0;
+    if (!Number.isInteger(rowOffset) || rowOffset < 0 || rowOffset > this.length) {
+      throw new RangeError('Gaussian splat update row offset is outside the prepared source batch');
+    }
+
+    const columnUpdates = this.getColumnUpdates(update);
+    let updatedRowCount: number | undefined;
+    for (const columnUpdate of columnUpdates) {
+      if (
+        columnUpdate.source.constructor !== columnUpdate.values.constructor ||
+        columnUpdate.scalarStride === 0 ||
+        columnUpdate.values.length % columnUpdate.scalarStride !== 0
+      ) {
+        throw new Error(
+          'Gaussian splat updates must preserve source column types and complete rows'
+        );
+      }
+
+      const columnRowCount = columnUpdate.values.length / columnUpdate.scalarStride;
+      if (updatedRowCount !== undefined && updatedRowCount !== columnRowCount) {
+        throw new Error('Gaussian splat update columns must contain matching row counts');
+      }
+      if (rowOffset + columnRowCount > this.length) {
+        throw new RangeError('Gaussian splat update rows exceed the prepared source batch');
+      }
+      updatedRowCount = columnRowCount;
+    }
+
+    if (columnUpdates.length === 0 || updatedRowCount === 0) {
+      return;
+    }
+
+    for (const columnUpdate of columnUpdates) {
+      const sourceBytes = new Uint8Array(
+        columnUpdate.source.buffer,
+        columnUpdate.source.byteOffset,
+        columnUpdate.source.byteLength
+      );
+      const updatedBytes = new Uint8Array(
+        columnUpdate.values.buffer,
+        columnUpdate.values.byteOffset,
+        columnUpdate.values.byteLength
+      );
+      const byteOffset =
+        rowOffset * columnUpdate.scalarStride * columnUpdate.source.BYTES_PER_ELEMENT;
+      columnUpdate.vector.data[0].buffer.write(columnUpdate.values, byteOffset);
+      sourceBytes.set(updatedBytes, byteOffset);
+    }
+
+    this.currentRevision++;
+  }
+
+  /** Updates complete source rows beginning at a batch-local row offset. */
+  updateRows(rowOffset: number, update: Omit<SplatDataUpdate, 'rowOffset'>): void {
+    this.update({...update, rowOffset});
+  }
+
   /** Releases each owned source-column allocation exactly once. */
   destroy(): void {
     if (this.isDestroyed) {
       return;
     }
     this.table.destroy();
+    this.semanticIds?.destroy();
+    this.sphericalHarmonics?.destroy();
     this.isDestroyed = true;
+  }
+
+  private getColumnUpdates(update: SplatDataUpdate): SplatDataColumnUpdate[] {
+    const updates: SplatDataColumnUpdate[] = [];
+    const addUpdate = (
+      source: Float32Array | Uint8Array | Uint32Array | undefined,
+      values: Float32Array | Uint8Array | Uint32Array | undefined,
+      vector: GPUVector | undefined,
+      scalarStride: number
+    ): void => {
+      if (!values) {
+        return;
+      }
+      if (!source || !vector) {
+        throw new Error('Gaussian splat update requires an existing prepared source column');
+      }
+      updates.push({source, values, vector, scalarStride});
+    };
+
+    addUpdate(this.source.positions, update.positions, this.positions, 3);
+    addUpdate(this.source.scales, update.scales, this.scales, 3);
+    addUpdate(this.source.rotations, update.rotations, this.rotations, 4);
+    addUpdate(this.source.colors, update.colors, this.colors, 4);
+    addUpdate(this.source.opacities, update.opacities, this.opacities, 1);
+    addUpdate(this.source.semanticIds, update.semanticIds, this.semanticIds, 1);
+    addUpdate(
+      this.source.sphericalHarmonics,
+      update.sphericalHarmonics,
+      this.sphericalHarmonics,
+      getSplatSphericalHarmonicCoefficientCount(this.sphericalHarmonicsDegree)
+    );
+    return updates;
   }
 }
 
@@ -185,11 +366,40 @@ function getSplatSourceLength(source: SplatSource): number {
     source.scales.length !== length * 3 ||
     source.rotations.length !== length * 4 ||
     source.colors.length !== length * 4 ||
-    source.opacities.length !== length
+    source.opacities.length !== length ||
+    (source.semanticIds && source.semanticIds.length !== length)
   ) {
     throw new Error('SplatSource columns must contain matching Gaussian splat rows');
   }
   return length;
+}
+
+function getSplatSourceSphericalHarmonicsDegree(
+  source: SplatSource,
+  rowCount: number
+): SplatSphericalHarmonicsDegree {
+  const coefficients = source.sphericalHarmonics;
+  const explicitDegree = source.sphericalHarmonicsDegree;
+  if (!coefficients) {
+    if (explicitDegree !== undefined && explicitDegree !== 0) {
+      throw new Error('Gaussian splat spherical harmonics require coefficient data');
+    }
+    return 0;
+  }
+
+  if (rowCount === 0) {
+    if (coefficients.length !== 0) {
+      throw new Error('Gaussian splat spherical-harmonic coefficients require source rows');
+    }
+    return explicitDegree ?? 0;
+  }
+
+  const coefficientCount = coefficients.length / rowCount;
+  const inferredDegree = getSplatSphericalHarmonicsDegree(coefficientCount);
+  if (explicitDegree !== undefined && explicitDegree !== inferredDegree) {
+    throw new Error('Gaussian splat spherical-harmonic coefficients do not match their degree');
+  }
+  return inferredDegree;
 }
 
 function createSplatGPUVector<

--- a/modules/splats/src/splat-filter.ts
+++ b/modules/splats/src/splat-filter.ts
@@ -1,0 +1,59 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {GPUSplatData} from './splat-data';
+
+/** Numeric semantic classes accepted by a Gaussian splat visibility filter. */
+export type SplatSemanticSelection = ReadonlySet<number> | readonly number[];
+
+/** Optional semantic-class and stable source-row visibility controls. */
+export type SplatSemanticFilter = {
+  /** Retain only these semantic class identifiers when this selection is supplied. */
+  include?: SplatSemanticSelection;
+  /** Remove these semantic class identifiers after applying the inclusion selection. */
+  exclude?: SplatSemanticSelection;
+  /** Retain batches without semantic metadata even when an inclusion selection is active. */
+  includeUnlabeled?: boolean;
+  /** Additional application-owned filtering using the original streamed source identity. */
+  predicate?: (
+    semanticId: number | undefined,
+    rowIndex: number,
+    sourceBatchIndex: number
+  ) => boolean;
+};
+
+/** Returns whether one prepared source row passes the current semantic visibility controls. */
+export function acceptsSplatSemantic(
+  filter: SplatSemanticFilter | null | undefined,
+  data: Pick<GPUSplatData, 'source' | 'rowIndexBase' | 'sourceBatchIndex'>,
+  batchRowIndex: number
+): boolean {
+  if (!filter) {
+    return true;
+  }
+
+  const semanticId = data.source.semanticIds?.[batchRowIndex];
+  if (semanticId === undefined) {
+    if (filter.includeUnlabeled === false || (filter.include && !filter.includeUnlabeled)) {
+      return false;
+    }
+  } else {
+    if (filter.include && !hasSplatSemanticId(filter.include, semanticId)) {
+      return false;
+    }
+    if (filter.exclude && hasSplatSemanticId(filter.exclude, semanticId)) {
+      return false;
+    }
+  }
+
+  return (
+    filter.predicate?.(semanticId, data.rowIndexBase + batchRowIndex, data.sourceBatchIndex) ?? true
+  );
+}
+
+function hasSplatSemanticId(selection: SplatSemanticSelection, semanticId: number): boolean {
+  return selection instanceof Set
+    ? selection.has(semanticId)
+    : (selection as readonly number[]).includes(semanticId);
+}

--- a/modules/splats/src/splat-picking.ts
+++ b/modules/splats/src/splat-picking.ts
@@ -1,0 +1,616 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Device, RenderPass} from '@luma.gl/core';
+import {
+  indexColorPicking,
+  indexPicking,
+  PickingManager,
+  resolvePickingMode,
+  ShaderInputs,
+  supportsIndexPicking,
+  type PickInfo,
+  type PickingMode,
+  type PickingShouldPickOptions,
+  type ResolvedPickingMode
+} from '@luma.gl/engine';
+import {GPUTableModel} from '@luma.gl/tables';
+import type {GPUSplatData} from './splat-data';
+import {SplatRenderer, type SplatDrawRun} from './splat-renderer';
+import {
+  SPLAT_ATTRIBUTE_SHADER_LAYOUT,
+  SPLAT_ATTRIBUTE_WGSL_SHADER,
+  SPLAT_FS_GLSL,
+  SPLAT_STORAGE_SHADER_LAYOUT,
+  SPLAT_STORAGE_WGSL_SHADER,
+  SPLAT_VS_GLSL,
+  splatUniforms,
+  type SplatUniforms
+} from './splat-shaders';
+
+/** Stable source identity and optional semantic class returned by a Gaussian picking pass. */
+export type SplatPickingInfo = {
+  /** Original streamed source batch identity, or `null` when nothing is picked. */
+  batchIndex: number | null;
+  /** Stable global source row identity, or `null` when nothing is picked. */
+  rowIndex: number | null;
+  /** Zero-based row within the original source batch, or `null` when unavailable. */
+  batchRowIndex: number | null;
+  /** Optional numeric semantic class belonging to the picked source row. */
+  semanticId: number | null;
+};
+
+/** Backend selection and callbacks for an independently owned Gaussian splat picker. */
+export type SplatPickingProps = {
+  /** Prefer integer WebGPU picking, falling back to encoded colors on WebGL2. */
+  mode?: PickingMode;
+  /** Receives stable streamed source identity whenever the picked Gaussian changes. */
+  onPick?: (info: SplatPickingInfo) => void;
+  /** Optional tooltip content derived from the stable picked Gaussian source identity. */
+  getTooltip?: (info: SplatPickingInfo) => string | null;
+};
+
+type SplatPickingShaderInputs = ShaderInputs<{
+  splat: SplatUniforms;
+  picking: typeof indexPicking.props;
+}>;
+
+type SplatColorPickingBatch = {
+  batchIndex: number;
+  rowOffset: number;
+  rowCount: number;
+};
+
+type SplatColorPickingSlot = {
+  batches: SplatColorPickingBatch[];
+  rowCount: number;
+};
+
+type SplatColorPickingBatchLocation = {
+  slotIndex: number;
+  rowOffset: number;
+};
+
+const MAX_COLOR_PICKING_ROWS_PER_SLOT = 16_777_215;
+const MAX_COLOR_PICKING_SLOTS = 255;
+
+const EMPTY_SPLAT_PICKING_INFO: SplatPickingInfo = {
+  batchIndex: null,
+  rowIndex: null,
+  batchRowIndex: null,
+  semanticId: null
+};
+
+const SPLAT_INDEX_PICKING_WGSL_FRAGMENT = /* wgsl */ `\
+
+struct SplatPickingFragmentOutputs {
+  @location(0) color : vec4<f32>,
+  @location(1) pickingColor : vec2<i32>,
+};
+
+@fragment
+fn fragmentPicking(input : SplatFragmentInputs) -> SplatPickingFragmentOutputs {
+  let gaussianWeight = exp(-0.5 * dot(input.gaussianCoordinate, input.gaussianCoordinate));
+  let alpha = input.color.a * gaussianWeight;
+  if (alpha <= 0.0 || alpha < splat.alphaCutoff) {
+    discard;
+  }
+
+  var output : SplatPickingFragmentOutputs;
+  output.color = vec4<f32>(0.0);
+  output.pickingColor = picking_getPickingColor(input.sourceRowIndex);
+  return output;
+}
+`;
+
+const SPLAT_COLOR_PICKING_WGSL_FRAGMENT = /* wgsl */ `\
+
+@fragment
+fn fragmentColorPicking(input : SplatFragmentInputs) -> @location(0) vec4<f32> {
+  let gaussianWeight = exp(-0.5 * dot(input.gaussianCoordinate, input.gaussianCoordinate));
+  let alpha = input.color.a * gaussianWeight;
+  if (alpha <= 0.0 || alpha < splat.alphaCutoff) {
+    discard;
+  }
+  return picking_getPickingColor(input.sourceRowIndex);
+}
+`;
+
+/** Storage-backed WebGPU Gaussian shader with an exact integer source-row picking attachment. */
+export const SPLAT_PICKING_STORAGE_WGSL_SHADER = `${SPLAT_STORAGE_WGSL_SHADER}${SPLAT_INDEX_PICKING_WGSL_FRAGMENT}`;
+
+/** Attribute-backed Gaussian shader with an exact integer source-row picking attachment. */
+export const SPLAT_PICKING_ATTRIBUTE_WGSL_SHADER = `${SPLAT_ATTRIBUTE_WGSL_SHADER}${SPLAT_INDEX_PICKING_WGSL_FRAGMENT}`;
+
+const SPLAT_PICKING_VS_GLSL = SPLAT_VS_GLSL.replace(
+  'sourceRowIndex = int(rowIndices);',
+  'sourceRowIndex = int(rowIndices);\n  picking_setObjectIndex(sourceRowIndex);'
+);
+
+const SPLAT_COLOR_PICKING_VS_GLSL = SPLAT_VS_GLSL.replace(
+  'sourceRowIndex = int(rowIndices);',
+  'sourceRowIndex = int(rowIndices);\n  picking_setObjectIndex(gl_InstanceID + int(splat.sortedOffset));'
+);
+
+const SPLAT_GLSL_DISPLAY_COLOR =
+  /  vec3 linearColor =[\s\S]*?  fragmentColor = vec4\(mappedColor, alpha\);/;
+
+/** WebGL2 fragment shader writing global source rows into a dedicated integer attachment. */
+export const SPLAT_PICKING_FS_GLSL = SPLAT_FS_GLSL.replace(
+  'out vec4 fragmentColor;',
+  'layout(location = 0) out vec4 fragmentColor;\nlayout(location = 1) out ivec4 pickingColor;'
+).replace(
+  SPLAT_GLSL_DISPLAY_COLOR,
+  '  fragmentColor = vec4(0.0);\n  pickingColor = picking_getPickingColor();'
+);
+
+/** Portable WebGL2 fragment shader encoding stable Gaussian source rows into RGBA bytes. */
+export const SPLAT_COLOR_PICKING_FS_GLSL = SPLAT_FS_GLSL.replace(
+  SPLAT_GLSL_DISPLAY_COLOR,
+  '  fragmentColor = picking_getPickingColor();'
+);
+
+/** Resolves an engine picking payload into stable streamed Gaussian source-row identity. */
+export function resolveSplatPickInfo(
+  pickInfo: PickInfo | null | undefined,
+  batches: readonly GPUSplatData[]
+): SplatPickingInfo {
+  if (pickInfo?.batchIndex === null || pickInfo?.objectIndex === null || !pickInfo) {
+    return {...EMPTY_SPLAT_PICKING_INFO};
+  }
+
+  const batch = batches[pickInfo.batchIndex];
+  if (!batch || batch.destroyed || !Number.isInteger(pickInfo.objectIndex)) {
+    return {...EMPTY_SPLAT_PICKING_INFO};
+  }
+
+  const batchRowIndex = pickInfo.objectIndex - batch.rowIndexBase;
+  if (batchRowIndex < 0 || batchRowIndex >= batch.rowCount) {
+    return {...EMPTY_SPLAT_PICKING_INFO};
+  }
+
+  return {
+    batchIndex: batch.sourceBatchIndex,
+    rowIndex: pickInfo.objectIndex,
+    batchRowIndex,
+    semanticId: batch.source.semanticIds?.[batchRowIndex] ?? null
+  };
+}
+
+/**
+ * Dedicated GPU Gaussian picker that borrows renderer batches and sorted-index allocations.
+ *
+ * WebGPU and capable WebGL devices use exact integer attachments. Other WebGL devices use the
+ * engine's compatible RGBA picking path without changing or taking ownership of source buffers.
+ */
+export class SplatPicker {
+  /** Device shared with the borrowing Gaussian renderer. */
+  readonly device: Device;
+  /** Renderer supplying preserved batches, semantic visibility masks, and sorted GPU runs. */
+  readonly renderer: SplatRenderer;
+  /** Engine-owned picking framebuffer, pointer tracking, and asynchronous GPU readback. */
+  readonly manager: PickingManager;
+  /** Shader inputs owned by this dedicated picking pipeline. */
+  readonly shaderInputs: SplatPickingShaderInputs;
+  /** Dedicated integer/color picking model; source buffers remain owned by their original batches. */
+  model?: GPUTableModel;
+  /** Application-owned picking callback and tooltip configuration. */
+  props: SplatPickingProps;
+  /** Latest stable streamed source identity resolved from a GPU picking pass. */
+  pickInfo: SplatPickingInfo = {...EMPTY_SPLAT_PICKING_INFO};
+
+  private colorPickingSlots: SplatColorPickingSlot[] = [];
+  private readonly colorPickingBatchLocations = new Map<number, SplatColorPickingBatchLocation>();
+  private isDestroyed = false;
+
+  /** Creates a dedicated Gaussian picking pipeline while borrowing the supplied renderer. */
+  constructor(renderer: SplatRenderer, props: SplatPickingProps = {}) {
+    if (renderer.destroyed) {
+      throw new Error('SplatPicker requires a live Gaussian splat renderer');
+    }
+
+    this.renderer = renderer;
+    this.device = renderer.device;
+    this.props = props;
+    const mode = resolvePickingMode(
+      this.device.type,
+      props.mode ?? 'auto',
+      supportsIndexPicking(this.device)
+    );
+    const pickingModule = mode === 'index' ? indexPicking : indexColorPicking;
+    this.shaderInputs = new ShaderInputs<{
+      splat: SplatUniforms;
+      picking: typeof indexPicking.props;
+    }>({splat: splatUniforms, picking: pickingModule});
+    this.shaderInputs.setProps({picking: {indexMode: 'attribute', batchIndex: 0}});
+    this.manager = new PickingManager(this.device, {
+      mode,
+      shaderInputs: this.shaderInputs,
+      onObjectPicked: this.handleObjectPicked,
+      getTooltip: info => this.props.getTooltip?.(this.resolvePickingResult(info)) ?? null
+    });
+  }
+
+  /** Resolved integer or portable RGBA picking backend. */
+  get mode(): ResolvedPickingMode {
+    return this.manager.mode;
+  }
+
+  /** Whether dedicated picking resources have already been released. */
+  get destroyed(): boolean {
+    return this.isDestroyed;
+  }
+
+  /**
+   * Renders a semantic-aware Gaussian picking pass and asynchronously resolves stable source rows.
+   *
+   * A `null` pointer clears the current selection. Repeat positions reuse the latest result unless
+   * `options.force` requests a fresh render/readback for animated or newly streamed source data.
+   */
+  async pick(
+    mousePosition: readonly [number, number] | number[] | null | undefined,
+    options: PickingShouldPickOptions = {}
+  ): Promise<SplatPickingInfo | null> {
+    if (this.isDestroyed || this.renderer.destroyed) {
+      return null;
+    }
+    if (!mousePosition) {
+      this.clear();
+      return this.pickInfo;
+    }
+
+    const position: [number, number] = [mousePosition[0], mousePosition[1]];
+    if (!this.manager.shouldPick(position, options)) {
+      return this.pickInfo;
+    }
+
+    const drawRuns = this.renderer.getDrawRuns();
+    if (!this.renderer.table || drawRuns.length === 0) {
+      this.clear();
+      return this.pickInfo;
+    }
+
+    if (this.usesPackedColorPicking) {
+      this.updateColorPickingSlots(drawRuns);
+    }
+    this.updateShaderInputs();
+    const model = this.getPickingModel();
+    if (!model) {
+      this.clear();
+      return this.pickInfo;
+    }
+
+    const firstColorLocation = this.colorPickingBatchLocations.get(drawRuns[0].batchIndex);
+    this.shaderInputs.setProps({
+      picking: {
+        isActive: true,
+        batchIndex: this.usesPackedColorPicking
+          ? (firstColorLocation?.slotIndex ?? 0)
+          : drawRuns[0].batchIndex
+      },
+      ...(this.usesPackedColorPicking
+        ? {splat: {sortedOffset: firstColorLocation?.rowOffset ?? 0}}
+        : {})
+    });
+    model.predraw(this.device.commandEncoder);
+    const pickingPass = this.manager.beginRenderPass();
+    let didDraw = false;
+    try {
+      didDraw = this.drawRuns(pickingPass);
+    } finally {
+      pickingPass.end();
+      this.shaderInputs.setProps({picking: {isActive: false}});
+    }
+
+    if (!didDraw) {
+      this.clear();
+      return this.pickInfo;
+    }
+
+    if (this.device.type === 'webgpu') {
+      this.device.submit();
+    }
+    const pickInfo = await this.manager.updatePickInfo(position);
+    if (!pickInfo) {
+      return null;
+    }
+    return this.updatePickingResult(pickInfo);
+  }
+
+  /** Clears the current source selection and emits a null pick after an earlier successful hit. */
+  clear(): void {
+    const hadSelection = this.pickInfo.rowIndex !== null;
+    this.manager.clearPickState();
+    this.manager.pickInfo = {batchIndex: null, objectIndex: null};
+    this.pickInfo = {...EMPTY_SPLAT_PICKING_INFO};
+    if (hadSelection) {
+      this.props.onPick?.(this.pickInfo);
+    }
+  }
+
+  /** Releases the picking model/framebuffer without destroying borrowed renderer/source buffers. */
+  destroy(): void {
+    if (this.isDestroyed) {
+      return;
+    }
+    this.model?.destroy();
+    this.model = undefined;
+    this.manager.destroy();
+    this.shaderInputs.destroy();
+    this.isDestroyed = true;
+  }
+
+  private readonly handleObjectPicked = (pickInfo: PickInfo): void => {
+    this.updatePickingResult(pickInfo);
+  };
+
+  private updatePickingResult(pickInfo: PickInfo): SplatPickingInfo {
+    const resolved = this.resolvePickingResult(pickInfo);
+    if (
+      resolved.batchIndex !== this.pickInfo.batchIndex ||
+      resolved.rowIndex !== this.pickInfo.rowIndex ||
+      resolved.batchRowIndex !== this.pickInfo.batchRowIndex ||
+      resolved.semanticId !== this.pickInfo.semanticId
+    ) {
+      this.pickInfo = resolved;
+      this.props.onPick?.(resolved);
+    }
+    return this.pickInfo;
+  }
+
+  private resolvePickingResult(pickInfo: PickInfo): SplatPickingInfo {
+    if (this.usesPackedColorPicking) {
+      return this.resolveColorPickingResult(pickInfo);
+    }
+
+    const resolved = resolveSplatPickInfo(pickInfo, this.renderer.batches);
+    if (resolved.rowIndex !== null || pickInfo.objectIndex === null) {
+      return resolved;
+    }
+
+    // Multiple WebGPU draws share one uniform allocation while their render pass is open. Stable
+    // globally unique source rows still identify their original batch if a queued batch uniform
+    // cannot change between recorded draws.
+    let matchingBatchIndex = -1;
+    for (const [batchIndex, batch] of this.renderer.batches.entries()) {
+      if (
+        pickInfo.objectIndex >= batch.rowIndexBase &&
+        pickInfo.objectIndex < batch.rowIndexBase + batch.rowCount
+      ) {
+        if (matchingBatchIndex !== -1) {
+          return resolved;
+        }
+        matchingBatchIndex = batchIndex;
+      }
+    }
+
+    return matchingBatchIndex === -1
+      ? resolved
+      : resolveSplatPickInfo(
+          {batchIndex: matchingBatchIndex, objectIndex: pickInfo.objectIndex},
+          this.renderer.batches
+        );
+  }
+
+  private get usesPackedColorPicking(): boolean {
+    return this.mode === 'color' && this.device.type !== 'webgpu';
+  }
+
+  private updateColorPickingSlots(drawRuns: readonly SplatDrawRun[]): void {
+    this.colorPickingSlots = [];
+    this.colorPickingBatchLocations.clear();
+
+    for (const drawRun of drawRuns) {
+      if (this.colorPickingBatchLocations.has(drawRun.batchIndex)) {
+        continue;
+      }
+
+      const batch = this.renderer.batches[drawRun.batchIndex];
+      if (!batch || batch.rowCount > MAX_COLOR_PICKING_ROWS_PER_SLOT) {
+        continue;
+      }
+
+      let slotIndex = this.colorPickingSlots.findIndex(
+        slot => slot.rowCount + batch.rowCount <= MAX_COLOR_PICKING_ROWS_PER_SLOT
+      );
+      if (slotIndex === -1) {
+        if (this.colorPickingSlots.length >= MAX_COLOR_PICKING_SLOTS) {
+          continue;
+        }
+        slotIndex = this.colorPickingSlots.length;
+        this.colorPickingSlots.push({batches: [], rowCount: 0});
+      }
+
+      const slot = this.colorPickingSlots[slotIndex];
+      const rowOffset = slot.rowCount;
+      slot.batches.push({batchIndex: drawRun.batchIndex, rowOffset, rowCount: batch.rowCount});
+      slot.rowCount += batch.rowCount;
+      this.colorPickingBatchLocations.set(drawRun.batchIndex, {slotIndex, rowOffset});
+    }
+  }
+
+  private resolveColorPickingResult(pickInfo: PickInfo): SplatPickingInfo {
+    if (pickInfo.batchIndex === null || pickInfo.objectIndex === null) {
+      return {...EMPTY_SPLAT_PICKING_INFO};
+    }
+
+    const slot = this.colorPickingSlots[pickInfo.batchIndex];
+    const matchingBatch = slot?.batches.find(
+      batch =>
+        pickInfo.objectIndex! >= batch.rowOffset &&
+        pickInfo.objectIndex! < batch.rowOffset + batch.rowCount
+    );
+    if (!matchingBatch) {
+      return {...EMPTY_SPLAT_PICKING_INFO};
+    }
+
+    const batch = this.renderer.batches[matchingBatch.batchIndex];
+    if (!batch) {
+      return {...EMPTY_SPLAT_PICKING_INFO};
+    }
+
+    return resolveSplatPickInfo(
+      {
+        batchIndex: matchingBatch.batchIndex,
+        objectIndex: batch.rowIndexBase + pickInfo.objectIndex - matchingBatch.rowOffset
+      },
+      this.renderer.batches
+    );
+  }
+
+  private updateShaderInputs(): void {
+    const props = this.renderer.props;
+    this.shaderInputs.setProps({
+      splat: {
+        modelViewProjectionMatrix: props.modelViewProjectionMatrix,
+        viewportSize: props.viewportSize,
+        radiusScale: props.radiusScale,
+        alphaScale: props.alphaScale,
+        alphaCutoff: props.alphaCutoff,
+        screenSizeCutoffPixels: props.screenSizeCutoffPixels,
+        gaussianSupportRadius: props.gaussianSupportRadius,
+        kernel2DSize: props.kernel2DSize,
+        maxScreenSpaceSplatSize: props.maxScreenSpaceSplatSize,
+        sortedOffset: 0,
+        exposure: props.exposure,
+        toneMapping: props.toneMapping === 'reinhard' ? 1 : 0,
+        cameraPosition: props.cameraPosition,
+        sphericalHarmonicsDegree: props.sphericalHarmonicsDegree
+      }
+    });
+  }
+
+  private getPickingModel(): GPUTableModel | undefined {
+    const table = this.renderer.table;
+    const firstDrawRun = this.renderer.getDrawRuns()[0];
+    if (!table || !firstDrawRun) {
+      return undefined;
+    }
+    if (this.model?.table === table) {
+      return this.model;
+    }
+
+    this.model?.destroy();
+    const isWebGPU = this.device.type === 'webgpu';
+    const isIndexPicking = this.mode === 'index';
+    const firstBatch = table.batches[firstDrawRun.batchIndex];
+    const source = isWebGPU
+      ? isIndexPicking
+        ? SPLAT_PICKING_STORAGE_WGSL_SHADER
+        : `${SPLAT_STORAGE_WGSL_SHADER}${SPLAT_COLOR_PICKING_WGSL_FRAGMENT}`
+      : isIndexPicking
+        ? SPLAT_PICKING_ATTRIBUTE_WGSL_SHADER
+        : `${SPLAT_ATTRIBUTE_WGSL_SHADER}${SPLAT_COLOR_PICKING_WGSL_FRAGMENT}`;
+
+    this.model = new GPUTableModel(this.device, {
+      id: 'gaussian-splat-picking',
+      source,
+      vs: this.usesPackedColorPicking ? SPLAT_COLOR_PICKING_VS_GLSL : SPLAT_PICKING_VS_GLSL,
+      fs: isIndexPicking ? SPLAT_PICKING_FS_GLSL : SPLAT_COLOR_PICKING_FS_GLSL,
+      fragmentEntryPoint: isIndexPicking ? 'fragmentPicking' : 'fragmentColorPicking',
+      shaderLayout: isWebGPU ? SPLAT_STORAGE_SHADER_LAYOUT : SPLAT_ATTRIBUTE_SHADER_LAYOUT,
+      modules: this.shaderInputs.getModules(),
+      shaderInputs: this.shaderInputs,
+      table,
+      tableCount: 'none',
+      ...(isWebGPU
+        ? {
+            bindings: {
+              splatPositions: firstBatch.gpuData['positions'].buffer,
+              splatScales: firstBatch.gpuData['scales'].buffer,
+              splatRotations: firstBatch.gpuData['rotations'].buffer,
+              splatColors: firstBatch.gpuData['colors'].buffer,
+              splatOpacities: this.renderer.getBatchOpacityBuffer(firstDrawRun.batchIndex),
+              splatRowIndices: firstBatch.gpuData['rowIndices'].buffer,
+              splatSortedIndices: firstDrawRun.indexBuffer!,
+              splatSphericalHarmonics: this.renderer.getBatchSphericalHarmonicsBuffer(
+                firstDrawRun.batchIndex
+              )
+            }
+          }
+        : {}),
+      colorAttachmentFormats: isIndexPicking ? ['rgba8unorm', 'rg32sint'] : ['rgba8unorm'],
+      depthStencilAttachmentFormat: 'depth24plus',
+      isInstanced: true,
+      instanceCount: firstDrawRun.rowIndices.length,
+      vertexCount: 4,
+      topology: 'triangle-strip',
+      parameters: {
+        depthWriteEnabled: true,
+        depthCompare: 'less-equal',
+        blend: false
+      }
+    });
+
+    return this.model;
+  }
+
+  private drawRuns(renderPass: RenderPass): boolean {
+    const model = this.model;
+    const table = this.renderer.table;
+    if (!model || !table) {
+      return false;
+    }
+
+    let didDraw = false;
+    let drawSuccess = true;
+    const drawnAttributeBatches = new Set<number>();
+    for (const drawRun of this.renderer.getDrawRuns()) {
+      const batch = table.batches[drawRun.batchIndex];
+      if (
+        !batch ||
+        (this.device.type !== 'webgpu' && drawnAttributeBatches.has(drawRun.batchIndex))
+      ) {
+        continue;
+      }
+
+      const colorLocation = this.colorPickingBatchLocations.get(drawRun.batchIndex);
+      if (this.usesPackedColorPicking && !colorLocation) {
+        continue;
+      }
+      this.shaderInputs.setProps({
+        picking: {
+          batchIndex: this.usesPackedColorPicking ? colorLocation!.slotIndex : drawRun.batchIndex
+        },
+        ...(this.usesPackedColorPicking ? {splat: {sortedOffset: colorLocation!.rowOffset}} : {})
+      });
+      if (this.device.type === 'webgpu') {
+        if (!drawRun.indexBuffer) {
+          continue;
+        }
+        model.setBindings({
+          splatPositions: batch.gpuData['positions'].buffer,
+          splatScales: batch.gpuData['scales'].buffer,
+          splatRotations: batch.gpuData['rotations'].buffer,
+          splatColors: batch.gpuData['colors'].buffer,
+          splatOpacities: this.renderer.getBatchOpacityBuffer(drawRun.batchIndex),
+          splatRowIndices: batch.gpuData['rowIndices'].buffer,
+          splatSortedIndices: drawRun.indexBuffer,
+          splatSphericalHarmonics: this.renderer.getBatchSphericalHarmonicsBuffer(
+            drawRun.batchIndex
+          )
+        });
+        model.setInstanceCount(drawRun.rowIndices.length);
+      } else {
+        model.setAttributes(
+          Object.fromEntries(
+            Object.entries(batch.gpuData).map(([name, data]) => [
+              name,
+              name === 'opacities'
+                ? this.renderer.getBatchOpacityBuffer(drawRun.batchIndex)
+                : data.buffer
+            ])
+          )
+        );
+        model.setInstanceCount(batch.numRows);
+        drawnAttributeBatches.add(drawRun.batchIndex);
+      }
+
+      didDraw = true;
+      drawSuccess = model.draw(renderPass) && drawSuccess;
+    }
+
+    return didDraw && drawSuccess;
+  }
+}

--- a/modules/splats/src/splat-renderer.ts
+++ b/modules/splats/src/splat-renderer.ts
@@ -5,6 +5,7 @@
 import {
   Buffer,
   type BufferLayout,
+  type CompareFunction,
   type CommandEncoder,
   type Device,
   type RenderPass
@@ -19,6 +20,11 @@ import {
 } from '@luma.gl/tables';
 import {GPUSplatData} from './splat-data';
 import {projectSplatCovarianceToScreen} from './splat-covariance';
+import {acceptsSplatSemantic, type SplatSemanticFilter} from './splat-filter';
+import {
+  evaluateSplatSphericalHarmonics,
+  type SplatSphericalHarmonicsDegree
+} from './splat-spherical-harmonics';
 import {
   sortSplatReferences,
   SPLAT_TILE_SIZE_PIXELS,
@@ -44,6 +50,12 @@ export type SplatRendererProps = {
   modelViewProjectionMatrix?: ArrayLike<number>;
   /** Drawing-buffer width and height in physical pixels. */
   viewportSize?: readonly [number, number];
+  /** World-space camera location used for view-dependent spherical-harmonic radiance. */
+  cameraPosition?: readonly [number, number, number];
+  /** Highest spherical-harmonic degree evaluated for prepared source coefficients. */
+  sphericalHarmonicsDegree?: SplatSphericalHarmonicsDegree;
+  /** Optional semantic classes or application-owned predicate used to exclude source rows. */
+  semanticFilter?: SplatSemanticFilter;
   /** Camera-dependent depth ordering strategy. Defaults to `global`. */
   sortMode?: SplatSortMode;
   /** Minimum fragment opacity retained after Gaussian attenuation. */
@@ -68,6 +80,23 @@ export type SplatRendererProps = {
   exposure?: number;
   /** SDR highlight compression, automatically enabled for Float32 colors on SDR targets. */
   toneMapping?: 'none' | 'reinhard';
+  /** Depth comparison against opaque meshes already recorded into the same render pass. */
+  depthCompare?: CompareFunction;
+  /** Whether transparent splats update the shared mesh depth buffer. Defaults to `false`. */
+  depthWriteEnabled?: boolean;
+};
+
+/** Application-owned opaque or transparent mesh compatible with an existing render pass. */
+export type SplatMeshRenderable = {
+  draw(renderPass: RenderPass): boolean | void;
+};
+
+/** Ordered scene integration points surrounding depth-tested Gaussian splat rendering. */
+export type SplatMixedRenderOptions = {
+  /** Opaque meshes drawn first so their shared depth buffer occludes farther splats. */
+  opaqueMeshes?: readonly SplatMeshRenderable[];
+  /** Additional transparent meshes composited after the globally sorted splat runs. */
+  transparentMeshes?: readonly SplatMeshRenderable[];
 };
 
 /** Renderer diagnostics aggregated across all caller-owned source batches. */
@@ -95,6 +124,9 @@ export type SplatRendererStats = {
 type ResolvedSplatRendererProps = {
   modelViewProjectionMatrix: SplatUniforms['modelViewProjectionMatrix'];
   viewportSize: [number, number];
+  cameraPosition: [number, number, number];
+  sphericalHarmonicsDegree: SplatSphericalHarmonicsDegree;
+  semanticFilter?: SplatSemanticFilter;
   sortMode: SplatSortMode;
   alphaCutoff: number;
   screenSizeCutoffPixels: number;
@@ -105,9 +137,12 @@ type ResolvedSplatRendererProps = {
   alphaScale: number;
   exposure: number;
   toneMapping: 'none' | 'reinhard';
+  depthCompare: CompareFunction;
+  depthWriteEnabled: boolean;
 };
 
-type SplatDrawRun = {
+/** Borrowed batch-local draw run and optional WebGPU sorted-index allocation. */
+export type SplatDrawRun = {
   batchIndex: number;
   rowIndices: Uint32Array;
   indexBuffer?: Buffer;
@@ -184,10 +219,15 @@ export class SplatRenderer {
 
   private readonly shaderInputs = new ShaderInputs<{splat: SplatUniforms}>({splat: splatUniforms});
   private readonly cachedReferences: Array<Array<SplatSortReference | undefined>> = [];
+  private readonly cachedBatchRevisions: number[] = [];
+  private readonly evaluatedColorBuffers: Array<Buffer | undefined> = [];
+  private readonly opacityMaskBuffers: Array<Buffer | undefined> = [];
   private drawRuns: SplatDrawRun[] = [];
   private placeholderIndexBuffer?: Buffer;
+  private placeholderSphericalHarmonicsBuffer?: Buffer;
   private requiresUpdate = true;
   private requiresUniformUpdate = false;
+  private requiresWebGLSourceUpdate = false;
   private hasExplicitToneMapping = false;
   private isDestroyed = false;
 
@@ -197,6 +237,9 @@ export class SplatRenderer {
     this.props = {
       modelViewProjectionMatrix: toSplatMatrix(props.modelViewProjectionMatrix),
       viewportSize: [...(props.viewportSize ?? [1, 1])],
+      cameraPosition: [...(props.cameraPosition ?? [0, 0, 0])],
+      sphericalHarmonicsDegree: props.sphericalHarmonicsDegree ?? 3,
+      semanticFilter: props.semanticFilter,
       sortMode: props.sortMode ?? 'global',
       alphaCutoff: props.alphaCutoff ?? props.opacityThreshold ?? 1 / 255,
       screenSizeCutoffPixels: props.screenSizeCutoffPixels ?? 0,
@@ -206,7 +249,9 @@ export class SplatRenderer {
       radiusScale: props.radiusScale ?? props.pointSize ?? 1,
       alphaScale: props.alphaScale ?? 1,
       exposure: props.exposure ?? 1,
-      toneMapping: props.toneMapping ?? 'none'
+      toneMapping: props.toneMapping ?? 'none',
+      depthCompare: props.depthCompare ?? 'less-equal',
+      depthWriteEnabled: props.depthWriteEnabled ?? false
     };
     this.hasExplicitToneMapping = props.toneMapping !== undefined;
     this.updateShaderInputs();
@@ -235,6 +280,9 @@ export class SplatRenderer {
     const borrowedBatch = createBorrowedSplatBatch(data, this.device.type === 'webgpu');
     this.batches.push(data);
     this.cachedReferences.push([]);
+    this.cachedBatchRevisions.push(data.revision);
+    this.evaluatedColorBuffers.push(undefined);
+    this.opacityMaskBuffers.push(undefined);
     if (
       !this.hasExplicitToneMapping &&
       data.colors.format === 'float32x4' &&
@@ -250,6 +298,7 @@ export class SplatRenderer {
       this.model = this.createModel(this.table);
     }
     this.requiresUpdate = true;
+    this.requiresWebGLSourceUpdate = this.device.type !== 'webgpu';
   }
 
   /** Updates camera, sorting, visibility, and styling controls in place. */
@@ -281,6 +330,20 @@ export class SplatRenderer {
       !areSplatArrayValuesEqual(this.props.viewportSize, props.viewportSize)
     ) {
       this.setResolvedProp('viewportSize', [...props.viewportSize]);
+    }
+    if (
+      props.cameraPosition !== undefined &&
+      !areSplatArrayValuesEqual(this.props.cameraPosition, props.cameraPosition)
+    ) {
+      this.setResolvedProp('cameraPosition', [...props.cameraPosition]);
+    }
+    if (props.sphericalHarmonicsDegree !== undefined) {
+      this.setResolvedProp('sphericalHarmonicsDegree', props.sphericalHarmonicsDegree);
+    }
+    if ('semanticFilter' in props && !Object.is(this.props.semanticFilter, props.semanticFilter)) {
+      this.props.semanticFilter = props.semanticFilter;
+      this.requiresUpdate = true;
+      this.requiresWebGLSourceUpdate = this.device.type !== 'webgpu';
     }
     if (props.sortMode !== undefined) {
       this.setResolvedProp('sortMode', props.sortMode);
@@ -319,6 +382,19 @@ export class SplatRenderer {
       this.hasExplicitToneMapping = true;
       this.setResolvedProp('toneMapping', props.toneMapping);
     }
+    if (
+      (props.depthCompare !== undefined && props.depthCompare !== this.props.depthCompare) ||
+      (props.depthWriteEnabled !== undefined &&
+        props.depthWriteEnabled !== this.props.depthWriteEnabled)
+    ) {
+      this.props.depthCompare = props.depthCompare ?? this.props.depthCompare;
+      this.props.depthWriteEnabled = props.depthWriteEnabled ?? this.props.depthWriteEnabled;
+      this.model?.setParameters({
+        ...this.model.parameters,
+        depthCompare: this.props.depthCompare,
+        depthWriteEnabled: this.props.depthWriteEnabled
+      });
+    }
   }
 
   /** Recomputes camera-dependent ordering and flushes managed uniforms before a render pass. */
@@ -343,6 +419,64 @@ export class SplatRenderer {
     return this.draw(renderPass);
   }
 
+  /** Draws opaque meshes, depth-tested splats, and transparent overlays into one shared pass. */
+  drawMixed(renderPass: RenderPass, options: SplatMixedRenderOptions = {}): boolean {
+    this.update();
+    let drawSuccess = true;
+    let recordedDraw = false;
+    for (const mesh of options.opaqueMeshes ?? []) {
+      drawSuccess = mesh.draw(renderPass) !== false && drawSuccess;
+      recordedDraw = true;
+    }
+    if (this.sortedReferences.length > 0) {
+      drawSuccess = this.draw(renderPass) && drawSuccess;
+      recordedDraw = true;
+    }
+    for (const mesh of options.transparentMeshes ?? []) {
+      drawSuccess = mesh.draw(renderPass) !== false && drawSuccess;
+      recordedDraw = true;
+    }
+    return recordedDraw && drawSuccess;
+  }
+
+  /** Returns renderer-owned sorted runs borrowed by application-owned auxiliary render passes. */
+  getDrawRuns(): readonly SplatDrawRun[] {
+    this.update();
+    return this.drawRuns;
+  }
+
+  /** Returns the source opacity buffer or the renderer-owned WebGL semantic visibility mask. */
+  getBatchOpacityBuffer(batchIndex: number): Buffer {
+    this.update();
+    const batch = this.batches[batchIndex];
+    if (!batch) {
+      throw new Error('Unknown Gaussian splat source batch');
+    }
+    const buffer =
+      this.props.semanticFilter && this.device.type !== 'webgpu'
+        ? (this.opacityMaskBuffers[batchIndex] ?? batch.opacities.data[0].buffer)
+        : batch.opacities.data[0].buffer;
+    if (!(buffer instanceof Buffer)) {
+      throw new Error('Gaussian splat opacity requires a prepared GPU buffer');
+    }
+    return buffer;
+  }
+
+  /** Returns borrowed higher-order coefficients or the renderer-owned zero storage fallback. */
+  getBatchSphericalHarmonicsBuffer(batchIndex: number): Buffer {
+    this.update();
+    const batch = this.batches[batchIndex];
+    if (!batch) {
+      throw new Error('Unknown Gaussian splat source batch');
+    }
+    const buffer =
+      batch.sphericalHarmonics?.data[0]?.buffer ?? this.placeholderSphericalHarmonicsBuffer;
+    if (!(buffer instanceof Buffer)) {
+      throw new Error('Spherical-harmonic storage requires a WebGPU source batch');
+    }
+    return buffer;
+  }
+
   /** Returns current renderer diagnostics after refreshing camera-dependent source ordering. */
   getStats(): SplatRendererStats {
     this.update();
@@ -353,7 +487,10 @@ export class SplatRenderer {
     );
     const rendererGpuByteLength =
       (this.placeholderIndexBuffer?.byteLength ?? 0) +
+      (this.placeholderSphericalHarmonicsBuffer?.byteLength ?? 0) +
       (this.model?.tableBindingByteLength ?? 0) +
+      this.evaluatedColorBuffers.reduce((total, buffer) => total + (buffer?.byteLength ?? 0), 0) +
+      this.opacityMaskBuffers.reduce((total, buffer) => total + (buffer?.byteLength ?? 0), 0) +
       this.drawRuns.reduce((totalBytes, run) => totalBytes + (run.indexBuffer?.byteLength ?? 0), 0);
     return {
       splatCount,
@@ -385,8 +522,12 @@ export class SplatRenderer {
     this.table?.destroy();
     this.table = undefined;
     this.cachedReferences.length = 0;
+    this.cachedBatchRevisions.length = 0;
+    this.destroyWebGLSourceBuffers();
     this.placeholderIndexBuffer?.destroy();
     this.placeholderIndexBuffer = undefined;
+    this.placeholderSphericalHarmonicsBuffer?.destroy();
+    this.placeholderSphericalHarmonicsBuffer = undefined;
     this.shaderInputs.destroy();
     this.isDestroyed = true;
   }
@@ -397,6 +538,13 @@ export class SplatRenderer {
       this.placeholderIndexBuffer = this.device.createBuffer({
         id: 'splat-empty-sorted-indices',
         data: new Uint32Array(1),
+        usage: Buffer.STORAGE | Buffer.COPY_DST
+      });
+    }
+    if (isWebGPU && !this.placeholderSphericalHarmonicsBuffer) {
+      this.placeholderSphericalHarmonicsBuffer = this.device.createBuffer({
+        id: 'splat-empty-spherical-harmonics',
+        data: new Float32Array(1),
         usage: Buffer.STORAGE | Buffer.COPY_DST
       });
     }
@@ -419,7 +567,10 @@ export class SplatRenderer {
               splatColors: table.batches[0].gpuData['colors'].buffer,
               splatOpacities: table.batches[0].gpuData['opacities'].buffer,
               splatRowIndices: table.batches[0].gpuData['rowIndices'].buffer,
-              splatSortedIndices: this.placeholderIndexBuffer!
+              splatSortedIndices: this.placeholderIndexBuffer!,
+              splatSphericalHarmonics:
+                this.batches[0]?.sphericalHarmonics?.data[0]?.buffer ??
+                this.placeholderSphericalHarmonicsBuffer!
             }
           }
         : {}),
@@ -428,8 +579,8 @@ export class SplatRenderer {
       vertexCount: 4,
       topology: 'triangle-strip',
       parameters: {
-        depthWriteEnabled: false,
-        depthCompare: 'less-equal',
+        depthWriteEnabled: this.props.depthWriteEnabled,
+        depthCompare: this.props.depthCompare,
         blend: true,
         blendColorOperation: 'add',
         blendAlphaOperation: 'add',
@@ -445,9 +596,21 @@ export class SplatRenderer {
     if (this.isDestroyed) {
       return;
     }
+    for (let batchIndex = 0; batchIndex < this.batches.length; batchIndex++) {
+      const revision = this.batches[batchIndex].revision;
+      if (revision !== this.cachedBatchRevisions[batchIndex]) {
+        this.cachedBatchRevisions[batchIndex] = revision;
+        this.requiresUpdate = true;
+        this.requiresWebGLSourceUpdate = this.device.type !== 'webgpu';
+      }
+    }
     if (this.requiresUniformUpdate) {
       this.updateShaderInputs();
       this.requiresUniformUpdate = false;
+    }
+    if (this.requiresWebGLSourceUpdate) {
+      this.updateWebGLSourceBuffers();
+      this.requiresWebGLSourceUpdate = false;
     }
     if (!this.requiresUpdate) {
       return;
@@ -468,6 +631,10 @@ export class SplatRenderer {
     }
     this.props[propertyName] = value;
     this.requiresUniformUpdate = true;
+    if (propertyName === 'cameraPosition' || propertyName === 'sphericalHarmonicsDegree') {
+      this.requiresWebGLSourceUpdate = this.device.type !== 'webgpu';
+      return;
+    }
     if (
       propertyName === 'gaussianSupportRadius' ||
       propertyName === 'exposure' ||
@@ -503,7 +670,9 @@ export class SplatRenderer {
         maxScreenSpaceSplatSize: this.props.maxScreenSpaceSplatSize,
         sortedOffset: 0,
         exposure: this.props.exposure,
-        toneMapping: this.props.toneMapping === 'reinhard' ? 1 : 0
+        toneMapping: this.props.toneMapping === 'reinhard' ? 1 : 0,
+        cameraPosition: this.props.cameraPosition,
+        sphericalHarmonicsDegree: this.props.sphericalHarmonicsDegree
       }
     });
   }
@@ -521,6 +690,9 @@ export class SplatRenderer {
       const colorAlphaScale = colors instanceof Float32Array ? 1 : 1 / 255;
       const cachedBatchReferences = this.cachedReferences[batchIndex];
       for (let batchRowIndex = 0; batchRowIndex < batch.length; batchRowIndex++) {
+        if (!acceptsSplatSemantic(this.props.semanticFilter, batch, batchRowIndex)) {
+          continue;
+        }
         const opacity =
           opacities[batchRowIndex] *
           colors[batchRowIndex * 4 + 3] *
@@ -720,7 +892,10 @@ export class SplatRenderer {
         splatColors: batch.gpuData['colors'].buffer,
         splatOpacities: batch.gpuData['opacities'].buffer,
         splatRowIndices: batch.gpuData['rowIndices'].buffer,
-        splatSortedIndices: run.indexBuffer
+        splatSortedIndices: run.indexBuffer,
+        splatSphericalHarmonics:
+          this.batches[run.batchIndex].sphericalHarmonics?.data[0]?.buffer ??
+          this.placeholderSphericalHarmonicsBuffer!
       });
       this.model.setInstanceCount(run.rowIndices.length);
       drawSuccess = this.model.draw(renderPass) && drawSuccess;
@@ -742,8 +917,18 @@ export class SplatRenderer {
       if (!batch) {
         continue;
       }
+      const evaluatedColorBuffer = this.evaluatedColorBuffers[run.batchIndex];
       this.model.setAttributes(
-        Object.fromEntries(Object.entries(batch.gpuData).map(([name, data]) => [name, data.buffer]))
+        Object.fromEntries(
+          Object.entries(batch.gpuData).map(([name, data]) => [
+            name,
+            name === 'colors' && this.props.sphericalHarmonicsDegree > 0 && evaluatedColorBuffer
+              ? evaluatedColorBuffer
+              : name === 'opacities'
+                ? this.getBatchOpacityBuffer(run.batchIndex)
+                : data.buffer
+          ])
+        )
       );
       this.model.setInstanceCount(batch.numRows);
       drawSuccess = this.model.draw(renderPass) && drawSuccess;
@@ -760,6 +945,8 @@ export class SplatRenderer {
     this.table = undefined;
     this.batches.length = 0;
     this.cachedReferences.length = 0;
+    this.cachedBatchRevisions.length = 0;
+    this.destroyWebGLSourceBuffers();
     for (const batch of batches) {
       this.appendData(batch);
     }
@@ -771,6 +958,101 @@ export class SplatRenderer {
       run.indexBuffer?.destroy();
     }
     this.drawRuns = [];
+  }
+
+  private updateWebGLSourceBuffers(): void {
+    if (this.device.type === 'webgpu') {
+      return;
+    }
+    for (const [batchIndex, batch] of this.batches.entries()) {
+      const coefficients = batch.source.sphericalHarmonics;
+      if (coefficients && this.props.sphericalHarmonicsDegree > 0) {
+        this.updateWebGLSphericalHarmonicColors(batchIndex, batch, coefficients);
+      }
+      if (this.props.semanticFilter) {
+        const opacities = new Float32Array(batch.source.opacities);
+        for (let rowIndex = 0; rowIndex < batch.length; rowIndex++) {
+          if (!acceptsSplatSemantic(this.props.semanticFilter, batch, rowIndex)) {
+            opacities[rowIndex] = 0;
+          }
+        }
+        const existingBuffer = this.opacityMaskBuffers[batchIndex];
+        if (existingBuffer) {
+          existingBuffer.write(opacities);
+        } else {
+          this.opacityMaskBuffers[batchIndex] = this.device.createBuffer({
+            id: `splat-filtered-opacities-${batch.sourceBatchIndex}`,
+            ...(opacities.byteLength > 0
+              ? {data: opacities}
+              : {byteLength: Float32Array.BYTES_PER_ELEMENT}),
+            usage: Buffer.VERTEX | Buffer.COPY_DST
+          });
+        }
+      }
+    }
+  }
+
+  private updateWebGLSphericalHarmonicColors(
+    batchIndex: number,
+    batch: GPUSplatData,
+    coefficients: Float32Array
+  ): void {
+    const sourceColors = batch.source.colors;
+    const colors =
+      sourceColors instanceof Float32Array
+        ? new Float32Array(sourceColors)
+        : new Uint8Array(sourceColors);
+    const coefficientCount = batch.length > 0 ? coefficients.length / batch.length : 0;
+    const degree =
+      this.props.sphericalHarmonicsDegree < batch.sphericalHarmonicsDegree
+        ? this.props.sphericalHarmonicsDegree
+        : batch.sphericalHarmonicsDegree;
+    for (let rowIndex = 0; rowIndex < batch.length; rowIndex++) {
+      const colorOffset = rowIndex * 4;
+      const positionOffset = rowIndex * 3;
+      const sourceColorScale = sourceColors instanceof Float32Array ? 1 : 1 / 255;
+      const color = evaluateSplatSphericalHarmonics(
+        [
+          sourceColors[colorOffset] * sourceColorScale,
+          sourceColors[colorOffset + 1] * sourceColorScale,
+          sourceColors[colorOffset + 2] * sourceColorScale
+        ],
+        coefficients.subarray(rowIndex * coefficientCount, (rowIndex + 1) * coefficientCount),
+        [
+          batch.source.positions[positionOffset] - this.props.cameraPosition[0],
+          batch.source.positions[positionOffset + 1] - this.props.cameraPosition[1],
+          batch.source.positions[positionOffset + 2] - this.props.cameraPosition[2]
+        ],
+        degree
+      );
+      for (let colorComponentIndex = 0; colorComponentIndex < 3; colorComponentIndex++) {
+        colors[colorOffset + colorComponentIndex] =
+          colors instanceof Float32Array
+            ? color[colorComponentIndex]
+            : Math.round(Math.min(Math.max(color[colorComponentIndex], 0), 1) * 255);
+      }
+    }
+    const existingBuffer = this.evaluatedColorBuffers[batchIndex];
+    if (existingBuffer) {
+      existingBuffer.write(colors);
+    } else {
+      this.evaluatedColorBuffers[batchIndex] = this.device.createBuffer({
+        id: `splat-evaluated-colors-${batch.sourceBatchIndex}`,
+        ...(colors.byteLength > 0 ? {data: colors} : {byteLength: Float32Array.BYTES_PER_ELEMENT}),
+        usage: Buffer.VERTEX | Buffer.COPY_DST
+      });
+    }
+  }
+
+  private destroyWebGLSourceBuffers(): void {
+    for (const buffer of this.evaluatedColorBuffers) {
+      buffer?.destroy();
+    }
+    for (const buffer of this.opacityMaskBuffers) {
+      buffer?.destroy();
+    }
+    this.evaluatedColorBuffers.length = 0;
+    this.opacityMaskBuffers.length = 0;
   }
 }
 

--- a/modules/splats/src/splat-residency.ts
+++ b/modules/splats/src/splat-residency.ts
@@ -1,0 +1,652 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {GPUSplatData} from './splat-data';
+
+/** Independent limits applied to intact, independently uploaded Gaussian source batches. */
+export type SplatResidencyBudget = {
+  /** Maximum allocated bytes retained across resident Gaussian source batches. */
+  maxGpuBytes?: number;
+  /** Maximum logical source rows retained across resident Gaussian source batches. */
+  maxResidentSplats?: number;
+  /** Maximum independent source batches retained without combining their buffers. */
+  maxResidentChunks?: number;
+};
+
+/** Optional spatial metadata supplied by a caller-owned splat tile or hierarchy. */
+export type SplatResidencyBounds = {
+  /** World-space center used by callers when determining a tile's residency priority. */
+  center: readonly [number, number, number];
+  /** Optional world-space bounding-sphere radius. */
+  radius?: number;
+};
+
+/** Identity, priority, hierarchy, and ownership controls for one independent source batch. */
+export type SplatResidencyChunkOptions = {
+  /** Stable tile or chunk identity; defaults to the batch and global source-row identity. */
+  id?: string;
+  /** Higher-priority chunks displace lower-priority chunks when capacity is exhausted. */
+  priority?: number;
+  /** Pinned chunks are never removed automatically or by non-forced eviction. */
+  pinned?: boolean;
+  /** Caller-defined hierarchy level preserved without combining source batches. */
+  levelOfDetail?: number;
+  /** Optional tile bounds retained for camera-dependent priority updates. */
+  bounds?: SplatResidencyBounds;
+  /** Whether this manager owns and destroys this specific prepared source batch. */
+  ownsData?: boolean;
+  /** Upper-bound GPU bytes reserved before an asynchronous source batch is prepared. */
+  estimatedGpuBytes?: number;
+  /** Upper-bound source rows reserved before an asynchronous source batch is prepared. */
+  estimatedSplatCount?: number;
+};
+
+/** Explicit residency metadata stored directly on each independently retained source chunk. */
+export type SplatResidencyChunk = {
+  /** Stable caller-supplied tile identity or source batch and global-row identity. */
+  id: string;
+  /** Original independently prepared Gaussian source batch, never copied or combined. */
+  data: GPUSplatData;
+  /** Retention priority; larger values are more valuable. */
+  priority: number;
+  /** Whether automatic and non-forced eviction must preserve this chunk. */
+  pinned: boolean;
+  /** Caller-defined level-of-detail hierarchy position. */
+  levelOfDetail: number;
+  /** Optional caller-supplied spatial bounds. */
+  bounds?: SplatResidencyBounds;
+  /** Exact GPU allocation size of this independently owned source batch. */
+  byteLength: number;
+  /** Number of logical Gaussian source rows. */
+  splatCount: number;
+  /** Monotonic access counter used to resolve equal-priority eviction ties. */
+  lastUsed: number;
+  /** Whether this manager must destroy the prepared source batch when it leaves residency. */
+  ownsData: boolean;
+};
+
+/** Reason an intact Gaussian source batch was removed from the residency window. */
+export type SplatResidencyEvictionReason = 'budget' | 'evict' | 'remove' | 'replace' | 'destroy';
+
+/** Current bounded-residency allocations, logical rows, limits, and admission diagnostics. */
+export type SplatResidencyStats = {
+  /** Number of intact, independently prepared source batches in the residency window. */
+  residentChunkCount: number;
+  /** Number of logical Gaussian source rows retained without repacking. */
+  residentSplatCount: number;
+  /** Exact aggregate GPU allocation size across the retained source batches. */
+  residentGpuByteLength: number;
+  /** Number of pinned chunks protected against automatic eviction. */
+  pinnedChunkCount: number;
+  /** Number of currently running, coalesced asynchronous source-batch loads. */
+  pendingChunkCount: number;
+  /** Number of chunks removed by explicit or budget-triggered eviction. */
+  evictedChunkCount: number;
+  /** Number of incoming chunks rejected because they cannot fit without protected data. */
+  rejectedChunkCount: number;
+  /** Active exact GPU allocation budget. */
+  maxGpuBytes: number;
+  /** Active logical Gaussian source-row budget. */
+  maxResidentSplats: number;
+  /** Active intact source-batch budget. */
+  maxResidentChunks: number;
+  /** Whether protected chunks currently exceed a newly reduced residency budget. */
+  overBudget: boolean;
+};
+
+/** Optional integration hooks for updating a borrowing renderer or tile scheduler. */
+export type SplatResidencyCallbacks = {
+  /** Called after one intact source batch enters the residency window. */
+  onAdd?: (chunk: SplatResidencyChunk) => void;
+  /** Called after removal but before manager-owned source GPU buffers are destroyed. */
+  onEvict?: (chunk: SplatResidencyChunk, reason: SplatResidencyEvictionReason) => void;
+  /** Called with the current exact source-batch list after every residency change. */
+  onResidencyChange?: (batches: readonly GPUSplatData[], stats: SplatResidencyStats) => void;
+};
+
+/** Allocation budgets, default ownership, and optional renderer or scheduler integration. */
+export type SplatResidencyManagerProps = SplatResidencyBudget &
+  SplatResidencyCallbacks & {
+    /** Whether admitted source batches are owned by default. Borrowing is the default. */
+    ownsData?: boolean;
+    /** Optional callback collection, useful when composing renderer integrations. */
+    callbacks?: SplatResidencyCallbacks;
+  };
+
+type SplatResidencyTarget = string | GPUSplatData | SplatResidencyChunk;
+
+type SplatResidencyReservation = {
+  gpuByteLength: number;
+  splatCount: number;
+  released: boolean;
+};
+
+/**
+ * Keeps intact Gaussian source batches within bounded GPU, row, and chunk budgets.
+ *
+ * Priorities protect more important tiles, equal priorities use least-recently-used
+ * eviction, and pinned batches are never automatically removed. No source batch is
+ * combined, repacked, or destroyed unless its explicit ownership has been transferred.
+ */
+export class SplatResidencyManager {
+  private readonly chunks = new Map<string, SplatResidencyChunk>();
+  private readonly chunksByData = new Map<GPUSplatData, SplatResidencyChunk>();
+  private readonly pendingLoads = new Map<string, Promise<SplatResidencyChunk | undefined>>();
+  private readonly callbacks: SplatResidencyCallbacks;
+  private readonly ownsData: boolean;
+  private maxGpuBytes: number;
+  private maxResidentSplats: number;
+  private maxResidentChunks: number;
+  private residentGpuByteLength = 0;
+  private residentSplatCount = 0;
+  private reservedGpuByteLength = 0;
+  private reservedSplatCount = 0;
+  private reservedChunkCount = 0;
+  private pinnedChunkCount = 0;
+  private evictedChunkCount = 0;
+  private rejectedChunkCount = 0;
+  private accessCounter = 0;
+  private isDestroyed = false;
+
+  /** Creates an initially empty, borrowing residency window with optional finite budgets. */
+  constructor(props: SplatResidencyManagerProps = {}) {
+    this.maxGpuBytes = normalizeSplatResidencyBudget(props.maxGpuBytes);
+    this.maxResidentSplats = normalizeSplatResidencyBudget(props.maxResidentSplats);
+    this.maxResidentChunks = normalizeSplatResidencyBudget(props.maxResidentChunks);
+    this.ownsData = props.ownsData ?? false;
+    this.callbacks = {
+      ...props.callbacks,
+      ...(props.onAdd ? {onAdd: props.onAdd} : {}),
+      ...(props.onEvict ? {onEvict: props.onEvict} : {}),
+      ...(props.onResidencyChange ? {onResidencyChange: props.onResidencyChange} : {})
+    };
+  }
+
+  /** Whether this residency manager has already released its retained source batches. */
+  get destroyed(): boolean {
+    return this.isDestroyed;
+  }
+
+  /** Original caller-owned source batches in stable admission order. */
+  get residentBatches(): GPUSplatData[] {
+    return this.getResidentBatches();
+  }
+
+  /** Explicit source chunk, tile, priority, hierarchy, and ownership metadata. */
+  get residentChunks(): SplatResidencyChunk[] {
+    return this.getResidentChunks();
+  }
+
+  /** Current exact GPU allocations, logical rows, source batches, and budget diagnostics. */
+  get stats(): SplatResidencyStats {
+    return this.getStats();
+  }
+
+  /** Returns the original intact GPU source batches without copying or combining their buffers. */
+  getResidentBatches(): GPUSplatData[] {
+    return Array.from(this.chunks.values(), chunk => chunk.data);
+  }
+
+  /** Returns every admitted source chunk and its directly stored residency metadata. */
+  getResidentChunks(): SplatResidencyChunk[] {
+    return Array.from(this.chunks.values());
+  }
+
+  /** Returns one retained chunk using its tile identity or exact source-batch object. */
+  getChunk(target: SplatResidencyTarget): SplatResidencyChunk | undefined {
+    return this.resolveChunk(target);
+  }
+
+  /** Whether the exact source batch or source tile identity is currently resident. */
+  has(target: SplatResidencyTarget): boolean {
+    return this.resolveChunk(target) !== undefined;
+  }
+
+  /**
+   * Admits one intact source batch, evicting only lower-priority or older equal-priority chunks.
+   *
+   * Returns `undefined` without changing existing residency when the source batch cannot fit.
+   */
+  add(
+    data: GPUSplatData,
+    options: SplatResidencyChunkOptions = {}
+  ): SplatResidencyChunk | undefined {
+    if (this.isDestroyed || data.destroyed) {
+      throw new Error('Splat residency requires a live manager and source batch');
+    }
+
+    const chunkId = options.id ?? getSplatResidencyChunkId(data);
+    const existingChunk = this.chunks.get(chunkId);
+    const retainedData = this.resolveChunk(data);
+    if (retainedData) {
+      this.updateChunk(retainedData, options);
+      return this.resolveChunk(data);
+    }
+
+    const incomingPriority = options.priority ?? existingChunk?.priority ?? 0;
+    let prospectiveByteLength =
+      this.residentGpuByteLength +
+      this.reservedGpuByteLength -
+      (existingChunk?.byteLength ?? 0) +
+      data.byteLength;
+    let prospectiveSplatCount =
+      this.residentSplatCount +
+      this.reservedSplatCount -
+      (existingChunk?.splatCount ?? 0) +
+      data.length;
+    let prospectiveChunkCount =
+      this.chunks.size + this.reservedChunkCount + (existingChunk ? 0 : 1);
+    const evictedChunks: SplatResidencyChunk[] = [];
+
+    if (this.exceedsBudget(prospectiveByteLength, prospectiveSplatCount, prospectiveChunkCount)) {
+      for (const candidate of this.getEvictionCandidates(incomingPriority, existingChunk)) {
+        if (
+          !this.exceedsBudget(prospectiveByteLength, prospectiveSplatCount, prospectiveChunkCount)
+        ) {
+          break;
+        }
+        prospectiveByteLength -= candidate.byteLength;
+        prospectiveSplatCount -= candidate.splatCount;
+        prospectiveChunkCount--;
+        evictedChunks.push(candidate);
+      }
+    }
+
+    if (this.exceedsBudget(prospectiveByteLength, prospectiveSplatCount, prospectiveChunkCount)) {
+      this.rejectedChunkCount++;
+      return undefined;
+    }
+
+    if (existingChunk) {
+      this.removeChunk(existingChunk, 'replace');
+    }
+    for (const candidate of evictedChunks) {
+      this.removeChunk(candidate, 'budget');
+    }
+
+    const chunk: SplatResidencyChunk = {
+      id: chunkId,
+      data,
+      priority: incomingPriority,
+      pinned: options.pinned ?? false,
+      levelOfDetail: options.levelOfDetail ?? 0,
+      ...(options.bounds ? {bounds: options.bounds} : {}),
+      byteLength: data.byteLength,
+      splatCount: data.length,
+      lastUsed: ++this.accessCounter,
+      ownsData: options.ownsData ?? this.ownsData
+    };
+
+    this.chunks.set(chunk.id, chunk);
+    this.chunksByData.set(chunk.data, chunk);
+    this.residentGpuByteLength += chunk.byteLength;
+    this.residentSplatCount += chunk.splatCount;
+    if (chunk.pinned) {
+      this.pinnedChunkCount++;
+    }
+    this.callbacks.onAdd?.(chunk);
+    this.notifyResidencyChange();
+    return chunk;
+  }
+
+  /** Alias for registering one intact source tile or independently prepared streaming batch. */
+  register(
+    data: GPUSplatData,
+    options: SplatResidencyChunkOptions = {}
+  ): SplatResidencyChunk | undefined {
+    return this.add(data, options);
+  }
+
+  /**
+   * Loads one source tile at most once, retaining its exact source-batch boundaries.
+   *
+   * Optional GPU-byte and source-row estimates reserve capacity before the source loader runs.
+   * Protected or higher-priority chunks are retained transactionally when admission cannot fit.
+   * Manager-owned asynchronous results are destroyed if final admission fails or the manager
+   * has already been destroyed. Borrowed results always remain owned by their source loader.
+   */
+  load(
+    id: string,
+    loadData: () => GPUSplatData | Promise<GPUSplatData>,
+    options: Omit<SplatResidencyChunkOptions, 'id'> = {}
+  ): Promise<SplatResidencyChunk | undefined> {
+    if (this.isDestroyed) {
+      return Promise.reject(new Error('Splat residency manager has been destroyed'));
+    }
+
+    const existingChunk = this.chunks.get(id);
+    if (existingChunk) {
+      this.updateChunk(existingChunk, options);
+      return Promise.resolve(this.chunks.get(id));
+    }
+
+    const pendingLoad = this.pendingLoads.get(id);
+    if (pendingLoad) {
+      return pendingLoad;
+    }
+
+    const shouldReserve =
+      options.estimatedGpuBytes !== undefined || options.estimatedSplatCount !== undefined;
+    const reservation = shouldReserve ? this.reserveLoad(options) : undefined;
+    if (shouldReserve && !reservation) {
+      this.rejectedChunkCount++;
+      return Promise.resolve(undefined);
+    }
+
+    let requestedLoad: Promise<SplatResidencyChunk | undefined>;
+    requestedLoad = Promise.resolve()
+      .then(loadData)
+      .then(data => {
+        if (reservation) {
+          this.releaseReservation(reservation);
+        }
+        if (this.isDestroyed) {
+          if (options.ownsData ?? this.ownsData) {
+            data.destroy();
+          }
+          return undefined;
+        }
+
+        const chunk = this.add(data, {id, ...options});
+        if (!chunk && (options.ownsData ?? this.ownsData)) {
+          data.destroy();
+        }
+        return chunk;
+      })
+      .finally(() => {
+        if (reservation) {
+          this.releaseReservation(reservation);
+        }
+        if (this.pendingLoads.get(id) === requestedLoad) {
+          this.pendingLoads.delete(id);
+        }
+      });
+    this.pendingLoads.set(id, requestedLoad);
+    return requestedLoad;
+  }
+
+  /** Marks one source tile as recently used without changing its source buffers or identity. */
+  touch(target: SplatResidencyTarget): boolean {
+    const chunk = this.resolveChunk(target);
+    if (!chunk) {
+      return false;
+    }
+    chunk.lastUsed = ++this.accessCounter;
+    return true;
+  }
+
+  /** Updates the eviction priority of one source tile without moving or repacking its data. */
+  setPriority(target: SplatResidencyTarget, priority: number): boolean {
+    const chunk = this.resolveChunk(target);
+    if (!chunk) {
+      return false;
+    }
+    chunk.priority = priority;
+    chunk.lastUsed = ++this.accessCounter;
+    return true;
+  }
+
+  /** Protects a retained source tile against automatic and non-forced explicit eviction. */
+  pin(target: SplatResidencyTarget, pinned = true): boolean {
+    const chunk = this.resolveChunk(target);
+    if (!chunk) {
+      return false;
+    }
+    if (chunk.pinned !== pinned) {
+      this.pinnedChunkCount += pinned ? 1 : -1;
+    }
+    chunk.pinned = pinned;
+    chunk.lastUsed = ++this.accessCounter;
+    if (!pinned) {
+      this.trim();
+    }
+    return true;
+  }
+
+  /** Removes explicit eviction protection and immediately enforces any reduced budgets. */
+  unpin(target: SplatResidencyTarget): boolean {
+    return this.pin(target, false);
+  }
+
+  /** Updates any combination of exact GPU-byte, source-row, and independent-chunk budgets. */
+  setBudget(budget: SplatResidencyBudget | number): void {
+    const updatedBudget = typeof budget === 'number' ? {maxGpuBytes: budget} : budget;
+    if (updatedBudget.maxGpuBytes !== undefined) {
+      this.maxGpuBytes = normalizeSplatResidencyBudget(updatedBudget.maxGpuBytes);
+    }
+    if (updatedBudget.maxResidentSplats !== undefined) {
+      this.maxResidentSplats = normalizeSplatResidencyBudget(updatedBudget.maxResidentSplats);
+    }
+    if (updatedBudget.maxResidentChunks !== undefined) {
+      this.maxResidentChunks = normalizeSplatResidencyBudget(updatedBudget.maxResidentChunks);
+    }
+    this.trim();
+  }
+
+  /** Evicts one unpinned source tile, defaulting to the least valuable and oldest resident. */
+  evict(target?: SplatResidencyTarget): boolean {
+    const chunk = target
+      ? this.resolveChunk(target)
+      : this.getEvictionCandidates(Number.POSITIVE_INFINITY)[0];
+    if (!chunk || chunk.pinned) {
+      return false;
+    }
+    this.removeChunk(chunk, 'evict');
+    return true;
+  }
+
+  /** Explicitly removes one source tile, including chunks protected against automatic eviction. */
+  remove(target: SplatResidencyTarget): boolean {
+    const chunk = this.resolveChunk(target);
+    if (!chunk) {
+      return false;
+    }
+    this.removeChunk(chunk, 'remove');
+    return true;
+  }
+
+  /** Removes the least valuable unpinned chunks until every active residency budget is met. */
+  trim(): number {
+    let removedChunkCount = 0;
+    for (const chunk of this.getEvictionCandidates(Number.POSITIVE_INFINITY)) {
+      if (
+        !this.exceedsBudget(
+          this.residentGpuByteLength + this.reservedGpuByteLength,
+          this.residentSplatCount + this.reservedSplatCount,
+          this.chunks.size + this.reservedChunkCount
+        )
+      ) {
+        break;
+      }
+      this.removeChunk(chunk, 'budget');
+      removedChunkCount++;
+    }
+    return removedChunkCount;
+  }
+
+  /** Removes all retained source tiles while respecting each batch's explicit ownership. */
+  clear(): void {
+    for (const chunk of Array.from(this.chunks.values())) {
+      this.removeChunk(chunk, 'remove');
+    }
+  }
+
+  /** Returns exact retained GPU allocations, source boundaries, budgets, and eviction counts. */
+  getStats(): SplatResidencyStats {
+    return {
+      residentChunkCount: this.chunks.size,
+      residentSplatCount: this.residentSplatCount,
+      residentGpuByteLength: this.residentGpuByteLength,
+      pinnedChunkCount: this.pinnedChunkCount,
+      pendingChunkCount: this.pendingLoads.size,
+      evictedChunkCount: this.evictedChunkCount,
+      rejectedChunkCount: this.rejectedChunkCount,
+      maxGpuBytes: this.maxGpuBytes,
+      maxResidentSplats: this.maxResidentSplats,
+      maxResidentChunks: this.maxResidentChunks,
+      overBudget: this.exceedsBudget(
+        this.residentGpuByteLength,
+        this.residentSplatCount,
+        this.chunks.size
+      )
+    };
+  }
+
+  /** Releases retained source metadata and only source batches explicitly owned by this manager. */
+  destroy(): void {
+    if (this.isDestroyed) {
+      return;
+    }
+    this.isDestroyed = true;
+    this.pendingLoads.clear();
+    for (const chunk of Array.from(this.chunks.values())) {
+      this.removeChunk(chunk, 'destroy');
+    }
+  }
+
+  private resolveChunk(target: SplatResidencyTarget): SplatResidencyChunk | undefined {
+    if (typeof target === 'string') {
+      return this.chunks.get(target);
+    }
+    if ('data' in target) {
+      const retainedChunk = this.chunks.get(target.id);
+      return retainedChunk === target ? retainedChunk : undefined;
+    }
+    return this.chunksByData.get(target);
+  }
+
+  private reserveLoad(
+    options: Omit<SplatResidencyChunkOptions, 'id'>
+  ): SplatResidencyReservation | undefined {
+    const reservation: SplatResidencyReservation = {
+      gpuByteLength: Math.max(0, options.estimatedGpuBytes ?? 0),
+      splatCount: Math.max(0, options.estimatedSplatCount ?? 0),
+      released: false
+    };
+    let prospectiveByteLength =
+      this.residentGpuByteLength + this.reservedGpuByteLength + reservation.gpuByteLength;
+    let prospectiveSplatCount =
+      this.residentSplatCount + this.reservedSplatCount + reservation.splatCount;
+    let prospectiveChunkCount = this.chunks.size + this.reservedChunkCount + 1;
+    const evictedChunks: SplatResidencyChunk[] = [];
+
+    if (this.exceedsBudget(prospectiveByteLength, prospectiveSplatCount, prospectiveChunkCount)) {
+      for (const candidate of this.getEvictionCandidates(options.priority ?? 0)) {
+        if (
+          !this.exceedsBudget(prospectiveByteLength, prospectiveSplatCount, prospectiveChunkCount)
+        ) {
+          break;
+        }
+        prospectiveByteLength -= candidate.byteLength;
+        prospectiveSplatCount -= candidate.splatCount;
+        prospectiveChunkCount--;
+        evictedChunks.push(candidate);
+      }
+    }
+
+    if (this.exceedsBudget(prospectiveByteLength, prospectiveSplatCount, prospectiveChunkCount)) {
+      return undefined;
+    }
+
+    this.reservedGpuByteLength += reservation.gpuByteLength;
+    this.reservedSplatCount += reservation.splatCount;
+    this.reservedChunkCount++;
+    for (const candidate of evictedChunks) {
+      this.removeChunk(candidate, 'budget');
+    }
+    return reservation;
+  }
+
+  private releaseReservation(reservation: SplatResidencyReservation): void {
+    if (reservation.released) {
+      return;
+    }
+    reservation.released = true;
+    this.reservedGpuByteLength -= reservation.gpuByteLength;
+    this.reservedSplatCount -= reservation.splatCount;
+    this.reservedChunkCount--;
+  }
+
+  private updateChunk(chunk: SplatResidencyChunk, options: SplatResidencyChunkOptions): void {
+    if (options.priority !== undefined) {
+      chunk.priority = options.priority;
+    }
+    if (options.pinned !== undefined) {
+      if (chunk.pinned !== options.pinned) {
+        this.pinnedChunkCount += options.pinned ? 1 : -1;
+      }
+      chunk.pinned = options.pinned;
+    }
+    if (options.levelOfDetail !== undefined) {
+      chunk.levelOfDetail = options.levelOfDetail;
+    }
+    if (options.bounds !== undefined) {
+      chunk.bounds = options.bounds;
+    }
+    if (options.ownsData !== undefined) {
+      chunk.ownsData = options.ownsData;
+    }
+    chunk.lastUsed = ++this.accessCounter;
+    if (!chunk.pinned) {
+      this.trim();
+    }
+  }
+
+  private getEvictionCandidates(
+    maximumPriority: number,
+    excludedChunk?: SplatResidencyChunk
+  ): SplatResidencyChunk[] {
+    return Array.from(this.chunks.values())
+      .filter(
+        chunk => chunk !== excludedChunk && !chunk.pinned && chunk.priority <= maximumPriority
+      )
+      .sort(
+        (firstChunk, secondChunk) =>
+          firstChunk.priority - secondChunk.priority ||
+          firstChunk.lastUsed - secondChunk.lastUsed ||
+          firstChunk.id.localeCompare(secondChunk.id)
+      );
+  }
+
+  private exceedsBudget(byteLength: number, splatCount: number, chunkCount: number): boolean {
+    return (
+      byteLength > this.maxGpuBytes ||
+      splatCount > this.maxResidentSplats ||
+      chunkCount > this.maxResidentChunks
+    );
+  }
+
+  private removeChunk(chunk: SplatResidencyChunk, reason: SplatResidencyEvictionReason): void {
+    if (this.chunks.get(chunk.id) !== chunk) {
+      return;
+    }
+    this.chunks.delete(chunk.id);
+    this.chunksByData.delete(chunk.data);
+    this.residentGpuByteLength -= chunk.byteLength;
+    this.residentSplatCount -= chunk.splatCount;
+    if (chunk.pinned) {
+      this.pinnedChunkCount--;
+    }
+    if (reason === 'budget' || reason === 'evict') {
+      this.evictedChunkCount++;
+    }
+    this.callbacks.onEvict?.(chunk, reason);
+    this.notifyResidencyChange();
+    if (chunk.ownsData) {
+      chunk.data.destroy();
+    }
+  }
+
+  private notifyResidencyChange(): void {
+    this.callbacks.onResidencyChange?.(this.getResidentBatches(), this.getStats());
+  }
+}
+
+function getSplatResidencyChunkId(data: GPUSplatData): string {
+  return `${data.sourceBatchIndex}:${data.rowIndexBase}`;
+}
+
+function normalizeSplatResidencyBudget(value?: number): number {
+  return value === undefined ? Number.POSITIVE_INFINITY : Math.max(0, value);
+}

--- a/modules/splats/src/splat-shaders.ts
+++ b/modules/splats/src/splat-shaders.ts
@@ -36,6 +36,8 @@ export type SplatUniforms = {
   sortedOffset: number;
   exposure: number;
   toneMapping: number;
+  cameraPosition: [number, number, number];
+  sphericalHarmonicsDegree: number;
 };
 
 /** Uniform module shared by WebGPU storage and WebGL2 attribute-backed splat models. */
@@ -53,7 +55,9 @@ export const splatUniforms = {
     maxScreenSpaceSplatSize: 'f32',
     sortedOffset: 'u32',
     exposure: 'f32',
-    toneMapping: 'u32'
+    toneMapping: 'u32',
+    cameraPosition: 'vec3<f32>',
+    sphericalHarmonicsDegree: 'u32'
   }
 } satisfies ShaderModule<SplatUniforms>;
 
@@ -81,7 +85,8 @@ export const SPLAT_STORAGE_SHADER_LAYOUT = {
     {name: 'splatColors', type: 'read-only-storage', group: 0, location: 4},
     {name: 'splatOpacities', type: 'read-only-storage', group: 0, location: 5},
     {name: 'splatRowIndices', type: 'read-only-storage', group: 0, location: 6},
-    {name: 'splatSortedIndices', type: 'read-only-storage', group: 0, location: 7}
+    {name: 'splatSortedIndices', type: 'read-only-storage', group: 0, location: 7},
+    {name: 'splatSphericalHarmonics', type: 'read-only-storage', group: 0, location: 8}
   ]
 } satisfies ShaderLayout;
 
@@ -99,6 +104,8 @@ struct SplatUniforms {
   sortedOffset : u32,
   exposure : f32,
   toneMapping : u32,
+  cameraPosition : vec3<f32>,
+  sphericalHarmonicsDegree : u32,
 };
 
 @group(0) @binding(auto) var<uniform> splat : SplatUniforms;
@@ -107,6 +114,7 @@ struct SplatFragmentInputs {
   @builtin(position) position : vec4<f32>,
   @location(0) gaussianCoordinate : vec2<f32>,
   @location(1) color : vec4<f32>,
+  @location(2) @interpolate(flat) sourceRowIndex : i32,
 };
 
 fn getSplatScreenPosition(position : vec3<f32>) -> vec2<f32> {
@@ -138,7 +146,8 @@ fn projectSplatVertex(
   scale : vec3<f32>,
   rotation : vec4<f32>,
   color : vec4<f32>,
-  opacity : f32
+  opacity : f32,
+  rowIndex : u32
 ) -> SplatFragmentInputs {
   let corners = array<vec2<f32>, 4>(
     vec2<f32>(-1.0, -1.0), vec2<f32>(1.0, -1.0),
@@ -179,6 +188,7 @@ fn projectSplatVertex(
   var output : SplatFragmentInputs;
   output.position = vec4<f32>(clipCenter.xy + clipOffset, clipCenter.z, clipCenter.w);
   output.gaussianCoordinate = corner * splat.gaussianSupportRadius;
+  output.sourceRowIndex = i32(rowIndex);
   let visible = select(0.0, 1.0, maximumAxisLength * splat.radiusScale >= splat.screenSizeCutoffPixels);
   output.color = vec4<f32>(color.rgb, color.a * opacity * splat.alphaScale * visible);
   return output;
@@ -188,7 +198,7 @@ fn projectSplatVertex(
 fn fragmentMain(input : SplatFragmentInputs) -> @location(0) vec4<f32> {
   let gaussianWeight = exp(-0.5 * dot(input.gaussianCoordinate, input.gaussianCoordinate));
   let alpha = input.color.a * gaussianWeight;
-  if (alpha < splat.alphaCutoff) {
+  if (alpha <= 0.0 || alpha < splat.alphaCutoff) {
     discard;
   }
   let linearColor = max(input.color.rgb * splat.exposure, vec3<f32>(0.0));
@@ -212,6 +222,62 @@ ${SPLAT_WGSL_SHARED}
 @group(0) @binding(auto) var<storage, read> splatOpacities : array<f32>;
 @group(0) @binding(auto) var<storage, read> splatRowIndices : array<u32>;
 @group(0) @binding(auto) var<storage, read> splatSortedIndices : array<u32>;
+@group(0) @binding(auto) var<storage, read> splatSphericalHarmonics : array<f32>;
+
+fn getSplatSphericalHarmonicBasis(basisIndex : u32, direction : vec3<f32>) -> f32 {
+  let directionXX = direction.x * direction.x;
+  let directionYY = direction.y * direction.y;
+  let directionZZ = direction.z * direction.z;
+  switch basisIndex {
+    case 0u: { return -0.4886025119029199 * direction.y; }
+    case 1u: { return 0.4886025119029199 * direction.z; }
+    case 2u: { return -0.4886025119029199 * direction.x; }
+    case 3u: { return 1.0925484305920792 * direction.x * direction.y; }
+    case 4u: { return -1.0925484305920792 * direction.y * direction.z; }
+    case 5u: { return 0.31539156525252005 * (2.0 * directionZZ - directionXX - directionYY); }
+    case 6u: { return -1.0925484305920792 * direction.x * direction.z; }
+    case 7u: { return 0.5462742152960396 * (directionXX - directionYY); }
+    case 8u: { return -0.5900435899266435 * direction.y * (3.0 * directionXX - directionYY); }
+    case 9u: { return 2.890611442640554 * direction.x * direction.y * direction.z; }
+    case 10u: { return -0.4570457994644658 * direction.y * (4.0 * directionZZ - directionXX - directionYY); }
+    case 11u: { return 0.3731763325901154 * direction.z * (2.0 * directionZZ - 3.0 * directionXX - 3.0 * directionYY); }
+    case 12u: { return -0.4570457994644658 * direction.x * (4.0 * directionZZ - directionXX - directionYY); }
+    case 13u: { return 1.445305721320277 * direction.z * (directionXX - directionYY); }
+    case 14u: { return -0.5900435899266435 * direction.x * (directionXX - 3.0 * directionYY); }
+    default: { return 0.0; }
+  }
+}
+
+fn evaluateSplatSphericalHarmonics(
+  color : vec3<f32>,
+  position : vec3<f32>,
+  rowIndex : u32
+) -> vec3<f32> {
+  let coefficientCount = arrayLength(&splatSphericalHarmonics) /
+    max(arrayLength(&splatOpacities), 1u);
+  let requestedBasisCount =
+    (splat.sphericalHarmonicsDegree + 1u) * (splat.sphericalHarmonicsDegree + 1u) - 1u;
+  let basisCount = min(coefficientCount / 3u, requestedBasisCount);
+  let direction = position - splat.cameraPosition;
+  let directionLength = length(direction);
+  if (basisCount == 0u || directionLength <= 0.000001) {
+    return color;
+  }
+
+  let normalizedDirection = direction / directionLength;
+  var evaluatedColor = color;
+  for (var basisIndex = 0u; basisIndex < basisCount; basisIndex++) {
+    let coefficientOffset = rowIndex * coefficientCount + basisIndex * 3u;
+    let coefficients = vec3<f32>(
+      splatSphericalHarmonics[coefficientOffset],
+      splatSphericalHarmonics[coefficientOffset + 1u],
+      splatSphericalHarmonics[coefficientOffset + 2u]
+    );
+    evaluatedColor += coefficients *
+      getSplatSphericalHarmonicBasis(basisIndex, normalizedDirection);
+  }
+  return evaluatedColor;
+}
 
 @vertex
 fn vertexMain(
@@ -238,9 +304,11 @@ fn vertexMain(
       f32((packedColor >> 16u) & 255u), f32((packedColor >> 24u) & 255u)
     ) / 255.0;
   }
-  let sourceRowIndex = splatRowIndices[rowIndex];
-  _ = sourceRowIndex;
-  return projectSplatVertex(vertexIndex, position, scale, splatRotations[rowIndex], color, splatOpacities[rowIndex]);
+  color = vec4<f32>(evaluateSplatSphericalHarmonics(color.rgb, position, rowIndex), color.a);
+  return projectSplatVertex(
+    vertexIndex, position, scale, splatRotations[rowIndex], color,
+    splatOpacities[rowIndex], splatRowIndices[rowIndex]
+  );
 }
 `;
 
@@ -260,8 +328,10 @@ struct SplatVertexInputs {
 
 @vertex
 fn vertexMain(input : SplatVertexInputs) -> SplatFragmentInputs {
-  _ = input.rowIndices;
-  return projectSplatVertex(input.vertexIndex, input.positions, input.scales, input.rotations, input.colors, input.opacities);
+  return projectSplatVertex(
+    input.vertexIndex, input.positions, input.scales, input.rotations,
+    input.colors, input.opacities, input.rowIndices
+  );
 }
 `;
 
@@ -291,10 +361,13 @@ layout(std140) uniform splatUniforms {
   uint sortedOffset;
   float exposure;
   uint toneMapping;
+  vec3 cameraPosition;
+  uint sphericalHarmonicsDegree;
 } splat;
 
 out vec2 gaussianCoordinate;
 out vec4 splatColor;
+flat out int sourceRowIndex;
 
 vec2 getSplatScreenPosition(vec3 position) {
   vec4 clipPosition = splat.modelViewProjectionMatrix * vec4(position, 1.0);
@@ -354,6 +427,7 @@ void main() {
   vec2 clipOffset = vec2(screenOffset.x * 2.0 / max(splat.viewportSize.x, 1.0), -screenOffset.y * 2.0 / max(splat.viewportSize.y, 1.0)) * clipCenter.w;
   gl_Position = vec4(clipCenter.xy + clipOffset, clipCenter.z, clipCenter.w);
   gaussianCoordinate = corner * splat.gaussianSupportRadius;
+  sourceRowIndex = int(rowIndices);
   float visible = maximumAxisLength * splat.radiusScale >= splat.screenSizeCutoffPixels ? 1.0 : 0.0;
   splatColor = vec4(colors.rgb, colors.a * opacities * splat.alphaScale * visible);
 }
@@ -378,16 +452,19 @@ layout(std140) uniform splatUniforms {
   uint sortedOffset;
   float exposure;
   uint toneMapping;
+  vec3 cameraPosition;
+  uint sphericalHarmonicsDegree;
 } splat;
 
 in vec2 gaussianCoordinate;
 in vec4 splatColor;
+flat in int sourceRowIndex;
 out vec4 fragmentColor;
 
 void main() {
   float gaussianWeight = exp(-0.5 * dot(gaussianCoordinate, gaussianCoordinate));
   float alpha = splatColor.a * gaussianWeight;
-  if (alpha < splat.alphaCutoff) {
+  if (alpha <= 0.0 || alpha < splat.alphaCutoff) {
     discard;
   }
   vec3 linearColor = max(splatColor.rgb * splat.exposure, vec3(0.0));

--- a/modules/splats/src/splat-spherical-harmonics.ts
+++ b/modules/splats/src/splat-spherical-harmonics.ts
@@ -1,0 +1,99 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+/** Highest non-DC spherical-harmonic band retained by a Gaussian splat source. */
+export type SplatSphericalHarmonicsDegree = 0 | 1 | 2 | 3;
+
+const FIRST_ORDER_SCALE = 0.4886025119029199;
+
+/** Returns the number of non-DC RGB coefficients stored for one Gaussian splat. */
+export function getSplatSphericalHarmonicCoefficientCount(
+  degree: SplatSphericalHarmonicsDegree
+): number {
+  return ((degree + 1) ** 2 - 1) * 3;
+}
+
+/** Infers the spherical-harmonic degree from one row's non-DC RGB scalar count. */
+export function getSplatSphericalHarmonicsDegree(
+  coefficientCount: number
+): SplatSphericalHarmonicsDegree {
+  switch (coefficientCount) {
+    case 0:
+      return 0;
+    case 9:
+      return 1;
+    case 24:
+      return 2;
+    case 45:
+      return 3;
+    default:
+      throw new Error('Unsupported spherical-harmonic coefficient count');
+  }
+}
+
+/**
+ * Evaluates GraphDECO's real spherical-harmonic bands against a world-space view direction.
+ *
+ * The DC term is already reconstructed in `baseColor`; higher-order coefficients are packed as
+ * consecutive RGB triplets, one triplet for each non-DC basis function.
+ */
+export function evaluateSplatSphericalHarmonics(
+  baseColor: ArrayLike<number>,
+  coefficients: ArrayLike<number>,
+  viewDirection: ArrayLike<number>,
+  degree: SplatSphericalHarmonicsDegree = getSplatSphericalHarmonicsDegree(coefficients.length)
+): [number, number, number] {
+  const directionLength = Math.hypot(
+    viewDirection[0] ?? 0,
+    viewDirection[1] ?? 0,
+    viewDirection[2] ?? 0
+  );
+  const color: [number, number, number] = [baseColor[0] ?? 0, baseColor[1] ?? 0, baseColor[2] ?? 0];
+  if (degree === 0 || directionLength === 0) {
+    return color;
+  }
+
+  const directionX = (viewDirection[0] ?? 0) / directionLength;
+  const directionY = (viewDirection[1] ?? 0) / directionLength;
+  const directionZ = (viewDirection[2] ?? 0) / directionLength;
+  const directionXX = directionX * directionX;
+  const directionYY = directionY * directionY;
+  const directionZZ = directionZ * directionZ;
+  const basisValues = [
+    -FIRST_ORDER_SCALE * directionY,
+    FIRST_ORDER_SCALE * directionZ,
+    -FIRST_ORDER_SCALE * directionX
+  ];
+
+  if (degree >= 2) {
+    basisValues.push(
+      1.0925484305920792 * directionX * directionY,
+      -1.0925484305920792 * directionY * directionZ,
+      0.31539156525252005 * (2 * directionZZ - directionXX - directionYY),
+      -1.0925484305920792 * directionX * directionZ,
+      0.5462742152960396 * (directionXX - directionYY)
+    );
+  }
+  if (degree >= 3) {
+    basisValues.push(
+      -0.5900435899266435 * directionY * (3 * directionXX - directionYY),
+      2.890611442640554 * directionX * directionY * directionZ,
+      -0.4570457994644658 * directionY * (4 * directionZZ - directionXX - directionYY),
+      0.3731763325901154 * directionZ * (2 * directionZZ - 3 * directionXX - 3 * directionYY),
+      -0.4570457994644658 * directionX * (4 * directionZZ - directionXX - directionYY),
+      1.445305721320277 * directionZ * (directionXX - directionYY),
+      -0.5900435899266435 * directionX * (directionXX - 3 * directionYY)
+    );
+  }
+
+  for (let coefficientIndex = 0; coefficientIndex < basisValues.length; coefficientIndex++) {
+    const basisValue = basisValues[coefficientIndex];
+    for (let colorComponentIndex = 0; colorComponentIndex < 3; colorComponentIndex++) {
+      color[colorComponentIndex] +=
+        (coefficients[coefficientIndex * 3 + colorComponentIndex] ?? 0) * basisValue;
+    }
+  }
+
+  return color;
+}

--- a/modules/splats/test/gpu-splat-progressive-renderer.spec.ts
+++ b/modules/splats/test/gpu-splat-progressive-renderer.spec.ts
@@ -66,6 +66,24 @@ test('GPUSplatGraphRenderer progressively sorts preserved batches with one preco
       'does not repeat GPU projection or global sorting after streaming and camera motion stop'
     );
 
+    firstBatch.updateRows(0, {positions: new Float32Array([0, 0, 0.98])});
+    await verifyProgressiveFrame(t, device, renderer, [0, 4, 1, 2, 3, 5]);
+    t.equal(
+      renderer.compiledGraph,
+      initialCompiledGraph,
+      'reprojects dynamic source updates without rebuilding the compiled command graph'
+    );
+    t.equal(
+      firstBatch.positions.data[0].buffer,
+      sourceBuffers[0],
+      'retains the original dynamically updated source allocation'
+    );
+    t.equal(
+      renderer.encode(device.commandEncoder),
+      undefined,
+      'returns to an unchanged graph after encoding the updated source revision'
+    );
+
     renderer.destroy();
     for (const sourceBuffer of sourceBuffers) {
       t.notOk(sourceBuffer.destroyed, 'destroying graph slots never destroys borrowed source data');

--- a/modules/splats/test/index.ts
+++ b/modules/splats/test/index.ts
@@ -2,5 +2,11 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
+import './splat-data.node.spec';
+import './splat-interaction.node.spec';
+import './splat-interaction.spec';
+import './splat-mixed-renderer.node.spec';
+import './splat-residency.node.spec';
 import './splat-renderer.node.spec';
 import './splat-renderer.spec';
+import './splat-spherical-harmonics.node.spec';

--- a/modules/splats/test/splat-data.node.spec.ts
+++ b/modules/splats/test/splat-data.node.spec.ts
@@ -1,0 +1,287 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {makeGPUSplatData, SplatRenderer, type SplatSource} from '@luma.gl/splats';
+import {NullDevice} from '@luma.gl/test-utils';
+
+test('GPUSplatData preserves optional semantic and spherical-harmonic GPU storage', async t => {
+  const device = new NullDevice({});
+  const source = makeDynamicSplatSource();
+  source.semanticIds = new Uint32Array([4, 9]);
+  source.sphericalHarmonics = Float32Array.from({length: 18}, (_, index) => index / 10);
+  const prepared = makeGPUSplatData(device, source);
+
+  t.equal(prepared.sphericalHarmonicsDegree, 1, 'infers the first non-DC spherical-harmonic band');
+  t.equal(prepared.semanticIds?.format, 'uint32', 'retains compact GPU semantic identifiers');
+  t.equal(prepared.sphericalHarmonics?.format, 'float32', 'retains flattened Float32 coefficients');
+  t.equal(prepared.sphericalHarmonics?.length, 18, 'preserves every source coefficient');
+  t.notOk(
+    prepared.table.gpuVectors['semanticIds'],
+    'keeps optional semantic storage outside the fixed source-batch render schema'
+  );
+  t.notOk(
+    prepared.table.gpuVectors['sphericalHarmonics'],
+    'keeps flattened spherical harmonics outside the fixed-row source table'
+  );
+
+  const tableByteLength = Object.values(prepared.table.batches[0].gpuData).reduce(
+    (byteLength, data) => byteLength + data.buffer.byteLength,
+    0
+  );
+  t.equal(
+    prepared.byteLength,
+    tableByteLength + source.semanticIds.byteLength + source.sphericalHarmonics.byteLength,
+    'includes independently owned optional GPU storage in residency accounting'
+  );
+
+  const semanticBuffer = prepared.semanticIds!.data[0].buffer;
+  const sphericalHarmonicsBuffer = prepared.sphericalHarmonics!.data[0].buffer;
+  const semanticBytes = await semanticBuffer.readAsync();
+  t.deepEqual(
+    Array.from(new Uint32Array(semanticBytes.buffer)),
+    [4, 9],
+    'uploads stable source semantic identifiers'
+  );
+
+  prepared.destroy();
+  t.ok(semanticBuffer.destroyed, 'releases independently owned semantic GPU data');
+  t.ok(sphericalHarmonicsBuffer.destroyed, 'releases independently owned spherical harmonics');
+  t.end();
+});
+
+test('GPUSplatData updates source rows and GPU buffers in place', async t => {
+  const device = new NullDevice({});
+  const source = makeDynamicSplatSource();
+  source.semanticIds = new Uint32Array([4, 9]);
+  source.sphericalHarmonics = new Float32Array(18);
+  const prepared = makeGPUSplatData(device, source);
+  const positionBuffer = prepared.positions.data[0].buffer;
+  const semanticBuffer = prepared.semanticIds!.data[0].buffer;
+  const sphericalHarmonicsBuffer = prepared.sphericalHarmonics!.data[0].buffer;
+
+  prepared.updateRows(1, {
+    positions: new Float32Array([3, 4, 0.9]),
+    colors: new Uint8Array([20, 30, 40, 200]),
+    opacities: new Float32Array([0.25]),
+    semanticIds: new Uint32Array([17]),
+    sphericalHarmonics: new Float32Array([1, 2, 3, 4, 5, 6, 7, 8, 9])
+  });
+
+  t.equal(prepared.revision, 1, 'increments the source revision once per atomic row update');
+  t.equal(prepared.positions.data[0].buffer, positionBuffer, 'preserves existing GPU allocations');
+  t.deepEqual(
+    Array.from(source.positions),
+    [0, 0, 0.20000000298023224, 3, 4, 0.8999999761581421],
+    'updates only the selected packed CPU source rows'
+  );
+  t.deepEqual(Array.from(source.semanticIds), [4, 17], 'updates source semantic class metadata');
+  t.deepEqual(
+    Array.from(source.sphericalHarmonics.subarray(9)),
+    [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    'updates complete per-row spherical-harmonic coefficient sets'
+  );
+
+  const positionBytes = await positionBuffer.readAsync();
+  const semanticBytes = await semanticBuffer.readAsync();
+  const sphericalHarmonicsBytes = await sphericalHarmonicsBuffer.readAsync();
+  t.deepEqual(
+    Array.from(new Float32Array(positionBytes.buffer)),
+    Array.from(source.positions),
+    'uploads changed source positions to their original GPU byte offsets'
+  );
+  t.deepEqual(
+    Array.from(new Uint32Array(semanticBytes.buffer)),
+    [4, 17],
+    'updates semantic GPU storage without reallocating it'
+  );
+  t.deepEqual(
+    Array.from(new Float32Array(sphericalHarmonicsBytes.buffer).subarray(9)),
+    [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    'updates flattened coefficient GPU storage at the selected row boundary'
+  );
+
+  prepared.update({opacities: new Float32Array([0.75, 0.5])});
+  t.equal(prepared.revision, 2, 'accepts full-column updates without an explicit row offset');
+  prepared.update({rowOffset: 1});
+  t.equal(prepared.revision, 2, 'does not invalidate renderers for an empty update');
+
+  prepared.destroy();
+  t.end();
+});
+
+test('GPUSplatData validates dynamic updates before changing source rows', t => {
+  const device = new NullDevice({});
+  const source = makeDynamicSplatSource();
+  const prepared = makeGPUSplatData(device, source);
+  const originalPositions = source.positions.slice();
+
+  t.throws(
+    () => prepared.updateRows(1, {positions: new Float32Array([1, 2])}),
+    /complete rows/,
+    'rejects incomplete packed row updates'
+  );
+  t.throws(
+    () =>
+      prepared.update({
+        positions: new Float32Array([1, 2, 3]),
+        opacities: new Float32Array([1, 0.5])
+      }),
+    /matching row counts/,
+    'requires all updated source columns to target the same rows'
+  );
+  t.throws(
+    () => prepared.updateRows(2, {opacities: new Float32Array([1])}),
+    /exceed/,
+    'rejects writes beyond the existing source batch'
+  );
+  t.throws(
+    () => prepared.update({colors: new Float32Array([1, 1, 1, 1])}),
+    /source column types/,
+    'retains the original normalized or Float32 source color format'
+  );
+  t.throws(
+    () => prepared.update({semanticIds: new Uint32Array([1])}),
+    /existing prepared source column/,
+    'rejects updates for optional columns that were never allocated'
+  );
+  t.deepEqual(Array.from(source.positions), Array.from(originalPositions), 'preserves failed rows');
+  t.equal(prepared.revision, 0, 'does not invalidate borrowing renderers after a failed update');
+
+  prepared.destroy();
+  t.throws(
+    () => prepared.update({opacities: new Float32Array([1])}),
+    /destroyed/,
+    'rejects changes after releasing owned GPU resources'
+  );
+  t.end();
+});
+
+test('GPUSplatData keeps overlapping source-backed updates consistent on the CPU and GPU', async t => {
+  const device = new NullDevice({});
+  const source: SplatSource = {
+    ...makeDynamicSplatSource(),
+    positions: new Float32Array([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    scales: new Float32Array(9),
+    rotations: new Float32Array(12),
+    colors: new Uint8Array(12),
+    opacities: new Float32Array(3)
+  };
+  const prepared = makeGPUSplatData(device, source);
+
+  prepared.updateRows(1, {positions: source.positions.subarray(0, 6)});
+  const uploadedPositions = await prepared.positions.data[0].buffer.readAsync();
+
+  t.deepEqual(
+    Array.from(source.positions),
+    [1, 2, 3, 1, 2, 3, 4, 5, 6],
+    'copies overlapping source rows with typed-array copy semantics'
+  );
+  t.deepEqual(
+    Array.from(new Float32Array(uploadedPositions.buffer)),
+    Array.from(source.positions),
+    'uploads the original overlapping values before the source-backed view changes'
+  );
+
+  prepared.destroy();
+  t.end();
+});
+
+test('GPUSplatData validates optional semantic and spherical-harmonic source rows', t => {
+  const device = new NullDevice({});
+
+  t.throws(
+    () => makeGPUSplatData(device, {...makeDynamicSplatSource(), semanticIds: new Uint32Array(1)}),
+    /matching Gaussian splat rows/,
+    'requires semantic identifiers for every source row'
+  );
+  t.throws(
+    () =>
+      makeGPUSplatData(device, {
+        ...makeDynamicSplatSource(),
+        sphericalHarmonics: new Float32Array(16)
+      }),
+    /coefficient count/,
+    'rejects partial or unsupported spherical-harmonic coefficient bands'
+  );
+  t.throws(
+    () =>
+      makeGPUSplatData(device, {
+        ...makeDynamicSplatSource(),
+        sphericalHarmonics: new Float32Array(18),
+        sphericalHarmonicsDegree: 2
+      }),
+    /degree/,
+    'rejects coefficient counts that disagree with the explicit source degree'
+  );
+  t.throws(
+    () => makeGPUSplatData(device, {...makeDynamicSplatSource(), sphericalHarmonicsDegree: 1}),
+    /coefficient data/,
+    'requires coefficients when a non-DC source degree is declared'
+  );
+  t.end();
+});
+
+test('GPUSplatData rejects global rows outside the GPU picking index range', t => {
+  const device = new NullDevice({});
+
+  for (const rowIndexBase of [-1, Number.NaN, 2_147_483_647, 4_294_967_296]) {
+    t.throws(
+      () => makeGPUSplatData(device, {...makeDynamicSplatSource(), rowIndexBase}),
+      /signed 32-bit GPU indices/,
+      `rejects an unsupported stable source-row base of ${rowIndexBase}`
+    );
+  }
+
+  const prepared = makeGPUSplatData(device, {
+    ...makeDynamicSplatSource(),
+    rowIndexBase: 2_147_483_646
+  });
+  t.equal(
+    prepared.rowIndexBase,
+    2_147_483_646,
+    'accepts a source batch ending at the largest signed GPU picking index'
+  );
+
+  prepared.destroy();
+  t.end();
+});
+
+test('SplatRenderer refreshes visibility and depth ordering after dynamic source updates', t => {
+  const device = new NullDevice({});
+  const prepared = makeGPUSplatData(device, makeDynamicSplatSource());
+  const renderer = new SplatRenderer(device, {data: prepared, viewportSize: [100, 100]});
+
+  t.deepEqual(Array.from(renderer.getSortedIndices()), [6, 5], 'sorts original source rows');
+  prepared.updateRows(0, {positions: new Float32Array([0, 0, 0.95])});
+  t.deepEqual(
+    Array.from(renderer.getSortedIndices()),
+    [5, 6],
+    'refreshes camera-dependent ordering after source positions move'
+  );
+
+  prepared.updateRows(0, {opacities: new Float32Array([0])});
+  t.deepEqual(
+    Array.from(renderer.getSortedIndices()),
+    [6],
+    'refreshes source opacity visibility without replacing existing GPU batches'
+  );
+  t.equal(renderer.table?.batches.length, 1, 'preserves the original source-batch boundary');
+
+  renderer.destroy();
+  prepared.destroy();
+  t.end();
+});
+
+function makeDynamicSplatSource(): SplatSource {
+  return {
+    positions: new Float32Array([0, 0, 0.2, 0, 0, 0.8]),
+    scales: new Float32Array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1]),
+    rotations: new Float32Array([1, 0, 0, 0, 1, 0, 0, 0]),
+    colors: new Uint8Array([255, 128, 32, 255, 255, 128, 32, 255]),
+    opacities: new Float32Array([1, 1]),
+    sourceBatchIndex: 3,
+    rowIndexBase: 5
+  };
+}

--- a/modules/splats/test/splat-interaction.node.spec.ts
+++ b/modules/splats/test/splat-interaction.node.spec.ts
@@ -1,0 +1,335 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  acceptsSplatSemantic,
+  makeGPUSplatData,
+  resolveSplatPickInfo,
+  SPLAT_COLOR_PICKING_FS_GLSL,
+  SPLAT_PICKING_ATTRIBUTE_WGSL_SHADER,
+  SPLAT_PICKING_FS_GLSL,
+  SPLAT_PICKING_STORAGE_WGSL_SHADER,
+  SplatPicker,
+  SplatRenderer,
+  type SplatPickingInfo,
+  type SplatSource
+} from '@luma.gl/splats';
+import {NullDevice} from '@luma.gl/test-utils';
+
+test('Gaussian semantic filters preserve class selections and stable streamed source identity', t => {
+  const device = new NullDevice({});
+  const labeled = makeGPUSplatData(
+    device,
+    makeInteractionSplatSource({semanticIds: [3, 7, 3], sourceBatchIndex: 8, rowIndexBase: 40})
+  );
+  const unlabeled = makeGPUSplatData(
+    device,
+    makeInteractionSplatSource({rowCount: 1, sourceBatchIndex: 9, rowIndexBase: 43})
+  );
+
+  t.ok(acceptsSplatSemantic(undefined, labeled, 1), 'retains every row without a filter');
+  t.ok(acceptsSplatSemantic({include: [3]}, labeled, 0), 'includes selected semantic classes');
+  t.notOk(acceptsSplatSemantic({include: [3]}, labeled, 1), 'rejects unselected semantic classes');
+  t.notOk(
+    acceptsSplatSemantic({include: new Set([3]), exclude: [3]}, labeled, 0),
+    'exclusions take precedence over matching inclusions'
+  );
+  t.ok(
+    acceptsSplatSemantic({exclude: new Set([7])}, labeled, 2),
+    'accepts efficient Set-backed semantic selections'
+  );
+  t.notOk(
+    acceptsSplatSemantic({include: [3]}, unlabeled, 0),
+    'excludes unlabeled batches when selected classes are required'
+  );
+  t.ok(
+    acceptsSplatSemantic({include: [3], includeUnlabeled: true}, unlabeled, 0),
+    'optionally preserves unlabeled streamed batches'
+  );
+  t.notOk(
+    acceptsSplatSemantic({includeUnlabeled: false}, unlabeled, 0),
+    'can explicitly reject batches without semantic metadata'
+  );
+
+  const predicateCalls: Array<[number | undefined, number, number]> = [];
+  t.ok(
+    acceptsSplatSemantic(
+      {
+        predicate: (semanticId, rowIndex, sourceBatchIndex) => {
+          predicateCalls.push([semanticId, rowIndex, sourceBatchIndex]);
+          return rowIndex === 41;
+        }
+      },
+      labeled,
+      1
+    ),
+    'applies application-owned source-row predicates'
+  );
+  t.deepEqual(
+    predicateCalls,
+    [[7, 41, 8]],
+    'passes semantic classes, stable global rows, and original source batch identity'
+  );
+
+  labeled.destroy();
+  unlabeled.destroy();
+  t.end();
+});
+
+test('SplatRenderer applies semantic filters across mixed labeled and unlabeled source batches', async t => {
+  const device = new NullDevice({});
+  const labeled = makeGPUSplatData(
+    device,
+    makeInteractionSplatSource({semanticIds: [2, 5, 2], sourceBatchIndex: 4, rowIndexBase: 30})
+  );
+  const unlabeled = makeGPUSplatData(
+    device,
+    makeInteractionSplatSource({rowCount: 1, sourceBatchIndex: 9, rowIndexBase: 60})
+  );
+  const sourceOpacityBuffer = labeled.opacities.data[0].buffer;
+  const renderer = new SplatRenderer(device, {
+    data: [labeled, unlabeled],
+    viewportSize: [8, 8],
+    semanticFilter: {include: [2]}
+  });
+
+  t.deepEqual(
+    Array.from(renderer.getSortedIndices()),
+    [30, 32],
+    'retains selected stable source rows while excluding unlabeled source batches'
+  );
+  const maskedOpacity = await renderer.getBatchOpacityBuffer(0).readAsync();
+  t.deepEqual(
+    Array.from(
+      new Float32Array(
+        maskedOpacity.buffer,
+        maskedOpacity.byteOffset,
+        maskedOpacity.byteLength / Float32Array.BYTES_PER_ELEMENT
+      )
+    ),
+    [1, 0, 1],
+    'uses renderer-owned WebGL visibility masks without modifying source opacity buffers'
+  );
+
+  renderer.setProps({semanticFilter: {include: [5], includeUnlabeled: true}});
+  t.deepEqual(
+    Array.from(renderer.getSortedIndices()),
+    [31, 60],
+    'updates semantic selection while optionally retaining unlabeled source batches'
+  );
+  renderer.setProps({semanticFilter: undefined});
+  t.equal(renderer.stats.visibleSplatCount, 4, 'restores every source row when the filter clears');
+  t.equal(
+    renderer.getBatchOpacityBuffer(0),
+    sourceOpacityBuffer,
+    'reuses the original source opacity allocation after clearing semantic filtering'
+  );
+
+  renderer.destroy();
+  t.notOk(
+    sourceOpacityBuffer.destroyed,
+    'destroying semantic masks preserves caller-owned buffers'
+  );
+  labeled.destroy();
+  unlabeled.destroy();
+  t.end();
+});
+
+test('resolveSplatPickInfo preserves stable source rows and rejects stale batch identities', t => {
+  const device = new NullDevice({});
+  const firstBatch = makeGPUSplatData(
+    device,
+    makeInteractionSplatSource({semanticIds: [6, 9], sourceBatchIndex: 12, rowIndexBase: 100})
+  );
+  const secondBatch = makeGPUSplatData(
+    device,
+    makeInteractionSplatSource({rowCount: 1, sourceBatchIndex: 24, rowIndexBase: 500})
+  );
+
+  t.deepEqual(
+    resolveSplatPickInfo({batchIndex: 0, objectIndex: 101}, [firstBatch, secondBatch]),
+    {batchIndex: 12, rowIndex: 101, batchRowIndex: 1, semanticId: 9},
+    'maps GPU batch positions to original batch identities and stable semantic source rows'
+  );
+  t.deepEqual(
+    resolveSplatPickInfo({batchIndex: 1, objectIndex: 500}, [firstBatch, secondBatch]),
+    {batchIndex: 24, rowIndex: 500, batchRowIndex: 0, semanticId: null},
+    'preserves unlabeled source-row picks without inventing semantic metadata'
+  );
+  for (const invalidPick of [
+    {batchIndex: null, objectIndex: null},
+    {batchIndex: 3, objectIndex: 100},
+    {batchIndex: 0, objectIndex: 500},
+    {batchIndex: 0, objectIndex: 99},
+    {batchIndex: 0, objectIndex: Number.NaN}
+  ]) {
+    t.deepEqual(
+      resolveSplatPickInfo(invalidPick, [firstBatch, secondBatch]),
+      {batchIndex: null, rowIndex: null, batchRowIndex: null, semanticId: null},
+      'rejects missing, stale, out-of-bounds, and noninteger picking payloads'
+    );
+  }
+
+  firstBatch.destroy();
+  t.equal(
+    resolveSplatPickInfo({batchIndex: 0, objectIndex: 100}, [firstBatch]).rowIndex,
+    null,
+    'rejects source batches already evicted or destroyed by their owners'
+  );
+  secondBatch.destroy();
+  t.end();
+});
+
+test('SplatPicker owns a dedicated GPU pipeline and preserves semantic source identity', async t => {
+  const device = new NullDevice({});
+  const encodedReadbacks: Uint8Array[] = [new Uint8Array([2, 0, 0, 1])];
+  let readbackCount = 0;
+  device.readPixelsToArrayWebGL = () => {
+    readbackCount++;
+    return encodedReadbacks[encodedReadbacks.length - 1];
+  };
+
+  const firstBatch = makeGPUSplatData(
+    device,
+    makeInteractionSplatSource({semanticIds: [4], sourceBatchIndex: 3, rowIndexBase: 10})
+  );
+  const secondBatch = makeGPUSplatData(
+    device,
+    makeInteractionSplatSource({semanticIds: [4, 8], sourceBatchIndex: 7, rowIndexBase: 20})
+  );
+  const renderer = new SplatRenderer(device, {
+    data: [firstBatch, secondBatch],
+    viewportSize: [1, 1],
+    semanticFilter: {include: [8]}
+  });
+  const callbacks: SplatPickingInfo[] = [];
+  const picker = new SplatPicker(renderer, {onPick: info => callbacks.push(info)});
+  const sourceBuffer = secondBatch.positions.data[0].buffer;
+
+  t.equal(picker.mode, 'color', 'falls back to portable RGBA picking without integer attachments');
+  t.deepEqual(
+    await picker.pick([0, 0]),
+    {batchIndex: 7, rowIndex: 21, batchRowIndex: 1, semanticId: 8},
+    'reconstructs globally stable source rows from compact batch-local GPU picking slots'
+  );
+  t.ok(picker.model, 'creates a dedicated GPU picking model independently of the display model');
+  t.equal(callbacks.length, 1, 'emits exactly one changed-pick notification');
+
+  await picker.pick([0, 0]);
+  t.equal(readbackCount, 1, 'reuses the latest GPU result when the cursor does not move');
+  await picker.pick([0, 0], {force: true});
+  t.equal(readbackCount, 2, 'supports forced readback for animated or newly streamed splats');
+
+  picker.clear();
+  t.deepEqual(
+    callbacks[1],
+    {batchIndex: null, rowIndex: null, batchRowIndex: null, semanticId: null},
+    'clears previously selected semantic source identity'
+  );
+  picker.destroy();
+  picker.destroy();
+  t.notOk(sourceBuffer.destroyed, 'destroying picking resources preserves borrowed source buffers');
+  t.notOk(renderer.destroyed, 'destroying the picker never destroys its borrowing renderer');
+
+  renderer.destroy();
+  firstBatch.destroy();
+  secondBatch.destroy();
+  t.end();
+});
+
+test('SplatPicker packs hundreds of resident WebGL batches without truncating global source rows', async t => {
+  const device = new NullDevice({});
+  let encodedReadback = new Uint8Array([2, 0, 0, 1]);
+  device.readPixelsToArrayWebGL = () => encodedReadback;
+
+  const batches = Array.from({length: 260}, (_, batchIndex) =>
+    makeGPUSplatData(
+      device,
+      makeInteractionSplatSource({
+        rowCount: 1,
+        sourceBatchIndex: 1_000 + batchIndex,
+        rowIndexBase:
+          batchIndex === 0 ? 10 : batchIndex === 1 ? 16_777_225 : 30_000_000 + batchIndex
+      })
+    )
+  );
+  const renderer = new SplatRenderer(device, {data: batches, viewportSize: [1, 1]});
+  const picker = new SplatPicker(renderer);
+
+  t.deepEqual(
+    await picker.pick([0, 0]),
+    {batchIndex: 1_001, rowIndex: 16_777_225, batchRowIndex: 0, semanticId: null},
+    'distinguishes globally separated source rows with identical 24-bit modulo residues'
+  );
+
+  encodedReadback = new Uint8Array([4, 1, 0, 1]);
+  t.deepEqual(
+    await picker.pick([0, 0], {force: true}),
+    {batchIndex: 1_259, rowIndex: 30_000_259, batchRowIndex: 0, semanticId: null},
+    'packs batch ordinals above the RGBA alpha limit into shared batch-local picking slots'
+  );
+
+  picker.destroy();
+  renderer.destroy();
+  for (const batch of batches) {
+    batch.destroy();
+  }
+  t.end();
+});
+
+test('Gaussian GPU picking shaders preserve source identity and Gaussian alpha visibility', t => {
+  for (const shader of [SPLAT_PICKING_STORAGE_WGSL_SHADER, SPLAT_PICKING_ATTRIBUTE_WGSL_SHADER]) {
+    t.ok(shader.includes('@location(1) pickingColor : vec2<i32>'), 'writes integer GPU pick IDs');
+    t.ok(
+      shader.includes('picking_getPickingColor(input.sourceRowIndex)'),
+      'uses global source rows'
+    );
+    t.ok(shader.includes('alpha < splat.alphaCutoff'), 'rejects transparent Gaussian fragments');
+  }
+  t.ok(SPLAT_PICKING_FS_GLSL.includes('out ivec4 pickingColor'), 'supports integer WebGL targets');
+  t.ok(
+    SPLAT_COLOR_PICKING_FS_GLSL.includes('picking_getPickingColor()'),
+    'supports portable RGBA WebGL picking targets'
+  );
+  t.end();
+});
+
+function makeInteractionSplatSource({
+  rowCount,
+  semanticIds,
+  sourceBatchIndex = 0,
+  rowIndexBase = 0
+}: {
+  rowCount?: number;
+  semanticIds?: readonly number[];
+  sourceBatchIndex?: number;
+  rowIndexBase?: number;
+}): SplatSource {
+  const sourceRowCount = semanticIds?.length ?? rowCount ?? 1;
+  const positions = new Float32Array(sourceRowCount * 3);
+  const scales = new Float32Array(sourceRowCount * 3);
+  const rotations = new Float32Array(sourceRowCount * 4);
+  const colors = new Uint8Array(sourceRowCount * 4);
+  const opacities = new Float32Array(sourceRowCount);
+
+  for (let rowIndex = 0; rowIndex < sourceRowCount; rowIndex++) {
+    positions[rowIndex * 3 + 2] = 0.5;
+    scales.set([0.5, 0.5, 0.1], rowIndex * 3);
+    rotations[rowIndex * 4] = 1;
+    colors.set([255, 128, 64, 255], rowIndex * 4);
+    opacities[rowIndex] = 1;
+  }
+
+  return {
+    positions,
+    scales,
+    rotations,
+    colors,
+    opacities,
+    ...(semanticIds ? {semanticIds: Uint32Array.from(semanticIds)} : {}),
+    sourceBatchIndex,
+    rowIndexBase
+  };
+}

--- a/modules/splats/test/splat-interaction.spec.ts
+++ b/modules/splats/test/splat-interaction.spec.ts
@@ -1,0 +1,128 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import type {Device} from '@luma.gl/core';
+import {
+  makeGPUSplatData,
+  SplatPicker,
+  SplatRenderer,
+  type SplatPickingInfo,
+  type SplatSource
+} from '@luma.gl/splats';
+import {getTestDevices} from '@luma.gl/test-utils';
+
+test('SplatPicker reads actual Gaussian source identities from WebGPU and WebGL picking targets', async t => {
+  const devices = await getTestDevices(['webgpu', 'webgl']);
+  t.ok(devices.length > 0, 'at least one browser graphics backend is available');
+
+  for (const device of devices) {
+    if (isSoftwareBackedDevice(device)) {
+      t.comment(`${device.type}: skipping picking readback on a software-backed adapter`);
+      continue;
+    }
+
+    const firstBatch = makeGPUSplatData(
+      device,
+      makeBrowserPickingSplatSource({depth: 0.8, semanticId: 4, sourceBatchIndex: 5, rowIndex: 100})
+    );
+    const secondBatch = makeGPUSplatData(
+      device,
+      makeBrowserPickingSplatSource({
+        depth: 0.2,
+        semanticId: 8,
+        sourceBatchIndex: 11,
+        rowIndex: 25_000_400
+      })
+    );
+    const renderer = new SplatRenderer(device, {
+      data: [firstBatch, secondBatch],
+      viewportSize: [1, 1],
+      alphaCutoff: 0,
+      semanticFilter: {include: [8]}
+    });
+    const notifications: SplatPickingInfo[] = [];
+    const picker = new SplatPicker(renderer, {
+      mode: device.type === 'webgpu' ? 'index' : 'color',
+      onPick: pickInfo => notifications.push(pickInfo)
+    });
+
+    t.equal(
+      picker.mode,
+      device.type === 'webgpu' ? 'index' : 'color',
+      `${device.type}: selects integer WebGPU picking or portable WebGL color picking`
+    );
+    const firstPick = await picker.pick([0, 0]);
+    t.notOk(
+      picker.model?.pipeline.isErrored,
+      `${device.type}: compiles the dedicated GPU pipeline`
+    );
+    t.deepEqual(
+      firstPick,
+      {batchIndex: 11, rowIndex: 25_000_400, batchRowIndex: 0, semanticId: 8},
+      `${device.type}: GPU readback resolves stable source batch, global row, and semantic class`
+    );
+
+    renderer.setProps({semanticFilter: {include: [4, 8]}});
+    t.deepEqual(
+      await picker.pick([0, 0], {force: true}),
+      {batchIndex: 11, rowIndex: 25_000_400, batchRowIndex: 0, semanticId: 8},
+      `${device.type}: resolves the nearest globally identified row across overlapping source batches`
+    );
+    t.equal(
+      notifications.length,
+      1,
+      `${device.type}: changing shared GPU batch uniforms never duplicates stable source callbacks`
+    );
+
+    renderer.setProps({semanticFilter: {include: [4]}});
+    t.deepEqual(
+      await picker.pick([0, 0], {force: true}),
+      {batchIndex: 5, rowIndex: 100, batchRowIndex: 0, semanticId: 4},
+      `${device.type}: excludes filtered Gaussian rows from GPU picking fragments`
+    );
+    t.equal(notifications.length, 2, `${device.type}: publishes each changed source-row pick once`);
+
+    const sourcePositionBuffer = firstBatch.positions.data[0].buffer;
+    picker.destroy();
+    t.notOk(
+      sourcePositionBuffer.destroyed,
+      `${device.type}: destroying picking resources preserves independently owned source buffers`
+    );
+    renderer.destroy();
+    firstBatch.destroy();
+    secondBatch.destroy();
+  }
+
+  t.end();
+});
+
+function makeBrowserPickingSplatSource({
+  depth,
+  semanticId,
+  sourceBatchIndex,
+  rowIndex
+}: {
+  depth: number;
+  semanticId: number;
+  sourceBatchIndex: number;
+  rowIndex: number;
+}): SplatSource {
+  return {
+    positions: new Float32Array([0, 0, depth]),
+    scales: new Float32Array([1, 1, 0.1]),
+    rotations: new Float32Array([1, 0, 0, 0]),
+    colors: new Uint8Array([255, 128, 64, 255]),
+    opacities: new Float32Array([1]),
+    semanticIds: new Uint32Array([semanticId]),
+    sourceBatchIndex,
+    rowIndexBase: rowIndex
+  };
+}
+
+function isSoftwareBackedDevice(device: Device): boolean {
+  return (
+    device.info.gpu === 'software' || device.info.gpuType === 'cpu' || Boolean(device.info.fallback)
+  );
+}

--- a/modules/splats/test/splat-mixed-renderer.node.spec.ts
+++ b/modules/splats/test/splat-mixed-renderer.node.spec.ts
@@ -1,0 +1,118 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {makeGPUSplatData, SplatRenderer, type SplatSource} from '@luma.gl/splats';
+import {NullDevice} from '@luma.gl/test-utils';
+
+test('SplatRenderer composites opaque meshes, sorted splats, and transparent mesh overlays', t => {
+  const device = new NullDevice({});
+  const prepared = makeGPUSplatData(device, makeMixedSplatSource());
+  const renderer = new SplatRenderer(device, {data: prepared, viewportSize: [64, 64]});
+  const renderPass = device.getDefaultRenderPass();
+  const drawOrder: string[] = [];
+  const model = renderer.model;
+  if (!model) {
+    t.fail('creates a Gaussian splat render model');
+    renderer.destroy();
+    prepared.destroy();
+    t.end();
+    return;
+  }
+
+  const drawSplats = model.draw.bind(model);
+  model.draw = pass => {
+    t.equal(pass, renderPass, 'records splats into the shared mesh render pass');
+    drawOrder.push('splats');
+    return drawSplats(pass);
+  };
+  t.ok(
+    renderer.drawMixed(renderPass, {
+      opaqueMeshes: [
+        {
+          draw(pass) {
+            t.equal(pass, renderPass, 'records the opaque mesh into the same depth attachment');
+            drawOrder.push('opaque');
+            return true;
+          }
+        }
+      ],
+      transparentMeshes: [
+        {
+          draw() {
+            drawOrder.push('transparent');
+          }
+        }
+      ]
+    }),
+    'draws an integrated mesh and Gaussian splat scene'
+  );
+  t.deepEqual(drawOrder, ['opaque', 'splats', 'transparent'], 'preserves scene compositing order');
+  t.equal(model.parameters.depthCompare, 'less-equal', 'tests splats against opaque mesh depth');
+  t.equal(model.parameters.depthWriteEnabled, false, 'preserves opaque depth beneath transparency');
+
+  renderer.setProps({depthCompare: 'greater-equal', depthWriteEnabled: true});
+  t.equal(model.parameters.depthCompare, 'greater-equal', 'supports reversed-depth mesh scenes');
+  t.equal(model.parameters.depthWriteEnabled, true, 'supports explicitly requested depth writes');
+
+  renderer.destroy();
+  prepared.destroy();
+  t.end();
+});
+
+test('SplatRenderer enforces semantic filtering on WebGL without changing source opacity', async t => {
+  const device = new NullDevice({});
+  const source = makeMixedSplatSource();
+  const prepared = makeGPUSplatData(device, source);
+  const renderer = new SplatRenderer(device, {
+    data: prepared,
+    semanticFilter: {include: [7]},
+    viewportSize: [64, 64]
+  });
+
+  t.deepEqual(
+    Array.from(renderer.getSortedIndices()),
+    [2, 0],
+    'filters before stable depth sorting'
+  );
+  const opacityBuffer = renderer.getBatchOpacityBuffer(0);
+  const bytes = await opacityBuffer.readAsync();
+  t.deepEqual(
+    Array.from(new Float32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4)),
+    [1, 0, 1],
+    'masks rejected WebGL rows in a renderer-owned opacity allocation'
+  );
+  t.deepEqual(Array.from(source.opacities), [1, 1, 1], 'preserves caller-owned source opacity');
+
+  renderer.draw(device.getDefaultRenderPass());
+  t.equal(
+    renderer.model?.vertexArray.attributes[4],
+    opacityBuffer,
+    'binds semantic masking to the fallback instanced shader'
+  );
+  renderer.setProps({semanticFilter: undefined});
+  t.equal(renderer.stats.visibleSplatCount, 3, 'restores every source row when the filter clears');
+  t.equal(
+    renderer.getBatchOpacityBuffer(0),
+    prepared.opacities.data[0].buffer,
+    'restores caller-owned opacity when semantic masking is disabled'
+  );
+
+  renderer.destroy();
+  t.ok(opacityBuffer.destroyed, 'releases only the renderer-owned semantic opacity mask');
+  t.notOk(prepared.opacities.data[0].buffer.destroyed, 'preserves caller-owned opacity');
+  prepared.destroy();
+  t.end();
+});
+
+function makeMixedSplatSource(): SplatSource {
+  return {
+    positions: new Float32Array([0, 0, 0.2, 0, 0, 0.5, 0, 0, 0.8]),
+    scales: new Float32Array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]),
+    rotations: new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0]),
+    colors: new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255]),
+    opacities: new Float32Array([1, 1, 1]),
+    semanticIds: new Uint32Array([7, 9, 7])
+  };
+}

--- a/modules/splats/test/splat-renderer.spec.ts
+++ b/modules/splats/test/splat-renderer.spec.ts
@@ -4,6 +4,7 @@
 
 import test from 'test/utils/vitest-tape';
 import {Buffer, type Device, Texture} from '@luma.gl/core';
+import {Model} from '@luma.gl/engine';
 import {makeGPUSplatData, SplatRenderer, type SplatSource} from '@luma.gl/splats';
 import {getTestDevices} from '@luma.gl/test-utils';
 
@@ -154,6 +155,179 @@ test('SplatRenderer preserves and tone-maps Float32 Gaussian radiance on WebGPU 
     readback.destroy();
     renderer.destroy();
     prepared.destroy();
+    framebuffer.destroy();
+    colorTexture.destroy();
+  }
+
+  t.end();
+});
+
+test('SplatRenderer evaluates higher-order directional radiance on WebGPU and WebGL2', async t => {
+  const devices = await getTestDevices(['webgpu', 'webgl']);
+  t.ok(devices.length > 0, 'at least one browser graphics backend is available');
+
+  for (const device of devices) {
+    if (isSoftwareBackedDevice(device)) {
+      t.comment(
+        `Skipping Gaussian splat ${device.type} directional readback on a software adapter`
+      );
+      continue;
+    }
+
+    const textureSize = 16;
+    const colorTexture = device.createTexture({
+      width: textureSize,
+      height: textureSize,
+      format: 'rgba8unorm',
+      usage: Texture.RENDER_ATTACHMENT | Texture.COPY_SRC
+    });
+    const framebuffer = device.createFramebuffer({
+      width: textureSize,
+      height: textureSize,
+      colorAttachments: [colorTexture],
+      depthStencilAttachment: 'depth24plus'
+    });
+    const source = makeBrowserSplatSource(0.5, 0);
+    source.colors = new Float32Array([0.5, 0.5, 0.25, 1]);
+    source.scales.set([0.8, 0.8, 0.05]);
+    source.sphericalHarmonics = new Float32Array(9);
+    source.sphericalHarmonics[2 * 3] = 0.75;
+    source.sphericalHarmonicsDegree = 1;
+    const prepared = makeGPUSplatData(device, source);
+    const renderer = new SplatRenderer(device, {
+      data: prepared,
+      viewportSize: [textureSize, textureSize],
+      alphaCutoff: 0,
+      toneMapping: 'none'
+    });
+    const layout = colorTexture.computeMemoryLayout({width: textureSize, height: textureSize});
+    const readback = device.createBuffer({
+      byteLength: layout.byteLength,
+      usage: Buffer.COPY_DST | Buffer.MAP_READ
+    });
+    const centerColors: Uint8Array[] = [];
+
+    for (const cameraPosition of [
+      [-1, 0, 0.5],
+      [1, 0, 0.5]
+    ] as const) {
+      renderer.setProps({cameraPosition});
+      renderer.predraw(device.commandEncoder);
+      const renderPass = device.beginRenderPass({
+        framebuffer,
+        clearColor: [0, 0, 0, 0],
+        clearDepth: 1
+      });
+      t.ok(renderer.draw(renderPass), `${device.type}: renders higher-order directional radiance`);
+      renderPass.end();
+      device.submit();
+      colorTexture.readBuffer({width: textureSize, height: textureSize}, readback);
+      const pixels = await readback.readAsync(0, layout.byteLength);
+      const centerPixelOffset = 8 * layout.bytesPerRow + 8 * 4;
+      centerColors.push(pixels.slice(centerPixelOffset, centerPixelOffset + 4));
+    }
+
+    t.ok(
+      centerColors[1][0] > centerColors[0][0] + 120,
+      `${device.type}: reverses the first-order red basis when the camera crosses the Gaussian`
+    );
+    t.ok(
+      Math.abs(centerColors[1][1] - centerColors[0][1]) < 5,
+      `${device.type}: leaves unrelated DC color channels unchanged`
+    );
+    t.deepEqual(
+      Array.from(source.colors),
+      [0.5, 0.5, 0.25, 1],
+      `${device.type}: preserves caller-owned DC color coefficients`
+    );
+
+    readback.destroy();
+    renderer.destroy();
+    prepared.destroy();
+    framebuffer.destroy();
+    colorTexture.destroy();
+  }
+
+  t.end();
+});
+
+test('SplatRenderer composites mixed mesh scenes against a shared WebGPU or WebGL depth buffer', async t => {
+  const devices = await getTestDevices(['webgpu', 'webgl']);
+  t.ok(devices.length > 0, 'at least one browser graphics backend is available');
+
+  for (const device of devices) {
+    if (isSoftwareBackedDevice(device)) {
+      t.comment(
+        `Skipping Gaussian splat ${device.type} mixed-depth readback on a software adapter`
+      );
+      continue;
+    }
+
+    const textureSize = 16;
+    const colorTexture = device.createTexture({
+      width: textureSize,
+      height: textureSize,
+      format: 'rgba8unorm',
+      usage: Texture.RENDER_ATTACHMENT | Texture.COPY_SRC
+    });
+    const framebuffer = device.createFramebuffer({
+      width: textureSize,
+      height: textureSize,
+      colorAttachments: [colorTexture],
+      depthStencilAttachment: 'depth24plus'
+    });
+    const source = makeBrowserSplatSource(0.5, 0);
+    source.colors = new Uint8Array([255, 0, 0, 255]);
+    source.scales.set([0.8, 0.8, 0.05]);
+    const prepared = makeGPUSplatData(device, source);
+    const renderer = new SplatRenderer(device, {
+      data: prepared,
+      viewportSize: [textureSize, textureSize],
+      alphaCutoff: 0
+    });
+    const nearerMesh = makeOpaqueBrowserMesh(device, 0.25);
+    const fartherMesh = makeOpaqueBrowserMesh(device, 0.75);
+    const layout = colorTexture.computeMemoryLayout({width: textureSize, height: textureSize});
+    const readback = device.createBuffer({
+      byteLength: layout.byteLength,
+      usage: Buffer.COPY_DST | Buffer.MAP_READ
+    });
+    const centerColors: Uint8Array[] = [];
+
+    for (const mesh of [nearerMesh, fartherMesh]) {
+      mesh.predraw(device.commandEncoder);
+      renderer.predraw(device.commandEncoder);
+      const renderPass = device.beginRenderPass({
+        framebuffer,
+        clearColor: [0, 0, 0, 0],
+        clearDepth: 1
+      });
+      t.ok(
+        renderer.drawMixed(renderPass, {opaqueMeshes: [mesh]}),
+        `${device.type}: composites opaque mesh and Gaussian draws into the shared pass`
+      );
+      renderPass.end();
+      device.submit();
+      colorTexture.readBuffer({width: textureSize, height: textureSize}, readback);
+      const pixels = await readback.readAsync(0, layout.byteLength);
+      const centerPixelOffset = 8 * layout.bytesPerRow + 8 * 4;
+      centerColors.push(pixels.slice(centerPixelOffset, centerPixelOffset + 4));
+    }
+
+    t.ok(
+      centerColors[0][2] > 220 && centerColors[0][0] < 15,
+      `${device.type}: nearer opaque mesh depth fully occludes the red Gaussian`
+    );
+    t.ok(
+      centerColors[1][0] > 180 && centerColors[1][2] < 80,
+      `${device.type}: nearer Gaussian remains visible over the farther opaque mesh`
+    );
+
+    readback.destroy();
+    renderer.destroy();
+    prepared.destroy();
+    nearerMesh.destroy();
+    fartherMesh.destroy();
     framebuffer.destroy();
     colorTexture.destroy();
   }
@@ -326,6 +500,52 @@ function makeBrowserSplatSource(depth: number, rowIndex: number): SplatSource {
     sourceBatchIndex: rowIndex,
     rowIndexBase: rowIndex
   };
+}
+
+function makeOpaqueBrowserMesh(device: Device, depth: number): Model {
+  const source = /* wgsl */ `\
+@vertex
+fn vertexMain(@builtin(vertex_index) vertexIndex : u32) -> @builtin(position) vec4<f32> {
+  let positions = array<vec2<f32>, 3>(
+    vec2<f32>(-1.0, -1.0),
+    vec2<f32>(3.0, -1.0),
+    vec2<f32>(-1.0, 3.0)
+  );
+  return vec4<f32>(positions[vertexIndex], ${depth}, 1.0);
+}
+
+@fragment
+fn fragmentMain() -> @location(0) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 1.0, 1.0);
+}
+`;
+  const vertexShader = /* glsl */ `\
+#version 300 es
+void main() {
+  vec2 position = gl_VertexID == 0
+    ? vec2(-1.0, -1.0)
+    : gl_VertexID == 1 ? vec2(3.0, -1.0) : vec2(-1.0, 3.0);
+  gl_Position = vec4(position, ${depth}, 1.0);
+}
+`;
+  const fragmentShader = /* glsl */ `\
+#version 300 es
+precision highp float;
+out vec4 fragmentColor;
+void main() {
+  fragmentColor = vec4(0.0, 0.0, 1.0, 1.0);
+}
+`;
+  return new Model(device, {
+    id: `splat-opaque-mesh-${depth}`,
+    source,
+    vs: vertexShader,
+    fs: fragmentShader,
+    shaderLayout: {attributes: [], bindings: []},
+    vertexCount: 3,
+    topology: 'triangle-list',
+    parameters: {depthCompare: 'less-equal', depthWriteEnabled: true}
+  });
 }
 
 function makeOverlappingBrowserSplatSource(batchIndex: number): SplatSource {

--- a/modules/splats/test/splat-residency.node.spec.ts
+++ b/modules/splats/test/splat-residency.node.spec.ts
@@ -1,0 +1,622 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  makeGPUSplatData,
+  SplatRenderer,
+  SplatResidencyManager,
+  type GPUSplatData,
+  type SplatResidencyEvictionReason,
+  type SplatSource
+} from '@luma.gl/splats';
+import {NullDevice} from '@luma.gl/test-utils';
+
+test('SplatResidencyManager preserves independent source batches and exact GPU allocations', t => {
+  const device = new NullDevice({});
+  const firstBatch = makeGPUSplatData(device, makeSplatResidencySource(2, 4, 11));
+  const secondBatch = makeGPUSplatData(device, makeSplatResidencySource(3, 5, 13));
+  const manager = new SplatResidencyManager({
+    maxGpuBytes: firstBatch.byteLength + secondBatch.byteLength,
+    maxResidentSplats: 5,
+    maxResidentChunks: 2
+  });
+  const firstChunk = manager.add(firstBatch, {
+    priority: 3,
+    levelOfDetail: 2,
+    bounds: {center: [1, 2, 3], radius: 4}
+  });
+  const secondChunk = manager.register(secondBatch, {id: 'tile/5/13', priority: 7});
+
+  t.equal(firstChunk?.id, '4:11', 'derives stable default identity from source metadata');
+  t.equal(secondChunk?.id, 'tile/5/13', 'retains explicit streamed tile identity');
+  t.equal(firstChunk?.levelOfDetail, 2, 'retains caller-defined hierarchy level');
+  t.deepEqual(
+    firstChunk?.bounds,
+    {center: [1, 2, 3], radius: 4},
+    'retains explicit source tile bounds'
+  );
+  t.deepEqual(
+    manager.getResidentBatches(),
+    [firstBatch, secondBatch],
+    'preserves independently prepared source batches in admission order'
+  );
+  t.equal(manager.residentChunks.length, 2, 'exposes explicit independent chunk metadata');
+  t.equal(manager.stats.residentChunkCount, 2, 'counts intact source batches');
+  t.equal(manager.stats.residentSplatCount, 5, 'counts logical source rows');
+  t.equal(
+    manager.stats.residentGpuByteLength,
+    firstBatch.byteLength + secondBatch.byteLength,
+    'accounts for every original source GPU allocation'
+  );
+  t.deepEqual(
+    manager.residentBatches.map(batch => batch.sourceInfo),
+    [firstBatch.sourceInfo, secondBatch.sourceInfo],
+    'never combines source batch identities or global row offsets'
+  );
+  t.equal(manager.getChunk(firstBatch), firstChunk, 'resolves exact prepared source-batch objects');
+  t.equal(manager.getChunk('tile/5/13'), secondChunk, 'resolves explicit tile identities');
+
+  manager.destroy();
+  t.notOk(firstBatch.destroyed, 'borrowing residency preserves the first caller-owned batch');
+  t.notOk(secondBatch.destroyed, 'borrowing residency preserves the second caller-owned batch');
+  firstBatch.destroy();
+  secondBatch.destroy();
+  t.end();
+});
+
+test('SplatResidencyManager evicts by priority and least-recently-used access', t => {
+  const device = new NullDevice({});
+  const firstBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 0, 0));
+  const secondBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 1, 1));
+  const thirdBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 2, 2));
+  const fourthBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 3, 3));
+  const manager = new SplatResidencyManager({maxResidentChunks: 2});
+
+  manager.add(firstBatch, {id: 'low', priority: 1});
+  manager.add(secondBatch, {id: 'high', priority: 5});
+  manager.add(thirdBatch, {id: 'medium', priority: 3});
+
+  t.notOk(manager.has('low'), 'evicts a less valuable resident before a more valuable one');
+  t.ok(manager.has('high'), 'preserves higher-priority source batches');
+  t.ok(manager.has('medium'), 'admits the more valuable replacement');
+  t.equal(manager.stats.evictedChunkCount, 1, 'records the budget-triggered eviction');
+  t.equal(
+    manager.add(fourthBatch, {id: 'rejected', priority: 2}),
+    undefined,
+    'rejects a tile that would require evicting more valuable resident data'
+  );
+  t.deepEqual(
+    manager.residentBatches,
+    [secondBatch, thirdBatch],
+    'leaves all resident batches untouched after a rejected admission'
+  );
+  t.equal(manager.stats.rejectedChunkCount, 1, 'records rejected source tiles');
+
+  manager.setPriority('high', 3);
+  manager.touch('high');
+  manager.add(fourthBatch, {id: 'replacement', priority: 3});
+
+  t.ok(manager.has('high'), 'retains the recently accessed equal-priority tile');
+  t.notOk(manager.has('medium'), 'evicts the least-recently-used equal-priority tile');
+  t.ok(manager.has(fourthBatch), 'retains exact replacement source identity');
+  t.equal(manager.stats.evictedChunkCount, 2, 'records both bounded-residency evictions');
+
+  manager.destroy();
+  firstBatch.destroy();
+  secondBatch.destroy();
+  thirdBatch.destroy();
+  fourthBatch.destroy();
+  t.end();
+});
+
+test('SplatResidencyManager protects pinned tiles across shrinking budgets', t => {
+  const device = new NullDevice({});
+  const pinnedBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 0, 0));
+  const transientBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 1, 1));
+  const replacementBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 2, 2));
+  const manager = new SplatResidencyManager({maxResidentChunks: 2});
+
+  manager.add(pinnedBatch, {id: 'pinned', priority: 0, pinned: true});
+  manager.add(transientBatch, {id: 'transient', priority: 10});
+  manager.setBudget({maxResidentChunks: 1});
+
+  t.ok(manager.has('pinned'), 'retains a pinned tile despite its lower priority');
+  t.notOk(manager.has('transient'), 'evicts unprotected data after a reduced chunk budget');
+  t.equal(manager.stats.pinnedChunkCount, 1, 'reports protected source tiles');
+  t.notOk(manager.evict('pinned'), 'does not explicitly evict protected data without force');
+  t.equal(
+    manager.add(replacementBatch, {id: 'replacement', priority: 100}),
+    undefined,
+    'never evicts pinned data for a more valuable incoming source tile'
+  );
+
+  manager.setBudget(0);
+  t.ok(manager.stats.overBudget, 'reports pinned allocations exceeding a reduced byte budget');
+  t.ok(manager.has('pinned'), 'never destroys or removes protected over-budget data');
+  t.ok(manager.unpin('pinned'), 'allows callers to release explicit residency protection');
+  t.notOk(manager.has('pinned'), 'immediately trims the newly unprotected over-budget tile');
+  t.notOk(manager.stats.overBudget, 'restores all active allocation limits after eviction');
+
+  manager.destroy();
+  pinnedBatch.destroy();
+  transientBatch.destroy();
+  replacementBatch.destroy();
+  t.end();
+});
+
+test('SplatResidencyManager never returns a source chunk evicted by metadata updates', async t => {
+  const device = new NullDevice({});
+  const registeredBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 0, 0));
+  const loadedBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 1, 1));
+  const registeredManager = new SplatResidencyManager({ownsData: true});
+  const loadedManager = new SplatResidencyManager({ownsData: true});
+
+  registeredManager.register(registeredBatch, {id: 'registered', pinned: true});
+  registeredManager.setBudget(0);
+  t.ok(registeredManager.stats.overBudget, 'preserves an over-budget pinned registered source');
+
+  const registeredChunk = registeredManager.register(registeredBatch, {
+    id: 'registered',
+    pinned: false
+  });
+  t.equal(registeredChunk, undefined, 'does not return a registered chunk evicted by unpinning');
+  t.ok(registeredBatch.destroyed, 'releases explicitly owned source data during unpinning');
+  t.notOk(registeredManager.has('registered'), 'removes the stale source identity');
+  t.notOk(registeredManager.stats.overBudget, 'restores the active byte budget');
+
+  loadedManager.add(loadedBatch, {id: 'loaded', pinned: true});
+  loadedManager.setBudget(0);
+  let requestedLoad = false;
+  const loadedChunk = await loadedManager.load(
+    'loaded',
+    () => {
+      requestedLoad = true;
+      return loadedBatch;
+    },
+    {pinned: false}
+  );
+  t.equal(loadedChunk, undefined, 'does not return a cached loaded chunk evicted by unpinning');
+  t.notOk(requestedLoad, 'never reloads an already registered source identity');
+  t.ok(loadedBatch.destroyed, 'releases the manager-owned previously loaded source');
+  t.notOk(loadedManager.has('loaded'), 'never reports destroyed loaded data as resident');
+
+  registeredManager.destroy();
+  loadedManager.destroy();
+  t.end();
+});
+
+test('SplatResidencyManager enforces byte, row, and chunk budgets transactionally', t => {
+  const device = new NullDevice({});
+  const firstBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 0, 0));
+  const protectedBatch = makeGPUSplatData(device, makeSplatResidencySource(2, 1, 1));
+  const oversizedBatch = makeGPUSplatData(device, makeSplatResidencySource(3, 2, 3));
+  const evictionEvents: string[] = [];
+  const manager = new SplatResidencyManager({
+    maxGpuBytes: firstBatch.byteLength + protectedBatch.byteLength,
+    maxResidentSplats: 3,
+    maxResidentChunks: 2,
+    onEvict: chunk => evictionEvents.push(chunk.id)
+  });
+
+  manager.add(firstBatch, {id: 'first', priority: 1});
+  manager.add(protectedBatch, {id: 'protected', priority: 10});
+  const rejectedChunk = manager.add(oversizedBatch, {id: 'oversized', priority: 5});
+
+  t.equal(rejectedChunk, undefined, 'rejects an incoming source batch that cannot fit');
+  t.deepEqual(evictionEvents, [], 'does not partially evict data before confirming admission');
+  t.deepEqual(
+    manager.residentBatches,
+    [firstBatch, protectedBatch],
+    'retains every resident batch after transactional rejection'
+  );
+  t.notOk(oversizedBatch.destroyed, 'does not claim ownership of synchronously rejected data');
+
+  manager.setBudget({maxResidentSplats: 2});
+  t.deepEqual(manager.residentBatches, [protectedBatch], 'enforces logical row budgets');
+  manager.setBudget({maxResidentChunks: 0});
+  t.deepEqual(manager.residentBatches, [], 'enforces independent source-chunk budgets');
+
+  manager.destroy();
+  firstBatch.destroy();
+  protectedBatch.destroy();
+  oversizedBatch.destroy();
+  t.end();
+});
+
+test('SplatResidencyManager destroys only explicitly owned data after renderer callbacks', t => {
+  const device = new NullDevice({});
+  const firstBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 0, 0));
+  const borrowedBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 1, 1));
+  const finalBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 2, 2));
+  const evictionEvents: Array<[string, SplatResidencyEvictionReason, boolean]> = [];
+  const residencyEvents: number[][] = [];
+  const manager = new SplatResidencyManager({
+    maxResidentChunks: 1,
+    ownsData: true,
+    callbacks: {
+      onEvict: (chunk, reason) => evictionEvents.push([chunk.id, reason, chunk.data.destroyed]),
+      onResidencyChange: batches =>
+        residencyEvents.push(batches.map(batch => batch.sourceBatchIndex))
+    }
+  });
+
+  manager.add(firstBatch, {id: 'owned', priority: 1});
+  manager.add(borrowedBatch, {id: 'borrowed', priority: 2, ownsData: false});
+
+  t.ok(firstBatch.destroyed, 'destroys source buffers after manager-owned eviction');
+  t.deepEqual(
+    evictionEvents[0],
+    ['owned', 'budget', false],
+    'notifies renderer integrations before destroying manager-owned GPU buffers'
+  );
+
+  manager.add(finalBatch, {id: 'final', priority: 3});
+  t.notOk(borrowedBatch.destroyed, 'preserves individually borrowed source buffers on eviction');
+  t.deepEqual(
+    residencyEvents,
+    [[0], [], [1], [], [2]],
+    'provides exact source-batch lists for borrowing renderer synchronization'
+  );
+
+  manager.destroy();
+  manager.destroy();
+  t.ok(finalBatch.destroyed, 'destroys the final manager-owned source batch exactly once');
+  t.notOk(borrowedBatch.destroyed, 'never destroys an individually borrowed batch');
+  t.deepEqual(
+    evictionEvents[2],
+    ['final', 'destroy', false],
+    'keeps owned GPU buffers live until destruction callbacks have finished'
+  );
+  borrowedBatch.destroy();
+  t.end();
+});
+
+test('SplatResidencyManager updates pinned and replacement source chunk metadata', t => {
+  const device = new NullDevice({});
+  const firstBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 0, 0));
+  const replacementBatch = makeGPUSplatData(device, makeSplatResidencySource(2, 1, 1));
+  const manager = new SplatResidencyManager({maxResidentChunks: 1});
+  const firstChunk = manager.add(firstBatch, {id: 'tile', priority: 1, levelOfDetail: 3});
+  const updatedChunk = manager.register(firstBatch, {
+    id: 'tile',
+    priority: 5,
+    pinned: true,
+    levelOfDetail: 1,
+    bounds: {center: [5, 6, 7]}
+  });
+
+  t.equal(updatedChunk, firstChunk, 'updates explicit metadata without duplicating source batches');
+  t.equal(updatedChunk?.priority, 5, 'retains updated source tile priority');
+  t.ok(updatedChunk?.pinned, 'retains updated eviction protection');
+  t.equal(updatedChunk?.levelOfDetail, 1, 'retains updated hierarchy level');
+  t.deepEqual(updatedChunk?.bounds, {center: [5, 6, 7]}, 'retains updated tile bounds');
+  t.equal(manager.stats.residentChunkCount, 1, 'never duplicates source allocations');
+  t.ok(manager.remove('tile'), 'allows callers to explicitly remove pinned source tiles');
+  t.notOk(firstBatch.destroyed, 'preserves explicitly removed caller-owned source batches');
+
+  manager.add(firstBatch, {id: 'replaceable', priority: 10});
+  const replacementChunk = manager.add(replacementBatch, {id: 'replaceable', priority: 1});
+  t.equal(replacementChunk?.data, replacementBatch, 'replaces one explicit tile identity');
+  t.equal(manager.stats.residentChunkCount, 1, 'preserves the intact chunk budget on replacement');
+  t.equal(manager.stats.residentSplatCount, 2, 'accounts for replacement source row counts');
+
+  manager.destroy();
+  firstBatch.destroy();
+  replacementBatch.destroy();
+  t.end();
+});
+
+test('SplatResidencyManager coalesces asynchronous tile loads and respects late ownership', async t => {
+  const device = new NullDevice({});
+  const firstBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 0, 0));
+  const rejectedBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 1, 1));
+  const lateBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 2, 2));
+  const manager = new SplatResidencyManager({maxResidentChunks: 1, ownsData: true});
+  let loadCount = 0;
+  const firstRequest = manager.load('tile', () => {
+    loadCount++;
+    return firstBatch;
+  });
+  const secondRequest = manager.load('tile', () => {
+    loadCount++;
+    return rejectedBatch;
+  });
+
+  t.equal(firstRequest, secondRequest, 'coalesces concurrent requests for the same source tile');
+  t.equal(manager.stats.pendingChunkCount, 1, 'reports the pending source-batch load');
+  const loadedChunk = await firstRequest;
+  t.equal(loadCount, 1, 'invokes the source-batch loader exactly once');
+  t.equal(loadedChunk?.data, firstBatch, 'retains the exact independently loaded source batch');
+  t.equal(manager.stats.pendingChunkCount, 0, 'releases completed streaming requests');
+
+  const rejectedChunk = await manager.load('rejected', () => rejectedBatch, {priority: -1});
+  t.equal(rejectedChunk, undefined, 'rejects a lower-priority asynchronously loaded tile');
+  t.ok(rejectedBatch.destroyed, 'releases manager-owned rejected asynchronous GPU allocations');
+
+  let finishLoad: (data: GPUSplatData) => void = () => {};
+  const pendingBatch = new Promise<GPUSplatData>(resolve => {
+    finishLoad = resolve;
+  });
+  const lateRequest = manager.load('late', () => pendingBatch, {priority: 10});
+  manager.destroy();
+  finishLoad(lateBatch);
+  t.equal(await lateRequest, undefined, 'does not admit source data after manager destruction');
+  t.ok(lateBatch.destroyed, 'releases manager-owned source batches finishing after destruction');
+  t.ok(firstBatch.destroyed, 'releases the original manager-owned resident source batch');
+  t.end();
+});
+
+test('SplatResidencyManager reserves source allocations before asynchronous preparation', async t => {
+  const device = new NullDevice({});
+  const residentBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 0, 0));
+  const estimatedGpuBytes = residentBatch.byteLength;
+  const residencyEvents: string[] = [];
+  let loadedBatch: GPUSplatData | undefined;
+  let loaderInvocationCount = 0;
+  const manager = new SplatResidencyManager({
+    maxGpuBytes: estimatedGpuBytes,
+    maxResidentSplats: 1,
+    maxResidentChunks: 1,
+    ownsData: true,
+    onEvict: chunk => {
+      residencyEvents.push(`evict:${chunk.id}:${chunk.data.destroyed}`);
+    },
+    onResidencyChange: batches => {
+      residencyEvents.push(`resident:${batches.length}`);
+    }
+  });
+  manager.add(residentBatch, {id: 'resident', priority: 1});
+
+  const pendingChunk = manager.load(
+    'incoming',
+    () => {
+      loaderInvocationCount++;
+      residencyEvents.push(`load:${residentBatch.destroyed}`);
+      loadedBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 1, 1));
+      return loadedBatch;
+    },
+    {priority: 1, estimatedGpuBytes, estimatedSplatCount: 1}
+  );
+
+  t.ok(residentBatch.destroyed, 'destroys owned source buffers before the loader can allocate');
+  t.equal(loaderInvocationCount, 0, 'reserves capacity before invoking asynchronous preparation');
+  t.deepEqual(manager.residentBatches, [], 'detaches evicted source batches before loading');
+  t.equal(manager.stats.pendingChunkCount, 1, 'retains the coalesced pending load');
+
+  const incomingChunk = await pendingChunk;
+  t.equal(incomingChunk?.data, loadedBatch, 'admits the exact independently prepared source batch');
+  t.deepEqual(
+    residencyEvents,
+    ['resident:1', 'evict:resident:false', 'resident:0', 'load:true', 'resident:1'],
+    'notifies renderers, releases owned GPU buffers, then invokes source preparation'
+  );
+  t.equal(manager.stats.residentGpuByteLength, estimatedGpuBytes, 'retains the exact byte budget');
+
+  manager.destroy();
+  t.ok(loadedBatch?.destroyed, 'preserves explicit ownership of the newly prepared source');
+  t.end();
+});
+
+test('SplatResidencyManager rejects protected reservations without preparing or partially evicting', async t => {
+  const device = new NullDevice({});
+  const pinnedBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 0, 0));
+  const lowerPriorityBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 1, 1));
+  const higherPriorityBatch = makeGPUSplatData(device, makeSplatResidencySource(2, 2, 2));
+  const evictionEvents: string[] = [];
+  let pinnedLoaderInvocationCount = 0;
+  let protectedLoaderInvocationCount = 0;
+  const pinnedManager = new SplatResidencyManager({
+    maxGpuBytes: pinnedBatch.byteLength,
+    maxResidentSplats: 1,
+    maxResidentChunks: 1,
+    ownsData: true,
+    onEvict: chunk => evictionEvents.push(chunk.id)
+  });
+  const protectedManager = new SplatResidencyManager({
+    maxGpuBytes: lowerPriorityBatch.byteLength + higherPriorityBatch.byteLength,
+    maxResidentSplats: 3,
+    maxResidentChunks: 2,
+    ownsData: true,
+    onEvict: chunk => evictionEvents.push(chunk.id)
+  });
+  pinnedManager.add(pinnedBatch, {id: 'pinned', priority: 0, pinned: true});
+  protectedManager.add(lowerPriorityBatch, {id: 'lower', priority: 1});
+  protectedManager.add(higherPriorityBatch, {id: 'higher', priority: 10});
+
+  const rejectedPinnedChunk = await pinnedManager.load(
+    'pinned-replacement',
+    () => {
+      pinnedLoaderInvocationCount++;
+      return makeGPUSplatData(device, makeSplatResidencySource(1, 3, 4));
+    },
+    {priority: 100, estimatedGpuBytes: pinnedBatch.byteLength, estimatedSplatCount: 1}
+  );
+  const rejectedProtectedChunk = await protectedManager.load(
+    'protected-replacement',
+    () => {
+      protectedLoaderInvocationCount++;
+      return makeGPUSplatData(device, makeSplatResidencySource(3, 4, 5));
+    },
+    {
+      priority: 5,
+      estimatedGpuBytes: lowerPriorityBatch.byteLength + higherPriorityBatch.byteLength,
+      estimatedSplatCount: 3
+    }
+  );
+
+  t.equal(rejectedPinnedChunk, undefined, 'rejects loads requiring a pinned source allocation');
+  t.equal(pinnedLoaderInvocationCount, 0, 'never allocates a source protected by pinned residency');
+  t.equal(rejectedProtectedChunk, undefined, 'rejects loads requiring higher-priority allocations');
+  t.equal(
+    protectedLoaderInvocationCount,
+    0,
+    'never prepares data that cannot displace more valuable source tiles'
+  );
+  t.deepEqual(evictionEvents, [], 'does not partially evict admissible tiles when admission fails');
+  t.deepEqual(pinnedManager.residentBatches, [pinnedBatch], 'retains the protected pinned source');
+  t.deepEqual(
+    protectedManager.residentBatches,
+    [lowerPriorityBatch, higherPriorityBatch],
+    'retains every original batch after transactional reservation rejection'
+  );
+  t.equal(pinnedManager.stats.rejectedChunkCount, 1, 'counts rejected pinned reservations');
+  t.equal(protectedManager.stats.rejectedChunkCount, 1, 'counts rejected protected reservations');
+  t.equal(pinnedManager.stats.pendingChunkCount, 0, 'never registers rejected pinned loads');
+  t.equal(protectedManager.stats.pendingChunkCount, 0, 'never registers rejected protected loads');
+
+  pinnedManager.destroy();
+  protectedManager.destroy();
+  t.end();
+});
+
+test('SplatResidencyManager prevents concurrent pending reservations from exceeding budgets', async t => {
+  const device = new NullDevice({});
+  const firstBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 0, 0));
+  const secondBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 1, 1));
+  const unreservedBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 2, 2));
+  const estimatedGpuBytes = firstBatch.byteLength;
+  const manager = new SplatResidencyManager({
+    maxGpuBytes: estimatedGpuBytes * 2,
+    maxResidentSplats: 2,
+    maxResidentChunks: 2,
+    ownsData: true
+  });
+  let finishFirstLoad: (data: GPUSplatData) => void = () => {};
+  let finishSecondLoad: (data: GPUSplatData) => void = () => {};
+  let rejectedLoaderInvocationCount = 0;
+  const firstData = new Promise<GPUSplatData>(resolve => {
+    finishFirstLoad = resolve;
+  });
+  const secondData = new Promise<GPUSplatData>(resolve => {
+    finishSecondLoad = resolve;
+  });
+  const reservationOptions = {estimatedGpuBytes, estimatedSplatCount: 1};
+  const firstRequest = manager.load('first', () => firstData, reservationOptions);
+  const duplicateFirstRequest = manager.load('first', () => secondBatch, reservationOptions);
+  const secondRequest = manager.load('second', () => secondData, reservationOptions);
+  const rejectedRequest = manager.load(
+    'rejected',
+    () => {
+      rejectedLoaderInvocationCount++;
+      return makeGPUSplatData(device, makeSplatResidencySource(1, 3, 3));
+    },
+    {priority: 100, ...reservationOptions}
+  );
+
+  t.equal(firstRequest, duplicateFirstRequest, 'coalesces reservations for the same source tile');
+  t.equal(
+    await rejectedRequest,
+    undefined,
+    'protects every previously reserved pending allocation'
+  );
+  t.equal(rejectedLoaderInvocationCount, 0, 'never invokes an overcommitted concurrent loader');
+  t.equal(manager.stats.pendingChunkCount, 2, 'retains both independently reserved pending loads');
+  t.equal(
+    manager.add(unreservedBatch, {id: 'unreserved', priority: 100}),
+    undefined,
+    'prevents synchronous admission from consuming reserved source capacity'
+  );
+  t.notOk(unreservedBatch.destroyed, 'preserves ownership of synchronously rejected source data');
+
+  finishSecondLoad(secondBatch);
+  const secondChunk = await secondRequest;
+  t.equal(secondChunk?.data, secondBatch, 'admits a later reservation finishing first');
+  t.equal(manager.stats.pendingChunkCount, 1, 'retains the first pending reservation');
+
+  finishFirstLoad(firstBatch);
+  const firstChunk = await firstRequest;
+  t.equal(firstChunk?.data, firstBatch, 'admits the remaining independently reserved source');
+  t.deepEqual(
+    manager.residentBatches,
+    [secondBatch, firstBatch],
+    'retains independent source batches in actual admission order'
+  );
+  t.equal(manager.stats.residentGpuByteLength, estimatedGpuBytes * 2, 'preserves the byte budget');
+  t.equal(manager.stats.residentSplatCount, 2, 'preserves the logical row budget');
+  t.equal(manager.stats.pendingChunkCount, 0, 'releases every completed pending reservation');
+
+  manager.destroy();
+  unreservedBatch.destroy();
+  t.end();
+});
+
+test('SplatResidencyManager releases failed asynchronous allocation reservations', async t => {
+  const device = new NullDevice({});
+  const incomingBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 0, 0));
+  const manager = new SplatResidencyManager({
+    maxGpuBytes: incomingBatch.byteLength,
+    maxResidentSplats: 1,
+    maxResidentChunks: 1,
+    ownsData: true
+  });
+  const reservationOptions = {
+    estimatedGpuBytes: incomingBatch.byteLength,
+    estimatedSplatCount: 1
+  };
+  const expectedError = new Error('Source preparation failed');
+  const rejectedLoad = await manager
+    .load('rejected', () => Promise.reject(expectedError), reservationOptions)
+    .then(
+      () => undefined,
+      error => error
+    );
+
+  t.equal(rejectedLoad, expectedError, 'preserves the original asynchronous loader failure');
+  t.equal(manager.stats.pendingChunkCount, 0, 'releases the rejected pending source identity');
+  const admittedChunk = await manager.load('incoming', () => incomingBatch, reservationOptions);
+  t.equal(admittedChunk?.data, incomingBatch, 'reuses GPU and source-row reservation capacity');
+  t.equal(manager.stats.residentChunkCount, 1, 'reuses the independent source-chunk reservation');
+
+  manager.destroy();
+  t.ok(incomingBatch.destroyed, 'preserves manager ownership after reservation recovery');
+  t.end();
+});
+
+test('SplatResidencyManager synchronizes borrowing renderers before owned batch eviction', t => {
+  const device = new NullDevice({});
+  const firstBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 0, 0));
+  const secondBatch = makeGPUSplatData(device, makeSplatResidencySource(1, 1, 1));
+  const renderer = new SplatRenderer(device, {viewportSize: [100, 100]});
+  const manager = new SplatResidencyManager({
+    maxResidentChunks: 1,
+    ownsData: true,
+    onResidencyChange: batches => renderer.setProps({data: batches})
+  });
+
+  manager.add(firstBatch, {priority: 0});
+  t.deepEqual(renderer.batches, [firstBatch], 'adds the independently resident source batch');
+  manager.add(secondBatch, {priority: 1});
+  t.ok(firstBatch.destroyed, 'destroys manager-owned data after renderer detachment');
+  t.deepEqual(renderer.batches, [secondBatch], 'retains only the current source residency window');
+  t.equal(renderer.stats.splatCount, 1, 'keeps renderer diagnostics within residency limits');
+
+  manager.destroy();
+  t.deepEqual(renderer.batches, [], 'detaches every source batch before final destruction');
+  t.ok(secondBatch.destroyed, 'releases the final manager-owned source allocation');
+  renderer.destroy();
+  t.end();
+});
+
+function makeSplatResidencySource(
+  splatCount: number,
+  sourceBatchIndex: number,
+  rowIndexBase: number
+): SplatSource {
+  const positions = new Float32Array(splatCount * 3);
+  const scales = new Float32Array(splatCount * 3);
+  const rotations = new Float32Array(splatCount * 4);
+  const colors = new Uint8Array(splatCount * 4);
+  const opacities = new Float32Array(splatCount);
+
+  for (let splatIndex = 0; splatIndex < splatCount; splatIndex++) {
+    positions[splatIndex * 3 + 2] = splatIndex * 0.1;
+    scales.set([0.1, 0.08, 0.06], splatIndex * 3);
+    rotations[splatIndex * 4] = 1;
+    colors.set([255, 128, 32, 255], splatIndex * 4);
+    opacities[splatIndex] = 1;
+  }
+
+  return {positions, scales, rotations, colors, opacities, sourceBatchIndex, rowIndexBase};
+}

--- a/modules/splats/test/splat-spherical-harmonics.node.spec.ts
+++ b/modules/splats/test/splat-spherical-harmonics.node.spec.ts
@@ -1,0 +1,175 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {Buffer} from '@luma.gl/core';
+import {
+  evaluateSplatSphericalHarmonics,
+  getSplatSphericalHarmonicCoefficientCount,
+  getSplatSphericalHarmonicsDegree,
+  makeGPUSplatData,
+  SplatRenderer,
+  SPLAT_STORAGE_WGSL_SHADER,
+  type SplatSource
+} from '@luma.gl/splats';
+import {NullDevice} from '@luma.gl/test-utils';
+
+test('Gaussian spherical harmonics retain GraphDECO basis order through degree three', t => {
+  t.deepEqual(
+    ([0, 1, 2, 3] as const).map(getSplatSphericalHarmonicCoefficientCount),
+    [0, 9, 24, 45],
+    'counts only non-DC RGB scalar coefficients'
+  );
+  t.deepEqual(
+    [0, 9, 24, 45].map(getSplatSphericalHarmonicsDegree),
+    [0, 1, 2, 3],
+    'infers every supported spherical-harmonic degree'
+  );
+  t.throws(
+    () => getSplatSphericalHarmonicsDegree(12),
+    /coefficient count/,
+    'rejects incomplete spherical-harmonic bands'
+  );
+
+  const coefficients = new Float32Array(45);
+  coefficients[2 * 3] = 2;
+  coefficients[5 * 3 + 1] = 1;
+  coefficients[11 * 3 + 2] = 1;
+  const firstOrder = evaluateSplatSphericalHarmonics(
+    [0.5, 0.25, 0.125],
+    coefficients,
+    [2, 0, 0],
+    1
+  );
+  t.ok(
+    Math.abs(firstOrder[0] - (0.5 - 2 * 0.4886025119029199)) < 1e-6,
+    'normalizes the view direction and evaluates the first-order X basis'
+  );
+  t.equal(firstOrder[1], 0.25, 'excludes higher bands when the requested degree is capped');
+
+  const thirdOrder = evaluateSplatSphericalHarmonics(
+    [0.5, 0.25, 0.125],
+    coefficients,
+    [0, 0, 1],
+    3
+  );
+  t.ok(
+    Math.abs(thirdOrder[1] - (0.25 + 2 * 0.31539156525252005)) < 1e-6,
+    'evaluates the second-order zonal basis'
+  );
+  t.ok(
+    Math.abs(thirdOrder[2] - (0.125 + 2 * 0.3731763325901154)) < 1e-6,
+    'evaluates the third-order zonal basis'
+  );
+  t.end();
+});
+
+test('SplatRenderer evaluates view-dependent spherical harmonics without mutating source colors', async t => {
+  const device = new NullDevice({});
+  const source = makeSphericalHarmonicSource();
+  const prepared = makeGPUSplatData(device, source);
+  const renderer = new SplatRenderer(device, {
+    data: prepared,
+    cameraPosition: [0, 0, 0],
+    sphericalHarmonicsDegree: 1,
+    viewportSize: [32, 32]
+  });
+  const renderPass = device.getDefaultRenderPass();
+  renderer.draw(renderPass);
+  const evaluatedColorBuffer = renderer.model?.vertexArray.attributes[3];
+  if (!(evaluatedColorBuffer instanceof Buffer)) {
+    t.fail('creates an independently owned evaluated color buffer');
+    renderer.destroy();
+    prepared.destroy();
+    t.end();
+    return;
+  }
+
+  const firstColors = await readFloat32Buffer(evaluatedColorBuffer);
+  t.ok(firstColors[0] < 0.5, 'evaluates directional red radiance from the first camera position');
+  t.deepEqual(Array.from(source.colors), [0.5, 0.25, 0.125, 1], 'preserves caller-owned DC colors');
+  const sortedReferences = renderer.sortedReferences;
+  renderer.setProps({cameraPosition: [2, 0, 0]});
+  renderer.draw(renderPass);
+  const secondColors = await readFloat32Buffer(evaluatedColorBuffer);
+  t.ok(secondColors[0] > 0.5, 'updates directional radiance as the camera crosses the Gaussian');
+  t.equal(renderer.sortedReferences, sortedReferences, 'updates radiance without resorting rows');
+  t.equal(
+    renderer.model?.vertexArray.attributes[3],
+    evaluatedColorBuffer,
+    'reuses the renderer-owned evaluated color allocation'
+  );
+
+  renderer.setProps({sphericalHarmonicsDegree: 0});
+  renderer.draw(renderPass);
+  t.equal(
+    renderer.model?.vertexArray.attributes[3],
+    prepared.colors.data[0].buffer,
+    'restores the caller-owned DC color buffer when higher bands are disabled'
+  );
+
+  const coefficientBuffer = prepared.sphericalHarmonics?.data[0].buffer;
+  renderer.destroy();
+  t.ok(evaluatedColorBuffer.destroyed, 'releases the renderer-owned evaluated colors');
+  t.notOk(coefficientBuffer?.destroyed, 'preserves the caller-owned coefficient buffer');
+  prepared.destroy();
+  t.ok(coefficientBuffer?.destroyed, 'caller destruction releases the coefficient buffer');
+  t.end();
+});
+
+test('SplatRenderer binds batch-local spherical harmonics to the WebGPU storage pipeline', t => {
+  const device = new NullDevice({});
+  Object.defineProperties(device, {
+    type: {value: 'webgpu'},
+    info: {value: {...device.info, type: 'webgpu', shadingLanguage: 'wgsl'}}
+  });
+  const prepared = makeGPUSplatData(device, makeSphericalHarmonicSource());
+  const renderer = new SplatRenderer(device, {data: prepared, viewportSize: [32, 32]});
+  const renderPass = device.getDefaultRenderPass();
+  renderer.draw(renderPass);
+
+  t.equal(
+    renderer.model?.bindings['splatSphericalHarmonics'],
+    prepared.sphericalHarmonics?.data[0].buffer,
+    'binds the prepared source coefficient allocation without repacking it'
+  );
+  t.equal(
+    renderer.getBatchSphericalHarmonicsBuffer(0),
+    prepared.sphericalHarmonics?.data[0].buffer,
+    'exposes borrowed coefficients to GPU picking passes'
+  );
+  t.ok(
+    SPLAT_STORAGE_WGSL_SHADER.includes('getSplatSphericalHarmonicBasis'),
+    'evaluates higher-order spherical harmonics inside the WebGPU vertex shader'
+  );
+  t.ok(
+    SPLAT_STORAGE_WGSL_SHADER.includes('sourceRowIndex : i32'),
+    'retains stable flat source indices for GPU picking'
+  );
+
+  renderer.destroy();
+  prepared.destroy();
+  t.end();
+});
+
+function makeSphericalHarmonicSource(): SplatSource {
+  const sphericalHarmonics = new Float32Array(9);
+  sphericalHarmonics[2 * 3] = 0.5;
+  return {
+    positions: new Float32Array([1, 0, 0]),
+    scales: new Float32Array([0.1, 0.1, 0.1]),
+    rotations: new Float32Array([1, 0, 0, 0]),
+    colors: new Float32Array([0.5, 0.25, 0.125, 1]),
+    opacities: new Float32Array([1]),
+    sphericalHarmonics,
+    sphericalHarmonicsDegree: 1
+  };
+}
+
+async function readFloat32Buffer(buffer: {
+  readAsync(): Promise<Uint8Array>;
+}): Promise<Float32Array> {
+  const bytes = await buffer.readAsync();
+  return new Float32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4);
+}


### PR DESCRIPTION
## Goals
- Scale Gaussian splat rendering and interaction without breaking caller ownership, source batch boundaries, or the existing progressive WebGPU command graph.

## Changes
- Evaluate GraphDECO spherical harmonics through degree three with WebGPU storage shaders and a WebGL directional-color fallback; decode `f_rest_*` columns and configurable degree limits from Arrow.
- Add semantic class filtering and dedicated integer/color GPU picking with stable source identities, large global rows, and hundreds of independently resident batches.
- Support in-place dynamic source updates, revision-aware standard and command-graph renderers, and mixed opaque mesh / depth-tested splat / transparent mesh composition.
- Add priority/LRU/pinned residency management with GPU-byte, row, and chunk limits, asynchronous load deduplication, ownership-safe eviction callbacks, and pre-upload memory reservations.
- Preserve lazy Arrow record-batch streaming, validate nullable semantic data and signed GPU row identities, and document the standard-versus-command-graph capability boundary.
- Update the Gaussian showcase, API documentation, release notes, and published capability matrix.
- Repair three pre-existing Arrow SPDX copyright headers currently breaking `master` CI.

## Verification
- `yarn build` — passes across every module, including cross-package declarations.
- `yarn lint fix` and commit-time `yarn lint` — pass.
- Full `CI=1 yarn test` — **1,745 Node tests passed / 1 skipped** and **1,893 browser tests passed / 25 skipped** across 560 files.
- Focused splat, Arrow, and SPDX Node suites — **77 passed**.
- Real hardware Chromium WebGPU/WebGL splat, picking, and progressive graph suites — **11 passed**.
- GitHub Actions browser coverage shards, examples/website build, aggregate test gate, and Coveralls — **all green**.
- Gaussian showcase and splat/Arrow package TypeScript checks pass.

## Follow-up / limitations
- `GPUSplatGraphRenderer` remains the high-throughput DC-only path; advanced SH, semantic filtering/picking, and mixed mesh composition use `SplatRenderer`. The showcase avoids allocating unsupported graph SH coefficients.
- Global source rows are explicitly limited to signed 32-bit GPU picking indices.
- Nullable Arrow semantic columns are rejected rather than silently fabricating class zero.