### PR TITLE
Add partitioned GPU indexed range compaction

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -463,6 +463,13 @@ For matching vector input, flags, and output, compaction uses vector-wide scan o
 existing output chunks as one logical sequence. It does not concatenate, repack, or replace caller
 buffers, and the count remains a single total for the complete vector.
 
+Candidate-driven applications can compact only active source ranges. `GPUIndexedRangeCompaction`
+keeps one dense output sequence, while `GPUPartitionedIndexedRangeCompaction` preserves matching
+flag and output chunks. The partitioned form scans each chunk's canonical range interval
+independently, emits global source IDs into bounded destinations, and publishes both per-partition
+and total counts. This lets a trace viewer move visibility scratch and visible-ID lists beyond one
+storage-buffer binding without changing source identity or reading candidate counts on the CPU.
+
 ## Composable visibility masks
 
 Interactive applications rarely have one visibility predicate. A trace viewer may combine its

--- a/modules/experimental/src/gpu-primitives/gpu-indexed-range-compaction.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-indexed-range-compaction.ts
@@ -4,12 +4,19 @@
 
 import {type Binding, type Buffer, type Device} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
-import {GPUCommandGraph, type GraphBufferHandle, type GraphDataView} from './gpu-command-graph';
+import {
+  GPUCommandGraph,
+  type GraphBufferHandle,
+  type GraphDataView,
+  GraphVectorView
+} from './gpu-command-graph';
 import {GPUScan} from './gpu-scan';
 import {
+  createTransientVectorView,
   createTransientView,
   getViewBinding,
   getViewElementOffset,
+  validateMatchingVectorTopology,
   validatePackedUint32View
 } from './graph-data-view-utils';
 
