### PR TITLE
feat(effects): production-ready bloom with batched spectral FFT

### DIFF
--- a/examples/experimental/bloom/app.ts
+++ b/examples/experimental/bloom/app.ts
@@ -13,7 +13,7 @@ import {
 } from '@luma.gl/engine';
 import {getGPUConvolutionBloomSupport, GPUConvolutionBloom} from '@luma.gl/experimental';
 import type {ShaderModule, ShaderPass, ShaderPassPipeline} from '@luma.gl/shadertools';
-import {type Panel, type SettingsSchema, type SettingsState} from '@deck.gl-community/panels';
+import type {Panel, SettingsSchema, SettingsState} from '@deck.gl-community/panels';
 import {
   ExamplePanelManager,
   ExampleSettingsPanelManager,
@@ -30,11 +30,13 @@ const BLOOM_TECHNIQUES = ['Multiscale HDR', 'FFT Convolution', 'Compact', 'Off']
 const BLOOM_QUALITIES = ['low', 'medium', 'high', 'ultra'] as const;
 const BLOOM_RECONSTRUCTION_MODES = ['tent', 'bicubic'] as const;
 const BLOOM_DOWNSAMPLE_MODES = ['auto', 'render', 'compute'] as const;
+const BLOOM_BLUR_ALGORITHMS = ['dual-kawase', 'gaussian'] as const;
 
 type BloomTechnique = (typeof BLOOM_TECHNIQUES)[number];
 type BloomQuality = (typeof BLOOM_QUALITIES)[number];
 type BloomReconstruction = (typeof BLOOM_RECONSTRUCTION_MODES)[number];
 type BloomDownsample = (typeof BLOOM_DOWNSAMPLE_MODES)[number];
+type BloomBlurAlgorithm = (typeof BLOOM_BLUR_ALGORITHMS)[number];
 type BloomSettings = {
   technique: BloomTechnique;
   quality: BloomQuality;
@@ -50,6 +52,8 @@ type BloomSettings = {
   anamorphicRatio: number;
   reconstruction: BloomReconstruction;
   downsample: BloomDownsample;
+  blurAlgorithm: BloomBlurAlgorithm;
+  energyConserving: boolean;
   reuseRenderTargets: boolean;
   temporalStability: number;
   starburstIntensity: number;
@@ -63,6 +67,8 @@ type BloomSettings = {
   haloRadius: number;
   chromaticAberration: number;
   dirtIntensity: number;
+  guardBand: number;
+  spectralSpread: number;
   animate: boolean;
 };
 type SceneUniforms = {
@@ -86,6 +92,8 @@ const DEFAULT_SETTINGS: BloomSettings = {
   anamorphicRatio: 0.2,
   reconstruction: 'bicubic',
   downsample: 'auto',
+  blurAlgorithm: 'dual-kawase',
+  energyConserving: false,
   reuseRenderTargets: true,
   temporalStability: 0.58,
   starburstIntensity: 0.72,
@@ -99,14 +107,16 @@ const DEFAULT_SETTINGS: BloomSettings = {
   haloRadius: 0.32,
   chromaticAberration: 0.44,
   dirtIntensity: 0.42,
+  guardBand: 0.125,
+  spectralSpread: 0.65,
   animate: true
 };
 
 const BLOOM_BACKGROUND_HTML = `
 <p><b>Multiscale HDR bloom:</b> exposure-aware highlight extraction feeds an adaptive two-to-five-level pyramid. Supported WebGPU devices fuse every downsampling level into one compute dispatch, and expired extraction textures are reused during reconstruction.</p>
-<p><b>FFT convolution:</b> premium WebGPU optics transform each color channel into the frequency domain, multiply it by a cached aperture point-spread function, and reconstruct energy-conserving diffraction. The transform runs at one quarter of the selected processing resolution.</p>
-<p><b>Lens optics:</b> one optional half-resolution pass adds adjustable aperture-diffraction streaks, chromatic lens-element ghosts, and a radial halo. A sampled dirt mask reuses the existing bloom composite without adding a pass.</p>
-<p><b>Stability and cost:</b> neighborhood-clamped glow history reduces highlight shimmer for one extra half-resolution pass. Diffraction cost grows with the number of rays; ghosts scale with their reflection count and spectral separation.</p>
+<p><b>FFT convolution:</b> packed RGB transforms share one dispatch sequence and apply independent wavelength-aware aperture kernels. Zero-padded guard bands prevent opposite-edge wraparound, while area-weighted extraction retains tiny HDR emitters.</p>
+<p><b>Lens optics:</b> adjustable chromatic ghosts, a radial halo, sampled dirt, and optional temporal history are available in both multiscale and FFT modes. FFT optics reuse the existing composite dispatch.</p>
+<p><b>Stability and cost:</b> dual-Kawase reconstruction removes separable blur passes, while Gaussian remains available for wider artistic shaping. Physical mode scatters all light without additively duplicating scene energy.</p>
 <p><b>Compact bloom:</b> the legacy single-pass glow samples one small neighborhood directly from the source image. It is cheaper, but it cannot spread highlights as naturally as the multiscale pyramid.</p>
 <p><b>Scene setup:</b> this page renders animated HDR emitters into an offscreen texture before bloom. The previous static image hid the useful part of the effect by baking most of the lighting into SDR pixels.</p>
 `;
@@ -432,7 +442,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           threshold: this.settings.threshold,
           intensity: this.settings.intensity,
           exposure: this.settings.exposure,
-          exposureCompensation: this.settings.exposureCompensation
+          exposureCompensation: this.settings.exposureCompensation,
+          lensDirtTexture: this.settings.dirtIntensity > 0 ? this.lensDirtTexture : undefined
         });
       }
     }
@@ -482,6 +493,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           anamorphicRatio: this.settings.anamorphicRatio,
           reconstruction: this.settings.reconstruction,
           downsample: this.settings.downsample,
+          blurAlgorithm: this.settings.blurAlgorithm,
+          energyConserving: this.settings.energyConserving,
           reuseRenderTargets: this.settings.reuseRenderTargets,
           temporalStability: this.settings.temporalStability,
           lens: {
@@ -543,9 +556,22 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       width,
       height,
       resolutionScale: this.settings.resolutionScale * 0.25,
+      guardBand: this.settings.guardBand,
       apertureBlades: this.settings.starburstSpikes,
       diffractionStrength: this.settings.starburstIntensity,
-      anamorphicRatio: this.settings.anamorphicRatio
+      anamorphicRatio: this.settings.anamorphicRatio,
+      spectralSpread: this.settings.spectralSpread,
+      energyConserving: this.settings.energyConserving,
+      temporalStability: this.settings.temporalStability,
+      lens: {
+        ghostIntensity: this.settings.ghostIntensity,
+        ghostCount: this.settings.ghostCount,
+        ghostSpacing: this.settings.ghostSpacing,
+        haloIntensity: this.settings.haloIntensity,
+        haloRadius: this.settings.haloRadius,
+        chromaticAberration: this.settings.chromaticAberration,
+        dirtIntensity: this.settings.dirtIntensity
+      }
     });
     return this.convolutionBloom;
   }
@@ -554,7 +580,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     return getGPUConvolutionBloomSupport(this.device, {
       width,
       height,
-      resolutionScale: this.settings.resolutionScale * 0.25
+      resolutionScale: this.settings.resolutionScale * 0.25,
+      guardBand: this.settings.guardBand,
+      temporalStability: this.settings.temporalStability
     });
   }
 
@@ -638,6 +666,13 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       downsample: isBloomDownsample(settings['downsample'])
         ? settings['downsample']
         : this.settings.downsample,
+      blurAlgorithm: isBloomBlurAlgorithm(settings['blurAlgorithm'])
+        ? settings['blurAlgorithm']
+        : this.settings.blurAlgorithm,
+      energyConserving:
+        typeof settings['energyConserving'] === 'boolean'
+          ? settings['energyConserving']
+          : this.settings.energyConserving,
       reuseRenderTargets:
         typeof settings['reuseRenderTargets'] === 'boolean'
           ? settings['reuseRenderTargets']
@@ -690,6 +725,14 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         typeof settings['dirtIntensity'] === 'number'
           ? clampNumber(settings['dirtIntensity'], 0, 3)
           : this.settings.dirtIntensity,
+      guardBand:
+        typeof settings['guardBand'] === 'number'
+          ? clampNumber(settings['guardBand'], 0, 0.5)
+          : this.settings.guardBand,
+      spectralSpread:
+        typeof settings['spectralSpread'] === 'number'
+          ? clampNumber(settings['spectralSpread'], 0, 1)
+          : this.settings.spectralSpread,
       animate:
         typeof settings['animate'] === 'boolean' ? settings['animate'] : this.settings.animate
     };
@@ -726,10 +769,12 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.settings.downsample !== 'render' &&
       this.device.getTextureFormatCapabilities(this.colorFormat).store &&
       this.device.limits.maxStorageTexturesPerShaderStage >= levelCount;
+    const basePassCount =
+      this.settings.blurAlgorithm === 'dual-kawase'
+        ? levelCount * (supportsCompute ? 1 : 2)
+        : levelCount * (supportsCompute ? 3 : 4);
     const passCount =
-      levelCount * (supportsCompute ? 3 : 4) +
-      Number(hasLensArtifacts) +
-      Number(this.settings.temporalStability > 0);
+      basePassCount + Number(hasLensArtifacts) + Number(this.settings.temporalStability > 0);
     const computeDescription = supportsCompute ? ' plus one fused compute dispatch' : '';
     const convolutionSupport = this.getConvolutionSupport(
       this.sceneFramebuffer.width,
@@ -839,6 +884,22 @@ export function makeBloomSettingsSchema(): SettingsSchema {
               {label: 'Portable render passes', value: 'render'},
               {label: 'Fused compute', value: 'compute'}
             ]
+          },
+          {
+            name: 'blurAlgorithm',
+            label: 'Blur Algorithm',
+            type: 'select',
+            persist: 'none',
+            options: [
+              {label: 'Dual-Kawase (faster)', value: 'dual-kawase'},
+              {label: 'Separable Gaussian', value: 'gaussian'}
+            ]
+          },
+          {
+            name: 'energyConserving',
+            label: 'Physical Energy Conservation',
+            type: 'boolean',
+            persist: 'none'
           },
           {
             name: 'reconstruction',
@@ -1039,6 +1100,24 @@ export function makeBloomSettingsSchema(): SettingsSchema {
             min: 0,
             max: 3,
             step: 0.05
+          },
+          {
+            name: 'guardBand',
+            label: 'FFT Edge Guard Band',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 0.5,
+            step: 0.025
+          },
+          {
+            name: 'spectralSpread',
+            label: 'FFT Wavelength Spread',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1,
+            step: 0.05
           }
         ]
       }
