### PR TITLE
docs(effects): add complete interactive shader-pass catalog

### DIFF
--- a/docs/api-guide/shaders/shader-passes.md
+++ b/docs/api-guide/shaders/shader-passes.md
@@ -280,12 +280,21 @@ to explicitly trade edge quality for fewer shaded pixels and smaller history tex
 4. Apply the adapted exposure to HDR scene color or visualize luminance as a false-color heat map.
 
 Pair it with `createBloomShaderPassPipeline()`, which extracts HDR highlights at half resolution,
-then progressively filters, blurs, and reconstructs two to five `rgba16float` pyramid levels.
+then progressively filters and reconstructs two to five `rgba16float` pyramid levels.
 `quality: 'ultra'` reaches one-thirty-second resolution. `resolutionScale` controls the entire
-pyramid without clamping highlight radiance to 8-bit normalized color. `exposure` and
-`exposureCompensation` keep highlight thresholds aligned with camera adaptation, while
-`reconstruction: 'bicubic'` selects a normalized four-fetch B-spline instead of the default
-nine-tap tent.
+pyramid without clamping highlight radiance to 8-bit normalized color. The pipeline supports:
+
+- Exposure-aware highlight thresholds, soft knees, isolated-highlight suppression, configurable
+  scatter, tint, and horizontal or vertical anamorphic stretching.
+- Separable Gaussian blur or `blurAlgorithm: 'dual-kawase'`, which reconstructs the downsampled
+  pyramid without the separate Gaussian passes.
+- Normalized tent reconstruction or `reconstruction: 'bicubic'`, which uses four bilinear
+  samples for a B-spline reconstruction.
+- `energyConserving: true` for thresholdless normalized scattering instead of additive glow.
+- Optional lens dirt, chromatic ghosts, radial halos, and aperture-diffraction starbursts.
+- Neighborhood-clamped temporal history, optional motion/depth reprojection, disocclusion
+  rejection, and exposure-corrected history.
+- WebGPU compute downsampling with automatic WebGL and unsupported-device render-pass fallback.
 
 `downsample: 'auto'` fuses extraction and the complete downsampling pyramid into one WebGPU
 compute dispatch when the chosen format supports storage writes and the device has enough storage
@@ -293,12 +302,15 @@ bindings. `downsample: 'render'` forces the portable fragment implementation. Ex
 textures are reused for reconstruction by default; set `reuseRenderTargets: false` to retain
 separate allocations for inspection.
 
-| Quality | Portable render passes | WebGPU fused work | Physical targets with reuse |
-| --- | --- | --- | --- |
-| `low` | 8 | 6 render + 1 compute | 6 |
-| `medium` | 12 | 9 render + 1 compute | 9 |
-| `high` | 16 | 12 render + 1 compute | 12 |
-| `ultra` | 20 | 15 render + 1 compute | 15 |
+| Quality | Levels | Gaussian portable | Gaussian WebGPU | Dual-Kawase portable | Dual-Kawase WebGPU |
+| --- | --- | --- | --- | --- | --- |
+| `low` | 2 | 8 render | 6 render + 1 compute | 4 render | 2 render + 1 compute |
+| `medium` | 3 | 12 render | 9 render + 1 compute | 6 render | 3 render + 1 compute |
+| `high` | 4 | 16 render | 12 render + 1 compute | 8 render | 4 render + 1 compute |
+| `ultra` | 5 | 20 render | 15 render + 1 compute | 10 render | 5 render + 1 compute |
+
+These counts describe bloom-pipeline work only; optional lens/history passes and renderer
+source-seeding or presentation passes are additional.
 
 Enable optional photographic optics through `lens`: aperture-diffraction starbursts, mirrored
 chromatic ghosts, and radial halos share one extra half-resolution pass. `lens.dirtIntensity`
@@ -307,12 +319,44 @@ no pass or intermediate render target. Pass that mask through
 `renderer.renderToScreen({sourceTexture, bindings: {lensDirtTexture}})`.
 
 `temporalStability` enables neighborhood-clamped, persistent half-resolution glow history for one