@@ -57,6 +64,44 @@ export type GPUIndexedRangeCompactionResult = {
   rangeCounts: GraphDataView<'uint32'>;
   /** Exclusive selected-row offset for every range in canonical range order. */
   rangeOffsets: GraphDataView<'uint32'>;
+};
+
+/** Properties for partition-preserving candidate-driven source-index compaction. */
+export type GPUPartitionedIndexedRangeCompactionProps = {
+  /** Prefix for generated resources and graph nodes. */
+  id?: string;
+  /** Source-aligned flags split at complete range boundaries. */
+  flags: GraphVectorView<'uint32'>;
+  /** Packed source-range records shared by every partition. */
+  ranges: GraphDataView<'uint32'>;
+  /** Number of range records. */
+  rangeCount: number;
+  /** Packed range-record layout. */
+  rangeLayout: GPUIndexedRangeLayout;
+  /** Exclusive ordered range ends, one for each flags chunk. */
+  partitionRangeEnds: readonly number[];
+  /** Stable compacted IDs of active range records. */
+  activeRangeIds: GraphDataView<'uint32'>;
+  /** Indirect dispatch whose X dimension is one and Y dimension is the active range count. */
+  activeRangeDispatch: GraphBufferHandle;
+  /** Maximum number of source rows in one range. Must not exceed 256. */
+  maximumRangeLength: number;
+  /** Partitioned output with the same capacity and chunk topology as flags. */
+  output: GraphVectorView<'uint32'>;
+  /** Destination whose first row receives the total selected count. */
+  count: GraphDataView<'uint32'>;
+};
+
+/** GPU-generated partition metadata exposed to range-aware downstream consumers. */
+export type GPUPartitionedIndexedRangeCompactionResult = {
+  /** Source-aligned local offsets preserving the flags chunk topology. */
+  localOffsets: GraphVectorView<'uint32'>;
+  /** Selected row count for every canonical range. */
+  rangeCounts: GraphDataView<'uint32'>;
+  /** Partition-local exclusive selected-row offset for every canonical range. */
+  rangeOffsets: GraphDataView<'uint32'>;
+  /** Total selected row count for every output partition. */
+  partitionCounts: GraphDataView<'uint32'>;
 };
 
 /**
@@ -141,13 +186,13 @@ export class GPUIndexedRangeCompaction {
       'uint32',
       this.flags.length
     );
-    const rangeCounts = createTransientView(
+    const rangeCounts: GraphDataView<'uint32'> = createTransientView(
       graph,
       `${this.id}-range-counts`,
       'uint32',
       this.rangeCount
     );
-    const rangeOffsets = createTransientView(
+    const rangeOffsets: GraphDataView<'uint32'> = createTransientView(
       graph,
       `${this.id}-range-offsets`,
       'uint32',
@@ -165,6 +210,465 @@ export class GPUIndexedRangeCompaction {
     addCountPass(graph, this.id, rangeCounts, rangeOffsets, this.count);
     return {localOffsets, rangeCounts, rangeOffsets};
   }
+}
+
+/**
+ * Stably compacts active ranges into matching bounded output partitions.
+ *
+ * Range records remain one logical canonical index, while source flags, local scratch, and output
+ * IDs preserve caller-provided chunk boundaries. Every range must be wholly contained by the flags
+ * chunk selected by `partitionRangeEnds`. Each partition receives an independent compacted list;
+ * emitted values remain global source indices.
+ */
+export class GPUPartitionedIndexedRangeCompaction {
+  readonly id: string;
+  readonly flags: GraphVectorView<'uint32'>;
+  readonly ranges: GraphDataView<'uint32'>;
+  readonly rangeCount: number;
+  readonly rangeLayout: GPUIndexedRangeLayout;
+  readonly partitionRangeEnds: readonly number[];
+  readonly activeRangeIds: GraphDataView<'uint32'>;
+  readonly activeRangeDispatch: GraphBufferHandle;
+  readonly maximumRangeLength: number;
+  readonly output: GraphVectorView<'uint32'>;
+  readonly count: GraphDataView<'uint32'>;
+
+  constructor(props: GPUPartitionedIndexedRangeCompactionProps) {
+    this.id = props.id ?? 'gpu-partitioned-indexed-range-compaction';
+    this.flags = props.flags;
+    this.ranges = props.ranges;
+    this.rangeCount = props.rangeCount;
+    this.rangeLayout = props.rangeLayout;
+    this.partitionRangeEnds = props.partitionRangeEnds;
+    this.activeRangeIds = props.activeRangeIds;
+    this.activeRangeDispatch = props.activeRangeDispatch;
+    this.maximumRangeLength = props.maximumRangeLength;
+    this.output = props.output;
+    this.count = props.count;
+
+    for (const [name, view] of [
+      ['ranges', this.ranges],
+      ['activeRangeIds', this.activeRangeIds],
+      ['count', this.count]
+    ] as const) {
+      validatePackedUint32View(view, `${this.id} ${name}`);
+    }
+    validatePartitionedVector(this.id, 'flags', this.flags);
+    validatePartitionedVector(this.id, 'output', this.output);
+    validateMatchingVectorTopology(this.flags, this.output, `${this.id} output`);
+    validateRangeCompactionShape(this);
+    validatePartitionRangeEnds(
+      this.id,
+      this.partitionRangeEnds,
+      this.flags.data.length,
+      this.rangeCount
+    );
+  }
+
+  /** Adds partitioned local scans, bounded range scans, scatter, and count publication. */
+  addToGraph<Parameters>(
+    graph: GPUCommandGraph<Parameters>
+  ): GPUPartitionedIndexedRangeCompactionResult {
+    for (const view of [
+      ...this.flags.data,
+      this.ranges,
+      this.activeRangeIds,
+      ...this.output.data,
+      this.count
+    ]) {
+      if (view.buffer.graph !== graph) {
+        throw new Error(`${this.id} views must belong to the target graph`);
+      }
+    }
+    if (this.activeRangeDispatch.graph !== graph) {
+      throw new Error(`${this.id} activeRangeDispatch must belong to the target graph`);
+    }
+
+    const localOffsets = createTransientVectorView(graph, `${this.id}-local-offsets`, this.flags);
+    const rangeCounts: GraphDataView<'uint32'> = createTransientView(
+      graph,
+      `${this.id}-range-counts`,
+      'uint32',
+      this.rangeCount
+    );
+    const rangeOffsets: GraphDataView<'uint32'> = createTransientView(
+      graph,
+      `${this.id}-range-offsets`,
+      'uint32',
+      this.rangeCount
+    );
+    const partitionCounts: GraphDataView<'uint32'> = createTransientView(
+      graph,
+      `${this.id}-partition-counts`,
+      'uint32',
+      this.partitionRangeEnds.length
+    );
+
+    addClearRangeCountsPass(graph, this.id, rangeCounts);
+    let sourceStart = 0;
+    let rangeStart = 0;
+    for (let partitionIndex = 0; partitionIndex < this.flags.data.length; partitionIndex++) {
+      const flags = this.flags.data[partitionIndex];
+      const output = this.output.data[partitionIndex];
+      const offsets = localOffsets.data[partitionIndex];
+      const sourceEnd = sourceStart + flags.length;
+      const rangeEnd = this.partitionRangeEnds[partitionIndex];
+      addPartitionLocalScanPass(graph, this, {
+        partitionIndex,
+        sourceStart,
+        sourceEnd,
+        rangeStart,
+        rangeEnd,
+        flags,
+        localOffsets: offsets,
+        rangeCounts
+      });
+      const partitionRangeCount = rangeEnd - rangeStart;
+      const partitionRangeCounts = graph.createDataView<'uint32'>(rangeCounts.buffer, {
+        format: 'uint32',
+        length: partitionRangeCount,
+        byteOffset: rangeStart * Uint32Array.BYTES_PER_ELEMENT
+      });
+      const partitionRangeOffsets = graph.createDataView<'uint32'>(rangeOffsets.buffer, {
+        format: 'uint32',
+        length: partitionRangeCount,
+        byteOffset: rangeStart * Uint32Array.BYTES_PER_ELEMENT
+      });
+      new GPUScan({
+        id: `${this.id}-partition-${partitionIndex}-range-scan`,
+        input: partitionRangeCounts,
+        output: partitionRangeOffsets
+      }).addToGraph(graph);
+      addPartitionScatterPass(graph, this, {
+        partitionIndex,
+        sourceStart,
+        sourceEnd,
+        rangeStart,
+        rangeEnd,
+        flags,
+        localOffsets: offsets,
+        rangeOffsets,
+        output
+      });
+      sourceStart = sourceEnd;
+      rangeStart = rangeEnd;
+    }
+    addPartitionCountPass(graph, this, rangeCounts, rangeOffsets, partitionCounts);
+    return {localOffsets, rangeCounts, rangeOffsets, partitionCounts};
+  }
+}
+
+function validatePartitionedVector(
+  id: string,
+  name: string,
+  vector: GraphVectorView<'uint32'>
+): void {
+  if (!(vector instanceof GraphVectorView) || vector.format !== 'uint32') {
+    throw new Error(`${id} ${name} must be a uint32 GraphVectorView`);
+  }
+  if (vector.data.length < 1 || vector.data.some(chunk => chunk.length < 1)) {
+    throw new Error(`${id} ${name} must contain non-empty chunks`);
+  }
+  if (vector.data.length > RANGE_COMPACTION_WORKGROUP_SIZE || vector.length > 0xffffffff) {
+    throw new Error(`${id} ${name} must contain at most 256 chunks and uint32 rows`);
+  }
+  for (const chunk of vector.data) {
+    validatePackedUint32View(chunk, `${id} ${name} chunk`);
+  }
+}
+
+function validateRangeCompactionShape(
+  compaction: Pick<
+    GPUPartitionedIndexedRangeCompaction,
+    | 'id'
+    | 'ranges'
+    | 'rangeCount'
+    | 'rangeLayout'
+    | 'activeRangeIds'
+    | 'maximumRangeLength'
+    | 'count'
+  >
+): void {
+  if (
+    !Number.isSafeInteger(compaction.rangeCount) ||
+    compaction.rangeCount < 1 ||
+    compaction.rangeCount > 0xffffffff
+  ) {
+    throw new Error(`${compaction.id} rangeCount must be a positive uint32`);
+  }
+  validateRangeLayout(compaction.id, compaction.rangeLayout);
+  if (compaction.ranges.length < compaction.rangeCount * compaction.rangeLayout.wordStride) {
+    throw new Error(`${compaction.id} ranges does not contain rangeCount records`);
+  }
+  if (compaction.activeRangeIds.length < compaction.rangeCount) {
+    throw new Error(`${compaction.id} activeRangeIds must have rangeCount capacity`);
+  }
+  if (
+    !Number.isSafeInteger(compaction.maximumRangeLength) ||
+    compaction.maximumRangeLength < 1 ||
+    compaction.maximumRangeLength > RANGE_COMPACTION_WORKGROUP_SIZE
+  ) {
+    throw new Error(`${compaction.id} maximumRangeLength must be between 1 and 256`);
+  }
+  if (compaction.count.length < 1) {
+    throw new Error(`${compaction.id} count must contain one uint32 row`);
+  }
+}
+
+function validatePartitionRangeEnds(
+  id: string,
+  partitionRangeEnds: readonly number[],
+  partitionCount: number,
+  rangeCount: number
+): void {
+  if (partitionRangeEnds.length !== partitionCount) {
+    throw new Error(`${id} partitionRangeEnds must contain one end per vector chunk`);
+  }
+  let previousEnd = 0;
+  for (const rangeEnd of partitionRangeEnds) {
+    if (!Number.isSafeInteger(rangeEnd) || rangeEnd <= previousEnd || rangeEnd > rangeCount) {
+      throw new Error(`${id} partitionRangeEnds must be strictly increasing range indices`);
+    }
+    previousEnd = rangeEnd;
+  }
+  if (previousEnd !== rangeCount) {
+    throw new Error(`${id} partitionRangeEnds must terminate at rangeCount`);
+  }
+}
+
+function addPartitionLocalScanPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  compaction: GPUPartitionedIndexedRangeCompaction,
+  props: {
+    partitionIndex: number;
+    sourceStart: number;
+    sourceEnd: number;
+    rangeStart: number;
+    rangeEnd: number;
+    flags: GraphDataView<'uint32'>;
+    localOffsets: GraphDataView<'uint32'>;
+    rangeCounts: GraphDataView<'uint32'>;
+  }
+): void {
+  const {rangeLayout} = compaction;
+  const source = /* wgsl */ `
+const RANGE_START: u32 = ${props.rangeStart}u;
+const RANGE_END: u32 = ${props.rangeEnd}u;
+const SOURCE_START: u32 = ${props.sourceStart}u;
+const SOURCE_END: u32 = ${props.sourceEnd}u;
+const RANGE_WORD_STRIDE: u32 = ${rangeLayout.wordStride}u;
+const RANGE_FIRST_WORD: u32 = ${rangeLayout.firstIndexWordOffset}u;
+const RANGE_COUNT_WORD: u32 = ${rangeLayout.countWordOffset}u;
+const FLAGS_OFFSET: u32 = ${getViewElementOffset(props.flags)}u;
+const RANGES_OFFSET: u32 = ${getViewElementOffset(compaction.ranges)}u;
+const ACTIVE_RANGE_IDS_OFFSET: u32 = ${getViewElementOffset(compaction.activeRangeIds)}u;
+const LOCAL_OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.localOffsets)}u;
+const RANGE_COUNTS_OFFSET: u32 = ${getViewElementOffset(props.rangeCounts)}u;
+@group(0) @binding(0) var<storage, read> flags: array<u32>;
+@group(0) @binding(1) var<storage, read> ranges: array<u32>;
+@group(0) @binding(2) var<storage, read> activeRangeIds: array<u32>;
+@group(0) @binding(3) var<storage, read_write> localOffsets: array<u32>;
+@group(0) @binding(4) var<storage, read_write> rangeCounts: array<u32>;
+var<workgroup> prefixes: array<u32, ${RANGE_COMPACTION_WORKGROUP_SIZE}>;
+
+@compute @workgroup_size(${RANGE_COMPACTION_WORKGROUP_SIZE})
+fn main(
+  @builtin(local_invocation_id) localId: vec3<u32>,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  let rangeId = activeRangeIds[ACTIVE_RANGE_IDS_OFFSET + workgroupId.y];
+  if (rangeId < RANGE_START || rangeId >= RANGE_END) {
+    return;
+  }
+  let recordOffset = RANGES_OFFSET + rangeId * RANGE_WORD_STRIDE;
+  let firstIndex = ranges[recordOffset + RANGE_FIRST_WORD];
+  let elementCount = ranges[recordOffset + RANGE_COUNT_WORD];
+  if (firstIndex < SOURCE_START || firstIndex + elementCount > SOURCE_END) {
+    return;
+  }
+  let localIndex = localId.x;
+  let chunkIndex = firstIndex - SOURCE_START + localIndex;
+  var selected = 0u;
+  if (localIndex < elementCount && flags[FLAGS_OFFSET + chunkIndex] != 0u) {
+    selected = 1u;
+  }
+  prefixes[localIndex] = selected;
+  workgroupBarrier();
+
+  var step = 1u;
+  loop {
+    if (step >= ${RANGE_COMPACTION_WORKGROUP_SIZE}u) {
+      break;
+    }
+    var addend = 0u;
+    if (localIndex >= step) {
+      addend = prefixes[localIndex - step];
+    }
+    workgroupBarrier();
+    prefixes[localIndex] += addend;
+    workgroupBarrier();
+    step *= 2u;
+  }
+
+  if (localIndex < elementCount) {
+    localOffsets[LOCAL_OFFSETS_OFFSET + chunkIndex] = prefixes[localIndex] - selected;
+  }
+  if (localIndex == 0u) {
+    var selectedCount = 0u;
+    if (elementCount != 0u) {
+      selectedCount = prefixes[elementCount - 1u];
+    }
+    rangeCounts[RANGE_COUNTS_OFFSET + rangeId] = selectedCount;
+  }
+}`;
+  addIndirectPass(graph, {
+    id: `${compaction.id}-partition-${props.partitionIndex}-local-scan`,
+    source,
+    views: {
+      flags: props.flags,
+      ranges: compaction.ranges,
+      activeRangeIds: compaction.activeRangeIds,
+      localOffsets: props.localOffsets,
+      rangeCounts: props.rangeCounts
+    },
+    resources: [
+      {buffer: props.flags, usage: 'storage-read'},
+      {buffer: compaction.ranges, usage: 'storage-read'},
+      {buffer: compaction.activeRangeIds, usage: 'storage-read'},
+      {buffer: props.localOffsets, usage: 'storage-write'},
+      {buffer: props.rangeCounts, usage: 'storage-write'}
+    ],
+    dispatchBuffer: compaction.activeRangeDispatch
+  });
+}
+
+function addPartitionScatterPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  compaction: GPUPartitionedIndexedRangeCompaction,
+  props: {
+    partitionIndex: number;
+    sourceStart: number;
+    sourceEnd: number;
+    rangeStart: number;
+    rangeEnd: number;
+    flags: GraphDataView<'uint32'>;
+    localOffsets: GraphDataView<'uint32'>;
+    rangeOffsets: GraphDataView<'uint32'>;
+    output: GraphDataView<'uint32'>;
+  }
+): void {
+  const {rangeLayout} = compaction;
+  const source = /* wgsl */ `
+const RANGE_START: u32 = ${props.rangeStart}u;
+const RANGE_END: u32 = ${props.rangeEnd}u;
+const SOURCE_START: u32 = ${props.sourceStart}u;
+const SOURCE_END: u32 = ${props.sourceEnd}u;
+const RANGE_WORD_STRIDE: u32 = ${rangeLayout.wordStride}u;
+const RANGE_FIRST_WORD: u32 = ${rangeLayout.firstIndexWordOffset}u;
+const RANGE_COUNT_WORD: u32 = ${rangeLayout.countWordOffset}u;
+const FLAGS_OFFSET: u32 = ${getViewElementOffset(props.flags)}u;
+const RANGES_OFFSET: u32 = ${getViewElementOffset(compaction.ranges)}u;
+const ACTIVE_RANGE_IDS_OFFSET: u32 = ${getViewElementOffset(compaction.activeRangeIds)}u;
+const LOCAL_OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.localOffsets)}u;
+const RANGE_OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.rangeOffsets)}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
+@group(0) @binding(0) var<storage, read> flags: array<u32>;
+@group(0) @binding(1) var<storage, read> ranges: array<u32>;
+@group(0) @binding(2) var<storage, read> activeRangeIds: array<u32>;
+@group(0) @binding(3) var<storage, read> localOffsets: array<u32>;
+@group(0) @binding(4) var<storage, read> rangeOffsets: array<u32>;
+@group(0) @binding(5) var<storage, read_write> outputIds: array<u32>;
+
+@compute @workgroup_size(${RANGE_COMPACTION_WORKGROUP_SIZE})
+fn main(
+  @builtin(local_invocation_id) localId: vec3<u32>,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  let rangeId = activeRangeIds[ACTIVE_RANGE_IDS_OFFSET + workgroupId.y];
+  if (rangeId < RANGE_START || rangeId >= RANGE_END) {
+    return;
+  }
+  let recordOffset = RANGES_OFFSET + rangeId * RANGE_WORD_STRIDE;
+  let firstIndex = ranges[recordOffset + RANGE_FIRST_WORD];
+  let elementCount = ranges[recordOffset + RANGE_COUNT_WORD];
+  if (firstIndex < SOURCE_START || firstIndex + elementCount > SOURCE_END ||
+      localId.x >= elementCount) {
+    return;
+  }
+  let chunkIndex = firstIndex - SOURCE_START + localId.x;
+  if (flags[FLAGS_OFFSET + chunkIndex] != 0u) {
+    let outputIndex = rangeOffsets[RANGE_OFFSETS_OFFSET + rangeId] +
+      localOffsets[LOCAL_OFFSETS_OFFSET + chunkIndex];
+    outputIds[OUTPUT_OFFSET + outputIndex] = firstIndex + localId.x;
+  }
+}`;
+  addIndirectPass(graph, {
+    id: `${compaction.id}-partition-${props.partitionIndex}-scatter`,
+    source,
+    views: {
+      flags: props.flags,
+      ranges: compaction.ranges,
+      activeRangeIds: compaction.activeRangeIds,
+      localOffsets: props.localOffsets,
+      rangeOffsets: props.rangeOffsets,
+      outputIds: props.output
+    },
+    resources: [
+      {buffer: props.flags, usage: 'storage-read'},
+      {buffer: compaction.ranges, usage: 'storage-read'},
+      {buffer: compaction.activeRangeIds, usage: 'storage-read'},
+      {buffer: props.localOffsets, usage: 'storage-read'},
+      {buffer: props.rangeOffsets, usage: 'storage-read'},
+      {buffer: props.output, usage: 'storage-write'}
+    ],
+    dispatchBuffer: compaction.activeRangeDispatch
+  });
+}
+
+function addPartitionCountPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  compaction: GPUPartitionedIndexedRangeCompaction,
+  rangeCounts: GraphDataView<'uint32'>,
+  rangeOffsets: GraphDataView<'uint32'>,
+  partitionCounts: GraphDataView<'uint32'>
+): void {
+  const rangeEnds = compaction.partitionRangeEnds.map(rangeEnd => `${rangeEnd}u`).join(', ');
+  const source = /* wgsl */ `
+const PARTITION_COUNT: u32 = ${compaction.partitionRangeEnds.length}u;
+const RANGE_ENDS = array<u32, ${compaction.partitionRangeEnds.length}>(${rangeEnds});
+const RANGE_COUNTS_OFFSET: u32 = ${getViewElementOffset(rangeCounts)}u;
+const RANGE_OFFSETS_OFFSET: u32 = ${getViewElementOffset(rangeOffsets)}u;
+const PARTITION_COUNTS_OFFSET: u32 = ${getViewElementOffset(partitionCounts)}u;
+const COUNT_OFFSET: u32 = ${getViewElementOffset(compaction.count)}u;
+@group(0) @binding(0) var<storage, read> rangeCounts: array<u32>;
+@group(0) @binding(1) var<storage, read> rangeOffsets: array<u32>;
+@group(0) @binding(2) var<storage, read_write> partitionCounts: array<u32>;
+@group(0) @binding(3) var<storage, read_write> outputCount: array<u32>;
+
+@compute @workgroup_size(1)
+fn main() {
+  var totalCount = 0u;
+  for (var partitionIndex = 0u; partitionIndex < PARTITION_COUNT; partitionIndex++) {
+    let lastRangeIndex = RANGE_ENDS[partitionIndex] - 1u;
+    let partitionCount = rangeOffsets[RANGE_OFFSETS_OFFSET + lastRangeIndex] +
+      rangeCounts[RANGE_COUNTS_OFFSET + lastRangeIndex];
+    partitionCounts[PARTITION_COUNTS_OFFSET + partitionIndex] = partitionCount;
+    totalCount += partitionCount;
+  }
+  outputCount[COUNT_OFFSET] = totalCount;
+}`;
+  addDirectPass(graph, {
+    id: `${compaction.id}-publish-counts`,
+    source,
+    views: {rangeCounts, rangeOffsets, partitionCounts, outputCount: compaction.count},
+    resources: [
+      {buffer: rangeCounts, usage: 'storage-read'},
+      {buffer: rangeOffsets, usage: 'storage-read'},
+      {buffer: partitionCounts, usage: 'storage-write'},
+      {buffer: compaction.count, usage: 'storage-write'}
+    ],
+    dispatchCount: 1
+  });
 }
 
 function validateRangeLayout(id: string, layout: GPUIndexedRangeLayout): void {

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -72,11 +72,16 @@ export {GPUScan} from './gpu-scan';
 export type {GPUScanInput, GPUScanProps} from './gpu-scan';
 export {GPUCompaction} from './gpu-compaction';
 export type {GPUCompactionInput, GPUCompactionProps} from './gpu-compaction';
-export {GPUIndexedRangeCompaction} from './gpu-indexed-range-compaction';
+export {
+  GPUIndexedRangeCompaction,
+  GPUPartitionedIndexedRangeCompaction
+} from './gpu-indexed-range-compaction';
 export type {
   GPUIndexedRangeCompactionProps,
   GPUIndexedRangeCompactionResult,
-  GPUIndexedRangeLayout
+  GPUIndexedRangeLayout,
+  GPUPartitionedIndexedRangeCompactionProps,
+  GPUPartitionedIndexedRangeCompactionResult
 } from './gpu-indexed-range-compaction';
 export {GPUChunkedIndexedScatter} from './gpu-chunked-indexed-scatter';
 export type {

--- a/modules/experimental/test/gpu-primitives/gpu-partitioned-indexed-range-compaction.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-partitioned-indexed-range-compaction.node.spec.ts
@@ -1,0 +1,143 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer} from '@luma.gl/core';
+import {
+  GPUCommandGraph,
+  GPUPartitionedIndexedRangeCompaction,
+  GraphVectorView
+} from '@luma.gl/experimental';
+import {NullDevice} from '@luma.gl/test-utils';
+import {describe, expect, test, vi} from 'vitest';
+
+describe('GPUPartitionedIndexedRangeCompaction graph construction', () => {
+  test('preserves source partitions through local range compaction', () => {
+    const fixture = createCompactionFixture();
+    const addComputePass = vi.spyOn(fixture.graph, 'addComputePass');
+
+    try {
+      const result = fixture.compaction.addToGraph(fixture.graph);
+      expect(addComputePass.mock.calls.map(([pass]) => pass.id)).toEqual([
+        'visible-clear-range-counts',
+        'visible-partition-0-local-scan',
+        'visible-partition-0-range-scan-level-0-scan',
+        'visible-partition-0-scatter',
+        'visible-partition-1-local-scan',
+        'visible-partition-1-range-scan-level-0-scan',
+        'visible-partition-1-scatter',
+        'visible-publish-counts'
+      ]);
+      expect(result.localOffsets.data.map(chunk => chunk.length)).toEqual([6, 5]);
+      expect(result.rangeCounts.length).toBe(4);
+      expect(result.rangeOffsets.length).toBe(4);
+      expect(result.partitionCounts.length).toBe(2);
+    } finally {
+      addComputePass.mockRestore();
+      fixture.device.destroy();
+    }
+  });
+
+  test('requires matching bounded chunks and complete range partitions', () => {
+    const fixture = createCompactionFixture();
+    const props = {
+      flags: fixture.compaction.flags,
+      ranges: fixture.compaction.ranges,
+      rangeCount: fixture.compaction.rangeCount,
+      rangeLayout: fixture.compaction.rangeLayout,
+      partitionRangeEnds: fixture.compaction.partitionRangeEnds,
+      activeRangeIds: fixture.compaction.activeRangeIds,
+      activeRangeDispatch: fixture.compaction.activeRangeDispatch,
+      maximumRangeLength: fixture.compaction.maximumRangeLength,
+      output: fixture.compaction.output,
+      count: fixture.compaction.count
+    };
+
+    try {
+      expect(
+        () =>
+          new GPUPartitionedIndexedRangeCompaction({
+            ...props,
+            partitionRangeEnds: [2]
+          })
+      ).toThrow(/one end per vector chunk/i);
+      expect(
+        () =>
+          new GPUPartitionedIndexedRangeCompaction({
+            ...props,
+            partitionRangeEnds: [2, 3]
+          })
+      ).toThrow(/terminate at rangeCount/i);
+      expect(
+        () =>
+          new GPUPartitionedIndexedRangeCompaction({
+            ...props,
+            output: createVector(fixture.graph, 'mismatched-output', [5, 6])
+          })
+      ).toThrow(/same chunk topology/i);
+    } finally {
+      fixture.device.destroy();
+    }
+  });
+});
+
+function createCompactionFixture(): {
+  device: NullDevice;
+  graph: GPUCommandGraph;
+  compaction: GPUPartitionedIndexedRangeCompaction;
+} {
+  const device = new NullDevice({id: 'partitioned-range-compaction-node-device'});
+  Object.defineProperty(device, 'type', {value: 'webgpu'});
+  Object.defineProperty(device, 'limits', {
+    value: {...device.limits, maxComputeWorkgroupsPerDimension: 65_535}
+  });
+  const graph = new GPUCommandGraph(device, {id: 'partitioned-range-compaction-node-graph'});
+  const compaction = new GPUPartitionedIndexedRangeCompaction({
+    id: 'visible',
+    flags: createVector(graph, 'flags', [6, 5]),
+    ranges: createView(graph, 'ranges', 8),
+    rangeCount: 4,
+    rangeLayout: {wordStride: 2, firstIndexWordOffset: 0, countWordOffset: 1},
+    partitionRangeEnds: [2, 4],
+    activeRangeIds: createView(graph, 'active-range-ids', 4),
+    activeRangeDispatch: graph.createTransientBuffer({
+      id: 'active-range-dispatch',
+      byteLength: 3 * Uint32Array.BYTES_PER_ELEMENT,
+      usage: Buffer.STORAGE | Buffer.INDIRECT
+    }),
+    maximumRangeLength: 4,
+    output: createVector(graph, 'output', [6, 5]),
+    count: createView(graph, 'count', 1)
+  });
+  return {device, graph, compaction};
+}
+
+function createVector(
+  graph: GPUCommandGraph,
+  id: string,
+  chunkLengths: readonly number[]
+): GraphVectorView<'uint32'> {
+  const data = chunkLengths.map((length, chunkIndex) =>
+    createView(graph, `${id}-${chunkIndex}`, length)
+  );
+  return new GraphVectorView({
+    id,
+    name: id,
+    format: 'uint32',
+    length: chunkLengths.reduce((sum, length) => sum + length, 0),
+    valueLength: chunkLengths.reduce((sum, length) => sum + length, 0),
+    stride: 1,
+    byteStride: Uint32Array.BYTES_PER_ELEMENT,
+    rowByteLength: Uint32Array.BYTES_PER_ELEMENT,
+    data
+  });
+}
+
+function createView(graph: GPUCommandGraph, id: string, length: number) {
+  const buffer = graph.createTransientBuffer({
+    id,
+    byteLength: Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE
+  });
+  return graph.createDataView(buffer, {format: 'uint32', length});
+}

--- a/modules/experimental/test/gpu-primitives/gpu-partitioned-indexed-range-compaction.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-partitioned-indexed-range-compaction.spec.ts
@@ -22,24 +22,12 @@ test('GPUPartitionedIndexedRangeCompaction keeps visible IDs in bounded chunks',
 
   const resources: Buffer[] = [];
   const graph = new GPUCommandGraph(device, {id: 'partitioned-range-compaction-graph'});
-  const flags = createImportedVector(
-    graph,
-    device,
-    resources,
-    'flags',
-    [
-      [1, 0, 1, 0, 1, 1],
-      [0, 1, 1, 0, 1]
-    ]
-  );
+  const flags = createImportedVector(graph, device, resources, 'flags', [
+    [1, 0, 1, 0, 1, 1],
+    [0, 1, 1, 0, 1]
+  ]);
   const output = createOutputVector(graph, device, resources, 'output', [6, 5]);
-  const ranges = createImportedView(
-    graph,
-    device,
-    resources,
-    'ranges',
-    [0, 3, 3, 3, 6, 2, 8, 3]
-  );
+  const ranges = createImportedView(graph, device, resources, 'ranges', [0, 3, 3, 3, 6, 2, 8, 3]);
   const activeRangeIdsResource = createImportedBuffer(
     graph,
     device,
@@ -84,7 +72,11 @@ test('GPUPartitionedIndexedRangeCompaction keeps visible IDs in bounded chunks',
     await encodeAndSubmit(device, compiled, 'partitioned-range-compaction-subset');
     t.deepEqual(await readUint32(output.buffers[0], 2), [4, 5], 'first candidate partition');
     t.deepEqual(await readUint32(output.buffers[1], 2), [8, 10], 'second candidate partition');
-    t.deepEqual(await readUint32(count.buffer, 1), [4], 'GPU candidate changes avoid recompilation');
+    t.deepEqual(
+      await readUint32(count.buffer, 1),
+      [4],
+      'GPU candidate changes avoid recompilation'
+    );
   } finally {
     compiled.destroy();
     for (const resource of resources) resource.destroy();
@@ -168,7 +160,11 @@ function createImportedBuffer(
     {id, byteLength: buffer.byteLength, usage: buffer.usage},
     buffer
   );
-  return {buffer, handle, view: graph.createDataView(handle, {format: 'uint32', length: values.length})};
+  return {
+    buffer,
+    handle,
+    view: graph.createDataView(handle, {format: 'uint32', length: values.length})
+  };
 }
 
 function createOutputView(

--- a/modules/experimental/test/gpu-primitives/gpu-partitioned-indexed-range-compaction.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-partitioned-indexed-range-compaction.spec.ts
@@ -1,0 +1,206 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {
+  GPUCommandGraph,
+  GPUPartitionedIndexedRangeCompaction,
+  GraphVectorView,
+  type GraphDataView
+} from '@luma.gl/experimental';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import test from 'test/utils/vitest-tape';
+
+test('GPUPartitionedIndexedRangeCompaction keeps visible IDs in bounded chunks', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const resources: Buffer[] = [];
+  const graph = new GPUCommandGraph(device, {id: 'partitioned-range-compaction-graph'});
+  const flags = createImportedVector(
+    graph,
+    device,
+    resources,
+    'flags',
+    [
+      [1, 0, 1, 0, 1, 1],
+      [0, 1, 1, 0, 1]
+    ]
+  );
+  const output = createOutputVector(graph, device, resources, 'output', [6, 5]);
+  const ranges = createImportedView(
+    graph,
+    device,
+    resources,
+    'ranges',
+    [0, 3, 3, 3, 6, 2, 8, 3]
+  );
+  const activeRangeIdsResource = createImportedBuffer(
+    graph,
+    device,
+    resources,
+    'active-range-ids',
+    [0, 1, 2, 3],
+    Buffer.STORAGE | Buffer.COPY_DST
+  );
+  const activeRangeDispatch = createImportedBuffer(
+    graph,
+    device,
+    resources,
+    'active-range-dispatch',
+    [1, 4, 1],
+    Buffer.STORAGE | Buffer.INDIRECT | Buffer.COPY_DST
+  );
+  const count = createOutputView(graph, device, resources, 'count', 1);
+  const compaction = new GPUPartitionedIndexedRangeCompaction({
+    id: 'visible',
+    flags,
+    ranges,
+    rangeCount: 4,
+    rangeLayout: {wordStride: 2, firstIndexWordOffset: 0, countWordOffset: 1},
+    partitionRangeEnds: [2, 4],
+    activeRangeIds: activeRangeIdsResource.view,
+    activeRangeDispatch: activeRangeDispatch.handle,
+    maximumRangeLength: 3,
+    output: output.view,
+    count: count.view
+  });
+  compaction.addToGraph(graph);
+  const compiled = graph.compile();
+
+  try {
+    await encodeAndSubmit(device, compiled, 'partitioned-range-compaction-all');
+    t.deepEqual(await readUint32(output.buffers[0], 4), [0, 2, 4, 5], 'first output chunk');
+    t.deepEqual(await readUint32(output.buffers[1], 3), [7, 8, 10], 'second output chunk');
+    t.deepEqual(await readUint32(count.buffer, 1), [7], 'total selected count');
+
+    activeRangeIdsResource.buffer.write(Uint32Array.from([1, 3, 2, 0]));
+    activeRangeDispatch.buffer.write(Uint32Array.from([1, 2, 1]));
+    await encodeAndSubmit(device, compiled, 'partitioned-range-compaction-subset');
+    t.deepEqual(await readUint32(output.buffers[0], 2), [4, 5], 'first candidate partition');
+    t.deepEqual(await readUint32(output.buffers[1], 2), [8, 10], 'second candidate partition');
+    t.deepEqual(await readUint32(count.buffer, 1), [4], 'GPU candidate changes avoid recompilation');
+  } finally {
+    compiled.destroy();
+    for (const resource of resources) resource.destroy();
+  }
+
+  t.end();
+});
+
+function createImportedVector(
+  graph: GPUCommandGraph,
+  device: Device,
+  resources: Buffer[],
+  id: string,
+  chunks: readonly (readonly number[])[]
+): GraphVectorView<'uint32'> {
+  const data = chunks.map((chunk, chunkIndex) =>
+    createImportedView(graph, device, resources, `${id}-${chunkIndex}`, chunk)
+  );
+  const length = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  return new GraphVectorView({
+    id,
+    name: id,
+    format: 'uint32',
+    length,
+    valueLength: length,
+    stride: 1,
+    byteStride: Uint32Array.BYTES_PER_ELEMENT,
+    rowByteLength: Uint32Array.BYTES_PER_ELEMENT,
+    data
+  });
+}
+
+function createOutputVector(
+  graph: GPUCommandGraph,
+  device: Device,
+  resources: Buffer[],
+  id: string,
+  chunkLengths: readonly number[]
+): {buffers: Buffer[]; view: GraphVectorView<'uint32'>} {
+  const outputs = chunkLengths.map((length, chunkIndex) =>
+    createOutputView(graph, device, resources, `${id}-${chunkIndex}`, length)
+  );
+  const length = chunkLengths.reduce((sum, chunkLength) => sum + chunkLength, 0);
+  return {
+    buffers: outputs.map(output => output.buffer),
+    view: new GraphVectorView({
+      id,
+      name: id,
+      format: 'uint32',
+      length,
+      valueLength: length,
+      stride: 1,
+      byteStride: Uint32Array.BYTES_PER_ELEMENT,
+      rowByteLength: Uint32Array.BYTES_PER_ELEMENT,
+      data: outputs.map(output => output.view)
+    })
+  };
+}
+
+function createImportedView(
+  graph: GPUCommandGraph,
+  device: Device,
+  resources: Buffer[],
+  id: string,
+  values: readonly number[]
+): GraphDataView<'uint32'> {
+  return createImportedBuffer(graph, device, resources, id, values, Buffer.STORAGE).view;
+}
+
+function createImportedBuffer(
+  graph: GPUCommandGraph,
+  device: Device,
+  resources: Buffer[],
+  id: string,
+  values: readonly number[],
+  usage: number
+): {buffer: Buffer; handle: GraphDataView<'uint32'>['buffer']; view: GraphDataView<'uint32'>} {
+  const buffer = device.createBuffer({data: Uint32Array.from(values), usage});
+  resources.push(buffer);
+  const handle = graph.importBuffer(
+    {id, byteLength: buffer.byteLength, usage: buffer.usage},
+    buffer
+  );
+  return {buffer, handle, view: graph.createDataView(handle, {format: 'uint32', length: values.length})};
+}
+
+function createOutputView(
+  graph: GPUCommandGraph,
+  device: Device,
+  resources: Buffer[],
+  id: string,
+  length: number
+): {buffer: Buffer; view: GraphDataView<'uint32'>} {
+  const buffer = device.createBuffer({
+    byteLength: Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  resources.push(buffer);
+  const handle = graph.importBuffer(
+    {id, byteLength: buffer.byteLength, usage: buffer.usage},
+    buffer
+  );
+  return {buffer, view: graph.createDataView(handle, {format: 'uint32', length})};
+}
+
+async function encodeAndSubmit(
+  device: Device,
+  compiled: ReturnType<GPUCommandGraph<void>['compile']>,
+  id: string
+): Promise<void> {
+  const commandEncoder = device.createCommandEncoder({id});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+}
+
+async function readUint32(buffer: Buffer, length: number): Promise<number[]> {
+  const bytes = await buffer.readAsync(0, Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT);
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, length));
+}


### PR DESCRIPTION
## What changed

- add `GPUPartitionedIndexedRangeCompaction` for candidate-driven compaction into bounded GPU vector chunks
- preserve global source IDs while publishing per-partition and total GPU-resident counts
- add graph-construction and WebGPU execution coverage
- document the partitioned visibility use case

## Why

The trace viewer now chunks source span records, but visibility flags and compacted visible IDs still require monolithic storage buffers. This reusable primitive establishes the partition-preserving compaction substrate needed to remove that ceiling and continue toward 100M-span traces.

## Validation

- focused graph-construction tests: 2 passed
- focused WebGPU fixture: 1 passed/skipped when WebGPU is unavailable
- `git diff --check`
- touched files formatted with the repository Biome settings

The full repository Yarn gates could not run locally because this isolated worktree has no Yarn install state; CI is the authoritative full gate.