@@ -1112,6 +1191,10 @@ function isBloomReconstruction(value: unknown): value is BloomReconstruction {
 
 function isBloomDownsample(value: unknown): value is BloomDownsample {
   return BLOOM_DOWNSAMPLE_MODES.includes(value as BloomDownsample);
+}
+
+function isBloomBlurAlgorithm(value: unknown): value is BloomBlurAlgorithm {
+  return BLOOM_BLUR_ALGORITHMS.includes(value as BloomBlurAlgorithm);
 }
 
 function clampNumber(value: number, minimum: number, maximum: number): number {

--- a/examples/experimental/bloom/vite.config.ts
+++ b/examples/experimental/bloom/vite.config.ts
@@ -2,6 +2,7 @@ import {defineConfig} from 'vite';
 
 const alias = {
   '@luma.gl/core': `${__dirname}/../../../modules/core/src`,
+  '@luma.gl/effects': `${__dirname}/../../../modules/effects/src`,
   '@luma.gl/engine': `${__dirname}/../../../modules/engine/src`,
   '@luma.gl/experimental': `${__dirname}/../../../modules/experimental/src`,
   '@luma.gl/gltf': `${__dirname}/../../../modules/gltf/src`,

--- a/modules/effects/README.md
+++ b/modules/effects/README.md
@@ -42,7 +42,11 @@ levels. `exposure` and photographic `exposureCompensation` adjust the scene-refe
 `threshold / (exposure * 2 ** exposureCompensation)`. Choose normalized nine-tap tent filtering or
 four-fetch bicubic B-spline reconstruction with `reconstruction`. `scatter`, `softKnee`,
 `fireflyReduction`, `anamorphicRatio`, and `tint` shape the resulting glow without requiring
-application-owned intermediate textures.
+application-owned intermediate textures. `blurAlgorithm: 'dual-kawase'` removes both separable
+Gaussian passes at every level while retaining normalized pyramid reconstruction; the default
+`'gaussian'` preserves the original wider-radius appearance. `energyConserving: true` forces
+thresholdless extraction and blends normalized scattered light instead of additively duplicating
+the original image.
 
 By default, `downsample: 'auto'` replaces the complete extraction/downsampling chain with one
 workgroup-local compute dispatch on supported WebGPU devices. WebGL and devices without enough
@@ -51,16 +55,19 @@ floating-point storage bindings retain the complete render-pass implementation. 
 compute while retaining the same capability fallback. `reuseRenderTargets` defaults to `true` and
 reuses expired extraction textures during reconstruction.
 
-| Quality | Pyramid levels | Portable render passes | Fused WebGPU work | Physical targets with / without reuse |
-| --- | --- | --- | --- | --- |
-| `low` | 2 | 8 | 6 render + 1 compute | 6 / 7 |
-| `medium` | 3 | 12 | 9 render + 1 compute | 9 / 11 |
-| `high` | 4 | 16 | 12 render + 1 compute | 12 / 15 |
-| `ultra` | 5 | 20 | 15 render + 1 compute | 15 / 19 |
+| Quality | Pyramid levels | Gaussian portable | Gaussian WebGPU | Dual-Kawase portable | Dual-Kawase WebGPU |
+| --- | --- | --- | --- | --- | --- |
+| `low` | 2 | 8 render | 6 render + 1 compute | 4 render | 2 render + 1 compute |
+| `medium` | 3 | 12 render | 9 render + 1 compute | 6 render | 3 render + 1 compute |
+| `high` | 4 | 16 render | 12 render + 1 compute | 8 render | 4 render + 1 compute |
+| `ultra` | 5 | 20 render | 15 render + 1 compute | 10 render | 5 render + 1 compute |
 
 Optional `lens` controls add aperture diffraction, spectral lens-element ghosts, a radial halo,
 and sampled lens dirt. Set `temporalStability` to accumulate neighborhood-clamped glow history.
-Every lens feature and temporal history is disabled by default.
+Add `temporalReprojection: true` when the application supplies `velocityTexture` and `depthTexture`
+bindings: bloom reprojects motion, rejects disocclusions with `temporalDepthThreshold`, and stores
+previous depth in the existing history alpha channel. `previousExposure` rescales history when
+adapted camera exposure changes. Every lens feature and temporal history is disabled by default.
 
 | Feature | Added render passes | Additional targets | Main sampling cost |
 | --- | --- | --- | --- |
@@ -71,6 +78,8 @@ Every lens feature and temporal history is disabled by default.
 | Lens halo | Shares the same lens pass | Shares the same target | One sample, or three with chromatic separation. |
 | Diffraction starburst | Shares the same lens pass | Shares the same target | Eight samples per configured diffraction ray. |
 | Temporal stability | 1 half-resolution history pass | 2 persistent half-resolution textures | Five current-neighborhood samples and one history sample. |
+| Motion reprojection | 0 beyond temporal stability | 0 | One velocity sample and one depth load; previous depth shares history alpha. |
+| Energy conservation | 0 | 0 | Thresholdless extraction and normalized final mixing. |
 
 The lens pass exists only when at least one of `starburstIntensity`, `ghostIntensity`, or
 `haloIntensity` is positive. Dirt-only configurations therefore preserve the base pass count. Reduce
@@ -94,6 +103,7 @@ const renderer = new ShaderPassRenderer(device, {
       exposure: 1,
       exposureCompensation: 0,
       intensity: 1.25,
+      blurAlgorithm: 'dual-kawase',
       reconstruction: 'bicubic',
       downsample: 'auto',
       scatter: 0.55,

--- a/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-lens-effects.ts
+++ b/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-lens-effects.ts
@@ -375,18 +375,76 @@ vec4 bloomLens_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texCoord)
 
 type BloomTemporalBindings = {
   historyTexture?: Texture;
+  velocityTexture?: Texture;
+  depthTexture?: Texture;
 };
 
-export const bloomTemporalPass = {
-  name: 'bloomTemporal',
-  source: /* wgsl */ `
+type BloomTemporalUniforms = {
+  stability: number;
+  depthThreshold: number;
+  exposureScale: number;
+};
+
+/** Builds optional motion-aware history without requiring scene textures in the portable mode. */
+export function createBloomTemporalPass(
+  motionReprojection: boolean
+): ShaderPass<
+  Partial<BloomTemporalUniforms> & BloomTemporalBindings,
+  BloomTemporalUniforms,
+  BloomTemporalBindings
+> {
+  const motionBindingsWGSL = motionReprojection
+    ? `
+@group(0) @binding(auto) var velocityTexture: texture_2d<f32>;
+@group(0) @binding(auto) var velocityTextureSampler: sampler;
+@group(0) @binding(auto) var depthTexture: texture_depth_2d;`
+    : '';
+  const motionBindingsGLSL = motionReprojection
+    ? '\nuniform sampler2D velocityTexture;\nuniform sampler2D depthTexture;'
+    : '';
+  const historyCoordinateWGSL = motionReprojection
+    ? 'texCoord - textureSampleLevel(velocityTexture, velocityTextureSampler, texCoord, 0.0).xy'
+    : 'texCoord';
+  const historyCoordinateGLSL = motionReprojection
+    ? 'texCoord - textureLod(velocityTexture, texCoord, 0.0).xy'
+    : 'texCoord';
+  const historyValidationWGSL = motionReprojection
+    ? `
+  let depthDimensions = textureDimensions(depthTexture);
+  let depthCoordinate = min(vec2u(texCoord * vec2f(depthDimensions)), depthDimensions - vec2u(1));
+  let currentDepth = textureLoad(depthTexture, vec2i(depthCoordinate), 0);
+  let validHistory = history.a > 0.5 && all(historyCoord >= vec2f(0.0)) &&
+    all(historyCoord <= vec2f(1.0)) &&
+    abs((history.a - 1.0) - currentDepth) <= bloomTemporal.depthThreshold;
+  let historyAlpha = currentDepth + 1.0;`
+    : `
+  let validHistory = history.a > 0.5;
+  let historyAlpha = 1.0;`;
+  const historyValidationGLSL = motionReprojection
+    ? `
+  ivec2 depthDimensions = textureSize(depthTexture, 0);
+  ivec2 depthCoordinate = min(ivec2(texCoord * vec2(depthDimensions)), depthDimensions - ivec2(1));
+  float currentDepth = texelFetch(depthTexture, depthCoordinate, 0).r;
+  bool validHistory = history.a > 0.5 && all(greaterThanEqual(historyCoord, vec2(0.0))) &&
+    all(lessThanEqual(historyCoord, vec2(1.0))) &&
+    abs((history.a - 1.0) - currentDepth) <= bloomTemporal.depthThreshold;
+  float historyAlpha = currentDepth + 1.0;`
+    : `
+  bool validHistory = history.a > 0.5;
+  float historyAlpha = 1.0;`;
+
+  return {
+    name: 'bloomTemporal',
+    source: /* wgsl */ `
 struct bloomTemporalUniforms {
   stability: f32,
+  depthThreshold: f32,
+  exposureScale: f32,
 };
 
 @group(0) @binding(auto) var<uniform> bloomTemporal: bloomTemporalUniforms;
 @group(0) @binding(auto) var historyTexture: texture_2d<f32>;
-@group(0) @binding(auto) var historyTextureSampler: sampler;
+@group(0) @binding(auto) var historyTextureSampler: sampler;${motionBindingsWGSL}
 
 fn bloomTemporal_sampleColor(
   sourceTexture: texture_2d<f32>,
@@ -402,18 +460,26 @@ fn bloomTemporal_sampleColor(
   let bottom = textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord + vec2f(0.0, texel.y), 0.0).rgb;
   let minimumColor = min(current, min(min(left, right), min(top, bottom)));
   let maximumColor = max(current, max(max(left, right), max(top, bottom)));
-  let history = textureSampleLevel(historyTexture, historyTextureSampler, texCoord, 0.0);
-  let clampedHistory = clamp(history.rgb, minimumColor, maximumColor);
-  let historyWeight = select(0.0, clamp(bloomTemporal.stability, 0.0, 0.95), history.a > 0.5);
-  return vec4f(mix(current, clampedHistory, historyWeight), 1.0);
+  let historyCoord = ${historyCoordinateWGSL};
+  let history = textureSampleLevel(
+    historyTexture,
+    historyTextureSampler,
+    clamp(historyCoord, vec2f(0.0), vec2f(1.0)),
+    0.0
+  );${historyValidationWGSL}
+  let clampedHistory = clamp(history.rgb * bloomTemporal.exposureScale, minimumColor, maximumColor);
+  let historyWeight = select(0.0, clamp(bloomTemporal.stability, 0.0, 0.95), validHistory);
+  return vec4f(mix(current, clampedHistory, historyWeight), historyAlpha);
 }
 `,
-  fs: /* glsl */ `
+    fs: /* glsl */ `
 layout(std140) uniform bloomTemporalUniforms {
   float stability;
+  float depthThreshold;
+  float exposureScale;
 } bloomTemporal;
 
-uniform sampler2D historyTexture;
+uniform sampler2D historyTexture;${motionBindingsGLSL}
 
 vec4 bloomTemporal_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texCoord) {
   vec2 texel = 1.0 / vec2(textureSize(sourceTexture, 0));
@@ -424,28 +490,38 @@ vec4 bloomTemporal_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texCo
   vec3 bottom = textureLod(sourceTexture, texCoord + vec2(0.0, texel.y), 0.0).rgb;
   vec3 minimumColor = min(current, min(min(left, right), min(top, bottom)));
   vec3 maximumColor = max(current, max(max(left, right), max(top, bottom)));
-  vec4 history = textureLod(historyTexture, texCoord, 0.0);
-  vec3 clampedHistory = clamp(history.rgb, minimumColor, maximumColor);
-  float historyWeight = history.a > 0.5 ? clamp(bloomTemporal.stability, 0.0, 0.95) : 0.0;
-  return vec4(mix(current, clampedHistory, historyWeight), 1.0);
+  vec2 historyCoord = ${historyCoordinateGLSL};
+  vec4 history = textureLod(historyTexture, clamp(historyCoord, vec2(0.0), vec2(1.0)), 0.0);
+  ${historyValidationGLSL}
+  vec3 clampedHistory = clamp(history.rgb * bloomTemporal.exposureScale, minimumColor, maximumColor);
+  float historyWeight = validHistory ? clamp(bloomTemporal.stability, 0.0, 0.95) : 0.0;
+  return vec4(mix(current, clampedHistory, historyWeight), historyAlpha);
 }
 `,
-  bindingLayout: [{name: 'historyTexture', group: 0}],
-  uniforms: {} as {stability: number},
-  bindings: {} as BloomTemporalBindings,
-  uniformTypes: {stability: 'f32'},
-  defaultUniforms: {stability: 0},
-  passes: [{sampler: true}]
-} as const satisfies ShaderPass<
-  {stability?: number} & BloomTemporalBindings,
-  {stability: number},
-  BloomTemporalBindings
->;
+    bindingLayout: [
+      {name: 'historyTexture', group: 0},
+      ...(motionReprojection
+        ? [
+            {name: 'velocityTexture', group: 0},
+            {name: 'depthTexture', group: 0}
+          ]
+        : [])
+    ],
+    uniforms: {} as BloomTemporalUniforms,
+    bindings: {} as BloomTemporalBindings,
+    uniformTypes: {stability: 'f32', depthThreshold: 'f32', exposureScale: 'f32'},
+    defaultUniforms: {stability: 0, depthThreshold: 0.01, exposureScale: 1},
+    passes: [{sampler: true}]
+  };
+}
+
+export const bloomTemporalPass = createBloomTemporalPass(false);
 
 type BloomLensCompositeUniforms = {
   tint: [number, number, number];
   intensity: number;
   dirtIntensity: number;
+  energyConserving: number;
 };
 
 type BloomLensCompositeBindings = {
@@ -488,6 +564,7 @@ struct bloomCompositeUniforms {
   tint: vec3f,
   intensity: f32,
   dirtIntensity: f32,
+  energyConserving: f32,
 };
 
 @group(0) @binding(auto) var<uniform> bloomComposite: bloomCompositeUniforms;
@@ -505,8 +582,14 @@ fn bloomComposite_sampleColor(
   let lensColor = ${lensSampleWGSL};
   let dirtMask = ${dirtSampleWGSL};
   let cinematicGlow = (glowColor + lensColor) * (vec3f(1.0) + dirtMask * bloomComposite.dirtIntensity);
+  let additiveColor = sourceColor.rgb + cinematicGlow * bloomComposite.tint * bloomComposite.intensity;
+  let physicalColor = mix(
+    sourceColor.rgb,
+    cinematicGlow * bloomComposite.tint,
+    clamp(bloomComposite.intensity, 0.0, 1.0)
+  );
   return vec4f(
-    sourceColor.rgb + cinematicGlow * bloomComposite.tint * bloomComposite.intensity,
+    select(additiveColor, physicalColor, bloomComposite.energyConserving > 0.5),
     sourceColor.a
   );
 }
@@ -516,6 +599,7 @@ layout(std140) uniform bloomCompositeUniforms {
   vec3 tint;
   float intensity;
   float dirtIntensity;
+  float energyConserving;
 } bloomComposite;
 
 uniform sampler2D glowTexture;${lensBindingsGLSL}${dirtBindingsGLSL}
@@ -526,8 +610,14 @@ vec4 bloomComposite_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texC
   vec3 lensColor = ${lensSampleGLSL};
   vec3 dirtMask = ${dirtSampleGLSL};
   vec3 cinematicGlow = (glowColor + lensColor) * (vec3(1.0) + dirtMask * bloomComposite.dirtIntensity);
+  vec3 additiveColor = sourceColor.rgb + cinematicGlow * bloomComposite.tint * bloomComposite.intensity;
+  vec3 physicalColor = mix(
+    sourceColor.rgb,
+    cinematicGlow * bloomComposite.tint,
+    clamp(bloomComposite.intensity, 0.0, 1.0)
+  );
   return vec4(
-    sourceColor.rgb + cinematicGlow * bloomComposite.tint * bloomComposite.intensity,
+    bloomComposite.energyConserving > 0.5 ? physicalColor : additiveColor,
     sourceColor.a
   );
 }
@@ -542,12 +632,14 @@ vec4 bloomComposite_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texC
     uniformTypes: {
       tint: 'vec3<f32>',
       intensity: 'f32',
-      dirtIntensity: 'f32'
+      dirtIntensity: 'f32',
+      energyConserving: 'f32'
     },
     defaultUniforms: {
       tint: [1, 1, 1],
       intensity: 1,
-      dirtIntensity: 0
+      dirtIntensity: 0,
+      energyConserving: 0
     },
     passes: [{sampler: true}]
   };

--- a/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline.ts
+++ b/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline.ts
@@ -13,8 +13,8 @@ import type {BloomProps, BloomUniforms} from './bloom';
 import {createBloomComputePyramid} from './bloom-compute-pyramid';
 import {
   bloomLensArtifactsPass,
-  bloomTemporalPass,
   createBloomLensCompositePass,
+  createBloomTemporalPass,
   MAX_BLOOM_LENS_GHOSTS,
   MAX_BLOOM_LENS_SPIKES,
   type BloomLensEffectsOptions
@@ -66,6 +66,16 @@ export type BloomShaderPassPipelineOptions = BloomProps & {
   lens?: BloomLensEffectsOptions;
   /** Neighborhood-clamped history contribution for stable highlights. Defaults to zero. */
   temporalStability?: number;
+  /** Reproject temporal history with externally supplied velocityTexture and depthTexture. */
+  temporalReprojection?: boolean;
+  /** Maximum encoded scene-depth change accepted by motion-aware temporal history. */
+  temporalDepthThreshold?: number;
+  /** Previous adapted exposure used to rescale glow history when camera exposure changes. */
+  previousExposure?: number;
+  /** Separable Gaussian filtering or a lower-cost downsample/reconstruction-only pyramid. */
+  blurAlgorithm?: 'gaussian' | 'dual-kawase';
+  /** Scatter every source pixel and blend normalized glow without duplicating scene energy. */
+  energyConserving?: boolean;
   /** Normalized tent reconstruction or four-fetch bicubic B-spline filtering. */
   reconstruction?: 'tent' | 'bicubic';
   /** Select fragment downsampling or the fused WebGPU compute pyramid when available. */
@@ -763,6 +773,7 @@ type BloomAdaptiveCompositeBindings = {
 type BloomAdaptiveCompositeUniforms = {
   tint?: [number, number, number];
   intensity?: number;
+  energyConserving?: number;
 };
 
 const bloomAdaptiveCompositePass = {
@@ -771,6 +782,7 @@ const bloomAdaptiveCompositePass = {
 struct bloomCompositeUniforms {
   tint: vec3f,
   intensity: f32,
+  energyConserving: f32,
 };
 
 @group(0) @binding(auto) var<uniform> bloomComposite: bloomCompositeUniforms;
@@ -786,13 +798,23 @@ fn bloomComposite_sampleColor(
   let sourceColor = textureSample(sourceTexture, sourceTextureSampler, texCoord);
   let glowColor = textureSample(glowTexture, glowTextureSampler, texCoord).rgb;
   let tintedGlow = glowColor * bloomComposite.tint * bloomComposite.intensity;
-  return vec4f(sourceColor.rgb + tintedGlow, sourceColor.a);
+  let additiveColor = sourceColor.rgb + tintedGlow;
+  let physicalColor = mix(
+    sourceColor.rgb,
+    glowColor * bloomComposite.tint,
+    clamp(bloomComposite.intensity, 0.0, 1.0)
+  );
+  return vec4f(
+    select(additiveColor, physicalColor, bloomComposite.energyConserving > 0.5),
+    sourceColor.a
+  );
 }
 `,
   fs: /* glsl */ `
 layout(std140) uniform bloomCompositeUniforms {
   vec3 tint;
   float intensity;
+  float energyConserving;
 } bloomComposite;
 
 uniform sampler2D glowTexture;
@@ -801,7 +823,16 @@ vec4 bloomComposite_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texC
   vec4 sourceColor = texture(sourceTexture, texCoord);
   vec3 glowColor = texture(glowTexture, texCoord).rgb;
   vec3 tintedGlow = glowColor * bloomComposite.tint * bloomComposite.intensity;
-  return vec4(sourceColor.rgb + tintedGlow, sourceColor.a);
+  vec3 additiveColor = sourceColor.rgb + tintedGlow;
+  vec3 physicalColor = mix(
+    sourceColor.rgb,
+    glowColor * bloomComposite.tint,
+    clamp(bloomComposite.intensity, 0.0, 1.0)
+  );
+  return vec4(
+    bloomComposite.energyConserving > 0.5 ? physicalColor : additiveColor,
+    sourceColor.a
+  );
 }
 `,
   bindingLayout: [{name: 'glowTexture', group: 0}],
@@ -809,15 +840,18 @@ vec4 bloomComposite_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texC
   bindings: {} as BloomAdaptiveCompositeBindings,
   uniformTypes: {
     tint: 'vec3<f32>',
-    intensity: 'f32'
+    intensity: 'f32',
+    energyConserving: 'f32'
   },
   defaultUniforms: {
     tint: [1, 1, 1] as [number, number, number],
-    intensity: 1
+    intensity: 1,
+    energyConserving: 0
   },
   propTypes: {
     tint: {value: [1, 1, 1] as [number, number, number]},
-    intensity: {value: 1, min: 0, softMax: 3}
+    intensity: {value: 1, min: 0, softMax: 3},
+    energyConserving: {value: 0, min: 0, max: 1, private: true}
   },
   passes: [{sampler: true}]
 } as const satisfies ShaderPass<
@@ -917,7 +951,8 @@ export function createBloomShaderPassPipeline(
 ): ShaderPassPipeline {
   const resolutionScale = options.resolutionScale ?? 1;
   const colorFormat = options.colorFormat ?? 'rgba16float';
-  const threshold = options.threshold ?? 0.8;
+  const energyConserving = options.energyConserving ?? false;
+  const threshold = energyConserving ? 0 : (options.threshold ?? 0.8);
   const radius = options.radius ?? 8;
   const intensity = options.intensity ?? 1;
   const quality = options.quality ?? 'high';
@@ -929,9 +964,13 @@ export function createBloomShaderPassPipeline(
   const reconstruction = options.reconstruction === 'bicubic' ? 1 : 0;
   const downsample = options.downsample ?? 'auto';
   const reuseRenderTargets = options.reuseRenderTargets ?? true;
+  const blurAlgorithm = options.blurAlgorithm ?? 'gaussian';
   const anamorphicRatio = Math.min(Math.max(options.anamorphicRatio ?? 0, -1), 1);
   const tint = options.tint ?? [1, 1, 1];
   const temporalStability = Math.min(Math.max(options.temporalStability ?? 0, 0), 0.95);
+  const temporalReprojection = options.temporalReprojection ?? false;
+  const temporalDepthThreshold = Math.max(options.temporalDepthThreshold ?? 0.01, 0.0001);
+  const previousExposure = Math.max(options.previousExposure ?? exposure, 0.0001);
   const lens = options.lens;
   const starburstIntensity = Math.max(lens?.starburstIntensity ?? 0, 0);
   const starburstSpikes = Math.min(
@@ -975,8 +1014,10 @@ export function createBloomShaderPassPipeline(
       ...makeRenderTarget(level.scale),
       ...(downsample !== 'render' ? {storage: true} : {})
     };
-    renderTargets[blurScratchTarget] = makeRenderTarget(level.scale);
-    renderTargets[blurTarget] = makeRenderTarget(level.scale);
+    if (blurAlgorithm === 'gaussian') {
+      renderTargets[blurScratchTarget] = makeRenderTarget(level.scale);
+      renderTargets[blurTarget] = makeRenderTarget(level.scale);
+    }
 
     if (levelIndex === 0) {
       steps.push({
@@ -994,29 +1035,35 @@ export function createBloomShaderPassPipeline(
       });
     }
 
-    steps.push(
-      {
-        shaderPass: bloomBlurPass,
-        inputs: {sourceTexture: extractionTarget},
-        output: blurScratchTarget,
-        uniforms: {radius: horizontalRadius, delta: [1, 0]}
-      },
-      {
-        shaderPass: bloomBlurPass,
-        inputs: {sourceTexture: blurScratchTarget},
-        output: blurTarget,
-        uniforms: {radius: verticalRadius, delta: [0, 1]}
-      }
-    );
+    if (blurAlgorithm === 'gaussian') {
+      steps.push(
+        {
+          shaderPass: bloomBlurPass,
+          inputs: {sourceTexture: extractionTarget},
+          output: blurScratchTarget,
+          uniforms: {radius: horizontalRadius, delta: [1, 0]}
+        },
+        {
+          shaderPass: bloomBlurPass,
+          inputs: {sourceTexture: blurScratchTarget},
+          output: blurTarget,
+          uniforms: {radius: verticalRadius, delta: [0, 1]}
+        }
+      );
+    }
   }
 
-  let reconstructedGlow = `blur${levels[levels.length - 1].name}`;
+  const getLevelGlow = (levelName: string): string =>
+    `${blurAlgorithm === 'gaussian' ? 'blur' : 'extract'}${levelName}`;
+  let reconstructedGlow = getLevelGlow(levels[levels.length - 1].name);
   for (let levelIndex = levels.length - 2; levelIndex >= 0; levelIndex--) {
     const level = levels[levelIndex];
     const upsampleTarget = `upsample${level.name}`;
     renderTargets[upsampleTarget] = {
       ...makeRenderTarget(level.scale),
-      ...(reuseRenderTargets && (!hasLensArtifacts || level.name !== 'Half')
+      ...(reuseRenderTargets &&
+      blurAlgorithm === 'gaussian' &&
+      (!hasLensArtifacts || level.name !== 'Half')
         ? {aliasFor: `extract${level.name}`}
         : {})
     };
@@ -1024,7 +1071,7 @@ export function createBloomShaderPassPipeline(
       shaderPass: bloomUpsamplePass,
       inputs: {
         sourceTexture: reconstructedGlow,
-        higherResolutionGlow: `blur${level.name}`
+        higherResolutionGlow: getLevelGlow(level.name)
       },
       output: upsampleTarget,
       uniforms: {scatter, reconstruction}
@@ -1039,10 +1086,14 @@ export function createBloomShaderPassPipeline(
       initialize: {clearColor: [0, 0, 0, 0]}
     };
     steps.push({
-      shaderPass: bloomTemporalPass,
+      shaderPass: createBloomTemporalPass(temporalReprojection),
       inputs: {sourceTexture: reconstructedGlow, historyTexture: 'bloomGlowHistory'},
       output: 'bloomGlowHistory',
-      uniforms: {stability: temporalStability}
+      uniforms: {
+        stability: temporalStability,
+        depthThreshold: temporalDepthThreshold,
+        exposureScale: exposure / previousExposure
+      }
     });
     reconstructedGlow = 'bloomGlowHistory';
   }
@@ -1077,14 +1128,14 @@ export function createBloomShaderPassPipeline(
         ...(hasLensArtifacts ? {lensTexture: 'bloomLensArtifacts'} : {})
       },
       output: 'previous',
-      uniforms: {tint, intensity, dirtIntensity}
+      uniforms: {tint, intensity, dirtIntensity, energyConserving: Number(energyConserving)}
     });
   } else {
     steps.push({
       shaderPass: bloomAdaptiveCompositePass,
       inputs: {sourceTexture: 'previous', glowTexture: reconstructedGlow},
       output: 'previous',
-      uniforms: {tint, intensity}
+      uniforms: {tint, intensity, energyConserving: Number(energyConserving)}
     });
   }
 

--- a/modules/effects/test/passes/image-blur-filters/bloom.node.spec.ts
+++ b/modules/effects/test/passes/image-blur-filters/bloom.node.spec.ts
@@ -135,3 +135,88 @@ test('HDR bloom supports exposure-aware extraction and four-fetch bicubic recons
   );
   testCase.end();
 });
+
+test('HDR bloom can remove separable passes with a normalized dual-Kawase pyramid', testCase => {
+  const gaussian = createBloomShaderPassPipeline({quality: 'ultra'});
+  const dualKawase = createBloomShaderPassPipeline({
+    quality: 'ultra',
+    blurAlgorithm: 'dual-kawase'
+  });
+
+  testCase.equal(gaussian.steps.length, 20, 'the compatible Gaussian path keeps its original cost');
+  testCase.equal(dualKawase.steps.length, 10, 'portable dual-Kawase removes ten separable passes');
+  testCase.equal(
+    dualKawase.steps.filter(step => step.shaderPass.name === 'bloomBlur').length,
+    0,
+    'the reconstruction-only path does not allocate or execute Gaussian kernels'
+  );
+  testCase.ok(
+    Object.keys(dualKawase.renderTargets || {}).every(name => !name.startsWith('blur')),
+    'dual-Kawase avoids all separable intermediate textures'
+  );
+  testCase.equal(
+    dualKawase.steps.length - (dualKawase.compute?.replacedPasses ? 5 : 0),
+    5,
+    'WebGPU needs five render passes and one compute dispatch at ultra quality'
+  );
+  testCase.end();
+});
+
+test('HDR bloom reprojects depth-validated history without another history target', testCase => {
+  const pipeline = createBloomShaderPassPipeline({
+    temporalStability: 0.8,
+    temporalReprojection: true,
+    temporalDepthThreshold: 0.025,
+    exposure: 2,
+    previousExposure: 0.5
+  });
+  const temporal = pipeline.steps.find(step => step.shaderPass.name === 'bloomTemporal');
+  const reflection = new WgslReflect(temporal?.shaderPass.source || '');
+
+  testCase.deepEqual(
+    temporal?.shaderPass.bindingLayout?.map(binding => binding.name),
+    ['historyTexture', 'velocityTexture', 'depthTexture'],
+    'motion-aware history consumes existing scene velocity and depth bindings'
+  );
+  testCase.deepEqual(
+    temporal?.uniforms,
+    {stability: 0.8, depthThreshold: 0.025, exposureScale: 4},
+    'history combines exposure correction with a configurable disocclusion threshold'
+  );
+  testCase.equal(reflection.textures.length, 3, 'WGSL exposes history, velocity, and scene depth');
+  testCase.match(
+    temporal?.shaderPass.source || '',
+    /history\.a - 1\.0\) - currentDepth/,
+    'the glow history alpha carries previous scene depth without another target'
+  );
+  testCase.match(
+    temporal?.shaderPass.fs || '',
+    /texCoord - textureLod\(velocityTexture/,
+    'the WebGL fallback uses the same motion-vector reprojection'
+  );
+  testCase.end();
+});
+
+test('HDR bloom can scatter every source pixel without additive energy duplication', testCase => {
+  const pipeline = createBloomShaderPassPipeline({
+    threshold: 3,
+    intensity: 0.4,
+    energyConserving: true
+  });
+  const extraction = pipeline.steps.find(step => step.shaderPass.name === 'bloomExtract');
+  const composite = pipeline.steps.find(step => step.shaderPass.name === 'bloomComposite');
+
+  testCase.equal(
+    extraction?.uniforms?.threshold,
+    0,
+    'physical bloom cannot discard dim scene light'
+  );
+  testCase.equal(pipeline.compute?.uniforms.threshold, 0, 'fused extraction remains thresholdless');
+  testCase.equal(composite?.uniforms?.energyConserving, 1, 'composition selects normalized mixing');
+  testCase.match(
+    composite?.shaderPass.source || '',
+    /mix\(\s*sourceColor\.rgb,\s*glowColor \* bloomComposite\.tint/,
+    'physical composition redistributes source energy instead of adding another copy'
+  );
+  testCase.end();
+});

--- a/modules/experimental/README.md
+++ b/modules/experimental/README.md
@@ -16,12 +16,19 @@ and frame helpers, with WebGL-only raw camera textures. See the
 
 ## FFT Convolution Bloom
 
-`GPUConvolutionBloom` performs physically motivated optical convolution on WebGPU. It extracts
-exposure-aware HDR highlights, transforms red, green, and blue into frequency space, multiplies
-them by one cached aperture point-spread spectrum, applies inverse transforms, and composites the
-result into a caller-owned `rgba16float` storage texture. Generated aperture kernels support blade
-count, diffraction strength, and anamorphic stretch; applications can provide any nonnegative
-`Float32Array` point-spread function and replace it with `setPointSpreadFunction()`.
+`GPUConvolutionBloom` performs physically motivated optical convolution on WebGPU. Area-weighted
+HDR extraction preserves subpixel emitters and centers the sampled image inside zero-padded guard
+bands, preventing diffraction from wrapping onto the opposite edge. Packed RGB fields share one
+forward and one inverse FFT schedule instead of six independent transforms. Each wavelength uses
+its own cached aperture spectrum, with configurable blade count, diffraction strength, anamorphic
+stretch, and spectral spread. Applications can provide either one nonnegative `Float32Array`
+kernel or independently measured `{red, green, blue}` kernels and replace them with
+`setPointSpreadFunction()`.
+
+Set `energyConserving: true` for thresholdless normalized scattering. Optional chromatic ghosts,
+radial halo, sampled dirt, and neighborhood-clamped temporal stabilization execute inside the
+existing final compute dispatch. Supplying `exposureTexture` to `encode()` consumes GPU-resident
+adapted exposure directly and automatically compensates temporal history without CPU readback.
 
 ```ts
 import {Texture} from '@luma.gl/core';
@@ -42,8 +49,12 @@ const bloom = new GPUConvolutionBloom(device, {
   width,
   height,
   resolutionScale: 0.25,
+  guardBand: 0.125,
   apertureBlades: 6,
-  diffractionStrength: 0.3
+  diffractionStrength: 0.3,
+  spectralSpread: 0.65,
+  temporalStability: 0.55,
+  lens: {ghostIntensity: 0.25, haloIntensity: 0.15}
 });
 
 const encoder = device.createCommandEncoder();
@@ -52,13 +63,15 @@ device.submit(encoder.finish());
 ```
 
 The caller owns source/output textures and command submission; the renderer owns reusable FFT
-buffers and its cached optical spectrum. `bloom.stats` publishes exact transform dimensions,
-complex-buffer allocation, steady-state dispatch count, and one-time kernel initialization work.
-At 1920 x 1080 with quarter-resolution sampling, the power-of-two transform is 512 x 512 and
-requires nine reusable complex buffers totaling 18 MiB, 123 steady-state dispatches, and 20
-additional dispatches whenever the point-spread function changes. Prefer the fused multiscale
-pipeline in `@luma.gl/effects` for routine real-time bloom; reserve FFT convolution for premium
-optical fidelity or applications with measured compute headroom.
+buffers, its cached RGB optical spectrum, and optional history. `bloom.stats` publishes exact
+sampled content bounds, transform dimensions, packed complex-buffer allocation, steady-state
+dispatch count, and one-time kernel initialization work. At 1920 x 1080 with quarter-resolution
+sampling and the default 12.5% guard band, the transform is 1024 x 512 and requires four packed RGB
+buffers totaling 48 MiB, 45 steady-state dispatches, and 21 dispatches when the aperture changes.
+Setting `guardBand: 0` reduces that to a 512 x 512 transform, 24 MiB, and 43 dispatches, while
+trading away explicit wraparound protection. The previous independent-channel path required 123
+steady-state dispatches. On devices with `timestamp-query`, create the command encoder with a
+`timeProfilingQuerySet` to collect actual GPU timings for every FFT and optical compute pass.
 
 Optional algorithm entry points keep specialized workflows out of the default experimental bundle:
 

--- a/modules/experimental/src/gpu-primitives/gpu-fft2d-shaders.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-fft2d-shaders.ts
@@ -37,8 +37,9 @@ fn reverseLowBits(value: u32, bitCount: u32) -> u32 {
   return reversed;
 }
 
-fn getLinearIndex(xCoordinate: u32, yCoordinate: u32) -> u32 {
-  return yCoordinate * parameters.width + xCoordinate;
+fn getLinearIndex(xCoordinate: u32, yCoordinate: u32, batchIndex: u32) -> u32 {
+  return batchIndex * parameters.width * parameters.height +
+    yCoordinate * parameters.width + xCoordinate;
 }
 
 fn multiplyComplex(left: vec2f, right: vec2f) -> vec2f {
@@ -73,8 +74,8 @@ fn main(@builtin(global_invocation_id) globalIdentifier: vec3u) {
     let firstY = select(firstCoordinate, globalIdentifier.y, horizontal);
     let secondX = select(globalIdentifier.x, secondCoordinate, horizontal);
     let secondY = select(secondCoordinate, globalIdentifier.y, horizontal);
-    let firstValue = inputValues[getLinearIndex(firstX, firstY)];
-    let secondValue = inputValues[getLinearIndex(secondX, secondY)];
+    let firstValue = inputValues[getLinearIndex(firstX, firstY, globalIdentifier.z)];
+    let secondValue = inputValues[getLinearIndex(secondX, secondY, globalIdentifier.z)];
     let angle = parameters.directionSign * 2.0 * GPU_FFT2D_PI *
       f32(twiddleIndex) / f32(butterflySpan);
     let twiddle = vec2f(cos(angle), sin(angle));
@@ -84,14 +85,15 @@ fn main(@builtin(global_invocation_id) globalIdentifier: vec3u) {
       firstValue - rotatedSecondValue,
       butterflyOffset >= butterflyHalfSpan
     );
-    outputValues[getLinearIndex(globalIdentifier.x, globalIdentifier.y)] =
+    outputValues[getLinearIndex(globalIdentifier.x, globalIdentifier.y, globalIdentifier.z)] =
       butterflyValue * parameters.normalizationScale;
     return;
   }
 
   let sourceX = select(globalIdentifier.x, sourceCoordinate, horizontal);
   let sourceY = select(sourceCoordinate, globalIdentifier.y, horizontal);
-  outputValues[getLinearIndex(globalIdentifier.x, globalIdentifier.y)] =
-    inputValues[getLinearIndex(sourceX, sourceY)] * parameters.normalizationScale;
+  outputValues[getLinearIndex(globalIdentifier.x, globalIdentifier.y, globalIdentifier.z)] =
+    inputValues[getLinearIndex(sourceX, sourceY, globalIdentifier.z)] *
+      parameters.normalizationScale;
 }
 `;

--- a/modules/experimental/src/gpu-primitives/gpu-fft2d.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-fft2d.ts
@@ -23,6 +23,8 @@ export type GPUFFT2DProps = {
   width: number;
   /** Number of complex values in each column. Must be a power of two from 2 through 2048. */
   height: number;
+  /** Number of independent, tightly packed transforms encoded by each dispatch. Defaults to one. */
+  batchCount?: number;
 };
 
 /** Transform sign and normalization convention. */
@@ -42,6 +44,8 @@ export type GPUFFT2DEncodeOptions = {
 export type GPUFFT2DStats = {
   width: number;
   height: number;
+  /** Present when one dispatch processes multiple independent packed transforms. */
+  batchCount?: number;
   elementCount: number;
   complexBufferByteLength: number;
   horizontalStageCount: number;
@@ -96,6 +100,7 @@ export class GPUFFT2D {
   readonly id: string;
   readonly width: number;
   readonly height: number;
+  readonly batchCount: number;
   readonly stats: GPUFFT2DStats;
 
   private readonly scratchBuffer: Buffer;
@@ -113,6 +118,7 @@ export class GPUFFT2D {
     this.id = props.id ?? 'gpu-fft2d';
     this.width = props.width;
     this.height = props.height;
+    this.batchCount = props.batchCount ?? 1;
     this.stats = support.stats;
     const resources = createGPUFFT2DResources(device, {
       id: this.id,
@@ -191,12 +197,16 @@ export class GPUFFT2D {
 
 /** Reports whether a device can allocate and dispatch the requested bounded radix-2 transform. */
 export function getGPUFFT2DSupport(device: Device, props: GPUFFT2DProps): GPUFFT2DSupport {
-  const dimensionReason = getGPUFFT2DDimensionReason(props.width, props.height);
+  const dimensionReason = getGPUFFT2DDimensionReason(
+    props.width,
+    props.height,
+    props.batchCount ?? 1
+  );
   if (dimensionReason) {
     return {supported: false, reason: dimensionReason};
   }
 
-  const stats = makeGPUFFT2DStats(props.width, props.height);
+  const stats = makeGPUFFT2DStats(props.width, props.height, props.batchCount ?? 1);
   if (device.type !== 'webgpu') {
     return {supported: false, reason: 'GPUFFT2D requires WebGPU.', stats};
   }
@@ -216,7 +226,8 @@ export function getGPUFFT2DSupport(device: Device, props: GPUFFT2DProps): GPUFFT
   }
   if (
     stats.workgroupCount[0] > device.limits.maxComputeWorkgroupsPerDimension ||
-    stats.workgroupCount[1] > device.limits.maxComputeWorkgroupsPerDimension
+    stats.workgroupCount[1] > device.limits.maxComputeWorkgroupsPerDimension ||
+    stats.workgroupCount[2] > device.limits.maxComputeWorkgroupsPerDimension
   ) {
     return {
       supported: false,
@@ -238,8 +249,8 @@ export function getGPUFFT2DSupport(device: Device, props: GPUFFT2DProps): GPUFFT
 }
 
 /** Builds the immutable CPU-side plan exposed by support queries and class instances. */
-export function makeGPUFFT2DStats(width: number, height: number): GPUFFT2DStats {
-  const dimensionReason = getGPUFFT2DDimensionReason(width, height);
+export function makeGPUFFT2DStats(width: number, height: number, batchCount = 1): GPUFFT2DStats {
+  const dimensionReason = getGPUFFT2DDimensionReason(width, height, batchCount);
   if (dimensionReason) {
     throw new Error(dimensionReason);
   }
@@ -247,10 +258,11 @@ export function makeGPUFFT2DStats(width: number, height: number): GPUFFT2DStats 
   const verticalStageCount = Math.log2(height);
   const passCount = horizontalStageCount + verticalStageCount + 2;
   const elementCount = width * height;
-  const complexBufferByteLength = elementCount * 2 * Float32Array.BYTES_PER_ELEMENT;
+  const complexBufferByteLength = elementCount * batchCount * 2 * Float32Array.BYTES_PER_ELEMENT;
   return Object.freeze({
     width,
     height,
+    ...(batchCount > 1 ? {batchCount} : {}),
     elementCount,
     complexBufferByteLength,
     horizontalStageCount,
@@ -265,7 +277,7 @@ export function makeGPUFFT2DStats(width: number, height: number): GPUFFT2DStats 
     workgroupCount: Object.freeze([
       Math.ceil(width / GPU_FFT2D_WORKGROUP_DIMENSION),
       Math.ceil(height / GPU_FFT2D_WORKGROUP_DIMENSION),
-      1
+      batchCount
     ]) as readonly [number, number, number],
     scratchBufferByteLength: complexBufferByteLength,
     parameterBufferCount: passCount * 2,
@@ -382,12 +394,23 @@ function makeGPUFFT2DParameterData(props: {
   return unsignedValues;
 }
 
-function getGPUFFT2DDimensionReason(width: number, height: number): string | undefined {
+function getGPUFFT2DDimensionReason(
+  width: number,
+  height: number,
+  batchCount = 1
+): string | undefined {
   const widthReason = getDimensionReason('width', width);
   if (widthReason) {
     return widthReason;
   }
-  return getDimensionReason('height', height);
+  const heightReason = getDimensionReason('height', height);
+  if (heightReason) {
+    return heightReason;
+  }
+  if (!Number.isSafeInteger(batchCount) || batchCount <= 0) {
+    return 'GPUFFT2D batchCount must be a positive integer.';
+  }
+  return undefined;
 }
 
 function getDimensionReason(name: string, dimension: number): string | undefined {

--- a/modules/experimental/src/index.ts
+++ b/modules/experimental/src/index.ts
@@ -154,8 +154,11 @@ export type {
 } from './rendering/g-buffer';
 export {GBuffer} from './rendering/g-buffer';
 export type {
+  BloomPointSpreadFunction,
   BloomPointSpreadFunctionOptions,
+  BloomSpectralPointSpreadFunction,
   GPUConvolutionBloomEncodeOptions,
+  GPUConvolutionBloomLensOptions,
   GPUConvolutionBloomProps,
   GPUConvolutionBloomStats,
   GPUConvolutionBloomSupport
@@ -164,6 +167,7 @@ export {
   getGPUConvolutionBloomSupport,
   GPUConvolutionBloom,
   makeBloomPointSpreadFunction,
+  makeBloomSpectralPointSpreadFunction,
   makeGPUConvolutionBloomStats
 } from './rendering/fft-bloom';
 export type {DeferredAmbientLightingProps} from './rendering/deferred-ambient-lighting';

--- a/modules/experimental/src/rendering/fft-bloom-shaders.ts
+++ b/modules/experimental/src/rendering/fft-bloom-shaders.ts
@@ -5,23 +5,80 @@
 export const FFT_BLOOM_WORKGROUP_DIMENSION = 8;
 export const FFT_BLOOM_MULTIPLY_WORKGROUP_SIZE = 64;
 export const FFT_BLOOM_MULTIPLY_WORKGROUPS_PER_ROW = 1024;
-export const FFT_BLOOM_PARAMETER_BYTE_LENGTH = 32;
+export const FFT_BLOOM_PARAMETER_BYTE_LENGTH = 96;
 
-export const FFT_BLOOM_EXTRACT_SHADER = /* wgsl */ `
+const FFT_BLOOM_PARAMETER_STRUCT = /* wgsl */ `
 struct FFTBloomParameters {
   sourceDimensions: vec2u,
+  contentDimensions: vec2u,
   transformDimensions: vec2u,
+  contentOffset: vec2u,
   threshold: f32,
   intensity: f32,
   exposure: f32,
   exposureCompensation: f32,
+  energyConserving: f32,
+  useExposureTexture: f32,
+  temporalStability: f32,
+  exposureScale: f32,
+  ghostIntensity: f32,
+  ghostSpacing: f32,
+  haloIntensity: f32,
+  haloRadius: f32,
+  chromaticAberration: f32,
+  dirtIntensity: f32,
+  ghostCount: f32,
+  historyValid: f32,
 };
+`;
+
+export const FFT_BLOOM_EXTRACT_SHADER = /* wgsl */ `
+${FFT_BLOOM_PARAMETER_STRUCT}
 
 @group(0) @binding(0) var<uniform> parameters: FFTBloomParameters;
 @group(0) @binding(1) var sourceTexture: texture_2d<f32>;
-@group(0) @binding(2) var<storage, read_write> redChannel: array<vec2f>;
-@group(0) @binding(3) var<storage, read_write> greenChannel: array<vec2f>;
-@group(0) @binding(4) var<storage, read_write> blueChannel: array<vec2f>;
+@group(0) @binding(2) var exposureTexture: texture_2d<f32>;
+@group(0) @binding(3) var<storage, read_write> spatialChannels: array<vec2f>;
+
+fn extractHighlight(sourceColor: vec3f) -> vec3f {
+  let luminance = dot(sourceColor, vec3f(0.2126, 0.7152, 0.0722));
+  let adaptedExposure = select(
+    parameters.exposure,
+    textureLoad(exposureTexture, vec2i(0), 0).r,
+    parameters.useExposureTexture > 0.5
+  );
+  let exposure = max(adaptedExposure * exp2(parameters.exposureCompensation), 0.0001);
+  let threshold = select(parameters.threshold / exposure, 0.0, parameters.energyConserving > 0.5);
+  let contribution = max(luminance - threshold, 0.0) / max(luminance, 0.00001);
+  return sourceColor * contribution;
+}
+
+fn filterSourcePixel(contentCoordinate: vec2u) -> vec3f {
+  let sourceStart = vec2f(contentCoordinate) * vec2f(parameters.sourceDimensions) /
+    vec2f(parameters.contentDimensions);
+  let sourceEnd = vec2f(contentCoordinate + vec2u(1)) * vec2f(parameters.sourceDimensions) /
+    vec2f(parameters.contentDimensions);
+  let minimumCoordinate = vec2u(floor(sourceStart));
+  let maximumCoordinate = min(
+    vec2u(ceil(sourceEnd)),
+    parameters.sourceDimensions
+  );
+  var filteredColor = vec3f(0.0);
+  var totalWeight = 0.0;
+
+  for (var sampleY = minimumCoordinate.y; sampleY < maximumCoordinate.y; sampleY++) {
+    let weightY = min(f32(sampleY + 1u), sourceEnd.y) - max(f32(sampleY), sourceStart.y);
+    for (var sampleX = minimumCoordinate.x; sampleX < maximumCoordinate.x; sampleX++) {
+      let weightX = min(f32(sampleX + 1u), sourceEnd.x) - max(f32(sampleX), sourceStart.x);
+      let sampleWeight = max(weightX * weightY, 0.0);
+      let sourceColor = textureLoad(sourceTexture, vec2i(vec2u(sampleX, sampleY)), 0).rgb;
+      filteredColor += extractHighlight(sourceColor) * sampleWeight;
+      totalWeight += sampleWeight;
+    }
+  }
+
+  return filteredColor / max(totalWeight, 0.00001);
+}
 
 @compute @workgroup_size(${FFT_BLOOM_WORKGROUP_DIMENSION}, ${FFT_BLOOM_WORKGROUP_DIMENSION})
 fn main(@builtin(global_invocation_id) globalInvocation: vec3u) {
@@ -30,31 +87,23 @@ fn main(@builtin(global_invocation_id) globalInvocation: vec3u) {
     return;
   }
 
-  let sourceCoordinate = min(
-    vec2u((vec2f(coordinate) + vec2f(0.5)) * vec2f(parameters.sourceDimensions) /
-      vec2f(parameters.transformDimensions)),
-    parameters.sourceDimensions - vec2u(1)
-  );
-  let sourceColor = textureLoad(sourceTexture, vec2i(sourceCoordinate), 0).rgb;
-  let luminance = dot(sourceColor, vec3f(0.2126, 0.7152, 0.0722));
-  let exposure = max(parameters.exposure * exp2(parameters.exposureCompensation), 0.0001);
-  let threshold = parameters.threshold / exposure;
-  let contribution = max(luminance - threshold, 0.0) / max(luminance, 0.00001);
   let index = coordinate.y * parameters.transformDimensions.x + coordinate.x;
-  redChannel[index] = vec2f(sourceColor.r * contribution, 0.0);
-  greenChannel[index] = vec2f(sourceColor.g * contribution, 0.0);
-  blueChannel[index] = vec2f(sourceColor.b * contribution, 0.0);
+  let elementCount = parameters.transformDimensions.x * parameters.transformDimensions.y;
+  var sourceColor = vec3f(0.0);
+  if (all(coordinate >= parameters.contentOffset) &&
+      all(coordinate < parameters.contentOffset + parameters.contentDimensions)) {
+    sourceColor = filterSourcePixel(coordinate - parameters.contentOffset);
+  }
+  spatialChannels[index] = vec2f(sourceColor.r, 0.0);
+  spatialChannels[index + elementCount] = vec2f(sourceColor.g, 0.0);
+  spatialChannels[index + elementCount * 2u] = vec2f(sourceColor.b, 0.0);
 }
 `;
 
 export const FFT_BLOOM_MULTIPLY_SHADER = /* wgsl */ `
-@group(0) @binding(0) var<storage, read> redSpectrum: array<vec2f>;
-@group(0) @binding(1) var<storage, read> greenSpectrum: array<vec2f>;
-@group(0) @binding(2) var<storage, read> blueSpectrum: array<vec2f>;
-@group(0) @binding(3) var<storage, read> kernelSpectrum: array<vec2f>;
-@group(0) @binding(4) var<storage, read_write> filteredRed: array<vec2f>;
-@group(0) @binding(5) var<storage, read_write> filteredGreen: array<vec2f>;
-@group(0) @binding(6) var<storage, read_write> filteredBlue: array<vec2f>;
+@group(0) @binding(0) var<storage, read> sourceSpectrum: array<vec2f>;
+@group(0) @binding(1) var<storage, read> kernelSpectrum: array<vec2f>;
+@group(0) @binding(2) var<storage, read_write> filteredChannels: array<vec2f>;
 
 fn multiplyComplex(first: vec2f, second: vec2f) -> vec2f {
   return vec2f(
@@ -71,43 +120,74 @@ fn main(@builtin(global_invocation_id) globalInvocation: vec3u) {
     return;
   }
 
-  let kernel = kernelSpectrum[index];
-  filteredRed[index] = multiplyComplex(redSpectrum[index], kernel);
-  filteredGreen[index] = multiplyComplex(greenSpectrum[index], kernel);
-  filteredBlue[index] = multiplyComplex(blueSpectrum[index], kernel);
+  filteredChannels[index] = multiplyComplex(sourceSpectrum[index], kernelSpectrum[index]);
 }
 `;
 
-export const FFT_BLOOM_COMPOSITE_SHADER = /* wgsl */ `
-struct FFTBloomParameters {
-  sourceDimensions: vec2u,
-  transformDimensions: vec2u,
-  threshold: f32,
-  intensity: f32,
-  exposure: f32,
-  exposureCompensation: f32,
-};
+/** Builds the final optical resolve while keeping persistent history strictly optional. */
+export function makeFFTBloomCompositeShader(temporalStability: boolean): string {
+  const historyBindings = temporalStability
+    ? `
+@group(0) @binding(6) var historyTexture: texture_2d<f32>;
+@group(0) @binding(7) var historyOutput: texture_storage_2d<rgba16float, write>;`
+    : '';
+  const historyResolve = temporalStability
+    ? `
+  let historyState = textureLoad(historyTexture, vec2i(coordinate), 0);
+  let adaptedExposure = select(
+    parameters.exposure,
+    textureLoad(exposureTexture, vec2i(0), 0).r,
+    parameters.useExposureTexture > 0.5
+  );
+  let exposureScale = select(
+    parameters.exposureScale,
+    adaptedExposure / max(historyState.a, 0.0001),
+    parameters.useExposureTexture > 0.5
+  );
+  let previousGlow = historyState.rgb * exposureScale;
+  let previousWeight = select(
+    0.0,
+    clamp(parameters.temporalStability, 0.0, 0.95),
+    parameters.historyValid > 0.5
+  );
+  let leftGlow = sampleConvolvedColor(vec2u(max(vec2i(coordinate) - vec2i(1, 0), vec2i(0))));
+  let rightGlow = sampleConvolvedColor(min(coordinate + vec2u(1, 0), parameters.sourceDimensions - vec2u(1)));
+  let topGlow = sampleConvolvedColor(vec2u(max(vec2i(coordinate) - vec2i(0, 1), vec2i(0))));
+  let bottomGlow = sampleConvolvedColor(min(coordinate + vec2u(0, 1), parameters.sourceDimensions - vec2u(1)));
+  let minimumGlow = min(glowColor, min(min(leftGlow, rightGlow), min(topGlow, bottomGlow)));
+  let maximumGlow = max(glowColor, max(max(leftGlow, rightGlow), max(topGlow, bottomGlow)));
+  glowColor = mix(glowColor, clamp(previousGlow, minimumGlow, maximumGlow), previousWeight);
+  textureStore(historyOutput, vec2i(coordinate), vec4f(glowColor, adaptedExposure));`
+    : '';
+
+  return /* wgsl */ `
+${FFT_BLOOM_PARAMETER_STRUCT}
 
 @group(0) @binding(0) var<uniform> parameters: FFTBloomParameters;
 @group(0) @binding(1) var sourceTexture: texture_2d<f32>;
-@group(0) @binding(2) var<storage, read> redChannel: array<vec2f>;
-@group(0) @binding(3) var<storage, read> greenChannel: array<vec2f>;
-@group(0) @binding(4) var<storage, read> blueChannel: array<vec2f>;
-@group(0) @binding(5) var outputTexture: texture_storage_2d<rgba16float, write>;
+@group(0) @binding(2) var<storage, read> convolvedChannels: array<vec2f>;
+@group(0) @binding(3) var outputTexture: texture_storage_2d<rgba16float, write>;
+@group(0) @binding(4) var lensDirtTexture: texture_2d<f32>;
+@group(0) @binding(5) var exposureTexture: texture_2d<f32>;${historyBindings}
 
 fn loadConvolvedColor(coordinate: vec2i) -> vec3f {
-  let clampedCoordinate = vec2u(clamp(
-    coordinate,
-    vec2i(0),
-    vec2i(parameters.transformDimensions) - vec2i(1)
-  ));
+  let contentMaximum = vec2i(parameters.contentOffset + parameters.contentDimensions) - vec2i(1);
+  let clampedCoordinate = vec2u(clamp(coordinate, vec2i(parameters.contentOffset), contentMaximum));
   let index = clampedCoordinate.y * parameters.transformDimensions.x + clampedCoordinate.x;
-  return max(vec3f(redChannel[index].x, greenChannel[index].x, blueChannel[index].x), vec3f(0.0));
+  let elementCount = parameters.transformDimensions.x * parameters.transformDimensions.y;
+  return max(
+    vec3f(
+      convolvedChannels[index].x,
+      convolvedChannels[index + elementCount].x,
+      convolvedChannels[index + elementCount * 2u].x
+    ),
+    vec3f(0.0)
+  );
 }
 
 fn sampleConvolvedColor(sourceCoordinate: vec2u) -> vec3f {
-  let transformCoordinate =
-    (vec2f(sourceCoordinate) + vec2f(0.5)) * vec2f(parameters.transformDimensions) /
+  let transformCoordinate = vec2f(parameters.contentOffset) +
+    (vec2f(sourceCoordinate) + vec2f(0.5)) * vec2f(parameters.contentDimensions) /
       vec2f(parameters.sourceDimensions) - vec2f(0.5);
   let baseCoordinate = vec2i(floor(transformCoordinate));
   let fraction = fract(transformCoordinate);
@@ -124,6 +204,60 @@ fn sampleConvolvedColor(sourceCoordinate: vec2u) -> vec3f {
   return mix(top, bottom, fraction.y);
 }
 
+fn loadLensSource(coordinate: vec2f) -> vec3f {
+  if (any(coordinate < vec2f(0.0)) || any(coordinate > vec2f(1.0))) {
+    return vec3f(0.0);
+  }
+  let sourceCoordinate = min(
+    vec2u(coordinate * vec2f(parameters.sourceDimensions)),
+    parameters.sourceDimensions - vec2u(1)
+  );
+  let color = textureLoad(sourceTexture, vec2i(sourceCoordinate), 0).rgb;
+  let luminance = dot(color, vec3f(0.2126, 0.7152, 0.0722));
+  let adaptedExposure = select(
+    parameters.exposure,
+    textureLoad(exposureTexture, vec2i(0), 0).r,
+    parameters.useExposureTexture > 0.5
+  );
+  let exposure = max(adaptedExposure * exp2(parameters.exposureCompensation), 0.0001);
+  let threshold = select(parameters.threshold / exposure, 0.0, parameters.energyConserving > 0.5);
+  return color * max(luminance - threshold, 0.0) / max(luminance, 0.00001);
+}
+
+fn sampleSpectralLens(coordinate: vec2f, direction: vec2f) -> vec3f {
+  let spectralOffset = direction * parameters.chromaticAberration * 0.018;
+  return vec3f(
+    loadLensSource(coordinate + spectralOffset).r,
+    loadLensSource(coordinate).g,
+    loadLensSource(coordinate - spectralOffset).b
+  );
+}
+
+fn sampleLensArtifacts(coordinate: vec2u) -> vec3f {
+  let uv = (vec2f(coordinate) + vec2f(0.5)) / vec2f(parameters.sourceDimensions);
+  let centerDirection = vec2f(0.5) - uv;
+  var artifacts = vec3f(0.0);
+  if (parameters.ghostIntensity > 0.0) {
+    for (var ghostIndex = 1u; ghostIndex <= 6u; ghostIndex++) {
+      if (f32(ghostIndex) > parameters.ghostCount) {
+        break;
+      }
+      let ghostCoordinate = uv + centerDirection * parameters.ghostSpacing * f32(ghostIndex);
+      artifacts += sampleSpectralLens(ghostCoordinate, centerDirection) *
+        parameters.ghostIntensity / max(parameters.ghostCount, 1.0);
+    }
+  }
+  if (parameters.haloIntensity > 0.0) {
+    let radialLength = max(length(centerDirection), 0.00001);
+    let radialDirection = centerDirection / radialLength;
+    let haloCoordinate = vec2f(0.5) - radialDirection * parameters.haloRadius;
+    artifacts += sampleSpectralLens(haloCoordinate, radialDirection) *
+      parameters.haloIntensity *
+        (1.0 - smoothstep(0.05, 0.75, abs(radialLength - parameters.haloRadius)));
+  }
+  return artifacts;
+}
+
 @compute @workgroup_size(${FFT_BLOOM_WORKGROUP_DIMENSION}, ${FFT_BLOOM_WORKGROUP_DIMENSION})
 fn main(@builtin(global_invocation_id) globalInvocation: vec3u) {
   let coordinate = globalInvocation.xy;
@@ -132,7 +266,25 @@ fn main(@builtin(global_invocation_id) globalInvocation: vec3u) {
   }
 
   let sourceColor = textureLoad(sourceTexture, vec2i(coordinate), 0);
-  let glowColor = sampleConvolvedColor(coordinate) * parameters.intensity;
-  textureStore(outputTexture, vec2i(coordinate), vec4f(sourceColor.rgb + glowColor, sourceColor.a));
+  var glowColor = sampleConvolvedColor(coordinate);${historyResolve}
+  let artifactColor = sampleLensArtifacts(coordinate);
+  var opticalColor = glowColor + artifactColor;
+  if (parameters.dirtIntensity > 0.0) {
+    let dirtDimensions = textureDimensions(lensDirtTexture);
+    let dirtCoordinate = min(
+      vec2u((vec2f(coordinate) + vec2f(0.5)) * vec2f(dirtDimensions) /
+        vec2f(parameters.sourceDimensions)),
+      dirtDimensions - vec2u(1)
+    );
+    let dirtMask = textureLoad(lensDirtTexture, vec2i(dirtCoordinate), 0).rgb;
+    opticalColor *= vec3f(1.0) + dirtMask * parameters.dirtIntensity;
+  }
+  let additiveColor = sourceColor.rgb + opticalColor * parameters.intensity;
+  let physicalColor = mix(sourceColor.rgb, opticalColor, clamp(parameters.intensity, 0.0, 1.0));
+  let finalColor = select(additiveColor, physicalColor, parameters.energyConserving > 0.5);
+  textureStore(outputTexture, vec2i(coordinate), vec4f(finalColor, sourceColor.a));
 }
 `;
+}
+
+export const FFT_BLOOM_COMPOSITE_SHADER = makeFFTBloomCompositeShader(false);

--- a/modules/experimental/src/rendering/fft-bloom.ts
+++ b/modules/experimental/src/rendering/fft-bloom.ts
@@ -842,6 +842,15 @@ function validateGPUConvolutionBloomTextures(
   ) {
     throw new Error('GPUConvolutionBloom source and output textures must be separate.');
   }
+  for (const auxiliaryTexture of [options.exposureTexture, options.lensDirtTexture]) {
+    if (
+      auxiliaryTexture &&
+      (auxiliaryTexture === options.outputTexture ||
+        auxiliaryTexture.handle === options.outputTexture.handle)
+    ) {
+      throw new Error('GPUConvolutionBloom auxiliary and output textures must be separate.');
+    }
+  }
 }
 
 function destroyGPUConvolutionBloomResources(resources: GPUConvolutionBloomResources): void {

--- a/modules/experimental/src/rendering/fft-bloom.ts
+++ b/modules/experimental/src/rendering/fft-bloom.ts
@@ -18,8 +18,30 @@ import {
   FFT_BLOOM_MULTIPLY_WORKGROUP_SIZE,
   FFT_BLOOM_MULTIPLY_WORKGROUPS_PER_ROW,
   FFT_BLOOM_PARAMETER_BYTE_LENGTH,
-  FFT_BLOOM_WORKGROUP_DIMENSION
+  FFT_BLOOM_WORKGROUP_DIMENSION,
+  makeFFTBloomCompositeShader
 } from './fft-bloom-shaders';
+
+/** Optional lens reflections and dirt composited without another FFT or render pass. */
+export type GPUConvolutionBloomLensOptions = {
+  ghostIntensity?: number;
+  ghostCount?: number;
+  ghostSpacing?: number;
+  haloIntensity?: number;
+  haloRadius?: number;
+  chromaticAberration?: number;
+  dirtIntensity?: number;
+};
+
+/** Independent wavelength responses for measured or generated RGB diffraction. */
+export type BloomSpectralPointSpreadFunction = {
+  red: Float32Array;
+  green: Float32Array;
+  blue: Float32Array;
+};
+
+/** One shared optical response or separate measured responses per wavelength. */
+export type BloomPointSpreadFunction = Float32Array | BloomSpectralPointSpreadFunction;
 
 /** Construction options for frequency-domain photographic bloom. */
 export type GPUConvolutionBloomProps = {
@@ -28,6 +50,8 @@ export type GPUConvolutionBloomProps = {
   height: number;
   /** Fractional source resolution before rounding up to power-of-two FFT dimensions. */
   resolutionScale?: number;
+  /** Zero-padded border around the sampled image, expressed as a fraction of its dimensions. */
+  guardBand?: number;
   /** Scene-referred highlight threshold. Defaults to 0.8. */
   threshold?: number;
   /** Additive intensity applied after energy-normalized optical convolution. */
@@ -42,8 +66,16 @@ export type GPUConvolutionBloomProps = {
   diffractionStrength?: number;
   /** Horizontal or vertical stretching applied to the generated point-spread function. */
   anamorphicRatio?: number;
-  /** Optional custom point-spread kernel containing one scalar per transform pixel. */
-  pointSpreadFunction?: Float32Array;
+  /** Wavelength-dependent aperture spread. Zero keeps all three diffraction kernels identical. */
+  spectralSpread?: number;
+  /** Blend all scene light through the normalized optical kernel instead of adding highlights. */
+  energyConserving?: boolean;
+  /** Optional neighborhood-clamped optical history accumulated during the existing composite. */
+  temporalStability?: number;
+  /** Chromatic ghosts, radial halo, and sampled dirt resolved during the existing composite. */
+  lens?: GPUConvolutionBloomLensOptions;
+  /** Shared or wavelength-specific point-spread kernels containing one scalar per FFT pixel. */
+  pointSpreadFunction?: BloomPointSpreadFunction;
 };
 
 /** Per-frame inputs and optical overrides for {@link GPUConvolutionBloom.encode}. */
@@ -55,18 +87,30 @@ export type GPUConvolutionBloomEncodeOptions = {
   intensity?: number;
   exposure?: number;
   exposureCompensation?: number;
+  /** Previous camera exposure used to correct persistent history between frames. */
+  previousExposure?: number;
+  /** Optional GPU-adapted 1x1 exposure state; no CPU luminance readback is required. */
+  exposureTexture?: Texture;
+  /** Optional sampled dirt texture used when lens.dirtIntensity is positive. */
+  lensDirtTexture?: Texture;
 };
 
 /** Immutable resource and dispatch budget for the premium convolution path. */
 export type GPUConvolutionBloomStats = {
   width: number;
   height: number;
+  contentWidth: number;
+  contentHeight: number;
+  contentOffsetX: number;
+  contentOffsetY: number;
+  guardBand: number;
   transformWidth: number;
   transformHeight: number;
   elementCount: number;
   complexBufferCount: number;
   complexBufferByteLength: number;
   totalComplexBufferByteLength: number;
+  batchCount: number;
   transformDispatchCount: number;
   steadyStateDispatchCount: number;
   kernelInitializationDispatchCount: number;
@@ -86,15 +130,19 @@ export type BloomPointSpreadFunctionOptions = {
   apertureBlades?: number;
   diffractionStrength?: number;
   anamorphicRatio?: number;
+  /** Wavelength in nanometers used to widen or contract the diffraction profile. */
+  wavelength?: number;
+  /** Interpolates between a common green response and independent red/green/blue wavelengths. */
+  spectralSpread?: number;
 };
 
 type GPUConvolutionBloomResources = {
   transform: GPUFFT2D;
   parameters: Buffer;
-  kernelSpatial: Buffer;
   kernelSpectrum: Buffer;
-  spatialChannels: Buffer[];
-  spectralChannels: Buffer[];
+  spatialChannels: Buffer;
+  spectralChannels: Buffer;
+  historyTextures?: [Texture, Texture];
   extract: Computation;
   multiply: Computation;
   composite: Computation;
@@ -118,7 +166,13 @@ export class GPUConvolutionBloom {
   private readonly defaults: Required<
     Pick<GPUConvolutionBloomProps, 'threshold' | 'intensity' | 'exposure' | 'exposureCompensation'>
   >;
+  private readonly energyConserving: boolean;
+  private readonly temporalStability: number;
+  private readonly lens: Required<GPUConvolutionBloomLensOptions>;
   private kernelNeedsTransform = true;
+  private historyValid = false;
+  private historyIndex = 0;
+  private previousExposure?: number;
   private destroyed = false;
 
   constructor(device: Device, props: GPUConvolutionBloomProps) {
@@ -138,29 +192,42 @@ export class GPUConvolutionBloom {
       exposure: props.exposure ?? 1,
       exposureCompensation: props.exposureCompensation ?? 0
     };
+    this.energyConserving = props.energyConserving ?? false;
+    this.temporalStability = Math.min(Math.max(props.temporalStability ?? 0, 0), 0.95);
+    this.lens = {
+      ghostIntensity: Math.max(props.lens?.ghostIntensity ?? 0, 0),
+      ghostCount: Math.min(Math.max(Math.round(props.lens?.ghostCount ?? 3), 1), 6),
+      ghostSpacing: Math.min(Math.max(props.lens?.ghostSpacing ?? 0.32, 0), 1),
+      haloIntensity: Math.max(props.lens?.haloIntensity ?? 0, 0),
+      haloRadius: Math.min(Math.max(props.lens?.haloRadius ?? 0.34, 0), 1),
+      chromaticAberration: Math.min(Math.max(props.lens?.chromaticAberration ?? 0, 0), 1),
+      dirtIntensity: Math.max(props.lens?.dirtIntensity ?? 0, 0)
+    };
 
     const pointSpreadFunction =
       props.pointSpreadFunction ||
-      makeBloomPointSpreadFunction({
+      makeBloomSpectralPointSpreadFunction({
         width: this.stats.transformWidth,
         height: this.stats.transformHeight,
         apertureBlades: props.apertureBlades,
         diffractionStrength: props.diffractionStrength,
-        anamorphicRatio: props.anamorphicRatio
+        anamorphicRatio: props.anamorphicRatio,
+        spectralSpread: props.spectralSpread
       });
     this.resources = createGPUConvolutionBloomResources(device, {
       id: this.id,
       stats: this.stats,
-      pointSpreadFunction
+      pointSpreadFunction,
+      temporalStability: this.temporalStability > 0
     });
   }
 
   /** Replaces and normalizes the cached point-spread kernel without reallocating FFT resources. */
-  setPointSpreadFunction(pointSpreadFunction: Float32Array): void {
+  setPointSpreadFunction(pointSpreadFunction: BloomPointSpreadFunction): void {
     if (this.destroyed) {
       throw new Error('GPUConvolutionBloom has been destroyed.');
     }
-    this.resources.kernelSpatial.write(
+    this.resources.spatialChannels.write(
       makeComplexPointSpreadFunction(pointSpreadFunction, this.stats.elementCount)
     );
     this.kernelNeedsTransform = true;
@@ -176,18 +243,29 @@ export class GPUConvolutionBloom {
     }
     validateGPUConvolutionBloomTextures(this.device, this.stats, options);
 
+    const exposure = Math.max(options.exposure ?? this.defaults.exposure, 0.0001);
+    const previousExposure = Math.max(
+      options.previousExposure ?? this.previousExposure ?? exposure,
+      0.0001
+    );
     this.resources.parameters.write(
       makeGPUConvolutionBloomParameters(this.stats, {
         threshold: options.threshold ?? this.defaults.threshold,
         intensity: options.intensity ?? this.defaults.intensity,
-        exposure: options.exposure ?? this.defaults.exposure,
-        exposureCompensation: options.exposureCompensation ?? this.defaults.exposureCompensation
+        exposure,
+        exposureCompensation: options.exposureCompensation ?? this.defaults.exposureCompensation,
+        energyConserving: this.energyConserving,
+        useExposureTexture: Boolean(options.exposureTexture),
+        temporalStability: this.temporalStability,
+        exposureScale: exposure / previousExposure,
+        lens: this.lens,
+        historyValid: this.historyValid
       })
     );
 
     if (this.kernelNeedsTransform) {
       this.resources.transform.encode(commandEncoder, {
-        inputBuffer: this.resources.kernelSpatial,
+        inputBuffer: this.resources.spatialChannels,
         outputBuffer: this.resources.kernelSpectrum,
         direction: 'forward'
       });
@@ -197,9 +275,8 @@ export class GPUConvolutionBloom {
     this.resources.extract.setBindings({
       parameters: this.resources.parameters,
       sourceTexture: options.sourceTexture.view,
-      redChannel: this.resources.spatialChannels[0],
-      greenChannel: this.resources.spatialChannels[1],
-      blueChannel: this.resources.spatialChannels[2]
+      exposureTexture: (options.exposureTexture || options.sourceTexture).view,
+      spatialChannels: this.resources.spatialChannels
     });
     dispatchConvolutionComputation(
       commandEncoder,
@@ -209,25 +286,19 @@ export class GPUConvolutionBloom {
       Math.ceil(this.stats.transformHeight / FFT_BLOOM_WORKGROUP_DIMENSION)
     );
 
-    for (let channelIndex = 0; channelIndex < 3; channelIndex++) {
-      this.resources.transform.encode(commandEncoder, {
-        inputBuffer: this.resources.spatialChannels[channelIndex],
-        outputBuffer: this.resources.spectralChannels[channelIndex],
-        direction: 'forward'
-      });
-    }
+    this.resources.transform.encode(commandEncoder, {
+      inputBuffer: this.resources.spatialChannels,
+      outputBuffer: this.resources.spectralChannels,
+      direction: 'forward'
+    });
 
     this.resources.multiply.setBindings({
-      redSpectrum: this.resources.spectralChannels[0],
-      greenSpectrum: this.resources.spectralChannels[1],
-      blueSpectrum: this.resources.spectralChannels[2],
+      sourceSpectrum: this.resources.spectralChannels,
       kernelSpectrum: this.resources.kernelSpectrum,
-      filteredRed: this.resources.spatialChannels[0],
-      filteredGreen: this.resources.spatialChannels[1],
-      filteredBlue: this.resources.spatialChannels[2]
+      filteredChannels: this.resources.spatialChannels
     });
     const multiplyWorkgroupCount = Math.ceil(
-      this.stats.elementCount / FFT_BLOOM_MULTIPLY_WORKGROUP_SIZE
+      (this.stats.elementCount * this.stats.batchCount) / FFT_BLOOM_MULTIPLY_WORKGROUP_SIZE
     );
     dispatchConvolutionComputation(
       commandEncoder,
@@ -237,22 +308,26 @@ export class GPUConvolutionBloom {
       Math.ceil(multiplyWorkgroupCount / FFT_BLOOM_MULTIPLY_WORKGROUPS_PER_ROW)
     );
 
-    for (let channelIndex = 0; channelIndex < 3; channelIndex++) {
-      this.resources.transform.encode(commandEncoder, {
-        inputBuffer: this.resources.spatialChannels[channelIndex],
-        outputBuffer: this.resources.spectralChannels[channelIndex],
-        direction: 'inverse'
-      });
-    }
+    this.resources.transform.encode(commandEncoder, {
+      inputBuffer: this.resources.spatialChannels,
+      outputBuffer: this.resources.spectralChannels,
+      direction: 'inverse'
+    });
 
-    this.resources.composite.setBindings({
+    const compositeBindings: Record<string, Buffer | Texture['view']> = {
       parameters: this.resources.parameters,
       sourceTexture: options.sourceTexture.view,
-      redChannel: this.resources.spectralChannels[0],
-      greenChannel: this.resources.spectralChannels[1],
-      blueChannel: this.resources.spectralChannels[2],
-      outputTexture: options.outputTexture.view
-    });
+      convolvedChannels: this.resources.spectralChannels,
+      outputTexture: options.outputTexture.view,
+      lensDirtTexture: (options.lensDirtTexture || options.sourceTexture).view,
+      exposureTexture: (options.exposureTexture || options.sourceTexture).view
+    };
+    if (this.resources.historyTextures) {
+      compositeBindings['historyTexture'] = this.resources.historyTextures[this.historyIndex].view;
+      compositeBindings['historyOutput'] =
+        this.resources.historyTextures[1 - this.historyIndex].view;
+    }
+    this.resources.composite.setBindings(compositeBindings);
     dispatchConvolutionComputation(
       commandEncoder,
       this.resources.composite,
@@ -260,7 +335,18 @@ export class GPUConvolutionBloom {
       Math.ceil(this.width / FFT_BLOOM_WORKGROUP_DIMENSION),
       Math.ceil(this.height / FFT_BLOOM_WORKGROUP_DIMENSION)
     );
+    if (this.resources.historyTextures) {
+      this.historyIndex = 1 - this.historyIndex;
+      this.historyValid = true;
+    }
+    this.previousExposure = exposure;
     return options.outputTexture;
+  }
+
+  /** Drops optical history without reallocating cached FFT buffers or lens resources. */
+  resetHistory(): void {
+    this.historyValid = false;
+    this.previousExposure = undefined;
   }
 
   /** Releases the FFT, cached optical spectrum, compute pipelines, and all owned GPU buffers. */
@@ -276,7 +362,10 @@ export class GPUConvolutionBloom {
 /** Reports the exact transform dimensions, steady-state GPU work, and capability failures. */
 export function getGPUConvolutionBloomSupport(
   device: Device,
-  props: Pick<GPUConvolutionBloomProps, 'width' | 'height' | 'resolutionScale'>
+  props: Pick<
+    GPUConvolutionBloomProps,
+    'width' | 'height' | 'resolutionScale' | 'guardBand' | 'temporalStability'
+  >
 ): GPUConvolutionBloomSupport {
   let stats: GPUConvolutionBloomStats;
   try {
@@ -287,18 +376,26 @@ export function getGPUConvolutionBloomSupport(
 
   const transformSupport = getGPUFFT2DSupport(device, {
     width: stats.transformWidth,
-    height: stats.transformHeight
+    height: stats.transformHeight,
+    batchCount: stats.batchCount
   });
   if (!transformSupport.supported) {
     return {supported: false, reason: transformSupport.reason, stats};
   }
-  if (device.limits.maxStorageBuffersPerShaderStage < 7) {
-    return {supported: false, reason: 'GPUConvolutionBloom requires seven storage buffers.', stats};
+  if (device.limits.maxStorageBuffersPerShaderStage < 3) {
+    return {supported: false, reason: 'GPUConvolutionBloom requires three storage buffers.', stats};
   }
-  if (device.limits.maxStorageTexturesPerShaderStage < 1) {
-    return {supported: false, reason: 'GPUConvolutionBloom requires one storage texture.', stats};
+  const requiredStorageTextures = (props.temporalStability ?? 0) > 0 ? 2 : 1;
+  if (device.limits.maxStorageTexturesPerShaderStage < requiredStorageTextures) {
+    return {
+      supported: false,
+      reason: `GPUConvolutionBloom requires ${requiredStorageTextures} storage textures.`,
+      stats
+    };
   }
-  const multiplyWorkgroupCount = Math.ceil(stats.elementCount / FFT_BLOOM_MULTIPLY_WORKGROUP_SIZE);
+  const multiplyWorkgroupCount = Math.ceil(
+    (stats.elementCount * stats.batchCount) / FFT_BLOOM_MULTIPLY_WORKGROUP_SIZE
+  );
   if (
     Math.min(multiplyWorkgroupCount, FFT_BLOOM_MULTIPLY_WORKGROUPS_PER_ROW) >
       device.limits.maxComputeWorkgroupsPerDimension ||
@@ -323,7 +420,7 @@ export function getGPUConvolutionBloomSupport(
 
 /** Computes the bounded power-of-two transform and its exact steady-state dispatch budget. */
 export function makeGPUConvolutionBloomStats(
-  props: Pick<GPUConvolutionBloomProps, 'width' | 'height' | 'resolutionScale'>
+  props: Pick<GPUConvolutionBloomProps, 'width' | 'height' | 'resolutionScale' | 'guardBand'>
 ): GPUConvolutionBloomStats {
   if (!Number.isInteger(props.width) || props.width <= 0) {
     throw new Error('GPUConvolutionBloom width must be a positive integer.');
@@ -337,22 +434,39 @@ export function makeGPUConvolutionBloomStats(
       'GPUConvolutionBloom resolutionScale must be greater than zero and at most one.'
     );
   }
-  const transformWidth = nextPowerOfTwo(Math.max(Math.ceil(props.width * resolutionScale), 2));
-  const transformHeight = nextPowerOfTwo(Math.max(Math.ceil(props.height * resolutionScale), 2));
-  const transformStats = makeGPUFFT2DStats(transformWidth, transformHeight);
-  const complexBufferCount = 9;
+  const guardBand = props.guardBand ?? 0.125;
+  if (!Number.isFinite(guardBand) || guardBand < 0 || guardBand > 1) {
+    throw new Error('GPUConvolutionBloom guardBand must be between zero and one.');
+  }
+  const contentWidth = Math.max(Math.ceil(props.width * resolutionScale), 1);
+  const contentHeight = Math.max(Math.ceil(props.height * resolutionScale), 1);
+  const transformWidth = nextPowerOfTwo(
+    Math.max(contentWidth + Math.ceil(contentWidth * guardBand) * 2, 2)
+  );
+  const transformHeight = nextPowerOfTwo(
+    Math.max(contentHeight + Math.ceil(contentHeight * guardBand) * 2, 2)
+  );
+  const batchCount = 3;
+  const transformStats = makeGPUFFT2DStats(transformWidth, transformHeight, batchCount);
+  const complexBufferCount = 4;
 
   return Object.freeze({
     width: props.width,
     height: props.height,
+    contentWidth,
+    contentHeight,
+    contentOffsetX: Math.floor((transformWidth - contentWidth) / 2),
+    contentOffsetY: Math.floor((transformHeight - contentHeight) / 2),
+    guardBand,
     transformWidth,
     transformHeight,
     elementCount: transformStats.elementCount,
     complexBufferCount,
     complexBufferByteLength: transformStats.complexBufferByteLength,
     totalComplexBufferByteLength: transformStats.complexBufferByteLength * complexBufferCount,
+    batchCount,
     transformDispatchCount: transformStats.dispatchCountPerEncode,
-    steadyStateDispatchCount: transformStats.dispatchCountPerEncode * 6 + 3,
+    steadyStateDispatchCount: transformStats.dispatchCountPerEncode * 2 + 3,
     kernelInitializationDispatchCount: transformStats.dispatchCountPerEncode
   });
 }
@@ -373,6 +487,8 @@ export function makeBloomPointSpreadFunction(
   const anamorphicRatio = Math.min(Math.max(options.anamorphicRatio ?? 0, -1), 1);
   const horizontalStretch = 1 + Math.max(anamorphicRatio, 0) * 2;
   const verticalStretch = 1 + Math.max(-anamorphicRatio, 0) * 2;
+  const wavelength = Math.min(Math.max(options.wavelength ?? 550, 380), 780);
+  const wavelengthScale = wavelength / 550;
   const kernel = new Float32Array(options.width * options.height);
   let totalEnergy = 0;
 
@@ -383,11 +499,11 @@ export function makeBloomPointSpreadFunction(
       const normalizedX = signedX / horizontalStretch;
       const normalizedY = signedY / verticalStretch;
       const distance = Math.hypot(normalizedX, normalizedY);
-      const radialPhase = distance * 0.95;
+      const radialPhase = (distance * 0.95) / wavelengthScale;
       const airyLobe = radialPhase < 0.00001 ? 1 : (Math.sin(radialPhase) / radialPhase) ** 2;
       const diffractionAngle = Math.atan2(normalizedY, normalizedX);
       const spoke = Math.abs(Math.cos(diffractionAngle * apertureBlades * 0.5)) ** 32;
-      const diffraction = spoke / (1 + distance * distance * 0.065);
+      const diffraction = spoke / (1 + (distance * distance * 0.065) / wavelengthScale);
       const value = airyLobe + diffraction * diffractionStrength;
       kernel[pixelY * options.width + pixelX] = value;
       totalEnergy += value;
@@ -400,13 +516,37 @@ export function makeBloomPointSpreadFunction(
   return kernel;
 }
 
+/** Generates separately normalized red, green, and blue wavelength-dependent optical kernels. */
+export function makeBloomSpectralPointSpreadFunction(
+  options: BloomPointSpreadFunctionOptions
+): BloomSpectralPointSpreadFunction {
+  const spectralSpread = Math.min(Math.max(options.spectralSpread ?? 0, 0), 1);
+  return {
+    red: makeBloomPointSpreadFunction({
+      ...options,
+      wavelength: 550 + (650 - 550) * spectralSpread
+    }),
+    green: makeBloomPointSpreadFunction({...options, wavelength: 550}),
+    blue: makeBloomPointSpreadFunction({
+      ...options,
+      wavelength: 550 + (460 - 550) * spectralSpread
+    })
+  };
+}
+
 function createGPUConvolutionBloomResources(
   device: Device,
-  options: {id: string; stats: GPUConvolutionBloomStats; pointSpreadFunction: Float32Array}
+  options: {
+    id: string;
+    stats: GPUConvolutionBloomStats;
+    pointSpreadFunction: BloomPointSpreadFunction;
+    temporalStability: boolean;
+  }
 ): GPUConvolutionBloomResources {
   let transform: GPUFFT2D | undefined;
   const buffers: Buffer[] = [];
   const computations: Computation[] = [];
+  const textures: Texture[] = [];
   const makeStorageBuffer = (name: string, data?: Float32Array): Buffer => {
     const buffer = device.createBuffer({
       id: `${options.id}-${name}`,
@@ -421,7 +561,8 @@ function createGPUConvolutionBloomResources(
     transform = new GPUFFT2D(device, {
       id: `${options.id}-fft`,
       width: options.stats.transformWidth,
-      height: options.stats.transformHeight
+      height: options.stats.transformHeight,
+      batchCount: options.stats.batchCount
     });
     const parameters = device.createBuffer({
       id: `${options.id}-parameters`,
@@ -429,17 +570,25 @@ function createGPUConvolutionBloomResources(
       usage: Buffer.UNIFORM | Buffer.COPY_DST
     });
     buffers.push(parameters);
-    const kernelSpatial = makeStorageBuffer(
-      'kernel-spatial',
+    const kernelSpectrum = makeStorageBuffer('kernel-spectrum');
+    const spatialChannels = makeStorageBuffer(
+      'rgb-spatial',
       makeComplexPointSpreadFunction(options.pointSpreadFunction, options.stats.elementCount)
     );
-    const kernelSpectrum = makeStorageBuffer('kernel-spectrum');
-    const spatialChannels = ['red', 'green', 'blue'].map(channel =>
-      makeStorageBuffer(`${channel}-spatial`)
-    );
-    const spectralChannels = ['red', 'green', 'blue'].map(channel =>
-      makeStorageBuffer(`${channel}-spectrum`)
-    );
+    const spectralChannels = makeStorageBuffer('rgb-spectrum');
+    const historyTextures = options.temporalStability
+      ? ([0, 1].map(historyIndex => {
+          const texture = device.createTexture({
+            id: `${options.id}-history-${historyIndex}`,
+            width: options.stats.width,
+            height: options.stats.height,
+            format: 'rgba16float',
+            usage: Texture.SAMPLE | Texture.STORAGE
+          });
+          textures.push(texture);
+          return texture;
+        }) as [Texture, Texture])
+      : undefined;
     const extract = makeConvolutionComputation(
       device,
       `${options.id}-extract`,
@@ -453,9 +602,14 @@ function createGPUConvolutionBloomResources(
           location: 1,
           sampleType: 'unfilterable-float'
         },
-        {name: 'redChannel', type: 'storage', group: 0, location: 2},
-        {name: 'greenChannel', type: 'storage', group: 0, location: 3},
-        {name: 'blueChannel', type: 'storage', group: 0, location: 4}
+        {
+          name: 'exposureTexture',
+          type: 'texture',
+          group: 0,
+          location: 2,
+          sampleType: 'unfilterable-float'
+        },
+        {name: 'spatialChannels', type: 'storage', group: 0, location: 3}
       ]
     );
     computations.push(extract);
@@ -464,20 +618,16 @@ function createGPUConvolutionBloomResources(
       `${options.id}-multiply`,
       FFT_BLOOM_MULTIPLY_SHADER,
       [
-        {name: 'redSpectrum', type: 'read-only-storage', group: 0, location: 0},
-        {name: 'greenSpectrum', type: 'read-only-storage', group: 0, location: 1},
-        {name: 'blueSpectrum', type: 'read-only-storage', group: 0, location: 2},
-        {name: 'kernelSpectrum', type: 'read-only-storage', group: 0, location: 3},
-        {name: 'filteredRed', type: 'storage', group: 0, location: 4},
-        {name: 'filteredGreen', type: 'storage', group: 0, location: 5},
-        {name: 'filteredBlue', type: 'storage', group: 0, location: 6}
+        {name: 'sourceSpectrum', type: 'read-only-storage', group: 0, location: 0},
+        {name: 'kernelSpectrum', type: 'read-only-storage', group: 0, location: 1},
+        {name: 'filteredChannels', type: 'storage', group: 0, location: 2}
       ]
     );
     computations.push(multiply);
     const composite = makeConvolutionComputation(
       device,
       `${options.id}-composite`,
-      FFT_BLOOM_COMPOSITE_SHADER,
+      options.temporalStability ? makeFFTBloomCompositeShader(true) : FFT_BLOOM_COMPOSITE_SHADER,
       [
         {name: 'parameters', type: 'uniform', group: 0, location: 0},
         {
@@ -487,17 +637,48 @@ function createGPUConvolutionBloomResources(
           location: 1,
           sampleType: 'unfilterable-float'
         },
-        {name: 'redChannel', type: 'read-only-storage', group: 0, location: 2},
-        {name: 'greenChannel', type: 'read-only-storage', group: 0, location: 3},
-        {name: 'blueChannel', type: 'read-only-storage', group: 0, location: 4},
+        {name: 'convolvedChannels', type: 'read-only-storage', group: 0, location: 2},
         {
           name: 'outputTexture',
           type: 'storage',
           group: 0,
-          location: 5,
+          location: 3,
           access: 'write-only',
           format: 'rgba16float'
-        }
+        },
+        {
+          name: 'lensDirtTexture',
+          type: 'texture',
+          group: 0,
+          location: 4,
+          sampleType: 'unfilterable-float'
+        },
+        {
+          name: 'exposureTexture',
+          type: 'texture',
+          group: 0,
+          location: 5,
+          sampleType: 'unfilterable-float'
+        },
+        ...(options.temporalStability
+          ? ([
+              {
+                name: 'historyTexture',
+                type: 'texture',
+                group: 0,
+                location: 6,
+                sampleType: 'unfilterable-float'
+              },
+              {
+                name: 'historyOutput',
+                type: 'storage',
+                group: 0,
+                location: 7,
+                access: 'write-only',
+                format: 'rgba16float'
+              }
+            ] satisfies BindingDeclaration[])
+          : [])
       ]
     );
     computations.push(composite);
@@ -505,10 +686,10 @@ function createGPUConvolutionBloomResources(
     return {
       transform,
       parameters,
-      kernelSpatial,
       kernelSpectrum,
       spatialChannels,
       spectralChannels,
+      historyTextures,
       extract,
       multiply,
       composite
@@ -519,6 +700,9 @@ function createGPUConvolutionBloomResources(
     }
     for (const buffer of buffers) {
       buffer.destroy();
+    }
+    for (const texture of textures) {
+      texture.destroy();
     }
     transform?.destroy();
     throw error;
@@ -547,43 +731,81 @@ function dispatchConvolutionComputation(
   computePass.end();
 }
 
-function makeComplexPointSpreadFunction(kernel: Float32Array, elementCount: number): Float32Array {
-  if (kernel.length !== elementCount) {
-    throw new Error('Point-spread function must match the transform dimensions.');
-  }
+function makeComplexPointSpreadFunction(
+  pointSpreadFunction: BloomPointSpreadFunction,
+  elementCount: number
+): Float32Array {
+  const kernels =
+    pointSpreadFunction instanceof Float32Array
+      ? [pointSpreadFunction, pointSpreadFunction, pointSpreadFunction]
+      : [pointSpreadFunction.red, pointSpreadFunction.green, pointSpreadFunction.blue];
+  const complexKernel = new Float32Array(elementCount * 3 * 2);
 
-  let energy = 0;
-  for (const value of kernel) {
-    if (!Number.isFinite(value) || value < 0) {
-      throw new Error('Point-spread samples must be finite and nonnegative.');
+  for (const [channelIndex, kernel] of kernels.entries()) {
+    if (kernel.length !== elementCount) {
+      throw new Error('Point-spread function must match the transform dimensions.');
     }
-    energy += value;
-  }
-  if (energy <= 0) {
-    throw new Error('Point-spread function must contain positive energy.');
+
+    let energy = 0;
+    for (const value of kernel) {
+      if (!Number.isFinite(value) || value < 0) {
+        throw new Error('Point-spread samples must be finite and nonnegative.');
+      }
+      energy += value;
+    }
+    if (energy <= 0) {
+      throw new Error('Point-spread function must contain positive energy.');
+    }
+    const channelOffset = channelIndex * elementCount * 2;
+    for (let index = 0; index < elementCount; index++) {
+      complexKernel[channelOffset + index * 2] = kernel[index] / energy;
+    }
   }
 
-  const complexKernel = new Float32Array(elementCount * 2);
-  for (let index = 0; index < elementCount; index++) {
-    complexKernel[index * 2] = kernel[index] / energy;
-  }
   return complexKernel;
 }
 
 function makeGPUConvolutionBloomParameters(
   stats: GPUConvolutionBloomStats,
-  options: {threshold: number; intensity: number; exposure: number; exposureCompensation: number}
+  options: {
+    threshold: number;
+    intensity: number;
+    exposure: number;
+    exposureCompensation: number;
+    energyConserving: boolean;
+    useExposureTexture: boolean;
+    temporalStability: number;
+    exposureScale: number;
+    lens: Required<GPUConvolutionBloomLensOptions>;
+    historyValid: boolean;
+  }
 ): ArrayBuffer {
   const buffer = new ArrayBuffer(FFT_BLOOM_PARAMETER_BYTE_LENGTH);
   const view = new DataView(buffer);
   view.setUint32(0, stats.width, true);
   view.setUint32(4, stats.height, true);
-  view.setUint32(8, stats.transformWidth, true);
-  view.setUint32(12, stats.transformHeight, true);
-  view.setFloat32(16, options.threshold, true);
-  view.setFloat32(20, options.intensity, true);
-  view.setFloat32(24, options.exposure, true);
-  view.setFloat32(28, options.exposureCompensation, true);
+  view.setUint32(8, stats.contentWidth, true);
+  view.setUint32(12, stats.contentHeight, true);
+  view.setUint32(16, stats.transformWidth, true);
+  view.setUint32(20, stats.transformHeight, true);
+  view.setUint32(24, stats.contentOffsetX, true);
+  view.setUint32(28, stats.contentOffsetY, true);
+  view.setFloat32(32, options.threshold, true);
+  view.setFloat32(36, options.intensity, true);
+  view.setFloat32(40, options.exposure, true);
+  view.setFloat32(44, options.exposureCompensation, true);
+  view.setFloat32(48, Number(options.energyConserving), true);
+  view.setFloat32(52, Number(options.useExposureTexture), true);
+  view.setFloat32(56, options.temporalStability, true);
+  view.setFloat32(60, options.exposureScale, true);
+  view.setFloat32(64, options.lens.ghostIntensity, true);
+  view.setFloat32(68, options.lens.ghostSpacing, true);
+  view.setFloat32(72, options.lens.haloIntensity, true);
+  view.setFloat32(76, options.lens.haloRadius, true);
+  view.setFloat32(80, options.lens.chromaticAberration, true);
+  view.setFloat32(84, options.lens.dirtIntensity, true);
+  view.setFloat32(88, options.lens.ghostCount, true);
+  view.setFloat32(92, Number(options.historyValid), true);
   return buffer;
 }
 
@@ -592,7 +814,12 @@ function validateGPUConvolutionBloomTextures(
   stats: GPUConvolutionBloomStats,
   options: GPUConvolutionBloomEncodeOptions
 ): void {
-  if (options.sourceTexture.device !== device || options.outputTexture.device !== device) {
+  if (
+    options.sourceTexture.device !== device ||
+    options.outputTexture.device !== device ||
+    (options.exposureTexture && options.exposureTexture.device !== device) ||
+    (options.lensDirtTexture && options.lensDirtTexture.device !== device)
+  ) {
     throw new Error('GPUConvolutionBloom textures must belong to the same device.');
   }
   if (
@@ -623,10 +850,11 @@ function destroyGPUConvolutionBloomResources(resources: GPUConvolutionBloomResou
   resources.composite.destroy();
   resources.transform.destroy();
   resources.parameters.destroy();
-  resources.kernelSpatial.destroy();
   resources.kernelSpectrum.destroy();
-  for (const buffer of [...resources.spatialChannels, ...resources.spectralChannels]) {
-    buffer.destroy();
+  resources.spatialChannels.destroy();
+  resources.spectralChannels.destroy();
+  for (const texture of resources.historyTextures || []) {
+    texture.destroy();
   }
 }
 

--- a/modules/experimental/test/gpu-primitives/gpu-fft2d.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-fft2d.node.spec.ts
@@ -53,6 +53,18 @@ test('GPUFFT2D validates both transform dimensions before allocation', testCase 
   testCase.throws(() => makeGPUFFT2DStats(1, 4), /width must be from 2 through 2048/);
   testCase.throws(() => makeGPUFFT2DStats(4, 4096), /height must be from 2 through 2048/);
   testCase.throws(() => makeGPUFFT2DStats(4.5, 8), /width must be an integer/);
+  testCase.throws(() => makeGPUFFT2DStats(4, 8, 0), /batchCount must be a positive integer/);
+  testCase.end();
+});
+
+test('GPUFFT2D batches independent packed transforms in the dispatch depth dimension', testCase => {
+  const stats = makeGPUFFT2DStats(8, 4, 3);
+
+  testCase.equal(stats.batchCount, 3, 'the plan exposes the independent transform count');
+  testCase.equal(stats.elementCount, 32, 'each transform retains its own spatial element count');
+  testCase.equal(stats.complexBufferByteLength, 768, 'buffers contain all three packed transforms');
+  testCase.deepEqual(stats.workgroupCount, [1, 1, 3], 'the batch index uses dispatch depth');
+  testCase.equal(stats.dispatchCountPerEncode, 7, 'batching does not add FFT stage dispatches');
   testCase.end();
 });
 

--- a/modules/experimental/test/gpu-primitives/gpu-fft2d.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-fft2d.spec.ts
@@ -67,6 +67,58 @@ test('GPUFFT2D matches a CPU DFT and composes forward/inverse passes in one enco
   t.end();
 });
 
+test('GPUFFT2D transforms packed RGB fields in one batched dispatch sequence', async testCase => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const width = 4;
+  const height = 4;
+  const batchCount = 3;
+  const channelLength = width * height * 2;
+  const inputValues = new Float32Array(channelLength * batchCount);
+  const expectedValues: number[] = [];
+  for (let channelIndex = 0; channelIndex < batchCount; channelIndex++) {
+    const channelValues = makeComplexInput(width, height).map(value => value * (channelIndex + 1));
+    inputValues.set(channelValues, channelIndex * channelLength);
+    expectedValues.push(...makeCPUDFT2D(channelValues, width, height, 'forward'));
+  }
+
+  const transform = new GPUFFT2D(device, {width, height, batchCount});
+  const inputBuffer = device.createBuffer({
+    data: inputValues,
+    usage: Buffer.STORAGE | Buffer.COPY_DST
+  });
+  const outputBuffer = makeOutputBuffer(device, 'gpu-fft2d-batched-output', inputValues.byteLength);
+
+  try {
+    const commandEncoder = device.createCommandEncoder();
+    transform.encode(commandEncoder, {inputBuffer, outputBuffer});
+    device.submit(commandEncoder.finish());
+    const actualValues = await readFloat32(outputBuffer, inputValues.length);
+    assertClose(
+      testCase,
+      actualValues,
+      expectedValues,
+      0.002,
+      'independent batched RGB transforms'
+    );
+    testCase.equal(
+      transform.stats.dispatchCountPerEncode,
+      6,
+      'batching preserves one FFT schedule'
+    );
+  } finally {
+    transform.destroy();
+    inputBuffer.destroy();
+    outputBuffer.destroy();
+  }
+  testCase.end();
+});
+
 test('GPUFFT2D rejects aliased and incompatible caller buffers', async t => {
   const device = await getWebGPUTestDevice();
   if (!device) {

--- a/modules/experimental/test/rendering/fft-bloom.node.spec.ts
+++ b/modules/experimental/test/rendering/fft-bloom.node.spec.ts
@@ -6,6 +6,7 @@ import type {Device} from '@luma.gl/core';
 import {
   getGPUConvolutionBloomSupport,
   makeBloomPointSpreadFunction,
+  makeBloomSpectralPointSpreadFunction,
   makeGPUConvolutionBloomStats
 } from '@luma.gl/experimental';
 import {WgslReflect} from 'wgsl_reflect';
@@ -25,17 +26,23 @@ test('GPUConvolutionBloom publishes bounded FFT memory and dispatch costs', test
     {
       width: 1920,
       height: 1080,
-      transformWidth: 512,
+      contentWidth: 480,
+      contentHeight: 270,
+      contentOffsetX: 272,
+      contentOffsetY: 121,
+      guardBand: 0.125,
+      transformWidth: 1024,
       transformHeight: 512,
-      elementCount: 262144,
-      complexBufferCount: 9,
-      complexBufferByteLength: 2097152,
-      totalComplexBufferByteLength: 18874368,
-      transformDispatchCount: 20,
-      steadyStateDispatchCount: 123,
-      kernelInitializationDispatchCount: 20
+      elementCount: 524288,
+      complexBufferCount: 4,
+      complexBufferByteLength: 12582912,
+      totalComplexBufferByteLength: 50331648,
+      batchCount: 3,
+      transformDispatchCount: 21,
+      steadyStateDispatchCount: 45,
+      kernelInitializationDispatchCount: 21
     },
-    'a quarter-resolution 1080p kernel reports every RGB transform, buffer, and dispatch'
+    'a padded quarter-resolution 1080p kernel reports every batched RGB buffer and dispatch'
   );
   testCase.ok(Object.isFrozen(stats), 'the performance contract cannot be mutated');
   testCase.throws(
@@ -47,6 +54,40 @@ test('GPUConvolutionBloom publishes bounded FFT memory and dispatch costs', test
     () => makeGPUConvolutionBloomStats({width: 8192, height: 1080, resolutionScale: 1}),
     /width must be from 2 through 2048/,
     'oversized FFT plans fail before allocating GPU resources'
+  );
+  testCase.throws(
+    () => makeGPUConvolutionBloomStats({width: 64, height: 64, guardBand: -0.1}),
+    /guardBand/,
+    'negative convolution guard bands are rejected'
+  );
+  const unpadded = makeGPUConvolutionBloomStats({width: 1920, height: 1080, guardBand: 0});
+  testCase.equal(unpadded.transformWidth, 512, 'applications can opt out of the padded FFT size');
+  testCase.equal(
+    unpadded.steadyStateDispatchCount,
+    43,
+    'packed RGB reduces the old 123 dispatches'
+  );
+  testCase.end();
+});
+
+test('makeBloomSpectralPointSpreadFunction normalizes each physical wavelength', testCase => {
+  const kernels = makeBloomSpectralPointSpreadFunction({
+    width: 32,
+    height: 32,
+    diffractionStrength: 0.6,
+    spectralSpread: 1
+  });
+
+  for (const [channel, kernel] of Object.entries(kernels)) {
+    testCase.ok(
+      Math.abs(kernel.reduce((energy, sample) => energy + sample, 0) - 1) < 0.000001,
+      `${channel} independently preserves optical energy`
+    );
+  }
+  testCase.notEqual(
+    kernels.red[2],
+    kernels.blue[2],
+    'red and blue use different diffraction widths'
   );
   testCase.end();
 });
@@ -97,12 +138,13 @@ test('getGPUConvolutionBloomSupport reports WebGPU and storage requirements', te
   const supported = getGPUConvolutionBloomSupport(supportedDevice, {width: 256, height: 128});
 
   testCase.equal(supported.supported, true, 'representative WebGPU limits support RGB convolution');
-  testCase.equal(supported.stats?.transformWidth, 64, 'support queries include the transform plan');
+  testCase.equal(supported.stats?.transformWidth, 128, 'support queries include the padded plan');
   testCase.equal(
     getGPUConvolutionBloomSupport(supportedDevice, {
       width: 2048,
       height: 2048,
-      resolutionScale: 1
+      resolutionScale: 1,
+      guardBand: 0
     }).supported,
     true,
     'two-dimensional frequency dispatch supports the largest bounded FFT without exceeding WebGPU limits'
@@ -114,12 +156,12 @@ test('getGPUConvolutionBloomSupport reports WebGPU and storage requirements', te
     'WebGL devices fall back before allocating premium resources'
   );
   testCase.match(
-    getGPUConvolutionBloomSupport(makeSupportDevice({maxStorageBuffersPerShaderStage: 6}), {
+    getGPUConvolutionBloomSupport(makeSupportDevice({maxStorageBuffersPerShaderStage: 2}), {
       width: 64,
       height: 64
     }).reason || '',
-    /seven storage buffers/,
-    'RGB spectrum multiplication checks its seven simultaneous storage bindings'
+    /three storage buffers/,
+    'packed RGB multiplication checks only three simultaneous storage bindings'
   );
   testCase.match(
     getGPUConvolutionBloomSupport(makeSupportDevice({store: false}), {width: 64, height: 64})
@@ -138,10 +180,10 @@ test('GPUConvolutionBloom WGSL exposes extraction, multiplication, and HDR outpu
   testCase.equal(extract.entry.compute.length, 1, 'extraction exposes one bounded compute stage');
   testCase.equal(multiply.entry.compute.length, 1, 'all RGB spectra share one multiply dispatch');
   testCase.equal(composite.entry.compute.length, 1, 'HDR composition exposes one compute stage');
-  testCase.equal(multiply.storage.length, 7, 'frequency multiplication binds exactly seven fields');
+  testCase.equal(multiply.storage.length, 3, 'packed RGB multiplication binds only three fields');
   testCase.match(
     FFT_BLOOM_EXTRACT_SHADER,
-    /parameters\.exposure \* exp2\(parameters\.exposureCompensation\)/,
+    /adaptedExposure \* exp2\(parameters\.exposureCompensation\)/,
     'highlight extraction applies exposure compensation in photographic stops'
   );
   testCase.match(
@@ -154,7 +196,12 @@ test('GPUConvolutionBloom WGSL exposes extraction, multiplication, and HDR outpu
     /globalInvocation\.y \*\s+65536u/,
     'frequency multiplication tiles across both dispatch dimensions for maximum-sized transforms'
   );
-  testCase.equal(FFT_BLOOM_PARAMETER_BYTE_LENGTH, 32, 'uniform packing remains explicitly bounded');
+  testCase.match(
+    FFT_BLOOM_EXTRACT_SHADER,
+    /coordinate < parameters\.contentOffset \+ parameters\.contentDimensions/,
+    'the extraction shader leaves guard-band pixels zero instead of stretching the image'
+  );
+  testCase.equal(FFT_BLOOM_PARAMETER_BYTE_LENGTH, 96, 'uniform packing remains explicitly bounded');
   testCase.end();
 });
 

--- a/modules/experimental/test/rendering/fft-bloom.node.spec.ts
+++ b/modules/experimental/test/rendering/fft-bloom.node.spec.ts
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import type {Device} from '@luma.gl/core';
+import {Texture, type CommandEncoder, type Device} from '@luma.gl/core';
 import {
   getGPUConvolutionBloomSupport,
+  GPUConvolutionBloom,
   makeBloomPointSpreadFunction,
   makeBloomSpectralPointSpreadFunction,
   makeGPUConvolutionBloomStats
@@ -169,6 +170,53 @@ test('getGPUConvolutionBloomSupport reports WebGPU and storage requirements', te
     /rgba16float storage textures/,
     'HDR storage support is mandatory for the final composite'
   );
+  testCase.end();
+});
+
+test('GPUConvolutionBloom rejects auxiliary textures aliasing its output', testCase => {
+  const device = makeSupportDevice();
+  const renderer = Object.create(GPUConvolutionBloom.prototype) as GPUConvolutionBloom;
+  Object.assign(renderer, {
+    device,
+    stats: makeGPUConvolutionBloomStats({width: 16, height: 16})
+  });
+  const makeTexture = (handle: object = {}): Texture =>
+    ({
+      device,
+      width: 16,
+      height: 16,
+      format: 'rgba16float',
+      props: {usage: Texture.STORAGE},
+      handle
+    }) as Texture;
+  const sourceTexture = makeTexture();
+  const outputTexture = makeTexture();
+  const outputAlias = makeTexture(outputTexture.handle as object);
+  const commandEncoder = {device} as CommandEncoder;
+
+  for (const auxiliaryName of ['exposureTexture', 'lensDirtTexture'] as const) {
+    testCase.throws(
+      () =>
+        renderer.encode(commandEncoder, {
+          sourceTexture,
+          outputTexture,
+          [auxiliaryName]: outputTexture
+        }),
+      /auxiliary and output textures must be separate/,
+      `${auxiliaryName} cannot directly alias the writable output`
+    );
+    testCase.throws(
+      () =>
+        renderer.encode(commandEncoder, {
+          sourceTexture,
+          outputTexture,
+          [auxiliaryName]: outputAlias
+        }),
+      /auxiliary and output textures must be separate/,
+      `${auxiliaryName} cannot share the output handle through a separate wrapper`
+    );
+  }
+
   testCase.end();
 });
 

--- a/modules/experimental/test/rendering/fft-bloom.spec.ts
+++ b/modules/experimental/test/rendering/fft-bloom.spec.ts
@@ -18,7 +18,12 @@ test('GPUConvolutionBloom convolves RGB highlights with caller-supplied optical 
 
   const width = 16;
   const height = 16;
-  const support = getGPUConvolutionBloomSupport(device, {width, height, resolutionScale: 1});
+  const support = getGPUConvolutionBloomSupport(device, {
+    width,
+    height,
+    resolutionScale: 1,
+    guardBand: 0
+  });
   if (!support.supported) {
     testCase.comment(support.reason || 'FFT convolution is not supported');
     testCase.end();
@@ -57,6 +62,7 @@ test('GPUConvolutionBloom convolves RGB highlights with caller-supplied optical 
     width,
     height,
     resolutionScale: 1,
+    guardBand: 0,
     threshold: 0.5,
     pointSpreadFunction: identityKernel
   });
@@ -108,8 +114,95 @@ test('GPUConvolutionBloom convolves RGB highlights with caller-supplied optical 
       readPixel(diffractionPixels, centerX, centerY) < readPixel(identityPixels, centerX, centerY),
       'normalized diffraction reduces the central peak instead of duplicating energy'
     );
+
+    const redKernel = new Float32Array(width * height);
+    const greenKernel = new Float32Array(width * height);
+    const blueKernel = new Float32Array(width * height);
+    redKernel[1] = 1;
+    greenKernel[0] = 1;
+    blueKernel[width - 1] = 1;
+    renderer.setPointSpreadFunction({red: redKernel, green: greenKernel, blue: blueKernel});
+    const spectralEncoder = device.createCommandEncoder({id: 'fft-bloom-spectral-encoder'});
+    renderer.encode(spectralEncoder, {sourceTexture, outputTexture});
+    device.submit(spectralEncoder.finish());
+    const spectralPixels = await readHDRPixels(outputTexture, width, height);
+
+    testCase.ok(
+      readPixel(spectralPixels, centerX + 1, centerY, 0) > 5,
+      'the measured red point-spread function shifts red diffraction right'
+    );
+    testCase.ok(
+      readPixel(spectralPixels, centerX - 1, centerY, 2) > 1,
+      'the independent blue point-spread function shifts blue diffraction left'
+    );
   } finally {
     renderer.destroy();
+    renderer.destroy();
+    sourceTexture.destroy();
+    outputTexture.destroy();
+  }
+  testCase.end();
+});
+
+test('GPUConvolutionBloom zero-padded guard bands prevent opposite-edge diffraction', async testCase => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const width = 16;
+  const height = 16;
+  const support = getGPUConvolutionBloomSupport(device, {
+    width,
+    height,
+    resolutionScale: 1,
+    guardBand: 0.25
+  });
+  if (!support.supported || !support.stats) {
+    testCase.comment(support.reason || 'Padded FFT convolution is not supported');
+    testCase.end();
+    return;
+  }
+
+  const sourceValues = new Uint16Array(width * height * 4);
+  for (let pixelIndex = 0; pixelIndex < width * height; pixelIndex++) {
+    sourceValues[pixelIndex * 4 + 3] = toHalfFloat(1);
+  }
+  sourceValues.set([toHalfFloat(8), toHalfFloat(8), toHalfFloat(8), toHalfFloat(1)], 8 * width * 4);
+  const sourceTexture = device.createTexture({
+    width,
+    height,
+    format: 'rgba16float',
+    data: sourceValues,
+    usage: Texture.SAMPLE | Texture.COPY_DST
+  });
+  const outputTexture = device.createTexture({
+    width,
+    height,
+    format: 'rgba16float',
+    usage: Texture.SAMPLE | Texture.STORAGE | Texture.COPY_SRC
+  });
+  const kernel = new Float32Array(support.stats.elementCount);
+  kernel[0] = 0.5;
+  kernel[support.stats.transformWidth - 1] = 0.5;
+  const renderer = new GPUConvolutionBloom(device, {
+    width,
+    height,
+    resolutionScale: 1,
+    guardBand: 0.25,
+    pointSpreadFunction: kernel
+  });
+
+  try {
+    const encoder = device.createCommandEncoder();
+    renderer.encode(encoder, {sourceTexture, outputTexture});
+    device.submit(encoder.finish());
+    const pixels = await readHDRPixels(outputTexture, width, height);
+    testCase.ok(pixels[(8 * width + width - 1) * 4] < 0.02, 'left-edge light cannot wrap right');
+    testCase.ok(pixels[8 * width * 4] > 8, 'the original edge highlight remains visible');
+  } finally {
     renderer.destroy();
     sourceTexture.destroy();
     outputTexture.destroy();

--- a/test/examples/homepage-navigation.node.spec.ts
+++ b/test/examples/homepage-navigation.node.spec.ts
@@ -173,6 +173,36 @@ describe('homepage navigation', () => {
     }
   });
 
+  test('features cinematic bloom in the showcase catalog and homepage gallery', () => {
+    const homepageSource = readFileSync(HOMEPAGE_SOURCE_PATH, 'utf8');
+    const tableOfContents = JSON.parse(
+      readFileSync(path.join(EXAMPLE_CONTENT_DIRECTORY, 'table-of-contents.json'), 'utf8')
+    ) as ExampleSidebarEntry[];
+    const showcaseCategory = tableOfContents.find(
+      entry => typeof entry !== 'string' && entry.type === 'category' && entry.label === 'Showcase'
+    );
+
+    expect(showcaseCategory).toBeDefined();
+    if (
+      showcaseCategory &&
+      typeof showcaseCategory !== 'string' &&
+      showcaseCategory.type === 'category'
+    ) {
+      expect(showcaseCategory.items).toContainEqual({
+        type: 'doc',
+        id: 'experimental/bloom',
+        label: 'Effects: Bloom'
+      });
+    }
+
+    expect(homepageSource).toMatch(
+      /title:\s*['"]Cinematic Bloom['"][\s\S]*?route:\s*['"]experimental\/bloom['"]/
+    );
+    expect(
+      existsSync(path.join(process.cwd(), 'website/static/images/examples/experimental/bloom.jpg'))
+    ).toBe(true);
+  });
+
   test('maintains WCAG AAA foreground contrast for normal and highlighted primary actions', () => {
     const homepageStyles = readFileSync(HOMEPAGE_STYLES_PATH, 'utf8');
     const normalActionRule = homepageStyles.match(/\.primaryAction\s*\{([^}]*)\}/);

--- a/website/content/examples/table-of-contents.json
+++ b/website/content/examples/table-of-contents.json
@@ -26,6 +26,11 @@
       },
       {
         "type": "doc",
+        "id": "experimental/bloom",
+        "label": "Effects: Bloom"
+      },
+      {
+        "type": "doc",
         "id": "showcase/persistence",
         "label": "Effects: Persistence"
       }
@@ -182,11 +187,6 @@
         "type": "doc",
         "id": "experimental/antialiasing",
         "label": "Antialiasing Techniques"
-      },
-      {
-        "type": "doc",
-        "id": "experimental/bloom",
-        "label": "Effects: Bloom"
       },
       "experimental/fp64",
       "experimental/text-space-crawl",

--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -49,6 +49,19 @@ const FEATURED_EXAMPLES = [
     topics: ['simulation', 'compute']
   },
   {
+    title: 'Cinematic Bloom',
+    route: 'experimental/bloom',
+    image: 'experimental/bloom.jpg',
+    description:
+      'Shape HDR highlights with physically based glow, spectral diffraction, chromatic lens ghosts, and temporal stabilization.',
+    category: 'Showcase',
+    backends: ['webgpu', 'webgl2'],
+    highDynamicRange: true,
+    difficulty: 'advanced',
+    maturity: 'experimental',
+    topics: ['effects', 'bloom']
+  },
+  {
     title: 'Volumetric Fire Forge',
     route: 'experimental/volumetric-fire-forge',
     image: 'experimental/volumetric-fire-forge.jpg',


### PR DESCRIPTION
## Summary

- Add optional motion-vector/depth-aware temporal reprojection, exposure-corrected bloom history, thresholdless energy-conserving composition, and a dual-Kawase pyramid mode.
- Add reusable batched GPU FFT transforms and rebuild premium bloom around packed RGB spectra, zero-padded edge guard bands, area-weighted highlight extraction, wavelength-specific or measured optical kernels, and GPU-resident exposure.
- Unify chromatic ghosts, halos, dirt, and temporal stabilization with FFT composition, and expose all production controls in the bloom example.
- Add CPU planning/shader regressions and WebGPU numerical coverage for batched transforms, independent spectral PSFs, and opposite-edge wraparound.

## Performance

- Ultra multiscale bloom: 15 render passes + 1 compute dispatch to **5 render passes + 1 compute dispatch** with dual-Kawase.
- 1080p quarter-resolution FFT: 123 dispatches to **45 dispatches with edge guard bands**, or **43 dispatches without padding**.
- FFT frequency multiplication drops from seven simultaneous storage buffers to three.

## Verification

- `yarn build` completed successfully across all workspace packages.
- Focused Node tests: 16 passing across the bloom, FFT plan, and FFT optical suites.
- Bloom example manually verified on WebGPU, including FFT mode, and WebGL fallback with no application console errors.
- Changed TypeScript files formatted and checked with Biome.
- Automated headless-browser execution could not start in the local Chrome environment; numerical browser regressions are included for CI.