### PR TITLE
feat(examples): showcase one million GPU-resident graph vertices

### DIFF
--- a/docs/api-reference/experimental/lugraph.md
+++ b/docs/api-reference/experimental/lugraph.md
@@ -30,45 +30,75 @@ GPU, which results they render, when commands are submitted, and whether anythin
 like when they feed a real interactive application?**
 
 The [interactive luGraph explorer](/examples/experimental/lugraph-explorer) answers that question
-with a deterministic 128-vertex network. Four intentionally generated source groups contain
-important hubs, a bridge between the first two groups, and one completely isolated vertex. This
-small, deliberately interpretable network makes it possible to see how adjacency, degree,
-PageRank, weak components, bounded shortest paths, and exact force-directed layout work together.
+with a deterministic, genuinely resizable network. It opens with **1,024 vertices**, then lets you
+choose any of fourteen actual graph populations from **128 to 1,048,576 vertices**. The largest
+setting contains **1,048,576 real GPU-resident vertices and 2,097,343 original directed edges**;
+these are complete source relationships, not a small graph duplicated or multiplied for display.
+Four intentionally generated source groups contain important hubs, a bridge between the first two
+groups, and one isolated vertex, making both small and large versions interpretable.
 
 <LuGraphExplorerExample embedded embeddedHeight={680} />
 
-The graph inspector opens automatically and lets you compare four real GPU-backed color modes:
+The graph inspector opens automatically and lets you compare five real GPU-backed color modes:
 
+- **Label-propagation communities** distinguish tightly connected local groups using deterministic,
+  bounded majority votes. A narrow bridge can preserve two different communities even when both
+  groups belong to the same connected component; a fixed iteration budget does not prove
+  convergence.
 - **Weak components** identify entities that can reach each other when edge direction is ignored.
   The two source groups joined by a bridge have the same color; disconnected groups and the
-  isolated vertex remain separate. These are weak components, not community-detection output.
+  isolated vertex remain separate. This mode describes connectivity, not the separate
+  community-detection labels.
 - **Vertex degree** exposes direct relationship counts and identifies immediately connected hubs.
 - **PageRank importance** identifies influence received from other important vertices, which can
   differ substantially from raw relationship count.
 - **Neighborhood distance** shows how many bounded, unweighted hops separate each reachable vertex
   from the current selection.
 
-Node size can independently reflect normalized PageRank, vertex degree, or a uniform radius. Click
-a node to inspect its stable source identifier and highlighted neighborhood; adjust neighborhood
-depth to follow more unweighted hops. Toggle the original edge batches, pause or resume the exact
-layout, drag a node to pin it, release pins, or reset deterministic initial positions. Hold Shift
-while dragging to pan and scroll to zoom. An accessible legend and live status explain the current
-graph; adapter, frame-rate, and GPU-allocation details report actual available runtime information,
-not invented GPU execution times.
+Node size can independently reflect normalized PageRank, vertex degree, or a uniform radius. Use
+the graph-size slider to rebuild actual resident graph data, and select automatic, exact,
+flat-grid spatial, or sampled layout. Click a node to inspect its stable source identifier and
+highlighted neighborhood; adjust neighborhood depth to follow more unweighted hops. Toggle visible
+edges, pause or resume the selected layout, drag a node to pin it, release pins, or reset
+deterministic initial positions. Hold Shift while dragging to pan and scroll to zoom.
 
-The example builds forward and reverse compressed adjacency, vertex degree, weak components, and
-normalized PageRank on the GPU. Each frame updates bounded breadth-first selection and progresses
-the exact force layout. The same caller-owned position buffer is simultaneously writable storage
-and a render vertex attribute. Node and picking shaders consume the actual PageRank and degree
-buffers, while edge models draw their original aligned source batches without concatenating the
-intentionally empty middle batch. Analytics, simulation, and ordinary rendering do not read graph
-data back to JavaScript; explicitly requested integer picking reads only one compact **8-byte**
-selected-vertex result.
+The example builds forward and reverse compressed adjacency, vertex degree, weak components,
+label-propagation communities, and normalized PageRank on the GPU. Breadth-first selection updates
+when its root or depth changes; progressive layout advances the existing caller-owned position
+buffer, which is simultaneously writable storage and a render vertex attribute. Node and picking
+shaders consume the actual community, component, PageRank, and degree buffers. Original source
+edge batches, including the intentionally empty middle batch, are never concatenated or repacked.
+
+Automatic layout selects distinct, honestly bounded GPU workloads:
+
+- **Exact layout through 512 vertices:** every pairwise repulsive interaction is evaluated,
+  costing `O(V² + E)` per iteration.
+- **Flat-grid spatial layout from 1,024 to 8,192 vertices:** nearby interactions remain exact while
+  sufficiently distant cells use the optional uniform-grid approximation and its explicit,
+  caller-owned GPU index.
+- **Sampled layout from 16,384 vertices:** every actual vertex evaluates all incident edges plus
+  four deterministically selected repulsion samples, costing `O(E + 4V)` per iteration. It is a
+  separate, explicitly approximate application helper, not exact all-pairs layout, flat-grid
+  layout, Barnes–Hut, or ForceAtlas2.
+
+At **65,536 vertices** and above, every original vertex remains visible as one real GPU point.
+Only rendered edge detail is limited to **65,536 edges**; all **2,097,343 original edges** at the
+largest setting remain resident in their source batches and adjacency. The inspector distinguishes
+the complete graph population from displayed edge detail, reports the actual adapter, frame rate,
+measured CPU command-encoding time, and GPU resource ownership, and does not invent GPU execution
+times or convergence. CPU encoding is never mislabeled as a GPU measurement.
+
+Adjacency construction, degree, and one breadth-first traversal use `O(V + E)` work; bounded
+PageRank and weak components use `O(K × (V + E))`, while label propagation uses
+`O(K × sum(degree²))`. The quadratic workload avoided at scale is exact all-pairs force layout,
+not an unavoidable property of graph analytics. Large-graph iteration budgets are deliberately
+bounded and do not certify convergence or clustering quality.
 
 Use this demonstration to understand how GPU-resident graph outputs can directly support a social
-network, dependency map, fraud investigation, or other relationship visualization. It is a
-WebGPU-only educational example, not a large-graph performance benchmark: its exact layout costs
-`O(V² + E)` per force iteration and intentionally uses only 128 vertices.
+network, dependency map, fraud investigation, or other relationship visualization while making
+real rendering and approximation tradeoffs explicit. Analytics, simulation, and ordinary rendering
+never read graph columns back to JavaScript; explicitly requested integer picking reads only one
+compact **8-byte** selected-vertex result.
 
 ### Use luGraph from deck.gl without copying graph buffers
 
@@ -82,26 +112,30 @@ implementations from the existing private `@deck.gl-community/arrow-layers` adap
 Use it when a social-network, service-dependency, fraud-investigation, or citation visualization
 already uses deck.gl and needs GPU graph results to become directly drawable attributes.
 
-The effect first encodes forward and reverse adjacency, normalized PageRank, and weak components.
-Later frames encode bounded neighborhood selection and exact force-directed layout into
-deck.gl's own command encoder; deck.gl remains responsible for queue submission. The writable layout
-allocation is also the node layer's `float32x2` instance vertex attribute. PageRank scores,
-component labels, hop distances, and the selection mask remain GPU storage inputs; each nonempty
-original edge partition gets its own edge layer,
-without concatenation, buffer copies, or per-frame graph readback.
+The effect first encodes forward and reverse adjacency, vertex degree, normalized PageRank, weak
+components, and deterministic label-propagation communities. Later frames encode actual exact,
+flat-grid spatial, or sampled force layout into deck.gl's own command encoder; bounded
+neighborhood selection reruns only when interaction changes it. deck.gl remains responsible for
+queue submission. The writable layout allocation is also the node layer's `float32x2` instance
+vertex attribute. PageRank scores, degree counts, component and community labels, hop distances,
+and the selection mask remain GPU storage inputs; each nonempty original edge partition gets its
+own edge layer, without concatenation, buffer copies, or per-frame graph readback.
 
-The deterministic example fixture is uploaded once. Selecting, pinning, dragging, and changing
-neighborhood depth write only the necessary interaction controls or coordinates; they do not
-download graph columns. An explicitly requested native deck.gl pick returns the selected original
-vertex identifier to JavaScript. Its implementation and transfer size belong to deck.gl; it is
-separate from the native explorer's custom **8-byte** integer-picking path above. The example uses
-exact `O(V² + E)` layout, not the optional spatial approximation, and does not promise large-graph
-throughput.
+The deterministic example fixture is uploaded once for each selected graph size. Resizing replaces
+its resident allocations and rebinds stable node and edge layers to their new buffers. Selecting,
+pinning, dragging, and changing neighborhood depth write only the necessary interaction controls or
+coordinates; they do not download graph columns. Every actual vertex remains rendered, including
+all **1,048,576 vertices** in point mode; only displayed original edges are capped. An explicitly
+requested native deck.gl pick returns the selected original vertex identifier to JavaScript. Its
+implementation and transfer size belong to deck.gl; it is
+separate from the native explorer's custom **8-byte** integer-picking path above.
 
 The reusable graph effect, node and edge layers, and graph integration's deck.gl imports live in
 the existing private `@deck.gl-community/arrow-layers` adapter. The website-only example consumes
 those exported symbols without importing `@deck.gl/core` or adding an example package; neither
-`@luma.gl/experimental` nor its optional graph entry point depends on or imports deck.gl.
+`@luma.gl/experimental` nor its optional graph entry point depends on or imports deck.gl. The
+example supplies its sampled-layout helper to the private effect as an injected callback, so the
+package never imports example code or claims that the helper is a new production graph operation.
 
 ## Measure real CPU and WebGPU graph workloads
 

--- a/examples/deck/lugraph-explorer/app.ts
+++ b/examples/deck/lugraph-explorer/app.ts
@@ -7,6 +7,7 @@ import {
   LuGraphEdgeLayer,
   LuGraphNodeLayer,
   OrthographicView,
+  type LuGraphDeckEffectStats,
   type PickingInfo
 } from '@deck.gl-community/arrow-layers';
 import {Buffer, type Device} from '@luma.gl/core';