-additional pass. The default configuration allocates neither history nor lens artifacts. Screen-space
-diffraction costs eight samples per ray, while each ghost costs one sample or three when chromatic
-aberration is enabled. Applications that require true aperture convolution can instead use
-`GPUConvolutionBloom` from `@luma.gl/experimental`, which performs independent RGB FFT transforms,
-caches an energy-normalized point-spread spectrum, and exposes exact memory/dispatch costs through
-`stats`. Use the HDR order: temporal effects, auto exposure, bloom, then tone mapping.
+additional pass. `temporalReprojection: true` additionally consumes caller-provided
+`velocityTexture` and `depthTexture` bindings, rejects disocclusions, and stores previous depth in
+the existing history alpha channel. `previousExposure` corrects history when exposure changes.
+The default configuration allocates neither history nor lens artifacts. Screen-space diffraction
+costs eight samples per ray, while each ghost costs one sample or three when chromatic aberration
+is enabled.
+
+For full-kernel optical convolution, `GPUConvolutionBloom` from `@luma.gl/experimental` provides a
+separate WebGPU implementation. It accepts generated or measured point-spread functions, including
+independent red, green, and blue kernels; packs those channels into one forward and one inverse FFT
+schedule; and uses zero-padded guard bands to prevent opposite-edge wraparound. Optional lens
+artifacts, sampled dirt, and temporal history execute in its existing final compute pass. An
+optional GPU-resident exposure texture supplies adapted exposure without CPU readback. At
+1920 x 1080 with quarter-resolution sampling and the default 12.5% guard band, the FFT uses a
+1024 x 512 transform, 48 MiB of complex buffers, and 45 steady-state compute dispatches.
+Disabling the guard band reduces that configuration to a 512 x 512 transform, 24 MiB, and
+43 dispatches while removing edge-wrap protection. Changing the optical kernel adds
+21 initialization dispatches for the guarded configuration.
+
+Keep bloom in linear floating-point scene color before tone mapping. The stock deck.gl
+`PostProcessEffect` accepts shader-pass modules, but does not execute named-target
+`ShaderPassPipeline` graphs or the WebGPU FFT renderer. Its current intermediate buffers default
+to `rgba8unorm`, so an integration requiring unclamped HDR highlights must first arrange
+floating-point scene/postprocessing targets.
+
+Related technical references:
+
+- [Unreal Engine bloom documentation](https://dev.epicgames.com/documentation/en-us/unreal-engine/bloom-in-unreal-engine)
+  documents FFT convolution, image-defined optical kernels, energy conservation, lens dirt, and
+  edge-padding controls.
+- [AMD FidelityFX Single Pass Downsampler](https://gpuopen.com/manuals/fidelityfx_sdk/techniques/single-pass-downsampler/)
+  describes workgroup-local image reduction in a single compute dispatch.
+- [Google Filament imaging pipeline](https://google.github.io/filament/main/filament.html)
+  documents camera exposure, scene-linear bloom, and processing before tone mapping.
+- [deck.gl PostProcessEffect](https://deck.gl/docs/api-reference/core/post-process-effect)
+  documents deck.gl's existing shader-module postprocessing interface.
+
+Use the HDR order: temporal effects, auto exposure, bloom, then tone mapping.
 
 ### Recommended ordering
 

--- a/docs/api-reference/shadertools/shader-passes/bloom.mdx
+++ b/docs/api-reference/shadertools/shader-passes/bloom.mdx
@@ -1,0 +1,146 @@
+import {BloomExample} from '@site/src/examples';
+
+# Bloom
+
+Spread bright scene highlights into a controllable photographic glow. luma.gl provides a compact
+single-pass bloom effect, a composable HDR multiscale pipeline, and a separate WebGPU FFT
+convolution renderer for measured or generated optical point-spread functions.
+
+<BloomExample embedded showStats={false} />
+
+## At a Glance
+
+| Implementation | Export | Backends | Suitable for |
+| --- | --- | --- | --- |
+| Compact bloom | `bloom` from `@luma.gl/effects` | WebGPU and WebGL2 | A single inexpensive highlight-glow pass. |
+| Multiscale HDR bloom | `createBloomShaderPassPipeline` from `@luma.gl/effects` | WebGPU and WebGL2 | Configurable HDR scattering, temporal stabilization, and photographic lens effects. |
+| FFT optical convolution | `GPUConvolutionBloom` from `@luma.gl/experimental` | WebGPU | Full-image generated or measured RGB lens-response kernels. |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {createBloomShaderPassPipeline, toneMapping} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  colorFormat: 'rgba16float',
+  shaderPasses: [
+    createBloomShaderPassPipeline({
+      quality: 'high',
+      blurAlgorithm: 'dual-kawase',
+      downsample: 'auto',
+      threshold: 0.8,
+      intensity: 1,
+      scatter: 0.55,
+      reconstruction: 'bicubic',
+      temporalStability: 0.75,
+      lens: {starburstIntensity: 0.3, ghostIntensity: 0.15, dirtIntensity: 0.2}
+    }),
+    toneMapping
+  ]
+});
+
+renderer.renderToScreen({
+  sourceTexture: hdrSceneTexture,
+  bindings: {lensDirtTexture}
+});
+```
+
+For the compact implementation, place `bloom` directly in the `shaderPasses` array and provide
+`uniforms: {bloom: {radius: 4, threshold: 0.8, intensity: 1}}` when rendering.
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `quality` | `'high'` | Pyramid depth: `low`, `medium`, `high`, and `ultra` create two through five levels. |
+| `radius` | `8` | Blur radius for the configurable HDR pipeline; compact `bloom` defaults to `4`. |
+| `threshold` | `0.8` | Scene-referred luminance at which highlights begin contributing to glow. |
+| `intensity` | `1` | Strength of the reconstructed bloom contribution. |
+| `scatter` | `0.55` | Relative contribution from progressively wider pyramid levels. |
+| `softKnee` | `0.5` | Width of the smooth highlight-threshold transition. |
+| `blurAlgorithm` | `'gaussian'` | Separable Gaussian filtering or the lower-pass-count `'dual-kawase'` pyramid. |
+| `reconstruction` | `'tent'` | Normalized tent filtering or four-bilinear-fetch `'bicubic'` reconstruction. |
+| `downsample` | `'auto'` | Select fused WebGPU compute when available; `'render'` forces portable fragment stages. |
+| `resolutionScale` | `1` | Multiplier applied to every extraction and reconstruction target. |
+| `fireflyReduction` | `0` | Suppression strength for isolated, unusually bright source samples. |
+| `anamorphicRatio` | `0` | Horizontal or vertical stretching, clamped between `-1` and `1`. |
+| `energyConserving` | `false` | Replace additive thresholded glow with normalized, thresholdless scene scattering. |
+| `temporalStability` | `0` | Contribution from neighborhood-clamped persistent glow history. |
+| `reuseRenderTargets` | `true` | Reuse expired extraction targets for compatible reconstruction stages. |
+
+`exposure`, `exposureCompensation`, `previousExposure`, `tint`, `temporalReprojection`, and
+`temporalDepthThreshold` provide additional control over camera response and motion-aware history.
+The default intermediate format is `rgba16float` to preserve unclamped highlight energy.
+
+## Performance by Quality
+
+| Quality | Pyramid levels | Gaussian portable | Gaussian WebGPU | Dual-Kawase portable | Dual-Kawase WebGPU |
+| --- | --- | --- | --- | --- | --- |
+| `low` | `2` | 8 render passes | 6 render + 1 compute | 4 render passes | 2 render + 1 compute |
+| `medium` | `3` | 12 render passes | 9 render + 1 compute | 6 render passes | 3 render + 1 compute |
+| `high` | `4` | 16 render passes | 12 render + 1 compute | 8 render passes | 4 render + 1 compute |
+| `ultra` | `5` | 20 render passes | 15 render + 1 compute | 10 render passes | 5 render + 1 compute |
+
+Counts describe the bloom pipeline itself; renderer presentation, optional lens artifacts, and
+optional history stages are additional. The fused compute path requires WebGPU, storage-write
+support for the chosen format, and sufficient storage bindings. Unsupported configurations
+automatically retain the portable render implementation.
+
+## Lens Effects and Temporal History
+
+`lens.starburstIntensity`, `lens.ghostIntensity`, and `lens.haloIntensity` enable aperture-style
+diffraction streaks, mirrored lens-element reflections, and radial halos. When any of these are
+positive, all three effects share one additional half-resolution pass. Each starburst ray uses
+eight samples; a ghost uses one sample, or three with chromatic aberration.
+
+`lens.dirtIntensity` samples an application-provided `lensDirtTexture` during the existing
+composite. Dirt alone therefore adds neither a render pass nor an intermediate target.
+
+Enabling `temporalStability` adds one persistent half-resolution history texture and one extra
+resolve pass. `temporalReprojection: true` additionally requires caller-provided `velocityTexture`
+and `depthTexture` bindings, rejects disocclusions, and stores prior depth in the existing history
+alpha channel. `previousExposure` corrects accumulated history after camera-exposure changes.
+
+## FFT Optical Convolution
+
+`GPUConvolutionBloom` applies a complete point-spread function in the frequency domain rather
+than approximating broad optical response with a local pyramid. It accepts a shared generated or
+measured kernel, or independent red, green, and blue kernels. Its packed FFT schedule processes
+the three channels together, while zero-padded guard bands prevent highlights from wrapping around
+opposite image edges.
+
+At 1920 by 1080 with quarter-resolution sampling and the default 12.5% guard band:
+
+| Configuration | FFT dimensions | Complex buffers | Steady-state compute dispatches |
+| --- | --- | --- | --- |
+| Default guard band | `1024 x 512` | `48 MiB` | `45` |
+| `guardBand: 0` | `512 x 512` | `24 MiB` | `43` |
+
+Changing the optical kernel requires 21 additional initialization dispatches for the guarded
+configuration. Chromatic ghosts, radial halo, lens dirt, temporal history, and optional
+GPU-resident exposure execute in the existing final compute stage.
+
+## Composition and Integration
+
+Keep bloom in linear floating-point scene color after lighting and adaptive exposure, but before
+[Tone Mapping](./tone-mapping). A typical HDR order is temporal reconstruction, auto exposure,
+bloom, and then the display transform.
+
+deck.gl's existing `PostProcessEffect` can execute the compact `bloom` shader-pass descriptor. It
+does not execute named-target `ShaderPassPipeline` graphs or the separate WebGPU FFT renderer, and
+its default intermediate format is `rgba8unorm`; retaining unclamped HDR highlights therefore
+requires an integration that arranges floating-point scene and postprocessing targets.
+
+## Technical References
+
+- [Unreal Engine bloom documentation](https://dev.epicgames.com/documentation/en-us/unreal-engine/bloom-in-unreal-engine) describes convolution kernels, lens dirt, energy conservation, and edge-padding controls.
+- [AMD FidelityFX Single Pass Downsampler](https://gpuopen.com/manuals/fidelityfx_sdk/techniques/single-pass-downsampler/) documents single-dispatch workgroup-local image reduction.
+- [Google Filament imaging pipeline](https://google.github.io/filament/main/filament.html) explains scene-linear bloom, camera exposure, and processing before tone mapping.
+- [deck.gl PostProcessEffect](https://deck.gl/docs/api-reference/core/post-process-effect) documents deck.gl's existing shader-module postprocessing interface.
+
+## Related Effects
+
+- [HDR Auto Exposure](./hdr-auto-exposure) supplies adaptive camera response before bloom.
+- [Gaussian Blur](./gaussian-blur) documents the standalone separable blur kernel.
+- [Tone Mapping](./tone-mapping) converts composed HDR lighting into display-ready color.

--- a/docs/api-reference/shadertools/shader-passes/brightness-contrast.mdx
+++ b/docs/api-reference/shadertools/shader-passes/brightness-contrast.mdx
@@ -1,0 +1,55 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Brightness and Contrast
+
+Shape overall exposure and tonal separation with a compact, single-pass color adjustment. Use
+`brightnessContrast` for interactive image correction, restrained scene grading, or graphic
+high-contrast treatments.
+
+<PostprocessingExample embedded showStats={false} effect="brightnessContrast" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `brightnessContrast` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One fullscreen color-filter pass |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {brightnessContrast} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [brightnessContrast]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {brightnessContrast: {brightness: 0.08, contrast: 0.28}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Range | Description |
+| --- | --- | --- | --- |
+| `brightness` | `0` | `-1` to `1` | Adds or subtracts light uniformly; `-1` approaches black and `1` approaches white. |
+| `contrast` | `0` | `-1` to `1` | Compresses or expands tonal separation around the image midpoint. |
+
+Both defaults preserve the source image. Positive contrast emphasizes existing differences;
+negative contrast compresses the image toward neutral gray.
+
+## Composition and Cost
+
+This pass samples only the current source color and does not allocate history or named textures.
+Apply moderate adjustments after exposure or tone mapping for predictable display-space grading.
+When combined with edge extraction or halftones, placing contrast first gives the later effect a
+more distinct source signal.
+
+## Related Effects
+
+- [Hue and Saturation](./hue-saturation) rotates or expands the color palette.
+- [Vibrance](./vibrance) targets muted colors without treating every hue equally.
+- [Tone Mapping](./tone-mapping) compresses scene-linear HDR highlights with a filmic curve.

--- a/docs/api-reference/shadertools/shader-passes/bulge-pinch.mdx
+++ b/docs/api-reference/shadertools/shader-passes/bulge-pinch.mdx
@@ -1,0 +1,54 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Bulge and Pinch
+
+Push image coordinates outward or pull them inward inside a circular region. `bulgePinch`
+simulates an adjustable local lens distortion without changing geometry or requiring scene depth.
+
+<PostprocessingExample embedded showStats={false} effect="bulgePinch" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `bulgePinch` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One fullscreen texture-sampling pass |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {bulgePinch} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [bulgePinch]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {bulgePinch: {center: [0.5, 0.5], radius: 240, strength: 0.45}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Range or purpose |
+| --- | --- | --- |
+| `center` | `[0.5, 0.5]` | Normalized image position at the center of the lens distortion. |
+| `radius` | `200` | Circular effect radius in source-image pixels; minimum is `1`. |
+| `strength` | `0.5` | Distortion direction and magnitude, from `-1` through `1`. |
+
+Positive and negative strengths bend the sampling field in opposite directions; a zero strength
+preserves the original image geometry.
+
+## Composition and Cost
+
+Bulge and pinch uses one texture-sampling pass and owns no intermediate history. Because it moves
+color coordinates without moving scene depth, normal, or velocity attachments, place it after
+scene-aware lighting, outlines, motion blur, and temporal reconstruction.
+
+## Related Effects
+
+- [Magnify](./magnify) enlarges pixels inside an adjustable circular lens.
+- [Swirl](./swirl) rotates sample positions around a focal center.
+- [Zoom Blur](./zoom-blur) produces radial motion streaks around a selected point.

--- a/docs/api-reference/shadertools/shader-passes/camera-reprojection-antialiasing.mdx
+++ b/docs/api-reference/shadertools/shader-passes/camera-reprojection-antialiasing.mdx
@@ -1,0 +1,73 @@
+import {ANARIPlaygroundExample} from '@site/src/examples';
+
+# Camera-Reprojection Antialiasing
+
+Reconstruct previous-frame image coordinates from scene depth and camera transforms when a
+per-pixel velocity buffer is unavailable. `createCameraReprojectionTAAShaderPassPipeline` powers
+the camera-aware temporal antialiasing path in luma.gl's ANARI rendering runtime.
+
+<ANARIPlaygroundExample />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `createCameraReprojectionTAAShaderPassPipeline` |
+| Backend | WebGPU |
+| Render passes | Three: temporal resolve, resolved-color copy, and depth-history copy |
+| Required binding | `depthTexture` |
+| Persistent state | Full-resolution `rgba16float` color and depth history |
+| Motion model | Camera motion and static-world geometry; no object-velocity attachment |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {createCameraReprojectionTAAShaderPassPipeline} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  colorFormat: 'rgba16float',
+  shaderPasses: [createCameraReprojectionTAAShaderPassPipeline()]
+});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  bindings: {depthTexture: sceneDepthTexture},
+  uniforms: {
+    cameraReprojectionTaaResolve: {
+      inverseViewProjectionMatrix,
+      previousViewProjectionMatrix,
+      historyWeight: 0.9,
+      depthThreshold: 0.0025,
+      currentJitter,
+      previousJitter
+    }
+  },
+  resetHistory: cameraCut || sceneTopologyChanged
+});
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `inverseViewProjectionMatrix` | Identity | Inverse current unjittered camera transform used to reconstruct world position. |
+| `previousViewProjectionMatrix` | Identity | Previous unjittered camera transform used to project that position into history. |
+| `historyWeight` | `0.9` | Fraction of accepted previous-frame color blended into the current pixel. |
+| `depthThreshold` | `0.0025` | Maximum normalized-device-depth disagreement before history is discarded. |
+| `currentJitter` | `[0, 0]` | Current projection jitter expressed in normalized image coordinates. |
+| `previousJitter` | `[0, 0]` | Previous projection jitter expressed in normalized image coordinates. |
+
+## Limitations and History Management
+
+Camera reprojection can follow static-world surfaces as the view changes, but it cannot infer
+independent object motion without a velocity texture. Reset history when moving-object topology,
+render resolution, or camera continuity changes. Use velocity-aware
+[Temporal Antialiasing](./temporal-antialiasing) for animated scenes that already publish
+per-pixel motion vectors.
+
+## Related Effects
+
+- [Temporal Antialiasing](./temporal-antialiasing) supports application-provided object velocity.
+- [FXAA](./fxaa) requires no history, depth, jitter, or camera transforms.
+- [ANARI Rendering](/docs/api-guide/engine/anari-rendering) documents the renderer that consumes this pipeline.

--- a/docs/api-reference/shadertools/shader-passes/clustered-volumetric-lighting.mdx
+++ b/docs/api-reference/shadertools/shader-passes/clustered-volumetric-lighting.mdx
@@ -1,0 +1,109 @@
+import {DeferredRenderingExample} from '@site/src/examples';
+
+# Clustered Volumetric Lighting
+
+Integrate participating-media illumination from the same directional and clustered point lights
+used by scene shading. `createClusteredVolumetricLightingShaderPassPipeline` combines height fog,
+anisotropic scattering, depth-occluded light shafts, temporal reprojection, bilateral denoising,
+and Beer-Lambert extinction.
+
+<DeferredRenderingExample embedded showStats={false} />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `createClusteredVolumetricLightingShaderPassPipeline` |
+| Backend | WebGPU |
+| Render passes | Six: integration, temporal resolve, depth history, two bilateral filters, and composite |
+| Required scene inputs | Depth, velocity, camera transforms, directional lighting, and point-light storage |
+| Required clustered inputs | `clusterLightCounts`, `clusterLightIndices`, and matching grid uniforms |
+| Persistent state | Atmospheric radiance history and compact `rg16float` depth history |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {createClusteredVolumetricLightingShaderPassPipeline} from '@luma.gl/effects';
+
+clusteredLightGrid.encode(device.commandEncoder, {
+  pointLights,
+  pointLightCount,
+  projectionMatrix,
+  nearPlane,
+  farPlane
+});
+
+const renderer = new ShaderPassRenderer(device, {
+  colorFormat: 'rgba16float',
+  shaderPasses: [
+    createClusteredVolumetricLightingShaderPassPipeline({resolutionScale: 0.5})
+  ]
+});
+
+renderer.renderToScreen({
+  sourceTexture: gBuffer.colorTexture,
+  bindings: {
+    ...gBuffer.getShaderPassBindings(),
+    pointLights,
+    ...clusteredLightGrid.getShaderPassBindings()
+  },
+  uniforms: {
+    clusteredVolumetricTrace: {
+      projectionMatrix,
+      inverseProjectionMatrix,
+      inverseViewMatrix,
+      directionalLightDirectionView,
+      directionalLightColor,
+      ...clusteredLightGrid.getShaderPassUniforms(nearPlane, farPlane),
+      density: 0.055,
+      sampleCount: 10,
+      godRayIntensity: 0.8
+    },
+    clusteredVolumetricTemporal: {
+      inverseProjectionMatrix,
+      inverseViewProjectionMatrix,
+      previousViewProjectionMatrix
+    },
+    clusteredVolumetricDepthHistoryCopy: {inverseProjectionMatrix}
+  }
+});
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `resolutionScale` | `1` | Relative resolution of atmospheric integration, history, and bilateral filtering. |
+| `density` | `0.055` | Participating-media density along each view ray. |
+| `heightFalloff` | `0.23` | World-height density attenuation. |
+| `fogHeight` | `0.2` | Reference height of the atmospheric density profile. |
+| `anisotropy` | `0.45` | Scattering direction preference; supported range is `-0.8` to `0.85`. |
+| `directionalIntensity` | `2.2` | Strength of the directional scene light inside the medium. |
+| `pointLightIntensity` | `1.8` | Strength of retained clustered point-light candidates. |
+| `sampleCount` | `10` | View-ray integration samples; supported range is `3` to `20`. |
+| `godRayIntensity` | `0` | Strength of depth-occluded crepuscular light shafts. |
+| `godRaySampleCount` | `18` | Radial visibility samples when god rays are enabled; maximum is `32`. |
+| `historyWeight` | `0.88` | Contribution from camera- and velocity-reprojected atmospheric history. |
+| `strength` | `0.9` | Final `clusteredVolumetricComposite` contribution. |
+
+## Lighting Contract and Cost
+
+Encode the `ClusteredLightGrid` after updating the point-light buffer and before running the
+fullscreen pipeline. The volumetric trace evaluates a bounded set of compute-retained cluster
+candidates instead of scanning every active light at each ray step. It also requires matching
+cluster dimensions, near/far planes, and the same camera transforms used to render scene depth.
+
+The six fullscreen stages are separate from the application's cluster-binning compute work.
+Lowering `resolutionScale`, `sampleCount`, or `godRaySampleCount` reduces integration cost;
+temporal history and two depth-aware filters reconstruct a more stable lower-resolution result.
+Reset history after camera cuts or scene-target recreation.
+
+See [Clustered Lighting](/docs/api-reference/experimental/clustered-lighting) for point-light
+packing, cluster-grid allocation, buffer bindings, and the complete per-frame encode sequence.
+
+## Related Effects
+
+- [Volumetric Fog](./volumetric-fog) offers a compact two-pass atmosphere without clustered scene-light evaluation.
+- [Depth-Aware Blur](./depth-aware-blur) describes the edge-preserving denoising stages.
+- [Bloom](./bloom) spreads bright scattering and god-ray highlights later in the HDR pipeline.

--- a/docs/api-reference/shadertools/shader-passes/color-halftone.mdx
+++ b/docs/api-reference/shadertools/shader-passes/color-halftone.mdx
@@ -1,0 +1,55 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Color Halftone
+
+Rebuild an image as rotated, offset print-screen patterns for its individual color channels.
+`colorHalftone` creates a configurable full-color halftone treatment reminiscent of traditional
+printed imagery.
+
+<PostprocessingExample embedded showStats={false} effect="colorHalftone" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `colorHalftone` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One fullscreen color-filter pass |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {colorHalftone} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [colorHalftone]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {colorHalftone: {center: [0.5, 0.5], angle: 0.32, size: 5}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `center` | `[0.5, 0.5]` | Normalized image position used as the print-screen pattern origin. |
+| `angle` | `1.1` | Pattern rotation in radians; individual channels receive offset orientations. |
+| `size` | `4` | Dot-cell size in source-image pixels; minimum is `1`. |
+
+Increasing `size` makes the individual printed dots more visible. Moving the center changes the
+pattern alignment without moving scene geometry.
+
+## Composition and Cost
+
+Color halftone is one source-color pass and owns no auxiliary textures. Apply
+[Hue and Saturation](./hue-saturation) first when palette rotation should affect the separated
+print channels, or apply [Vibrance](./vibrance) afterward to emphasize the resulting colors.
+
+## Related Effects
+
+- [Dot Screen](./dot-screen) creates a monochrome luminance-based print pattern.
+- [Hexagonal Pixelate](./hexagonal-pixelate) replaces dots with a geometric mosaic.
+- [Vibrance](./vibrance) selectively emphasizes quieter print colors.

--- a/docs/api-reference/shadertools/shader-passes/denoise.mdx
+++ b/docs/api-reference/shadertools/shader-passes/denoise.mdx
@@ -1,0 +1,54 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Denoise
+
+Reduce visible image grain while preserving local color boundaries. `denoise` applies a
+color-weighted 9-by-9 neighborhood filter in two fullscreen sampling passes.
+
+<PostprocessingExample embedded showStats={false} effect="denoise" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `denoise` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | Two fullscreen bilateral-style sampling passes |
+| Samples | 81 source-color candidates per pass |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {denoise} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [denoise]});
+
+renderer.renderToScreen({
+  sourceTexture: noisySceneTexture,
+  uniforms: {denoise: {strength: 0.55}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Range | Description |
+| --- | --- | --- | --- |
+| `strength` | `0.5` | `0` to `1` | Controls the color-difference weighting applied to the 9-by-9 neighborhood. |
+
+The implementation derives an internal exponent from `strength`. Samples whose color differs
+substantially from the center contribute less than nearby colors with similar intensity.
+
+## Performance and Composition
+
+Denoise is considerably more sample-intensive than a simple color adjustment: both configured
+passes evaluate an 81-pixel neighborhood. Apply it only where source cleanup is necessary, and
+consider lower-resolution processing for large render targets. For depth-buffer-aware lighting
+data, [Depth-Aware Blur](./depth-aware-blur) preserves explicit scene boundaries more directly.
+
+## Related Effects
+
+- [Noise](./noise) adds intentional grain instead of removing it.
+- [Depth-Aware Blur](./depth-aware-blur) preserves geometry boundaries using a scene depth texture.
+- [Gaussian Blur](./gaussian-blur) smooths uniformly without color-similarity rejection.

--- a/docs/api-reference/shadertools/shader-passes/depth-aware-blur.mdx
+++ b/docs/api-reference/shadertools/shader-passes/depth-aware-blur.mdx
@@ -1,0 +1,60 @@
+import {AdvancedEffectsExample} from '@site/src/examples';
+
+# Depth-Aware Blur
+
+Smooth noisy screen-space results without bleeding across foreground/background boundaries.
+`depthAwareBlurShaderPassPipeline` combines Gaussian spatial weights with scene-depth similarity
+in two separable bilateral-filter passes.
+
+<AdvancedEffectsExample embedded showStats={false} />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Exports | `depthAwareBlur` and `depthAwareBlurShaderPassPipeline` |
+| Backend | WebGPU |
+| Render passes | Two separable bilateral-filter passes |
+| Required binding | `depthTexture` |
+| Intermediate storage | One renderer-owned scratch texture |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {depthAwareBlurShaderPassPipeline} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  shaderPasses: [depthAwareBlurShaderPassPipeline]
+});
+
+renderer.renderToScreen({
+  sourceTexture: noisyLightingTexture,
+  bindings: {depthTexture: sceneDepthTexture},
+  uniforms: {depthAwareBlur: {radius: 4, depthSigma: 0.01, spatialSigma: 3}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Range | Description |
+| --- | --- | --- | --- |
+| `radius` | `4` | `1` to `8` | Number of bilateral-filter samples on each side of the center pixel. |
+| `depthSigma` | `0.01` | Minimum `0.0001` | Accepted depth variation; smaller values preserve stronger depth discontinuities. |
+| `spatialSigma` | `3` | Minimum `0.1` | Width of the Gaussian spatial weighting profile. |
+| `direction` | `[1, 0]` | Set by the pipeline | Horizontal or vertical sample direction for the low-level standalone pass. |
+
+The pipeline automatically supplies `[1, 0]` and `[0, 1]` for its two blur directions. Near-depth
+neighbors contribute normally, while samples separated by a depth edge are exponentially reduced.
+
+## Performance and Composition
+
+Each direction visits at most eight samples on either side of the center pixel. The reusable
+filter also appears inside several higher-level scene-aware pipelines, where it denoises
+occlusion, indirect illumination, reflections, or volumetric lighting while retaining silhouettes.
+
+## Related Effects
+
+- [Gaussian Blur](./gaussian-blur) deliberately ignores depth boundaries.
+- [SSAO](./ssao) uses edge-aware filtering to stabilize ambient-occlusion estimates.
+- [Screen-Space Global Illumination](./screen-space-global-illumination) denoises indirect light with depth- and normal-aware filtering.

--- a/docs/api-reference/shadertools/shader-passes/depth-of-field.mdx
+++ b/docs/api-reference/shadertools/shader-passes/depth-of-field.mdx
@@ -1,0 +1,68 @@
+import {DOFExample} from '@site/src/examples';
+
+# Depth of Field
+
+Keep a selected camera-space distance sharp while softening nearer and farther geometry.
+`dofShaderPassPipeline` reconstructs depth from the scene attachment and applies separable
+horizontal and vertical lens blur.
+
+<DOFExample embedded showStats={false} />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Exports | `dof` and `dofShaderPassPipeline` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | Two separable depth-driven sampling passes |
+| Required binding | `depthTexture` |
+| Intermediate storage | One renderer-owned scratch texture |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {dofShaderPassPipeline} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  shaderPasses: [dofShaderPassPipeline]
+});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  bindings: {depthTexture: sceneDepthTexture},
+  uniforms: {
+    dof: {
+      depthRange: [0.1, 100],
+      focusDistance: 8,
+      blurCoefficient: 1.4,
+      pixelsPerMillimeter: 1.2
+    }
+  }
+});
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `depthRange` | `[0.1, 100]` | Camera near and far clip distances used to reconstruct linear view depth. |
+| `focusDistance` | `1` | View-space distance of the focal plane that remains sharp. |
+| `blurCoefficient` | `1` | Lens blur strength derived from the chosen focal length and aperture. |
+| `pixelsPerMillimeter` | `1` | Conversion factor from lens-space blur size to image-space pixels. |
+
+The implementation caps the blur radius at 20 source samples per direction. The internal
+`texelOffset` uniform is selected by the pipeline and is intentionally excluded from the public
+`DofUniforms` interface.
+
+## Required Inputs and Composition
+
+The supplied `depthTexture` must correspond to the same camera, viewport, and scene as the input
+color texture. Apply depth of field before screen-coordinate warps and after opaque scene
+rendering. Keep it before the final tone-map step when preserving HDR highlight intensity matters.
+
+## Related Effects
+
+- [Tilt Shift](./tilt-shift) approximates selective focus without a depth attachment.
+- [Depth-Aware Blur](./depth-aware-blur) smooths intermediate data while preserving depth edges.
+- [Bloom](./bloom) spreads bright highlights through a separate multiscale optical pipeline.

--- a/docs/api-reference/shadertools/shader-passes/dot-screen.mdx
+++ b/docs/api-reference/shadertools/shader-passes/dot-screen.mdx
@@ -1,0 +1,55 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Dot Screen
+
+Convert source-image luminance into a rotated monochrome dot pattern. `dotScreen` produces a
+graphic halftone treatment whose orientation, origin, and cell size remain fully adjustable.
+
+<PostprocessingExample embedded showStats={false} effect="dotScreen" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `dotScreen` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One fullscreen color-filter pass |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {dotScreen} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [dotScreen]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {dotScreen: {center: [0.5, 0.5], angle: 0.42, size: 5}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `center` | `[0.5, 0.5]` | Normalized origin of the rotated screen pattern. |
+| `angle` | `1.1` | Dot-screen rotation in radians. |
+| `size` | `3` | Dot-cell size in image pixels; minimum is `1`. |
+
+Fine cells preserve more source detail, while larger cells make the underlying print structure
+more prominent.
+
+## Composition and Cost
+
+The effect runs in one fullscreen pass and derives its pattern from current color and image
+coordinates. Raising [Brightness and Contrast](./brightness-contrast) before the dot screen can
+sharpen tonal separation; [Color Halftone](./color-halftone) preserves multiple color channels
+when a monochrome treatment is not desired.
+
+## Related Effects
+
+- [Color Halftone](./color-halftone) creates independent full-color print patterns.
+- [Brightness and Contrast](./brightness-contrast) controls the luminance entering the screen.
+- [Ink](./ink) produces a complementary contour-oriented illustrated style.

--- a/docs/api-reference/shadertools/shader-passes/edge-work.mdx
+++ b/docs/api-reference/shadertools/shader-passes/edge-work.mdx
@@ -1,0 +1,54 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Edge Work
+
+Extract image contours by comparing neighborhood frequencies at different blur widths.
+`edgeWork` transforms a source image into a high-contrast line-oriented treatment without
+requiring scene depth or surface normals.
+
+<PostprocessingExample embedded showStats={false} effect="edgeWork" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `edgeWork` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | Two fullscreen sampling passes |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {edgeWork} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [edgeWork]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {edgeWork: {radius: 3}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Suggested range | Description |
+| --- | --- | --- | --- |
+| `radius` | `2` | `1` to `50` | Neighborhood size in pixels used to isolate image-frequency differences. |
+
+The descriptor selects its two internal `mode` values automatically. That implementation detail
+is not intended as a public control.
+
+## Performance and Composition
+
+Edge work uses two sampling passes, and larger radii increase the amount of neighborhood work.
+Because contours come entirely from visible color, it can respond to textures and lighting as well
+as geometry. Choose [Screen-Space Outlines](./outlines) when object depth and normal boundaries
+should determine the result instead.
+
+## Related Effects
+
+- [Ink](./ink) provides a one-pass color-neighborhood illustration effect.
+- [Screen-Space Outlines](./outlines) detects geometric depth and normal discontinuities.
+- [Brightness and Contrast](./brightness-contrast) can strengthen source-edge separation.

--- a/docs/api-reference/shadertools/shader-passes/fxaa.mdx
+++ b/docs/api-reference/shadertools/shader-passes/fxaa.mdx
@@ -1,0 +1,51 @@
+import {AntialiasingExample} from '@site/src/examples';
+
+# FXAA
+
+Reduce jagged high-contrast image edges with Fast Approximate Anti-Aliasing. `fxaa` operates on a
+single completed color image, making it suitable when multisampling, scene motion vectors, or
+temporal history are unavailable.
+
+<AntialiasingExample embedded showStats={false} />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `fxaa` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One fullscreen edge-aware sampling pass |
+| Required inputs | Current color texture only |
+| Persistent state | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {fxaa, toneMapping} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  shaderPasses: [toneMapping, fxaa]
+});
+
+renderer.renderToScreen({sourceTexture: hdrSceneTexture});
+```
+
+## Parameters
+
+`fxaa` currently exposes no runtime tuning uniforms. Its quality settings are compiled into the
+shader implementation. The pass derives luminance from source RGB, detects local edge direction,
+and searches along that edge before blending a smoother result.
+
+## Performance and Placement
+
+FXAA requires one render pass but can sample multiple neighboring texels around candidate edges.
+It does not allocate temporal history, consume depth or velocity attachments, or eliminate
+frame-to-frame subpixel shimmer. Apply it close to final presentation so edge detection sees the
+display-referred contrast created by tone mapping and grading.
+
+## Related Effects
+
+- [Temporal Antialiasing](./temporal-antialiasing) accumulates jittered frames with velocity and depth rejection.
+- [Camera-Reprojection Antialiasing](./camera-reprojection-antialiasing) reconstructs camera motion without a velocity attachment.
+- [Tone Mapping](./tone-mapping) typically precedes display-space FXAA.

--- a/docs/api-reference/shadertools/shader-passes/gaussian-blur.mdx
+++ b/docs/api-reference/shadertools/shader-passes/gaussian-blur.mdx
@@ -1,0 +1,54 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Gaussian Blur
+
+Soften an image with a smooth, bell-shaped Gaussian kernel. `gaussianBlur` applies independent
+horizontal and vertical passes to approximate a two-dimensional photographic blur without a
+full two-dimensional sampling loop.
+
+<PostprocessingExample embedded showStats={false} effect="gaussianBlur" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `gaussianBlur` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | Two separable fullscreen sampling passes |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {gaussianBlur} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [gaussianBlur]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {gaussianBlur: {radius: 10}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Range | Description |
+| --- | --- | --- | --- |
+| `radius` | `12` | `0` to `32` | Gaussian sampling radius in source-image pixels. |
+
+The internal `delta` uniform selects the horizontal and vertical direction automatically; callers
+should not manage it directly.
+
+## Composition and Cost
+
+Two fullscreen passes are always used, and larger radii increase sampling work inside each pass.
+For very wide glow, the multiscale [Bloom](./bloom) pipeline reduces work by filtering smaller
+pyramid levels instead of sampling a large full-resolution neighborhood. Unlike
+[Depth-Aware Blur](./depth-aware-blur), Gaussian blur intentionally mixes across depth edges.
+
+## Related Effects
+
+- [Triangle Blur](./triangle-blur) uses a triangular rather than Gaussian weight profile.
+- [Depth-Aware Blur](./depth-aware-blur) preserves depth discontinuities.
+- [Bloom](./bloom) combines multiscale blur with highlight extraction and reconstruction.

--- a/docs/api-reference/shadertools/shader-passes/gtao.mdx
+++ b/docs/api-reference/shadertools/shader-passes/gtao.mdx
@@ -1,0 +1,77 @@
+import {DeferredRenderingExample} from '@site/src/examples';
+
+# Ground-Truth Ambient Occlusion
+
+Estimate horizon-based ambient visibility with temporally reprojected history and edge-aware
+spatial denoising. `createGTAOShaderPassPipeline` can attenuate either the complete lit image or
+only a separately supplied ambient-light contribution.
+
+<DeferredRenderingExample embedded showStats={false} />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `createGTAOShaderPassPipeline` |
+| Backend | WebGPU |
+| Render passes | Six: evaluation, temporal resolve, depth history, two bilateral blurs, and composite |
+| Required bindings | `depthTexture`, `normalTexture`, and `velocityTexture` |
+| Optional binding | `ambientLightingTexture` when `composition: 'ambient-only'` |
+| Persistent state | Occlusion and depth history textures |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {createGTAOShaderPassPipeline} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  colorFormat: 'rgba16float',
+  shaderPasses: [
+    createGTAOShaderPassPipeline({resolutionScale: 0.5, composition: 'ambient-only'})
+  ]
+});
+
+renderer.renderToScreen({
+  sourceTexture: litSceneTexture,
+  bindings: {...gBuffer.getShaderPassBindings(), ambientLightingTexture},
+  uniforms: {
+    gtaoEvaluate: {projectionMatrix, inverseProjectionMatrix, radius: 2.2, intensity: 3.2},
+    gtaoTemporal: {inverseProjectionMatrix, historyWeight: 0.88, depthThreshold: 0.015},
+    gtaoAmbientComposite: {strength: 0.68}
+  }
+});
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `resolutionScale` | `1` | Resolution multiplier for visibility, temporal history, and bilateral denoising. |
+| `composition` | `'color'` | Apply visibility to full scene color, or use `'ambient-only'` with an explicit ambient-light texture. |
+| `radius` | `2.2` | View-space sampling distance for the horizon evaluation. |
+| `bias` | `0.04` | Depth tolerance used to reduce self-occlusion. |
+| `intensity` | `3.2` | Strength of the evaluated horizon occlusion. |
+| `historyWeight` | `0.88` | Contribution from reprojected, depth-validated occlusion history. |
+| `depthThreshold` | `0.015` | Maximum accepted temporal depth disagreement. |
+| `strength` | `0.68` | Final composite strength in `gtaoComposite` or `gtaoAmbientComposite`. |
+
+## Ambient-Only Composition
+
+With `composition: 'ambient-only'`, the final stage subtracts only the occluded portion of the
+separate `ambientLightingTexture`. Direct lighting, emissive materials, and source alpha remain
+unchanged. The application owns that ambient texture and must provide it as an explicit binding;
+the effect does not reach across other pipelines to discover hidden render targets.
+
+## Performance and Placement
+
+GTAO creates five intermediate targets, including persistent occlusion and depth history.
+Half-resolution evaluation reduces intermediate pixel count substantially but can soften narrow
+contact edges. Reset history after camera cuts or attachment-size changes. Compose after deferred
+lighting and before diffuse global illumination or reflective postprocessing.
+
+## Related Effects
+
+- [SSAO](./ssao) provides a four-pass, non-temporal ambient-occlusion path.
+- [Screen-Space Global Illumination](./screen-space-global-illumination) adds diffuse bounced light instead of removing ambient energy.
+- [Screen-Space Reflections](./screen-space-reflections) resolves directional specular response.

--- a/docs/api-reference/shadertools/shader-passes/hdr-auto-exposure.mdx
+++ b/docs/api-reference/shadertools/shader-passes/hdr-auto-exposure.mdx
@@ -1,0 +1,85 @@
+import {DeferredRenderingExample} from '@site/src/examples';
+
+# HDR Auto Exposure
+
+Continuously meter scene luminance and adapt camera exposure entirely on the GPU.
+`createHDRAutoExposureShaderPassPipeline` uses a center-weighted logarithmic luminance pyramid,
+persistent exposure history, and independent brightening and darkening response speeds.
+
+<DeferredRenderingExample embedded showStats={false} />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `createHDRAutoExposureShaderPassPipeline` |
+| Backend | WebGPU |
+| Render passes | Seven: extraction, four reductions, adaptation, and application |
+| Persistent state | One GPU-owned exposure-history texture |
+| Recommended input | Linear `rgba16float` scene color |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {
+  createBloomShaderPassPipeline,
+  createHDRAutoExposureShaderPassPipeline,
+  toneMapping
+} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  colorFormat: 'rgba16float',
+  shaderPasses: [
+    createHDRAutoExposureShaderPassPipeline({meteringScale: 0.25, initialExposure: 1}),
+    createBloomShaderPassPipeline({quality: 'high'}),
+    toneMapping
+  ]
+});
+
+renderer.renderToScreen({
+  sourceTexture: hdrSceneTexture,
+  uniforms: {
+    hdrAutoExposureAdapt: {
+      keyValue: 0.48,
+      minimumExposure: 0.45,
+      maximumExposure: 2.4,
+      brightenSpeed: 1.6,
+      darkenSpeed: 2.8,
+      deltaTime: frameDeltaSeconds,
+      enabled: 1
+    }
+  }
+});
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `meteringScale` | `0.25` | Initial luminance-target scale; smaller values are clamped to `0.25`. |
+| `initialExposure` | `1` | Value used to initialize or recreate persistent exposure history. |
+| `keyValue` | `0.48` | Target middle-gray response used to derive scene exposure. |
+| `minimumExposure` | `0.45` | Lower bound on the adapted exposure multiplier. |
+| `maximumExposure` | `2.4` | Upper bound on the adapted exposure multiplier. |
+| `brightenSpeed` | `1.6` | Adaptation rate when the image needs to become brighter. |
+| `darkenSpeed` | `2.8` | Adaptation rate when the image needs to become darker. |
+| `deltaTime` | `0.016` | Current frame duration in seconds; update this application-owned uniform every frame. |
+
+## How It Works
+
+1. Sample a 4-by-4 footprint and accumulate center-weighted logarithmic luminance.
+2. Reduce four successively smaller floating-point pyramid levels.
+3. Derive geometric-mean scene brightness without copying results back to the CPU.
+4. Adapt and clamp the persistent exposure target with direction-specific response speeds.
+5. Multiply the original HDR scene color by the current adapted exposure.
+
+The pipeline can also expose a false-color luminance visualization through the application-stage
+debug uniform. Reset renderer history when a resize, camera cut, or scene replacement should
+discard the previous adaptation state.
+
+## Related Effects
+
+- [Bloom](./bloom) supports exposure-aware highlight thresholds and exposure-corrected temporal history.
+- [Tone Mapping](./tone-mapping) converts the adapted HDR image into display-ready color.
+- [Temporal Antialiasing](./temporal-antialiasing) normally precedes exposure and bloom in the render stack.