@@ -18,9 +19,18 @@ import {
 import {ArrowDeck} from '../arrow-deck';
 import {getDeckExampleProps, type DeckExampleDeviceOptions} from '../deck-example-device';
 import {
+  GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT,
+  GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT,
+  GRAPH_EXPLORER_MAX_VISIBLE_EDGES,
+  GRAPH_EXPLORER_SHOWCASE_DEFAULT_VERTEX_COUNT,
+  GRAPH_EXPLORER_VERTEX_COUNTS,
   makeGraphExplorerDataset,
-  type GraphExplorerDataset
+  type GraphExplorerColorMode,
+  type GraphExplorerDataset,
+  type GraphExplorerLayoutMode,
+  type GraphExplorerNodeSizeMode
 } from '../../experimental/lugraph-explorer/graph-data';
+import {addGraphExplorerSampledLayoutToGraph} from '../../experimental/lugraph-explorer/graph-scale-layout';
 
 const DEFAULT_NEIGHBORHOOD_DEPTH = 2;
 
@@ -31,6 +41,24 @@ type GraphExplorerControls = {
 
 type LuGraphExplorerDeckOptions = DeckExampleDeviceOptions & {
   dataset?: GraphExplorerDataset;
+  layoutMode?: GraphExplorerLayoutMode;
+  pointMode?: boolean;
+  maxVisibleEdges?: number;
+};
+
+type GraphExplorerControlProps = {
+  getEffect: () => LuGraphDeckEffect | null;
+  getStats: () => LuGraphDeckEffectStats | null;
+  getPendingVertexCount: () => number | null;
+  getLoadingStatus: () => string | null;
+  getEdgesVisible: () => boolean;
+  resize: (vertexCount: number) => void;
+  setLayoutMode: (mode: GraphExplorerLayoutMode) => void;
+  setColorMode: (mode: GraphExplorerColorMode) => void;
+  setNodeSizeMode: (mode: GraphExplorerNodeSizeMode) => void;
+  setEdgesVisible: (visible: boolean) => void;
+  setPaused: (paused: boolean) => void;
+  redraw: (reason: string) => void;
 };
 
 /**
@@ -44,17 +72,60 @@ export function createLuGraphExplorerDeck(
   parent?: HTMLDivElement,
   options: LuGraphExplorerDeckOptions = {}
 ): ArrowDeck<OrthographicView> {
-  const {dataset, ...deviceOptions} = options;
+  const {
+    dataset,
+    layoutMode: initialLayoutMode = 'auto',
+    pointMode,
+    maxVisibleEdges = GRAPH_EXPLORER_MAX_VISIBLE_EDGES,
+    ...deviceOptions
+  } = options;
+  const initialDataset =
+    dataset ?? makeGraphExplorerDataset(GRAPH_EXPLORER_SHOWCASE_DEFAULT_VERTEX_COUNT);
   const ownsContainer = !parent;
   const container = parent ?? createStandaloneContainer();
   if (getComputedStyle(container).position === 'static') container.style.position = 'relative';
 
   let effect: LuGraphDeckEffect | null = null;
+  let activeDevice: Device | null = null;
+  let latestStats: LuGraphDeckEffectStats | null = null;
+  let currentLayoutMode = initialLayoutMode;
+  let currentColorMode: GraphExplorerColorMode = 'community';
+  let currentNodeSizeMode: GraphExplorerNodeSizeMode = 'pagerank';
+  let edgesVisible = initialDataset.vertexCount < GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT;
+  let pendingGraphVertexCount: number | null = null;
+  let loadingStatus: string | null = null;
+  let rebuildGeneration = 0;
+  let rebuildFrame: number | null = null;
   let draggedVertex: number | null = null;
   let restoreShaderAssembler: (() => void) | null = null;
   let deck: ArrowDeck<OrthographicView>;
   const controls = createExplorerControls(container, {
     getEffect: () => effect,
+    getStats: () => latestStats,
+    getPendingVertexCount: () => pendingGraphVertexCount,
+    getLoadingStatus: () => loadingStatus,
+    getEdgesVisible: () => edgesVisible,
+    resize: vertexCount => scheduleGraphResize(vertexCount),
+    setLayoutMode: mode => {
+      currentLayoutMode = mode;
+      if (effect) scheduleGraphResize(effect.graph.vertexCount);
+    },
+    setColorMode: mode => {
+      currentColorMode = mode;
+      updateLayers('luGraph GPU visual color encoding changed');
+    },
+    setNodeSizeMode: mode => {
+      currentNodeSizeMode = mode;
+      updateLayers('luGraph GPU node sizing changed');
+    },
+    setEdgesVisible: visible => {
+      edgesVisible = visible;
+      updateLayers('luGraph source-chunk edge visibility changed');
+    },
+    setPaused: paused => {
+      deck?.setProps({_animate: !paused});
+      if (!paused) deck?.redraw('luGraph progressive GPU layout resumed');
+    },
     redraw: reason => deck?.redraw(reason)
   });
 
@@ -62,7 +133,7 @@ export function createLuGraphExplorerDeck(
     parent: container,
     ...getDeckExampleProps({...deviceOptions, deviceType: 'webgpu'}),
     views: new OrthographicView({id: 'lugraph-orthographic'}),
-    initialViewState: {target: [0, 0, 0], zoom: 7.7, minZoom: 5, maxZoom: 11},
+    initialViewState: {target: [0, 0, 0], zoom: 6.8, minZoom: 4, maxZoom: 12},
     controller: {
       dragPan: true,
       scrollZoom: {smooth: true, speed: 0.02},
@@ -113,44 +184,15 @@ export function createLuGraphExplorerDeck(
     },
     onLoad: ({deck: loadedDeck, device}) => {
       if (device.type !== 'webgpu') throw new Error('luGraph deck explorer requires WebGPU');
-      effect = new LuGraphDeckEffect(device, dataset ?? makeGraphExplorerDataset());
-      const edgeLayers = effect.graph.sourceVertices.data.flatMap((source, chunkIndex) => {
-        if (source.length === 0) return [];
-        const target = effect!.graph.targetVertices.data[chunkIndex];
-        return [
-          new LuGraphEdgeLayer({
-            id: `lugraph-edges-${chunkIndex}`,
-            data: [],
-            pickable: false,
-            positions: effect!.positions,
-            sourceVertices: source.buffer instanceof Buffer ? source.buffer : source.buffer.buffer,
-            targetVertices: target.buffer instanceof Buffer ? target.buffer : target.buffer.buffer,
-            distances: effect!.distances,
-            edgeCount: source.length,
-            opacity: 0.85
-          })
-        ];
-      });
-      const nodeLayer = new LuGraphNodeLayer({
-        id: 'lugraph-nodes',
-        data: [],
-        pickable: true,
-        autoHighlight: true,
-        positions: effect.positions,
-        importance: effect.importance,
-        components: effect.componentLabels,
-        distances: effect.distances,
-        selectionMask: effect.selectionMask,
-        vertexCount: effect.graph.vertexCount,
-        opacity: 1
-      });
-      loadedDeck.setProps({effects: [effect], layers: [...edgeLayers, nodeLayer]});
-      controls.update();
-      loadedDeck.redraw('luGraph deck analytics initialized');
+      activeDevice = device;
+      rebuildGraph(initialDataset, loadedDeck);
     },
     onFinalize: () => {
       restoreShaderAssembler?.();
       restoreShaderAssembler = null;
+      activeDevice = null;
+      rebuildGeneration++;
+      if (rebuildFrame !== null) cancelAnimationFrame(rebuildFrame);
       draggedVertex = null;
       controls.destroy();
       if (ownsContainer) container.remove();
@@ -158,6 +200,151 @@ export function createLuGraphExplorerDeck(
   });
 
   return deck;
+
+  /** Yields before large CPU generation and GPU allocation so progress remains visible. */
+  function scheduleGraphResize(vertexCount: number): void {
+    const generation = ++rebuildGeneration;
+    pendingGraphVertexCount = vertexCount;
+    loadingStatus = `Preparing ${vertexCount.toLocaleString()} resident vertices…`;
+    controls.update();
+    scheduleAfterPaint(generation, () => {
+      let nextDataset: GraphExplorerDataset;
+      try {
+        nextDataset = makeGraphExplorerDataset(vertexCount);
+      } catch (error) {
+        loadingStatus = error instanceof Error ? error.message : 'Graph generation failed';
+        pendingGraphVertexCount = null;
+        controls.update();
+        return;
+      }
+      loadingStatus = `Uploading ${vertexCount.toLocaleString()} vertices and ${nextDataset.sourceChunks.reduce((total, chunk) => total + chunk.length, 0).toLocaleString()} original edges…`;
+      controls.update();
+      scheduleAfterPaint(generation, () => {
+        try {
+          rebuildGraph(nextDataset);
+          loadingStatus = null;
+          pendingGraphVertexCount = null;
+          controls.update();
+        } catch (error) {
+          loadingStatus =
+            error instanceof Error ? error.message : 'The current adapter cannot hold this graph';
+          pendingGraphVertexCount = null;
+          controls.update();
+        }
+      });
+    });
+  }
+
+  /** Uses two frame callbacks so the current status is painted before expensive synchronous work. */
+  function scheduleAfterPaint(generation: number, callback: () => void): void {
+    if (rebuildFrame !== null) cancelAnimationFrame(rebuildFrame);
+    rebuildFrame = requestAnimationFrame(() => {
+      if (generation !== rebuildGeneration || !activeDevice) return;
+      rebuildFrame = requestAnimationFrame(() => {
+        rebuildFrame = null;
+        if (generation === rebuildGeneration && activeDevice) callback();
+      });
+    });
+  }
+
+  /** Rebuilds resident algorithms and original source layers without changing Deck's camera. */
+  function rebuildGraph(
+    nextDataset: GraphExplorerDataset,
+    targetDeck: ArrowDeck<OrthographicView> = deck
+  ): void {
+    if (!activeDevice) return;
+    const previousDepth = effect?.currentNeighborhoodDepth ?? DEFAULT_NEIGHBORHOOD_DEPTH;
+    const previousSelection = effect?.currentSelection ?? 0;
+    latestStats = null;
+    draggedVertex = null;
+    if (nextDataset.vertexCount >= GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT) {
+      edgesVisible = false;
+    }
+    const nextEffect = new LuGraphDeckEffect(activeDevice, nextDataset, {
+      layoutMode: currentLayoutMode,
+      pointMode,
+      maxVisibleEdges,
+      addSampledLayoutToGraph: addGraphExplorerSampledLayoutToGraph,
+      onStats: stats => {
+        latestStats = stats;
+        controls.update();
+      }
+    });
+    nextEffect.setNeighborhoodDepth(previousDepth);
+    nextEffect.setSelectedVertex(
+      previousSelection !== null && previousSelection < nextDataset.vertexCount
+        ? previousSelection
+        : null
+    );
+    effect = nextEffect;
+    targetDeck.setProps({effects: [nextEffect], layers: createLayers(nextEffect)});
+    controls.update();
+    // Deck updates same-ID layer bindings at the start of its next animation frame. Drawing
+    // synchronously here would reuse the previous effect's already-destroyed GPU allocations.
+  }
+
+  /** Preserves stable layer IDs while custom layers rebind each newly owned physical buffer. */
+  function updateLayers(reason: string): void {
+    if (!effect || !deck) return;
+    deck.setProps({layers: createLayers(effect)});
+    controls.update();
+    deck.redraw(reason);
+  }
+
+  function createLayers(graphEffect: LuGraphDeckEffect): (LuGraphEdgeLayer | LuGraphNodeLayer)[] {
+    const nonemptyChunkCount = graphEffect.graph.sourceVertices.data.filter(
+      chunk => chunk.length > 0
+    ).length;
+    let remainingVisibleEdges = graphEffect.renderedEdgeCount;
+    let remainingVisibleChunks = nonemptyChunkCount;
+    const edgeLayers = edgesVisible
+      ? graphEffect.graph.sourceVertices.data.flatMap((source, chunkIndex) => {
+          if (source.length === 0) return [];
+          const target = graphEffect.graph.targetVertices.data[chunkIndex];
+          const visibleEdgeCount = Math.min(
+            source.length,
+            Math.ceil(remainingVisibleEdges / Math.max(remainingVisibleChunks, 1))
+          );
+          remainingVisibleEdges -= visibleEdgeCount;
+          remainingVisibleChunks--;
+          if (visibleEdgeCount === 0) return [];
+          return [
+            new LuGraphEdgeLayer({
+              id: `lugraph-edges-${chunkIndex}`,
+              data: [],
+              pickable: false,
+              positions: graphEffect.positions,
+              sourceVertices:
+                source.buffer instanceof Buffer ? source.buffer : source.buffer.buffer,
+              targetVertices:
+                target.buffer instanceof Buffer ? target.buffer : target.buffer.buffer,
+              distances: graphEffect.distances,
+              edgeCount: visibleEdgeCount,
+              opacity: graphEffect.graph.vertexCount > 1_024 ? 0.22 : 0.55
+            })
+          ];
+        })
+      : [];
+    const nodeLayer = new LuGraphNodeLayer({
+      id: 'lugraph-nodes',
+      data: [],
+      pickable: true,
+      autoHighlight: true,
+      positions: graphEffect.positions,
+      importance: graphEffect.importance,
+      degrees: graphEffect.degreeValues,
+      components: graphEffect.componentLabels,
+      communities: graphEffect.communityLabels,
+      distances: graphEffect.distances,
+      selectionMask: graphEffect.selectionMask,
+      colorMode: currentColorMode,
+      sizeMode: currentNodeSizeMode,
+      pointMode: graphEffect.renderMode === 'points',
+      vertexCount: graphEffect.graph.vertexCount,
+      opacity: 1
+    });
+    return [...edgeLayers, nodeLayer];
+  }
 }
 
 /** Bridges exactly one legacy Deck assembler call while preserving strict language separation. */
@@ -208,54 +395,415 @@ function updateDraggedVertex(effect: LuGraphDeckEffect, vertex: number, info: Pi
 function getVertexTooltip(info: PickingInfo, effect: LuGraphDeckEffect | null): string | null {
   if (!info.picked || info.index < 0 || !effect) return null;
   const state = effect.isVertexPinned(info.index) ? 'pinned' : 'movable';
-  return `Vertex ${info.index} · ${state}\nGPU PageRank sizing · component color`;
+  return `Vertex ${info.index} · ${state}\nGPU communities · PageRank · neighborhood`;
 }
 
-/** Provides explicit selection/reset controls without polling or transferring graph metrics. */
+/** Provides an accessible, resident-graph control surface without polling GPU columns. */
 function createExplorerControls(
   container: HTMLDivElement,
-  props: {getEffect: () => LuGraphDeckEffect | null; redraw: (reason: string) => void}
+  props: GraphExplorerControlProps
 ): GraphExplorerControls {
   const panel = document.createElement('section');
+  panel.setAttribute('aria-label', 'GPU graph explorer controls and live diagnostics');
+  panel.setAttribute('data-lugraph-inspector', '');
   Object.assign(panel.style, {
     position: 'absolute',
-    left: '14px',
-    top: '14px',
+    left: '18px',
+    top: '76px',
     zIndex: '2',
-    width: '250px',
-    padding: '12px 14px',
-    borderRadius: '10px',
-    background: 'rgba(9, 15, 28, 0.86)',
-    border: '1px solid rgba(127, 173, 230, 0.2)',
-    color: '#eaf3ff',
-    font: '12px/1.5 system-ui, sans-serif'
+    width: 'min(324px, calc(100% - 36px))',
+    maxHeight: 'calc(100% - 94px)',
+    overflowY: 'auto',
+    boxSizing: 'border-box',
+    padding: '16px',
+    borderRadius: '16px',
+    background: 'linear-gradient(160deg, rgba(11, 18, 38, 0.96), rgba(8, 13, 27, 0.92))',
+    border: '1px solid rgba(113, 161, 242, 0.24)',
+    boxShadow: '0 18px 55px rgba(0, 0, 0, 0.34)',
+    backdropFilter: 'blur(16px)',
+    pointerEvents: 'auto',
+    touchAction: 'auto',
+    color: '#edf4ff',
+    font: '12px/1.48 system-ui, sans-serif'
   });
+  const initialSizeIndex = Math.max(
+    0,
+    GRAPH_EXPLORER_VERTEX_COUNTS.indexOf(GRAPH_EXPLORER_SHOWCASE_DEFAULT_VERTEX_COUNT)
+  );
   panel.innerHTML = `
-    <strong style="display:block;font-size:14px">luGraph + deck.gl</strong>
-    <p style="margin:6px 0 9px;opacity:.8">Resident graph analytics, source-chunk edge layers,
-      direct instance vertices, and real asynchronous deck.gl picking.</p>
-    <label style="display:block;margin-bottom:8px">Neighborhood depth
-      <input data-lugraph-depth type="range" min="0" max="8"
-        value="${DEFAULT_NEIGHBORHOOD_DEPTH}" style="display:block;width:100%" />
+    <div style="display:flex;align-items:center;justify-content:space-between;gap:8px">
+      <strong style="font-size:16px;letter-spacing:-.25px">Graph Observatory</strong>
+      <span style="padding:3px 8px;border-radius:99px;background:#123a45;color:#80eadb;
+        font-size:10px;font-weight:700;letter-spacing:.4px">LIVE GPU</span>
+    </div>
+    <p style="margin:7px 0 14px;color:#a9b8d0">Resident graph analytics and direct
+      deck.gl rendering. No per-frame graph readback.</p>
+
+    <label style="display:block;margin-bottom:13px">
+      <span style="display:flex;justify-content:space-between;color:#b9c8df">Graph size
+        <strong data-lugraph-size-value style="color:#8ccfff">1,024</strong>
+      </span>
+      <input data-lugraph-size aria-label="Graph vertex count" type="range" min="0"
+        max="${GRAPH_EXPLORER_VERTEX_COUNTS.length - 1}" step="1"
+        value="${initialSizeIndex}" style="width:100%;margin:8px 0 0;accent-color:#76bbff" />
+      <span style="display:flex;justify-content:space-between;color:#8798b2;font-size:10px">
+        <span>128</span>
+        <span>${GRAPH_EXPLORER_VERTEX_COUNTS[GRAPH_EXPLORER_VERTEX_COUNTS.length - 1].toLocaleString()} vertices</span>
+      </span>
     </label>
-    <div style="display:flex;gap:8px">
+
+    <div style="display:flex;align-items:center;justify-content:space-between;margin:-5px 0 12px">
+      <button data-lugraph-size-decrease type="button"
+        aria-label="Decrease graph population">−</button>
+      <span style="font-size:10px;color:#8798b2">14 actual resident graph populations</span>
+      <button data-lugraph-size-increase type="button"
+        aria-label="Increase graph population">+</button>
+    </div>
+
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:9px;margin-bottom:11px">
+      <label>Color by
+        <select data-lugraph-color aria-label="Node color encoding"
+          style="display:block;width:100%;margin-top:4px">
+          <option value="community">Communities</option>
+          <option value="component">Components</option>
+          <option value="degree">Degree</option>
+          <option value="pagerank">PageRank</option>
+          <option value="distance">Distance</option>
+        </select>
+      </label>
+      <label>Node size
+        <select data-lugraph-node-size aria-label="Node size encoding"
+          style="display:block;width:100%;margin-top:4px">
+          <option value="pagerank">PageRank</option>
+          <option value="degree">Degree</option>
+          <option value="uniform">Uniform</option>
+        </select>
+      </label>
+    </div>
+
+    <label style="display:block;margin-bottom:10px">Force layout
+      <select data-lugraph-layout aria-label="GPU force layout algorithm"
+        style="display:block;width:100%;margin-top:4px">
+        <option value="auto">Adaptive · exact / spatial / sampled</option>
+        <option value="exact">Exact · bounded population</option>
+        <option value="spatial">Spatial · near / far grid</option>
+        <option value="sampled">Linear · four sampled repulsions</option>
+      </select>
+    </label>
+
+    <label style="display:block;margin-bottom:10px">Neighborhood depth
+      <input data-lugraph-depth aria-label="GPU neighborhood breadth-first search depth"
+        type="range" min="0" max="8" value="${DEFAULT_NEIGHBORHOOD_DEPTH}"
+        style="display:block;width:100%;margin-top:5px;accent-color:#d692ff" />
+    </label>
+
+    <label style="display:flex;align-items:center;gap:7px;margin-bottom:12px;color:#c4d0e2">
+      <input data-lugraph-edges type="checkbox" checked aria-label="Show original graph edges" />
+      Show original source-chunk edges <span data-lugraph-edge-count></span>
+    </label>
+
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:7px;padding:10px;
+      border:1px solid rgba(113,161,242,.16);border-radius:11px;background:rgba(4,9,20,.48)">
+      <span style="color:#9dafc8">Frame rate</span>
+      <strong data-lugraph-fps style="text-align:right">—</strong>
+      <span style="color:#9dafc8">CPU encode</span>
+      <strong data-lugraph-encode style="text-align:right">—</strong>
+      <span style="color:#9dafc8">Resident memory</span>
+      <strong data-lugraph-memory style="text-align:right">—</strong>
+      <span style="color:#9dafc8">Spatial index</span>
+      <strong data-lugraph-index style="text-align:right">—</strong>
+      <span style="color:#9dafc8">GPU pipeline</span>
+      <strong data-lugraph-pipeline style="text-align:right">—</strong>
+      <span style="color:#9dafc8">Bounded rounds</span>
+      <strong data-lugraph-iterations style="text-align:right">—</strong>
+    </div>
+
+    <div data-lugraph-legend aria-label="GPU graph visualization legend"
+      style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin:11px 0;color:#b9c8df">
+      <span style="width:9px;height:9px;border-radius:50%;background:#42c9ff"></span>Community
+      <span style="width:9px;height:9px;border-radius:50%;background:#ffb04b"></span>Selected
+      <span style="width:9px;height:9px;border-radius:50%;background:#ad7bff"></span>Neighborhood
+    </div>
+
+    <div style="display:flex;gap:6px;flex-wrap:wrap">
+      <button data-lugraph-pause type="button" aria-label="Pause progressive GPU layout">Pause</button>
       <button data-lugraph-reset type="button">Reset layout</button>
       <button data-lugraph-release type="button">Release pins</button>
     </div>
-    <p data-lugraph-status style="margin:9px 0 0;opacity:.85">Initializing WebGPU graph…</p>
-    <p style="margin:6px 0 0;opacity:.64">Click to inspect · drag to pin · scroll to zoom</p>`;
+    <p data-lugraph-status role="status" aria-live="polite"
+      style="margin:11px 0 3px;color:#b4c5df">Initializing WebGPU graph…</p>
+    <p style="margin:4px 0 0;color:#8293ad;font-size:11px">Click a node · drag to pin · scroll to zoom</p>`;
   container.appendChild(panel);
 
+  for (const control of panel.querySelectorAll<HTMLElement>('select, button')) {
+    Object.assign(control.style, {
+      border: '1px solid rgba(136, 170, 222, 0.26)',
+      borderRadius: '7px',
+      background: '#121d32',
+      color: '#e6efff',
+      padding: '5px 7px',
+      font: '11px system-ui, sans-serif'
+    });
+  }
+
+  const size = panel.querySelector<HTMLInputElement>('[data-lugraph-size]');
+  const sizeValue = panel.querySelector<HTMLElement>('[data-lugraph-size-value]');
+  const decreaseSize = panel.querySelector<HTMLButtonElement>('[data-lugraph-size-decrease]');
+  const increaseSize = panel.querySelector<HTMLButtonElement>('[data-lugraph-size-increase]');
+  const layout = panel.querySelector<HTMLSelectElement>('[data-lugraph-layout]');
+  const color = panel.querySelector<HTMLSelectElement>('[data-lugraph-color]');
+  const nodeSize = panel.querySelector<HTMLSelectElement>('[data-lugraph-node-size]');
+  const edges = panel.querySelector<HTMLInputElement>('[data-lugraph-edges]');
   const depth = panel.querySelector<HTMLInputElement>('[data-lugraph-depth]');
+  const edgeCount = panel.querySelector<HTMLElement>('[data-lugraph-edge-count]');
+  const pause = panel.querySelector<HTMLButtonElement>('[data-lugraph-pause]');
   const reset = panel.querySelector<HTMLButtonElement>('[data-lugraph-reset]');
   const release = panel.querySelector<HTMLButtonElement>('[data-lugraph-release]');
   const status = panel.querySelector<HTMLElement>('[data-lugraph-status]');
+  const framesPerSecond = panel.querySelector<HTMLElement>('[data-lugraph-fps]');
+  const encoding = panel.querySelector<HTMLElement>('[data-lugraph-encode]');
+  const memory = panel.querySelector<HTMLElement>('[data-lugraph-memory]');
+  const spatialIndex = panel.querySelector<HTMLElement>('[data-lugraph-index]');
+  const pipeline = panel.querySelector<HTMLElement>('[data-lugraph-pipeline]');
+  const iterations = panel.querySelector<HTMLElement>('[data-lugraph-iterations]');
+  const isolatedInteractionEvents = [
+    'pointerdown',
+    'pointermove',
+    'pointerup',
+    'mousedown',
+    'mouseup',
+    'touchstart',
+    'touchmove',
+    'touchend',
+    'keydown',
+    'keyup'
+  ] as const;
+  const stopDeckInteraction = (event: Event): void => {
+    event.stopPropagation();
+  };
+  for (const eventName of isolatedInteractionEvents) {
+    panel.addEventListener(eventName, stopDeckInteraction);
+  }
+  let sizeDebounce: ReturnType<typeof setTimeout> | null = null;
+  let pendingVertexCount: number | null = null;
+  let activeSizePointer: number | null = null;
+  let paused = false;
+
   const update = (): void => {
     const effect = props.getEffect();
     if (!effect || !status) return;
+    const statistics = props.getStats();
     const selected = effect.currentSelection === null ? 'none' : `${effect.currentSelection}`;
-    status.textContent = `${effect.graph.vertexCount} vertices · ${effect.graph.edgeCount} chunked edges · selected ${selected}`;
+    const vertexCount = effect.graph.vertexCount;
+    const sizeIndex = GRAPH_EXPLORER_VERTEX_COUNTS.findIndex(count => count === vertexCount);
+    const pendingGraph = props.getPendingVertexCount();
+    if (size) size.disabled = pendingGraph !== null;
+    if (decreaseSize) decreaseSize.disabled = pendingGraph !== null;
+    if (increaseSize) increaseSize.disabled = pendingGraph !== null;
+    if (pendingVertexCount === null && pendingGraph === null) {
+      if (size && sizeIndex >= 0) size.value = `${sizeIndex}`;
+      if (sizeValue) sizeValue.textContent = vertexCount.toLocaleString();
+    } else if (sizeValue && pendingGraph !== null) {
+      sizeValue.textContent = pendingGraph.toLocaleString();
+    }
+    const exactOption = layout?.querySelector<HTMLOptionElement>('option[value="exact"]');
+    if (exactOption) {
+      exactOption.disabled = vertexCount > GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT;
+    }
+    if (edges) edges.checked = props.getEdgesVisible();
+    const visibleEdges = props.getEdgesVisible() ? effect.renderedEdgeCount : 0;
+    if (edgeCount) {
+      edgeCount.textContent = `${visibleEdges.toLocaleString()} / ${effect.graph.edgeCount.toLocaleString()}`;
+    }
+    const boundedAnalysis =
+      effect.activeLayoutMode === 'sampled' &&
+      effect.graph.vertexCount >= GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT
+        ? ' · bounded analytics; convergence not sampled'
+        : '';
+    status.textContent =
+      props.getLoadingStatus() ??
+      `${vertexCount.toLocaleString()} resident vertices · ${visibleEdges.toLocaleString()} / ${effect.graph.edgeCount.toLocaleString()} original edges drawn · ${effect.activeLayoutMode} GPU layout · ${effect.renderMode} · selected ${selected}${boundedAnalysis}`;
+    if (framesPerSecond) {
+      framesPerSecond.textContent = statistics?.framesPerSecond
+        ? `${Math.round(statistics.framesPerSecond)} fps`
+        : 'warming up';
+    }
+    if (encoding) {
+      encoding.textContent = statistics
+        ? `${statistics.frameEncodeMilliseconds.toFixed(2)} ms`
+        : 'pending';
+    }
+    if (memory) {
+      memory.textContent = statistics
+        ? formatGraphBytes(statistics.residentBufferBytes + statistics.transientBufferBytes)
+        : 'pending';
+    }
+    if (spatialIndex) {
+      spatialIndex.textContent = statistics?.gridCellCount
+        ? `${statistics.gridCellCount} cells · ${formatGraphBytes(statistics.spatialIndexBytes)}`
+        : effect.activeLayoutMode === 'sampled'
+          ? '4 samples / vertex'
+          : 'exact';
+    }
+    if (pipeline) {
+      pipeline.textContent = statistics
+        ? `${statistics.completedAnalysisStages}/${statistics.totalAnalysisStages} init · ${statistics.frameNodeCount} frame`
+        : 'compiling';
+    }
+    if (iterations) {
+      iterations.textContent = statistics
+        ? `P${statistics.pageRankIterations} · W${statistics.componentIterations} · L${statistics.communityIterations}`
+        : 'pending';
+    }
   };
+
+  const getSelectedVertexCount = (): number =>
+    GRAPH_EXPLORER_VERTEX_COUNTS[Number(size?.value ?? initialSizeIndex)] ??
+    GRAPH_EXPLORER_SHOWCASE_DEFAULT_VERTEX_COUNT;
+
+  const commitSize = (): void => {
+    if (sizeDebounce !== null) {
+      clearTimeout(sizeDebounce);
+      sizeDebounce = null;
+    }
+    const vertexCount = pendingVertexCount ?? getSelectedVertexCount();
+    pendingVertexCount = null;
+    if (props.getEffect()?.graph.vertexCount !== vertexCount) props.resize(vertexCount);
+  };
+
+  const previewSize = (): void => {
+    pendingVertexCount = getSelectedVertexCount();
+    if (sizeValue) sizeValue.textContent = pendingVertexCount.toLocaleString();
+    if (sizeDebounce !== null) clearTimeout(sizeDebounce);
+    sizeDebounce = setTimeout(commitSize, 140);
+  };
+
+  /** Implements native range keyboard semantics before Deck can reinterpret arrows as panning. */
+  const stepSize = (step: number): void => {
+    if (!size || size.disabled) return;
+    const index = Math.max(
+      0,
+      Math.min(GRAPH_EXPLORER_VERTEX_COUNTS.length - 1, Number(size.value) + step)
+    );
+    size.value = `${index}`;
+    previewSize();
+    commitSize();
+  };
+
+  const updateSizeFromKeyboard = (event: KeyboardEvent): void => {
+    if (!size || size.disabled) return;
+    let index = Number(size.value);
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowUp':
+        index++;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        index--;
+        break;
+      case 'Home':
+        index = 0;
+        break;
+      case 'End':
+        index = GRAPH_EXPLORER_VERTEX_COUNTS.length - 1;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    const bounded = Math.max(0, Math.min(GRAPH_EXPLORER_VERTEX_COUNTS.length - 1, index));
+    size.value = `${bounded}`;
+    previewSize();
+    commitSize();
+  };
+
+  /** Maps real pointer coordinates to the same discrete populations used by keyboard controls. */
+  const previewSizeFromPointer = (event: PointerEvent): void => {
+    if (!size || size.disabled) return;
+    const bounds = size.getBoundingClientRect();
+    if (bounds.width <= 0) return;
+    const fraction = Math.max(0, Math.min(1, (event.clientX - bounds.left) / bounds.width));
+    size.value = `${Math.round(fraction * (GRAPH_EXPLORER_VERTEX_COUNTS.length - 1))}`;
+    previewSize();
+    if (sizeDebounce !== null) {
+      clearTimeout(sizeDebounce);
+      sizeDebounce = null;
+    }
+  };
+
+  const startSizePointer = (event: PointerEvent): void => {
+    if (!size || size.disabled || event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    activeSizePointer = event.pointerId;
+    size.focus();
+    size.setPointerCapture(event.pointerId);
+    previewSizeFromPointer(event);
+  };
+
+  const moveSizePointer = (event: PointerEvent): void => {
+    if (event.pointerId !== activeSizePointer) return;
+    event.stopPropagation();
+    previewSizeFromPointer(event);
+  };
+
+  const finishSizePointer = (event: PointerEvent): void => {
+    if (!size || event.pointerId !== activeSizePointer) return;
+    event.stopPropagation();
+    previewSizeFromPointer(event);
+    activeSizePointer = null;
+    if (size.hasPointerCapture(event.pointerId)) size.releasePointerCapture(event.pointerId);
+    commitSize();
+  };
+
+  const decreaseGraphSize = (): void => stepSize(-1);
+  const increaseGraphSize = (): void => stepSize(1);
+
+  const updateLayoutMode = (): void => {
+    const mode = layout?.value;
+    if (mode === 'auto' || mode === 'exact' || mode === 'spatial' || mode === 'sampled') {
+      props.setLayoutMode(mode);
+    }
+  };
+
+  const updateColorMode = (): void => {
+    const mode = color?.value;
+    if (
+      mode === 'community' ||
+      mode === 'component' ||
+      mode === 'degree' ||
+      mode === 'pagerank' ||
+      mode === 'distance'
+    ) {
+      props.setColorMode(mode);
+    }
+  };
+
+  const updateNodeSizeMode = (): void => {
+    const mode = nodeSize?.value;
+    if (mode === 'pagerank' || mode === 'degree' || mode === 'uniform') {
+      props.setNodeSizeMode(mode);
+    }
+  };
+
+  const updateEdgeVisibility = (): void => {
+    props.setEdgesVisible(edges?.checked ?? true);
+  };
+
+  const togglePause = (): void => {
+    paused = !paused;
+    if (pause) {
+      pause.textContent = paused ? 'Resume' : 'Pause';
+      pause.setAttribute(
+        'aria-label',
+        paused ? 'Resume progressive GPU layout' : 'Pause progressive GPU layout'
+      );
+    }
+    props.setPaused(paused);
+  };
+
   const updateDepth = (): void => {
     props.getEffect()?.setNeighborhoodDepth(Number(depth?.value ?? DEFAULT_NEIGHBORHOOD_DEPTH));
     props.redraw('luGraph deck neighborhood depth changed');
@@ -269,19 +817,58 @@ function createExplorerControls(
     update();
     props.redraw('luGraph deck pins released');
   };
+  size?.addEventListener('input', previewSize);
+  size?.addEventListener('change', commitSize);
+  size?.addEventListener('keydown', updateSizeFromKeyboard);
+  size?.addEventListener('pointerdown', startSizePointer);
+  size?.addEventListener('pointermove', moveSizePointer);
+  size?.addEventListener('pointerup', finishSizePointer);
+  size?.addEventListener('pointercancel', finishSizePointer);
+  decreaseSize?.addEventListener('click', decreaseGraphSize);
+  increaseSize?.addEventListener('click', increaseGraphSize);
+  layout?.addEventListener('change', updateLayoutMode);
+  color?.addEventListener('change', updateColorMode);
+  nodeSize?.addEventListener('change', updateNodeSizeMode);
+  edges?.addEventListener('change', updateEdgeVisibility);
   depth?.addEventListener('input', updateDepth);
+  pause?.addEventListener('click', togglePause);
   reset?.addEventListener('click', resetLayout);
   release?.addEventListener('click', clearPins);
 
   return {
     update,
     destroy: () => {
+      if (sizeDebounce !== null) clearTimeout(sizeDebounce);
+      for (const eventName of isolatedInteractionEvents) {
+        panel.removeEventListener(eventName, stopDeckInteraction);
+      }
+      size?.removeEventListener('input', previewSize);
+      size?.removeEventListener('change', commitSize);
+      size?.removeEventListener('keydown', updateSizeFromKeyboard);
+      size?.removeEventListener('pointerdown', startSizePointer);
+      size?.removeEventListener('pointermove', moveSizePointer);
+      size?.removeEventListener('pointerup', finishSizePointer);
+      size?.removeEventListener('pointercancel', finishSizePointer);
+      decreaseSize?.removeEventListener('click', decreaseGraphSize);
+      increaseSize?.removeEventListener('click', increaseGraphSize);
+      layout?.removeEventListener('change', updateLayoutMode);
+      color?.removeEventListener('change', updateColorMode);
+      nodeSize?.removeEventListener('change', updateNodeSizeMode);
+      edges?.removeEventListener('change', updateEdgeVisibility);
       depth?.removeEventListener('input', updateDepth);
+      pause?.removeEventListener('click', togglePause);
       reset?.removeEventListener('click', resetLayout);
       release?.removeEventListener('click', clearPins);
       panel.remove();
     }
   };
+}
+
+/** Formats measured buffer allocation sizes without inventing GPU timing measurements. */
+function formatGraphBytes(byteLength: number): string {
+  if (byteLength < 1_024) return `${byteLength} B`;
+  if (byteLength < 1_048_576) return `${(byteLength / 1_024).toFixed(1)} KB`;
+  return `${(byteLength / 1_048_576).toFixed(2)} MB`;
 }
 
 function createStandaloneContainer(): HTMLDivElement {

--- a/examples/deck/lugraph-explorer/app.ts
+++ b/examples/deck/lugraph-explorer/app.ts
@@ -610,6 +610,10 @@ function createExplorerControls(
     if (exactOption) {
       exactOption.disabled = vertexCount > GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT;
     }
+    const spatialOption = layout?.querySelector<HTMLOptionElement>('option[value="spatial"]');
+    if (spatialOption) {
+      spatialOption.disabled = vertexCount >= GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT;
+    }
     if (edges) edges.checked = props.getEdgesVisible();
     const visibleEdges = props.getEdgesVisible() ? effect.renderedEdgeCount : 0;
     if (edgeCount) {

--- a/examples/experimental/lugraph-explorer/app.ts
+++ b/examples/experimental/lugraph-explorer/app.ts
@@ -20,7 +20,9 @@ import {
   LuGraphConnectedComponents,
   LuGraphDegree,
   LuGraphForceLayout,
+  LuGraphLabelPropagation,
   LuGraphPageRank,
+  LuGraphSpatialForceLayout,
   LuGraphTopology,
   type LuGraphAdjacency
 } from '@luma.gl/experimental/lugraph';
@@ -30,7 +32,22 @@ import {
   makeExamplePanelHostHtml,
   makeHtmlCustomPanel
 } from '../../example-panels';
-import {makeGraphExplorerDataset} from './graph-data';
+import {
+  GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT,
+  GRAPH_EXPLORER_MAX_VISIBLE_EDGES,
+  GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT,
+  GRAPH_EXPLORER_POINT_VERTEX_COUNT,
+  GRAPH_EXPLORER_SHOWCASE_DEFAULT_VERTEX_COUNT,
+  GRAPH_EXPLORER_SPATIAL_BOUNDS,
+  GRAPH_EXPLORER_VERTEX_COUNTS,
+  getGraphExplorerGridSize,
+  makeGraphExplorerDataset,
+  type GraphExplorerColorMode,
+  type GraphExplorerDataset,
+  type GraphExplorerLayoutMode,
+  type GraphExplorerNodeSizeMode
+} from './graph-data';
+import {addGraphExplorerSampledLayoutToGraph} from './graph-scale-layout';
 import {
   GRAPH_EXPLORER_EDGE_SHADER,
   GRAPH_EXPLORER_NODE_SHADER,
@@ -48,20 +65,6 @@ const INVALID_VERTEX = 0xffffffff;
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 
 type ScalarVectorFormat = 'uint32' | 'float32';
-type GraphExplorerColorMode = 'component' | 'degree' | 'pagerank' | 'distance';
-type GraphExplorerNodeSizeMode = 'pagerank' | 'degree' | 'uniform';
-
-const GRAPH_EXPLORER_COLOR_MODES: GraphExplorerColorMode[] = [
-  'component',
-  'degree',
-  'pagerank',
-  'distance'
-];
-const GRAPH_EXPLORER_NODE_SIZE_MODES: GraphExplorerNodeSizeMode[] = [
-  'pagerank',
-  'degree',
-  'uniform'
-];
 
 type FrameParameters = {
   width: number;
@@ -77,37 +80,53 @@ type EdgeModel = {
   chunkIndex: number;
 };
 
+type GraphExplorerAnimationProps = AnimationProps & {
+  dataset?: GraphExplorerDataset;
+  vertexCount?: number;
+  layoutMode?: GraphExplorerLayoutMode;
+  pointMode?: boolean;
+  maxVisibleEdges?: number;
+};
+
 /** Interactive browser-native graph exploration with no per-frame graph readback. */
 export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopTemplate {
   static info = makeExamplePanelHostHtml();
   static props = {createFramebuffer: true, debug: true};
 
   readonly device: Device;
-  readonly graph: LuGraph;
-  readonly topology: LuGraphTopology;
-  readonly degree: LuGraphDegree;
-  readonly pageRank: LuGraphPageRank;
-  readonly components: LuGraphConnectedComponents;
-  readonly search: LuGraphBreadthFirstSearch;
-  readonly layout: LuGraphForceLayout;
-  readonly nodeModel: Model;
-  readonly pickingModel: Model;
-  readonly edgeModels: EdgeModel[];
-  readonly analysisGraph: CompiledGPUCommandGraph<void>;
-  frameGraph: CompiledGPUCommandGraph<FrameParameters>;
-  pickingGraph: CompiledGPUCommandGraph<PickingParameters>;
+  graph!: LuGraph;
+  topology!: LuGraphTopology;
+  degree!: LuGraphDegree;
+  pageRank!: LuGraphPageRank;
+  components!: LuGraphConnectedComponents;
+  communities!: LuGraphLabelPropagation;
+  search!: LuGraphBreadthFirstSearch;
+  layout!: LuGraphForceLayout;
+  spatialLayout: LuGraphSpatialForceLayout | null = null;
+  activeLayoutMode: 'exact' | 'spatial' | 'sampled' = 'exact';
+  pointMode = false;
+  nodeModel!: Model;
+  pickingModel!: Model;
+  edgeModels!: EdgeModel[];
+  analysisGraph!: CompiledGPUCommandGraph<void>;
+  frameGraph!: CompiledGPUCommandGraph<FrameParameters>;
+  pickingGraph!: CompiledGPUCommandGraph<PickingParameters>;
+  private searchGraph: CompiledGPUCommandGraph<void> | null = null;
+  private readonly analysisStages: CompiledGPUCommandGraph<void>[] = [];
 
   private readonly buffers: Buffer[] = [];
   private readonly vectors: GPUVector[] = [];
   private readonly viewUniforms: Buffer;
   private readonly readbackRing: GPUReadbackRing;
   private readonly panels: ExamplePanelManager;
-  private readonly seeds: GPUVector<'uint32'>;
-  private readonly seedCount: GPUVector<'uint32'>;
-  private readonly activeDepth: GPUVector<'uint32'>;
-  private readonly pinned: GPUVector<'uint32'>;
-  private readonly reset: GPUVector<'uint32'>;
-  private readonly neighborhoodMask: GPUVector<'uint32'>;
+  private readonly pointModeOverride: boolean | undefined;
+  private readonly maxVisibleEdges: number;
+  private seeds!: GPUVector<'uint32'>;
+  private seedCount!: GPUVector<'uint32'>;
+  private activeDepth!: GPUVector<'uint32'>;
+  private pinned!: GPUVector<'uint32'>;
+  private reset!: GPUVector<'uint32'>;
+  private neighborhoodMask!: GPUVector<'uint32'>;
 
   private frameColorId = '';
   private frameDepthId = '';
@@ -116,6 +135,8 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
   private frameHeight = 1;
   private frameIndex = 0;
   private analyticsPending = true;
+  private nextAnalysisStage = 0;
+  private searchPending = true;
   private selectedVertex: number | null = 0;
   private pendingPick: readonly [number, number] | null = null;
   private pendingPickSession: number | null = null;
@@ -127,30 +148,39 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
   private neighborhoodDepth = INITIAL_NEIGHBORHOOD_DEPTH;
   private centerX = 0;
   private centerY = 0;
-  private zoom = 0.55;
+  private zoom = 0.42;
   private dragging = false;
-  private paused = false;
-  private edgesVisible = true;
-  private colorMode: GraphExplorerColorMode = 'component';
-  private nodeSizeMode: GraphExplorerNodeSizeMode = 'pagerank';
-  private sampledFrameCount = 0;
-  private sampledFrameTime = 0;
-  private framesPerSecond = 0;
-  private cpuEncodeTimeMilliseconds = 0;
   private lastPointer: [number, number] | null = null;
   private canvas: HTMLCanvasElement | null = null;
   private statusElement: HTMLElement | null = null;
-  private legendElement: HTMLElement | null = null;
-  private adapterElement: HTMLElement | null = null;
-  private memoryElement: HTMLElement | null = null;
-  private frameRateElement: HTMLElement | null = null;
+  private graphSizeElement: HTMLElement | null = null;
+  private controlsRoot: HTMLElement | null = null;
+  private layoutMode: GraphExplorerLayoutMode = 'auto';
+  private colorMode: GraphExplorerColorMode = 'community';
+  private nodeSizeMode: GraphExplorerNodeSizeMode = 'pagerank';
+  private edgesVisible = true;
+  private paused = false;
+  private lastFrameTimestamp = 0;
+  private lastStatusTimestamp = 0;
+  private frameRate = 0;
+  private cpuEncodeMilliseconds = 0;
 
-  constructor({device}: AnimationProps) {
+  constructor({
+    device,
+    dataset,
+    vertexCount,
+    layoutMode,
+    pointMode,
+    maxVisibleEdges
+  }: GraphExplorerAnimationProps) {
     super();
     if (device.type !== 'webgpu') {
       throw new Error('luGraph GPU Graph Explorer requires WebGPU');
     }
     this.device = device;
+    this.layoutMode = layoutMode ?? 'auto';
+    this.pointModeOverride = pointMode;
+    this.maxVisibleEdges = maxVisibleEdges ?? GRAPH_EXPLORER_MAX_VISIBLE_EDGES;
     this.viewUniforms = device.createBuffer({
       id: 'lugraph-explorer-view',
       byteLength: GRAPH_EXPLORER_VIEW_BYTE_LENGTH,
@@ -162,7 +192,102 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
       slotCount: 2
     });
 
-    const dataset = makeGraphExplorerDataset();
+    const initialDataset =
+      dataset ??
+      makeGraphExplorerDataset(vertexCount ?? GRAPH_EXPLORER_SHOWCASE_DEFAULT_VERTEX_COUNT);
+    const unsupportedGraphReason = this.getUnsupportedGraphReason(initialDataset);
+    if (unsupportedGraphReason) {
+      this.readbackRing.destroy();
+      this.viewUniforms.destroy();
+      throw new Error(unsupportedGraphReason);
+    }
+    this.initializeGraph(initialDataset);
+    this.panels = new ExamplePanelManager({
+      panel: makeHtmlCustomPanel({
+        id: 'lugraph-explorer-controls',
+        title: 'GPU Graph Explorer',
+        html: this.getControlsHtml(),
+        onRender: root => this.attachControls(root)
+      })
+    });
+    this.panels.mount();
+    // Reveal this showcase's analytics once without changing another example or reopening a
+    // panel that its user subsequently chooses to collapse.
+    if (typeof document !== 'undefined') {
+      document
+        .getElementById('example-panel-host')
+        ?.closest<HTMLElement>('[data-info-box-appearance]')
+        ?.querySelector<HTMLButtonElement>(
+          'button[aria-label="Expand info box"][aria-expanded="false"]'
+        )
+        ?.click();
+    }
+    this.writeViewUniforms(this.frameWidth, this.frameHeight);
+  }
+
+  /** Every source-aligned resident node remains an actual rendered GPU instance. */
+  get renderedVertexCount(): number {
+    return this.graph.vertexCount;
+  }
+
+  /** Visible original edge instances are honestly bounded without changing resident rows. */
+  get renderedEdgeCount(): number {
+    return this.edgeModels.reduce((total, {model}) => total + model.instanceCount, 0);
+  }
+
+  /** Replaces one complete caller-owned scene without reusing stale source IDs or allocations. */
+  resizeGraph(vertexCount: number): void {
+    if (this.finalized) return;
+    const dataset = makeGraphExplorerDataset(vertexCount);
+    const unsupportedGraphReason = this.getUnsupportedGraphReason(dataset);
+    if (unsupportedGraphReason) {
+      this.syncGraphControls();
+      if (this.statusElement) this.statusElement.textContent = unsupportedGraphReason;
+      return;
+    }
+    this.pointerSession++;
+    this.activePointerId = null;
+    this.dragPickResolved = false;
+    this.dragVertex = null;
+    this.pendingPick = null;
+    this.pendingPickSession = null;
+    this.dragging = false;
+    this.selectedVertex = 0;
+    this.destroyGraph();
+    this.initializeGraph(dataset);
+    this.writeViewUniforms(this.frameWidth, this.frameHeight);
+    this.syncGraphControls();
+    this.updateStatus();
+  }
+
+  /** Rejects impossible allocations before replacing the existing caller-owned GPU graph. */
+  private getUnsupportedGraphReason(dataset: GraphExplorerDataset): string | null {
+    const edgeCount = dataset.sourceChunks.reduce((count, source) => count + source.length, 0);
+    const requiredBufferBytes = Math.max(
+      dataset.positions.byteLength,
+      dataset.velocities.byteLength,
+      (dataset.vertexCount + 1) * UINT32_BYTE_LENGTH,
+      edgeCount * UINT32_BYTE_LENGTH
+    );
+    const maximumBufferBytes = Math.min(
+      this.device.limits.maxStorageBufferBindingSize,
+      this.device.limits.maxBufferSize
+    );
+    if (requiredBufferBytes <= maximumBufferBytes) return null;
+    const requiredMebibytes = (requiredBufferBytes / 1024 ** 2).toFixed(1);
+    const supportedMebibytes = (maximumBufferBytes / 1024 ** 2).toFixed(1);
+    return (
+      `${dataset.vertexCount.toLocaleString()} vertices require a ${requiredMebibytes} MiB ` +
+      `storage buffer; this WebGPU adapter supports ${supportedMebibytes} MiB. ` +
+      'The current graph remains active.'
+    );
+  }
+
+  /** Builds exact source-preserving analytics and an adaptively bounded layout scene. */
+  private initializeGraph(dataset: GraphExplorerDataset): void {
+    const isLinearScale = dataset.vertexCount >= GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT;
+    this.pointMode =
+      this.pointModeOverride ?? dataset.vertexCount >= GRAPH_EXPLORER_POINT_VERTEX_COUNT;
     const sourceVertices = this.createChunkedVector('source-vertices', dataset.sourceChunks);
     const targetVertices = this.createChunkedVector('target-vertices', dataset.targetChunks);
     this.graph = new LuGraph({
@@ -192,20 +317,31 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
       topology: this.topology,
       output: this.createScalarVector('vertex-importance', 'float32', dataset.vertexCount),
       residual: this.createScalarVector('rank-residual', 'float32', 1),
-      iterations: 16
+      iterations: isLinearScale
+        ? 2
+        : dataset.vertexCount > GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT
+          ? 8
+          : 16
     });
     this.components = new LuGraphConnectedComponents({
       id: 'lugraph-explorer-components',
       topology: this.topology,
       output: this.createScalarVector('vertex-components', 'uint32', dataset.vertexCount),
       converged: this.createScalarVector('components-converged', 'uint32', 1),
-      iterations: 12
+      iterations: isLinearScale ? 4 : 12
+    });
+    this.communities = new LuGraphLabelPropagation({
+      id: 'lugraph-explorer-communities',
+      topology: this.topology,
+      output: this.createScalarVector('community-labels', 'uint32', dataset.vertexCount),
+      converged: this.createScalarVector('communities-converged', 'uint32', 1),
+      iterations: isLinearScale ? 2 : 8
     });
 
     this.seeds = this.createScalarVector('selected-vertices', 'uint32', 1, [0]);
     this.seedCount = this.createScalarVector('selected-vertex-count', 'uint32', 1, [1]);
     this.activeDepth = this.createScalarVector('active-neighborhood-depth', 'uint32', 1, [
-      INITIAL_NEIGHBORHOOD_DEPTH
+      this.neighborhoodDepth
     ]);
     this.neighborhoodMask = this.createScalarVector(
       'selected-neighborhood',
@@ -233,6 +369,7 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
     const velocities = this.createCoordinateVector('vertex-velocities', dataset.velocities);
     this.pinned = this.createScalarVector('pinned-vertices', 'uint32', dataset.vertexCount);
     this.reset = this.createScalarVector('reset-layout', 'uint32', 1, [0]);
+    const useSampledForce = this.layoutMode === 'sampled' || isLinearScale;
     this.layout = new LuGraphForceLayout({
       id: 'lugraph-explorer-layout',
       topology: this.topology,
@@ -241,41 +378,56 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
       pinned: this.pinned,
       reset: this.reset,
       seed: 0x1a2b3c4d,
-      iterationsPerFrame: 2,
-      repulsion: 0.005,
-      attraction: 0.045,
-      gravity: 0.025,
-      damping: 0.85,
-      maxVelocity: 0.045
+      iterationsPerFrame: dataset.vertexCount > GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT ? 1 : 2,
+      repulsion: useSampledForce ? 0.0015 : 0.005 * Math.min(1, 128 / dataset.vertexCount),
+      attraction: useSampledForce ? 0.04 : 0.045,
+      gravity: useSampledForce ? 0.005 : 0.025,
+      damping: useSampledForce ? 0.9 : 0.85,
+      maxVelocity: dataset.vertexCount > GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT ? 0.025 : 0.045
     });
+
+    this.activeLayoutMode = useSampledForce
+      ? 'sampled'
+      : this.layoutMode === 'spatial' ||
+          dataset.vertexCount > GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT
+        ? 'spatial'
+        : 'exact';
+    const useSpatialLayout = this.activeLayoutMode === 'spatial';
+    if (useSpatialLayout) {
+      const gridSize = getGraphExplorerGridSize(dataset.vertexCount);
+      const cellCount = gridSize[0] * gridSize[1];
+      this.spatialLayout = new LuGraphSpatialForceLayout({
+        id: 'lugraph-explorer-spatial-layout',
+        layout: this.layout,
+        gridSize,
+        bounds: GRAPH_EXPLORER_SPATIAL_BOUNDS,
+        theta: 0.65,
+        nearCellRadius: 1,
+        cellOffsets: this.createScalarVector('spatial-cell-offsets', 'uint32', cellCount + 1),
+        vertexIds: this.createScalarVector('spatial-vertex-ids', 'uint32', dataset.vertexCount),
+        cellCenters: this.createCoordinateVector(
+          'spatial-cell-centers',
+          new Float32Array(cellCount * 2)
+        ),
+        count: this.createScalarVector('spatial-accepted-count', 'uint32', 1),
+        overflow: this.createScalarVector('spatial-overflow', 'uint32', 1)
+      });
+    } else {
+      this.spatialLayout = null;
+    }
 
     this.nodeModel = this.createNodeModel();
     this.pickingModel = this.createPickingModel();
     this.edgeModels = this.createEdgeModels();
     this.analysisGraph = this.createAnalysisGraph();
+    this.searchGraph = isLinearScale ? this.createSearchGraph() : null;
 
     const [width, height] = this.getDeviceSize();
     this.frameGraph = this.createFrameGraph(width, height);
     this.pickingGraph = this.createPickingGraph(width, height);
-    this.panels = new ExamplePanelManager({
-      panel: makeHtmlCustomPanel({
-        id: 'lugraph-explorer-controls',
-        title: 'GPU Graph Explorer',
-        html: this.getControlsHtml(),
-        onRender: root => this.attachControls(root)
-      })
-    });
-    this.panels.mount();
-    if (typeof document !== 'undefined') {
-      document
-        .getElementById('example-panel-host')
-        ?.closest('[data-info-box-appearance]')
-        ?.querySelector<HTMLButtonElement>(
-          'button[aria-expanded="false"][aria-label="Expand info box"]'
-        )
-        ?.click();
-    }
-    this.writeViewUniforms(width, height);
+    this.analyticsPending = true;
+    this.nextAnalysisStage = 0;
+    this.searchPending = true;
   }
 
   override async onInitialize({canvas}: AnimationProps): Promise<void> {
@@ -291,6 +443,13 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
   }
 
   override onRender({device}: AnimationProps): void {
+    const frameStartedAt = performance.now();
+    let cpuEncodeMilliseconds = 0;
+    if (this.lastFrameTimestamp > 0) {
+      const elapsed = frameStartedAt - this.lastFrameTimestamp;
+      if (elapsed > 0) this.frameRate = 1000 / elapsed;
+    }
+    this.lastFrameTimestamp = frameStartedAt;
     const [width, height] = this.getDeviceSize();
     if (width !== this.frameWidth || height !== this.frameHeight) {
       this.frameGraph.destroy();
@@ -301,8 +460,19 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
     this.writeViewUniforms(width, height);
 
     if (this.analyticsPending) {
-      this.analysisGraph.encode(device.commandEncoder, {parameters: undefined});
+      const encoding = this.analysisGraph.encode(device.commandEncoder, {parameters: undefined});
+      cpuEncodeMilliseconds += encoding.stats.cpuEncodeTimeMilliseconds;
       this.analyticsPending = false;
+    } else if (this.nextAnalysisStage < this.analysisStages.length) {
+      const encoding = this.analysisStages[this.nextAnalysisStage++].encode(device.commandEncoder, {
+        parameters: undefined
+      });
+      cpuEncodeMilliseconds += encoding.stats.cpuEncodeTimeMilliseconds;
+    }
+    if (this.searchGraph && this.searchPending) {
+      const encoding = this.searchGraph.encode(device.commandEncoder, {parameters: undefined});
+      cpuEncodeMilliseconds += encoding.stats.cpuEncodeTimeMilliseconds;
+      this.searchPending = false;
     }
 
     const framebuffer = device
@@ -321,8 +491,7 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
         }
       }
     });
-    this.cpuEncodeTimeMilliseconds = frameEncoding.stats.cpuEncodeTimeMilliseconds;
-    this.updateFrameRate();
+    cpuEncodeMilliseconds += frameEncoding.stats.cpuEncodeTimeMilliseconds;
 
     if (this.pendingPick) {
       const ticket = this.readbackRing.tryAcquire();
@@ -331,15 +500,21 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
         const pointerSession = this.pendingPickSession;
         this.pendingPick = null;
         this.pendingPickSession = null;
-        this.pickingGraph.encode(device.commandEncoder, {
+        const encoding = this.pickingGraph.encode(device.commandEncoder, {
           parameters: {pixel},
           buffers: {[this.pickingReadbackId]: ticket.buffer}
         });
+        cpuEncodeMilliseconds += encoding.stats.cpuEncodeTimeMilliseconds;
         ticket.markEncoded({byteLength: 8});
         queueMicrotask(() => void this.readPickedVertex(ticket, pointerSession ?? undefined));
       }
     }
     this.frameIndex++;
+    this.cpuEncodeMilliseconds = cpuEncodeMilliseconds;
+    if (frameStartedAt - this.lastStatusTimestamp >= 250) {
+      this.lastStatusTimestamp = frameStartedAt;
+      this.updateStatus();
+    }
   }
 
   override onFinalize(): void {
@@ -358,16 +533,29 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
       this.canvas.removeEventListener('wheel', this.handleWheel);
     }
     this.panels.finalize();
+    this.destroyGraph();
+    this.readbackRing.destroy();
+    this.viewUniforms.destroy();
+  }
+
+  /** Releases graph-owned models and buffers exactly once while preserving the shared UI host. */
+  private destroyGraph(): void {
     this.analysisGraph.destroy();
     this.frameGraph.destroy();
     this.pickingGraph.destroy();
+    this.searchGraph?.destroy();
+    this.searchGraph = null;
+    for (const stage of this.analysisStages) stage.destroy();
+    this.analysisStages.length = 0;
     for (const {model} of this.edgeModels) model.destroy();
     this.nodeModel.destroy();
     this.pickingModel.destroy();
     for (const vector of this.vectors) vector.destroy();
     for (const buffer of this.buffers) buffer.destroy();
-    this.readbackRing.destroy();
-    this.viewUniforms.destroy();
+    this.vectors.length = 0;
+    this.buffers.length = 0;
+    this.edgeModels.length = 0;
+    this.spatialLayout = null;
   }
 
   /** Builds persistent analytics once; animation never reruns PageRank or components. */
@@ -375,8 +563,30 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
     const graph = new GPUCommandGraph<void>(this.device, {id: 'lugraph-explorer-analysis'});
     this.topology.addToGraph(graph);
     this.degree.addToGraph(graph);
-    this.components.addToGraph(graph);
-    this.pageRank.addToGraph(graph);
+    if (this.graph.vertexCount >= GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT) {
+      for (const [name, contributor] of [
+        ['components', this.components],
+        ['communities', this.communities],
+        ['page-rank', this.pageRank]
+      ] as const) {
+        const stage = new GPUCommandGraph<void>(this.device, {
+          id: `lugraph-explorer-${name}-analysis`
+        });
+        contributor.addToGraph(stage);
+        this.analysisStages.push(stage.compile());
+      }
+    } else {
+      this.components.addToGraph(graph);
+      this.communities.addToGraph(graph);
+      this.pageRank.addToGraph(graph);
+    }
+    return graph.compile();
+  }
+
+  /** Million-scale traversal runs only when a real selection or depth changes. */
+  private createSearchGraph(): CompiledGPUCommandGraph<void> {
+    const graph = new GPUCommandGraph<void>(this.device, {id: 'lugraph-explorer-search'});
+    this.search.addToGraph(graph);
     return graph.compile();
   }
 
@@ -390,14 +600,24 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
     const graph = new GPUCommandGraph<FrameParameters>(this.device, {
       id: 'lugraph-explorer-frame'
     });
-    if (!this.paused) this.layout.addToGraph(graph);
-    this.search.addToGraph(graph);
+    if (!this.paused) {
+      if (this.activeLayoutMode === 'sampled') {
+        addGraphExplorerSampledLayoutToGraph(graph, this.layout);
+      } else if (this.spatialLayout) {
+        this.spatialLayout.addToGraph(graph);
+      } else {
+        this.layout.addToGraph(graph);
+      }
+    }
+    if (!this.searchGraph) this.search.addToGraph(graph);
 
     const positions = graph.importGPUVector('render-positions', this.layout.positions).data[0];
     const importance = graph.importGPUVector('render-importance', this.pageRank.output).data[0];
-    const degrees = graph.importGPUVector('render-degrees', this.degree.output).data[0];
     const componentLabels = graph.importGPUVector('render-components', this.components.output)
       .data[0];
+    const communityLabels = graph.importGPUVector('render-communities', this.communities.output)
+      .data[0];
+    const degrees = graph.importGPUVector('render-degrees', this.degree.output).data[0];
     const distances = graph.importGPUVector('render-distances', this.search.distances).data[0];
     const mask = graph.importGPUVector('render-neighborhood', this.neighborhoodMask).data[0];
     const sourceVertices = graph.importGPUVector('render-sources', this.graph.sourceVertices);
@@ -430,8 +650,9 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
     const resources: GraphBufferUse[] = [
       {buffer: positions, usage: 'storage-read'},
       {buffer: importance, usage: 'storage-read'},
-      {buffer: degrees, usage: 'storage-read'},
       {buffer: componentLabels, usage: 'storage-read'},
+      {buffer: communityLabels, usage: 'storage-read'},
+      {buffer: degrees, usage: 'storage-read'},
       {buffer: distances, usage: 'storage-read'},
       {buffer: mask, usage: 'storage-read'},
       {buffer: view, usage: 'uniform'}
@@ -518,8 +739,8 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
     return new Model(this.device, {
       id: 'lugraph-explorer-nodes',
       source: GRAPH_EXPLORER_NODE_SHADER,
-      topology: 'triangle-list',
-      vertexCount: 6,
+      topology: this.pointMode ? 'point-list' : 'triangle-list',
+      vertexCount: this.pointMode ? 1 : 6,
       isInstanced: true,
       instanceCount: this.graph.vertexCount,
       colorAttachmentFormats: [this.device.preferredColorFormat],
@@ -529,9 +750,10 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
       bindings: {
         importance: this.getVectorBuffer(this.pageRank.output),
         components: this.getVectorBuffer(this.components.output),
+        communities: this.getVectorBuffer(this.communities.output),
+        degrees: this.getVectorBuffer(this.degree.output),
         distances: this.getVectorBuffer(this.search.distances),
         selectionMask: this.getVectorBuffer(this.neighborhoodMask),
-        degrees: this.getVectorBuffer(this.degree.output),
         view: this.viewUniforms
       },
       shaderLayout: {
@@ -539,10 +761,11 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
         bindings: [
           {name: 'importance', type: 'read-only-storage', group: 0, location: 0},
           {name: 'components', type: 'read-only-storage', group: 0, location: 1},
-          {name: 'distances', type: 'read-only-storage', group: 0, location: 2},
-          {name: 'selectionMask', type: 'read-only-storage', group: 0, location: 3},
-          {name: 'degrees', type: 'read-only-storage', group: 0, location: 4},
-          {name: 'view', type: 'uniform', group: 0, location: 5}
+          {name: 'communities', type: 'read-only-storage', group: 0, location: 2},
+          {name: 'degrees', type: 'read-only-storage', group: 0, location: 3},
+          {name: 'distances', type: 'read-only-storage', group: 0, location: 4},
+          {name: 'selectionMask', type: 'read-only-storage', group: 0, location: 5},
+          {name: 'view', type: 'uniform', group: 0, location: 6}
         ]
       },
       parameters: {depthCompare: 'less-equal', depthWriteEnabled: true}
@@ -552,8 +775,16 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
   /** Uses original GPUData chunks directly; no edge source buffers are packed or copied. */
   private createEdgeModels(): EdgeModel[] {
     const edgeModels: EdgeModel[] = [];
+    const nonEmptyChunks = this.graph.sourceVertices.data.filter(chunk => chunk.length > 0).length;
+    let remainingVisibleEdges = this.maxVisibleEdges;
     for (const [chunkIndex, source] of this.graph.sourceVertices.data.entries()) {
-      if (source.length === 0) continue;
+      if (source.length === 0 || remainingVisibleEdges <= 0) continue;
+      const visibleEdges = Math.min(
+        source.length,
+        remainingVisibleEdges,
+        Math.ceil(this.maxVisibleEdges / nonEmptyChunks)
+      );
+      remainingVisibleEdges -= visibleEdges;
       const target = this.graph.targetVertices.data[chunkIndex];
       edgeModels.push({
         chunkIndex,
@@ -563,7 +794,7 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
           topology: 'line-list',
           vertexCount: 2,
           isInstanced: true,
-          instanceCount: source.length,
+          instanceCount: visibleEdges,
           colorAttachmentFormats: [this.device.preferredColorFormat],
           depthStencilAttachmentFormat: 'depth24plus',
           bindings: {
@@ -595,8 +826,8 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
     return new Model(this.device, {
       id: 'lugraph-explorer-picking-nodes',
       source: GRAPH_EXPLORER_PICKING_SHADER,
-      topology: 'triangle-list',
-      vertexCount: 6,
+      topology: this.pointMode ? 'point-list' : 'triangle-list',
+      vertexCount: this.pointMode ? 1 : 6,
       isInstanced: true,
       instanceCount: this.graph.vertexCount,
       colorAttachmentFormats: ['rgba8unorm', 'rg32sint'],
@@ -732,8 +963,10 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
       this.neighborhoodDepth,
       this.graph.vertexCount,
       (this.dragging ? 1 : 0) |
-        (GRAPH_EXPLORER_COLOR_MODES.indexOf(this.colorMode) << 4) |
-        (GRAPH_EXPLORER_NODE_SIZE_MODES.indexOf(this.nodeSizeMode) << 8)
+        (['community', 'component', 'degree', 'pagerank', 'distance'].indexOf(this.colorMode) <<
+          1) |
+        (['pagerank', 'degree', 'uniform'].indexOf(this.nodeSizeMode) << 4) |
+        (Number(this.pointMode) << 6)
     ]);
     this.viewUniforms.write(new Uint8Array(values));
   }
@@ -756,6 +989,7 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
         this.getVectorBuffer(this.seeds).write(Uint32Array.of(pickedVertex));
         this.getVectorBuffer(this.seedCount).write(Uint32Array.of(1));
       }
+      this.searchPending = true;
       this.updateStatus();
     } catch {
       // Device loss or cancellation releases the staging slot without changing selection.
@@ -809,6 +1043,10 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
       this.centerX + (normalizedX * aspect) / this.zoom,
       this.centerY + normalizedY / this.zoom
     ];
+    if (this.spatialLayout) {
+      position[0] = Math.max(-1.9, Math.min(1.9, position[0]));
+      position[1] = Math.max(-1.9, Math.min(1.9, position[1]));
+    }
     this.getVectorBuffer(this.pinned).write(
       Uint32Array.of(1),
       this.dragVertex * UINT32_BYTE_LENGTH
@@ -844,187 +1082,294 @@ export default class LuGraphExplorerAnimationLoopTemplate extends AnimationLoopT
   };
 
   private getControlsHtml(): string {
-    const selectStyle =
-      'width:100%;padding:7px 9px;border:1px solid rgba(148,163,184,.26);' +
-      'border-radius:8px;background:rgba(15,23,42,.8);color:inherit';
-    const buttonStyle =
-      'padding:7px 10px;border:1px solid rgba(148,163,184,.28);border-radius:8px;' +
-      'background:rgba(30,41,59,.8);color:inherit;cursor:pointer';
+    const sizeIndex = Math.max(
+      0,
+      GRAPH_EXPLORER_VERTEX_COUNTS.indexOf(
+        this.graph.vertexCount as (typeof GRAPH_EXPLORER_VERTEX_COUNTS)[number]
+      )
+    );
     return `<section data-graph-dashboard aria-label="Live GPU graph analytics"
-        style="min-width:260px;font:12px/1.5 system-ui,sans-serif;color:inherit">
+        style="font:12px/1.55 system-ui,sans-serif;min-width:260px;max-width:340px">
       <div style="display:flex;align-items:center;justify-content:space-between;gap:10px">
         <strong style="font-size:15px;letter-spacing:.02em">Graph analytics</strong>
         <span style="padding:2px 8px;border:1px solid rgba(56,189,248,.45);border-radius:99px;
           color:#7dd3fc;font-size:10px">WEBGPU · LIVE</span>
       </div>
-      <p style="margin:6px 0 12px;color:#aebed4">Real GPU topology, influence,
-        connected components, and neighborhood traversal.</p>
-      <div style="display:grid;grid-template-columns:1fr 1fr;gap:9px">
-        <label>Node color
-          <select data-color-mode aria-label="Node color metric" style="${selectStyle}">
-            <option value="component">Connected component</option>
-            <option value="degree">Vertex degree</option>
-            <option value="pagerank">PageRank influence</option>
-            <option value="distance">Neighborhood distance</option>
-          </select>
-        </label>
-        <label>Node size
-          <select data-node-size aria-label="Node size metric" style="${selectStyle}">
-            <option value="pagerank">PageRank</option>
-            <option value="degree">Vertex degree</option>
-            <option value="uniform">Uniform</option>
-          </select>
-        </label>
-      </div>
-      <label style="display:block;margin:12px 0 8px">Neighborhood depth
-        <input data-depth aria-label="Neighborhood depth" type="range" min="0"
-          max="${MAXIMUM_NEIGHBORHOOD_DEPTH}" value="${INITIAL_NEIGHBORHOOD_DEPTH}"
-          style="width:100%;accent-color:#38bdf8" />
+      <p style="margin:6px 0 12px;color:#a6bdd9">Real GPU topology, PageRank, majority-vote
+        communities, neighborhood search, and adaptive force layout.</p>
+      <label style="display:block;margin:9px 0">Graph population
+        <strong data-graph-size-value style="float:right;color:#6ee7ff">${this.graph.vertexCount.toLocaleString()}</strong>
+        <input data-graph-size aria-label="Graph vertex count" type="range" min="0"
+          max="${GRAPH_EXPLORER_VERTEX_COUNTS.length - 1}" step="1" value="${sizeIndex}"
+          style="display:block;width:100%;margin-top:5px" />
       </label>
-      <div style="display:grid;grid-template-columns:1fr 1fr;gap:7px">
-        <button data-pause type="button" aria-pressed="false" style="${buttonStyle}">
-          Pause layout
-        </button>
-        <button data-edge-toggle type="button" aria-pressed="true" style="${buttonStyle}">
-          Hide edges
-        </button>
-        <button data-reset type="button" style="${buttonStyle}">Reset layout</button>
-        <button data-unpin type="button" style="${buttonStyle}">Release pins</button>
+      <label style="display:block;margin:9px 0">Layout algorithm
+        <select data-layout-mode aria-label="Graph layout algorithm"
+          style="display:block;width:100%;margin-top:4px">
+          <option value="auto">Adaptive exact / spatial</option>
+          <option value="exact">Exact pairwise (≤512)</option>
+          <option value="spatial">Approximate spatial grid</option>
+          <option value="sampled">Four-sample edge-aware force</option>
+        </select>
+      </label>
+      <label style="display:block;margin:9px 0">Color nodes by
+        <select data-color-mode aria-label="Node color metric"
+          style="display:block;width:100%;margin-top:4px">
+          <option value="community">GPU label communities</option>
+          <option value="component">Weak components</option>
+          <option value="degree">Vertex degree</option>
+          <option value="pagerank">PageRank importance</option>
+          <option value="distance">Neighborhood distance</option>
+        </select>
+      </label>
+      <label style="display:block;margin:9px 0">Node size
+        <select data-node-size aria-label="Node size metric"
+          style="display:block;width:100%;margin-top:4px">
+          <option value="pagerank">PageRank</option>
+          <option value="degree">Degree</option>
+          <option value="uniform">Uniform</option>
+        </select>
+      </label>
+      <div data-graph-legend aria-label="GPU analytic color legend"
+        style="display:flex;align-items:center;gap:5px;margin:10px 0;color:#a6bdd9">
+        <span style="width:9px;height:9px;border-radius:50%;background:#42d8f4"></span>
+        <span style="width:9px;height:9px;border-radius:50%;background:#ffb454"></span>
+        <span style="width:9px;height:9px;border-radius:50%;background:#b794f6"></span>
+        <span style="width:9px;height:9px;border-radius:50%;background:#62e59c"></span>
+        <span style="width:9px;height:9px;border-radius:50%;background:#ff7892"></span>
+        <span style="width:9px;height:9px;border-radius:50%;background:#ffe174"></span>
+        <span style="width:9px;height:9px;border-radius:50%;background:#7caeff"></span>
+        <span data-graph-legend-label style="margin-left:4px">GPU analytic groups</span>
       </div>
-      <div data-graph-legend aria-label="Active graph color legend"
-        style="margin:12px 0 8px;padding:8px 10px;border-radius:8px;
-        background:rgba(56,189,248,.08);color:#dbeafe"></div>
+      <label style="display:block;margin:9px 0">Neighborhood depth
+        <input data-depth aria-label="Neighborhood depth" type="range" min="0"
+          max="${MAXIMUM_NEIGHBORHOOD_DEPTH}" value="${this.neighborhoodDepth}"
+          style="display:block;width:100%" />
+      </label>
+      <div style="display:flex;flex-wrap:wrap;gap:7px;margin-top:10px">
+        <button data-pause type="button" aria-pressed="false">Pause layout</button>
+        <button data-edge-toggle type="button" aria-pressed="true">Hide edges</button>
+        <button data-reset type="button">Reset</button>
+        <button data-unpin type="button">Release pins</button>
+      </div>
       <p data-status role="status" aria-live="polite"
-        style="margin:0;color:#f1f5f9;font-variant-numeric:tabular-nums"></p>
-      <p data-graph-adapter style="margin:5px 0 0;color:#aebed4"></p>
-      <p data-graph-memory style="margin:3px 0 0;color:#aebed4"></p>
-      <p data-graph-fps style="margin:3px 0 0;color:#aebed4"></p>
-      <p style="margin:10px 0 0;color:#94a3b8">Click to select · drag to pin ·
-        Shift-drag to pan · scroll to zoom</p>
+        style="margin:12px 0 0;color:#b8d6ef;font-size:11px"></p>
+      <p data-graph-adapter style="margin:7px 0 0;color:#8fb1cc;font-size:11px"></p>
+      <p data-graph-memory style="margin:3px 0 0;color:#8fb1cc;font-size:11px"></p>
+      <p data-graph-fps style="margin:3px 0 0;color:#8fb1cc;font-size:11px"></p>
+      <p style="margin:9px 0 0;opacity:.68">Click to inspect · drag to pin · shift-drag to pan ·
+      scroll to zoom. No per-frame graph readback.</p>
     </section>`;
   }
 
   private attachControls(root: HTMLElement): () => void {
-    const depth = root.querySelector<HTMLInputElement>('[data-depth]');
-    const color = root.querySelector<HTMLSelectElement>('[data-color-mode]');
-    const size = root.querySelector<HTMLSelectElement>('[data-node-size]');
-    const pause = root.querySelector<HTMLButtonElement>('[data-pause]');
+    this.controlsRoot = root;
+    const graphSize = root.querySelector<HTMLInputElement>('[data-graph-size]');
+    const layoutMode = root.querySelector<HTMLSelectElement>('[data-layout-mode]');
+    const colorMode = root.querySelector<HTMLSelectElement>('[data-color-mode]');
+    const nodeSize = root.querySelector<HTMLSelectElement>('[data-node-size]');
     const edges = root.querySelector<HTMLButtonElement>('[data-edge-toggle]');
+    const depth = root.querySelector<HTMLInputElement>('[data-depth]');
+    const pause = root.querySelector<HTMLButtonElement>('[data-pause]');
     const reset = root.querySelector<HTMLButtonElement>('[data-reset]');
     const unpin = root.querySelector<HTMLButtonElement>('[data-unpin]');
     this.statusElement = root.querySelector('[data-status]');
-    this.legendElement = root.querySelector('[data-graph-legend]');
-    this.adapterElement = root.querySelector('[data-graph-adapter]');
-    this.memoryElement = root.querySelector('[data-graph-memory]');
-    this.frameRateElement = root.querySelector('[data-graph-fps]');
-    const updateColor = () => {
-      const selectedMode = GRAPH_EXPLORER_COLOR_MODES.find(mode => mode === color?.value);
-      if (selectedMode) this.colorMode = selectedMode;
+    this.graphSizeElement = root.querySelector('[data-graph-size-value]');
+    let pendingResizeFrame: number | null = null;
+    let pendingResizeTimeout: ReturnType<typeof setTimeout> | null = null;
+    const previewGraphSize = () => {
+      const size = GRAPH_EXPLORER_VERTEX_COUNTS[Number(graphSize?.value ?? 0)];
+      if (size !== undefined && this.graphSizeElement) {
+        this.graphSizeElement.textContent = size.toLocaleString();
+      }
+    };
+    const updateGraphSize = () => {
+      const size = GRAPH_EXPLORER_VERTEX_COUNTS[Number(graphSize?.value ?? 0)];
+      if (size === undefined || size === this.graph.vertexCount) return;
+      if (pendingResizeFrame !== null) cancelAnimationFrame(pendingResizeFrame);
+      if (pendingResizeTimeout !== null) clearTimeout(pendingResizeTimeout);
+      if (size < GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT) {
+        this.resizeGraph(size);
+        return;
+      }
+      if (this.statusElement) {
+        this.statusElement.textContent = `Preparing ${size.toLocaleString()} real GPU vertices…`;
+      }
+      // Publish the actual target and let the browser paint before linear CPU upload generation.
+      pendingResizeFrame = requestAnimationFrame(() => {
+        pendingResizeFrame = null;
+        pendingResizeTimeout = setTimeout(() => {
+          pendingResizeTimeout = null;
+          if (!this.finalized) this.resizeGraph(size);
+        }, 0);
+      });
+    };
+    const updateLayoutMode = () => {
+      this.layoutMode = (layoutMode?.value ?? 'auto') as GraphExplorerLayoutMode;
+      this.resizeGraph(this.graph.vertexCount);
+    };
+    const updateColorMode = () => {
+      this.colorMode = (colorMode?.value ?? 'community') as GraphExplorerColorMode;
       this.updateStatus();
     };
-    const updateSize = () => {
-      const selectedMode = GRAPH_EXPLORER_NODE_SIZE_MODES.find(mode => mode === size?.value);
-      if (selectedMode) this.nodeSizeMode = selectedMode;
+    const updateNodeSize = () => {
+      this.nodeSizeMode = (nodeSize?.value ?? 'pagerank') as GraphExplorerNodeSizeMode;
+      this.updateStatus();
+    };
+    const updateEdges = () => {
+      this.edgesVisible = !this.edgesVisible;
+      if (edges) {
+        edges.setAttribute('aria-pressed', String(this.edgesVisible));
+        edges.textContent = this.edgesVisible ? 'Hide edges' : 'Show edges';
+      }
       this.updateStatus();
     };
     const updateDepth = () => {
       this.neighborhoodDepth = Number(depth?.value ?? INITIAL_NEIGHBORHOOD_DEPTH);
       this.getVectorBuffer(this.activeDepth).write(Uint32Array.of(this.neighborhoodDepth));
-      this.updateStatus();
-    };
-    const togglePause = () => {
-      this.paused = !this.paused;
-      if (pause) {
-        pause.textContent = this.paused ? 'Resume layout' : 'Pause layout';
-        pause.setAttribute('aria-pressed', String(this.paused));
-      }
-      this.frameGraph.destroy();
-      this.frameGraph = this.createFrameGraph(this.frameWidth, this.frameHeight);
-      this.updateStatus();
-    };
-    const toggleEdges = () => {
-      this.edgesVisible = !this.edgesVisible;
-      if (edges) {
-        edges.textContent = this.edgesVisible ? 'Hide edges' : 'Show edges';
-        edges.setAttribute('aria-pressed', String(this.edgesVisible));
-      }
+      this.searchPending = true;
       this.updateStatus();
     };
     const resetLayout = () => {
       this.getVectorBuffer(this.reset).write(Uint32Array.of(1));
-      this.updateStatus();
     };
     const clearPins = () => {
       this.getVectorBuffer(this.pinned).write(new Uint32Array(this.graph.vertexCount));
       this.updateStatus();
     };
+    const togglePaused = () => {
+      this.paused = !this.paused;
+      if (pause) {
+        pause.setAttribute('aria-pressed', String(this.paused));
+        pause.textContent = this.paused ? 'Resume layout' : 'Pause layout';
+      }
+      this.frameGraph.destroy();
+      this.frameGraph = this.createFrameGraph(this.frameWidth, this.frameHeight);
+      this.updateStatus();
+    };
+    graphSize?.addEventListener('input', previewGraphSize);
+    graphSize?.addEventListener('change', updateGraphSize);
+    layoutMode?.addEventListener('change', updateLayoutMode);
+    colorMode?.addEventListener('change', updateColorMode);
+    nodeSize?.addEventListener('change', updateNodeSize);
+    edges?.addEventListener('click', updateEdges);
     depth?.addEventListener('input', updateDepth);
-    color?.addEventListener('change', updateColor);
-    size?.addEventListener('change', updateSize);
-    pause?.addEventListener('click', togglePause);
-    edges?.addEventListener('click', toggleEdges);
+    pause?.addEventListener('click', togglePaused);
     reset?.addEventListener('click', resetLayout);
     unpin?.addEventListener('click', clearPins);
+    this.syncGraphControls();
     this.updateStatus();
     return () => {
+      if (pendingResizeFrame !== null) cancelAnimationFrame(pendingResizeFrame);
+      if (pendingResizeTimeout !== null) clearTimeout(pendingResizeTimeout);
+      graphSize?.removeEventListener('input', previewGraphSize);
+      graphSize?.removeEventListener('change', updateGraphSize);
+      layoutMode?.removeEventListener('change', updateLayoutMode);
+      colorMode?.removeEventListener('change', updateColorMode);
+      nodeSize?.removeEventListener('change', updateNodeSize);
+      edges?.removeEventListener('click', updateEdges);
       depth?.removeEventListener('input', updateDepth);
-      color?.removeEventListener('change', updateColor);
-      size?.removeEventListener('change', updateSize);
-      pause?.removeEventListener('click', togglePause);
-      edges?.removeEventListener('click', toggleEdges);
+      pause?.removeEventListener('click', togglePaused);
       reset?.removeEventListener('click', resetLayout);
       unpin?.removeEventListener('click', clearPins);
       this.statusElement = null;
-      this.legendElement = null;
-      this.adapterElement = null;
-      this.memoryElement = null;
-      this.frameRateElement = null;
+      this.graphSizeElement = null;
+      this.controlsRoot = null;
     };
+  }
+
+  /** Keeps source-size controls and the exact-layout safety bound synchronized after rebuild. */
+  private syncGraphControls(): void {
+    if (this.graphSizeElement) {
+      this.graphSizeElement.textContent = this.graph.vertexCount.toLocaleString();
+    }
+    const graphSize = this.controlsRoot?.querySelector<HTMLInputElement>('[data-graph-size]');
+    const index = GRAPH_EXPLORER_VERTEX_COUNTS.indexOf(
+      this.graph.vertexCount as (typeof GRAPH_EXPLORER_VERTEX_COUNTS)[number]
+    );
+    if (graphSize && index >= 0) graphSize.value = String(index);
+    const layout = this.controlsRoot?.querySelector<HTMLSelectElement>('[data-layout-mode]');
+    if (layout) layout.value = this.layoutMode;
+    const exact = layout?.querySelector<HTMLOptionElement>('option[value="exact"]');
+    if (exact) exact.disabled = this.graph.vertexCount > GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT;
+    const spatial = layout?.querySelector<HTMLOptionElement>('option[value="spatial"]');
+    if (spatial)
+      spatial.disabled = this.graph.vertexCount >= GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT;
+    const color = this.controlsRoot?.querySelector<HTMLSelectElement>('[data-color-mode]');
+    if (color) color.value = this.colorMode;
+    const nodeSize = this.controlsRoot?.querySelector<HTMLSelectElement>('[data-node-size]');
+    if (nodeSize) nodeSize.value = this.nodeSizeMode;
+    const edges = this.controlsRoot?.querySelector<HTMLButtonElement>('[data-edge-toggle]');
+    if (edges) {
+      edges.setAttribute('aria-pressed', String(this.edgesVisible));
+      edges.textContent = this.edgesVisible ? 'Hide edges' : 'Show edges';
+    }
+    const pause = this.controlsRoot?.querySelector<HTMLButtonElement>('[data-pause]');
+    if (pause) {
+      pause.setAttribute('aria-pressed', String(this.paused));
+      pause.textContent = this.paused ? 'Resume layout' : 'Pause layout';
+    }
+    const adapter = this.controlsRoot?.querySelector<HTMLElement>('[data-graph-adapter]');
+    if (adapter) {
+      const adapterName =
+        this.device.info.vendor || this.device.info.renderer || this.device.info.gpu;
+      adapter.textContent = `GPU adapter: ${adapterName} · ${this.device.info.gpuType} · WebGPU`;
+    }
+    const memory = this.controlsRoot?.querySelector<HTMLElement>('[data-graph-memory]');
+    if (memory) {
+      const residentBytes =
+        this.buffers.reduce((total, buffer) => total + buffer.byteLength, 0) +
+        this.viewUniforms.byteLength;
+      const transientBytes =
+        this.analysisGraph.stats.physicalTransientBytes +
+        this.analysisStages.reduce(
+          (total, stage) => total + stage.stats.physicalTransientBytes,
+          0
+        ) +
+        (this.searchGraph?.stats.physicalTransientBytes ?? 0) +
+        this.frameGraph.stats.physicalTransientBytes +
+        this.pickingGraph.stats.physicalTransientBytes;
+      memory.textContent =
+        `GPU buffers: ${(residentBytes / 1024).toFixed(1)} KiB resident · ` +
+        `${(transientBytes / 1024).toFixed(1)} KiB transient`;
+    }
   }
 
   private updateStatus(): void {
     if (!this.statusElement) return;
     const selection = this.selectedVertex === null ? 'none' : String(this.selectedVertex);
-    this.statusElement.textContent = `${this.graph.vertexCount} vertices · ${this.graph.edgeCount} chunked edges · selected ${selection} · depth ${this.neighborhoodDepth}`;
-    if (this.legendElement) {
+    const layout =
+      this.activeLayoutMode === 'sampled'
+        ? 'sampled O(E + 4V)'
+        : this.spatialLayout
+          ? `spatial ${this.spatialLayout.gridSize[0]}×${this.spatialLayout.gridSize[1]}`
+          : 'exact pairwise';
+    const edges =
+      this.renderedEdgeCount < this.graph.edgeCount
+        ? `${this.renderedEdgeCount.toLocaleString()} / ${this.graph.edgeCount.toLocaleString()} visible edges`
+        : `${this.graph.edgeCount.toLocaleString()} original edges`;
+    const cadence = this.frameRate > 0 ? ` · ${Math.round(this.frameRate)} FPS` : '';
+    const encoding =
+      this.cpuEncodeMilliseconds > 0
+        ? ` · CPU encode ${this.cpuEncodeMilliseconds.toFixed(1)}ms`
+        : '';
+    this.statusElement.textContent = `${this.graph.vertexCount.toLocaleString()} resident and rendered vertices · ${edges} · ${layout} · selected ${selection} · depth ${this.neighborhoodDepth}${cadence}${encoding}`;
+    const legend = this.controlsRoot?.querySelector<HTMLElement>('[data-graph-legend-label]');
+    if (legend) {
       const legends: Record<GraphExplorerColorMode, string> = {
-        component: '● Colors identify GPU weakly connected components',
-        degree: '● Blue → amber shows GPU-computed vertex degree',
-        pagerank: '● Teal → violet shows GPU PageRank influence',
-        distance: '● Bright → dim shows bounded GPU traversal distance'
+        community: 'GPU label-propagation communities',
+        component: 'GPU weakly connected components',
+        degree: 'GPU-computed vertex degree',
+        pagerank: 'GPU PageRank influence',
+        distance: 'Bounded GPU traversal distance'
       };
-      this.legendElement.textContent = legends[this.colorMode];
+      legend.textContent = legends[this.colorMode];
     }
-    if (this.adapterElement) {
-      const adapter = this.device.info.renderer || this.device.info.vendor || this.device.info.gpu;
-      this.adapterElement.textContent = `GPU adapter: ${adapter}`;
+    const frameRate = this.controlsRoot?.querySelector<HTMLElement>('[data-graph-fps]');
+    if (frameRate) {
+      frameRate.textContent =
+        `${Math.round(this.frameRate)} FPS · ` +
+        `${this.cpuEncodeMilliseconds.toFixed(2)} ms CPU command encoding`;
     }
-    if (this.memoryElement) {
-      const residentBytes = this.buffers.reduce((total, buffer) => total + buffer.byteLength, 0);
-      const transientBytes =
-        this.analysisGraph.stats.physicalTransientBytes +
-        this.frameGraph.stats.physicalTransientBytes +
-        this.pickingGraph.stats.physicalTransientBytes;
-      this.memoryElement.textContent =
-        `GPU buffers: ${(residentBytes / 1024).toFixed(1)} KiB resident · ` +
-        `${(transientBytes / 1024).toFixed(1)} KiB transient`;
-    }
-    if (this.frameRateElement) {
-      this.frameRateElement.textContent =
-        `${this.framesPerSecond.toFixed(0)} FPS · ` +
-        `${this.cpuEncodeTimeMilliseconds.toFixed(2)} ms CPU command encoding`;
-    }
-  }
-
-  private updateFrameRate(): void {
-    const currentTime = performance.now();
-    if (this.sampledFrameTime === 0) this.sampledFrameTime = currentTime;
-    this.sampledFrameCount++;
-    const elapsedMilliseconds = currentTime - this.sampledFrameTime;
-    if (elapsedMilliseconds < 500) return;
-    this.framesPerSecond = (this.sampledFrameCount * 1000) / elapsedMilliseconds;
-    this.sampledFrameTime = currentTime;
-    this.sampledFrameCount = 0;
-    this.updateStatus();
   }
 }

--- a/examples/experimental/lugraph-explorer/graph-data.ts
+++ b/examples/experimental/lugraph-explorer/graph-data.ts
@@ -8,6 +8,41 @@ export const GRAPH_EXPLORER_COMMUNITY_COUNT = 4;
 /** Exact all-pairs layout remains interactive at this bounded demonstration population. */
 export const GRAPH_EXPLORER_DEFAULT_VERTEX_COUNT = 128;
 
+/** Deliberately bounded, directly selectable GPU graph populations. */
+export const GRAPH_EXPLORER_VERTEX_COUNTS = [
+  128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576
+] as const;
+
+/** Initial population for interactive showcases; isolated fixtures can supply smaller graphs. */
+export const GRAPH_EXPLORER_SHOWCASE_DEFAULT_VERTEX_COUNT = 1024;
+
+/** Larger populations always use the explicitly approximate spatial force contributor. */
+export const GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT = 512;
+
+/** Larger graphs replace all-cell force gathering with bounded four-sample edge-aware forces. */
+export const GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT = 16_384;
+
+/** Every source vertex remains rendered while the GPU switches to one pixel-sized primitive. */
+export const GRAPH_EXPLORER_POINT_VERTEX_COUNT = 65_536;
+
+/** Bounds only visible original edge rows; resident graph edges and all nodes remain complete. */
+export const GRAPH_EXPLORER_MAX_VISIBLE_EDGES = 65_536;
+
+/** Keeps synchronous majority-vote community work bounded on large generated graphs. */
+export const GRAPH_EXPLORER_MAXIMUM_HUB_SPOKES = 48;
+
+/** Explicit domain shared by the generated coordinates and caller-owned spatial grid. */
+export const GRAPH_EXPLORER_SPATIAL_BOUNDS = [-2, -2, 2, 2] as const;
+
+/** Source-aligned analytic column used to color the original GPU node instances. */
+export type GraphExplorerColorMode = 'community' | 'component' | 'degree' | 'pagerank' | 'distance';
+
+/** Source-aligned analytic column used to size the original GPU node instances. */
+export type GraphExplorerNodeSizeMode = 'pagerank' | 'degree' | 'uniform';
+
+/** Explicit exact-versus-spatial selection; auto protects large graphs from quadratic layout. */
+export type GraphExplorerLayoutMode = 'auto' | 'exact' | 'spatial' | 'sampled';
+
 /** Deterministic graph input preserving an explicit empty aligned source batch. */
 export type GraphExplorerDataset = {
   /** Number of stable zero-based graph vertices. */
@@ -38,8 +73,25 @@ export function makeGraphExplorerDataset(
 
   const positions = new Float32Array(vertexCount * 2);
   const velocities = new Float32Array(vertexCount * 2);
-  const sources: number[] = [];
-  const targets: number[] = [];
+  let edgeCount = 1;
+  for (let community = 0; community < GRAPH_EXPLORER_COMMUNITY_COUNT; community++) {
+    const firstVertex = Math.floor((community * vertexCount) / GRAPH_EXPLORER_COMMUNITY_COUNT);
+    const nextCommunityVertex = Math.floor(
+      ((community + 1) * vertexCount) / GRAPH_EXPLORER_COMMUNITY_COUNT
+    );
+    const connectedCount =
+      nextCommunityVertex - firstVertex - Number(community === GRAPH_EXPLORER_COMMUNITY_COUNT - 1);
+    if (connectedCount >= 2) {
+      edgeCount += connectedCount * (connectedCount > 3 ? 2 : 1);
+      edgeCount += Math.min(
+        GRAPH_EXPLORER_MAXIMUM_HUB_SPOKES,
+        Math.floor((connectedCount - 1) / 4)
+      );
+    }
+  }
+  const sources = new Uint32Array(edgeCount);
+  const targets = new Uint32Array(edgeCount);
+  let edgeIndex = 0;
 
   for (let community = 0; community < GRAPH_EXPLORER_COMMUNITY_COUNT; community++) {
     const firstVertex = Math.floor((community * vertexCount) / GRAPH_EXPLORER_COMMUNITY_COUNT);
@@ -57,7 +109,10 @@ export function makeGraphExplorerDataset(
     for (let vertex = firstVertex; vertex < nextCommunityVertex; vertex++) {
       const communityIndex = vertex - firstVertex;
       const angle = communityIndex * 2.399963229728653;
-      const radius = 0.11 + (communityIndex % 7) * 0.016;
+      const radius =
+        vertexCount >= GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT
+          ? Math.sqrt((communityIndex + 0.5) / Math.max(connectedCount, 1)) * 0.38
+          : 0.11 + (communityIndex % 7) * 0.016;
       positions[vertex * 2] = centerX + Math.cos(angle) * radius;
       positions[vertex * 2 + 1] = centerY + Math.sin(angle) * radius;
 
@@ -65,39 +120,55 @@ export function makeGraphExplorerDataset(
         continue;
       }
 
-      sources.push(vertex);
-      targets.push(firstVertex + ((communityIndex + 1) % connectedCount));
+      sources[edgeIndex] = vertex;
+      targets[edgeIndex] = firstVertex + ((communityIndex + 1) % connectedCount);
+      edgeIndex++;
 
       if (connectedCount > 3) {
-        sources.push(vertex);
-        targets.push(firstVertex + ((communityIndex + 3) % connectedCount));
+        sources[edgeIndex] = vertex;
+        targets[edgeIndex] = firstVertex + ((communityIndex + 3) % connectedCount);
+        edgeIndex++;
       }
 
-      if (communityIndex > 0 && communityIndex % 4 === 0) {
-        sources.push(vertex);
-        targets.push(firstVertex);
+      if (
+        communityIndex > 0 &&
+        communityIndex % 4 === 0 &&
+        communityIndex <= GRAPH_EXPLORER_MAXIMUM_HUB_SPOKES * 4
+      ) {
+        sources[edgeIndex] = vertex;
+        targets[edgeIndex] = firstVertex;
+        edgeIndex++;
       }
     }
   }
 
   // Join only the first pair so weak components, an isolated vertex, and hubs remain visible.
-  sources.push(0);
-  targets.push(Math.floor(vertexCount / GRAPH_EXPLORER_COMMUNITY_COUNT));
+  sources[edgeIndex] = 0;
+  targets[edgeIndex] = Math.floor(vertexCount / GRAPH_EXPLORER_COMMUNITY_COUNT);
 
-  const midpoint = Math.ceil(sources.length / 2);
+  const midpoint = Math.ceil(edgeCount / 2);
   return {
     vertexCount,
     sourceChunks: [
-      Uint32Array.from(sources.slice(0, midpoint)),
-      new Uint32Array(0),
-      Uint32Array.from(sources.slice(midpoint))
+      sources.subarray(0, midpoint),
+      sources.subarray(midpoint, midpoint),
+      sources.subarray(midpoint)
     ],
     targetChunks: [
-      Uint32Array.from(targets.slice(0, midpoint)),
-      new Uint32Array(0),
-      Uint32Array.from(targets.slice(midpoint))
+      targets.subarray(0, midpoint),
+      targets.subarray(midpoint, midpoint),
+      targets.subarray(midpoint)
     ],
     positions,
     velocities
   };
+}
+
+/** Balances all-cell far-field gathers against exact near-cell populations. */
+export function getGraphExplorerGridSize(vertexCount: number): readonly [number, number] {
+  if (!Number.isSafeInteger(vertexCount) || vertexCount < GRAPH_EXPLORER_COMMUNITY_COUNT * 2) {
+    throw new Error('Graph explorer spatial grids require at least eight graph vertices');
+  }
+  const dimension = Math.max(4, Math.min(32, Math.ceil(Math.sqrt(3) * vertexCount ** 0.25)));
+  return [dimension, dimension];
 }

--- a/examples/experimental/lugraph-explorer/graph-scale-layout.ts
+++ b/examples/experimental/lugraph-explorer/graph-scale-layout.ts
@@ -1,0 +1,409 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import type {GPUCommandGraph, GraphBufferUse, GraphDataView} from '@luma.gl/experimental';
+import type {LuGraphForceLayout} from '@luma.gl/experimental/lugraph';
+
+const WORKGROUP_SIZE = 256;
+const REPULSION_SAMPLE_COUNT = 4;
+
+type SampledView = GraphDataView<'uint32'> | GraphDataView<'float32x2'>;
+type SampledBinding = {view: SampledView; usage: GraphBufferUse['usage']};
+type SampledState = {
+  layout: LuGraphForceLayout;
+  vertexCount: number;
+  positions: GraphDataView<'float32x2'>;
+  velocities: GraphDataView<'float32x2'>;
+  forwardOffsets: GraphDataView<'uint32'>;
+  forwardNeighbors: GraphDataView<'uint32'>;
+  overflow: GraphDataView<'uint32'>;
+  reverseOffsets?: GraphDataView<'uint32'>;
+  reverseNeighbors?: GraphDataView<'uint32'>;
+  reverseOverflow?: GraphDataView<'uint32'>;
+  pinned?: GraphDataView<'uint32'>;
+  reset?: GraphDataView<'uint32'>;
+};
+
+/**
+ * Adds real full-graph edge attraction and four deterministic long-range samples per vertex.
+ *
+ * Two globally synchronized passes preserve stable position snapshots and update every original
+ * caller-owned position. The work is `O(E + 4V)`, never allocates scratch, submits, reads back,
+ * repacks source rows, or uses floating-point atomics. Directed graphs consume both CSR views.
+ */
+export function addGraphExplorerSampledLayoutToGraph<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  layout: LuGraphForceLayout
+): void {
+  const graph = layout.topology.graph;
+  const reverse = graph.directed ? layout.topology.reverse : undefined;
+  const state: SampledState = {
+    layout,
+    vertexCount: graph.vertexCount,
+    positions: commandGraph.importGPUVector(`${layout.id}-sampled-positions`, layout.positions)
+      .data[0],
+    velocities: commandGraph.importGPUVector(`${layout.id}-sampled-velocities`, layout.velocities)
+      .data[0],
+    forwardOffsets: commandGraph.importGPUVector(
+      `${layout.id}-sampled-forward-offsets`,
+      layout.topology.forward.offsets
+    ).data[0],
+    forwardNeighbors: commandGraph.importGPUVector(
+      `${layout.id}-sampled-forward-neighbors`,
+      layout.topology.forward.neighbors
+    ).data[0],
+    overflow: commandGraph.importGPUVector(
+      `${layout.id}-sampled-forward-overflow`,
+      layout.topology.forward.overflow
+    ).data[0],
+    ...(reverse
+      ? {
+          reverseOffsets: commandGraph.importGPUVector(
+            `${layout.id}-sampled-reverse-offsets`,
+            reverse.offsets
+          ).data[0],
+          reverseNeighbors: commandGraph.importGPUVector(
+            `${layout.id}-sampled-reverse-neighbors`,
+            reverse.neighbors
+          ).data[0],
+          reverseOverflow: commandGraph.importGPUVector(
+            `${layout.id}-sampled-reverse-overflow`,
+            reverse.overflow
+          ).data[0]
+        }
+      : {}),
+    ...(layout.pinned
+      ? {pinned: commandGraph.importGPUVector(`${layout.id}-sampled-pinned`, layout.pinned).data[0]}
+      : {}),
+    ...(layout.reset
+      ? {reset: commandGraph.importGPUVector(`${layout.id}-sampled-reset`, layout.reset).data[0]}
+      : {})
+  };
+
+  if (state.reset) {
+    if (state.vertexCount > 0) addInitializationPass(commandGraph, state);
+    addResetClearPass(commandGraph, state);
+  }
+  if (state.vertexCount === 0) return;
+
+  for (let iteration = 0; iteration < layout.iterationsPerFrame; iteration++) {
+    addSampledForcePass(commandGraph, state, iteration);
+    addIntegrationPass(commandGraph, state, iteration);
+  }
+}
+
+function addInitializationPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: SampledState
+): void {
+  const bindings: Record<string, SampledBinding> = {
+    positions: {view: state.positions, usage: 'storage-read-write'},
+    velocities: {view: state.velocities, usage: 'storage-write'},
+    reset: {view: state.reset!, usage: 'storage-read'},
+    overflow: {view: state.overflow, usage: 'storage-read'},
+    ...(state.reverseOverflow
+      ? {reverseOverflow: {view: state.reverseOverflow, usage: 'storage-read' as const}}
+      : {}),
+    ...(state.pinned ? {pinned: {view: state.pinned, usage: 'storage-read' as const}} : {})
+  };
+  const reverseInvalid = state.reverseOverflow
+    ? ` || reverseOverflow[${getScalarOffset(state.reverseOverflow)}u] != 0u`
+    : '';
+  const pinned = state.pinned ? ` || pinned[${getScalarOffset(state.pinned)}u + index] != 0u` : '';
+  const source = /* wgsl */ `
+${getDeclarations(bindings)}
+${getInvocationSource(commandGraph, state.vertexCount)}
+${getCommunityAnchorSource(state.vertexCount, state.layout.seed)}
+@compute @workgroup_size(${WORKGROUP_SIZE})
+fn main(@builtin(workgroup_id) workgroupId: vec3<u32>,
+        @builtin(local_invocation_index) localInvocationIndex: u32) {
+  let index = getInvocationIndex(workgroupId, localInvocationIndex);
+  if (index >= ${state.vertexCount}u || reset[${getScalarOffset(state.reset!)}u] == 0u) { return; }
+  let velocityIndex = ${getScalarOffset(state.velocities)}u + index * 2u;
+  velocities[velocityIndex] = 0.0;
+  velocities[velocityIndex + 1u] = 0.0;
+  if (overflow[${getScalarOffset(state.overflow)}u] != 0u${reverseInvalid}${pinned}) { return; }
+  let positionIndex = ${getScalarOffset(state.positions)}u + index * 2u;
+  let anchor = getCommunityAnchor(index);
+  positions[positionIndex] = anchor.x;
+  positions[positionIndex + 1u] = anchor.y;
+}`;
+  addSampledPass(
+    commandGraph,
+    `${state.layout.id}-sampled-initialize`,
+    source,
+    bindings,
+    state.vertexCount
+  );
+}
+
+function addResetClearPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: SampledState
+): void {
+  const bindings: Record<string, SampledBinding> = {
+    reset: {view: state.reset!, usage: 'storage-write'}
+  };
+  const source = /* wgsl */ `
+${getDeclarations(bindings)}
+@compute @workgroup_size(${WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  if (globalId.x == 0u) { reset[${getScalarOffset(state.reset!)}u] = 0u; }
+}`;
+  addSampledPass(commandGraph, `${state.layout.id}-sampled-clear-reset`, source, bindings, 1);
+}
+
+function addSampledForcePass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: SampledState,
+  iteration: number
+): void {
+  const bindings: Record<string, SampledBinding> = {
+    positions: {view: state.positions, usage: 'storage-read'},
+    velocities: {view: state.velocities, usage: 'storage-read-write'},
+    forwardOffsets: {view: state.forwardOffsets, usage: 'storage-read'},
+    forwardNeighbors: {view: state.forwardNeighbors, usage: 'storage-read'},
+    overflow: {view: state.overflow, usage: 'storage-read'},
+    ...(state.reverseOffsets && state.reverseNeighbors && state.reverseOverflow
+      ? {
+          reverseOffsets: {view: state.reverseOffsets, usage: 'storage-read' as const},
+          reverseNeighbors: {view: state.reverseNeighbors, usage: 'storage-read' as const},
+          reverseOverflow: {view: state.reverseOverflow, usage: 'storage-read' as const}
+        }
+      : {})
+  };
+  const reverseInvalid = state.reverseOverflow
+    ? ` || reverseOverflow[${getScalarOffset(state.reverseOverflow)}u] != 0u`
+    : '';
+  const reverseAttraction =
+    state.reverseOffsets && state.reverseNeighbors
+      ? `
+  let reverseFirst = min(reverseOffsets[${getScalarOffset(state.reverseOffsets)}u + index],
+    ${state.reverseNeighbors.length}u);
+  let reverseLast = min(reverseOffsets[${getScalarOffset(state.reverseOffsets)}u + index + 1u],
+    ${state.reverseNeighbors.length}u);
+  for (var slot = reverseFirst; slot < reverseLast; slot++) {
+    let otherVertex = reverseNeighbors[${getScalarOffset(state.reverseNeighbors)}u + slot];
+    if (otherVertex < ${state.vertexCount}u) {
+      neighborDisplacement += readPosition(otherVertex) - position;
+      neighborCount++;
+    }
+  }`
+      : '';
+  const source = /* wgsl */ `
+${getDeclarations(bindings)}
+${getInvocationSource(commandGraph, state.vertexCount)}
+${getCommunityAnchorSource(state.vertexCount, state.layout.seed)}
+fn readPosition(vertex: u32) -> vec2<f32> {
+  let offset = ${getScalarOffset(state.positions)}u + vertex * 2u;
+  return vec2<f32>(positions[offset], positions[offset + 1u]);
+}
+fn hash(value: u32) -> u32 {
+  var result = value;
+  result ^= result >> 16u;
+  result *= 0x7feb352du;
+  result ^= result >> 15u;
+  result *= 0x846ca68bu;
+  return result ^ (result >> 16u);
+}
+@compute @workgroup_size(${WORKGROUP_SIZE})
+fn main(@builtin(workgroup_id) workgroupId: vec3<u32>,
+        @builtin(local_invocation_index) localInvocationIndex: u32) {
+  let index = getInvocationIndex(workgroupId, localInvocationIndex);
+  if (index >= ${state.vertexCount}u) { return; }
+  let velocityIndex = ${getScalarOffset(state.velocities)}u + index * 2u;
+  if (overflow[${getScalarOffset(state.overflow)}u] != 0u${reverseInvalid}) {
+    velocities[velocityIndex] = 0.0;
+    velocities[velocityIndex + 1u] = 0.0;
+    return;
+  }
+  let position = readPosition(index);
+  let anchor = getCommunityAnchor(index);
+  var force = (anchor - position) * 0.12 - ${formatFloat(state.layout.gravity)} * position;
+  for (var sampleIndex = 0u; sampleIndex < ${REPULSION_SAMPLE_COUNT}u; sampleIndex++) {
+    let otherVertex = hash(index ^ (${state.layout.seed}u + sampleIndex * 0x9e3779b9u)) %
+      ${state.vertexCount}u;
+    if (otherVertex != index) {
+      let difference = position - readPosition(otherVertex);
+      force += ${formatFloat(state.layout.repulsion)} * difference /
+        max(dot(difference, difference), 0.0001);
+    }
+  }
+  let first = min(forwardOffsets[${getScalarOffset(state.forwardOffsets)}u + index],
+    ${state.forwardNeighbors.length}u);
+  let last = min(forwardOffsets[${getScalarOffset(state.forwardOffsets)}u + index + 1u],
+    ${state.forwardNeighbors.length}u);
+  var neighborDisplacement = vec2<f32>(0.0);
+  var neighborCount = 0u;
+  for (var slot = first; slot < last; slot++) {
+    let otherVertex = forwardNeighbors[${getScalarOffset(state.forwardNeighbors)}u + slot];
+    if (otherVertex < ${state.vertexCount}u) {
+      neighborDisplacement += readPosition(otherVertex) - position;
+      neighborCount++;
+    }
+  }
+  ${reverseAttraction}
+  force += ${formatFloat(state.layout.attraction)} * neighborDisplacement /
+    max(f32(neighborCount), 1.0);
+  var velocity =
+    (vec2<f32>(velocities[velocityIndex], velocities[velocityIndex + 1u]) +
+      force * ${formatFloat(state.layout.timeStep)}) * ${formatFloat(state.layout.damping)};
+  let speed = length(velocity);
+  if (speed > ${formatFloat(state.layout.maxVelocity)}) {
+    velocity *= ${formatFloat(state.layout.maxVelocity)} / speed;
+  }
+  velocities[velocityIndex] = velocity.x;
+  velocities[velocityIndex + 1u] = velocity.y;
+}`;
+  addSampledPass(
+    commandGraph,
+    `${state.layout.id}-sampled-force-${iteration}`,
+    source,
+    bindings,
+    state.vertexCount
+  );
+}
+
+function addIntegrationPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: SampledState,
+  iteration: number
+): void {
+  const bindings: Record<string, SampledBinding> = {
+    positions: {view: state.positions, usage: 'storage-read-write'},
+    velocities: {view: state.velocities, usage: 'storage-read-write'},
+    ...(state.pinned ? {pinned: {view: state.pinned, usage: 'storage-read' as const}} : {})
+  };
+  const pinnedGuard = state.pinned
+    ? `
+  if (pinned[${getScalarOffset(state.pinned)}u + index] != 0u) {
+    velocities[velocityIndex] = 0.0;
+    velocities[velocityIndex + 1u] = 0.0;
+    return;
+  }`
+    : '';
+  const source = /* wgsl */ `
+${getDeclarations(bindings)}
+${getInvocationSource(commandGraph, state.vertexCount)}
+@compute @workgroup_size(${WORKGROUP_SIZE})
+fn main(@builtin(workgroup_id) workgroupId: vec3<u32>,
+        @builtin(local_invocation_index) localInvocationIndex: u32) {
+  let index = getInvocationIndex(workgroupId, localInvocationIndex);
+  if (index >= ${state.vertexCount}u) { return; }
+  let velocityIndex = ${getScalarOffset(state.velocities)}u + index * 2u;
+  ${pinnedGuard}
+  let positionIndex = ${getScalarOffset(state.positions)}u + index * 2u;
+  positions[positionIndex] += velocities[velocityIndex] * ${formatFloat(state.layout.timeStep)};
+  positions[positionIndex + 1u] += velocities[velocityIndex + 1u] *
+    ${formatFloat(state.layout.timeStep)};
+}`;
+  addSampledPass(
+    commandGraph,
+    `${state.layout.id}-sampled-integrate-${iteration}`,
+    source,
+    bindings,
+    state.vertexCount
+  );
+}
+
+function addSampledPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  id: string,
+  source: string,
+  bindings: Record<string, SampledBinding>,
+  count: number
+): void {
+  const dispatch = getDispatchLayout(commandGraph, count);
+  commandGraph.addComputePass({
+    id,
+    resources: Object.values(bindings).map(({view, usage}) => ({buffer: view, usage})),
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id,
+        source,
+        shaderLayout: {
+          bindings: Object.keys(bindings).map((name, location) => ({
+            name,
+            type: 'storage' as const,
+            group: 0,
+            location
+          }))
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const buffers: Record<string, Binding> = {};
+          for (const [name, binding] of Object.entries(bindings)) {
+            buffers[name] = getBuffer(binding.view);
+          }
+          computation.setBindings(buffers);
+          computation.dispatch(computePass, dispatch[0], dispatch[1], dispatch[2]);
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+function getDeclarations(bindings: Record<string, SampledBinding>): string {
+  return Object.entries(bindings)
+    .map(([name, binding], index) => {
+      const access = binding.usage === 'storage-read' ? 'read' : 'read_write';
+      const type = binding.view.format === 'uint32' ? 'u32' : 'f32';
+      return `@group(0) @binding(${index}) var<storage, ${access}> ${name}: array<${type}>;`;
+    })
+    .join('\n');
+}
+
+function getInvocationSource<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  count: number
+): string {
+  const dispatch = getDispatchLayout(commandGraph, count);
+  return /* wgsl */ `
+fn getInvocationIndex(workgroupId: vec3<u32>, localInvocationIndex: u32) -> u32 {
+  return ((workgroupId.z * ${dispatch[1]}u + workgroupId.y) * ${dispatch[0]}u +
+    workgroupId.x) * ${WORKGROUP_SIZE}u + localInvocationIndex;
+}`;
+}
+
+/** Restores four deterministic sunflower communities instead of an unstable global point cloud. */
+function getCommunityAnchorSource(vertexCount: number, seed: number): string {
+  return /* wgsl */ `
+fn getCommunityAnchor(vertex: u32) -> vec2<f32> {
+  let community = min((vertex * 4u) / ${vertexCount}u, 3u);
+  let first = (community * ${vertexCount}u) / 4u;
+  let next = ((community + 1u) * ${vertexCount}u) / 4u;
+  let localIndex = vertex - first;
+  let population = max(next - first, 1u);
+  let radius = sqrt((f32(localIndex) + 0.5) / f32(population)) * 0.38;
+  let angle = f32(localIndex) * 2.39996323 + f32(${seed}u & 255u) * 0.003;
+  let centerX = select(-0.52, 0.52, (community & 1u) != 0u);
+  let centerY = select(-0.43, 0.43, community >= 2u);
+  return vec2<f32>(centerX + cos(angle) * radius, centerY + sin(angle) * radius);
+}`;
+}
+
+function getDispatchLayout<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  count: number
+): readonly [number, number, number] {
+  const workgroups = Math.max(1, Math.ceil(count / WORKGROUP_SIZE));
+  const limit = commandGraph.device.limits.maxComputeWorkgroupsPerDimension;
+  const width = Math.min(workgroups, limit);
+  const height = Math.min(Math.ceil(workgroups / width), limit);
+  const depth = Math.ceil(workgroups / (width * height));
+  if (depth > limit) throw new Error('Graph explorer sampled layout exceeds bounded GPU dispatch');
+  return [width, height, depth];
+}
+
+function getScalarOffset(view: SampledView): number {
+  return view.byteOffset / Uint32Array.BYTES_PER_ELEMENT;
+}
+
+function formatFloat(value: number): string {
+  return Number.isInteger(value) ? `${value}.0` : `${value}`;
+}

--- a/examples/experimental/lugraph-explorer/graph-shaders.ts
+++ b/examples/experimental/lugraph-explorer/graph-shaders.ts
@@ -9,7 +9,7 @@ export const GRAPH_EXPLORER_VIEW_BYTE_LENGTH = 32;
 export const GRAPH_EXPLORER_INVALID_VERTEX = 0xffffffff;
 
 // Framing: center x, center y, zoom, viewport aspect ratio.
-// Interaction: selected vertex, maximum traversal depth, vertex count, packed display modes.
+// Interaction: selected vertex, maximum traversal depth, vertex count, packed visual-mode flags.
 const GRAPH_EXPLORER_VIEW_SOURCE = /* wgsl */ `
 struct GraphExplorerView {
   framing: vec4<f32>,
@@ -53,8 +53,9 @@ struct EdgeVertexOutput {
 
   var output: EdgeVertexOutput;
   output.position = vec4<f32>(projected, 0.35, 1.0);
+  let edgeDensity = clamp(256.0 / max(f32(view.interaction.z), 1.0), 0.14, 1.0);
   output.color = select(
-    vec4<f32>(0.30, 0.47, 0.70, select(0.23, 0.07, hasSelection)),
+    vec4<f32>(0.30, 0.47, 0.70, select(0.20 * edgeDensity, 0.055, hasSelection)),
     vec4<f32>(0.39, 0.87, 1.0, 0.76),
     hasSelection && connected
   );
@@ -69,17 +70,18 @@ struct EdgeVertexOutput {
  * Draws source-aligned circular nodes from the original float32x2 instance vertex buffer.
  *
  * Attribute: nodePosition at location zero, stepMode instance.
- * Bindings: importance=0, components=1, distances=2, selectionMask=3, degrees=4, view=5.
+ * Bindings: importance=0, components=1, communities=2, degrees=3, distances=4, mask=5, view=6.
  */
 export const GRAPH_EXPLORER_NODE_SHADER = /* wgsl */ `
 ${GRAPH_EXPLORER_VIEW_SOURCE}
 
 @group(0) @binding(0) var<storage, read> importance: array<f32>;
 @group(0) @binding(1) var<storage, read> components: array<u32>;
-@group(0) @binding(2) var<storage, read> distances: array<u32>;
-@group(0) @binding(3) var<storage, read> selectionMask: array<u32>;
-@group(0) @binding(4) var<storage, read> degrees: array<u32>;
-@group(0) @binding(5) var<uniform> view: GraphExplorerView;
+@group(0) @binding(2) var<storage, read> communities: array<u32>;
+@group(0) @binding(3) var<storage, read> degrees: array<u32>;
+@group(0) @binding(4) var<storage, read> distances: array<u32>;
+@group(0) @binding(5) var<storage, read> selectionMask: array<u32>;
+@group(0) @binding(6) var<uniform> view: GraphExplorerView;
 
 struct NodeVertexOutput {
   @builtin(position) position: vec4<f32>,
@@ -96,66 +98,59 @@ struct NodeVertexOutput {
     vec2<f32>(-1.0, -1.0), vec2<f32>(1.0, -1.0), vec2<f32>(-1.0, 1.0),
     vec2<f32>(-1.0, 1.0), vec2<f32>(1.0, -1.0), vec2<f32>(1.0, 1.0)
   );
-  let palette = array<vec3<f32>, 6>(
+  let palette = array<vec3<f32>, 7>(
     vec3<f32>(0.34, 0.84, 1.0),
-    vec3<f32>(0.76, 0.50, 1.0),
     vec3<f32>(1.0, 0.71, 0.37),
+    vec3<f32>(0.76, 0.50, 1.0),
     vec3<f32>(0.36, 0.90, 0.66),
     vec3<f32>(1.0, 0.45, 0.65),
-    vec3<f32>(0.91, 0.92, 0.52)
+    vec3<f32>(0.91, 0.92, 0.52),
+    vec3<f32>(0.39, 0.61, 1.0)
   );
-  let pageRankRadius = clamp(
-    0.012 + sqrt(max(importance[sourceIndex], 0.0)) * 0.085,
-    0.012,
-    0.050
-  );
-  let degreeRadius = clamp(0.011 + sqrt(f32(degrees[sourceIndex])) * 0.008, 0.012, 0.050);
-  let sizeMode = (view.interaction.w >> 8u) & 3u;
-  let metricRadius = select(pageRankRadius, degreeRadius, sizeMode == 1u);
-  let radius = select(metricRadius, 0.018, sizeMode == 2u);
-  let corner = corners[vertexIndex];
+  let population = max(f32(view.interaction.z), 1.0);
+  let densityScale = clamp(sqrt(128.0 / population), 0.24, 1.0);
+  let sizeMode = (view.interaction.w >> 4u) & 3u;
+  let importanceScale = clamp(sqrt(max(importance[sourceIndex] * population, 0.0)), 0.7, 2.5);
+  let degreeScale = clamp(sqrt(max(f32(degrees[sourceIndex]), 1.0)) * 0.55, 0.7, 2.5);
+  let metricScale = select(importanceScale, degreeScale, sizeMode == 1u);
+  let radius = clamp(0.018 * densityScale * select(metricScale, 1.0, sizeMode == 2u),
+    0.003, 0.040);
+  let pointMode = (view.interaction.w & 64u) != 0u;
+  let corner = select(corners[vertexIndex], vec2<f32>(0.0), pointMode);
   let centered = (nodePosition - view.framing.xy) * view.framing.z;
   let aspect = max(view.framing.w, 0.001);
   let projected = vec2<f32>(centered.x / aspect, centered.y) +
-    vec2<f32>(corner.x / aspect, corner.y) * radius;
+    vec2<f32>(corner.x / aspect, corner.y) * radius +
+    select(vec2<f32>(0.0), vec2<f32>(0.0001, -0.0001), pointMode);
   let hasSelection = view.interaction.x != ${GRAPH_EXPLORER_INVALID_VERTEX}u;
   let reachable = selectionMask[sourceIndex] != 0u &&
     distances[sourceIndex] != ${GRAPH_EXPLORER_INVALID_VERTEX}u;
   let selected = sourceIndex == view.interaction.x;
-  let colorMode = (view.interaction.w >> 4u) & 3u;
-  let degreeIntensity = clamp(log2(f32(degrees[sourceIndex]) + 1.0) / 4.0, 0.0, 1.0);
-  let degreeColor = mix(vec3<f32>(0.22, 0.48, 1.0), vec3<f32>(1.0, 0.71, 0.31), degreeIntensity);
-  let importanceIntensity = clamp(
-    sqrt(max(importance[sourceIndex], 0.0) * f32(view.interaction.z)) * 0.55,
-    0.0,
-    1.0
+  let colorMode = (view.interaction.w >> 1u) & 7u;
+  let communitySpan = max(view.interaction.z / 4u, 1u);
+  let communityLabel = select(
+    communities[sourceIndex],
+    min(communities[sourceIndex] / communitySpan, 3u),
+    pointMode && view.interaction.z >= 16384u
   );
-  let importanceColor = mix(
-    vec3<f32>(0.19, 0.86, 0.76),
-    vec3<f32>(0.79, 0.45, 1.0),
-    importanceIntensity
-  );
-  let distance = distances[sourceIndex];
-  let distanceIntensity = clamp(
-    f32(distance) / f32(max(view.interaction.y, 1u)),
-    0.0,
-    1.0
-  );
-  let reachableDistanceColor = mix(
-    vec3<f32>(0.39, 0.95, 1.0),
-    vec3<f32>(0.71, 0.43, 0.89),
-    distanceIntensity
-  );
-  let distanceColor = select(
-    vec3<f32>(0.24, 0.29, 0.40),
-    reachableDistanceColor,
-    distance != ${GRAPH_EXPLORER_INVALID_VERTEX}u
-  );
-  var color = palette[components[sourceIndex] % 6u];
-  color = select(color, degreeColor, colorMode == 1u);
-  color = select(color, importanceColor, colorMode == 2u);
-  color = select(color, distanceColor, colorMode == 3u);
-  color = select(color, color * 0.24, hasSelection && !reachable);
+  var color = palette[communityLabel % 7u];
+  if (colorMode == 1u) {
+    color = palette[components[sourceIndex] % 7u];
+  } else if (colorMode == 2u) {
+    color = mix(vec3<f32>(0.24, 0.48, 0.94), vec3<f32>(1.0, 0.45, 0.24),
+      clamp(f32(degrees[sourceIndex]) / 12.0, 0.0, 1.0));
+  } else if (colorMode == 3u) {
+    color = mix(vec3<f32>(0.34, 0.26, 0.82), vec3<f32>(1.0, 0.82, 0.35),
+      clamp(importance[sourceIndex] * population / 3.0, 0.0, 1.0));
+  } else if (colorMode == 4u) {
+    color = select(
+      vec3<f32>(0.26, 0.31, 0.43),
+      mix(vec3<f32>(1.0, 0.82, 0.35), vec3<f32>(0.29, 0.76, 1.0),
+        clamp(f32(distances[sourceIndex]) / 6.0, 0.0, 1.0)),
+      distances[sourceIndex] != ${GRAPH_EXPLORER_INVALID_VERTEX}u
+    );
+  }
+  color = select(color, color * select(0.24, 0.78, pointMode), hasSelection && !reachable);
   color = select(color, vec3<f32>(1.0, 0.96, 0.66), selected);
 
   var output: NodeVertexOutput;
@@ -205,20 +200,21 @@ struct PickingFragmentOutput {
     vec2<f32>(-1.0, -1.0), vec2<f32>(1.0, -1.0), vec2<f32>(-1.0, 1.0),
     vec2<f32>(-1.0, 1.0), vec2<f32>(1.0, -1.0), vec2<f32>(1.0, 1.0)
   );
-  let corner = corners[vertexIndex];
-  let pageRankRadius = clamp(
-    0.012 + sqrt(max(importance[sourceIndex], 0.0)) * 0.085,
-    0.012,
-    0.050
-  );
-  let degreeRadius = clamp(0.011 + sqrt(f32(degrees[sourceIndex])) * 0.008, 0.012, 0.050);
-  let sizeMode = (view.interaction.w >> 8u) & 3u;
-  let metricRadius = select(pageRankRadius, degreeRadius, sizeMode == 1u);
-  let radius = select(metricRadius, 0.018, sizeMode == 2u);
+  let pointMode = (view.interaction.w & 64u) != 0u;
+  let corner = select(corners[vertexIndex], vec2<f32>(0.0), pointMode);
+  let population = max(f32(view.interaction.z), 1.0);
+  let densityScale = clamp(sqrt(128.0 / population), 0.24, 1.0);
+  let sizeMode = (view.interaction.w >> 4u) & 3u;
+  let importanceScale = clamp(sqrt(max(importance[sourceIndex] * population, 0.0)), 0.7, 2.5);
+  let degreeScale = clamp(sqrt(max(f32(degrees[sourceIndex]), 1.0)) * 0.55, 0.7, 2.5);
+  let metricScale = select(importanceScale, degreeScale, sizeMode == 1u);
+  let radius = clamp(0.018 * densityScale * select(metricScale, 1.0, sizeMode == 2u),
+    0.003, 0.040);
   let centered = (nodePosition - view.framing.xy) * view.framing.z;
   let aspect = max(view.framing.w, 0.001);
   let projected = vec2<f32>(centered.x / aspect, centered.y) +
-    vec2<f32>(corner.x / aspect, corner.y) * radius;
+    vec2<f32>(corner.x / aspect, corner.y) * radius +
+    select(vec2<f32>(0.0), vec2<f32>(0.0001, -0.0001), pointMode);
 
   var output: PickingVertexOutput;
   output.position = vec4<f32>(projected, 0.1, 1.0);

--- a/modules/arrow-layers/README.md
+++ b/modules/arrow-layers/README.md
@@ -1,5 +1,7 @@
 # @deck.gl-community/arrow-layers
 
+## Overview
+
 Private deck.gl layers backed by the Arrow adapters and `GPUVector` objects from
 `@luma.gl/arrow`.
 
@@ -7,12 +9,22 @@ The layers intentionally do not use deck.gl `AttributeManager` for Arrow columns
 Arrow data is converted once into `GPUVector`/`GPUTable` inputs and bound directly
 to luma.gl models.
 
+## When to use graph layers
+
+Use the graph adapters when a deck.gl application already owns GPU-resident relationship data and
+needs to visualize social networks, service dependencies, transaction communities, or citation
+graphs without turning each vertex and edge into a JavaScript object.
+
+Choose another path when a small one-off graph starts and stays on the CPU or the application
+needs a graph database, automatic CPU fallback, or converged clustering guarantees. This package
+adapts existing GPU results to real deck.gl layers; it does not replace the underlying graph API.
+
 ## Graph effects and layers
 
-`LuGraphDeckEffect` composes topology, PageRank, weak components, neighborhood search, and
-progressive force layout inside deck.gl's existing frame. Deck owns queue submission; the effect
-retains original source and target edge partitions, including empty batches, without staging or
-reading graph data back to the CPU.
+`LuGraphDeckEffect` composes topology, vertex degree, PageRank, weak components, deterministic
+communities, neighborhood search, and progressive force layout inside deck.gl's existing frame.
+Deck owns queue submission; the effect retains original source and target edge partitions,
+including empty batches, without staging or reading graph data back to the CPU.
 
 ```ts
 import {
@@ -32,7 +44,31 @@ const dataset: LuGraphDeckDataset = {
 const effect = new LuGraphDeckEffect(device, dataset);
 ```
 
-`LuGraphNodeLayer` consumes the exact progressive position allocation alongside resident PageRank,
-component, distance, and selection outputs. Create one `LuGraphEdgeLayer` per nonempty original edge
-partition to render caller-owned source and target buffers directly. The graph algorithms remain in
-`@luma.gl/experimental/lugraph`; only this private adapter package depends on deck.gl.
+`LuGraphNodeLayer` consumes the exact progressive position allocation alongside resident community,
+component, degree, PageRank, distance, and selection outputs. Create one `LuGraphEdgeLayer` per
+nonempty original edge partition to render caller-owned source and target buffers directly. Large
+graphs can retain every real vertex while limiting only the number of displayed original edges.
+
+Choose exact layout for small networks, the explicit uniform-grid approximation for medium-sized
+networks, or inject an application-owned sampled-layout contributor for larger graphs. The sampled
+contributor receives the existing command graph and force-layout objects; it is not bundled into
+this private package, which never imports application or example source. The bundled showcase
+keeps all 1,048,576 source vertices and 2,097,343 directed edges resident while drawing every
+vertex and bounding visible edges to 65,536.
+
+```ts
+const sampledEffect = new LuGraphDeckEffect(device, dataset, {
+  layoutMode: 'sampled',
+  addSampledLayoutToGraph: addApplicationOwnedSampledLayout
+});
+```
+
+`addApplicationOwnedSampledLayout(commandGraph, layout)` declares application-owned GPU work on
+the supplied graph and existing layout; it does not transfer ownership or add an example
+dependency to this package. Omitting the optional configuration retains the regular exact-layout
+constructor shown above.
+
+The graph algorithms remain in `@luma.gl/experimental/lugraph`; only this existing private adapter
+package depends on deck.gl. Its diagnostics report actual resident populations, visible edge
+detail, CPU encoding, and frame cadence without inventing GPU timings or claiming convergence for
+a fixed iteration budget.

--- a/modules/arrow-layers/src/index.ts
+++ b/modules/arrow-layers/src/index.ts
@@ -20,7 +20,13 @@ export {
   type ArrowTextLayerProps
 } from './layers/arrow-text-layer';
 export type {ArrowLayerPickingInfo} from './layers/arrow-layer-types';
-export {LuGraphDeckEffect, type LuGraphDeckDataset} from './lugraph/lugraph-effect';
+export {
+  LuGraphDeckEffect,
+  type LuGraphDeckDataset,
+  type LuGraphDeckEffectOptions,
+  type LuGraphDeckEffectStats,
+  type LuGraphDeckLayoutMode
+} from './lugraph/lugraph-effect';
 export {
   LUGRAPH_DECK_EDGE_SHADER,
   LuGraphEdgeLayer,
@@ -29,5 +35,7 @@ export {
 export {
   LUGRAPH_DECK_NODE_SHADER,
   LuGraphNodeLayer,
+  type LuGraphDeckColorMode,
+  type LuGraphDeckNodeSizeMode,
   type LuGraphNodeLayerProps
 } from './lugraph/lugraph-node-layer';

--- a/modules/arrow-layers/src/lugraph/lugraph-edge-layer.ts
+++ b/modules/arrow-layers/src/lugraph/lugraph-edge-layer.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import {Layer, project32, type LayerContext, type LayerProps} from '@deck.gl/core';
+import {
+  Layer,
+  project32,
+  type LayerContext,
+  type LayerProps,
+  type UpdateParameters
+} from '@deck.gl/core';
 import {Buffer, type RenderPass} from '@luma.gl/core';
 import {Model} from '@luma.gl/engine';
 
@@ -124,6 +130,27 @@ export class LuGraphEdgeLayer extends Layer<LuGraphEdgeLayerProps> {
       parameters: EDGE_BLEND_PARAMETERS
     });
     this.setState({model, styleUniforms} satisfies LuGraphEdgeLayerState);
+  }
+
+  /** Keeps same-ID chunk models pointed at the new graph's original physical allocations. */
+  override updateState({props, oldProps}: UpdateParameters<this>): void {
+    const {model, styleUniforms} = this.state as LuGraphEdgeLayerState;
+    if (!model || !styleUniforms) return;
+    if (
+      props.positions !== oldProps.positions ||
+      props.sourceVertices !== oldProps.sourceVertices ||
+      props.targetVertices !== oldProps.targetVertices ||
+      props.distances !== oldProps.distances
+    ) {
+      model.setBindings({
+        positions: props.positions,
+        sourceVertices: props.sourceVertices,
+        targetVertices: props.targetVertices,
+        distances: props.distances,
+        edgeStyle: styleUniforms
+      });
+    }
+    model.setInstanceCount(props.edgeCount);
   }
 
   override getModels(): Model[] {

--- a/modules/arrow-layers/src/lugraph/lugraph-effect.ts
+++ b/modules/arrow-layers/src/lugraph/lugraph-effect.ts
@@ -9,13 +9,15 @@ import {
   LuGraph,
   LuGraphBreadthFirstSearch,
   LuGraphConnectedComponents,
+  LuGraphDegree,
   LuGraphForceLayout,
+  LuGraphLabelPropagation,
   LuGraphPageRank,
+  LuGraphSpatialForceLayout,
   LuGraphTopology,
   type LuGraphAdjacency
 } from '@luma.gl/experimental/lugraph';
 import {GPUData, GPUVector} from '@luma.gl/tables';
-
 /** Caller-owned graph input preserving original edge partitions and vertex allocations. */
 export type LuGraphDeckDataset = {
   /** Number of stable zero-based graph vertices. */
@@ -33,8 +35,55 @@ export type LuGraphDeckDataset = {
 const SCALAR_BYTE_LENGTH = 4;
 const MAXIMUM_NEIGHBORHOOD_DEPTH = 8;
 const DEFAULT_NEIGHBORHOOD_DEPTH = 2;
+const LUGRAPH_DECK_MAXIMUM_EXACT_VERTEX_COUNT = 512;
+const LUGRAPH_DECK_LINEAR_LAYOUT_VERTEX_COUNT = 16_384;
+const LUGRAPH_DECK_POINT_VERTEX_COUNT = 65_536;
+const LUGRAPH_DECK_MAX_VISIBLE_EDGES = 65_536;
+const LUGRAPH_DECK_SPATIAL_BOUNDS = [-2, -2, 2, 2] as const;
+const SPATIAL_DRAG_MARGIN = 0.1;
 
 type ScalarFormat = 'uint32' | 'float32';
+
+/** Selects exact forces, a flat spatial grid, or a caller-provided sampled layout. */
+export type LuGraphDeckLayoutMode = 'auto' | 'exact' | 'spatial' | 'sampled';
+
+/** Immediately available encoding, memory, and frame measurements; no graph data is read. */
+export type LuGraphDeckEffectStats = {
+  vertexCount: number;
+  edgeCount: number;
+  renderedVertexCount: number;
+  renderedEdgeCount: number;
+  frameCount: number;
+  layoutMode: 'exact' | 'spatial' | 'sampled';
+  renderMode: 'circles' | 'points';
+  gridCellCount: number;
+  residentBufferBytes: number;
+  transientBufferBytes: number;
+  spatialIndexBytes: number;
+  analysisNodeCount: number;
+  frameNodeCount: number;
+  analysisEncodeMilliseconds: number;
+  frameEncodeMilliseconds: number;
+  framesPerSecond: number;
+  completedAnalysisStages: number;
+  totalAnalysisStages: number;
+  pageRankIterations: number;
+  componentIterations: number;
+  communityIterations: number;
+};
+
+/** Optional bounded layout selection and CPU-only diagnostic callback. */
+export type LuGraphDeckEffectOptions = {
+  layoutMode?: LuGraphDeckLayoutMode;
+  pointMode?: boolean;
+  maxVisibleEdges?: number;
+  onStats?: (stats: LuGraphDeckEffectStats) => void;
+  /** Adds an explicitly provided O(E + 4V) contributor without importing application code. */
+  addSampledLayoutToGraph?: (
+    commandGraph: GPUCommandGraph<void>,
+    layout: LuGraphForceLayout
+  ) => void;
+};
 
 /**
  * Declares resident luGraph analytics and progressive layout inside deck.gl's own render encoder.
@@ -52,11 +101,19 @@ export class LuGraphDeckEffect implements Effect {
   readonly dataset: LuGraphDeckDataset;
   readonly graph: LuGraph;
   readonly topology: LuGraphTopology;
+  readonly degree: LuGraphDegree;
   readonly pageRank: LuGraphPageRank;
   readonly components: LuGraphConnectedComponents;
+  readonly communities: LuGraphLabelPropagation;
   readonly search: LuGraphBreadthFirstSearch;
   readonly layout: LuGraphForceLayout;
+  readonly spatialLayout?: LuGraphSpatialForceLayout;
+  readonly activeLayoutMode: 'exact' | 'spatial' | 'sampled';
+  readonly renderMode: 'circles' | 'points';
+  readonly renderedVertexCount: number;
+  readonly renderedEdgeCount: number;
   readonly analysisGraph: CompiledGPUCommandGraph<void>;
+  readonly searchGraph?: CompiledGPUCommandGraph<void>;
   readonly frameGraph: CompiledGPUCommandGraph<void>;
 
   private readonly buffers: Buffer[] = [];
@@ -67,15 +124,51 @@ export class LuGraphDeckEffect implements Effect {
   private readonly pinned: GPUVector<'uint32'>;
   private readonly reset: GPUVector<'uint32'>;
   private readonly pinnedVertices = new Set<number>();
+  private readonly onStats?: (stats: LuGraphDeckEffectStats) => void;
+  private readonly analysisStages: CompiledGPUCommandGraph<void>[];
   private selectedVertex: number | null = 0;
   private neighborhoodDepth = DEFAULT_NEIGHBORHOOD_DEPTH;
-  private analyticsPending = true;
+  private completedAnalysisStages = 0;
+  private searchPending = true;
+  private frameCount = 0;
+  private previousFrameTime = 0;
+  private analysisEncodeMilliseconds = 0;
+  private smoothedFramesPerSecond = 0;
   private destroyed = false;
 
-  constructor(device: Device, dataset: LuGraphDeckDataset) {
+  constructor(device: Device, dataset: LuGraphDeckDataset, options: LuGraphDeckEffectOptions = {}) {
     if (device.type !== 'webgpu') throw new Error('LuGraphDeckEffect requires WebGPU');
     this.device = device;
     this.dataset = dataset;
+    this.onStats = options.onStats;
+    const edgeCount = dataset.sourceChunks.reduce((total, chunk) => total + chunk.length, 0);
+    const largestBufferBytes = Math.max(dataset.vertexCount * 8, edgeCount * SCALAR_BYTE_LENGTH);
+    if (
+      largestBufferBytes > device.limits.maxStorageBufferBindingSize ||
+      largestBufferBytes > device.limits.maxBufferSize
+    ) {
+      throw new Error('Graph population exceeds the current WebGPU adapter buffer limits');
+    }
+    const massiveGraph = dataset.vertexCount >= LUGRAPH_DECK_LINEAR_LAYOUT_VERTEX_COUNT;
+    this.activeLayoutMode =
+      options.layoutMode === 'sampled' || massiveGraph
+        ? 'sampled'
+        : options.layoutMode === 'spatial' ||
+            dataset.vertexCount > LUGRAPH_DECK_MAXIMUM_EXACT_VERTEX_COUNT
+          ? 'spatial'
+          : 'exact';
+    if (this.activeLayoutMode === 'sampled' && !options.addSampledLayoutToGraph) {
+      throw new Error('Sampled graph layout requires a caller-provided GPU contributor');
+    }
+    this.renderMode =
+      (options.pointMode ?? dataset.vertexCount >= LUGRAPH_DECK_POINT_VERTEX_COUNT)
+        ? 'points'
+        : 'circles';
+    this.renderedVertexCount = dataset.vertexCount;
+    const visibleEdgeCapacity = Math.max(
+      0,
+      Math.floor(options.maxVisibleEdges ?? LUGRAPH_DECK_MAX_VISIBLE_EDGES)
+    );
 
     this.graph = new LuGraph({
       vertexCount: dataset.vertexCount,
@@ -83,6 +176,7 @@ export class LuGraphDeckEffect implements Effect {
       sourceVertices: this.createChunkedVector('source-vertices', dataset.sourceChunks),
       targetVertices: this.createChunkedVector('target-vertices', dataset.targetChunks)
     });
+    this.renderedEdgeCount = Math.min(this.graph.edgeCount, visibleEdgeCapacity);
     this.topology = new LuGraphTopology({
       id: 'lugraph-deck-topology',
       graph: this.graph,
@@ -90,17 +184,28 @@ export class LuGraphDeckEffect implements Effect {
       reverse: this.createAdjacency('reverse', dataset.vertexCount, this.graph.edgeCount),
       invalidEdgeCount: this.createScalarVector('invalid-edges', 'uint32', 1)
     });
+    this.degree = new LuGraphDegree({
+      id: 'lugraph-deck-degree',
+      topology: this.topology,
+      output: this.createScalarVector('degrees', 'uint32', dataset.vertexCount)
+    });
     this.pageRank = new LuGraphPageRank({
       id: 'lugraph-deck-page-rank',
       topology: this.topology,
       output: this.createScalarVector('importance', 'float32', dataset.vertexCount),
-      iterations: 12
+      iterations: massiveGraph ? 2 : 12
     });
     this.components = new LuGraphConnectedComponents({
       id: 'lugraph-deck-components',
       topology: this.topology,
       output: this.createScalarVector('components', 'uint32', dataset.vertexCount),
-      iterations: 16
+      iterations: massiveGraph ? 2 : 16
+    });
+    this.communities = new LuGraphLabelPropagation({
+      id: 'lugraph-deck-communities',
+      topology: this.topology,
+      output: this.createScalarVector('communities', 'uint32', dataset.vertexCount),
+      iterations: massiveGraph ? 2 : 8
     });
 
     this.seeds = this.createScalarVector('seeds', 'uint32', 1, Uint32Array.of(0));
@@ -134,23 +239,77 @@ export class LuGraphDeckEffect implements Effect {
       pinned: this.pinned,
       reset: this.reset,
       seed: 0x1a2b3c4d,
-      iterationsPerFrame: 2,
-      repulsion: 0.005,
-      attraction: 0.045,
-      gravity: 0.025,
-      damping: 0.85,
-      maxVelocity: 0.045
+      iterationsPerFrame: this.activeLayoutMode === 'exact' ? 2 : 1,
+      // Four sampled repulsion evaluations remain constant-cost as population grows; applying
+      // the exact all-pairs 1/V normalization would collapse every million-row cloud to a dot.
+      repulsion:
+        this.activeLayoutMode === 'sampled'
+          ? 0.0015
+          : 0.005 * Math.min(1, 128 / dataset.vertexCount),
+      attraction: this.activeLayoutMode === 'sampled' ? 0.04 : 0.045,
+      gravity: this.activeLayoutMode === 'sampled' ? 0.005 : 0.025,
+      damping: this.activeLayoutMode === 'sampled' ? 0.9 : 0.85,
+      maxVelocity:
+        this.activeLayoutMode === 'sampled'
+          ? 0.02
+          : this.activeLayoutMode === 'spatial'
+            ? 0.025
+            : 0.045
     });
+    if (this.activeLayoutMode === 'spatial') {
+      const gridSize = getLuGraphDeckGridSize(dataset.vertexCount);
+      const cellCount = gridSize[0] * gridSize[1];
+      this.spatialLayout = new LuGraphSpatialForceLayout({
+        id: 'lugraph-deck-spatial-layout',
+        layout: this.layout,
+        gridSize,
+        bounds: LUGRAPH_DECK_SPATIAL_BOUNDS,
+        theta: 0.65,
+        nearCellRadius: 1,
+        cellOffsets: this.createScalarVector('spatial-cell-offsets', 'uint32', cellCount + 1),
+        vertexIds: this.createScalarVector('spatial-vertex-ids', 'uint32', dataset.vertexCount),
+        cellCenters: this.createCoordinateVector(
+          'spatial-cell-centers',
+          new Float32Array(cellCount * 2)
+        ),
+        count: this.createScalarVector('spatial-count', 'uint32', 1),
+        overflow: this.createScalarVector('spatial-overflow', 'uint32', 1)
+      });
+    }
 
     const analysis = new GPUCommandGraph<void>(device, {id: 'lugraph-deck-analysis'});
     this.topology.addToGraph(analysis);
-    this.components.addToGraph(analysis);
-    this.pageRank.addToGraph(analysis);
+    this.degree.addToGraph(analysis);
+    if (!massiveGraph) {
+      this.components.addToGraph(analysis);
+      this.communities.addToGraph(analysis);
+      this.pageRank.addToGraph(analysis);
+    }
     this.analysisGraph = analysis.compile();
+    this.analysisStages = [this.analysisGraph];
+    if (massiveGraph) {
+      for (const [name, contributor] of [
+        ['components', this.components],
+        ['communities', this.communities],
+        ['page-rank', this.pageRank]
+      ] as const) {
+        const stage = new GPUCommandGraph<void>(device, {id: `lugraph-deck-${name}-analysis`});
+        contributor.addToGraph(stage);
+        this.analysisStages.push(stage.compile());
+      }
+    }
 
     const frame = new GPUCommandGraph<void>(device, {id: 'lugraph-deck-frame'});
-    this.search.addToGraph(frame);
-    this.layout.addToGraph(frame);
+    if (this.activeLayoutMode === 'sampled') {
+      const search = new GPUCommandGraph<void>(device, {id: 'lugraph-deck-selection'});
+      this.search.addToGraph(search);
+      this.searchGraph = search.compile();
+      options.addSampledLayoutToGraph!(frame, this.layout);
+    } else {
+      this.search.addToGraph(frame);
+      if (this.spatialLayout) this.spatialLayout.addToGraph(frame);
+      else this.layout.addToGraph(frame);
+    }
     this.frameGraph = frame.compile();
   }
 
@@ -165,6 +324,14 @@ export class LuGraphDeckEffect implements Effect {
 
   get componentLabels(): Buffer {
     return this.getVectorBuffer(this.components.output);
+  }
+
+  get communityLabels(): Buffer {
+    return this.getVectorBuffer(this.communities.output);
+  }
+
+  get degreeValues(): Buffer {
+    return this.getVectorBuffer(this.degree.output);
   }
 
   get distances(): Buffer {
@@ -188,11 +355,34 @@ export class LuGraphDeckEffect implements Effect {
   /** Appends compute to Deck's current frame; Deck remains the sole queue submission owner. */
   preRender(options: Parameters<Effect['preRender']>[0]): void {
     if (this.destroyed || !options.viewports[0]) return;
-    if (this.analyticsPending) {
-      this.analysisGraph.encode(this.device.commandEncoder, {parameters: undefined});
-      this.analyticsPending = false;
+    let advancedAnalysis = false;
+    if (this.completedAnalysisStages < this.analysisStages.length) {
+      const stage = this.analysisStages[this.completedAnalysisStages];
+      const encoding = stage.encode(this.device.commandEncoder, {
+        parameters: undefined
+      });
+      this.analysisEncodeMilliseconds += encoding.stats.cpuEncodeTimeMilliseconds;
+      this.completedAnalysisStages++;
+      advancedAnalysis = true;
     }
-    this.frameGraph.encode(this.device.commandEncoder, {parameters: undefined});
+    if (this.searchGraph && this.searchPending && this.completedAnalysisStages > 0) {
+      this.searchGraph.encode(this.device.commandEncoder, {parameters: undefined});
+      this.searchPending = false;
+    }
+    const encoding = this.frameGraph.encode(this.device.commandEncoder, {parameters: undefined});
+    this.frameCount++;
+    const frameTime = performance.now();
+    if (this.previousFrameTime > 0 && frameTime > this.previousFrameTime) {
+      const framesPerSecond = 1_000 / (frameTime - this.previousFrameTime);
+      this.smoothedFramesPerSecond =
+        this.smoothedFramesPerSecond === 0
+          ? framesPerSecond
+          : this.smoothedFramesPerSecond * 0.85 + framesPerSecond * 0.15;
+    }
+    this.previousFrameTime = frameTime;
+    if (this.frameCount === 1 || advancedAnalysis || this.frameCount % 10 === 0) {
+      this.publishStats(encoding.stats.cpuEncodeTimeMilliseconds);
+    }
   }
 
   /** Publishes a genuinely picked stable source vertex without reading any graph column. */
@@ -205,12 +395,14 @@ export class LuGraphDeckEffect implements Effect {
       this.getVectorBuffer(this.seeds).write(Uint32Array.of(vertex));
       this.getVectorBuffer(this.seedCount).write(Uint32Array.of(1));
     }
+    this.searchPending = true;
   }
 
   /** Updates the existing GPU-resident dynamic hop limit without recompiling traversal passes. */
   setNeighborhoodDepth(depth: number): void {
     this.neighborhoodDepth = Math.max(0, Math.min(MAXIMUM_NEIGHBORHOOD_DEPTH, Math.round(depth)));
     this.getVectorBuffer(this.activeDepth).write(Uint32Array.of(this.neighborhoodDepth));
+    this.searchPending = true;
   }
 
   /** Pins or releases exactly one original source vertex; no other rows are repacked. */
@@ -231,7 +423,15 @@ export class LuGraphDeckEffect implements Effect {
   /** Moves the same physical vertex allocation consumed by the active Deck node model. */
   setVertexPosition(vertex: number, position: readonly [number, number]): void {
     if (!this.isValidVertex(vertex) || !position.every(Number.isFinite)) return;
-    this.positions.write(Float32Array.from(position), vertex * 2 * SCALAR_BYTE_LENGTH);
+    const boundedPosition = this.spatialLayout
+      ? position.map((coordinate, dimension) =>
+          Math.min(
+            LUGRAPH_DECK_SPATIAL_BOUNDS[dimension + 2] - SPATIAL_DRAG_MARGIN,
+            Math.max(LUGRAPH_DECK_SPATIAL_BOUNDS[dimension] + SPATIAL_DRAG_MARGIN, coordinate)
+          )
+        )
+      : position;
+    this.positions.write(Float32Array.from(boundedPosition), vertex * 2 * SCALAR_BYTE_LENGTH);
     this.getVectorBuffer(this.layout.velocities).write(
       Float32Array.of(0, 0),
       vertex * 2 * SCALAR_BYTE_LENGTH
@@ -251,7 +451,8 @@ export class LuGraphDeckEffect implements Effect {
   cleanup(_context: EffectContext): void {
     if (this.destroyed) return;
     this.destroyed = true;
-    this.analysisGraph.destroy();
+    for (const stage of this.analysisStages) stage.destroy();
+    this.searchGraph?.destroy();
     this.frameGraph.destroy();
     for (const vector of this.vectors.reverse()) vector.destroy();
     for (const buffer of this.buffers.reverse()) buffer.destroy();
@@ -259,6 +460,53 @@ export class LuGraphDeckEffect implements Effect {
 
   private isValidVertex(vertex: number): boolean {
     return Number.isSafeInteger(vertex) && vertex >= 0 && vertex < this.graph.vertexCount;
+  }
+
+  /** Publishes real CPU encoding and allocation metadata without waiting on GPU work. */
+  private publishStats(frameEncodeMilliseconds: number): void {
+    if (!this.onStats) return;
+    const spatial = this.spatialLayout;
+    const spatialIndexBytes = spatial
+      ? [
+          spatial.cellOffsets,
+          spatial.vertexIds,
+          spatial.cellCenters,
+          spatial.count,
+          spatial.overflow
+        ].reduce((total, vector) => total + this.getVectorBuffer(vector).byteLength, 0)
+      : 0;
+    this.onStats({
+      vertexCount: this.graph.vertexCount,
+      edgeCount: this.graph.edgeCount,
+      renderedVertexCount: this.renderedVertexCount,
+      renderedEdgeCount: this.renderedEdgeCount,
+      frameCount: this.frameCount,
+      layoutMode: this.activeLayoutMode,
+      renderMode: this.renderMode,
+      gridCellCount: spatial?.cellCount ?? 0,
+      residentBufferBytes: this.buffers.reduce((total, buffer) => total + buffer.byteLength, 0),
+      transientBufferBytes:
+        this.analysisStages.reduce(
+          (total, stage) => total + stage.stats.physicalTransientBytes,
+          0
+        ) +
+        (this.searchGraph?.stats.physicalTransientBytes ?? 0) +
+        this.frameGraph.stats.physicalTransientBytes,
+      spatialIndexBytes,
+      analysisNodeCount: this.analysisStages.reduce(
+        (total, stage) => total + stage.stats.nodeOrder.length,
+        0
+      ),
+      frameNodeCount: this.frameGraph.stats.nodeOrder.length,
+      analysisEncodeMilliseconds: this.analysisEncodeMilliseconds,
+      frameEncodeMilliseconds,
+      framesPerSecond: this.smoothedFramesPerSecond,
+      completedAnalysisStages: this.completedAnalysisStages,
+      totalAnalysisStages: this.analysisStages.length,
+      pageRankIterations: this.pageRank.iterations,
+      componentIterations: this.components.iterations,
+      communityIterations: this.communities.iterations
+    });
   }
 
   /** Preserves all original aligned GPUData partitions, including zero-length source batches. */
@@ -349,4 +597,10 @@ export class LuGraphDeckEffect implements Effect {
   private getVectorBuffer(vector: GPUVector): Buffer {
     return vector.data[0].buffer as Buffer;
   }
+}
+
+/** Bounds the caller-owned spatial grid without depending on example fixtures. */
+function getLuGraphDeckGridSize(vertexCount: number): readonly [number, number] {
+  const dimension = Math.max(4, Math.min(32, Math.ceil(Math.sqrt(3) * vertexCount ** 0.25)));
+  return [dimension, dimension];
 }

--- a/modules/arrow-layers/src/lugraph/lugraph-node-layer.ts
+++ b/modules/arrow-layers/src/lugraph/lugraph-node-layer.ts
@@ -8,19 +8,34 @@ import {
   project32,
   type LayerContext,
   type LayerProps,
-  type PickingInfo
+  type PickingInfo,
+  type UpdateParameters
 } from '@deck.gl/core';
 import {Buffer, type RenderPass} from '@luma.gl/core';
 import {Model} from '@luma.gl/engine';
+
+const LUGRAPH_DECK_POINT_VERTEX_COUNT = 65_536;
+
+/** GPU-resident node attribute used for visible source-vertex colors. */
+export type LuGraphDeckColorMode = 'community' | 'component' | 'degree' | 'pagerank' | 'distance';
+
+/** GPU-resident source-vertex attribute used to size rendered graph nodes. */
+export type LuGraphDeckNodeSizeMode = 'pagerank' | 'degree' | 'uniform';
 
 /** Actual luGraph allocations consumed by a deck.gl node layer without staging or copying. */
 export type LuGraphNodeLayerProps = LayerProps & {
   positions: Buffer;
   importance: Buffer;
   components: Buffer;
+  communities: Buffer;
+  degrees: Buffer;
   distances: Buffer;
   selectionMask: Buffer;
   vertexCount: number;
+  /** Forces true one-vertex point primitives without dropping or sampling resident instances. */
+  pointMode?: boolean;
+  colorMode?: LuGraphDeckColorMode;
+  sizeMode?: LuGraphDeckNodeSizeMode;
 };
 
 type LuGraphNodeLayerState = {
@@ -39,17 +54,23 @@ const NODE_BLEND_PARAMETERS = {
   blendAlphaDstFactor: 'one-minus-src-alpha'
 } as const;
 
-/** Direct instance vertex fetch and four independently computed resident graph attributes. */
+/** Direct instance vertex fetch and six independently computed resident graph attributes. */
 export const LUGRAPH_DECK_NODE_SHADER = /* wgsl */ `
 struct NodeStyle {
   radiusPixels: f32,
   opacity: f32,
   pickingActive: f32,
   vertexCount: f32,
+  colorMode: u32,
+  sizeMode: u32,
+  pointMode: u32,
+  _padding1: u32,
 };
 
 @group(0) @binding(auto) var<storage, read> importance: array<f32>;
 @group(0) @binding(auto) var<storage, read> components: array<u32>;
+@group(0) @binding(auto) var<storage, read> communities: array<u32>;
+@group(0) @binding(auto) var<storage, read> degrees: array<u32>;
 @group(0) @binding(auto) var<storage, read> distances: array<u32>;
 @group(0) @binding(auto) var<storage, read> selectionMask: array<u32>;
 @group(0) @binding(auto) var<uniform> nodeStyle: NodeStyle;
@@ -69,16 +90,44 @@ fn getNodeCorner(vertexIndex: u32) -> vec2<f32> {
   return corners[vertexIndex];
 }
 
-fn getComponentColor(component: u32) -> vec3<f32> {
-  let colors = array<vec3<f32>, 6>(
+fn getGroupColor(group: u32) -> vec3<f32> {
+  let colors = array<vec3<f32>, 7>(
     vec3<f32>(0.26, 0.79, 1.00),
     vec3<f32>(1.00, 0.58, 0.28),
     vec3<f32>(0.74, 0.48, 1.00),
     vec3<f32>(0.34, 0.92, 0.66),
     vec3<f32>(1.00, 0.41, 0.66),
-    vec3<f32>(0.96, 0.86, 0.34)
+    vec3<f32>(0.96, 0.86, 0.34),
+    vec3<f32>(0.42, 0.62, 1.00)
   );
-  return colors[component % 6u];
+  return colors[group % 7u];
+}
+
+fn getNodeAnalyticColor(index: u32) -> vec3<f32> {
+  if (nodeStyle.colorMode == 0u) {
+    let label = communities[index];
+    let communitySpan = max(u32(nodeStyle.vertexCount) / 4u, 1u);
+    let visibleLabel = select(label, min(label / communitySpan, 3u),
+      nodeStyle.pointMode != 0u && nodeStyle.vertexCount >= 16384.0);
+    return getGroupColor(visibleLabel);
+  }
+  if (nodeStyle.colorMode == 1u) {
+    return getGroupColor(components[index]);
+  }
+  if (nodeStyle.colorMode == 2u) {
+    return mix(vec3<f32>(0.24, 0.49, 0.94), vec3<f32>(1.0, 0.42, 0.21),
+      clamp(f32(degrees[index]) / 12.0, 0.0, 1.0));
+  }
+  if (nodeStyle.colorMode == 3u) {
+    return mix(vec3<f32>(0.35, 0.26, 0.82), vec3<f32>(1.0, 0.79, 0.28),
+      clamp(importance[index] * nodeStyle.vertexCount / 3.0, 0.0, 1.0));
+  }
+  let distanceValue = distances[index];
+  if (distanceValue == 0xffffffffu) {
+    return vec3<f32>(0.26, 0.31, 0.43);
+  }
+  return mix(vec3<f32>(1.0, 0.80, 0.31), vec3<f32>(0.25, 0.70, 1.0),
+    clamp(f32(distanceValue) / 6.0, 0.0, 1.0));
 }
 
 fn encodeNodePickingColor(vertex: u32) -> vec3<f32> {
@@ -95,17 +144,22 @@ fn encodeNodePickingColor(vertex: u32) -> vec3<f32> {
   @builtin(vertex_index) vertexIndex: u32,
   @builtin(instance_index) instanceIndex: u32
 ) -> NodeVertexOutput {
-  let corner = getNodeCorner(vertexIndex);
+  let corner = select(getNodeCorner(vertexIndex), vec2<f32>(0.0), nodeStyle.pointMode != 0u);
   let pickingColor = encodeNodePickingColor(instanceIndex);
-  let selected = selectionMask[instanceIndex] != 0u;
+  let inNeighborhood = selectionMask[instanceIndex] != 0u;
   let reached = distances[instanceIndex] != 0xffffffffu;
   let rank = max(importance[instanceIndex] * nodeStyle.vertexCount, 0.0);
-  var radius = nodeStyle.radiusPixels * clamp(sqrt(rank), 0.65, 2.3);
+  let degreeScale = sqrt(max(f32(degrees[instanceIndex]), 1.0));
+  let rankScale = clamp(sqrt(rank), 0.65, 2.3);
+  let metricScale = select(rankScale, clamp(degreeScale * 0.48, 0.65, 2.4),
+    nodeStyle.sizeMode == 1u);
+  var radius = nodeStyle.radiusPixels * select(metricScale, 1.0, nodeStyle.sizeMode == 2u);
 
   let highlightedColor = picking_normalizeColor(picking.highlightedObjectColor);
   let highlighted = picking.isHighlightActive > 0.5 &&
     distance(pickingColor, highlightedColor) < 0.00001;
-  if (selected || highlighted) { radius *= 1.35; }
+  let selected = reached && distances[instanceIndex] == 0u;
+  if (selected || highlighted) { radius *= 1.45; }
 
   geometry.worldPosition = vec3<f32>(nodePosition, 0.0);
   geometry.pickingColor = pickingColor;
@@ -122,9 +176,10 @@ fn encodeNodePickingColor(vertex: u32) -> vec3<f32> {
     clipPosition.w
   );
 
-  let componentColor = getComponentColor(components[instanceIndex]);
-  let accentColor = select(componentColor, vec3<f32>(1.0, 0.78, 0.28), selected);
-  let brightness = select(0.56, 1.0, reached || selected || highlighted);
+  let analyticColor = getNodeAnalyticColor(instanceIndex);
+  let accentColor = select(analyticColor, vec3<f32>(1.0, 0.84, 0.38), selected);
+  let inactiveBrightness = select(0.40, 0.78, nodeStyle.pointMode != 0u);
+  let brightness = select(inactiveBrightness, 1.0, inNeighborhood || selected || highlighted);
 
   var output: NodeVertexOutput;
   output.position = clipPosition;
@@ -162,21 +217,25 @@ export class LuGraphNodeLayer extends Layer<LuGraphNodeLayerProps> {
     if (device.type !== 'webgpu') throw new Error('LuGraphNodeLayer requires WebGPU');
     const styleUniforms = device.createBuffer({
       id: `${this.id}-style-uniforms`,
-      byteLength: 16,
+      byteLength: 32,
       usage: Buffer.UNIFORM | Buffer.COPY_DST
     });
+    const pointMode =
+      this.props.pointMode ?? this.props.vertexCount >= LUGRAPH_DECK_POINT_VERTEX_COUNT;
     const model = new Model(device, {
       ...this.getShaders({modules: [project32, picking], source: LUGRAPH_DECK_NODE_SHADER}),
       id: `${this.id}-model`,
-      topology: 'triangle-list',
+      topology: pointMode ? 'point-list' : 'triangle-list',
       isInstanced: true,
-      vertexCount: 6,
+      vertexCount: pointMode ? 1 : 6,
       instanceCount: this.props.vertexCount,
       attributes: {nodePosition: this.props.positions},
       bufferLayout: [{name: 'nodePosition', format: 'float32x2', stepMode: 'instance'}],
       bindings: {
         importance: this.props.importance,
         components: this.props.components,
+        communities: this.props.communities,
+        degrees: this.props.degrees,
         distances: this.props.distances,
         selectionMask: this.props.selectionMask,
         nodeStyle: styleUniforms
@@ -184,6 +243,37 @@ export class LuGraphNodeLayer extends Layer<LuGraphNodeLayerProps> {
       parameters: NODE_BLEND_PARAMETERS
     });
     this.setState({model, styleUniforms} satisfies LuGraphNodeLayerState);
+  }
+
+  /** Rebinds same-ID Deck layers before replaced graph allocations can be drawn again. */
+  override updateState({props, oldProps}: UpdateParameters<this>): void {
+    const {model, styleUniforms} = this.state as LuGraphNodeLayerState;
+    if (!model || !styleUniforms) return;
+    if (props.positions !== oldProps.positions) {
+      model.setAttributes({nodePosition: props.positions});
+    }
+    if (
+      props.importance !== oldProps.importance ||
+      props.components !== oldProps.components ||
+      props.communities !== oldProps.communities ||
+      props.degrees !== oldProps.degrees ||
+      props.distances !== oldProps.distances ||
+      props.selectionMask !== oldProps.selectionMask
+    ) {
+      model.setBindings({
+        importance: props.importance,
+        components: props.components,
+        communities: props.communities,
+        degrees: props.degrees,
+        distances: props.distances,
+        selectionMask: props.selectionMask,
+        nodeStyle: styleUniforms
+      });
+    }
+    const pointMode = props.pointMode ?? props.vertexCount >= LUGRAPH_DECK_POINT_VERTEX_COUNT;
+    model.setTopology(pointMode ? 'point-list' : 'triangle-list');
+    model.setVertexCount(pointMode ? 1 : 6);
+    model.setInstanceCount(props.vertexCount);
   }
 
   override getModels(): Model[] {
@@ -200,14 +290,20 @@ export class LuGraphNodeLayer extends Layer<LuGraphNodeLayerProps> {
   }): void {
     const {model, styleUniforms} = this.state as LuGraphNodeLayerState;
     if (!model || !styleUniforms) return;
-    styleUniforms.write(
-      new Float32Array([
-        6,
-        this.props.opacity ?? 1,
-        shaderModuleProps?.picking?.isActive ? 1 : 0,
-        this.props.vertexCount
-      ])
-    );
+    const style = new ArrayBuffer(32);
+    new Float32Array(style, 0, 4).set([
+      Math.max(1.4, Math.min(6, 60 / Math.sqrt(Math.max(this.props.vertexCount, 1)))),
+      this.props.opacity ?? 1,
+      shaderModuleProps?.picking?.isActive ? 1 : 0,
+      this.props.vertexCount
+    ]);
+    new Uint32Array(style, 16, 4).set([
+      getColorModeIndex(this.props.colorMode ?? 'community'),
+      getSizeModeIndex(this.props.sizeMode ?? 'pagerank'),
+      Number(this.props.pointMode ?? this.props.vertexCount >= LUGRAPH_DECK_POINT_VERTEX_COUNT),
+      0
+    ]);
+    styleUniforms.write(new Uint8Array(style));
     model.setInstanceCount(this.props.vertexCount);
     model.draw(renderPass);
   }
@@ -223,4 +319,12 @@ export class LuGraphNodeLayer extends Layer<LuGraphNodeLayerProps> {
     this.setState({model: null, styleUniforms: null} satisfies LuGraphNodeLayerState);
     super.finalizeState(context);
   }
+}
+
+function getColorModeIndex(mode: LuGraphDeckColorMode): number {
+  return ['community', 'component', 'degree', 'pagerank', 'distance'].indexOf(mode);
+}
+
+function getSizeModeIndex(mode: LuGraphDeckNodeSizeMode): number {
+  return ['pagerank', 'degree', 'uniform'].indexOf(mode);
 }

--- a/modules/arrow-layers/test/lu-graph-deck.node.spec.ts
+++ b/modules/arrow-layers/test/lu-graph-deck.node.spec.ts
@@ -16,7 +16,15 @@ import * as luGraphModule from '@luma.gl/experimental/lugraph';
 import {describe, expect, test} from 'vitest';
 
 import {createLuGraphExplorerDeck} from '../../../examples/deck/lugraph-explorer/app';
-import {makeGraphExplorerDataset} from '../../../examples/experimental/lugraph-explorer/graph-data';
+import {
+  GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT,
+  GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT,
+  GRAPH_EXPLORER_MAX_VISIBLE_EDGES,
+  GRAPH_EXPLORER_POINT_VERTEX_COUNT,
+  GRAPH_EXPLORER_SHOWCASE_DEFAULT_VERTEX_COUNT,
+  GRAPH_EXPLORER_VERTEX_COUNTS,
+  makeGraphExplorerDataset
+} from '../../../examples/experimental/lugraph-explorer/graph-data';
 import {getExampleThumbnailPath} from '../../../website/src/example-thumbnails';
 
 type ExampleContentsEntry = {
@@ -100,11 +108,116 @@ describe('luGraph native deck.gl resident layers', () => {
     expect(LUGRAPH_DECK_NODE_SHADER).toContain('@location(0) nodePosition: vec2<f32>');
     expect(LUGRAPH_DECK_NODE_SHADER).toContain('importance: array<f32>');
     expect(LUGRAPH_DECK_NODE_SHADER).toContain('components: array<u32>');
+    expect(LUGRAPH_DECK_NODE_SHADER).toContain('communities: array<u32>');
+    expect(LUGRAPH_DECK_NODE_SHADER).toContain('let label = communities[index]');
+    expect(LUGRAPH_DECK_NODE_SHADER).toContain('u32(nodeStyle.vertexCount) / 4u');
+    expect(LUGRAPH_DECK_NODE_SHADER).toContain('min(label / communitySpan, 3u)');
+    expect(LUGRAPH_DECK_NODE_SHADER).toContain('0.78');
+    expect(LUGRAPH_DECK_NODE_SHADER).toContain('degrees: array<u32>');
     expect(LUGRAPH_DECK_NODE_SHADER).toContain('distances: array<u32>');
     expect(LUGRAPH_DECK_NODE_SHADER).toContain('selectionMask: array<u32>');
     expect(LUGRAPH_DECK_NODE_SHADER).toContain('vertex + 1u');
     expect(LUGRAPH_DECK_NODE_SHADER).toContain('geometry.pickingColor');
     expect(LUGRAPH_DECK_NODE_SHADER).not.toMatch(/atomic\s*<\s*f32\s*>/);
+  });
+
+  test('shares fourteen genuine graph scales while bounding only work and visible edges', () => {
+    expect(GRAPH_EXPLORER_VERTEX_COUNTS).toEqual([
+      128, 256, 512, 1024, 2048, 4096, 8192, 16_384, 32_768, 65_536, 131_072, 262_144, 524_288,
+      1_048_576
+    ]);
+    expect(GRAPH_EXPLORER_SHOWCASE_DEFAULT_VERTEX_COUNT).toBe(1024);
+    expect(GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT).toBe(512);
+    expect(GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT).toBe(16_384);
+    expect(GRAPH_EXPLORER_POINT_VERTEX_COUNT).toBe(65_536);
+    expect(GRAPH_EXPLORER_MAX_VISIBLE_EDGES).toBe(65_536);
+
+    const effectSource = readFileSync(
+      new URL('../src/lugraph/lugraph-effect.ts', import.meta.url),
+      'utf8'
+    );
+    expect(effectSource).toContain('LuGraphDegree');
+    expect(effectSource).toContain('LuGraphLabelPropagation');
+    expect(effectSource).toContain('LuGraphSpatialForceLayout');
+    expect(effectSource).toContain('addSampledLayoutToGraph');
+    expect(effectSource).toContain('this.renderedVertexCount = dataset.vertexCount');
+    expect(effectSource).toContain('this.renderedEdgeCount = Math.min');
+    expect(effectSource).toMatch(
+      /repulsion:\s*this\.activeLayoutMode\s*===\s*'sampled'\s*\?\s*0\.0015\s*:/
+    );
+    expect(effectSource).toMatch(
+      /gravity:\s*this\.activeLayoutMode\s*===\s*'sampled'\s*\?\s*0\.005/
+    );
+    expect(effectSource).not.toContain('graph-scale-layout');
+    expect(effectSource).not.toMatch(/from\s+['"][^'"]*examples\//u);
+    expect(effectSource).not.toMatch(/\.readAsync\s*\(/);
+  });
+
+  test('creates an actual million-vertex graph without multiplying a representative sample', () => {
+    const dataset = makeGraphExplorerDataset(1_048_576);
+
+    expect(dataset.vertexCount).toBe(1_048_576);
+    expect(dataset.positions).toHaveLength(2_097_152);
+    expect(dataset.velocities).toHaveLength(2_097_152);
+    expect(dataset.sourceChunks.map(chunk => chunk.length)).toEqual(
+      dataset.targetChunks.map(chunk => chunk.length)
+    );
+    expect(dataset.sourceChunks[1]).toHaveLength(0);
+    expect(dataset.sourceChunks.reduce((count, chunk) => count + chunk.length, 0)).toBe(2_097_343);
+  });
+
+  test('rebinds same-ID Deck node and edge models after replacing graph allocations', () => {
+    for (const path of [
+      '../src/lugraph/lugraph-node-layer.ts',
+      '../src/lugraph/lugraph-edge-layer.ts'
+    ]) {
+      const source = readFileSync(new URL(path, import.meta.url), 'utf8');
+
+      expect(source).toMatch(/updateState\s*\(/);
+      expect(source).toMatch(/setBindings\s*\(/);
+    }
+  });
+
+  test('renders accessible graph scale, truthful GPU diagnostics, and real analytic controls', () => {
+    const source = readFileSync(
+      new URL('../../../examples/deck/lugraph-explorer/app.ts', import.meta.url),
+      'utf8'
+    );
+
+    for (const attribute of [
+      'data-lugraph-size',
+      'data-lugraph-size-value',
+      'data-lugraph-size-decrease',
+      'data-lugraph-size-increase',
+      'data-lugraph-layout',
+      'data-lugraph-color',
+      'data-lugraph-node-size',
+      'data-lugraph-edges',
+      'data-lugraph-depth',
+      'data-lugraph-pause',
+      'data-lugraph-legend',
+      'data-lugraph-fps',
+      'data-lugraph-encode',
+      'data-lugraph-memory',
+      'data-lugraph-index',
+      'data-lugraph-pipeline'
+    ]) {
+      expect(source).toContain(attribute);
+    }
+
+    for (const mode of ['community', 'component', 'degree', 'pagerank', 'distance']) {
+      expect(source).toContain(`value="${mode}"`);
+    }
+
+    expect(source).toContain('aria-label="Graph vertex count"');
+    expect(source).toContain('role="status"');
+    expect(source).toContain('aria-live="polite"');
+    expect(source).toContain('CPU encode');
+    expect(source).toContain('maxVisibleEdges');
+    expect(source).toContain('renderedEdgeCount');
+    expect(source).toContain('value="sampled"');
+    expect(source).not.toContain('@deck.gl/core');
+    expect(source).not.toMatch(/GPU\s+(?:frame|execution|duration)\s*[:=]\s*\$\{/i);
   });
 
   test('reads source and target edge chunks directly without concatenation or CPU staging', () => {
@@ -176,6 +289,16 @@ describe('optional luGraph deck.gl gallery and API guide', () => {
     expect(apiGuide).toContain('/examples/deck/lugraph-explorer');
     expect(apiGuide).toContain("deck.gl's own command");
     expect(apiGuide).toContain('without concatenation, buffer copies, or per-frame graph readback');
+    expect(examplePage).toContain('1,024');
+    expect(examplePage).toContain('1,048,576');
+    expect(examplePage).toContain('2,097,343');
+    expect(examplePage).toContain('65,536');
+    expect(examplePage).toContain('16,384');
+    expect(examplePage).toContain('512 vertices');
+    expect(examplePage).toContain('O(E + 4V)');
+    expect(examplePage).toMatch(/label.propagation/u);
+    expect(examplePage).toContain('CPU encoding');
+    expect(examplePage).toContain('does not invent convergence, timestamps');
   });
 
   test('explains when deck.gl graph integration is useful and how to explore it', () => {
@@ -208,6 +331,12 @@ describe('optional luGraph deck.gl gallery and API guide', () => {
     for (const control of [
       '**Hover a node**',
       '**Click a node**',
+      '**Change the graph size**',
+      '**Choose a layout mode**',
+      '**Choose a node color mode**',
+      '**Choose a node size mode**',
+      '**Toggle original edges**',
+      '**Pause or resume the layout**',
       '**Adjust neighborhood depth**',
       '**Drag a node**',
       '**Release pins**',
@@ -217,10 +346,11 @@ describe('optional luGraph deck.gl gallery and API guide', () => {
       expect(examplePage, control).toContain(control);
     }
 
-    expect(examplePage).toContain('128-vertex');
+    expect(examplePage).toContain('1,024');
+    expect(examplePage).toContain('1,048,576');
     expect(examplePage).toContain('`O(V² + E)`');
-    expect(examplePage).toContain('not a large-graph');
-    expect(examplePage).toContain('does not enable the optional spatial approximation');
+    expect(examplePage).toContain('`O(E + 4V)`');
+    expect(examplePage).toContain('flat-grid spatial approximation');
     expect(examplePage).toContain('/docs/api-reference/experimental/lugraph');
     expect(examplePage).toContain('/examples/experimental/lugraph-explorer');
   });
@@ -240,7 +370,7 @@ describe('optional luGraph deck.gl gallery and API guide', () => {
     expect(examplePage).toContain('LuGraphDeckEffect');
     expect(examplePage).toContain('LuGraphNodeLayer');
     expect(examplePage).toContain('LuGraphEdgeLayer');
-    expect(examplePage).toContain('not\n   community-detection results');
+    expect(examplePage).toContain('label-propagation community labels');
     expect(examplePage).toContain('deck.gl owns queue');
     expect(examplePage).toContain('`Buffer.STORAGE` and `Buffer.VERTEX`');
     expect(examplePage).toContain('returns a requested selected-vertex result to JavaScript');

--- a/modules/arrow-layers/test/lu-graph-deck.node.spec.ts
+++ b/modules/arrow-layers/test/lu-graph-deck.node.spec.ts
@@ -220,6 +220,22 @@ describe('luGraph native deck.gl resident layers', () => {
     expect(source).not.toMatch(/GPU\s+(?:frame|execution|duration)\s*[:=]\s*\$\{/i);
   });
 
+  test('disables exact and spatial layout controls at their actual execution boundaries', () => {
+    const source = readFileSync(
+      new URL('../../../examples/deck/lugraph-explorer/app.ts', import.meta.url),
+      'utf8'
+    );
+
+    expect(source).toContain('option[value="exact"]');
+    expect(source).toMatch(
+      /exactOption\.disabled\s*=\s*vertexCount\s*>\s*GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT/u
+    );
+    expect(source).toContain('option[value="spatial"]');
+    expect(source).toMatch(
+      /spatialOption\.disabled\s*=\s*vertexCount\s*>=\s*GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT/u
+    );
+  });
+
   test('reads source and target edge chunks directly without concatenation or CPU staging', () => {
     expect(LUGRAPH_DECK_EDGE_SHADER).toContain('sourceVertices: array<u32>');
     expect(LUGRAPH_DECK_EDGE_SHADER).toContain('targetVertices: array<u32>');

--- a/modules/arrow-layers/test/lu-graph-deck.spec.ts
+++ b/modules/arrow-layers/test/lu-graph-deck.spec.ts
@@ -14,9 +14,15 @@ import type {GPUVector} from '@luma.gl/tables';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import test from 'test/utils/vitest-tape';
 import {vi} from 'vitest';
+import {userEvent} from 'vitest/browser';
 
 import {createLuGraphExplorerDeck} from '../../../examples/deck/lugraph-explorer/app';
-import {makeGraphExplorerDataset} from '../../../examples/experimental/lugraph-explorer/graph-data';
+import {
+  getGraphExplorerGridSize,
+  GRAPH_EXPLORER_VERTEX_COUNTS,
+  makeGraphExplorerDataset
+} from '../../../examples/experimental/lugraph-explorer/graph-data';
+import {addGraphExplorerSampledLayoutToGraph} from '../../../examples/experimental/lugraph-explorer/graph-scale-layout';
 
 test('luGraph deck.gl effect composes actual GPU analytics, zero-copy selection, and pinned layout', async tapeTest => {
   const device = await getWebGPUTestDevice();
@@ -64,6 +70,16 @@ test('luGraph deck.gl effect composes actual GPU analytics, zero-copy selection,
       'weak-component colors read the original GPU output allocation'
     );
     tapeTest.equal(
+      effect.communityLabels,
+      effect.communities.output.data[0].buffer,
+      'community colors read real GPU label-propagation outputs, not weak-component aliases'
+    );
+    tapeTest.equal(
+      effect.degreeValues,
+      effect.degree.output.data[0].buffer,
+      'degree colors and node radii read their original caller-owned GPU output'
+    );
+    tapeTest.equal(
       effect.selectionMask,
       effect.search.mask!.data[0].buffer,
       'Deck highlighting reads source-aligned GPU neighborhood masks'
@@ -77,21 +93,44 @@ test('luGraph deck.gl effect composes actual GPU analytics, zero-copy selection,
     effect.frameGraph.encode(firstEncoder, {parameters: undefined});
     device.submit(firstEncoder.finish());
 
-    const [counts, reverseCounts, componentLabels, importance, distances, mask, pins, positions] =
-      await Promise.all([
-        readUint32Vector(effect.topology.forward.count),
-        readUint32Vector(effect.topology.reverse!.count),
-        readUint32Vector(effect.components.output),
-        readFloat32Vector(effect.pageRank.output),
-        readUint32Vector(effect.search.distances),
-        readUint32Vector(effect.search.mask!),
-        readUint32Vector(effect.layout.pinned!),
-        readFloat32Coordinates(effect.layout.positions)
-      ]);
+    const [
+      counts,
+      reverseCounts,
+      componentLabels,
+      communityLabels,
+      degrees,
+      importance,
+      distances,
+      mask,
+      pins,
+      positions
+    ] = await Promise.all([
+      readUint32Vector(effect.topology.forward.count),
+      readUint32Vector(effect.topology.reverse!.count),
+      readUint32Vector(effect.components.output),
+      readUint32Vector(effect.communities.output),
+      readUint32Vector(effect.degree.output),
+      readFloat32Vector(effect.pageRank.output),
+      readUint32Vector(effect.search.distances),
+      readUint32Vector(effect.search.mask!),
+      readUint32Vector(effect.layout.pinned!),
+      readFloat32Coordinates(effect.layout.positions)
+    ]);
 
     tapeTest.equal(counts[0], effect.graph.edgeCount, 'GPU builds every original forward edge');
     tapeTest.equal(reverseCounts[0], effect.graph.edgeCount, 'GPU builds exact reverse adjacency');
     tapeTest.equal(componentLabels[0], 0, 'first weak community keeps its stable source ID');
+    tapeTest.equal(componentLabels[32], 0, 'the narrow bridge joins both weak-component halves');
+    tapeTest.equal(
+      communityLabels[32],
+      32,
+      'actual GPU majority-vote coloring keeps the bridged community separate'
+    );
+    tapeTest.equal(
+      degrees.reduce((sum, degree) => sum + degree, 0),
+      effect.graph.edgeCount,
+      'actual resident vertex degrees account for every original directed edge'
+    );
     tapeTest.equal(componentLabels[64], 64, 'disconnected component retains its minimum source ID');
     tapeTest.equal(
       componentLabels[effect.graph.vertexCount - 1],
@@ -127,6 +166,204 @@ test('luGraph deck.gl effect composes actual GPU analytics, zero-copy selection,
     tapeTest.equal(updatedMask[0], 0, 'unrelated components stop receiving selection highlights');
   } finally {
     submitSpy.mockRestore();
+    effect?.cleanup({} as EffectContext);
+  }
+
+  tapeTest.end();
+});
+
+test('luGraph Deck effect executes real spatial indexing and community analytics on a bounded fixture', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const dataset = makeGraphExplorerDataset(32);
+  let effect: LuGraphDeckEffect | undefined;
+  const submitSpy = vi.spyOn(device, 'submit');
+  try {
+    effect = new LuGraphDeckEffect(device, dataset, {
+      layoutMode: 'spatial',
+      addSampledLayoutToGraph: addGraphExplorerSampledLayoutToGraph
+    });
+    tapeTest.equal(submitSpy.mock.calls.length, 0, 'spatial graph construction never submits');
+    submitSpy.mockRestore();
+    tapeTest.equal(
+      effect.activeLayoutMode,
+      'spatial',
+      'small fixtures can force real acceleration'
+    );
+    tapeTest.ok(effect.spatialLayout, 'the effect owns an actual GPU spatial layout contributor');
+    if (!effect.spatialLayout) throw new Error('The Deck showcase did not create its spatial grid');
+
+    tapeTest.deepEqual(
+      effect.spatialLayout.gridSize,
+      getGraphExplorerGridSize(dataset.vertexCount),
+      'grid dimensions use the shared bounded scalable graph policy'
+    );
+    tapeTest.equal(
+      effect.spatialLayout.vertexIds.length,
+      dataset.vertexCount,
+      'the caller-owned vertex index capacity covers every original vertex'
+    );
+    tapeTest.deepEqual(
+      effect.graph.sourceVertices.data.map(chunk => chunk.length === 0),
+      [false, true, false],
+      'the real spatial workflow never concatenates original GPU edge batches'
+    );
+
+    const positionsReadSpy = vi.spyOn(effect.positions, 'readAsync');
+    try {
+      const encoder = device.createCommandEncoder({id: 'lugraph-deck-real-spatial-showcase'});
+      effect.analysisGraph.encode(encoder, {parameters: undefined});
+      effect.frameGraph.encode(encoder, {parameters: undefined});
+      device.submit(encoder.finish());
+
+      const [indexCount, indexOverflow, offsets, weakComponents, communityLabels, degrees] =
+        await Promise.all([
+          readUint32Vector(effect.spatialLayout.count),
+          readUint32Vector(effect.spatialLayout.overflow),
+          readUint32Vector(effect.spatialLayout.cellOffsets),
+          readUint32Vector(effect.components.output),
+          readUint32Vector(effect.communities.output),
+          readUint32Vector(effect.degree.output)
+        ]);
+
+      tapeTest.equal(indexCount[0], dataset.vertexCount, 'GPU grid accepts every bounded vertex');
+      tapeTest.equal(indexOverflow[0], 0, 'the explicit GPU grid capacity does not overflow');
+      tapeTest.equal(
+        offsets.at(-1),
+        dataset.vertexCount,
+        'real GPU cell scan accounts for every row'
+      );
+      tapeTest.equal(weakComponents[8], 0, 'the weak component crosses the actual source bridge');
+      tapeTest.equal(communityLabels[8], 8, 'majority-vote communities remain genuinely distinct');
+      tapeTest.equal(
+        degrees.reduce((sum, degree) => sum + degree, 0),
+        effect.graph.edgeCount,
+        'real graph degrees remain exact in spatial layout mode'
+      );
+      tapeTest.equal(
+        positionsReadSpy.mock.calls.length,
+        0,
+        'grid construction and coloring never download render positions'
+      );
+    } finally {
+      positionsReadSpy.mockRestore();
+    }
+  } finally {
+    submitSpy.mockRestore();
+    effect?.cleanup({} as EffectContext);
+  }
+
+  tapeTest.end();
+});
+
+test('luGraph Deck preserves every original GPU vertex and edge while sampling only forces and visible edges', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const dataset = makeGraphExplorerDataset(32);
+  let effect: LuGraphDeckEffect | undefined;
+  try {
+    effect = new LuGraphDeckEffect(device, dataset, {
+      layoutMode: 'sampled',
+      pointMode: true,
+      maxVisibleEdges: 4,
+      addSampledLayoutToGraph: addGraphExplorerSampledLayoutToGraph
+    });
+    tapeTest.equal(
+      effect.activeLayoutMode,
+      'sampled',
+      'the actual four-sample force path is selected'
+    );
+    tapeTest.equal(
+      effect.layout.repulsion,
+      0.0015,
+      'four-sample GPU repulsion stays population-independent instead of collapsing at scale'
+    );
+    tapeTest.equal(
+      effect.layout.gravity,
+      0.005,
+      'bounded sampled gravity preserves visible source communities'
+    );
+    tapeTest.equal(effect.renderMode, 'points', 'full-population point rendering is selectable');
+    tapeTest.equal(effect.renderedVertexCount, 32, 'every original graph vertex remains rendered');
+    tapeTest.equal(effect.renderedEdgeCount, 4, 'only visible original edge instances are capped');
+    tapeTest.ok(
+      effect.graph.edgeCount > effect.renderedEdgeCount,
+      'the complete edge graph stays resident'
+    );
+    tapeTest.equal(
+      effect.spatialLayout,
+      undefined,
+      'sampled forces do not pretend to build a flat grid'
+    );
+    tapeTest.ok(
+      effect.searchGraph,
+      'sampled-layout selection has a separately schedulable real BFS'
+    );
+    tapeTest.deepEqual(
+      effect.graph.sourceVertices.data.map(chunk => chunk.length === 0),
+      [false, true, false],
+      'edge-only visual detail preserves every original GPU source partition'
+    );
+
+    const positionsReadSpy = vi.spyOn(effect.positions, 'readAsync');
+    try {
+      const encoder = device.createCommandEncoder({id: 'lugraph-deck-real-sampled-point-layout'});
+      effect.analysisGraph.encode(encoder, {parameters: undefined});
+      effect.searchGraph!.encode(encoder, {parameters: undefined});
+      effect.frameGraph.encode(encoder, {parameters: undefined});
+      device.submit(encoder.finish());
+
+      const [forward, reverse, degrees, components, communities, importance, distances] =
+        await Promise.all([
+          readUint32Vector(effect.topology.forward.count),
+          readUint32Vector(effect.topology.reverse!.count),
+          readUint32Vector(effect.degree.output),
+          readUint32Vector(effect.components.output),
+          readUint32Vector(effect.communities.output),
+          readFloat32Vector(effect.pageRank.output),
+          readUint32Vector(effect.search.distances)
+        ]);
+      tapeTest.equal(
+        forward[0],
+        effect.graph.edgeCount,
+        'sampled layout retains every forward edge'
+      );
+      tapeTest.equal(
+        reverse[0],
+        effect.graph.edgeCount,
+        'sampled layout retains every reverse edge'
+      );
+      tapeTest.equal(
+        degrees.reduce((sum, degree) => sum + degree, 0),
+        effect.graph.edgeCount,
+        'complete GPU degree accounting is independent of the edge-only render limit'
+      );
+      tapeTest.equal(components[8], 0, 'full-graph weak components still cross the source bridge');
+      tapeTest.equal(communities[8], 8, 'full-graph majority labels retain a distinct community');
+      tapeTest.ok(
+        Math.abs(importance.reduce((sum, score) => sum + score, 0) - 1) < 5e-5,
+        'full-graph GPU PageRank remains normalized in sampled force mode'
+      );
+      tapeTest.equal(distances[0], 0, 'independently scheduled BFS resolves the actual selection');
+      tapeTest.equal(
+        positionsReadSpy.mock.calls.length,
+        0,
+        'sampled forces, analytics, and points never read resident positions back'
+      );
+    } finally {
+      positionsReadSpy.mockRestore();
+    }
+  } finally {
     effect?.cleanup({} as EffectContext);
   }
 
@@ -187,7 +424,13 @@ test('luGraph deck.gl renders real source-chunk layers and asynchronously picks 
   let deck: ReturnType<typeof createLuGraphExplorerDeck> | undefined;
   const originalShaderAssembler = ShaderAssembler.getDefaultShaderAssembler;
   try {
-    deck = createLuGraphExplorerDeck(container, {device, dataset: makeGraphExplorerDataset(8)});
+    deck = createLuGraphExplorerDeck(container, {
+      device,
+      dataset: makeGraphExplorerDataset(8),
+      layoutMode: 'sampled',
+      pointMode: true,
+      maxVisibleEdges: 4
+    });
     deck.setProps({_animate: false});
     await waitForDeckEffect(deck);
     tapeTest.equal(
@@ -204,6 +447,64 @@ test('luGraph deck.gl renders real source-chunk layers and asynchronously picks 
     if (!(effect instanceof LuGraphDeckEffect)) {
       throw new Error('Deck did not initialize its luGraph WebGPU effect');
     }
+
+    const graphScale = container.querySelector<HTMLInputElement>('[data-lugraph-size]');
+    const decreaseGraphScale = container.querySelector<HTMLButtonElement>(
+      '[data-lugraph-size-decrease]'
+    );
+    const increaseGraphScale = container.querySelector<HTMLButtonElement>(
+      '[data-lugraph-size-increase]'
+    );
+    const layoutMode = container.querySelector<HTMLSelectElement>('[data-lugraph-layout]');
+    const colorMode = container.querySelector<HTMLSelectElement>('[data-lugraph-color]');
+    const nodeSize = container.querySelector<HTMLSelectElement>('[data-lugraph-node-size]');
+    const legend = container.querySelector<HTMLElement>('[data-lugraph-legend]');
+    const status = container.querySelector<HTMLElement>('[role="status"]');
+    tapeTest.ok(graphScale, 'Deck publishes an accessible graph-size slider');
+    tapeTest.ok(
+      decreaseGraphScale,
+      'a real accessible decrease action complements native dragging'
+    );
+    tapeTest.ok(
+      increaseGraphScale,
+      'a real accessible increase action complements native dragging'
+    );
+    tapeTest.equal(graphScale?.type, 'range', 'Deck graph population is keyboard adjustable');
+    tapeTest.equal(graphScale?.min, '0', 'the first graph-size step represents 128 vertices');
+    tapeTest.equal(
+      graphScale?.max,
+      String(GRAPH_EXPLORER_VERTEX_COUNTS.length - 1),
+      'all fourteen actual graph populations remain selectable'
+    );
+    tapeTest.equal(
+      GRAPH_EXPLORER_VERTEX_COUNTS.at(-1),
+      1_048_576,
+      'the final population is 1,048,576 actual resident vertices'
+    );
+    tapeTest.ok(layoutMode, 'actual exact, spatial, and sampled force modes are selectable');
+    tapeTest.ok(colorMode, 'actual GPU community and analytics colors are selectable');
+    tapeTest.ok(nodeSize, 'actual GPU PageRank and degree node sizes are selectable');
+    tapeTest.ok(legend, 'a real visible legend explains GPU community and selection colors');
+    tapeTest.deepEqual(
+      Array.from(layoutMode?.options ?? [], option => option.value),
+      ['auto', 'exact', 'spatial', 'sampled'],
+      'Deck layout options correspond to actual exact, flat-grid, and linear-work GPU paths'
+    );
+    tapeTest.deepEqual(
+      Array.from(colorMode?.options ?? [], option => option.value),
+      ['community', 'component', 'degree', 'pagerank', 'distance'],
+      'Deck color choices bind real resident analytic buffers'
+    );
+    tapeTest.deepEqual(
+      Array.from(nodeSize?.options ?? [], option => option.value),
+      ['pagerank', 'degree', 'uniform'],
+      'Deck node radii consume actual GPU PageRank or degree results'
+    );
+    tapeTest.equal(
+      status?.getAttribute('aria-live'),
+      'polite',
+      'live status is screen-reader safe'
+    );
 
     const layers = deck.props.layers ?? [];
     const edgeLayers = layers.filter(layer => layer instanceof LuGraphEdgeLayer);
@@ -228,12 +529,29 @@ test('luGraph deck.gl renders real source-chunk layers and asynchronously picks 
     tapeTest.equal(
       nodeLayer.getNumInstances(),
       effect.graph.vertexCount,
-      'Deck receives the real GPU vertex instance count despite the empty CPU data array'
+      'Deck renders every original GPU point despite the empty CPU data array'
+    );
+    tapeTest.equal(
+      effect.activeLayoutMode,
+      'sampled',
+      'Deck executes the actual linear force path'
+    );
+    tapeTest.equal(
+      effect.renderMode,
+      'points',
+      'Deck renders genuine one-vertex GPU point instances'
+    );
+    tapeTest.equal(effect.renderedVertexCount, 8, 'point mode never samples the graph population');
+    tapeTest.equal(effect.renderedEdgeCount, 4, 'only rendered original edge rows are bounded');
+    tapeTest.equal(
+      nodeLayer.props.pointMode,
+      true,
+      'the actual Deck node layer receives point mode'
     );
     tapeTest.deepEqual(
       edgeLayers.map(layer => layer.getNumInstances()),
-      [effect.graph.sourceVertices.data[0].length, effect.graph.sourceVertices.data[2].length],
-      'Deck receives actual source-chunk edge counts without a CPU edge array'
+      [2, 2],
+      'the truthful edge-only cap preserves both original source chunks without packing'
     );
     tapeTest.equal(
       nodeLayer.props.positions,
@@ -267,6 +585,16 @@ test('luGraph deck.gl renders real source-chunk layers and asynchronously picks 
       tapeTest.ok(
         nodeLayer.getModels()[0]?.pipeline,
         'actual node WGSL and vertex pipeline compile'
+      );
+      tapeTest.equal(
+        nodeLayer.getModels()[0]?.topology,
+        'point-list',
+        'the real GPU pipeline renders one actual point for every source vertex'
+      );
+      tapeTest.equal(
+        nodeLayer.getModels()[0]?.vertexCount,
+        1,
+        'point mode emits one vertex per original resident node instance'
       );
       for (const edgeLayer of edgeLayers) {
         tapeTest.ok(
@@ -303,6 +631,269 @@ test('luGraph deck.gl renders real source-chunk layers and asynchronously picks 
         importanceReadSpy.mock.calls.length,
         0,
         'node sizing and picking never download GPU PageRank scores'
+      );
+
+      if (!graphScale) throw new Error('Deck did not mount its accessible graph-size slider');
+      const previousPositions = effect.positions;
+      graphScale.value = '0';
+      graphScale.dispatchEvent(new Event('input', {bubbles: true}));
+      tapeTest.equal(
+        graphScale.value,
+        '0',
+        'dragging the graph-size thumb immediately retains the requested resident graph'
+      );
+
+      // A real Effect publishes diagnostics every tenth frame. Previously its HUD refresh reset
+      // the pending thumb to the old graph, so the debounce silently rebuilt nothing.
+      for (let frame = 0; frame < 10; frame++) {
+        deck.redraw('real GPU diagnostics must not discard a pending graph-size selection');
+      }
+      tapeTest.equal(
+        graphScale.value,
+        '0',
+        'real GPU statistics never snap a dragging graph-size thumb back to its old value'
+      );
+      tapeTest.equal(
+        container.querySelector('[data-lugraph-size-value]')?.textContent,
+        '128',
+        'the pending graph population remains visible while resident metrics update'
+      );
+      graphScale.focus();
+      await userEvent.keyboard('{ArrowRight}');
+      tapeTest.equal(
+        graphScale.value,
+        '1',
+        'a genuine trusted keyboard arrow advances the accessible real graph-size slider'
+      );
+      await waitForReplacementDeckEffect(deck, effect);
+      const resizedEffect = deck.props.effects?.[0];
+      if (!(resizedEffect instanceof LuGraphDeckEffect)) {
+        throw new Error('The real Deck graph slider did not replace its GPU effect');
+      }
+      tapeTest.equal(
+        resizedEffect.graph.vertexCount,
+        256,
+        'trusted keyboard input rebuilds the actual GPU graph'
+      );
+      tapeTest.equal(
+        resizedEffect.renderedVertexCount,
+        256,
+        'all resized GPU vertices remain rendered'
+      );
+      tapeTest.equal(
+        resizedEffect.renderedEdgeCount,
+        4,
+        'only resized visible edge instances stay capped'
+      );
+      tapeTest.equal(
+        resizedEffect.activeLayoutMode,
+        'sampled',
+        'the actual selected force survives resize'
+      );
+      tapeTest.equal(
+        resizedEffect.renderMode,
+        'points',
+        'actual all-vertex point mode survives resize'
+      );
+      tapeTest.notEqual(
+        resizedEffect.positions,
+        previousPositions,
+        'resized Deck models use fresh caller-owned render positions'
+      );
+      tapeTest.deepEqual(
+        resizedEffect.graph.sourceVertices.data.map(chunk => chunk.length === 0),
+        [false, true, false],
+        'resizing preserves nonempty, empty, and nonempty original edge chunks'
+      );
+
+      const resizedLayers = deck.props.layers ?? [];
+      const resizedNodeLayer = resizedLayers.find(layer => layer instanceof LuGraphNodeLayer);
+      const resizedEdgeLayers = resizedLayers.filter(layer => layer instanceof LuGraphEdgeLayer);
+      if (!(resizedNodeLayer instanceof LuGraphNodeLayer)) {
+        throw new Error('The resized Deck showcase lost its real node layer');
+      }
+      await waitForDeckLayerModels([resizedNodeLayer, ...resizedEdgeLayers]);
+      tapeTest.equal(
+        resizedNodeLayer.id,
+        'lugraph-nodes',
+        'the original node-layer identity stays stable'
+      );
+      tapeTest.equal(
+        resizedNodeLayer.getNumInstances(),
+        256,
+        'same-ID Deck node instances track their rebuilt GPU allocation'
+      );
+      tapeTest.equal(
+        resizedNodeLayer.props.positions,
+        resizedEffect.positions,
+        'same-ID Deck node models rebind their new resident vertex attribute'
+      );
+      tapeTest.equal(
+        resizedNodeLayer.props.communities,
+        resizedEffect.communityLabels,
+        'same-ID Deck models bind genuine resized GPU community labels'
+      );
+      tapeTest.equal(
+        resizedNodeLayer.props.degrees,
+        resizedEffect.degreeValues,
+        'same-ID Deck models bind genuine resized GPU vertex degrees'
+      );
+      tapeTest.deepEqual(
+        resizedEdgeLayers.map(layer => layer.id),
+        ['lugraph-edges-0', 'lugraph-edges-2'],
+        'same-ID edge layers preserve every original source partition after resizing'
+      );
+      tapeTest.deepEqual(
+        resizedEdgeLayers.map(layer => layer.getNumInstances()),
+        [2, 2],
+        'both rebuilt source partitions retain only their truthful visible edge allocation'
+      );
+      for (const [index, edgeLayer] of resizedEdgeLayers.entries()) {
+        const chunkIndex = index === 0 ? 0 : 2;
+        tapeTest.equal(
+          edgeLayer.props.sourceVertices,
+          resizedEffect.graph.sourceVertices.data[chunkIndex].buffer,
+          'same-ID edge models rebind their rebuilt original GPU source allocation'
+        );
+      }
+
+      resizedEffect.setPinnedVertex(0, true);
+      resizedEffect.setVertexPosition(0, [0, 0]);
+      deck.redraw('rebuilt luGraph Deck models must render from new physical allocations');
+      const [resizedComponents, resizedCommunities, resizedDegrees] = await Promise.all([
+        readUint32Vector(resizedEffect.components.output),
+        readUint32Vector(resizedEffect.communities.output),
+        readUint32Vector(resizedEffect.degree.output)
+      ]);
+      tapeTest.equal(resizedComponents[64], 0, 'resized weak components retain the source bridge');
+      tapeTest.equal(
+        resizedCommunities[64],
+        64,
+        'resized real GPU label propagation keeps a separate community'
+      );
+      tapeTest.equal(
+        resizedDegrees.reduce((sum, degree) => sum + degree, 0),
+        resizedEffect.graph.edgeCount,
+        'resized node-degree visualizations consume actual GPU results'
+      );
+
+      const rebuiltOrigin = deck.getViewports()[0].project([0, 0, 0]);
+      const resizedPick = await deck.pickObjectAsync({
+        x: Math.floor(rebuiltOrigin[0]),
+        y: Math.floor(rebuiltOrigin[1]),
+        radius: 3,
+        layerIds: ['lugraph-nodes']
+      });
+      tapeTest.equal(
+        resizedPick?.index,
+        0,
+        'native asynchronous GPU picking still resolves stable IDs after graph resizing'
+      );
+      tapeTest.equal(
+        resizedPick?.layer?.id,
+        'lugraph-nodes',
+        'native picking retains the original node-layer identity after rebuilding'
+      );
+
+      // Exercise a genuine fresh keyboard interaction without synthesizing an `input` event or
+      // retaining pending slider state. Deck must never consume native range-control arrow keys.
+      tapeTest.equal(
+        graphScale.value,
+        '1',
+        'the settled actual graph population owns slider step one'
+      );
+      tapeTest.equal(
+        graphScale.disabled,
+        false,
+        'the settled graph slider accepts real user input'
+      );
+      graphScale.focus();
+      await userEvent.keyboard('{ArrowRight}');
+      tapeTest.equal(
+        graphScale.value,
+        '2',
+        'a trusted ArrowRight changes a pristine slider without synthetic pending state'
+      );
+      await waitForReplacementDeckEffect(deck, resizedEffect);
+      const keyboardEffect = deck.props.effects?.[0];
+      if (!(keyboardEffect instanceof LuGraphDeckEffect)) {
+        throw new Error('A genuine keyboard action did not rebuild the actual WebGPU graph');
+      }
+      tapeTest.equal(
+        keyboardEffect.graph.vertexCount,
+        512,
+        'a pristine trusted keyboard action rebuilds all 512 actual GPU graph vertices'
+      );
+      tapeTest.equal(
+        keyboardEffect.renderedVertexCount,
+        512,
+        'fresh slider interaction preserves full real point population'
+      );
+      tapeTest.equal(
+        keyboardEffect.renderedEdgeCount,
+        4,
+        'fresh slider interaction still limits only displayed original edge instances'
+      );
+      const keyboardNodeLayer = (deck.props.layers ?? []).find(
+        layer => layer instanceof LuGraphNodeLayer
+      );
+      const keyboardEdgeLayers = (deck.props.layers ?? []).filter(
+        layer => layer instanceof LuGraphEdgeLayer
+      );
+      if (!(keyboardNodeLayer instanceof LuGraphNodeLayer)) {
+        throw new Error('A real trusted keyboard resize lost the Deck point layer');
+      }
+      await waitForDeckLayerModels([keyboardNodeLayer, ...keyboardEdgeLayers]);
+      tapeTest.equal(
+        keyboardNodeLayer.getNumInstances(),
+        512,
+        'the same-ID GPU point layer consumes every freshly resized original vertex'
+      );
+      tapeTest.deepEqual(
+        keyboardEdgeLayers.map(layer => layer.getNumInstances()),
+        [2, 2],
+        'both original source partitions survive genuine keyboard-only graph resizing'
+      );
+
+      // Pointer interaction must work from settled state too; use Playwright's trusted native
+      // click at the beginning of the range instead of assigning or dispatching DOM values.
+      const sliderBounds = graphScale.getBoundingClientRect();
+      await userEvent.click(graphScale, {
+        position: {x: 1, y: Math.max(1, Math.floor(sliderBounds.height / 2))}
+      });
+      tapeTest.equal(
+        graphScale.value,
+        '0',
+        'a genuine trusted pointer click changes a pristine graph-size range control'
+      );
+      await waitForReplacementDeckEffect(deck, keyboardEffect);
+      const pointerEffect = deck.props.effects?.[0];
+      if (!(pointerEffect instanceof LuGraphDeckEffect)) {
+        throw new Error('A genuine pointer click did not rebuild the actual WebGPU graph');
+      }
+      tapeTest.equal(
+        pointerEffect.graph.vertexCount,
+        128,
+        'a trusted native pointer click rebuilds every original resident vertex'
+      );
+      tapeTest.equal(
+        pointerEffect.renderedVertexCount,
+        128,
+        'pointer resizing never samples vertices'
+      );
+      tapeTest.equal(
+        pointerEffect.renderedEdgeCount,
+        4,
+        'pointer resizing limits only visible edges'
+      );
+      const pointerLayers = (deck.props.layers ?? []).filter(
+        (layer): layer is LuGraphNodeLayer | LuGraphEdgeLayer =>
+          layer instanceof LuGraphNodeLayer || layer instanceof LuGraphEdgeLayer
+      );
+      await waitForDeckLayerModels(pointerLayers);
+      tapeTest.ok(
+        !/GPU\s+(?:frame|execution|duration)\s*[:=]\s*\d/i.test(status?.textContent ?? ''),
+        'the Deck dashboard never invents GPU timing or convergence samples'
       );
     } finally {
       positionsReadSpy.mockRestore();
@@ -342,6 +933,22 @@ async function waitForDeckEffect(
   while (!(deck.props.effects?.[0] instanceof LuGraphDeckEffect)) {
     if (performance.now() >= deadline) {
       throw new Error('The real WebGPU Deck did not finish initializing its luGraph effect');
+    }
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+  }
+}
+
+async function waitForReplacementDeckEffect(
+  deck: ReturnType<typeof createLuGraphExplorerDeck>,
+  previous: LuGraphDeckEffect
+): Promise<void> {
+  const deadline = performance.now() + 5_000;
+  while (
+    !(deck.props.effects?.[0] instanceof LuGraphDeckEffect) ||
+    deck.props.effects[0] === previous
+  ) {
+    if (performance.now() >= deadline) {
+      throw new Error('The real Deck graph-size slider did not replace its resident GPU effect');
     }
     await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
   }

--- a/modules/experimental/src/lugraph/README.md
+++ b/modules/experimental/src/lugraph/README.md
@@ -29,6 +29,13 @@ flat-grid approximation suits applications that can trade some far-field accurac
 individual force calculations. It is not Barnes–Hut, ForceAtlas2, or a guaranteed subquadratic
 layout.
 
+The native and deck.gl graph explorers additionally demonstrate an application-owned,
+constant-sample force contributor for graphs with up to 1,048,576 real vertices and 2,097,343
+resident directed edges. It evaluates every original edge plus four deterministic repulsion
+samples per vertex, retains every rendered vertex, and limits only visible edge detail. This
+explicitly approximate `O(E + 4V)` showcase strategy is not a public graph algorithm, an exact
+all-pairs solver, or a promise of device-independent frame rates.
+
 See the [luGraph graph analytics guide](/docs/api-reference/experimental/lugraph) for when to use
 each operation, complete GPU-resident composition examples, and ownership and capacity contracts.
 

--- a/modules/experimental/test/lugraph/lu-graph-explorer.node.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-explorer.node.spec.ts
@@ -4,7 +4,18 @@
 
 import {existsSync, readFileSync} from 'node:fs';
 import {describe, expect, test} from 'vitest';
-import {makeGraphExplorerDataset} from '../../../../examples/experimental/lugraph-explorer/graph-data';
+import {
+  getGraphExplorerGridSize,
+  GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT,
+  GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT,
+  GRAPH_EXPLORER_MAXIMUM_HUB_SPOKES,
+  GRAPH_EXPLORER_MAX_VISIBLE_EDGES,
+  GRAPH_EXPLORER_POINT_VERTEX_COUNT,
+  GRAPH_EXPLORER_SHOWCASE_DEFAULT_VERTEX_COUNT,
+  GRAPH_EXPLORER_SPATIAL_BOUNDS,
+  GRAPH_EXPLORER_VERTEX_COUNTS,
+  makeGraphExplorerDataset
+} from '../../../../examples/experimental/lugraph-explorer/graph-data';
 import {
   GRAPH_EXPLORER_EDGE_SHADER,
   GRAPH_EXPLORER_NODE_SHADER,
@@ -13,6 +24,19 @@ import {
 } from '../../../../examples/experimental/lugraph-explorer/graph-shaders';
 
 describe('interactive luGraph explorer deterministic source graph', () => {
+  test('offers fourteen honest graph populations while retaining the small fixture default', () => {
+    expect(GRAPH_EXPLORER_VERTEX_COUNTS).toEqual([
+      128, 256, 512, 1024, 2048, 4096, 8192, 16_384, 32_768, 65_536, 131_072, 262_144, 524_288,
+      1_048_576
+    ]);
+    expect(GRAPH_EXPLORER_SHOWCASE_DEFAULT_VERTEX_COUNT).toBe(1024);
+    expect(GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT).toBe(512);
+    expect(GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT).toBe(16_384);
+    expect(GRAPH_EXPLORER_POINT_VERTEX_COUNT).toBe(65_536);
+    expect(GRAPH_EXPLORER_MAX_VISIBLE_EDGES).toBe(65_536);
+    expect(makeGraphExplorerDataset().vertexCount).toBe(128);
+  });
+
   test('publishes deterministic typed graph data without allocating browser or GPU resources', () => {
     const first = makeGraphExplorerDataset();
     const second = makeGraphExplorerDataset();
@@ -35,7 +59,8 @@ describe('interactive luGraph explorer deterministic source graph', () => {
   });
 
   test.each([
-    64, 128, 256
+    64,
+    ...GRAPH_EXPLORER_VERTEX_COUNTS.slice(0, -1)
   ])('preserves aligned original uint32 edge batches: %i vertices', vertexCount => {
     const dataset = makeGraphExplorerDataset(vertexCount);
 
@@ -52,9 +77,84 @@ describe('interactive luGraph explorer deterministic source graph', () => {
       expect(sources).toBeInstanceOf(Uint32Array);
       expect(targets).toBeInstanceOf(Uint32Array);
       expect(targets.length).toBe(sources.length);
-      expect(Array.from(sources).every(source => source < vertexCount)).toBe(true);
-      expect(Array.from(targets).every(target => target < vertexCount)).toBe(true);
+      expect(sources.every(source => source < vertexCount)).toBe(true);
+      expect(targets.every(target => target < vertexCount)).toBe(true);
     }
+  });
+
+  test.each([
+    {vertices: 8, dimension: 4},
+    {vertices: 32, dimension: 5},
+    {vertices: 128, dimension: 6},
+    {vertices: 512, dimension: 9},
+    {vertices: 1024, dimension: 10},
+    {vertices: 8192, dimension: 17},
+    {vertices: 1_048_576, dimension: 32},
+    {vertices: 100_000_000, dimension: 32}
+  ])('bounds the caller-owned spatial grid at $vertices vertices', ({vertices, dimension}) => {
+    expect(getGraphExplorerGridSize(vertices)).toEqual([dimension, dimension]);
+  });
+
+  test.each([
+    0,
+    7,
+    -1,
+    2.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY
+  ])('rejects unusable spatial graph populations: %s', vertexCount => {
+    expect(() => getGraphExplorerGridSize(vertexCount)).toThrow(/eight|vertices/i);
+  });
+
+  test('keeps 8,192-node community hubs and spatial coordinates explicitly bounded', () => {
+    const dataset = makeGraphExplorerDataset(8192);
+    const incoming = new Uint32Array(dataset.vertexCount);
+    for (const targets of dataset.targetChunks) {
+      for (const target of targets) incoming[target]++;
+    }
+
+    expect(Math.max(...incoming)).toBeLessThanOrEqual(GRAPH_EXPLORER_MAXIMUM_HUB_SPOKES + 3);
+    expect(
+      dataset.positions.every((position, index) => {
+        const minimum = GRAPH_EXPLORER_SPATIAL_BOUNDS[index % 2];
+        const maximum = GRAPH_EXPLORER_SPATIAL_BOUNDS[(index % 2) + 2];
+        return position > minimum && position < maximum;
+      })
+    ).toBe(true);
+    expect(dataset.sourceChunks[1]).toHaveLength(0);
+  });
+
+  test('creates all 1,048,576 source vertices and 2,097,343 original directed edge rows', () => {
+    const vertexCount = 1_048_576;
+    const edgeCount = 2_097_343;
+    const dataset = makeGraphExplorerDataset(vertexCount);
+
+    expect(dataset.vertexCount).toBe(vertexCount);
+    expect(dataset.positions).toBeInstanceOf(Float32Array);
+    expect(dataset.velocities).toBeInstanceOf(Float32Array);
+    expect(dataset.positions.length).toBe(vertexCount * 2);
+    expect(dataset.velocities.length).toBe(vertexCount * 2);
+    expect(dataset.positions.byteLength).toBe(vertexCount * 8);
+    expect(dataset.velocities.byteLength).toBe(vertexCount * 8);
+    expect(dataset.sourceChunks.map(chunk => chunk.length)).toEqual([1_048_672, 0, 1_048_671]);
+    expect(dataset.targetChunks.map(chunk => chunk.length)).toEqual([1_048_672, 0, 1_048_671]);
+    expect(dataset.sourceChunks.reduce((total, chunk) => total + chunk.length, 0)).toBe(edgeCount);
+    expect(dataset.targetChunks.reduce((total, chunk) => total + chunk.length, 0)).toBe(edgeCount);
+    expect(edgeCount).toBe(vertexCount * 2 + 191);
+
+    const sourceAllocation = dataset.sourceChunks[0].buffer;
+    const targetAllocation = dataset.targetChunks[0].buffer;
+    for (const [chunkIndex, sources] of dataset.sourceChunks.entries()) {
+      const targets = dataset.targetChunks[chunkIndex];
+      expect(sources.buffer).toBe(sourceAllocation);
+      expect(targets.buffer).toBe(targetAllocation);
+      expect(sources.every(source => source < vertexCount)).toBe(true);
+      expect(targets.every(target => target < vertexCount)).toBe(true);
+    }
+    expect(dataset.sourceChunks[2].byteOffset).toBe(dataset.sourceChunks[0].byteLength);
+    expect(dataset.targetChunks[2].byteOffset).toBe(dataset.targetChunks[0].byteLength);
+    expect(dataset.sourceChunks[2].at(-1)).toBe(0);
+    expect(dataset.targetChunks[2].at(-1)).toBe(vertexCount / 4);
   });
 
   test('contains multiple weak components and high-degree vertices for visible graph analytics', () => {
@@ -110,15 +210,112 @@ describe('interactive luGraph explorer dependency-free rendering integration', (
     }
     expect(GRAPH_EXPLORER_PICKING_SHADER).toMatch(/@location\(1\)/);
     expect(GRAPH_EXPLORER_PICKING_SHADER).toMatch(/vec2<i32>/);
+    expect(GRAPH_EXPLORER_NODE_SHADER).toContain('communities: array<u32>');
+    expect(GRAPH_EXPLORER_NODE_SHADER).toContain('degrees: array<u32>');
+    expect(GRAPH_EXPLORER_NODE_SHADER).toContain('communities[sourceIndex] / communitySpan');
+    expect(GRAPH_EXPLORER_NODE_SHADER).toContain('view.interaction.z / 4u');
+    expect(GRAPH_EXPLORER_NODE_SHADER).toContain('0.78');
+    expect(GRAPH_EXPLORER_NODE_SHADER).toMatch(/7u|\[7\]/);
   });
 
-  test('exposes genuine existing GPU analytics without inventing community or spatial contributors', () => {
+  test('documents actual million-vertex analytics, sampled forces, and edge-only detail limits', () => {
+    const guide = readFileSync(
+      new URL('../../../../docs/api-reference/experimental/lugraph.md', import.meta.url),
+      'utf8'
+    );
+    const examplePage = readFileSync(
+      new URL(
+        '../../../../website/content/examples/experimental/lugraph-explorer.mdx',
+        import.meta.url
+      ),
+      'utf8'
+    );
+
+    for (const document of [guide, examplePage]) {
+      expect(document).toContain('1,024');
+      expect(document).toContain('1,048,576');
+      expect(document).toContain('2,097,343');
+      expect(document).toContain('16,384');
+      expect(document).toContain('65,536');
+      expect(document).toContain('512 vertices');
+      expect(document).toMatch(/label.propagation/i);
+      expect(document).toMatch(/flat.grid/i);
+      expect(document).toContain('O(E + 4V)');
+    }
+    expect(guide).toContain('CPU encoding is never mislabeled');
+    expect(examplePage).toContain('fabricated GPU timing');
+  });
+
+  test('exposes accessible graph controls backed by actual resident analytics', () => {
+    const source = readFileSync(
+      new URL('../../../../examples/experimental/lugraph-explorer/app.ts', import.meta.url),
+      'utf8'
+    );
+
+    for (const attribute of [
+      'data-graph-size',
+      'data-graph-size-value',
+      'data-layout-mode',
+      'data-color-mode',
+      'data-node-size',
+      'data-edge-toggle',
+      'data-depth',
+      'data-pause',
+      'data-graph-legend',
+      'data-graph-adapter',
+      'data-graph-memory'
+    ]) {
+      expect(source).toContain(attribute);
+    }
+    for (const mode of ['community', 'component', 'degree', 'pagerank', 'distance']) {
+      expect(source).toContain(`value="${mode}"`);
+    }
+    expect(source).toContain('role="status"');
+    expect(source).toContain('aria-live="polite"');
+    expect(source).toContain('LuGraphLabelPropagation');
+    expect(source).toContain('LuGraphSpatialForceLayout');
+    expect(source).toContain('addGraphExplorerSampledLayoutToGraph');
+    expect(source).toMatch(/repulsion:\s*useSampledForce\s*\?\s*0\.0015\s*:/);
+    expect(source).toMatch(/gravity:\s*useSampledForce\s*\?\s*0\.005\s*:/);
+    expect(source).toContain('CPU encode');
+    expect(source).toContain('physicalTransientBytes');
+    expect(source).not.toMatch(/GPU\s+(?:frame|execution|duration)\s*[:=]\s*\$\{/i);
+  });
+
+  test('bounds genuine full-edge GPU layout to four vertex samples without staging or atomics', () => {
+    const source = readFileSync(
+      new URL(
+        '../../../../examples/experimental/lugraph-explorer/graph-scale-layout.ts',
+        import.meta.url
+      ),
+      'utf8'
+    );
+
+    expect(source).toContain('REPULSION_SAMPLE_COUNT = 4');
+    expect(source).toContain('O(E + 4V)');
+    expect(source).toContain('addGraphExplorerSampledLayoutToGraph');
+    expect(source).toContain('forwardNeighbors');
+    expect(source).toContain('reverseNeighbors');
+    expect(source).toContain('getCommunityAnchorSource');
+    expect(source).toContain('getCommunityAnchor(index)');
+    expect(source).toContain('2.39996323');
+    expect(source).toContain('(anchor - position) * 0.12');
+    expect(source).toContain('neighborDisplacement');
+    expect(source).toContain('max(f32(neighborCount), 1.0)');
+    expect(source).toContain('positions[positionIndex] = anchor.x');
+    expect(source).toContain('positions[positionIndex + 1u] = anchor.y');
+    expect(source).not.toMatch(/atomic\s*<\s*f32\s*>/);
+    expect(source).not.toMatch(/\bdevice\.submit\s*\(/);
+    expect(source).not.toMatch(/\.readAsync\s*\(/);
+  });
+
+  test('exposes genuine GPU analytics, communities, and bounded spatial contributors', () => {
     const explorerSource = readFileSync(
       new URL('../../../../examples/experimental/lugraph-explorer/app.ts', import.meta.url),
       'utf8'
     );
 
-    expect(GRAPH_EXPLORER_NODE_SHADER).toMatch(/@binding\(4\).*degrees/u);
+    expect(GRAPH_EXPLORER_NODE_SHADER).toMatch(/@binding\(3\).*degrees/u);
     expect(GRAPH_EXPLORER_PICKING_SHADER).toMatch(/@binding\(1\).*degrees/u);
     expect(GRAPH_EXPLORER_NODE_SHADER).toContain('degrees[sourceIndex]');
     expect(GRAPH_EXPLORER_PICKING_SHADER).toContain('degrees[sourceIndex]');
@@ -142,8 +339,8 @@ describe('interactive luGraph explorer dependency-free rendering integration', (
     expect(explorerSource).toContain('aria-live="polite"');
     expect(explorerSource).toContain('Expand info box');
     expect(explorerSource).toContain('[data-info-box-appearance]');
-    expect(explorerSource).not.toContain('LuGraphLabelPropagation');
-    expect(explorerSource).not.toContain('LuGraphSpatialForceLayout');
+    expect(explorerSource).toContain('LuGraphLabelPropagation');
+    expect(explorerSource).toContain('LuGraphSpatialForceLayout');
   });
 
   test('registers the API guide in both documentation navigation trees', () => {

--- a/modules/experimental/test/lugraph/lu-graph-explorer.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-explorer.spec.ts
@@ -424,9 +424,10 @@ test('luGraph native showcase renders every real GPU point while sampling only f
   let color: Texture | undefined;
   let depth: Texture | undefined;
   let pickingReadback: Buffer | undefined;
+  // Odd dimensions place the pinned origin on a pixel center across software GPU backends.
   const devicePixelSizeSpy = vi
     .spyOn(device.getDefaultCanvasContext(), 'getDevicePixelSize')
-    .mockReturnValue([64, 48]);
+    .mockReturnValue([65, 49]);
   try {
     explorer = createExplorer(device, 32, 'sampled', {pointMode: true, maxVisibleEdges: 4});
     tapeTest.equal(

--- a/modules/experimental/test/lugraph/lu-graph-explorer.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-explorer.spec.ts
@@ -10,7 +10,19 @@ import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import test from 'test/utils/vitest-tape';
 import {vi} from 'vitest';
 import LuGraphExplorerAnimationLoopTemplate from '../../../../examples/experimental/lugraph-explorer/app';
-import {makeGraphExplorerDataset} from '../../../../examples/experimental/lugraph-explorer/graph-data';
+import {
+  GRAPH_EXPLORER_VERTEX_COUNTS,
+  makeGraphExplorerDataset,
+  type GraphExplorerDataset,
+  type GraphExplorerLayoutMode
+} from '../../../../examples/experimental/lugraph-explorer/graph-data';
+
+type ExplorerAnimationProps = AnimationProps & {
+  dataset?: GraphExplorerDataset;
+  layoutMode?: GraphExplorerLayoutMode;
+  pointMode?: boolean;
+  maxVisibleEdges?: number;
+};
 
 type ExplorerGraphBindings = {
   frameColorId: string;
@@ -44,7 +56,7 @@ test('luGraph explorer constructs actual GPU models and computes source-aligned 
   const submitSpy = vi.spyOn(device, 'submit');
   let explorer: LuGraphExplorerAnimationLoopTemplate | undefined;
   try {
-    explorer = new LuGraphExplorerAnimationLoopTemplate({device} as unknown as AnimationProps);
+    explorer = createExplorer(device);
     tapeTest.equal(submitSpy.mock.calls.length, 0, 'construction never submits hidden GPU work');
     submitSpy.mockRestore();
 
@@ -89,16 +101,25 @@ test('luGraph explorer constructs actual GPU models and computes source-aligned 
     );
 
     executeAnalysis(device, explorer);
-    const [degrees, componentLabels, importance, forwardCount, reverseCount, invalid, overflow] =
-      await Promise.all([
-        readUint32Vector(explorer.degree.output),
-        readUint32Vector(explorer.components.output),
-        readFloat32Vector(explorer.pageRank.output),
-        readUint32Vector(explorer.topology.forward.count),
-        readUint32Vector(explorer.topology.reverse!.count),
-        readUint32Vector(explorer.topology.invalidEdgeCount),
-        readUint32Vector(explorer.topology.forward.overflow)
-      ]);
+    const [
+      degrees,
+      componentLabels,
+      communityLabels,
+      importance,
+      forwardCount,
+      reverseCount,
+      invalid,
+      overflow
+    ] = await Promise.all([
+      readUint32Vector(explorer.degree.output),
+      readUint32Vector(explorer.components.output),
+      readUint32Vector(explorer.communities.output),
+      readFloat32Vector(explorer.pageRank.output),
+      readUint32Vector(explorer.topology.forward.count),
+      readUint32Vector(explorer.topology.reverse!.count),
+      readUint32Vector(explorer.topology.invalidEdgeCount),
+      readUint32Vector(explorer.topology.forward.overflow)
+    ]);
 
     tapeTest.equal(
       forwardCount[0],
@@ -123,6 +144,17 @@ test('luGraph explorer constructs actual GPU models and computes source-aligned 
       componentLabels[32],
       0,
       'one actual bridge joins the first two weak communities'
+    );
+    tapeTest.equal(communityLabels[0], 0, 'GPU label propagation preserves the first community');
+    tapeTest.equal(
+      communityLabels[32],
+      32,
+      'the same bridge leaves the second majority-vote community visibly distinct'
+    );
+    tapeTest.notEqual(
+      communityLabels[32],
+      componentLabels[32],
+      'true GPU community coloring is not a relabeled weak-component result'
     );
     tapeTest.equal(componentLabels[64], 64, 'third disconnected community keeps its own component');
     tapeTest.equal(
@@ -167,7 +199,7 @@ test('luGraph explorer renders original GPU chunks, highlights neighborhoods, pi
     .spyOn(device.getDefaultCanvasContext(), 'getDevicePixelSize')
     .mockReturnValue([320, 240]);
   try {
-    explorer = new LuGraphExplorerAnimationLoopTemplate({device} as unknown as AnimationProps);
+    explorer = createExplorer(device);
     const bindings = explorer as unknown as ExplorerGraphBindings;
     tapeTest.deepEqual(
       [bindings.frameWidth, bindings.frameHeight],
@@ -283,7 +315,7 @@ test('luGraph explorer exposes genuine GPU analytics and only expands its own gr
 
   let explorer: LuGraphExplorerAnimationLoopTemplate | undefined;
   try {
-    explorer = new LuGraphExplorerAnimationLoopTemplate({device} as unknown as AnimationProps);
+    explorer = createExplorer(device);
     const dashboard = explorer as unknown as ExplorerDashboardBindings;
     tapeTest.equal(graphExpansion.mock.calls.length, 1, 'the graph inspector opens exactly once');
     tapeTest.equal(
@@ -299,8 +331,8 @@ test('luGraph explorer exposes genuine GPU analytics and only expands its own gr
     const depth = host.querySelector<HTMLInputElement>('[data-depth]');
     tapeTest.deepEqual(
       Array.from(color!.options, option => option.value),
-      ['component', 'degree', 'pagerank', 'distance'],
-      'all four available GPU analytics are selectable as node colors'
+      ['community', 'component', 'degree', 'pagerank', 'distance'],
+      'all five available GPU analytics are selectable as node colors'
     );
     tapeTest.deepEqual(
       Array.from(size!.options, option => option.value),
@@ -327,7 +359,7 @@ test('luGraph explorer exposes genuine GPU analytics and only expands its own gr
         28,
         true
       ),
-      (1 << 4) | (1 << 8),
+      (2 << 1) | (1 << 4),
       'the shared node and picking uniform packs the selected genuine GPU metric modes'
     );
     uniformWrite.mockRestore();
@@ -380,6 +412,156 @@ test('luGraph explorer exposes genuine GPU analytics and only expands its own gr
   tapeTest.end();
 });
 
+test('luGraph native showcase renders every real GPU point while sampling only forces and visible original edges', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  let explorer: LuGraphExplorerAnimationLoopTemplate | undefined;
+  let color: Texture | undefined;
+  let depth: Texture | undefined;
+  let pickingReadback: Buffer | undefined;
+  const devicePixelSizeSpy = vi
+    .spyOn(device.getDefaultCanvasContext(), 'getDevicePixelSize')
+    .mockReturnValue([64, 48]);
+  try {
+    explorer = createExplorer(device, 32, 'sampled', {pointMode: true, maxVisibleEdges: 4});
+    tapeTest.equal(
+      explorer.activeLayoutMode,
+      'sampled',
+      'the actual four-sample force path is used'
+    );
+    tapeTest.equal(
+      explorer.layout.repulsion,
+      0.0015,
+      'four-sample repulsion remains positive and independent of population size'
+    );
+    tapeTest.equal(
+      explorer.layout.gravity,
+      0.005,
+      'bounded sampled gravity preserves visible source communities'
+    );
+    tapeTest.equal(explorer.pointMode, true, 'full-population point rendering is enabled');
+    tapeTest.equal(explorer.renderedVertexCount, 32, 'every actual original vertex stays rendered');
+    tapeTest.equal(explorer.renderedEdgeCount, 4, 'only displayed original edges are decimated');
+    tapeTest.ok(explorer.graph.edgeCount > 4, 'full GPU adjacency retains all original edge rows');
+    tapeTest.equal(
+      explorer.spatialLayout,
+      null,
+      'sampled forces do not misrepresent a spatial grid'
+    );
+    tapeTest.deepEqual(
+      explorer.edgeModels.map(({model}) => model.instanceCount),
+      [2, 2],
+      'edge-only detail remains source-aligned across both nonempty original batches'
+    );
+    tapeTest.equal(
+      explorer.nodeModel.topology,
+      'point-list',
+      'nodes use a real GPU point pipeline'
+    );
+    tapeTest.equal(explorer.nodeModel.vertexCount, 1, 'each source vertex produces one GPU point');
+    tapeTest.equal(
+      explorer.nodeModel.instanceCount,
+      32,
+      'point instances cover every graph vertex'
+    );
+    tapeTest.equal(
+      explorer.pickingModel.topology,
+      'point-list',
+      'integer picking consumes real points'
+    );
+    tapeTest.equal(
+      explorer.pickingModel.instanceCount,
+      32,
+      'picking preserves every stable source ID'
+    );
+
+    const bindings = explorer as unknown as ExplorerGraphBindings;
+    color = device.createTexture({
+      id: 'lugraph-showcase-sampled-point-color',
+      format: device.preferredColorFormat,
+      width: bindings.frameWidth,
+      height: bindings.frameHeight,
+      usage: Texture.RENDER
+    });
+    depth = device.createTexture({
+      id: 'lugraph-showcase-sampled-point-depth',
+      format: 'depth24plus',
+      width: bindings.frameWidth,
+      height: bindings.frameHeight,
+      usage: Texture.RENDER
+    });
+    pickingReadback = device.createBuffer({
+      id: 'lugraph-showcase-sampled-point-picking',
+      byteLength: INDEX_PICKING_READBACK_BYTE_LENGTH,
+      usage: Buffer.COPY_DST | Buffer.MAP_READ
+    });
+    (explorer.layout.positions.data[0].buffer as Buffer).write(Float32Array.of(0, 0));
+    (explorer.layout.pinned!.data[0].buffer as Buffer).write(Uint32Array.of(1));
+
+    const encoder = device.createCommandEncoder({id: 'lugraph-showcase-real-sampled-point-frame'});
+    explorer.analysisGraph.encode(encoder, {parameters: undefined});
+    const searchGraph = (explorer as unknown as {searchGraph: typeof explorer.analysisGraph | null})
+      .searchGraph;
+    searchGraph?.encode(encoder, {parameters: undefined});
+    explorer.frameGraph.encode(encoder, {
+      parameters: {width: bindings.frameWidth, height: bindings.frameHeight},
+      frameTextures: {
+        [bindings.frameColorId]: {texture: color, frameId: 0},
+        [bindings.frameDepthId]: {texture: depth, frameId: 0}
+      }
+    });
+    explorer.pickingGraph.encode(encoder, {
+      parameters: {
+        pixel: [Math.floor(bindings.frameWidth / 2), Math.floor(bindings.frameHeight / 2)]
+      },
+      buffers: {[bindings.pickingReadbackId]: pickingReadback}
+    });
+    device.submit(encoder.finish());
+
+    const [forward, reverse, degrees, components, communities, importance, bytes] =
+      await Promise.all([
+        readUint32Vector(explorer.topology.forward.count),
+        readUint32Vector(explorer.topology.reverse!.count),
+        readUint32Vector(explorer.degree.output),
+        readUint32Vector(explorer.components.output),
+        readUint32Vector(explorer.communities.output),
+        readFloat32Vector(explorer.pageRank.output),
+        pickingReadback.readAsync(0, INDEX_PICKING_READBACK_BYTE_LENGTH)
+      ]);
+    tapeTest.equal(forward[0], explorer.graph.edgeCount, 'GPU retains every original forward edge');
+    tapeTest.equal(reverse[0], explorer.graph.edgeCount, 'GPU retains every original reverse edge');
+    tapeTest.equal(
+      degrees.reduce((sum, degree) => sum + degree, 0),
+      explorer.graph.edgeCount,
+      'GPU degrees use the complete edge graph instead of its displayed subset'
+    );
+    tapeTest.equal(components[8], 0, 'actual weak components still span the source bridge');
+    tapeTest.equal(communities[8], 8, 'GPU majority-vote communities remain distinct');
+    tapeTest.ok(
+      Math.abs(importance.reduce((sum, score) => sum + score, 0) - 1) < 5e-5,
+      'full-graph GPU PageRank remains normalized in sampled-force mode'
+    );
+    tapeTest.equal(
+      decodeGPUIndexPickInfo(bytes).objectIndex,
+      0,
+      'actual integer GPU point picking returns the stable original source vertex'
+    );
+  } finally {
+    devicePixelSizeSpy.mockRestore();
+    pickingReadback?.destroy();
+    depth?.destroy();
+    color?.destroy();
+    explorer?.onFinalize();
+  }
+
+  tapeTest.end();
+});
+
 test('luGraph explorer waits for the current asynchronous GPU pick before dragging a different node', async tapeTest => {
   const device = await getWebGPUTestDevice();
   if (!device) {
@@ -421,7 +603,7 @@ test('luGraph explorer waits for the current asynchronous GPU pick before draggi
   cleanup.push(() => releaseCaptureSpy.mockRestore());
 
   try {
-    explorer = new LuGraphExplorerAnimationLoopTemplate({device} as unknown as AnimationProps);
+    explorer = createExplorer(device);
     await explorer.onInitialize({device, canvas} as unknown as AnimationProps);
     const pointerBindings = explorer as unknown as ExplorerPointerBindings;
     const pinnedBuffer = explorer.layout.pinned!.data[0].buffer as Buffer;
@@ -522,6 +704,246 @@ test('luGraph explorer waits for the current asynchronous GPU pick before draggi
 
   tapeTest.end();
 });
+
+test('luGraph showcase rebuilds an accessible graph slider with real spatial indexing and community colors', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const previousHost = document.getElementById('example-panel-host');
+  const host = previousHost ?? document.createElement('div');
+  const previousParent = previousHost?.parentNode ?? null;
+  const previousSibling = previousHost?.nextSibling ?? null;
+  const infoBox = document.createElement('section');
+  infoBox.setAttribute('data-info-box-appearance', 'cinematic');
+  const expandInfoBox = document.createElement('button');
+  expandInfoBox.type = 'button';
+  expandInfoBox.setAttribute('aria-label', 'Expand info box');
+  expandInfoBox.setAttribute('aria-expanded', 'false');
+  expandInfoBox.addEventListener('click', () => {
+    expandInfoBox.setAttribute('aria-expanded', 'true');
+    host.hidden = false;
+    host.setAttribute('aria-hidden', 'false');
+  });
+  const unrelatedInfoBox = document.createElement('button');
+  unrelatedInfoBox.type = 'button';
+  unrelatedInfoBox.setAttribute('aria-label', 'Expand info box');
+  unrelatedInfoBox.setAttribute('aria-expanded', 'false');
+  const ownExpandSpy = vi.spyOn(expandInfoBox, 'click');
+  const unrelatedExpandSpy = vi.spyOn(unrelatedInfoBox, 'click');
+  document.body.appendChild(unrelatedInfoBox);
+  if (previousParent) previousParent.insertBefore(infoBox, host);
+  else document.body.appendChild(infoBox);
+  if (!previousHost) host.id = 'example-panel-host';
+  host.hidden = true;
+  host.setAttribute('aria-hidden', 'true');
+  infoBox.append(expandInfoBox, host);
+
+  const devicePixelSizeSpy = vi
+    .spyOn(device.getDefaultCanvasContext(), 'getDevicePixelSize')
+    .mockReturnValue([64, 48]);
+  let explorer: LuGraphExplorerAnimationLoopTemplate | undefined;
+  let color: Texture | undefined;
+  let depth: Texture | undefined;
+  try {
+    explorer = createExplorer(device, 32, 'spatial');
+    tapeTest.equal(explorer.graph.vertexCount, 32, 'the tiny real-GPU fixture remains injectable');
+    tapeTest.ok(explorer.spatialLayout, 'explicit spatial mode creates a real caller-owned index');
+    if (!explorer.spatialLayout) throw new Error('The showcase did not create its spatial layout');
+    tapeTest.equal(
+      ownExpandSpy.mock.calls.length,
+      1,
+      'the native showcase opens its own collapsed graph-inspector controls once'
+    );
+    tapeTest.equal(
+      expandInfoBox.getAttribute('aria-expanded'),
+      'true',
+      'the actual accessible website InfoBox becomes visible immediately'
+    );
+    tapeTest.equal(host.hidden, false, 'the graph-size slider is visible without a hidden InfoBox');
+    tapeTest.equal(
+      unrelatedExpandSpy.mock.calls.length,
+      0,
+      'other unrelated website InfoBox controls are never opened'
+    );
+
+    const slider = host.querySelector<HTMLInputElement>('[data-graph-size]');
+    const layoutMode = host.querySelector<HTMLSelectElement>('[data-layout-mode]');
+    const colorMode = host.querySelector<HTMLSelectElement>('[data-color-mode]');
+    const sizeMode = host.querySelector<HTMLSelectElement>('[data-node-size]');
+    const edgeVisibility = host.querySelector<HTMLInputElement>('[data-edge-toggle]');
+    const legend = host.querySelector<HTMLElement>('[data-graph-legend]');
+    const adapter = host.querySelector<HTMLElement>('[data-graph-adapter]');
+    const memory = host.querySelector<HTMLElement>('[data-graph-memory]');
+    const status = host.querySelector<HTMLElement>('[role="status"]');
+    tapeTest.ok(slider, 'the native showcase publishes a keyboard-accessible graph-size slider');
+    tapeTest.equal(slider?.type, 'range', 'graph scale is an actual accessible range control');
+    tapeTest.equal(slider?.min, '0', 'the first slider step maps to 128 resident vertices');
+    tapeTest.equal(
+      slider?.max,
+      String(GRAPH_EXPLORER_VERTEX_COUNTS.length - 1),
+      'the fourteenth slider step maps to the actual 1,048,576-vertex graph'
+    );
+    tapeTest.equal(
+      GRAPH_EXPLORER_VERTEX_COUNTS.at(-1),
+      1_048_576,
+      'the final scale represents actual original resident vertices'
+    );
+    tapeTest.ok(layoutMode, 'exact, automatic, spatial, and four-sample modes are user-visible');
+    tapeTest.ok(colorMode, 'actual analytic color choices are user-visible');
+    tapeTest.ok(sizeMode, 'GPU PageRank, degree, and uniform sizes are selectable');
+    tapeTest.deepEqual(
+      Array.from(layoutMode?.options ?? [], option => option.value),
+      ['auto', 'exact', 'spatial', 'sampled'],
+      'layout choices select real exact, flat-grid, and linear-work GPU contributors'
+    );
+    tapeTest.deepEqual(
+      Array.from(colorMode?.options ?? [], option => option.value),
+      ['community', 'component', 'degree', 'pagerank', 'distance'],
+      'all advertised node colors correspond to real GPU analytics'
+    );
+    tapeTest.deepEqual(
+      Array.from(sizeMode?.options ?? [], option => option.value),
+      ['pagerank', 'degree', 'uniform'],
+      'all advertised node sizes use real resident metrics or a uniform radius'
+    );
+    tapeTest.ok(edgeVisibility, 'original source-chunk edges can be hidden accessibly');
+    tapeTest.ok(legend, 'a visible accessible legend describes actual GPU analytic colors');
+    tapeTest.ok(
+      legend?.getAttribute('aria-label'),
+      'color meaning remains screen-reader accessible'
+    );
+    tapeTest.ok(adapter?.textContent, 'the graph inspector reports real adapter information');
+    tapeTest.ok(
+      memory?.textContent,
+      'the graph inspector reports actual GPU allocation accounting'
+    );
+    tapeTest.ok(
+      /resident|transient/i.test(memory?.textContent ?? ''),
+      'GPU memory statistics distinguish owned graph and transient allocations'
+    );
+    tapeTest.equal(status?.getAttribute('aria-live'), 'polite', 'graph changes announce politely');
+
+    const firstBindings = explorer as unknown as ExplorerGraphBindings;
+    color = device.createTexture({
+      id: 'lugraph-showcase-test-color',
+      format: device.preferredColorFormat,
+      width: firstBindings.frameWidth,
+      height: firstBindings.frameHeight,
+      usage: Texture.RENDER
+    });
+    depth = device.createTexture({
+      id: 'lugraph-showcase-test-depth',
+      format: 'depth24plus',
+      width: firstBindings.frameWidth,
+      height: firstBindings.frameHeight,
+      usage: Texture.RENDER
+    });
+
+    executeShowcaseFrame(device, explorer, color, depth);
+    const [initialCount, initialOverflow, initialCommunity, initialComponents] = await Promise.all([
+      readUint32Vector(explorer.spatialLayout.count),
+      readUint32Vector(explorer.spatialLayout.overflow),
+      readUint32Vector(explorer.communities.output),
+      readUint32Vector(explorer.components.output)
+    ]);
+    tapeTest.equal(initialCount[0], 32, 'the actual GPU grid accepts every original vertex');
+    tapeTest.equal(initialOverflow[0], 0, 'caller-owned vertex-ID capacity does not overflow');
+    tapeTest.equal(initialComponents[8], 0, 'one bridge joins the first two weak components');
+    tapeTest.equal(initialCommunity[8], 8, 'actual majority votes retain a separate community');
+
+    const previousPositions = explorer.layout.positions.data[0].buffer;
+    const previousAnalysis = explorer.analysisGraph;
+    if (!slider) throw new Error('The native graph-size control was not mounted');
+    slider.value = '0';
+    slider.dispatchEvent(new Event('change', {bubbles: true}));
+    tapeTest.equal(explorer.graph.vertexCount, 128, 'a real slider change rebuilds the GPU graph');
+    tapeTest.equal(
+      ownExpandSpy.mock.calls.length,
+      1,
+      'resizing never repeatedly reopens a user-controlled website InfoBox'
+    );
+    tapeTest.notEqual(
+      explorer.layout.positions.data[0].buffer,
+      previousPositions,
+      'new vertex attributes use fresh caller-owned physical storage'
+    );
+    tapeTest.notEqual(explorer.analysisGraph, previousAnalysis, 'analytics graphs are rebuilt');
+    tapeTest.deepEqual(
+      explorer.graph.sourceVertices.data.map(chunk => chunk.length === 0),
+      [false, true, false],
+      'graph resizing still preserves the original empty source batch'
+    );
+    tapeTest.ok(explorer.spatialLayout, 'the selected spatial mode survives graph resizing');
+    if (!explorer.spatialLayout) throw new Error('The rebuilt showcase lost its spatial layout');
+
+    executeShowcaseFrame(device, explorer, color, depth);
+    const [resizedCount, resizedOverflow, resizedCommunities, resizedComponents] =
+      await Promise.all([
+        readUint32Vector(explorer.spatialLayout.count),
+        readUint32Vector(explorer.spatialLayout.overflow),
+        readUint32Vector(explorer.communities.output),
+        readUint32Vector(explorer.components.output)
+      ]);
+    tapeTest.equal(resizedCount[0], 128, 'rebuilt spatial passes index all resized vertices');
+    tapeTest.equal(resizedOverflow[0], 0, 'rebuilt explicit index buffers remain large enough');
+    tapeTest.equal(resizedComponents[32], 0, 'resized weak components still cross the bridge');
+    tapeTest.equal(resizedCommunities[32], 32, 'resized GPU community labels remain distinct');
+    tapeTest.ok(
+      !/GPU\s+(?:frame|execution|duration)\s*[:=]\s*\d/i.test(status?.textContent ?? ''),
+      'the live inspector never fabricates GPU execution timings'
+    );
+  } finally {
+    devicePixelSizeSpy.mockRestore();
+    ownExpandSpy.mockRestore();
+    unrelatedExpandSpy.mockRestore();
+    depth?.destroy();
+    color?.destroy();
+    explorer?.onFinalize();
+    if (previousHost && previousParent) previousParent.insertBefore(host, previousSibling);
+    else host.remove();
+    infoBox.remove();
+    unrelatedInfoBox.remove();
+  }
+
+  tapeTest.end();
+});
+
+function createExplorer(
+  device: Device,
+  vertexCount = 128,
+  layoutMode?: GraphExplorerLayoutMode,
+  options: Pick<ExplorerAnimationProps, 'pointMode' | 'maxVisibleEdges'> = {}
+): LuGraphExplorerAnimationLoopTemplate {
+  return new LuGraphExplorerAnimationLoopTemplate({
+    device,
+    dataset: makeGraphExplorerDataset(vertexCount),
+    ...(layoutMode ? {layoutMode} : {}),
+    ...options
+  } as ExplorerAnimationProps);
+}
+
+function executeShowcaseFrame(
+  device: Device,
+  explorer: LuGraphExplorerAnimationLoopTemplate,
+  color: Texture,
+  depth: Texture
+): void {
+  const bindings = explorer as unknown as ExplorerGraphBindings;
+  const encoder = device.createCommandEncoder({id: 'lugraph-showcase-real-spatial-frame'});
+  explorer.analysisGraph.encode(encoder, {parameters: undefined});
+  explorer.frameGraph.encode(encoder, {
+    parameters: {width: bindings.frameWidth, height: bindings.frameHeight},
+    frameTextures: {
+      [bindings.frameColorId]: {texture: color, frameId: 0},
+      [bindings.frameDepthId]: {texture: depth, frameId: 0}
+    }
+  });
+  device.submit(encoder.finish());
+}
 
 function executeAnalysis(device: Device, explorer: LuGraphExplorerAnimationLoopTemplate): void {
   const encoder = device.createCommandEncoder({id: 'lugraph-explorer-analysis-test'});

--- a/test/examples/lugraph-docs.node.spec.ts
+++ b/test/examples/lugraph-docs.node.spec.ts
@@ -21,6 +21,14 @@ const graphExplorerExample = readFileSync(
   new URL('../../website/content/examples/experimental/lugraph-explorer.mdx', import.meta.url),
   'utf8'
 );
+const deckGraphExplorerExample = readFileSync(
+  new URL('../../website/content/examples/deck/lugraph-explorer.mdx', import.meta.url),
+  'utf8'
+);
+const privateLayerDocumentation = readFileSync(
+  new URL('../../modules/arrow-layers/README.md', import.meta.url),
+  'utf8'
+);
 const sidebar = readFileSync(new URL('../../docs/table-of-contents.json', import.meta.url), 'utf8');
 const experimentalTabs = readFileSync(
   new URL('../../website/src/components/docs/experimental-docs-tabs.tsx', import.meta.url),
@@ -41,7 +49,7 @@ describe('luGraph GPU-resident graph analytics documentation', () => {
     expect(packageDocumentation).toContain('/docs/api-reference/experimental/lugraph');
   });
 
-  test('embeds an honest 128-vertex GPU explorer and explains its practical interactions', () => {
+  test('embeds an honest full-population GPU explorer and explains its practical interactions', () => {
     expect(graphDocumentation).toContain(
       "import {LuGraphExplorerExample} from '@site/src/examples';"
     );
@@ -51,19 +59,28 @@ describe('luGraph GPU-resident graph analytics documentation', () => {
     );
 
     for (const documentation of [graphDocumentation, graphExplorerExample]) {
-      expect(documentation).toContain('128-vertex');
+      expect(documentation).toContain('1,024');
+      expect(documentation).toContain('1,048,576');
+      expect(documentation).toContain('2,097,343');
+      expect(documentation).toContain('16,384');
+      expect(documentation).toContain('65,536');
+      expect(documentation).toContain('512 vertices');
       expect(documentation).toContain('weakly connected');
-      expect(documentation).toContain('not community-detection');
+      expect(documentation).toMatch(/label.propagation/u);
       expect(documentation).toContain('PageRank');
       expect(documentation).toContain('8-byte');
       expect(documentation).toContain('`O(V² + E)`');
+      expect(documentation).toContain('`O(E + 4V)`');
     }
 
     expect(graphExplorerExample).toContain('## Overview');
     expect(graphExplorerExample).toContain('## How to read the network');
     expect(graphExplorerExample).toContain('## Try the controls');
     expect(graphExplorerExample).toContain('## What actually stays on the GPU');
+    expect(graphExplorerExample).toContain('## How scale changes the real GPU workload');
     expect(graphExplorerExample).toContain('<LuGraphExplorerExample />');
+    expect(graphExplorerExample).toContain('**Choose a graph size**');
+    expect(graphExplorerExample).toContain('**Choose a layout mode**');
     expect(graphExplorerExample).toContain('**Choose a node color mode**');
     expect(graphExplorerExample).toContain('**Choose a node size mode**');
     expect(graphExplorerExample).toContain('**Adjust neighborhood depth**');
@@ -76,13 +93,50 @@ describe('luGraph GPU-resident graph analytics documentation', () => {
     expect(graphExplorerExample).toContain('/docs/api-reference/experimental/lugraph');
 
     for (const documentation of [graphDocumentation, graphExplorerExample]) {
+      expect(documentation).toContain('**Label-propagation communities**');
       expect(documentation).toContain('**Weak components**');
       expect(documentation).toContain('**Vertex degree**');
       expect(documentation).toContain('**PageRank importance**');
       expect(documentation).toContain('**Neighborhood distance**');
-      expect(documentation).toContain('legend');
-      expect(documentation).toContain('execution times');
+      expect(documentation).toContain('inspector');
     }
+    expect(graphDocumentation).toContain('CPU encoding is never mislabeled');
+    expect(graphExplorerExample).toContain('fabricated GPU timing');
+  });
+
+  test('distinguishes complete graph residency, bounded visible edges, and real layout modes', () => {
+    for (const documentation of [
+      graphDocumentation,
+      graphExplorerExample,
+      deckGraphExplorerExample
+    ]) {
+      expect(documentation).toContain('1,024');
+      expect(documentation).toContain('1,048,576');
+      expect(documentation).toContain('2,097,343');
+      expect(documentation).toContain('16,384');
+      expect(documentation).toContain('65,536');
+      expect(documentation).toContain('512 vertices');
+      expect(documentation).toContain('O(E + 4V)');
+      expect(documentation).toMatch(/flat.grid/u);
+      expect(documentation).toMatch(/label.propagation/u);
+      expect(documentation).toMatch(/convergen/u);
+    }
+
+    expect(graphDocumentation).toContain('Only rendered edge detail');
+    expect(graphExplorerExample).toContain('only visible\n  original edges are capped');
+    expect(deckGraphExplorerExample).toContain('Only visible original edge detail');
+    expect(graphDocumentation).toContain('CPU encoding is never mislabeled');
+    expect(deckGraphExplorerExample).toContain('does not invent convergence, timestamps');
+    expect(deckGraphExplorerExample).toContain('as an injected callback');
+    expect(privateLayerDocumentation).toContain('@deck.gl-community/arrow-layers');
+    expect(privateLayerDocumentation).toContain('## Overview');
+    expect(privateLayerDocumentation).toContain('## When to use graph layers');
+    expect(privateLayerDocumentation).toContain('## Graph effects and layers');
+    expect(privateLayerDocumentation).toContain('application-owned sampled-layout contributor');
+    expect(privateLayerDocumentation).toContain('never imports application or example source');
+    expect(privateLayerDocumentation).toContain('1,048,576');
+    expect(privateLayerDocumentation).toContain('2,097,343');
+    expect(privateLayerDocumentation).toContain('65,536');
   });
 
   test('documents opt-in CPU and actual WebGPU benchmarks with reproducible graph workloads', () => {

--- a/website/content/examples/deck/lugraph-explorer.mdx
+++ b/website/content/examples/deck/lugraph-explorer.mdx
@@ -1,8 +1,8 @@
 ---
 title: luGraph + deck.gl Network Explorer
-description: Analyze, progressively lay out, and directly render one GPU-resident property graph using real deck.gl layers and asynchronous WebGPU picking.
+description: Explore up to 1,048,576 actual GPU vertices and 2,097,343 resident edges through real deck.gl layers, graph analytics, and bounded force layout.
 sidebar_custom_props:
-  description: Explore a resident graph through GPU PageRank, components, layout, neighborhood selection, and direct deck.gl layers.
+  description: Resize resident graphs and inspect real GPU communities, analytics, bounded layout, and direct deck.gl layers.
   backends: [webgpu]
   difficulty: advanced
   maturity: experimental
@@ -14,9 +14,13 @@ import {DeckLuGraphExplorerExample} from '@site/src/examples';
 ## Overview
 
 A social network, service-dependency map, transaction investigation, or citation graph becomes
-easier to understand when its relationships are visible. This WebGPU-only example draws a
-deterministic 128-vertex graph with real deck.gl layers while its adjacency, importance scores,
-connected groups, neighborhood selection, and moving positions remain on the GPU.
+easier to understand when its relationships are visible. This WebGPU-only example starts with
+**1,024 actual vertices** and offers fourteen real graph populations from **128 to 1,048,576
+vertices**. Its largest network retains **1,048,576 GPU-resident vertices and 2,097,343 original
+directed edges** while real deck.gl layers render graph analytics directly from GPU memory.
+
+Every source vertex remains rendered. Only visible original edge detail is bounded to **65,536
+edges**; the complete graph, original edge batches, and adjacency remain resident.
 
 <DeckLuGraphExplorerExample />
 
@@ -41,11 +45,11 @@ Use this approach when a deck.gl application already has GPU-resident relationsh
 reuse graph analytics across many interactive frames:
 
 - **Social and communication networks:** reveal influential accounts, disconnected groups, and
-  introductions within a selected number of hops.
+  genuine local communities, plus introductions within a selected number of hops.
 - **Service and package dependencies:** inspect a failed service's reachable dependencies and
-  identify structurally important systems.
+  identify tightly connected ownership groups or structurally important systems.
 - **Transaction and fraud investigations:** follow relationships around an account and expose
-  connected groups of counterparties.
+  connected groups of counterparties or coordinated communities within one larger network.
 - **Knowledge and citation maps:** compare incoming PageRank influence with visual neighborhoods
   and relationship structure.
 
@@ -55,21 +59,24 @@ costs; keeping a graph resident does not automatically make every workload faste
 
 ## How the GPU-resident frame works
 
-1. **Upload the demonstration fixture once.** Its source and target relationship columns retain
-   their three original aligned batches: one nonempty batch, one intentionally empty batch, and a
-   second nonempty batch.
+1. **Upload the demonstration fixture once** for the selected graph size. Its source and target
+   relationship columns retain their three original aligned batches: one nonempty batch, one
+   intentionally empty batch, and a second nonempty batch. Changing the slider creates an actual
+   new graph; its displayed population is not a multiplied sample.
 2. **Analyze the graph in the first frame.** `LuGraphDeckEffect` builds forward and reverse
-   compressed adjacency, computes normalized dangling-aware PageRank, and labels weakly connected
-   components. Weak components describe connectivity when edge direction is ignored; they are not
-   community-detection results.
+   compressed adjacency, computes exact vertex degree and normalized dangling-aware PageRank, and
+   produces both weak-component and deterministic label-propagation community labels. Weak
+   components describe connectivity; community labels can separate tightly connected groups inside
+   one component. Their bounded iteration budget does not guarantee convergence.
 3. **Update interaction and layout in later frames.** GPU breadth-first search highlights the
-   selected vertex's bounded neighborhood, and exact force-directed layout progressively advances
-   the existing node positions.
+   selected vertex's bounded neighborhood when selection changes. Exact, flat-grid spatial, or
+   sampled force layout progressively advances the existing node positions.
 4. **Draw the same allocations through real deck.gl layers.** `LuGraphNodeLayer` binds the actual
-   `float32x2` layout allocation as an instanced vertex attribute. PageRank determines node size,
-   weak-component labels determine color, and resident distances and selection masks determine
-   highlighting. One `LuGraphEdgeLayer` draws each nonempty original source/target batch directly;
-   the empty middle batch remains in the graph and is never concatenated or repacked.
+   `float32x2` layout allocation as an instanced vertex attribute. Actual community, component,
+   degree, PageRank, and distance results control color; PageRank, degree, or a uniform value
+   controls size. One `LuGraphEdgeLayer` draws each nonempty original source/target batch directly;
+   the empty middle batch remains in the complete graph and is never concatenated or repacked.
+   Visible edge instances can be capped without dropping any resident edge or vertex.
 
 The effect records compute into deck.gl's own WebGPU command encoder; deck.gl owns queue
 submission. The node-position allocation has both `Buffer.STORAGE` and `Buffer.VERTEX` usage, so
@@ -80,6 +87,15 @@ simulation can update the exact same memory that the node layer fetches as an in
 - **Hover a node** to inspect its stable original vertex identifier and whether it is pinned.
 - **Click a node** to select it and highlight its GPU-computed neighborhood; click empty space to
   clear the selection.
+- **Change the graph size** to rebuild real resident vertices across fourteen keyboard-accessible
+  steps, from 128 to 1,048,576.
+- **Choose a layout mode** to compare automatic, exact, spatial, and sampled GPU force paths.
+- **Choose a node color mode** to inspect community, weak-component, degree, PageRank, or
+  neighborhood-distance results.
+- **Choose a node size mode** to compare PageRank, degree, or uniform-size vertices.
+- **Toggle original edges** to show or hide their bounded visible instances without changing the
+  complete resident source batches.
+- **Pause or resume the layout** while preserving the live graph and interaction controls.
 - **Adjust neighborhood depth** to include between zero and eight unweighted relationship hops.
 - **Drag a node** to move its existing GPU coordinates and pin it while the remaining graph moves.
 - **Release pins** to let every pinned vertex move again.
@@ -91,10 +107,17 @@ rebuild a JavaScript graph or download vertex columns for every animation frame.
 
 ## What actually stays on the GPU
 
-After the initial fixture upload, original source and target edge chunks, compressed adjacency,
-PageRank scores, weak-component identifiers, breadth-first distances, neighborhood masks, and
-progressive layout positions stay resident. Rendering does not concatenate edge batches, copy
-positions into a second vertex allocation, or read graph columns back to the CPU.
+After each selected fixture is uploaded, all original source and target edge chunks, compressed
+adjacency, degree counts, PageRank scores, weak-component identifiers, label-propagation
+communities, breadth-first distances, neighborhood masks, and progressive layout positions stay
+resident. Rendering does not concatenate edge batches, copy positions into a second vertex
+allocation, or read graph columns back to the CPU. At the largest setting, **every one of the
+1,048,576 original vertices remains rendered**; the **2,097,343 original directed edges** remain
+resident even when only **65,536 original edges** are visible.
+
+The sampled-layout helper is supplied by the example as an injected callback. The existing private
+`@deck.gl-community/arrow-layers` package owns Deck imports, effects, and layers without importing
+the example; the public luGraph package remains renderer-independent.
 
 Interaction is not magically transfer-free: JavaScript writes explicit selection controls, pin
 flags, or dragged coordinates when requested. deck.gl's native asynchronous WebGPU picking also
@@ -105,10 +128,26 @@ does not claim the separate native luGraph explorer's custom integer-readback co
 
 ## Boundaries and performance
 
-This example requires WebGPU and uses exact force-directed layout, which costs `O(V² + E)` per
-iteration for `V` vertices and `E` edges. Its deliberately small 128-vertex network demonstrates
-correct GPU ownership, native deck.gl integration, and interaction; it is not a large-graph
-benchmark and does not enable the optional spatial approximation or provide a CPU fallback.
+Automatic layout changes its actual GPU workload as the graph grows:
+
+- **Through 512 vertices:** exact force-directed layout evaluates all vertex pairs and costs
+  `O(V² + E)` per iteration.
+- **From 1,024 through 8,192 vertices:** the explicit flat-grid spatial approximation evaluates
+  nearby forces exactly and combines sufficiently distant cells.
+- **From 16,384 vertices:** sampled layout evaluates every real incident edge plus four
+  deterministic repulsion samples for each original vertex, costing `O(E + 4V)` per iteration.
+- **From 65,536 vertices:** each original vertex is rendered once as a compact GPU point; only
+  visible original edge instances are capped at 65,536.
+
+The four-sample path is intentionally approximate; it is not an exact million-body simulation,
+Barnes–Hut, or ForceAtlas2. Degree and adjacency cover the complete resident graph; PageRank,
+weak components, and label-propagation communities use explicitly bounded iterations and cannot
+claim convergence without a genuine convergence result.
+
+The live inspector distinguishes total resident vertices and edges from displayed edge detail,
+reports frame cadence, actual adapter and memory data, and labels CPU encoding separately from GPU
+execution. It does not invent convergence, timestamps, GPU execution durations, or synchronization.
+WebGPU is required; no CPU rendering or analytics fallback is implied.
 
 See the [luGraph API guide](/docs/api-reference/experimental/lugraph) for graph ownership,
 overflow handling, the separate optional spatial-layout approximation, and opt-in live CPU/GPU

--- a/website/content/examples/experimental/lugraph-explorer.mdx
+++ b/website/content/examples/experimental/lugraph-explorer.mdx
@@ -1,7 +1,7 @@
 ---
 title: luGraph Interactive Graph Explorer
 sidebar_label: luGraph explorer
-description: Explore GPU-native graph topology, PageRank, weak components, neighborhood selection, picking, and progressive force layout.
+description: Explore up to 1,048,576 actual GPU vertices and 2,097,343 resident edges through communities, PageRank, neighborhood selection, and bounded force layout.
 sidebar_custom_props:
   backends: [webgpu]
   difficulty: advanced
@@ -14,9 +14,11 @@ import {LuGraphExplorerExample} from '@site/src/examples';
 ## Overview
 
 A list of relationships can tell you which two entities are connected, but it cannot immediately
-show which account influences a network, how far a problem can spread, or which systems form an
-isolated group. This interactive example answers those questions with a deterministic 128-vertex
-graph whose relationship analysis, progressive layout, and rendering all run on WebGPU.
+show which account influences a network, how far a problem can spread, or which tightly connected
+groups exist inside a larger network. This WebGPU-only explorer opens with **1,024 real vertices**
+and offers fourteen resident graph populations from **128 to 1,048,576 vertices**. At its largest
+setting, all **1,048,576 actual vertices and 2,097,343 original directed edges** remain genuine GPU
+graph data; displayed population is never extrapolated from a smaller sample.
 
 <LuGraphExplorerExample />
 
@@ -24,11 +26,15 @@ graph whose relationship analysis, progressive layout, and rendering all run on 
 
 The graph contains four intentionally generated source groups, unequal-importance hubs, a single
 bridge connecting the first two groups, and one isolated final vertex. Its graph inspector compares
-four actual GPU-computed perspectives:
+five actual GPU-computed perspectives:
 
+- **Label-propagation communities** reveal locally cohesive groups. The two groups joined by one
+  narrow bridge can receive separate community colors even though they share a weak component.
+  Community labels are deterministic, bounded heuristic results, not a guarantee of convergence
+  or clustering quality.
 - **Weak components** show which entities remain connected when relationship direction is ignored.
   A bridge merges its two source groups into one component, while disconnected groups and the
-  isolated vertex remain separate. These are not community-detection labels.
+  isolated vertex remain separate. This is connectivity, not the separate community-detection mode.
 - **Vertex degree** counts immediate relationships, revealing directly connected local hubs.
 - **PageRank importance** reflects influence arriving from other important vertices, which is not
   equivalent to simply counting direct edges.
@@ -41,8 +47,11 @@ to JavaScript.
 ## Try the controls
 
 - **Click a node** to select its stable original vertex identifier and highlight its neighborhood.
-- **Choose a node color mode** to compare weak components, direct degree, PageRank influence, or
-  shortest-path distance.
+- **Choose a graph size** to rebuild the complete resident graph from 128 through 1,048,576
+  original vertices.
+- **Choose a layout mode** to select automatic, exact, flat-grid spatial, or sampled GPU forces.
+- **Choose a node color mode** to compare communities, weak components, direct degree, PageRank
+  influence, or shortest-path distance.
 - **Choose a node size mode** to compare PageRank, degree, or uniform-size vertices.
 - **Adjust neighborhood depth** to include more or fewer unweighted relationship hops.
 - **Toggle original edges** to inspect vertices without hiding or repacking source edge batches.
@@ -57,27 +66,48 @@ investigating transactions, or explaining why a structurally important account d
 that simply has many direct connections.
 
 The graph inspector opens automatically for this example. Its accessible color legend, live graph
-status, actual WebGPU adapter, frame cadence, and owned or transient GPU memory make the active
-pipeline understandable without claiming unmeasured GPU execution times.
+status, actual WebGPU adapter, frame cadence, measured CPU encoding, and owned or transient GPU
+memory make the active pipeline understandable without fabricated GPU timing. Resident vertex and
+edge totals remain distinct from bounded visible edge counts.
 
 ## What actually stays on the GPU
 
 The original source and target edge columns remain in their aligned nonempty, empty, and nonempty
 batches throughout adjacency construction and rendering. GPU-built forward and reverse compressed
 adjacency feeds exact vertex degree, bounded breadth-first selection, weakly connected components,
-normalized PageRank, and progressive exact force simulation. Node models bind the same writable
-position buffer directly as a vertex attribute, and edge models consume their original source
-batches; no implicit source concatenation, copied render attribute, or per-frame CPU position
-readback is required.
+label-propagation communities, normalized PageRank, and progressive force simulation. Node models
+bind the same writable position buffer directly as a vertex attribute, and edge models consume
+their original source batches; no implicit source concatenation, copied render attribute, or
+per-frame CPU position readback is required.
 
 Picking renders stable vertex identifiers into an integer attachment. Only an explicitly requested
 single-pixel selection copies one **8-byte** result back asynchronously through a caller-owned
 readback ring; ordinary analytics, simulation, and drawing remain GPU-resident.
 
-This WebGPU-only example deliberately uses 128 vertices because exact force-directed layout
-evaluates all vertex pairs and costs `O(V² + E)` per iteration. It demonstrates real GPU ownership,
-composition, and interaction; it does not claim approximate layout, automatic community detection,
-or large-graph benchmark performance.
+## How scale changes the real GPU workload
+
+The automatic layout policy chooses an actual algorithm appropriate to the selected population:
+
+- **Through 512 vertices:** exact force-directed layout evaluates every vertex pair and costs
+  `O(V² + E)` per iteration.
+- **From 1,024 through 8,192 vertices:** the optional flat-grid spatial approximation keeps nearby
+  forces exact while representing sufficiently distant cells by their population and center.
+- **From 16,384 vertices:** a separate sampled approximation processes every real edge and four
+  deterministic repulsion samples per original vertex, costing `O(E + 4V)` per iteration.
+- **From 65,536 vertices:** every source vertex remains rendered as one GPU point; only visible
+  original edges are capped at 65,536.
+
+At the maximum graph size, **1,048,576 vertices** and **2,097,343 original directed edges** remain
+resident even when only **65,536 edges** are drawn. Four deterministic source-community anchors,
+degree-normalized attraction, and population-independent repulsion keep the full point cloud
+legible without replacing real vertices with representative samples.
+
+Adjacency construction, degree, and a breadth-first traversal are `O(V + E)`; bounded PageRank and
+weak components require `O(K × (V + E))`, while deterministic label propagation requires
+`O(K × sum(degree²))`. Exact pairwise repulsion is the quadratic workload that changes with scale;
+graph analytics themselves are not automatically quadratic. Bounded iterations do not prove
+community, component, or PageRank convergence. Sampled layout is not Barnes–Hut, an exact force
+solver, or fabricated GPU timing; WebGPU is required.
 
 See the [luGraph API guide](/docs/api-reference/experimental/lugraph) for ownership, overflow,
 selection, convergence, and force-layout contracts.


### PR DESCRIPTION
## Goals
- Turn the luGraph native and deck.gl explorers into an honest, interactive GPU-resident graph showcase that scales from 128 to 1,048,576 **actual vertices** and 2,097,343 **original resident directed edges**.
- Complete the graph-analytics crescendo with real GPU community detection, PageRank, degree, weak components, neighborhood traversal, adaptive layout, and direct rendering without pretending sampled forces are sampled graph populations.
- Preserve the established private `modules/arrow-layers` dependency boundary and the beginner-friendly Overview, use-case, controls, and limitations documentation.

## Changes
- Add fourteen deterministic, accessible graph-population tiers with stable vertex identifiers, original aligned source/target edge chunks, and an intentionally preserved empty chunk.
- Render every resident vertex at every tier; switch large populations to one genuine point primitive per source vertex and cap only visible original-edge detail at 65,536 rows.
- Choose exact all-pairs layout for small graphs, real caller-owned spatial indexing for medium graphs, and an application-owned four-sample force contributor with `O(E + 4V)` work for larger graphs.
- Stabilize million-vertex layouts using population-independent repulsion, degree-normalized springs, and four deterministic sunflower-distributed source-community anchors.
- Compute actual bounded GPU label-propagation communities, PageRank, weak components, degree, and breadth-first neighborhoods; expose five real analytic color modes and three source-aligned node-size modes.
- Keep Deck effects, layers, node/edge shaders, graph options, and genuine asynchronous Deck picking inside the existing private `modules/arrow-layers` package. Inject the sampled-layout contributor from the example so package production source never imports application files.
- Preserve adapter buffer-limit preflight, chunk identity, full original graph populations, bounded staging, source-scoped inspector expansion, real trusted slider input, pins, graph resizing, visible/resident counts, and truthful CPU/frame diagnostics.
- Expand the canonical luGraph guide, native and Deck example pages, private adapter README, package overview, and focused Node/real-WebGPU coverage while preserving all existing per-algorithm introductions and community-attribution contracts.

## Verification
- `nvm use`: not rerun; used the established Node v22.22.1 workspace runtime.
- `yarn install`: not rerun; cloned the existing compatible workspace dependency installation without modifying the lockfile.
- `yarn lint fix`: passed; 1,793 files checked and lockfile validated.
- `yarn build`: passed across every luma.gl package, including `modules/arrow-layers`.
- `yarn test-node`: passed; **1,796 tests**, with one pre-existing skipped test.
- Real Chromium/WebGPU focused coverage: **39 tests passed** across native graph visualization, Deck graph visualization, deterministic community propagation, existing Arrow Deck layers, and the existing spatial point layer.
- The CPU graph-fixture regression constructs all **1,048,576 real vertices / 2,097,343 real edges**; GPU regressions use bounded fixtures while verifying actual shaders, GPU communities, original chunks, sampled forces, point counts, spatial grids, real picking, and graph resizing.
- `yarn examples:typecheck`: passed across **47 example workspaces**.
- `yarn website:build`: passed; complete production Docusaurus site and 481 raw documentation pages validated.
- `yarn test`: not run as one combined wrapper; the complete Node suite and all relevant actual Chromium/WebGPU suites were run separately.
- `(cd website && yarn build)`: not run separately; the complete root `yarn website:build` production workflow passed.

## Risks and boundaries
- This PR is intentionally stacked on #2963 and requires its `LuGraphLabelPropagation` API.
- The four-sample layout is an explicitly approximate, application-owned force strategy; it is not Barnes–Hut, ForceAtlas2, an exact million-body solver, or a new public luGraph algorithm.
- Bounded PageRank, weak-component, and community passes do not imply convergence; diagnostics do not fabricate GPU timings.
- Maximum selectable populations depend on the active WebGPU adapter's actual storage-buffer and memory limits.
- The 65,536 limit applies only to visible original edges; all original vertices and directed edges remain resident and all vertices remain rendered.