--- a/docs/api-reference/shadertools/shader-passes/hexagonal-pixelate.mdx
+++ b/docs/api-reference/shadertools/shader-passes/hexagonal-pixelate.mdx
@@ -1,0 +1,54 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Hexagonal Pixelate
+
+Replace fine image detail with a regular mosaic of hexagonal cells. `hexagonalPixelate` snaps
+source sampling positions to the nearest hexagonal center while preserving the broad scene
+composition and color palette.
+
+<PostprocessingExample embedded showStats={false} effect="hexagonalPixelate" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `hexagonalPixelate` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One fullscreen sampling pass |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {hexagonalPixelate} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [hexagonalPixelate]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {hexagonalPixelate: {center: [0.5, 0.5], scale: 12}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `center` | `[0.5, 0.5]` | Normalized image origin used to align the hexagonal grid. |
+| `scale` | `10` | Hexagonal cell size in image pixels; minimum is `1`. |
+
+Smaller cells preserve finer scene structure, while larger cells emphasize the mosaic geometry.
+Animating `center` moves the grid alignment without moving the original image.
+
+## Composition and Cost
+
+The effect requires one fullscreen source-texture sample and no depth, history, or named targets.
+Place it before [Bloom](./bloom) when highlights should spread from the geometric mosaic, or
+after grading when the cells should preserve the finished scene palette.
+
+## Related Effects
+
+- [Color Halftone](./color-halftone) uses rotated print-screen cells instead of a hexagonal grid.
+- [Dot Screen](./dot-screen) creates a monochrome dot mosaic.
+- [Bloom](./bloom) can soften bright cell boundaries and concentrated highlights.

--- a/docs/api-reference/shadertools/shader-passes/hue-saturation.mdx
+++ b/docs/api-reference/shadertools/shader-passes/hue-saturation.mdx
@@ -1,0 +1,55 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Hue and Saturation
+
+Rotate the image palette and control overall color intensity without changing the basic image
+geometry. `hueSaturation` is useful for color grading, thematic recoloring, and reducing a scene
+to monochrome.
+
+<PostprocessingExample embedded showStats={false} effect="hueSaturation" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `hueSaturation` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One fullscreen color-filter pass |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {hueSaturation} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [hueSaturation]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {hueSaturation: {hue: -0.08, saturation: 0.32}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Range | Description |
+| --- | --- | --- | --- |
+| `hue` | `0` | `-1` to `1` | Rotates RGB around the grayscale axis; the endpoints represent a half-turn in either direction. |
+| `saturation` | `0` | `-1` to `1` | Pulls colors toward gray or pushes them farther from their channel average. |
+
+A saturation value of `-1` produces a grayscale treatment. Hue rotation leaves perfectly neutral
+colors on the grayscale axis unchanged.
+
+## Composition and Cost
+
+The implementation operates directly on the current pixel and requires no neighboring samples,
+depth attachments, or history. Place it before color-dependent stylization when the rotated
+palette should affect printed channels, or after bloom when the entire composed image should be
+graded together.
+
+## Related Effects
+
+- [Vibrance](./vibrance) selectively boosts less saturated colors.
+- [Sepia](./sepia) applies a specific warm photographic color transform.
+- [Color Halftone](./color-halftone) converts a graded image into separated print channels.

--- a/docs/api-reference/shadertools/shader-passes/image-processing.mdx
+++ b/docs/api-reference/shadertools/shader-passes/image-processing.mdx
@@ -1,392 +1,83 @@
-# Image Processing
+import {PostprocessingExample} from '@site/src/examples';
 
-Screen space effects packaged as reusable shader modules in `@luma.gl/effects` based on the [glfx library](http://evanw.github.io/glfx.js/).
+# Shader Pass Catalog
 
-:::info
-luma.gl shader passes can be used directly with [deck.gl](https://deck.gl)'s
-postprocessing system. In luma.gl, run them through
-[`ShaderPassRenderer`](/docs/api-reference/engine/passes/shader-pass-renderer).
-The older `Pass` classes from luma.gl v7 are not the current execution API.
-:::
+Explore reusable image-processing filters, cinematic lens effects, temporal reconstruction, and
+scene-aware WebGPU pipelines from `@luma.gl/effects`. Every effect below has its own implementation
+guide, parameter reference, composition notes, and, where an existing showcase is available, a
+live interactive example.
 
-For guidance on similar-looking alternatives, including single-pass versus multiscale bloom,
-SSAO versus GTAO, environment-map versus screen-space reflections, and FXAA versus temporal AA,
-see [Rendering Techniques and Tradeoffs](/docs/api-guide/shaders/rendering-techniques).
+<PostprocessingExample embedded showStats={false} />
 
-## Attribution
+## Choosing an Effect
 
-Most of these image post processing effects (and this documentation page) are forked from Evan Wallace's [glfx](https://github.com/evanw/glfx.js) library and have just been repackaged as luma.gl shader modules / shader passes.
+| Category | Effects | Typical placement |
+| --- | --- | --- |
+| Color and tone | [Brightness and contrast](./brightness-contrast), [hue and saturation](./hue-saturation), [sepia](./sepia), [vibrance](./vibrance), [tone mapping](./tone-mapping), [HDR auto exposure](./hdr-auto-exposure) | Exposure and grading before the final display transform. |
+| Blur, bloom and focus | [Bloom](./bloom), [Gaussian blur](./gaussian-blur), [triangle blur](./triangle-blur), [tilt shift](./tilt-shift), [zoom blur](./zoom-blur), [depth of field](./depth-of-field), [depth-aware blur](./depth-aware-blur) | Scene-linear lighting and camera effects before tone mapping. |
+| Temporal and antialiasing | [Persistence](./persistence), [FXAA](./fxaa), [temporal antialiasing](./temporal-antialiasing), [camera-reprojection antialiasing](./camera-reprojection-antialiasing), [motion blur](./motion-blur) | Temporal accumulation before lens effects; FXAA near presentation. |
+| Lighting and visibility | [SSAO](./ssao), [GTAO](./gtao), [screen-space global illumination](./screen-space-global-illumination), [screen-space reflections](./screen-space-reflections), [outlines](./outlines) | After scene rendering while depth, normals, and velocity still align. |
+| Atmosphere | [Volumetric fog](./volumetric-fog), [clustered volumetric lighting](./clustered-volumetric-lighting) | After opaque lighting and visibility; before exposure and bloom. |
+| Stylization and detail | [Color halftone](./color-halftone), [dot screen](./dot-screen), [edge work](./edge-work), [hexagonal pixelation](./hexagonal-pixelate), [ink](./ink), [noise](./noise), [vignette](./vignette), [denoise](./denoise) | Creative finishing or targeted source cleanup. |
+| Warp and lens | [Bulge and pinch](./bulge-pinch), [magnify](./magnify), [swirl](./swirl) | After depth-dependent effects unless auxiliary attachments are transformed too. |
 
 ## Usage
 
-Import the shader module(s) you would like to use from `@luma.gl/effects`, e.g:
+Individual [`ShaderPass`](/docs/api-reference/shadertools/shader-pass) descriptors and complete
+[`ShaderPassPipeline`](/docs/api-reference/shadertools/shader-pass#shaderpasspipeline) graphs can
+share one ordered [`ShaderPassRenderer`](/docs/api-reference/engine/passes/shader-pass-renderer):
 
 ```typescript
-import {brightnessContrast} from '@luma.gl/effects';
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {createBloomShaderPassPipeline, toneMapping, vignette} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  colorFormat: 'rgba16float',
+  shaderPasses: [
+    createBloomShaderPassPipeline({quality: 'high', blurAlgorithm: 'dual-kawase'}),
+    toneMapping,
+    vignette
+  ]
+});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {
+    toneMapping: {exposure: 1, maximumLuminance: 1},
+    vignette: {radius: 0.7, amount: 0.35}
+  }
+});
 ```
 
-Pass imported effects to
-[`ShaderPassRenderer`](/docs/api-reference/engine/passes/shader-pass-renderer)
-when running them inside luma.gl.
-
-Some effects also consume extra bindings in addition to the default `sourceTexture`. For example,
-`persistenceEffect` expects a `persistenceTexture` binding containing the previously accumulated frame.
-
-## Shader Modules
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/mountain.jpg" />
-        <p><i>Original Image</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### brightnessContrast
-
-Provides additive brightness and multiplicative contrast control.
-
-- `brightness` -1 to 1 (-1 is solid black, 0 is no change, and 1 is solid white). Default value is `0`.
-- `contrast` -1 to 1 (-1 is solid gray, 0 is no change, and 1 is maximum contrast). Default value is `0`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/brightness.jpg" />
-        <p><i>Brightness / Contrast Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### hueSaturation
-
-Provides rotational hue and multiplicative saturation control. RGB color space can be imagined as a cube where the axes are the red, green, and blue color values.
-
-Hue changing works by rotating the color vector around the grayscale line, which is the straight line from black (0, 0, 0) to white (1, 1, 1).
-
-Saturation is implemented by scaling all color channel values either toward or away from the average color channel value.
-
-- `hue` -1 to 1 (-1 is 180 degree rotation in the negative direction, 0 is no change, and 1 is 180 degree rotation in the positive direction). Default value is `0`.
-- `saturation` -1 to 1 (-1 is solid gray, 0 is no change, and 1 is maximum contrast). Default value is `0`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/hue.jpg" />
-        <p><i>Hue / Saturation Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### noise
-
-Adds black and white noise to the image.
-
-- `amount` 0 to 1 (0 for no effect, 1 for maximum noise). Default value is `0.5`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/noise.jpg" />
-        <p><i>Noise Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### persistenceEffect
-
-Blends the current frame with a caller-provided history texture to create fading trails and similar temporal feedback effects.
-
-- Extra binding: `persistenceTexture` - the previously accumulated frame.
-- Current-frame color is boosted before blending (`color * 4.0`), then clamped back into display range.
-- Alpha is rebuilt from both the current frame coverage and the faded history alpha so sparse bright samples remain visible across frames.
-
-This pass is intended for temporal workflows where the application manages history textures explicitly, for example by alternating two `ShaderPassRenderer` instances or application-owned ping-pong textures.
-
-### sepia
-
-Gives the image a reddish-brown monochrome tint that imitates an old photograph.
-
-- `amount` 0 to 1 (0 for no effect, 1 for full sepia coloring). Default value is `0.5`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/sepia.jpg" />
-        <p><i>Sepia Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### vibrance
-
-Modifies the saturation of desaturated colors, leaving saturated colors unmodified.
-
-- `amount` -1 to 1 (-1 is minimum vibrance, 0 is no change, and 1 is maximum vibrance). Default value is `0`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/vibrance.jpg" />
-        <p><i>Vibrance Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### vignette
-
-Adds a simulated lens edge darkening effect.
-
-- `size` 0 to 1 (0 for center of frame, 1 for edge of frame). Default value is `0.5`.
-- `amount` 0 to 1 (0 for no effect, 1 for maximum lens darkening). Default value is `0.5`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/vignette.jpg" />
-        <p><i>Vignette Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### tiltShift
-
-Simulates the shallow depth of field normally encountered in close-up photography, which makes the scene seem much smaller than it actually is. This filter assumes the scene is relatively planar, in which case the part of the scene that is completely in focus can be described by a line (the intersection of the focal plane and the scene). An example of a planar scene might be looking at a road from above at a downward angle. The image is then blurred with a blur radius that starts at zero on the line and increases further from the line.
-
-- `start` [x, y] coordinate of the start of the line segment. `[0, 0]` is the bottom left corner, `[1, 1]` is the up right corner. Default value is `[0, 0]`.
-- `end` [x, y] coordinate of the end of the line segment. `[0, 0]` is the bottom left corner, `[1, 1]` is the up right corner. Default value is `[1, 1]`.
-- `blurRadius` The maximum radius of the pyramid blur in pixels. Default value is `15`.
-- `gradientRadius` The distance in pixels from the line at which the maximum blur radius is reached. Default value is `200`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/tilt_shift.jpg" />
-        <p><i>Tilt Shift Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### gaussianBlur
-
-Applies a true separable Gaussian blur with a radius-driven kernel and soft falloff. This is a better starting point than `triangleBlur` when you want a softer, more photographic blur kernel.
-
-- `radius` The blur radius in pixels. Default value is `12`, maximum value is `32`.
-
-### bloom
-
-Adds a glow to bright areas of the image by extracting pixels above a luminance threshold, softly blurring them, and mixing them back with the source color.
-
-- `radius` Radius of the sampling kernel in pixels. Default value is `4`.
-- `threshold` Luminance threshold above which a pixel contributes to bloom. Default value is `0.8`.
-- `intensity` Strength of the bloom contribution. Default value is `1`.
-
-`bloom` is the compact shader-pass implementation. For configurable multiscale HDR bloom,
-Gaussian or Dual-Kawase filtering, WebGPU compute downsampling, temporal stabilization,
-photographic lens artifacts, and the optional WebGPU FFT convolution path, see
-[Adaptive HDR exposure and cinematic bloom](/docs/api-guide/shaders/shader-passes#adaptive-hdr-exposure-and-cinematic-bloom).
-
-### triangleBlur
-
-This is the most basic blur filter, which convolves the image with a pyramid filter. The pyramid filter is separable and is applied as two perpendicular triangle filters.
-
-- `radius` The radius of the pyramid in pixels convolved with the image. Default value is `20`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/triangle_blur.jpg" />
-        <p><i>Triangle Blur Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### zoomBlur
-
-Blurs the image away from a certain point, which looks like radial motion blur.
-
-- `center` [x, y] coordinate of the blur origin. `[0, 0]` is the bottom left corner, `[1, 1]` is the up right corner. Default value is `[0.5, 0.5]`.
-- `strength` The strength of the blur. Values in the range 0 to 1 are usually sufficient, where 0 doesn't change the image and 1 creates a highly blurred image. Default value is `0.3`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/zoom_blur.jpg" />
-        <p><i>Zoom Blur Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### colorHalftone
-
-Simulates a CMYK halftone rendering of the image by multiplying pixel values with a four rotated 2D sine wave patterns, one each for cyan, magenta, yellow, and black.
-
-- `center` [x, y] coordinate of the pattern origin. `[0, 0]` is the bottom left corner, `[1, 1]` is the up right corner. Default value is `[0.5, 0.5]`.
-- `angle` The rotation of the pattern in radians. Default value is `1.1`.
-- `size` The diameter of a dot in pixels. Default value is `4`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/color_halftone.jpg" />
-        <p><i>Color Halftone Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### dotScreen
-
-Simulates a black and white halftone rendering of the image by multiplying pixel values with a rotated 2D sine wave pattern.
-
-- `center` [x, y] coordinate of the pattern origin. `[0, 0]` is the bottom left corner, `[1, 1]` is the up right corner. Default value is `[0.5, 0.5]`.
-- `angle` The rotation of the pattern in radians. Default value is `1.1`.
-- `size` The diameter of a dot in pixels. Default value is `3`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/dot_screen.jpg" />
-        <p><i>Dot Screen Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### edgeWork
-
-Picks out different frequencies in the image by subtracting two copies of the image blurred with different radii.
-
-- `radius` The radius of the effect in pixels. Default value is `2`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/edge_work.jpg" />
-        <p><i>Edge Work Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### hexagonalPixelate
-
-Renders the image using a pattern of hexagonal tiles. Tile colors are nearest-neighbor sampled from the centers of the tiles.
-
-- `center` [x, y] coordinate of the pattern center. `[0, 0]` is the bottom left corner, `[1, 1]` is the up right corner. Default value is `[0.5, 0.5]`.
-- `scale` The width of an individual tile in pixels. Default value is `10`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/hexagon.jpg" />
-        <p><i>Hexagonal Pixelate Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### ink
-
-Simulates outlining the image in ink by darkening edges stronger than a certain threshold. The edge detection value is the difference of two copies of the image, each blurred using a blur of a different radius.
-
-- `strength` The multiplicative scale of the ink edges. Values in the range 0 to 1 are usually sufficient, where 0 doesn't change the image and 1 adds lots of black edges. Negative strength values will create white ink edges instead of black ones. Default value is `0.25`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/ink.jpg" />
-        <p><i>Ink Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### bulgePinch
-
-Bulges or pinches the image in a circle.
-
-- `center` [x, y] coordinate of the center of the circle of effect. `[0, 0]` is the bottom left corner, `[1, 1]` is the up right corner. Default value is `[0.5, 0.5]`.
-- `radius` The radius of the circle of effect in pixels. Default value is `200`.
-- `strength` -1 to 1 (-1 is strong pinch, 0 is no effect, 1 is strong bulge). Default value is `0.5`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/bulge_pinch.jpg" />
-        <p><i>Bulge Pinch Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### swirl
-
-Warps a circular region of the image in a swirl.
-
-- `center` [x, y] coordinate of the center of the circular region. `[0, 0]` is the bottom left corner, `[1, 1]` is the up right corner. Default value is `[0.5, 0.5]`.
-- `radius` The radius of the circular region in pixels. Default value is `200`.
-- `angle` The angle in radians that the pixels in the center of the circular region will be rotated by. Default value is `3`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/uber-common/deck.gl-data/master/images/samples/glfx/results/swirl.jpg" />
-        <p><i>Swirl Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-### magnify
-
-Apply magnify effect to the surrounding area of a given position.
-
-- `screenXY`: x, y position in screen coords, both x and y is normalized and in range `[0, 1]`. `[0, 0]` is the up left corner, `[1, 1]` is the bottom right corner. Default value is `[0, 0]`.
-- `radiusPixels`: effect radius in pixels. Default value is `100`.
-- `zoom`: magnify level. Default value is `2`.
-- `borderWidthPixels`: border width of the effect circle, will not show border if value \<\= 0.0. Default value is `0`.
-- `borderColor`: border color of the effect circle. Default value is `[255, 255, 255, 255]`.
-
-<table style={{border: 0}} align="center">
-  <tbody>
-    <tr>
-      <td align="center">
-        <img height="340" src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/luma.gl/examples/effects/magnify.png" />
-        <p><i>Swirl Effect</i></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-## Remarks
-
-- Coordinate is based on the original image. `[0, 0]` is the bottom left corner, `[1, 1]` is the up right corner.
+Every pass receives the output from the preceding stage. Pipelines may additionally allocate
+named scratch textures or persistent history, and WebGPU-enabled pipelines can replace supported
+render stages with compute work. The renderer owns its internal targets; application-owned scene
+attachments remain explicit bindings.
+
+## Inputs and Compatibility
+
+| Input | Required by | Ownership |
+| --- | --- | --- |
+| `sourceTexture` | Every shader pass and pipeline. | Application provides the current scene or image. |
+| `depthTexture` | Depth of field, bilateral blur, occlusion, reflections, temporal reconstruction, motion blur, and atmosphere. | Application retains the scene depth attachment. |
+| `normalTexture` | Normal-aware occlusion, screen-space lighting and reflections, and optional outlines. | Application supplies view-space normals or a compatible G-buffer attachment. |
+| `velocityTexture` | Motion blur and velocity-based temporal reprojection. | Application supplies per-pixel screen-space motion. |
+| History textures | Temporal antialiasing, adaptive exposure, temporal occlusion/reflections, and fog. | Named pipeline targets are owned by `ShaderPassRenderer`; `persistenceEffect` uses an application-owned history texture. |
+
+The image-only adjustments, blur filters, stylization passes, warps, FXAA, and depth of field
+include both WGSL and GLSL implementations for WebGPU and WebGL2. The advanced scene-aware
+pipelines documented here use WGSL and target WebGPU. Bloom's portable render path works on both
+backends; fused downsampling and FFT convolution additionally require WebGPU.
+
+:::info
+deck.gl's existing [`PostProcessEffect`](https://deck.gl/docs/api-reference/core/post-process-effect)
+accepts individual shader-pass modules. Named-target `ShaderPassPipeline` graphs and the separate
+WebGPU FFT bloom renderer require an integration that explicitly executes those rendering paths.
+:::
+
+## Related Guides
+
+- [Shader Passes](/docs/api-guide/shaders/shader-passes) explains routing, history, and complete HDR render stacks.
+- [Rendering Techniques and Tradeoffs](/docs/api-guide/shaders/rendering-techniques) compares blur, occlusion, reflections, transparency, and temporal techniques.
+- [ShaderPassRenderer](/docs/api-reference/engine/passes/shader-pass-renderer) documents execution, bindings, intermediate targets, and presentation.
+- Many classic image filters are derived from Evan Wallace's [glfx.js](https://github.com/evanw/glfx.js).

--- a/docs/api-reference/shadertools/shader-passes/image-processing.mdx
+++ b/docs/api-reference/shadertools/shader-passes/image-processing.mdx
@@ -198,6 +198,11 @@ Adds a glow to bright areas of the image by extracting pixels above a luminance 
 - `threshold` Luminance threshold above which a pixel contributes to bloom. Default value is `0.8`.
 - `intensity` Strength of the bloom contribution. Default value is `1`.
 
+`bloom` is the compact shader-pass implementation. For configurable multiscale HDR bloom,
+Gaussian or Dual-Kawase filtering, WebGPU compute downsampling, temporal stabilization,
+photographic lens artifacts, and the optional WebGPU FFT convolution path, see
+[Adaptive HDR exposure and cinematic bloom](/docs/api-guide/shaders/shader-passes#adaptive-hdr-exposure-and-cinematic-bloom).
+
 ### triangleBlur
 
 This is the most basic blur filter, which convolves the image with a pyramid filter. The pyramid filter is separable and is applied as two perpendicular triangle filters.

--- a/docs/api-reference/shadertools/shader-passes/ink.mdx
+++ b/docs/api-reference/shadertools/shader-passes/ink.mdx
@@ -1,0 +1,59 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Ink
+
+Emphasize local image contrast as dark illustrated contours. `ink` produces a graphic,
+hand-drawn treatment directly from scene color without requiring depth, normals, or a separate
+object-identification buffer.
+
+<PostprocessingExample embedded showStats={false} effect="ink" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `ink` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One neighborhood-sampling pass |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {brightnessContrast, ink} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  shaderPasses: [brightnessContrast, ink]
+});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {
+    brightnessContrast: {brightness: 0.04, contrast: 0.28},
+    ink: {strength: 0.36}
+  }
+});
+```
+
+## Parameters
+
+| Parameter | Default | Suggested range | Description |
+| --- | --- | --- | --- |
+| `strength` | `0.25` | `0` to `1` | Weight of the dark contour response derived from neighboring source colors. |
+
+Higher strengths reveal more aggressive illustrative lines. A value of zero suppresses the
+visible treatment but does not remove the configured fullscreen pass.
+
+## Performance and Composition
+
+Ink performs one render pass but reads nearby pixels to derive its local contrast response.
+Increase contrast beforehand for stronger edge separation. Use
+[Screen-Space Outlines](./outlines) when geometric silhouettes should remain independent of
+surface texture or illumination patterns.
+
+## Related Effects
+
+- [Edge Work](./edge-work) isolates frequency differences in two configurable passes.
+- [Screen-Space Outlines](./outlines) uses scene depth and normals instead of color alone.
+- [Brightness and Contrast](./brightness-contrast) strengthens the source image before contour extraction.

--- a/docs/api-reference/shadertools/shader-passes/magnify.mdx
+++ b/docs/api-reference/shadertools/shader-passes/magnify.mdx
@@ -1,0 +1,65 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Magnify
+
+Place an adjustable circular magnifying lens over the current image. `magnify` samples the source
+at a configurable zoom factor inside the lens while preserving the surrounding image and
+optionally drawing a border.
+
+<PostprocessingExample embedded showStats={false} effect="magnify" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `magnify` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One fullscreen texture-sampling pass |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {magnify} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [magnify]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {
+    magnify: {
+      screenXY: [0.5, 0.5],
+      radiusPixels: 150,
+      zoom: 2,
+      borderWidthPixels: 2,
+      borderColor: [1, 1, 1, 1]
+    }
+  }
+});
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `screenXY` | `[0, 0]` | Normalized screen-space lens position; the origin is the upper-left corner. |
+| `radiusPixels` | `200` | Radius of the circular magnifying region in image pixels. |
+| `zoom` | `2` | Source magnification factor inside the lens. |
+| `borderWidthPixels` | `0` | Width of the optional lens outline; zero disables it. |
+| `borderColor` | `[255, 255, 255, 255]` | Default configured RGBA border color; use normalized shader color values when setting an explicit border. |
+
+The actual `radiusPixels` descriptor default is `200`; an older type comment describing `100` is
+not consistent with the current implementation.
+
+## Composition and Cost
+
+Magnification uses one fullscreen source-texture sample per output pixel. Drive `screenXY` from
+pointer coordinates to create an interactive inspection lens. Apply the effect after passes that
+depend on unwarped depth, normal, or velocity attachments.
+
+## Related Effects
+
+- [Bulge and Pinch](./bulge-pinch) applies smoothly varying circular lens distortion.
+- [Swirl](./swirl) rotates sample coordinates around a circular focal region.
+- [Zoom Blur](./zoom-blur) creates radial streaks instead of a sharply enlarged lens image.

--- a/docs/api-reference/shadertools/shader-passes/motion-blur.mdx
+++ b/docs/api-reference/shadertools/shader-passes/motion-blur.mdx
@@ -1,0 +1,58 @@
+import {AdvancedEffectsExample} from '@site/src/examples';
+
+# Motion Blur
+
+Integrate scene color along per-pixel motion vectors while reducing bleed across depth
+discontinuities. `createMotionBlurShaderPassPipeline` produces directional shutter blur from the
+same depth and velocity attachments used by temporal reconstruction.
+
+<AdvancedEffectsExample embedded showStats={false} />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `createMotionBlurShaderPassPipeline` |
+| Backend | WebGPU |
+| Render passes | One depth-aware directional sampling pass |
+| Required bindings | `depthTexture` and `velocityTexture` |
+| Sample limit | At most 16 samples per pixel |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {createMotionBlurShaderPassPipeline} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  shaderPasses: [createMotionBlurShaderPassPipeline()]
+});
+
+renderer.renderToScreen({
+  sourceTexture: gBuffer.colorTexture,
+  bindings: gBuffer.getShaderPassBindings(),
+  uniforms: {motionBlur: {strength: 1, sampleCount: 10}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Range | Description |
+| --- | --- | --- | --- |
+| `strength` | `1` | Minimum `0` | Multiplier applied to the encoded per-pixel screen-space velocity. |
+| `sampleCount` | `10` | `2` to `16` | Number of source/depth samples distributed along the motion path. |
+
+Each candidate sample is exponentially down-weighted when its depth differs from the current
+pixel, reducing foreground/background mixing across object silhouettes.
+
+## Performance and Composition
+
+Motion blur performs one fullscreen pass, but its cost rises directly with `sampleCount`. Both the
+source color and depth attachment are sampled at each step. Place it after temporal antialiasing
+and before exposure, bloom, or tone mapping when it should operate on stabilized HDR scene color.
+
+## Related Effects
+
+- [Temporal Antialiasing](./temporal-antialiasing) consumes the same depth and velocity attachments.
+- [Zoom Blur](./zoom-blur) creates an image-only radial effect without scene-authored velocity.
+- [Persistence](./persistence) accumulates fading trails across complete frames.

--- a/docs/api-reference/shadertools/shader-passes/noise.mdx
+++ b/docs/api-reference/shadertools/shader-passes/noise.mdx
@@ -1,0 +1,54 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Noise
+
+Add controllable monochrome grain to the current image. `noise` provides a simple tactile
+finishing effect for photographic grading, stylized presentation, and deliberately imperfect
+rendered imagery.
+
+<PostprocessingExample embedded showStats={false} effect="noise" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `noise` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One fullscreen color-filter pass |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {noise, sepia} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [sepia, noise]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {sepia: {amount: 0.6}, noise: {amount: 0.2}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Range | Description |
+| --- | --- | --- | --- |
+| `amount` | `0.5` | `0` to `1` | Strength of the added black-and-white image grain. |
+
+The zero setting leaves the image visually unchanged. Small positive values are usually enough
+for a subtle photographic finish.
+
+## Composition and Cost
+
+Noise uses one source-color pass and does not allocate scene attachments or temporal history.
+Place it late in the effect chain when grain should remain sharp; blurring or temporal
+accumulation afterward will soften or average it. Use [Denoise](./denoise) for the inverse
+operation on already noisy imagery.
+
+## Related Effects
+
+- [Denoise](./denoise) reduces existing grain with color-weighted neighborhood filtering.
+- [Sepia](./sepia) supplies a complementary warm photographic grade.
+- [Vignette](./vignette) adds a radial photographic finishing treatment.

--- a/docs/api-reference/shadertools/shader-passes/outlines.mdx
+++ b/docs/api-reference/shadertools/shader-passes/outlines.mdx
@@ -1,0 +1,71 @@
+import {AdvancedEffectsExample} from '@site/src/examples';
+
+# Screen-Space Outlines
+
+Reveal object silhouettes and hard surface transitions by comparing nearby depth and normal
+values. `createOutlineShaderPassPipeline` overlays a configurable edge color in one scene-aware
+fullscreen pass.
+
+<AdvancedEffectsExample embedded showStats={false} />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `createOutlineShaderPassPipeline` |
+| Shader uniform namespace | `screenSpaceOutline` |
+| Backend | WebGPU |
+| Render passes | One fullscreen depth/normal edge pass |
+| Required binding | `depthTexture` |
+| Optional binding | `normalTexture` when `normalSource: 'normal-texture'` |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {createOutlineShaderPassPipeline} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  shaderPasses: [createOutlineShaderPassPipeline({normalSource: 'normal-texture'})]
+});
+
+renderer.renderToScreen({
+  sourceTexture: gBuffer.colorTexture,
+  bindings: gBuffer.getShaderPassBindings(),
+  uniforms: {
+    screenSpaceOutline: {
+      color: [0.02, 0.08, 0.12, 0.48],
+      thickness: 1.5,
+      depthThreshold: 0.003,
+      normalThreshold: 0.18
+    }
+  }
+});
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `normalSource` | `'reconstruct-from-depth'` | Reconstruct geometric normals or use an explicit scene-normal texture. |
+| `color` | `[0.02, 0.08, 0.12, 0.48]` | RGBA outline color; alpha controls the overlay contribution. |
+| `thickness` | `1.5` | Neighbor offset in depth-texture pixels. |
+| `depthThreshold` | `0.003` | Depth change needed to begin drawing an edge. |
+| `normalThreshold` | `0.18` | Normal-direction difference needed to begin drawing an edge. |
+
+The pass samples four cardinal neighbors and combines smooth depth and normal edge responses.
+Supplying authored normals captures material or geometric detail that reconstructed depth normals
+cannot express.
+
+## Performance and Composition
+
+Outlines use one render pass, allocate no history, and require scene attachments to remain
+aligned with the current color image. Apply them before image-space warps, or transform the
+auxiliary attachments by the same amount. For a purely color-derived illustrated treatment,
+compare [Ink](./ink) or [Edge Work](./edge-work).
+
+## Related Effects
+
+- [Ink](./ink) derives graphic contours directly from image color.
+- [Edge Work](./edge-work) extracts image-frequency differences without scene attachments.
+- [SSAO](./ssao) can reuse the same depth and normal buffers.

--- a/docs/api-reference/shadertools/shader-passes/persistence.mdx
+++ b/docs/api-reference/shadertools/shader-passes/persistence.mdx
@@ -1,0 +1,70 @@
+import {PersistenceExample} from '@site/src/examples';
+
+# Persistence
+
+Accumulate the current frame into a fading history texture to create luminous motion trails and
+long-exposure visualizations. `persistenceEffect` keeps history ownership explicit so applications
+can control reset behavior and ping-pong resources.
+
+<PersistenceExample embedded showStats={false} />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `persistenceEffect` |
+| Shader uniform namespace | `persistence` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One fullscreen color-filter pass per frame |
+| Required binding | Application-owned `persistenceTexture` |
+
+## Usage
+
+```typescript
+import type {Texture} from '@luma.gl/core';
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {persistenceEffect} from '@luma.gl/effects';
+
+const accumulationRenderers = [
+  new ShaderPassRenderer(device, {shaderPasses: [persistenceEffect]}),
+  new ShaderPassRenderer(device, {shaderPasses: [persistenceEffect]})
+];
+
+let previousAccumulationTexture = clearedHistoryTexture;
+
+function accumulateFrame(frameIndex: number, currentSceneTexture: Texture): Texture {
+  const renderer = accumulationRenderers[frameIndex % accumulationRenderers.length];
+  previousAccumulationTexture = renderer.renderToTexture({
+    sourceTexture: currentSceneTexture,
+    bindings: {persistenceTexture: previousAccumulationTexture}
+  });
+  return previousAccumulationTexture;
+}
+```
+
+Alternating renderers prevents one pass from sampling and writing the same internal output
+texture. Clear or replace the history whenever canvas dimensions or scene ownership change.
+
+## Parameters
+
+The current implementation has no public scalar uniforms. Its visual response is defined by the
+following fixed shader behavior:
+
+| Behavior | Value | Purpose |
+| --- | --- | --- |
+| Current-frame color boost | `4` | Keeps sparse bright samples visible in the accumulated image. |
+| Previous-color contribution | `0.9` | Produces gradually decaying trails. |
+| Previous-alpha decay | `0.9` | Preserves coverage while reducing stale history over time. |
+| Output RGB range | Clamped to `1` | Prevents repeated accumulation from exceeding display range. |
+
+## Composition and Cost
+
+The shader adds one fullscreen pass and samples the caller-supplied previous accumulation. Unlike
+named-history `ShaderPassPipeline` effects, the standalone pass does not allocate, clear, or
+rotate history automatically. Use a cleared initial texture and explicitly avoid read/write aliasing.
+
+## Related Effects
+
+- [Motion Blur](./motion-blur) follows current per-pixel velocity instead of accumulating previous images.
+- [Temporal Antialiasing](./temporal-antialiasing) validates history with scene depth and motion vectors.
+- [Bloom](./bloom) can add stabilized photographic glow to bright accumulated trails.

--- a/docs/api-reference/shadertools/shader-passes/screen-space-global-illumination.mdx
+++ b/docs/api-reference/shadertools/shader-passes/screen-space-global-illumination.mdx
@@ -1,0 +1,85 @@
+import {DeferredRenderingExample} from '@site/src/examples';
+
+# Screen-Space Global Illumination
+
+Gather colored diffuse light bouncing between surfaces that are visible in the current frame.
+`createSSGIShaderPassPipeline` traces a screen-space hemisphere, reprojects indirect-light
+history, denoises across compatible surfaces, and adds the stabilized radiance to scene color.
+
+<DeferredRenderingExample embedded showStats={false} />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `createSSGIShaderPassPipeline` |
+| Backend | WebGPU |
+| Render passes | Six: hemisphere trace, temporal resolve, depth history, two spatial filters, and composite |
+| Required bindings | `depthTexture`, `normalTexture`, and `velocityTexture` |
+| Persistent state | `rgba16float` indirect-light and depth history |
+| Lighting model | Visible-screen diffuse bounce; no offscreen geometry |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {createGTAOShaderPassPipeline, createSSGIShaderPassPipeline} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  colorFormat: 'rgba16float',
+  shaderPasses: [
+    createGTAOShaderPassPipeline(),
+    createSSGIShaderPassPipeline({resolutionScale: 0.5})
+  ]
+});
+
+renderer.renderToScreen({
+  sourceTexture: litSceneTexture,
+  bindings: gBuffer.getShaderPassBindings(),
+  uniforms: {
+    ssgiTrace: {
+      projectionMatrix,
+      inverseProjectionMatrix,
+      radius: 4.5,
+      thickness: 0.32,
+      intensity: 2.2,
+      rayCount: 7,
+      stepCount: 8,
+      frameIndex
+    },
+    ssgiTemporal: {inverseProjectionMatrix, historyWeight: 0.89, depthThreshold: 0.022}
+  }
+});
+```
+
+## Parameters
+
+| Parameter | Default | Range or purpose |
+| --- | --- | --- |
+| `resolutionScale` | `1` | Relative resolution of tracing, history, denoising, and indirect-radiance textures. |
+| `radius` | `4.5` | View-space hemisphere tracing distance. |
+| `thickness` | `0.32` | Depth thickness accepted when a ray intersects visible scene geometry. |
+| `intensity` | `2.2` | Multiplier applied to gathered diffuse bounced radiance. |
+| `rayCount` | `7` | Hemisphere directions per pixel; supported range is `1` to `12`. |
+| `stepCount` | `8` | Samples per ray; supported range is `2` to `12`. |
+| `historyWeight` | `0.89` | Contribution from depth-validated indirect-light history. |
+| `depthThreshold` | `0.022` | Temporal depth rejection threshold. |
+| `strength` | `1` | Final `ssgiComposite` contribution added to scene color. |
+
+## Quality and Limitations
+
+The trace cost grows with both `rayCount` and `stepCount`, while resolution affects every
+intermediate and history texture. Only geometry and radiance visible in the current screen can
+contribute; offscreen emitters and surfaces hidden behind the first depth layer are unavailable.
+Velocity reprojection and depth/normal-aware denoising reduce frame-to-frame noise but do not
+recover missing scene information.
+
+Place SSGI after direct lighting and ambient occlusion. Place it before
+[Screen-Space Reflections](./screen-space-reflections) when reflective surfaces should include the
+newly added diffuse bounce.
+
+## Related Effects
+
+- [GTAO](./gtao) removes unavailable ambient lighting instead of adding bounced radiance.
+- [Screen-Space Reflections](./screen-space-reflections) gathers directional specular reflection.
+- [Depth-Aware Blur](./depth-aware-blur) explains edge-preserving screen-space denoising.

--- a/docs/api-reference/shadertools/shader-passes/screen-space-reflections.mdx
+++ b/docs/api-reference/shadertools/shader-passes/screen-space-reflections.mdx
@@ -1,0 +1,84 @@
+import {DeferredRenderingExample} from '@site/src/examples';
+
+# Screen-Space Reflections
+
+Reflect visible scene lighting from glossy and rough surfaces using depth, surface normals,
+roughness, and temporal reprojection. `createSSRShaderPassPipeline` traces reflection rays through
+the current frame and resolves them into a stabilized specular contribution.
+
+<DeferredRenderingExample embedded showStats={false} />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `createSSRShaderPassPipeline` |
+| Backend | WebGPU |
+| Render passes | Six: reflection trace, temporal resolve, depth history, two spatial filters, and composite |
+| Required bindings | `depthTexture`, `normalTexture`, and `velocityTexture` |
+| Persistent state | `rgba16float` reflection and depth history |
+| Reflection coverage | Visible scene color and first-layer screen depth |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {createSSGIShaderPassPipeline, createSSRShaderPassPipeline} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  colorFormat: 'rgba16float',
+  shaderPasses: [
+    createSSGIShaderPassPipeline({resolutionScale: 0.5}),
+    createSSRShaderPassPipeline({resolutionScale: 0.5})
+  ]
+});
+
+renderer.renderToScreen({
+  sourceTexture: litSceneTexture,
+  bindings: gBuffer.getShaderPassBindings(),
+  uniforms: {
+    ssrTrace: {
+      projectionMatrix,
+      inverseProjectionMatrix,
+      intensity: 1.35,
+      maxDistance: 60,
+      thickness: 0.45,
+      sampleCount: 48,
+      maxRoughness: 0.88,
+      frameIndex
+    },
+    ssrTemporal: {inverseProjectionMatrix, historyWeight: 0.86, depthThreshold: 0.018}
+  }
+});
+```
+
+## Parameters
+
+| Parameter | Default | Range or purpose |
+| --- | --- | --- |
+| `resolutionScale` | `1` | Relative resolution of reflection tracing, history, and spatial filtering. |
+| `intensity` | `1.35` | Strength of traced specular reflection before final composition. |
+| `maxDistance` | `60` | Maximum view-space reflection-ray travel distance. |
+| `thickness` | `0.45` | Accepted depth thickness when testing a possible screen-space hit. |
+| `sampleCount` | `48` | Ray-march budget; supported range is `8` to `96`. |
+| `maxRoughness` | `0.88` | Highest surface roughness that can contribute reflections. |
+| `historyWeight` | `0.86` | Contribution from depth-validated reflection history. |
+| `depthThreshold` | `0.018` | Temporal rejection threshold for disoccluded reflected surfaces. |
+| `strength` | `1` | Final `ssrComposite` contribution blended into scene color. |
+
+## Quality and Limitations
+
+SSR cannot reflect geometry outside the current viewport, hidden behind the first visible depth
+layer, or absent from the already-lit source color. Roughness-aware spatial filtering broadens
+reflections and rejects unrelated depth/normal surfaces. Lowering `sampleCount` or
+`resolutionScale` saves GPU work but can increase missed intersections or soften thin details.
+
+Trace reflections after direct lighting and [Screen-Space Global Illumination](./screen-space-global-illumination)
+when the reflected image should include their contributions. Reset history after camera cuts or
+changes to attachment dimensions.
+
+## Related Effects
+
+- [Screen-Space Global Illumination](./screen-space-global-illumination) gathers diffuse rather than specular light.
+- [GTAO](./gtao) provides complementary ambient visibility.
+- [Bloom](./bloom) spreads intense reflected highlights later in the HDR pipeline.

--- a/docs/api-reference/shadertools/shader-passes/sepia.mdx
+++ b/docs/api-reference/shadertools/shader-passes/sepia.mdx
@@ -1,0 +1,53 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Sepia
+
+Blend a warm, reddish-brown photographic treatment into the source image. `sepia` provides an
+adjustable archival look while retaining the underlying composition and brightness structure.
+
+<PostprocessingExample embedded showStats={false} effect="sepia" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `sepia` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One fullscreen color-filter pass |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {sepia} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [sepia]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {sepia: {amount: 0.7}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Range | Description |
+| --- | --- | --- | --- |
+| `amount` | `0.5` | `0` to `1` | Interpolates from the untouched image to the complete sepia color transform. |
+
+Lower values retain more of the source palette. Higher values make the warm monochromatic color
+bias increasingly prominent.
+
+## Composition and Cost
+
+The effect is one source-color filter with no extra textures or temporal state. Combining it with
+[Vignette](./vignette) and a small amount of [Noise](./noise) produces a photographic finishing
+stack. Run the sepia transform before those finishing effects when the grain and edge darkening
+should remain neutral.
+
+## Related Effects
+
+- [Hue and Saturation](./hue-saturation) offers freeform hue rotation and desaturation.
+- [Noise](./noise) adds controllable monochrome grain.
+- [Vignette](./vignette) concentrates attention toward the image center.

--- a/docs/api-reference/shadertools/shader-passes/ssao.mdx
+++ b/docs/api-reference/shadertools/shader-passes/ssao.mdx
@@ -1,0 +1,78 @@
+import {AdvancedEffectsExample} from '@site/src/examples';
+
+# Screen-Space Ambient Occlusion
+
+Darken tight creases and nearby surface contacts using the current scene depth buffer.
+`createSSAOShaderPassPipeline` evaluates screen-space ambient visibility, smooths it with a
+depth-aware bilateral blur, and composites the result into scene color.
+
+<AdvancedEffectsExample embedded showStats={false} />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `createSSAOShaderPassPipeline` |
+| Backend | WebGPU |
+| Render passes | Four: evaluate, horizontal blur, vertical blur, and composite |
+| Required binding | `depthTexture` |
+| Optional binding | `normalTexture` when `normalSource: 'normal-texture'` |
+| History | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {createSSAOShaderPassPipeline} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  shaderPasses: [
+    createSSAOShaderPassPipeline({
+      normalSource: 'normal-texture',
+      resolutionScale: 0.5
+    })
+  ]
+});
+
+renderer.renderToScreen({
+  sourceTexture: gBuffer.colorTexture,
+  bindings: gBuffer.getShaderPassBindings(),
+  uniforms: {
+    ssaoEvaluate: {
+      nearPlane: 0.1,
+      farPlane: 200,
+      radius: 7,
+      bias: 0.03,
+      intensity: 1.35
+    }
+  }
+});
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `normalSource` | `'reconstruct-from-depth'` | Reconstruct normals from depth or consume an explicit `normalTexture`. |
+| `resolutionScale` | `1` | Relative resolution of all three occlusion intermediates. |
+| `nearPlane` | `0.1` | Camera near plane used to linearize hardware depth. |
+| `farPlane` | `200` | Camera far plane used to linearize hardware depth. |
+| `radius` | `7` | Screen-space sampling radius around the current pixel. |
+| `bias` | `0.03` | Depth tolerance that reduces self-occlusion. |
+| `intensity` | `1.35` | Strength of the accumulated occlusion estimate. |
+
+## Performance and Composition
+
+The evaluation stage visits 12 nearby depth samples; two subsequent
+[Depth-Aware Blur](./depth-aware-blur) passes preserve foreground/background boundaries.
+`resolutionScale: 0.5` reduces intermediate pixel count to approximately one quarter. SSAO does
+not maintain temporal history and composites onto the complete source color.
+
+Choose [GTAO](./gtao) when horizon integration, temporal stabilization, or ambient-only
+composition is required.
+
+## Related Effects
+
+- [GTAO](./gtao) adds horizon-based visibility, temporal history, and ambient-only composition.
+- [Depth-Aware Blur](./depth-aware-blur) explains the bilateral denoising stages.
+- [Outlines](./outlines) can consume the same depth and normal attachments.

--- a/docs/api-reference/shadertools/shader-passes/swirl.mdx
+++ b/docs/api-reference/shadertools/shader-passes/swirl.mdx
@@ -1,0 +1,54 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Swirl
+
+Rotate image samples around a configurable circular focal region. `swirl` creates a controllable
+vortex distortion whose angular displacement decreases away from the selected center.
+
+<PostprocessingExample embedded showStats={false} effect="swirl" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `swirl` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One fullscreen texture-sampling pass |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {swirl} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [swirl]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {swirl: {center: [0.5, 0.5], radius: 300, angle: 1.05}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `center` | `[0.5, 0.5]` | Normalized origin of the circular distortion. |
+| `radius` | `200` | Maximum affected distance from the center in source-image pixels. |
+| `angle` | `3` | Rotation strength in radians; positive and negative values rotate in opposite directions. |
+
+The image outside the chosen radius remains unwarped. Animating `angle` creates continuous
+rotation without changing the original scene geometry.
+
+## Composition and Cost
+
+Swirl requires one fullscreen source-texture sampling pass and no auxiliary attachments. Because
+depth, normal, and velocity textures are not warped alongside the color result, run it after
+scene-aware effects and temporal reconstruction.
+
+## Related Effects
+
+- [Bulge and Pinch](./bulge-pinch) applies radial rather than angular distortion.
+- [Magnify](./magnify) creates an adjustable local inspection lens.
+- [Zoom Blur](./zoom-blur) stretches samples toward a central focal point.

--- a/docs/api-reference/shadertools/shader-passes/temporal-antialiasing.mdx
+++ b/docs/api-reference/shadertools/shader-passes/temporal-antialiasing.mdx
@@ -1,0 +1,73 @@
+import {AdvancedEffectsExample} from '@site/src/examples';
+
+# Temporal Antialiasing
+
+Accumulate jittered samples from successive frames while following scene motion and rejecting
+invalid history. `createTAAShaderPassPipeline` combines velocity reprojection, depth validation,
+and neighborhood clamping to reduce spatial aliasing and temporal shimmer.
+
+<AdvancedEffectsExample embedded showStats={false} />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `createTAAShaderPassPipeline` |
+| Backend | WebGPU |
+| Render passes | Three: temporal resolve, resolved-color copy, and depth-history copy |
+| Required bindings | `depthTexture` and `velocityTexture` |
+| Persistent state | Renderer-owned color and depth history textures |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {createTAAShaderPassPipeline, toneMapping} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  colorFormat: 'rgba16float',
+  shaderPasses: [createTAAShaderPassPipeline(), toneMapping]
+});
+
+renderer.renderToScreen({
+  sourceTexture: gBuffer.colorTexture,
+  bindings: gBuffer.getShaderPassBindings(),
+  uniforms: {
+    taaResolve: {
+      historyWeight: 0.9,
+      depthThreshold: 0.01,
+      currentJitter,
+      previousJitter
+    }
+  },
+  resetHistory: cameraCut
+});
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `historyWeight` | `0.9` | Fraction of valid accumulated history retained in the resolved color. |
+| `depthThreshold` | `0.01` | Maximum allowed difference between current and reprojected previous depth. |
+| `currentJitter` | `[0, 0]` | Current projection jitter in normalized image coordinates. |
+| `previousJitter` | `[0, 0]` | Previous projection jitter in normalized image coordinates. |
+
+The history weight is limited to `0.98`. The application must render the source scene with the
+same projection jitter and provide matching velocity and depth attachments every frame.
+
+## How It Works
+
+1. Move each current pixel into the previous frame with its velocity and jitter delta.
+2. Reject history outside the screen or across a depth disocclusion.
+3. Clamp valid history to the current 3-by-3 color neighborhood.
+4. Blend the current color and bounded history, then save current depth for the next frame.
+
+Call `renderer.resetHistory()` or pass `resetHistory: true` after resize, camera cuts, abrupt scene
+replacement, or invalid velocity generation.
+
+## Related Effects
+
+- [FXAA](./fxaa) smooths one display image without history or auxiliary attachments.
+- [Camera-Reprojection Antialiasing](./camera-reprojection-antialiasing) derives motion from camera matrices rather than a velocity texture.
+- [Motion Blur](./motion-blur) uses the same depth and velocity attachments for directional shutter blur.

--- a/docs/api-reference/shadertools/shader-passes/tilt-shift.mdx
+++ b/docs/api-reference/shadertools/shader-passes/tilt-shift.mdx
@@ -1,0 +1,62 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Tilt Shift
+
+Keep a chosen image-space line sharp while progressively blurring the surrounding scene.
+`tiltShift` creates a selective-focus miniature effect without requiring a scene depth texture.
+
+<PostprocessingExample embedded showStats={false} effect="tiltShift" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `tiltShift` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | Two directional fullscreen sampling passes |
+| Additional inputs | None; focus is defined entirely in image space |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {tiltShift} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [tiltShift]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {
+    tiltShift: {
+      start: [0.12, 0.36],
+      end: [0.88, 0.64],
+      blurRadius: 18,
+      gradientRadius: 130
+    }
+  }
+});
+```
+
+## Parameters
+
+| Parameter | Default | Range | Description |
+| --- | --- | --- | --- |
+| `start` | `[0, 0]` | Normalized image coordinates | First endpoint of the line that remains in focus. |
+| `end` | `[1, 1]` | Normalized image coordinates | Second endpoint of the line that remains in focus. |
+| `blurRadius` | `15` | `0` to `50` | Maximum blur radius in pixels away from the focal line. |
+| `gradientRadius` | `200` | `0` to `400` | Distance in pixels over which blur grows from zero to its maximum. |
+
+The focus model assumes the visible scene can be approximated by a planar image-space band.
+Objects at different real-world depths are not independently distinguished.
+
+## Composition and Cost
+
+Tilt shift uses two directional sampling passes, with cost increasing as the selected blur radius
+grows. Choose [Depth of Field](./depth-of-field) when a real depth attachment is available and
+foreground/background distance should determine focus instead of a manually positioned line.
+
+## Related Effects
+
+- [Depth of Field](./depth-of-field) derives blur from physical camera depth.
+- [Gaussian Blur](./gaussian-blur) blurs the entire image evenly.
+- [Zoom Blur](./zoom-blur) emphasizes motion toward a point rather than a focal band.

--- a/docs/api-reference/shadertools/shader-passes/tone-mapping.mdx
+++ b/docs/api-reference/shadertools/shader-passes/tone-mapping.mdx
@@ -1,0 +1,58 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Tone Mapping
+
+Convert scene-linear high-dynamic-range lighting into display-ready color with an ACES-style
+filmic response. `toneMapping` compresses bright highlights, preserves source alpha, and exposes
+explicit controls for scene exposure and supported display luminance.
+
+<PostprocessingExample embedded showStats={false} effect="toneMapping" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `toneMapping` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One fullscreen color-filter pass |
+| Recommended input | Scene-linear floating-point color, such as `rgba16float` |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {createBloomShaderPassPipeline, toneMapping} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  colorFormat: 'rgba16float',
+  shaderPasses: [createBloomShaderPassPipeline(), toneMapping]
+});
+
+renderer.renderToScreen({
+  sourceTexture: hdrSceneTexture,
+  uniforms: {toneMapping: {exposure: 1.2, maximumLuminance: 1}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Range | Description |
+| --- | --- | --- | --- |
+| `exposure` | `1` | `0` to `10` | Linear multiplier applied to scene color before the filmic response curve. |
+| `maximumLuminance` | `1` | `1` to `4` | Maximum output luminance; values above one preserve additional highlight range on compatible HDR displays. |
+
+The implementation smoothly introduces extended highlight output as scene luminance rises. Source
+alpha is passed through unchanged.
+
+## Composition and Cost
+
+Keep physically motivated lighting, adaptive exposure, temporal accumulation, and
+[Bloom](./bloom) in floating-point scene color before tone mapping. Apply presentation-oriented
+grading and FXAA afterward when those operations should see the final display-referred image.
+Tone mapping adds one inexpensive fullscreen color pass and owns no persistent textures.
+
+## Related Effects
+
+- [HDR Auto Exposure](./hdr-auto-exposure) meters changing scene brightness on the GPU.
+- [Bloom](./bloom) spreads highlights before the final display transform.
+- [FXAA](./fxaa) can smooth visible display-space contrast edges near presentation.

--- a/docs/api-reference/shadertools/shader-passes/triangle-blur.mdx
+++ b/docs/api-reference/shadertools/shader-passes/triangle-blur.mdx
@@ -1,0 +1,52 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Triangle Blur
+
+Blend neighboring pixels with a linearly weighted pyramid kernel. `triangleBlur` uses separable
+horizontal and vertical passes to produce an inexpensive, visibly soft image treatment.
+
+<PostprocessingExample embedded showStats={false} effect="triangleBlur" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `triangleBlur` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | Two separable fullscreen sampling passes |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {triangleBlur} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [triangleBlur]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {triangleBlur: {radius: 14}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Suggested range | Description |
+| --- | --- | --- | --- |
+| `radius` | `20` | `0` to `100` | Width of the triangular blur kernel in source-image pixels. |
+
+The descriptor owns its horizontal and vertical direction uniforms. A radius of zero suppresses
+the visible blur but does not remove the two configured fullscreen passes.
+
+## Composition and Cost
+
+The pass performs two separable draws and requires no scene depth or persistent history. Its
+triangular weights differ from the smoother bell-shaped [Gaussian Blur](./gaussian-blur) kernel;
+choose between them based on the desired reconstruction profile rather than pass count alone.
+
+## Related Effects
+
+- [Gaussian Blur](./gaussian-blur) produces a smoother photographic weight falloff.
+- [Tilt Shift](./tilt-shift) varies blur strength around a selected focal line.
+- [Zoom Blur](./zoom-blur) samples radially toward an adjustable focal center.

--- a/docs/api-reference/shadertools/shader-passes/vibrance.mdx
+++ b/docs/api-reference/shadertools/shader-passes/vibrance.mdx
@@ -1,0 +1,53 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Vibrance
+
+Adjust subdued colors while protecting hues that are already strongly saturated. `vibrance`
+offers a more selective color-grade control than a uniform saturation adjustment.
+
+<PostprocessingExample embedded showStats={false} effect="vibrance" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `vibrance` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One fullscreen color-filter pass |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {vibrance} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [vibrance]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {vibrance: {amount: 0.45}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Range | Description |
+| --- | --- | --- | --- |
+| `amount` | `0` | `-1` to `1` | Decreases or increases saturation in proportion to how muted each source color is. |
+
+The zero default leaves the source unchanged. Positive values reveal quieter color detail without
+applying the same increase to already vivid pixels.
+
+## Composition and Cost
+
+Vibrance is a single color-only pass and requires no intermediate history or scene attachments.
+It works well after a broad hue rotation, after a color halftone, or as a late finishing grade.
+Use [Hue and Saturation](./hue-saturation) when all colors should change with the same global
+saturation control.
+
+## Related Effects
+
+- [Hue and Saturation](./hue-saturation) adjusts all colors uniformly.
+- [Brightness and Contrast](./brightness-contrast) controls the tonal range instead of chroma.
+- [Color Halftone](./color-halftone) provides a complementary print-style color treatment.

--- a/docs/api-reference/shadertools/shader-passes/vignette.mdx
+++ b/docs/api-reference/shadertools/shader-passes/vignette.mdx
@@ -1,0 +1,56 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Vignette
+
+Darken the image perimeter with a smooth radial falloff. `vignette` concentrates visual attention
+toward the center and provides an adjustable photographic finishing effect.
+
+<PostprocessingExample embedded showStats={false} effect="vignette" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `vignette` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One fullscreen color-filter pass |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {bloom, vignette} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [bloom, vignette]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {
+    bloom: {radius: 9, threshold: 0.48, intensity: 1.85},
+    vignette: {radius: 0.7, amount: 0.45}
+  }
+});
+```
+
+## Parameters
+
+| Parameter | Default | Range | Description |
+| --- | --- | --- | --- |
+| `radius` | `0.5` | `0` to `1` | Normalized size of the central region before edge darkening becomes visible. |
+| `amount` | `0.5` | `0` to `1` | Strength of the perimeter-darkening treatment. |
+
+The public property is `radius`; older references that call it `size` do not match the current
+shader-pass implementation.
+
+## Composition and Cost
+
+Vignette adds one fullscreen color pass and requires no auxiliary textures or persistent state.
+It is normally composed late so it darkens the finished image evenly. Place it after bloom when
+the outer glow should also recede toward the frame edges.
+
+## Related Effects
+
+- [Bloom](./bloom) provides complementary central or highlight-focused glow.
+- [Sepia](./sepia) combines with edge darkening for an archival photographic grade.
+- [Noise](./noise) adds controllable finishing grain.

--- a/docs/api-reference/shadertools/shader-passes/volumetric-fog.mdx
+++ b/docs/api-reference/shadertools/shader-passes/volumetric-fog.mdx
@@ -1,0 +1,72 @@
+import {AdvancedEffectsExample} from '@site/src/examples';
+
+# Volumetric Fog
+
+Add depth-aware height fog, directional atmospheric scattering, and temporally stabilized haze.
+`createVolumetricFogShaderPassPipeline` provides a compact participating-media treatment when a
+full scene-lighting integration is unnecessary.
+
+<AdvancedEffectsExample embedded showStats={false} />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `createVolumetricFogShaderPassPipeline` |
+| Shader uniform namespace | `volumetricFog` |
+| Backend | WebGPU |
+| Render passes | Two: fog/history resolve and composed-color copy |
+| Required binding | `depthTexture` |
+| Persistent state | One renderer-owned fog-history texture |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {createVolumetricFogShaderPassPipeline} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  colorFormat: 'rgba16float',
+  shaderPasses: [createVolumetricFogShaderPassPipeline()]
+});
+
+renderer.renderToScreen({
+  sourceTexture: gBuffer.colorTexture,
+  bindings: {depthTexture: gBuffer.depthTexture},
+  uniforms: {
+    volumetricFog: {
+      fogColor: [0.18, 0.34, 0.48, 0.6],
+      density: 0.22,
+      heightFalloff: 3,
+      scattering: 0.35,
+      historyWeight: 0.82,
+      time: elapsedSeconds
+    }
+  }
+});
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `fogColor` | `[0.18, 0.34, 0.48, 0.6]` | Atmospheric RGB color and directional-scattering influence. |
+| `density` | `0.22` | Overall participating-media density. |
+| `heightFalloff` | `3` | Rate at which the simulated fog density decreases with height. |
+| `scattering` | `0.35` | Strength of the built-in directional light contribution. |
+| `historyWeight` | `0.82` | Contribution from the preceding temporally accumulated fog result. |
+| `time` | `0` | Application-owned animation value used to vary the sampling pattern. |
+
+## Performance and Limitations
+
+The main stage takes 20 depth-dependent integration samples and blends against one persistent
+history texture; the second stage copies the stabilized result back into the shared pass chain.
+This compact model does not inspect application point-light buffers or clustered light lists.
+Choose [Clustered Volumetric Lighting](./clustered-volumetric-lighting) when the atmosphere must
+react to actual scene lights, physically oriented anisotropy, or depth-occluded light shafts.
+
+## Related Effects
+
+- [Clustered Volumetric Lighting](./clustered-volumetric-lighting) integrates real directional and clustered point lights.
+- [Temporal Antialiasing](./temporal-antialiasing) explains scene-history reset and reprojection.
+- [Bloom](./bloom) can soften intense atmospheric highlights before tone mapping.

--- a/docs/api-reference/shadertools/shader-passes/zoom-blur.mdx
+++ b/docs/api-reference/shadertools/shader-passes/zoom-blur.mdx
@@ -1,0 +1,55 @@
+import {PostprocessingExample} from '@site/src/examples';
+
+# Zoom Blur
+
+Pull image samples toward a chosen focal point to suggest rapid zoom, radial motion, or a
+stylized optical rush. `zoomBlur` preserves the selected center while increasingly stretching
+detail farther away.
+
+<PostprocessingExample embedded showStats={false} effect="zoomBlur" />
+
+## At a Glance
+
+| Property | Value |
+| --- | --- |
+| Export | `zoomBlur` |
+| Backends | WebGPU and WebGL2 |
+| Render passes | One sample-heavy fullscreen pass |
+| Additional inputs | None |
+
+## Usage
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {zoomBlur} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {shaderPasses: [zoomBlur]});
+
+renderer.renderToScreen({
+  sourceTexture: sceneColorTexture,
+  uniforms: {zoomBlur: {center: [0.5, 0.5], strength: 0.16}}
+});
+```
+
+## Parameters
+
+| Parameter | Default | Suggested range | Description |
+| --- | --- | --- | --- |
+| `center` | `[0.5, 0.5]` | Normalized image coordinates | Focal position toward which the sampling path converges. |
+| `strength` | `0.3` | `0` to `1` | Radial sample displacement; larger values create longer streaks. |
+
+The pass animates naturally when the application changes the focal center or strength each frame.
+It does not require motion vectors and does not distinguish actual object movement.
+
+## Composition and Cost
+
+Although zoom blur occupies one render pass, it samples multiple positions along each radial path
+and can be materially more expensive than a one-sample color adjustment. Use reduced effect
+resolution for large canvases, and prefer [Motion Blur](./motion-blur) when physically meaningful
+per-pixel velocity is available.
+
+## Related Effects
+
+- [Motion Blur](./motion-blur) follows scene-authored velocity and respects depth edges.
+- [Swirl](./swirl) rotates image coordinates around a focal point.
+- [Tilt Shift](./tilt-shift) preserves a focused line rather than a single center.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -166,7 +166,7 @@
           "api-reference/engine/orbit-controls",
           "api-reference/engine/dynamic-texture",
           "api-reference/engine/video-texture",
-          "api-reference/engine/load-image-bitmap",          
+          "api-reference/engine/load-image-bitmap",
           "api-reference/engine/geometry/geometries",
           "api-reference/engine/geometry/geometry",
           "api-reference/engine/geometry/gpu-geometry",
@@ -449,7 +449,87 @@
           {
             "type": "category",
             "label": "Shader Pass Catalog",
-            "items": ["api-reference/shadertools/shader-passes/image-processing"]
+            "items": [
+              "api-reference/shadertools/shader-passes/image-processing",
+              {
+                "type": "category",
+                "label": "Color and Tone",
+                "items": [
+                  "api-reference/shadertools/shader-passes/brightness-contrast",
+                  "api-reference/shadertools/shader-passes/hue-saturation",
+                  "api-reference/shadertools/shader-passes/sepia",
+                  "api-reference/shadertools/shader-passes/vibrance",
+                  "api-reference/shadertools/shader-passes/tone-mapping",
+                  "api-reference/shadertools/shader-passes/hdr-auto-exposure"
+                ]
+              },
+              {
+                "type": "category",
+                "label": "Blur, Bloom and Focus",
+                "items": [
+                  "api-reference/shadertools/shader-passes/bloom",
+                  "api-reference/shadertools/shader-passes/gaussian-blur",
+                  "api-reference/shadertools/shader-passes/triangle-blur",
+                  "api-reference/shadertools/shader-passes/tilt-shift",
+                  "api-reference/shadertools/shader-passes/zoom-blur",
+                  "api-reference/shadertools/shader-passes/depth-of-field",
+                  "api-reference/shadertools/shader-passes/depth-aware-blur"
+                ]
+              },
+              {
+                "type": "category",
+                "label": "Temporal and Antialiasing",
+                "items": [
+                  "api-reference/shadertools/shader-passes/persistence",
+                  "api-reference/shadertools/shader-passes/fxaa",
+                  "api-reference/shadertools/shader-passes/temporal-antialiasing",
+                  "api-reference/shadertools/shader-passes/camera-reprojection-antialiasing",
+                  "api-reference/shadertools/shader-passes/motion-blur"
+                ]
+              },
+              {
+                "type": "category",
+                "label": "Lighting and Visibility",
+                "items": [
+                  "api-reference/shadertools/shader-passes/ssao",
+                  "api-reference/shadertools/shader-passes/gtao",
+                  "api-reference/shadertools/shader-passes/screen-space-global-illumination",
+                  "api-reference/shadertools/shader-passes/screen-space-reflections",
+                  "api-reference/shadertools/shader-passes/outlines"
+                ]
+              },
+              {
+                "type": "category",
+                "label": "Atmosphere",
+                "items": [
+                  "api-reference/shadertools/shader-passes/volumetric-fog",
+                  "api-reference/shadertools/shader-passes/clustered-volumetric-lighting"
+                ]
+              },
+              {
+                "type": "category",
+                "label": "Stylization and Detail",
+                "items": [
+                  "api-reference/shadertools/shader-passes/color-halftone",
+                  "api-reference/shadertools/shader-passes/dot-screen",
+                  "api-reference/shadertools/shader-passes/edge-work",
+                  "api-reference/shadertools/shader-passes/hexagonal-pixelate",
+                  "api-reference/shadertools/shader-passes/ink",
+                  "api-reference/shadertools/shader-passes/noise",
+                  "api-reference/shadertools/shader-passes/vignette",
+                  "api-reference/shadertools/shader-passes/denoise"
+                ]
+              },
+              {
+                "type": "category",
+                "label": "Warp and Lens",
+                "items": [
+                  "api-reference/shadertools/shader-passes/bulge-pinch",
+                  "api-reference/shadertools/shader-passes/magnify",
+                  "api-reference/shadertools/shader-passes/swirl"
+                ]
+              }
+            ]
           }
         ]
       },

--- a/examples/showcase/postprocessing/app.ts
+++ b/examples/showcase/postprocessing/app.ts
@@ -64,6 +64,35 @@ type LookDefinition = {
   values: Record<string, EffectState>;
 };
 
+const FOCUSED_EFFECT_PREVIEW_VALUES: Record<string, EffectState> = {
+  brightnessContrast: {brightness: 0.08, contrast: 0.28},
+  hueSaturation: {hue: -0.08, saturation: 0.32},
+  sepia: {amount: 0.7},
+  toneMapping: {exposure: 1.8, maximumLuminance: 1},
+  vibrance: {amount: 0.45},
+  bloom: {radius: 9, threshold: 0.48, intensity: 1.85},
+  gaussianBlur: {radius: 10},
+  tiltShift: {
+    start: [0.12, 0.36],
+    end: [0.88, 0.64],
+    blurRadius: 18,
+    gradientRadius: 130
+  },
+  triangleBlur: {radius: 14},
+  zoomBlur: {center: [0.5, 0.5], strength: 0.16},
+  colorHalftone: {center: [0.5, 0.5], angle: 0.32, size: 5},
+  dotScreen: {center: [0.5, 0.5], angle: 0.42, size: 5},
+  edgeWork: {radius: 3},
+  hexagonalPixelate: {center: [0.5, 0.5], scale: 12},
+  ink: {strength: 0.36},
+  bulgePinch: {center: [0.5, 0.5], radius: 240, strength: 0.45},
+  magnify: {screenXY: [0.5, 0.5], radiusPixels: 150, zoom: 2},
+  swirl: {center: [0.5, 0.5], radius: 300, angle: 1.05},
+  denoise: {strength: 0.55},
+  noise: {amount: 0.2},
+  vignette: {radius: 0.7, amount: 0.45}
+};
+
 const LOOK_DEFINITIONS: Record<LookName, LookDefinition> = {
   Original: {
     kicker: 'Reference',
@@ -147,6 +176,7 @@ const LOOK_ORDER: LookName[] = [
 
 export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   static info = makeExamplePanelHostHtml();
+  static initialEffectName?: string;
 
   readonly device: Device;
   readonly sourceTexture: Texture;
@@ -180,7 +210,15 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.shaderPassMap = getShaderPasses();
     this.effectValuesByName = getInitialEffectValues(this.shaderPassMap);
     this.applyLookValues(LOOK_DEFINITIONS[this.selectedLookName]);
-    this.activePassNames = [...LOOK_DEFINITIONS[this.selectedLookName].passNames];
+    const initialEffectName = (this.constructor as typeof AppAnimationLoopTemplate)
+      .initialEffectName;
+    this.activePassNames = getInitialPostprocessingPassNames(initialEffectName);
+    if (initialEffectName && this.activePassNames[0] === initialEffectName) {
+      this.effectValuesByName[initialEffectName] = {
+        ...this.effectValuesByName[initialEffectName],
+        ...cloneEffectState(FOCUSED_EFFECT_PREVIEW_VALUES[initialEffectName] || {})
+      };
+    }
 
     this.settingsPanel = new ExampleSettingsPanelManager({
       id: 'postprocessing-tune',
@@ -604,6 +642,15 @@ function getControllableProps(shaderPass: ShaderPass): [string, ShaderPropType][
     }
   }
   return controllableProps;
+}
+
+/** Opens documentation embeds on one actual effect without changing the gallery default. */
+export function getInitialPostprocessingPassNames(effectName?: string): string[] {
+  if (effectName && Object.hasOwn(EFFECT_SHADER_PASSES, effectName)) {
+    return [effectName];
+  }
+
+  return [...LOOK_DEFINITIONS[DEFAULT_LOOK_NAME].passNames];
 }
 
 /** Derives adaptive render resolution from the effects that are actually active. */

--- a/modules/effects/README.md
+++ b/modules/effects/README.md
@@ -62,6 +62,9 @@ reuses expired extraction textures during reconstruction.
 | `high` | 4 | 16 render | 12 render + 1 compute | 8 render | 4 render + 1 compute |
 | `ultra` | 5 | 20 render | 15 render + 1 compute | 10 render | 5 render + 1 compute |
 
+These counts describe bloom-pipeline work only; optional lens/history passes and renderer
+source-seeding or presentation passes are additional.
+
 Optional `lens` controls add aperture diffraction, spectral lens-element ghosts, a radial halo,
 and sampled lens dirt. Set `temporalStability` to accumulate neighborhood-clamped glow history.
 Add `temporalReprojection: true` when the application supplies `velocityTexture` and `depthTexture`
@@ -86,7 +89,16 @@ The lens pass exists only when at least one of `starburstIntensity`, `ghostInten
 `quality`, `resolutionScale`, `starburstSpikes`, or `ghostCount` to trade optical detail for
 throughput. For physically based full-kernel diffraction, the separately owned
 `GPUConvolutionBloom` renderer in `@luma.gl/experimental` applies true RGB FFT convolution instead
-of the lower-cost screen-space starburst approximation.
+of the lower-cost screen-space starburst approximation. It supports independent generated or
+measured red, green, and blue point-spread functions, zero-padded guard bands, exposure-aware
+extraction, and optional lens/temporal composition. At 1920 x 1080 with quarter-resolution
+sampling and the default 12.5% guard band, its 1024 x 512 transform uses 48 MiB of complex
+buffers and 45 steady-state compute dispatches. Setting `guardBand: 0` uses a 512 x 512 transform,
+24 MiB, and 43 dispatches without explicit edge-wrap protection.
+
+Keep the scene and bloom chain in `rgba16float` when unclamped highlight radiance is required.
+The existing deck.gl `PostProcessEffect` accepts shader-pass modules rather than named-target
+`ShaderPassPipeline` graphs; its default postprocessing buffers currently use `rgba8unorm`.
 
 `toneMapping` applies an ACES filmic curve after exposure and preserves the source alpha channel.
 Place it after bloom or other HDR effects so bright highlights roll off before presentation:
@@ -136,6 +148,17 @@ renderer.renderToScreen({
 `lensDirtTexture` is an application-owned, sampled color texture. Omit the binding when
 `lens.dirtIntensity` is zero. Like other persistent effects, temporal bloom history is reset by
 `renderer.resetHistory()`, `resetHistory: true`, or resizing the renderer.
+
+Related technique and integration references:
+
+- [Unreal Engine bloom documentation](https://dev.epicgames.com/documentation/en-us/unreal-engine/bloom-in-unreal-engine):
+  image-kernel FFT convolution, energy conservation, lens dirt, and edge-padding controls.
+- [AMD FidelityFX Single Pass Downsampler](https://gpuopen.com/manuals/fidelityfx_sdk/techniques/single-pass-downsampler/):
+  workgroup-local image reduction in one compute dispatch.
+- [Google Filament imaging pipeline](https://google.github.io/filament/main/filament.html):
+  camera exposure, bloom, and scene-linear postprocessing before tone mapping.
+- [deck.gl PostProcessEffect](https://deck.gl/docs/api-reference/core/post-process-effect):
+  deck.gl's existing shader-module postprocessing interface.
 
 See [Rendering Techniques and Tradeoffs](https://luma.gl/docs/api-guide/shaders/rendering-techniques)
 for comparisons between related effects, their GPU inputs, backend support, and composition order.

--- a/test/examples/example-panels.spec.ts
+++ b/test/examples/example-panels.spec.ts
@@ -25,6 +25,7 @@ import {isAnimatedGLTFCatalogModel} from '../../examples/showcase/gltf/gltf-cata
 import {
   flattenEffectSettings,
   getEffectResolutionScale,
+  getInitialPostprocessingPassNames,
   makePostprocessingUniforms,
   reorderEffectPassNames,
   unflattenEffectSettings,
@@ -649,6 +650,18 @@ describe('text 3D crawl color compatibility', () => {
 });
 
 describe('postprocessing effect settings', () => {
+  test('opens effect documentation on the requested shader pass only', () => {
+    expect(getInitialPostprocessingPassNames('brightnessContrast')).toEqual(['brightnessContrast']);
+    expect(getInitialPostprocessingPassNames('gaussianBlur')).toEqual(['gaussianBlur']);
+    expect(getInitialPostprocessingPassNames('magnify')).toEqual(['magnify']);
+  });
+
+  test('preserves the gallery preset when no valid documentation effect is requested', () => {
+    expect(getInitialPostprocessingPassNames()).toEqual(['bloom', 'vignette']);
+    expect(getInitialPostprocessingPassNames('missingEffect')).toEqual(['bloom', 'vignette']);
+    expect(getInitialPostprocessingPassNames('toString')).toEqual(['bloom', 'vignette']);
+  });
+
   test('renders empty and inexpensive effect stacks at native resolution', () => {
     expect(getEffectResolutionScale([])).toBe(1);
     expect(getEffectResolutionScale(['bloom', 'vignette'])).toBe(1);

--- a/test/examples/shader-pass-documentation.node.spec.ts
+++ b/test/examples/shader-pass-documentation.node.spec.ts
@@ -1,0 +1,374 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {existsSync, readFileSync, readdirSync} from 'node:fs';
+import path from 'node:path';
+import {describe, expect, test} from 'vitest';
+
+type SidebarEntry =
+  | string
+  | {type: 'doc'; id: string; label?: string}
+  | {type: 'category'; label: string; items: SidebarEntry[]};
+
+type EffectDocumentation = {
+  exportName: string;
+  exampleName: string;
+  effectName?: string;
+  backend: 'portable' | 'webgpu' | 'mixed';
+};
+
+const DOCS_DIRECTORY = path.join(process.cwd(), 'docs/api-reference/shadertools/shader-passes');
+const SHADER_PASS_DOCUMENT_PREFIX = 'api-reference/shadertools/shader-passes/';
+
+const EFFECT_DOCUMENTATION = {
+  'brightness-contrast': {
+    exportName: 'brightnessContrast',
+    exampleName: 'PostprocessingExample',
+    effectName: 'brightnessContrast',
+    backend: 'portable'
+  },
+  'hue-saturation': {
+    exportName: 'hueSaturation',
+    exampleName: 'PostprocessingExample',
+    effectName: 'hueSaturation',
+    backend: 'portable'
+  },
+  sepia: {
+    exportName: 'sepia',
+    exampleName: 'PostprocessingExample',
+    effectName: 'sepia',
+    backend: 'portable'
+  },
+  vibrance: {
+    exportName: 'vibrance',
+    exampleName: 'PostprocessingExample',
+    effectName: 'vibrance',
+    backend: 'portable'
+  },
+  'tone-mapping': {
+    exportName: 'toneMapping',
+    exampleName: 'PostprocessingExample',
+    effectName: 'toneMapping',
+    backend: 'portable'
+  },
+  'hdr-auto-exposure': {
+    exportName: 'createHDRAutoExposureShaderPassPipeline',
+    exampleName: 'DeferredRenderingExample',
+    backend: 'webgpu'
+  },
+  bloom: {exportName: 'bloom', exampleName: 'BloomExample', backend: 'mixed'},
+  'gaussian-blur': {
+    exportName: 'gaussianBlur',
+    exampleName: 'PostprocessingExample',
+    effectName: 'gaussianBlur',
+    backend: 'portable'
+  },
+  'triangle-blur': {
+    exportName: 'triangleBlur',
+    exampleName: 'PostprocessingExample',
+    effectName: 'triangleBlur',
+    backend: 'portable'
+  },
+  'tilt-shift': {
+    exportName: 'tiltShift',
+    exampleName: 'PostprocessingExample',
+    effectName: 'tiltShift',
+    backend: 'portable'
+  },
+  'zoom-blur': {
+    exportName: 'zoomBlur',
+    exampleName: 'PostprocessingExample',
+    effectName: 'zoomBlur',
+    backend: 'portable'
+  },
+  'depth-of-field': {exportName: 'dof', exampleName: 'DOFExample', backend: 'portable'},
+  'depth-aware-blur': {
+    exportName: 'depthAwareBlur',
+    exampleName: 'AdvancedEffectsExample',
+    backend: 'webgpu'
+  },
+  persistence: {
+    exportName: 'persistenceEffect',
+    exampleName: 'PersistenceExample',
+    backend: 'portable'
+  },
+  fxaa: {exportName: 'fxaa', exampleName: 'AntialiasingExample', backend: 'portable'},
+  'temporal-antialiasing': {
+    exportName: 'createTAAShaderPassPipeline',
+    exampleName: 'AdvancedEffectsExample',
+    backend: 'webgpu'
+  },
+  'camera-reprojection-antialiasing': {
+    exportName: 'createCameraReprojectionTAAShaderPassPipeline',
+    exampleName: 'ANARIPlaygroundExample',
+    backend: 'webgpu'
+  },
+  'motion-blur': {
+    exportName: 'createMotionBlurShaderPassPipeline',
+    exampleName: 'AdvancedEffectsExample',
+    backend: 'webgpu'
+  },
+  ssao: {
+    exportName: 'createSSAOShaderPassPipeline',
+    exampleName: 'AdvancedEffectsExample',
+    backend: 'webgpu'
+  },
+  gtao: {
+    exportName: 'createGTAOShaderPassPipeline',
+    exampleName: 'DeferredRenderingExample',
+    backend: 'webgpu'
+  },
+  'screen-space-global-illumination': {
+    exportName: 'createSSGIShaderPassPipeline',
+    exampleName: 'DeferredRenderingExample',
+    backend: 'webgpu'
+  },
+  'screen-space-reflections': {
+    exportName: 'createSSRShaderPassPipeline',
+    exampleName: 'DeferredRenderingExample',
+    backend: 'webgpu'
+  },
+  outlines: {
+    exportName: 'createOutlineShaderPassPipeline',
+    exampleName: 'AdvancedEffectsExample',
+    backend: 'webgpu'
+  },
+  'volumetric-fog': {
+    exportName: 'createVolumetricFogShaderPassPipeline',
+    exampleName: 'AdvancedEffectsExample',
+    backend: 'webgpu'
+  },
+  'clustered-volumetric-lighting': {
+    exportName: 'createClusteredVolumetricLightingShaderPassPipeline',
+    exampleName: 'DeferredRenderingExample',
+    backend: 'webgpu'
+  },
+  'color-halftone': {
+    exportName: 'colorHalftone',
+    exampleName: 'PostprocessingExample',
+    effectName: 'colorHalftone',
+    backend: 'portable'
+  },
+  'dot-screen': {
+    exportName: 'dotScreen',
+    exampleName: 'PostprocessingExample',
+    effectName: 'dotScreen',
+    backend: 'portable'
+  },
+  'edge-work': {
+    exportName: 'edgeWork',
+    exampleName: 'PostprocessingExample',
+    effectName: 'edgeWork',
+    backend: 'portable'
+  },
+  'hexagonal-pixelate': {
+    exportName: 'hexagonalPixelate',
+    exampleName: 'PostprocessingExample',
+    effectName: 'hexagonalPixelate',
+    backend: 'portable'
+  },
+  ink: {
+    exportName: 'ink',
+    exampleName: 'PostprocessingExample',
+    effectName: 'ink',
+    backend: 'portable'
+  },
+  noise: {
+    exportName: 'noise',
+    exampleName: 'PostprocessingExample',
+    effectName: 'noise',
+    backend: 'portable'
+  },
+  vignette: {
+    exportName: 'vignette',
+    exampleName: 'PostprocessingExample',
+    effectName: 'vignette',
+    backend: 'portable'
+  },
+  denoise: {
+    exportName: 'denoise',
+    exampleName: 'PostprocessingExample',
+    effectName: 'denoise',
+    backend: 'portable'
+  },
+  'bulge-pinch': {
+    exportName: 'bulgePinch',
+    exampleName: 'PostprocessingExample',
+    effectName: 'bulgePinch',
+    backend: 'portable'
+  },
+  magnify: {
+    exportName: 'magnify',
+    exampleName: 'PostprocessingExample',
+    effectName: 'magnify',
+    backend: 'portable'
+  },
+  swirl: {
+    exportName: 'swirl',
+    exampleName: 'PostprocessingExample',
+    effectName: 'swirl',
+    backend: 'portable'
+  }
+} as const satisfies Record<string, EffectDocumentation>;
+
+describe('shader-pass reference documentation', () => {
+  test('lists one dedicated MDX page for every documented effect in the categorized sidebar', () => {
+    const tableOfContents = JSON.parse(
+      readFileSync(path.join(process.cwd(), 'docs/table-of-contents.json'), 'utf8')
+    ) as SidebarEntry[];
+    const shaderPassCatalog = findCategory(tableOfContents, 'Shader Pass Catalog');
+
+    expect(shaderPassCatalog).toBeDefined();
+    if (!shaderPassCatalog) {
+      return;
+    }
+
+    const categoryNames = shaderPassCatalog.items
+      .filter(item => typeof item !== 'string' && item.type === 'category')
+      .map(category => category.label);
+
+    expect(categoryNames).toEqual([
+      'Color and Tone',
+      'Blur, Bloom and Focus',
+      'Temporal and Antialiasing',
+      'Lighting and Visibility',
+      'Atmosphere',
+      'Stylization and Detail',
+      'Warp and Lens'
+    ]);
+
+    const sidebarDocumentIds = collectDocumentIds(shaderPassCatalog.items).sort();
+    const expectedDocumentIds = [
+      `${SHADER_PASS_DOCUMENT_PREFIX}image-processing`,
+      ...Object.keys(EFFECT_DOCUMENTATION).map(
+        effectName => `${SHADER_PASS_DOCUMENT_PREFIX}${effectName}`
+      )
+    ].sort();
+
+    expect(sidebarDocumentIds).toEqual(expectedDocumentIds);
+    expect(new Set(sidebarDocumentIds).size).toBe(sidebarDocumentIds.length);
+
+    for (const documentId of sidebarDocumentIds) {
+      expect(existsSync(path.join(process.cwd(), 'docs', `${documentId}.mdx`)), documentId).toBe(
+        true
+      );
+    }
+
+    const actualDocumentationFiles = readdirSync(DOCS_DIRECTORY)
+      .filter(fileName => fileName.endsWith('.mdx'))
+      .sort();
+
+    expect(actualDocumentationFiles).toEqual(
+      [
+        'image-processing.mdx',
+        ...Object.keys(EFFECT_DOCUMENTATION).map(name => `${name}.mdx`)
+      ].sort()
+    );
+  });
+
+  test('gives every public effect a complete reference, a real export, and a matching live example', () => {
+    const effectsExportsSource = readFileSync(
+      path.join(process.cwd(), 'modules/effects/src/index.ts'),
+      'utf8'
+    );
+    const websiteExamplesSource = readFileSync(
+      path.join(process.cwd(), 'website/src/examples.tsx'),
+      'utf8'
+    );
+    const postprocessingCatalogSource = readFileSync(
+      path.join(process.cwd(), 'examples/showcase/postprocessing/effect-catalog.ts'),
+      'utf8'
+    );
+
+    for (const [pageName, documentation] of Object.entries(EFFECT_DOCUMENTATION)) {
+      const pageSource = readFileSync(path.join(DOCS_DIRECTORY, `${pageName}.mdx`), 'utf8');
+
+      expect(pageSource, pageName).toMatch(/^# .+$/m);
+      expect(pageSource, pageName).toContain('## At a Glance');
+      expect(pageSource, pageName).toContain('## Usage');
+      expect(pageSource, pageName).toContain('## Parameters');
+      expect(pageSource, pageName).toContain('## Related Effects');
+      expect(pageSource, pageName).toContain(documentation.exportName);
+      expect(pageSource, pageName).toContain(`import {${documentation.exampleName}}`);
+      expect(pageSource, pageName).toContain(`<${documentation.exampleName}`);
+      expect(effectsExportsSource, pageName).toContain(documentation.exportName);
+      expect(websiteExamplesSource, pageName).toContain(
+        `export const ${documentation.exampleName}`
+      );
+
+      if ('effectName' in documentation) {
+        expect(pageSource, pageName).toContain(`effect="${documentation.effectName}"`);
+        expect(postprocessingCatalogSource, pageName).toContain(`  ${documentation.effectName},`);
+      }
+
+      if (documentation.backend === 'portable') {
+        expect(pageSource, pageName).toContain('WebGPU and WebGL2');
+      }
+      if (documentation.backend === 'webgpu') {
+        expect(pageSource, pageName).toContain('| Backend | WebGPU |');
+      }
+    }
+  });
+
+  test('preserves the existing catalog route as an interactive, linked overview', () => {
+    const overviewSource = readFileSync(path.join(DOCS_DIRECTORY, 'image-processing.mdx'), 'utf8');
+
+    expect(overviewSource).toContain('<PostprocessingExample embedded showStats={false} />');
+    expect(overviewSource).toContain('## Choosing an Effect');
+    expect(overviewSource).toContain('## Inputs and Compatibility');
+    expect(overviewSource).not.toContain('### brightnessContrast');
+
+    for (const pageName of Object.keys(EFFECT_DOCUMENTATION)) {
+      expect(overviewSource, pageName).toContain(`](./${pageName})`);
+    }
+  });
+
+  test('documents factual pass budgets, corrected property names, and optical reference sources', () => {
+    const bloomSource = readFileSync(path.join(DOCS_DIRECTORY, 'bloom.mdx'), 'utf8');
+    const vignetteSource = readFileSync(path.join(DOCS_DIRECTORY, 'vignette.mdx'), 'utf8');
+    const magnifySource = readFileSync(path.join(DOCS_DIRECTORY, 'magnify.mdx'), 'utf8');
+    const clusteredVolumeSource = readFileSync(
+      path.join(DOCS_DIRECTORY, 'clustered-volumetric-lighting.mdx'),
+      'utf8'
+    );
+
+    expect(bloomSource).toContain('| `ultra` | `5` | 20 render passes |');
+    expect(bloomSource).toContain('| Default guard band | `1024 x 512` | `48 MiB` | `45` |');
+    expect(bloomSource).toContain('https://gpuopen.com/manuals/fidelityfx_sdk/techniques/');
+    expect(bloomSource).toContain('https://google.github.io/filament/main/filament.html');
+    expect(vignetteSource).toContain('| `radius` | `0.5` |');
+    expect(magnifySource).toContain('| `radiusPixels` | `200` |');
+    expect(clusteredVolumeSource).toContain('| Render passes | Six:');
+  });
+});
+
+function findCategory(
+  entries: SidebarEntry[],
+  categoryName: string
+): Extract<SidebarEntry, {type: 'category'}> | undefined {
+  for (const entry of entries) {
+    if (typeof entry === 'string' || entry.type !== 'category') {
+      continue;
+    }
+    if (entry.label === categoryName) {
+      return entry;
+    }
+
+    const nestedCategory = findCategory(entry.items, categoryName);
+    if (nestedCategory) {
+      return nestedCategory;
+    }
+  }
+
+  return undefined;
+}
+
+function collectDocumentIds(entries: SidebarEntry[]): string[] {
+  return entries.flatMap(entry => {
+    if (typeof entry === 'string') {
+      return [entry];
+    }
+    return entry.type === 'category' ? collectDocumentIds(entry.items) : [entry.id];
+  });
+}

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -1270,7 +1270,7 @@ export const TextSpaceCrawlExample: React.FC = props => (
   />
 );
 
-export const PersistenceExample: React.FC = props => (
+export const PersistenceExample: React.FC<WebsiteExampleProps> = props => (
   <LumaExample
     id="persistence"
     directory="showcase"
@@ -1280,16 +1280,31 @@ export const PersistenceExample: React.FC = props => (
   />
 );
 
-export const PostprocessingExample: React.FC<WebsiteExampleProps> = props => (
-  <LumaExample
-    id="postprocessing"
-    title="Effects: Image Processing"
-    directory="showcase"
-    template={PostprocessingApp}
-    config={exampleConfig}
-    {...props}
-  />
-);
+export const PostprocessingExample: React.FC<WebsiteExampleProps & {effect?: string}> = ({
+  effect,
+  ...props
+}) => {
+  const template = useMemo(() => {
+    if (!effect) {
+      return PostprocessingApp;
+    }
+
+    return class FocusedPostprocessingApp extends PostprocessingApp {
+      static override initialEffectName = effect;
+    };
+  }, [effect]);
+
+  return (
+    <LumaExample
+      id="postprocessing"
+      title="Effects: Image Processing"
+      directory="showcase"
+      template={template}
+      config={exampleConfig}
+      {...props}
+    />
+  );
+};
 
 export const AntialiasingExample: React.FC<WebsiteExampleProps> = props => (
   <LumaExample


### PR DESCRIPTION
## Goals

- Give each public `@luma.gl/effects` shader pass or logical effect pipeline a dedicated, discoverable, technically accurate reference page.
- Preserve the existing shader-pass catalog route while making live examples and rendering tradeoffs available throughout the documentation.

## Changes

- Replace the former all-in-one image-processing reference with a linked overview and **36 individual MDX effect pages** organized into seven sidebar categories.
- Document color grading, blur and focus, bloom, temporal accumulation and antialiasing, ambient occlusion, global illumination, reflections, outlines, atmospheric lighting, stylization, and image warps.
- Embed the existing bloom, depth-of-field, persistence, antialiasing, advanced-effects, deferred-rendering, ANARI, and postprocessing examples on the corresponding pages.
- Extend the postprocessing showcase so effect-specific documentation opens on the requested shader pass with a visible, curated preview configuration; preserve the gallery's default Neon Bloom preset.
- Add complete usage examples, actual public parameters and defaults, backend support, required scene bindings, persistent-history requirements, render-pass budgets, composition guidance, limitations, and related-effect links.
- Publish a dedicated cinematic bloom reference covering portable and WebGPU execution, Gaussian and Dual-Kawase quality costs, fused compute downsampling, lens effects, temporal reprojection, HDR integration, FFT memory/dispatch budgets, and neutral Unreal Engine, AMD FidelityFX, Google Filament, and deck.gl references.
- Add coverage ensuring every sidebar entry resolves to its own MDX page, every documented effect maps to a real public export and live example, classic previews target the correct shader pass, backend support stays accurate, and factual bloom/FFT budgets remain documented.

## Verification

- Production Docusaurus build completed successfully and emitted all **37 shader-pass catalog routes**.
- Every generated catalog HTML page contains its expected title and usage section.
- Complete Vitest Node project: **228 test files passed, 1,942 tests passed**; one unrelated file/test skipped.
- Docusaurus MDX checker: all **1,038 source and generated MDX files compiled successfully** after the production build.
- Focused Biome checks passed for the changed showcase code, tests, and navigation configuration.
- `git diff --cached --check`: passed.
- The separate focused Chrome/Playwright browser harness could not attach to a browser session in this local environment; the production website build, generated routes, MDX compilation, and complete Node suite all passed.