### PR TITLE
feat(experimental): complete Graphalytics GPU graph workloads

### DIFF
--- a/docs/api-reference/experimental/README.md
+++ b/docs/api-reference/experimental/README.md
@@ -138,14 +138,16 @@ visibility, flat scenes, and indirect rendering without adding trace concepts to
 </p>
 
 [`@luma.gl/experimental/lugraph`](/docs/api-reference/experimental/lugraph) turns existing GPU
-edge columns into reusable compressed adjacency, vertex degrees, bounded shortest-path searches,
-weakly connected components, and dangling-aware PageRank scores. Social networks, dependency graphs,
+edge columns into reusable compressed adjacency, vertex degrees, unweighted and nonnegative
+weighted shortest paths, weakly connected components, label-propagation communities, local
+clustering coefficients, and dangling-aware PageRank scores. Social networks, dependency graphs,
 transaction investigations, and infrastructure maps can compose those operations into one WebGPU
 command graph without copying source batches or reading complete results back to JavaScript.
 The [interactive graph explorer](/examples/experimental/lugraph-explorer) adds directly renderable
 exact force-layout coordinates, neighborhood highlighting, stable GPU picking, dragging, and pinning.
-An opt-in live benchmark compares six actual CPU and WebGPU graph workloads across five graph
-families while reporting command encoding, completion fences, setup costs, and layout accuracy.
+An opt-in live benchmark compares nine actual CPU and WebGPU graph workloads across five graph
+families, covering all six Graphalytics workload families while reporting command encoding,
+completion fences, setup costs, and layout accuracy.
 
 ## GPU-Resident Dataframes
 

--- a/docs/api-reference/experimental/lugraph.md
+++ b/docs/api-reference/experimental/lugraph.md
@@ -10,15 +10,17 @@ import {LuGraphExplorerExample} from '@site/src/examples';
 
 A graph answers questions that individual table rows cannot: which accounts share a transaction,
 which services depend on a failed service, which people are two introductions apart, which tightly
-connected groups exist inside a wider network, and which pages matter because other important
-pages link to them. Vertices represent those entities; edges represent their relationships.
+connected groups exist inside a wider network, which route has the lowest actual travel cost, how
+closely somebody's friends know one another, and which pages matter because other important pages
+link to them. Vertices represent those entities; edges represent their relationships.
 
 `@luma.gl/experimental/lugraph` answers these questions directly on a browser WebGPU device. It
 describes caller-owned GPU edge columns, builds reusable compressed adjacency, and publishes vertex
-degrees, shortest-path neighborhoods, weakly connected groups, densely connected communities,
-PageRank importance, and progressive two-dimensional graph layouts into caller-owned GPU buffers.
-Layout can evaluate every repulsive interaction exactly or explicitly approximate distant groups
-through a caller-owned uniform grid. Every operation composes with the existing `GPUCommandGraph`.
+degrees, unweighted shortest-path neighborhoods, weighted least-cost routes, weakly connected
+groups, densely connected communities, per-vertex local clustering, PageRank importance, and
+progressive two-dimensional graph layouts into caller-owned GPU buffers. Layout can evaluate every
+repulsive interaction exactly or explicitly approximate distant groups through a caller-owned
+uniform grid. Every operation composes with the existing `GPUCommandGraph`.
 
 This is an experimental, headless graph analytics API, not a graph database, visualization
 framework, file importer, or general-purpose dataframe. Applications decide how data reaches the
@@ -68,6 +70,8 @@ when its root or depth changes; progressive layout advances the existing caller-
 buffer, which is simultaneously writable storage and a render vertex attribute. Node and picking
 shaders consume the actual community, component, PageRank, and degree buffers. Original source
 edge batches, including the intentionally empty middle batch, are never concatenated or repacked.
+Weighted shortest paths and local clustering are separate reusable graph operations and benchmark
+workloads; the existing example does not claim to expose them as additional explorer controls.
 
 Automatic layout selects distinct, honestly bounded GPU workloads:
 
@@ -168,11 +172,15 @@ adapter, and secure origin are required; unavailable hardware never produces sim
 - **High-degree hub:** one central vertex connects to many neighbors, testing uneven relationship
   distributions such as a heavily depended-on service.
 
-The original source and target edges retain three ordered batches, including an intentionally empty
-middle batch. Each family runs six genuine GPU algorithms and independent CPU references:
-compressed adjacency, breadth-first neighborhood search, weak components, PageRank, exact force
-layout, and explicitly approximate uniform-grid force layout. These bounded demonstrations are not
-million-vertex benchmarks; dense graphs and exact force layout can require quadratic work.
+The original source, target, and deterministic nonnegative edge-weight columns retain three aligned
+ordered batches, including an intentionally empty middle batch. Each family runs nine genuine GPU
+algorithms and independent CPU references: compressed adjacency, breadth-first neighborhood
+search, weighted single-source shortest paths, weak components, label-propagation communities,
+local clustering coefficients, PageRank, exact force layout, and explicitly approximate
+uniform-grid force layout. The six Graphalytics workload families are represented, alongside
+adjacency construction and two visualization-oriented layouts. These bounded demonstrations are not
+million-vertex benchmarks; dense graphs, local triangle counting, and exact force layout can
+require much more work than sparse traversal.
 
 ### Read each timing without hiding its costs
 
@@ -198,12 +206,15 @@ grid result merely makes that cost visible. Working-memory columns distinguish i
 from transient graph storage, while caller-owned spatial-index bytes are reported independently.
 
 Every GPU result must match its independently computed CPU reference before timings are published.
-The spatial path is checked against a CPU implementation of the same approximation; its additional
-coordinate error is measured against the exact force reference. Weak components report their actual
+Weighted shortest paths are checked against an independent CPU least-cost calculation, local
+clustering against independently counted neighbor triangles, and community labels against the same
+bounded deterministic voting rules. The spatial path is checked against a CPU implementation of
+the same approximation; its coordinate error is measured against the exact force reference.
+Weak components report their actual
 GPU convergence flag, and PageRank reports its final GPU L1 residual. A fixed iteration budget does
 not imply convergence or early termination. Results apply only to this graph, browser, and
-adapter; they never promise a speedup, generalize across devices, or describe the approximation
-as Barnes–Hut or ForceAtlas2.
+adapter; they never promise a speedup, generalize across devices, establish official benchmark
+certification, or describe the approximation as Barnes–Hut or ForceAtlas2.
 
 ### Run the same benchmark programmatically
 
@@ -247,7 +258,7 @@ luGraph keeps the complete intermediate pipeline on one WebGPU device:
 ```text
 Existing GPU edge columns
     -> compressed adjacency
-    -> degree / shortest paths / weak components / communities / PageRank / force layout
+    -> degree / weighted paths / local clustering / communities / PageRank / force layout
     -> caller-owned GPU result columns and directly renderable positions
 ```
 
@@ -267,26 +278,46 @@ Use luGraph for browser applications that already own typed GPU relationship col
 combine graph analytics with further GPU work:
 
 - **Social and communication networks:** count contacts, highlight friends within a bounded number
-  of introductions, distinguish friend circles within connected networks, group disconnected
-  networks, rank influential accounts, and arrange connected people into a readable map.
+  of introductions, distinguish friend circles within connected networks, measure whether each
+  person's friends also know one another, group disconnected networks, rank influential accounts,
+  and arrange connected people into a readable map.
 - **Software and service dependencies:** follow incoming or outgoing dependency chains, find
-  isolated dependency islands, reveal tightly linked ownership groups, and identify packages that
-  many important packages depend on.
+  isolated dependency islands, reveal tightly linked ownership groups, identify unusually closed
+  service clusters, and compare dependency paths by latency, risk, or recovery cost.
 - **Transaction and fraud investigations:** follow transfers around a selected account, identify
-  coordinated clusters inside a larger connected group of counterparties, and prioritize
-  structurally important entities.
-- **Transport and infrastructure maps:** inspect junction degree, unweighted hop reachability,
-  disconnected subnetworks, and relationship-driven importance across a network.
+  coordinated clusters inside a larger connected group of counterparties, distinguish locally
+  interlinked transaction rings from simple hubs, and prioritize structurally important entities.
+- **Transport and infrastructure maps:** inspect junction degree, compare routes by nonnegative
+  travel time or distance, distinguish cheapest routes from fewest transfers, and find disconnected
+  subnetworks and relationship-driven importance across a network.
 - **Knowledge and citation graphs:** follow citation links, identify connected collections, and
   rank documents by incoming influence rather than raw citation count alone.
 
-Choose another tool when the application needs weighted shortest paths, a graph query language,
-automatic CPU fallback, distributed execution, or compatibility with a CUDA or Python graph API.
-Exact force-directed layout also becomes expensive on very large graphs because it evaluates every
-pair of vertices. An optional spatial layout can exchange some far-field accuracy for fewer
-individual repulsion calculations, but its flat grid does not guarantee subquadratic complexity or
-make arbitrary graph sizes interactive. luGraph operates on one browser WebGPU device and does not
-provide the other unsupported features above.
+Choose another tool when the application needs negative-weight routing, all-pairs shortest paths,
+a graph query language, automatic CPU fallback, distributed execution, or compatibility with a CUDA
+or Python graph API. Exact force-directed layout also becomes expensive on very large graphs
+because it evaluates every pair of vertices. An optional spatial layout can exchange some
+far-field accuracy for fewer force calculations, but it does not guarantee subquadratic complexity
+or make arbitrary graph sizes interactive. Local triangle enumeration can likewise become expensive
+around high-degree hubs. luGraph operates on one browser WebGPU device and does not provide the
+other unsupported features above.
+
+## What does complete Graphalytics workload coverage mean?
+
+Graphalytics describes six widely recognized graph-analysis workload families. luGraph now supplies
+an actual browser-GPU contributor for each: **breadth-first search (BFS)**, **single-source shortest
+paths (SSSP)**, **weakly connected components (WCC)**, **community detection by label propagation
+(CDLP)**, **local clustering coefficient (LCC)**, and **PageRank (PR)**. This is useful because the
+same resident adjacency can answer reachability, least-cost routing, connectivity, community,
+neighborhood-density, and influence questions without a CPU round trip between operations.
+
+Workload-family coverage is not a claim of official Graphalytics certification, identical reference
+configuration, distributed execution, comparable published scores, or performance parity with
+another framework. Each operation retains its actual WebGPU contracts: routing accepts nonnegative
+single-precision weights, label propagation is a bounded deterministic heuristic, clustering
+counts distinct directed weak-neighborhood closures, and fixed iteration budgets do not
+automatically prove convergence. Use the live benchmark to inspect real bounded CPU/GPU runs on
+your own device.
 
 ## Choose the right graph operation
 
@@ -295,7 +326,9 @@ provide the other unsupported features above.
 | `LuGraph` | Which GPU columns describe the graph? | Borrowed graph metadata and original chunks | Metadata only; no GPU dispatch |
 | `LuGraphTopology` | Which vertices are adjacent? | Forward and optional reverse compressed adjacency | `O(V + E)` |
 | `LuGraphDegree` | How many relationships touch each vertex in one direction? | One `uint32` degree per vertex | `O(V)` after adjacency exists |
+| `LuGraphLocalClusteringCoefficient` | How closely are each vertex's neighbors connected to one another? | One `float32` coefficient and optional triangle count per vertex | At most `O(sum(degree³))` with unsorted adjacency |
 | `LuGraphBreadthFirstSearch` | Which vertices are within a chosen number of unweighted hops? | Distances, deterministic predecessors, and an optional selection mask | At most `O(D × (V + E))` for `D` compiled hops |
+| `LuGraphSingleSourceShortestPath` | Which routes have the lowest nonnegative total edge cost from a selected source? | One `float32` distance and deterministic predecessor per vertex | At most `O(K × (V + E))` for `K` bounded relaxations |
 | `LuGraphConnectedComponents` | Which vertices belong to the same weakly connected group? | One `uint32` component identifier per vertex | At most `O(K × (V + E))` for `K` bounded iterations |
 | `LuGraphLabelPropagation` | Which densely connected communities exist inside a connected network? | One deterministic `uint32` community label per vertex | At most `O(K × sum(degree²))` for `K` bounded iterations |
 | `LuGraphPageRank` | Which vertices receive influence from other important vertices? | One normalized `float32` score per vertex | `O(K × (V + E))` for `K` iterations |
@@ -304,8 +337,9 @@ provide the other unsupported features above.
 
 `V` is the graph's explicit vertex count, `E` is its source-edge count, `G` is the uniform-grid
 cell count, `P` counts individual interactions in near or insufficiently distant cells, and
-`sum(degree²)` adds the squared weak-neighbor count of every vertex. Undirected adjacency contains
-both directions for ordinary edges; an undirected self-loop appears once.
+`sum(degree²)` and `sum(degree³)` add the squared and cubed weak-neighbor counts of every vertex.
+Undirected adjacency contains both directions for ordinary edges; an undirected self-loop appears
+once.
 
 ## Describe existing relationships with LuGraph
 
@@ -323,6 +357,7 @@ const graph = new LuGraph({
   vertexCount,
   sourceVertices,
   targetVertices,
+  edgeWeights,
   edgeIds,
   nodeAttributes,
   directed: true
@@ -359,6 +394,7 @@ const topology = new LuGraphTopology({
     offsets: outgoingOffsets,
     neighbors: outgoingNeighbors,
     edgeIds: outgoingEdgeIds,
+    edgeWeights: outgoingEdgeWeights,
     count: outgoingCount,
     overflow: outgoingOverflow
   },
@@ -366,6 +402,7 @@ const topology = new LuGraphTopology({
     offsets: incomingOffsets,
     neighbors: incomingNeighbors,
     edgeIds: incomingEdgeIds,
+    edgeWeights: incomingEdgeWeights,
     count: incomingCount,
     overflow: incomingOverflow
   },
@@ -379,9 +416,9 @@ Every shown output is an existing, caller-owned, single-chunk `GPUVector<'uint32
 each configured adjacency also requires a matching `float32` edge-weight output.
 
 Build reverse adjacency when a directed graph needs incoming-degree queries, incoming or
-bidirectional breadth-first search, or PageRank. Directed weak components use forward adjacency
-alone. Undirected graphs use one symmetric forward adjacency and must not provide reverse
-adjacency.
+bidirectional breadth-first search, weak-neighborhood community or local-clustering analysis, or
+PageRank. Directed weak components use forward adjacency alone, as do outgoing weighted shortest
+paths. Undirected graphs use one symmetric forward adjacency and must not provide reverse adjacency.
 
 Invalid endpoints are excluded and counted. `count` reports the complete number of accepted
 adjacency entries even if neighbor capacity is insufficient; `overflow` makes truncation explicit.
@@ -413,6 +450,62 @@ Degrees come from complete CSR offsets rather than the capacity-bounded neighbor
 remain exact even when the corresponding adjacency reports neighbor overflow. Degree is useful
 when raw connectivity is the question; it does not account for whether a vertex's neighbors are
 themselves important.
+
+## Measure neighborhood density with LuGraphLocalClusteringCoefficient
+
+**Question: Do this vertex's neighbors actually connect to one another, or do they only share the
+same central contact?**
+
+`LuGraphLocalClusteringCoefficient` distinguishes a tightly connected friend circle from a loose
+hub. A person with ten friends does not necessarily belong to a close community: if those friends
+also know one another, local clustering is high; if none of them connect, it is zero. Use the
+coefficient to identify closed friendship circles, mutually connected transaction accounts,
+strongly interlinked services, or citation neighborhoods with many shared relationships.
+
+Choose degree when you only need the number of direct relationships, local clustering when the
+relationships *among those neighbors* matter, and label propagation when you need one community
+identifier describing a larger connected region. The coefficient describes each vertex's immediate
+surroundings; it does not assign community membership or optimize a global clustering objective.
+
+```ts
+import {LuGraphLocalClusteringCoefficient} from '@luma.gl/experimental/lugraph';
+
+const localClustering = new LuGraphLocalClusteringCoefficient({
+  topology,
+  output: clusteringCoefficients,
+  triangles: incidentTriangleCounts
+});
+
+localClustering.addToGraph(workflow);
+```
+
+`output` is a caller-owned, packed `GPUVector<'float32'>` with exactly one row per vertex. The
+optional `triangles` result is a separate, caller-owned, packed `GPUVector<'uint32'>` with one
+row per vertex. Let `d` be the number of distinct incoming-or-outgoing neighbors. For a directed
+graph, count every distinct **directed** edge between those neighbors as `C`; the coefficient is
+`C / (d × (d - 1))`, and the optional `triangles` result contains that directed closure count `C`.
+Reciprocal neighbor relationships count as two directed closures, while repeated copies of the
+same directed edge count once. For an undirected graph, let `T` be the number of unique incident
+triangles: its coefficient is `2 × T / (d × (d - 1))`, and the optional `triangles` result contains
+`T`. A vertex with fewer than two distinct neighbors has coefficient and closure count zero.
+
+The neighbor set is an undirected, or **weak**, neighborhood: either an incoming or outgoing edge
+introduces the same neighbor. Its closure numerator still preserves direction for directed graphs;
+the two directions of a reciprocal pair are not silently collapsed. Directed graphs therefore
+require both forward and reverse CSR. Undirected graphs reuse their symmetric forward adjacency.
+Self-loops never make a vertex its own neighbor, and duplicate edges never duplicate neighbors,
+directed closures, or possible neighbor pairs. Edge weights do not change this structural
+coefficient.
+
+The contributor writes all results on the GPU without sorting adjacency, repacking edge columns,
+allocating a graph-owned scratch buffer, submitting commands, or reading results back. If either
+required adjacency overflows, or a closure count cannot fit in `uint32`, every affected
+coefficient fails closed to zero; optional triangle counts become `0xffffffff`. Empty graphs have
+no output rows. Because source adjacency is intentionally unsorted, exact neighbor deduplication
+and membership scans can require `O(sum(degree³))` work across all vertices. Dense regions and
+high-degree hubs can therefore be substantially more expensive than degree or traversal; this is
+not a claim of constant-time triangle counting, weighted clustering, or global community
+detection.
 
 ## Follow unweighted paths with LuGraphBreadthFirstSearch
 
@@ -453,6 +546,74 @@ Reached roots have distance zero. Unreachable vertices and root predecessors con
 equal-length parent ties select the numerically lowest stable vertex identifier. Invalid seeds are
 ignored, duplicate seeds are harmless, and the optional mask publishes zero or one per vertex.
 This is an unweighted shortest-path operation, not a weighted route or travel-time solver.
+
+## Find least-cost routes with LuGraphSingleSourceShortestPath
+
+**Question: Which route from my starting vertex costs the least when each connection has its own
+travel time, distance, latency, or other nonnegative price?**
+
+The route with the fewest steps is not necessarily the cheapest. Suppose a direct train takes
+40 minutes, while two connecting trains take 10 minutes each: breadth-first search chooses the
+one-hop direct train, but the least-cost route takes the two connections and arrives in 20 minutes.
+`LuGraphSingleSourceShortestPath` computes that minimum accumulated nonnegative edge weight from one
+selected starting vertex to every reachable destination without moving graph columns to the CPU.
+
+Use it for travel-time maps, delivery networks, communication latency, transaction fees, or
+service-dependency recovery costs. Choose breadth-first search when every edge has the same cost
+and only the number of hops matters; choose weighted shortest paths when the actual sum of edge
+weights can change which route wins. This operation computes routes from **one** selected source;
+it does not implement all-pairs routing, negative-weight paths, or A* geographic search.
+
+```ts
+import {LuGraphSingleSourceShortestPath} from '@luma.gl/experimental/lugraph';
+
+const shortestPaths = new LuGraphSingleSourceShortestPath({
+  topology,
+  sourceVertex: selectedVertex,
+  distances: routeCosts,
+  predecessors: routeParents,
+  direction: 'outgoing',
+  maxIterations: 64,
+  converged: shortestPathsConverged,
+  invalidWeightCount
+});
+
+shortestPaths.addToGraph(workflow);
+```
+
+`distances` is a caller-owned, packed `GPUVector<'float32'>` with exactly one row per vertex;
+`predecessors` is a separate, caller-owned, packed `GPUVector<'uint32'>` with the same row count.
+An unreachable vertex has distance positive infinity (`+Infinity`), not a large finite placeholder,
+and predecessor `0xffffffff`. The starting vertex has distance zero and predecessor `0xffffffff`.
+When two routes have the same total cost, the one with fewer hops wins; if their costs and hop
+counts also tie, the numerically lowest stable predecessor identifier wins. Zero-weight edges are
+valid. Distances are ordinary single-precision values, not `float64` or floating-point atomics.
+
+Weighted graphs must preserve their aligned source `GPUVector<'float32'>` edge-weight chunks and
+matching `float32` weights in every configured CSR direction. A graph without an edge-weight
+column is valid: every edge then costs one, allowing the same operation to run without fabricating
+a new weight column. Negative weights, `NaN`, positive infinity, and negative infinity are invalid.
+If any original edge with valid endpoints has an invalid weight, routing fails closed: all
+distances become `+Infinity`, all predecessors become `0xffffffff`, and an optional one-row
+`invalidWeightCount` records the number of invalid **source edges**, not duplicate entries in
+forward and reverse adjacency. Edges whose endpoints are already invalid are excluded by topology
+and do not contribute to this weight count.
+
+`outgoing` follows source-to-target relationships; `incoming` follows reverse relationships;
+`both` admits either direction. Directed `incoming` or `both` routing requires reverse CSR;
+directed `outgoing` routing requires forward CSR only. Undirected graphs reuse symmetric forward
+adjacency. If any selected adjacency overflowed, all distances again become `+Infinity`, all
+predecessors become `0xffffffff`, and an optional convergence status is zero.
+
+The contributor uses bounded Bellman–Ford-style synchronized relaxation, not a CPU Dijkstra queue.
+`maxIterations` can range from `0` through `1024`; its default is
+`min(max(vertexCount - 1, 0), 1024)`. The optional caller-owned one-row
+`GPUVector<'uint32'>` `converged` indicates whether the final compiled relaxation reached a fixed
+point. A zero-round budget initializes only the selected root. `sourceVertex` must identify an
+existing vertex; an empty graph permits the value zero and has no distance rows. A limited budget
+may publish partially relaxed routes without proving shortest-path completion; there is no
+automatic early termination or implicit CPU synchronization. With `K` compiled relaxation rounds,
+work is bounded by `O(K × (V + E))`, with `O(V)` graph-owned scratch.
 
 ## Find disconnected groups with LuGraphConnectedComponents
 
@@ -791,7 +952,9 @@ import {
   LuGraphDegree,
   LuGraphForceLayout,
   LuGraphLabelPropagation,
+  LuGraphLocalClusteringCoefficient,
   LuGraphPageRank,
+  LuGraphSingleSourceShortestPath,
   LuGraphSpatialForceLayout,
   LuGraphTopology
 } from '@luma.gl/experimental/lugraph';
@@ -800,6 +963,7 @@ const graph = new LuGraph({
   vertexCount,
   sourceVertices,
   targetVertices,
+  edgeWeights,
   directed: true
 });
 
@@ -809,6 +973,7 @@ const topology = new LuGraphTopology({
     offsets: outgoingOffsets,
     neighbors: outgoingNeighbors,
     edgeIds: outgoingEdgeIds,
+    edgeWeights: outgoingEdgeWeights,
     count: outgoingCount,
     overflow: outgoingOverflow
   },
@@ -816,6 +981,7 @@ const topology = new LuGraphTopology({
     offsets: incomingOffsets,
     neighbors: incomingNeighbors,
     edgeIds: incomingEdgeIds,
+    edgeWeights: incomingEdgeWeights,
     count: incomingCount,
     overflow: incomingOverflow
   },
@@ -826,6 +992,11 @@ const workflow = new GPUCommandGraph(device);
 
 topology.addToGraph(workflow);
 new LuGraphDegree({topology, output: outgoingDegrees}).addToGraph(workflow);
+new LuGraphLocalClusteringCoefficient({
+  topology,
+  output: clusteringCoefficients,
+  triangles: incidentTriangleCounts
+}).addToGraph(workflow);
 new LuGraphBreadthFirstSearch({
   topology,
   seeds: selectedVertexIds,
@@ -834,6 +1005,15 @@ new LuGraphBreadthFirstSearch({
   mask: neighborhoodMask,
   direction: 'both',
   maxDepth: 6
+}).addToGraph(workflow);
+new LuGraphSingleSourceShortestPath({
+  topology,
+  sourceVertex: selectedVertex,
+  distances: routeCosts,
+  predecessors: routeParents,
+  maxIterations: 64,
+  converged: shortestPathsConverged,
+  invalidWeightCount
 }).addToGraph(workflow);
 new LuGraphConnectedComponents({
   topology,
@@ -895,21 +1075,25 @@ when exact all-pairs repulsion is the better fit.
 - Writable outputs require physically distinct GPU buffer allocations, including when a
   `DynamicBuffer` wrapper exposes the same underlying allocation through different views.
 - Adjacency capacities and overflow statuses are explicit. Breadth-first search fails closed to
-  unreachable distances, weak components and community detection publish `0xffffffff`, and
-  PageRank publishes zero scores when a required neighbor list overflowed. Force layout preserves
-  its existing positions and clears velocities on required adjacency overflow.
+  unreachable distances, weighted routing publishes `+Infinity` and `0xffffffff` predecessors,
+  weak components and community detection publish `0xffffffff`, local clustering publishes zero
+  coefficients and optional `0xffffffff` triangle statuses, and PageRank publishes zero scores
+  when a required neighbor list overflowed. Force layout preserves its existing positions and
+  clears velocities on required adjacency overflow.
+- Invalid negative or nonfinite edge weights also fail weighted routing closed; optional
+  `invalidWeightCount` reports invalid original source edges without double-counting reverse CSR.
 - Spatial layout also preserves positions and clears velocities when its accepted count excludes
   any out-of-domain vertex or its explicit vertex-ID capacity overflows.
 - Degree remains exact under neighbor overflow because its input is the complete CSR offset range.
 - Renderable layout positions require both `Buffer.STORAGE` and `Buffer.VERTEX` usage on their
   original caller-owned allocation; position readback or repacking is never implicit.
-- Fixed component, community, and PageRank iteration budgets do not imply convergence. Their
-  optional status and final-change outputs remain GPU-resident until an application explicitly
-  requests readback.
+- Fixed weighted-routing, component, community, and PageRank iteration budgets do not imply
+  convergence. Their optional status and final-change outputs remain GPU-resident until an
+  application explicitly requests readback.
 - Work uses bounded WebGPU dispatch and portable storage bindings on one device. Original chunk
   preservation does not imply distributed or multi-GPU execution.
 - The optional graph subpath does not supply automatic Arrow import, rendering, graph persistence,
-  weighted shortest paths, or a CPU execution fallback.
+  negative-weight or all-pairs shortest paths, or a CPU execution fallback.
 
 See [GPU Primitives and Command Graphs](/docs/api-reference/experimental/gpu-primitives) for the
 underlying scheduling, typed GPU vectors, resource ownership, and explicit submission model.

--- a/docs/capabilities.mdx
+++ b/docs/capabilities.mdx
@@ -324,14 +324,17 @@ primitives](/docs/api-reference/experimental/gpu-primitives).
 | Compressed graph adjacency | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Build reusable forward and optional reverse compressed sparse row (CSR) adjacency for supported graph operations. |
 | Directional vertex degree | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Compute supported incoming or outgoing degree values directly into GPU result columns. |
 | Breadth-first graph search | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Traverse bounded unweighted neighborhoods and generate deterministic predecessor or selection results. |
+| Weighted single-source shortest paths | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Find least-cost routes over nonnegative single-precision edge weights with bounded relaxation and deterministic predecessors. |
 | Weakly connected components | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Label supported connected groups within an explicit iteration budget and expose convergence information. |
 | Deterministic graph communities | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | `LuGraphLabelPropagation` assigns communities through bounded unweighted majority votes and deterministic label tie-breaking. |
+| Local clustering coefficients | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Measure exact weak-neighborhood closure with distinct directed links or optional undirected triangle counts. |
 | GPU PageRank | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Rank vertices using iterative GPU execution with supported dangling-node redistribution. |
+| Six Graphalytics workload families | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Implement BFS, weighted SSSP, weak components, label propagation, local clustering, and PageRank without claiming official benchmark certification. |
 | Exact force-directed layout | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Generate directly renderable graph positions through supported pairwise attraction and repulsion. |
 | Spatially accelerated layout | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Approximate supported distant forces through a flat GPU spatial grid; this is not hierarchical Barnes-Hut. |
 | Interactive graph exploration | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Coordinate layout, neighborhood highlighting, GPU picking, dragging, and pinned graph vertices. |
 | deck.gl-native graph analytics | Experimental | WebGPU | `@deck.gl-community/arrow-layers` | Share supported GPU graph analytics and layout with deck.gl layers while preserving source batches and deck.gl-owned command submission. |
-| CPU and GPU graph benchmarks | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Compare bounded reference workloads while separately reporting encoding, completion, setup, and accuracy costs. |
+| CPU and GPU graph benchmarks | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Compare nine bounded reference workloads while separately reporting encoding, completion, setup, and accuracy costs. |
 
 Read the [GPU-resident graph analytics reference](/docs/api-reference/experimental/lugraph),
 the [interactive luGraph explorer](/examples/experimental/lugraph-explorer), or the
@@ -644,7 +647,7 @@ commitments to release dates.
 | Advanced dataframe analytics | Opportunity | WebGPU | `@luma.gl/experimental/ludf` | Extend existing grouped analytics, joins, lookups, sorting, and top-K toward non-unique/outer joins, temporal windows, and incremental updates. |
 | GPU vector similarity search | Opportunity | WebGPU | `@luma.gl/experimental` | Add embedding similarity, nearest-neighbor indexes, top-K distance queries, and compatible metadata filtering. |
 | Seam-safe multi-tile raster analysis | Opportunity | WebGPU | `@luma.gl/experimental/luraster` | Build on existing tile residency and graph reuse with assembled cross-tile halos, stitched contours, global aggregates, and generated analytical overviews. |
-| Advanced GPU graph analytics | Opportunity | WebGPU | `@luma.gl/experimental/lugraph` | Build on existing traversal, PageRank, label-propagation communities, and layouts with weighted paths, modularity-based clustering, and dynamic updates. |
+| Advanced GPU graph analytics | Opportunity | WebGPU | `@luma.gl/experimental/lugraph` | Build on existing weighted shortest paths, local clustering, all six Graphalytics workload families, PageRank, communities, and layouts with Louvain/Leiden modularity optimization and dynamic graph updates. |
 | Hierarchical spatial indexes | Opportunity | WebGPU | `@luma.gl/experimental/geospatial` | Extend supported spatial queries toward tiled indexing, nearest neighbors, and spatial joins. |
 | High-precision geospatial pipelines | Opportunity | WebGPU | `@luma.gl/experimental/luproj` | Broaden projection, local-origin precision, coordinate systems, and streamed map-scale workflows. |
 | Cross-view GPU-native provenance | Opportunity | WebGPU | `@luma.gl/experimental/luxfilter` | Extend existing linked filters and histograms with shared picking, provenance, and selection across more charts, maps, and scene views. |

--- a/modules/experimental/src/lugraph/README.md
+++ b/modules/experimental/src/lugraph/README.md
@@ -7,8 +7,9 @@ optional, headless graph model preserves existing source and target vertex colum
 identifiers, optional properties, and original GPU vector chunks without uploading or copying them.
 
 Reusable compressed adjacency supports vertex-degree queries, bounded breadth-first shortest paths,
-weakly connected components, deterministic label-propagation communities, normalized PageRank with
-dangling-vertex redistribution, and progressive exact force-directed layout with directly
+nonnegative weighted single-source routes, weakly connected components,
+deterministic label-propagation communities, local clustering coefficients, normalized PageRank
+with dangling-vertex redistribution, and progressive exact force-directed layout with directly
 renderable GPU positions. An optional `LuGraphSpatialForceLayout` can approximate distant
 uniform-grid cells while keeping nearby forces exact; it preserves the same positions, explicit
 bounds, caller-owned indexing buffers, and observable overflow status. These operations contribute
@@ -19,10 +20,42 @@ rendering, command submission, and any explicitly requested result readback.
 
 Use luGraph to explore relationships that already live on the GPU: inspect social connections,
 trace service dependencies, investigate transaction networks, or rank linked documents without
-copying every intermediate result back to JavaScript. Weakly connected components find disconnected
-islands; `LuGraphLabelPropagation` can expose friend circles, related service groups, or coordinated
-accounts inside a connected island. Its deterministic, bounded majority-vote heuristic is not
-Louvain or Leiden, does not optimize modularity, and does not guarantee convergence.
+copying every intermediate result back to JavaScript. Choose
+`LuGraphSingleSourceShortestPath` when edges represent actual nonnegative travel times, distances,
+latencies, or transaction costs and the cheapest route matters more than the fewest hops. Choose
+`LuGraphLocalClusteringCoefficient` when a vertex's neighbor count alone cannot distinguish a
+tightly connected friend circle or transaction ring from a loose hub.
+
+Weakly connected components find disconnected
+islands; `LuGraphLabelPropagation` can expose friend circles, related service groups, or
+coordinated accounts inside a connected island. Its deterministic, bounded majority-vote heuristic
+is not Louvain or Leiden, does not optimize modularity, and does not guarantee convergence. Local
+clustering instead measures each immediate neighborhood's distinct directed closure relationships;
+it does not assign a global community. Weighted routing uses existing `float32` edge weights, not
+negative-weight or all-pairs shortest-path algorithms.
+
+Together, breadth-first search, weighted single-source shortest paths, weakly connected
+components, label propagation, local clustering, and PageRank cover the six **Graphalytics workload
+families**. This means those analysis types have real browser-GPU implementations; it does not
+claim official benchmark certification, matching reference settings, distributed execution,
+published performance scores, or feature parity with another graph system.
+
+## Weighted routes and local neighborhoods
+
+`LuGraphSingleSourceShortestPath` follows outgoing, incoming, or bidirectional relationships from
+one chosen vertex. Existing nonnegative `float32` edge weights determine route cost; missing
+weights mean every relationship costs one. Unreachable vertices receive `+Infinity`, equal-cost
+routes choose fewer hops and then the lowest stable predecessor, and invalid or negative weights
+fail closed. Bounded synchronized relaxation and an optional GPU convergence flag keep the actual
+iteration budget visible; they do not imply automatic convergence or support negative weights.
+
+`LuGraphLocalClusteringCoefficient` asks whether each vertex's distinct incoming-or-outgoing
+neighbors also connect to one another. Directed graphs count distinct directed links among those
+neighbors, so reciprocal links count twice; undirected graphs count unique incident triangles.
+Self-loops and duplicate edges do not inflate the result. The caller receives one `float32`
+coefficient per vertex and can optionally request `uint32` directed-closure or triangle counts.
+Unsorted CSR makes exact neighbor matching up to `O(sum(degree³))`, so dense hubs need careful
+measurement.
 
 Exact layout suits smaller graphs and accuracy-sensitive workflows; the optional
 flat-grid approximation suits applications that can trade some far-field accuracy for fewer

--- a/modules/experimental/src/lugraph/index.ts
+++ b/modules/experimental/src/lugraph/index.ts
@@ -14,10 +14,17 @@ export type {
   LuGraphBreadthFirstSearchDirection,
   LuGraphBreadthFirstSearchProps
 } from './lu-graph-breadth-first-search';
+export {LuGraphSingleSourceShortestPath} from './lu-graph-single-source-shortest-path';
+export type {
+  LuGraphSingleSourceShortestPathDirection,
+  LuGraphSingleSourceShortestPathProps
+} from './lu-graph-single-source-shortest-path';
 export {LuGraphConnectedComponents} from './lu-graph-connected-components';
 export type {LuGraphConnectedComponentsProps} from './lu-graph-connected-components';
 export {LuGraphLabelPropagation} from './lu-graph-label-propagation';
 export type {LuGraphLabelPropagationProps} from './lu-graph-label-propagation';
+export {LuGraphLocalClusteringCoefficient} from './lu-graph-local-clustering-coefficient';
+export type {LuGraphLocalClusteringCoefficientProps} from './lu-graph-local-clustering-coefficient';
 export {LuGraphPageRank} from './lu-graph-page-rank';
 export type {LuGraphPageRankProps} from './lu-graph-page-rank';
 export {LuGraphForceLayout} from './lu-graph-force-layout';

--- a/modules/experimental/src/lugraph/lu-graph-benchmark-data.ts
+++ b/modules/experimental/src/lugraph/lu-graph-benchmark-data.ts
@@ -32,6 +32,8 @@ export type LuGraphBenchmarkDataset = {
   edgeCount: number;
   sourceChunks: Uint32Array[];
   targetChunks: Uint32Array[];
+  /** Positive float32 edge costs aligned with every original source partition. */
+  weightChunks: Float32Array[];
   positions: Float32Array;
 };
 
@@ -39,7 +41,10 @@ export type LuGraphBenchmarkDataset = {
 export type LuGraphBenchmarkAlgorithm =
   | 'topology'
   | 'breadth-first-search'
+  | 'single-source-shortest-path'
   | 'connected-components'
+  | 'label-propagation'
+  | 'local-clustering-coefficient'
   | 'page-rank'
   | 'exact-layout'
   | 'spatial-layout';
@@ -91,11 +96,19 @@ export type LuGraphBenchmarkReport = {
 export type LuGraphBenchmarkReference = {
   forwardOffsets: Uint32Array;
   forwardNeighbors: Uint32Array;
+  forwardWeights: Float32Array;
   reverseOffsets: Uint32Array;
   reverseNeighbors: Uint32Array;
+  reverseWeights: Float32Array;
   distances: Uint32Array;
   predecessors: Uint32Array;
+  weightedDistances: Float32Array;
+  weightedPredecessors: Uint32Array;
   components: Uint32Array;
+  communities: Uint32Array;
+  communityConverged: boolean;
+  clusteringCoefficients: Float32Array;
+  triangleCounts: Uint32Array;
   pageRank: Float32Array;
   exactPositions: Float32Array;
   exactVelocities: Float32Array;
@@ -113,10 +126,30 @@ export type LuGraphBenchmarkContext = {
 
 type LuGraphBenchmarkAdjacency = Pick<
   LuGraphBenchmarkReference,
-  'forwardOffsets' | 'forwardNeighbors' | 'reverseOffsets' | 'reverseNeighbors'
+  | 'forwardOffsets'
+  | 'forwardNeighbors'
+  | 'forwardWeights'
+  | 'reverseOffsets'
+  | 'reverseNeighbors'
+  | 'reverseWeights'
 >;
 
 type LuGraphBenchmarkSearch = Pick<LuGraphBenchmarkReference, 'distances' | 'predecessors'>;
+
+type LuGraphBenchmarkShortestPath = Pick<
+  LuGraphBenchmarkReference,
+  'weightedDistances' | 'weightedPredecessors'
+>;
+
+type LuGraphBenchmarkCommunities = Pick<
+  LuGraphBenchmarkReference,
+  'communities' | 'communityConverged'
+>;
+
+type LuGraphBenchmarkClustering = Pick<
+  LuGraphBenchmarkReference,
+  'clusteringCoefficients' | 'triangleCounts'
+>;
 
 type LuGraphBenchmarkLayout = {positions: Float32Array; velocities: Float32Array};
 
@@ -129,6 +162,8 @@ const UINT32_MAXIMUM = 0xffffffff;
 const MAXIMUM_VERTEX_COUNT = 0xfffffffe;
 const MINIMUM_REPULSION_DISTANCE_SQUARED = 0.0001;
 const PAGE_RANK_DAMPING = 0.85;
+/** @internal Fixed, honestly reported synchronous majority-vote workload. */
+export const LU_GRAPH_BENCHMARK_LABEL_ITERATIONS = 8;
 const DATASET_KINDS: readonly LuGraphBenchmarkDatasetKind[] = [
   'sparse',
   'dense',
@@ -262,6 +297,14 @@ export function makeLuGraphBenchmarkDataset(
   }
 
   const split = Math.ceil(sources.length / 2);
+  const weights = Float32Array.from(sources, (source, edgeIndex) =>
+    Math.fround(
+      0.25 +
+        (((Math.imul(source, 31) + Math.imul(targets[edgeIndex], 17) + edgeIndex + seed) >>> 0) %
+          16) *
+          0.25
+    )
+  );
   return {
     kind,
     vertexCount,
@@ -276,6 +319,7 @@ export function makeLuGraphBenchmarkDataset(
       new Uint32Array(0),
       Uint32Array.from(targets.slice(split))
     ],
+    weightChunks: [weights.slice(0, split), new Float32Array(0), weights.slice(split)],
     positions
   };
 }
@@ -290,8 +334,17 @@ export function prepareLuGraphBenchmark(options: LuGraphBenchmarkOptions): LuGra
   const search = measureLuGraphBenchmarkValue(normalizedOptions, () =>
     evaluateLuGraphBenchmarkBreadthFirstSearch(adjacency.value, normalizedOptions.maxDepth)
   );
+  const shortestPath = measureLuGraphBenchmarkValue(normalizedOptions, () =>
+    evaluateLuGraphBenchmarkShortestPath(adjacency.value)
+  );
   const components = measureLuGraphBenchmarkValue(normalizedOptions, () =>
     evaluateLuGraphBenchmarkConnectedComponents(dataset)
+  );
+  const communities = measureLuGraphBenchmarkValue(normalizedOptions, () =>
+    evaluateLuGraphBenchmarkLabelPropagation(adjacency.value, LU_GRAPH_BENCHMARK_LABEL_ITERATIONS)
+  );
+  const clustering = measureLuGraphBenchmarkValue(normalizedOptions, () =>
+    evaluateLuGraphBenchmarkLocalClustering(adjacency.value)
   );
   const pageRank = measureLuGraphBenchmarkValue(normalizedOptions, () =>
     evaluateLuGraphBenchmarkPageRank(adjacency.value, normalizedOptions.pageRankIterations)
@@ -309,7 +362,10 @@ export function prepareLuGraphBenchmark(options: LuGraphBenchmarkOptions): LuGra
     reference: {
       ...adjacency.value,
       ...search.value,
+      ...shortestPath.value,
       components: components.value,
+      ...communities.value,
+      ...clustering.value,
       pageRank: pageRank.value,
       exactPositions: exactLayout.value.positions,
       exactVelocities: exactLayout.value.velocities,
@@ -319,7 +375,10 @@ export function prepareLuGraphBenchmark(options: LuGraphBenchmarkOptions): LuGra
     cpuTimeMilliseconds: {
       topology: adjacency.timeMilliseconds,
       'breadth-first-search': search.timeMilliseconds,
+      'single-source-shortest-path': shortestPath.timeMilliseconds,
       'connected-components': components.timeMilliseconds,
+      'label-propagation': communities.timeMilliseconds,
+      'local-clustering-coefficient': clustering.timeMilliseconds,
       'page-rank': pageRank.timeMilliseconds,
       'exact-layout': exactLayout.timeMilliseconds,
       'spatial-layout': spatialLayout.timeMilliseconds
@@ -420,14 +479,27 @@ function buildLuGraphBenchmarkAdjacency(
     reverseOffsets[vertex + 1] += reverseOffsets[vertex];
   }
   const forwardNeighbors = new Uint32Array(dataset.edgeCount);
+  const forwardWeights = new Float32Array(dataset.edgeCount);
   const reverseNeighbors = new Uint32Array(dataset.edgeCount);
+  const reverseWeights = new Float32Array(dataset.edgeCount);
   const forwardCursors = forwardOffsets.slice(0, -1);
   const reverseCursors = reverseOffsets.slice(0, -1);
-  forEachBenchmarkEdge(dataset, (source, target) => {
-    forwardNeighbors[forwardCursors[source]++] = target;
-    reverseNeighbors[reverseCursors[target]++] = source;
+  forEachBenchmarkEdge(dataset, (source, target, weight) => {
+    const forwardSlot = forwardCursors[source]++;
+    const reverseSlot = reverseCursors[target]++;
+    forwardNeighbors[forwardSlot] = target;
+    forwardWeights[forwardSlot] = weight;
+    reverseNeighbors[reverseSlot] = source;
+    reverseWeights[reverseSlot] = weight;
   });
-  return {forwardOffsets, forwardNeighbors, reverseOffsets, reverseNeighbors};
+  return {
+    forwardOffsets,
+    forwardNeighbors,
+    forwardWeights,
+    reverseOffsets,
+    reverseNeighbors,
+    reverseWeights
+  };
 }
 
 function evaluateLuGraphBenchmarkBreadthFirstSearch(
@@ -463,6 +535,54 @@ function evaluateLuGraphBenchmarkBreadthFirstSearch(
   return {distances, predecessors};
 }
 
+/** Independently evaluates positive float32 shortest paths without reusing GPU relaxation. */
+function evaluateLuGraphBenchmarkShortestPath(
+  adjacency: LuGraphBenchmarkAdjacency
+): LuGraphBenchmarkShortestPath {
+  const vertexCount = adjacency.forwardOffsets.length - 1;
+  const weightedDistances = new Float32Array(vertexCount).fill(Number.POSITIVE_INFINITY);
+  const weightedPredecessors = new Uint32Array(vertexCount).fill(UINT32_MAXIMUM);
+  const hopCounts = new Uint32Array(vertexCount).fill(UINT32_MAXIMUM);
+  const visited = new Uint8Array(vertexCount);
+  weightedDistances[0] = 0;
+  hopCounts[0] = 0;
+
+  for (let iteration = 0; iteration < vertexCount; iteration++) {
+    let source = UINT32_MAXIMUM;
+    let nearestDistance = Number.POSITIVE_INFINITY;
+    for (let vertex = 0; vertex < vertexCount; vertex++) {
+      if (!visited[vertex] && weightedDistances[vertex] < nearestDistance) {
+        source = vertex;
+        nearestDistance = weightedDistances[vertex];
+      }
+    }
+    if (source === UINT32_MAXIMUM) break;
+    visited[source] = 1;
+
+    for (
+      let slot = adjacency.forwardOffsets[source];
+      slot < adjacency.forwardOffsets[source + 1];
+      slot++
+    ) {
+      const target = adjacency.forwardNeighbors[slot];
+      const distance = Math.fround(nearestDistance + adjacency.forwardWeights[slot]);
+      const hopCount = hopCounts[source] + 1;
+      if (
+        distance < weightedDistances[target] ||
+        (distance === weightedDistances[target] &&
+          (hopCount < hopCounts[target] ||
+            (hopCount === hopCounts[target] && source < weightedPredecessors[target])))
+      ) {
+        weightedDistances[target] = distance;
+        weightedPredecessors[target] = source;
+        hopCounts[target] = hopCount;
+      }
+    }
+  }
+
+  return {weightedDistances, weightedPredecessors};
+}
+
 function evaluateLuGraphBenchmarkConnectedComponents(
   dataset: LuGraphBenchmarkDataset
 ): Uint32Array {
@@ -484,6 +604,92 @@ function evaluateLuGraphBenchmarkConnectedComponents(
     else if (secondRoot < firstRoot) parents[firstRoot] = secondRoot;
   });
   return Uint32Array.from(parents, (_, vertex) => findRoot(vertex));
+}
+
+/** Independently reproduces duplicate-sensitive, synchronous weak-neighbor community voting. */
+function evaluateLuGraphBenchmarkLabelPropagation(
+  adjacency: LuGraphBenchmarkAdjacency,
+  iterations: number
+): LuGraphBenchmarkCommunities {
+  const vertexCount = adjacency.forwardOffsets.length - 1;
+  let communities = Uint32Array.from({length: vertexCount}, (_, vertex) => vertex);
+  let communityConverged = vertexCount === 0;
+
+  for (let iteration = 0; iteration < iterations; iteration++) {
+    const next = new Uint32Array(vertexCount);
+    communityConverged = true;
+    for (let vertex = 0; vertex < vertexCount; vertex++) {
+      const votes = new Map<number, number>([[communities[vertex], 1]]);
+      for (const [offsets, neighbors] of [
+        [adjacency.forwardOffsets, adjacency.forwardNeighbors],
+        [adjacency.reverseOffsets, adjacency.reverseNeighbors]
+      ] as const) {
+        for (let slot = offsets[vertex]; slot < offsets[vertex + 1]; slot++) {
+          const neighbor = neighbors[slot];
+          if (neighbor === vertex) continue;
+          const label = communities[neighbor];
+          votes.set(label, (votes.get(label) ?? 0) + 1);
+        }
+      }
+
+      let selectedLabel = communities[vertex];
+      let selectedVotes = votes.get(selectedLabel)!;
+      for (const [label, count] of votes) {
+        if (count > selectedVotes || (count === selectedVotes && label < selectedLabel)) {
+          selectedLabel = label;
+          selectedVotes = count;
+        }
+      }
+      next[vertex] = selectedLabel;
+      if (selectedLabel !== communities[vertex]) communityConverged = false;
+    }
+    communities = next;
+  }
+
+  return {communities, communityConverged};
+}
+
+/** Evaluates Graphalytics directed closure using unique weak neighbors and actual directed links. */
+function evaluateLuGraphBenchmarkLocalClustering(
+  adjacency: LuGraphBenchmarkAdjacency
+): LuGraphBenchmarkClustering {
+  const vertexCount = adjacency.forwardOffsets.length - 1;
+  const clusteringCoefficients = new Float32Array(vertexCount);
+  const triangleCounts = new Uint32Array(vertexCount);
+
+  for (let vertex = 0; vertex < vertexCount; vertex++) {
+    const neighbors = new Set<number>();
+    for (const [offsets, adjacent] of [
+      [adjacency.forwardOffsets, adjacency.forwardNeighbors],
+      [adjacency.reverseOffsets, adjacency.reverseNeighbors]
+    ] as const) {
+      for (let slot = offsets[vertex]; slot < offsets[vertex + 1]; slot++) {
+        if (adjacent[slot] !== vertex) neighbors.add(adjacent[slot]);
+      }
+    }
+    if (neighbors.size < 2) continue;
+
+    let closures = 0;
+    for (const source of neighbors) {
+      const uniqueTargets = new Set<number>();
+      for (
+        let slot = adjacency.forwardOffsets[source];
+        slot < adjacency.forwardOffsets[source + 1];
+        slot++
+      ) {
+        const target = adjacency.forwardNeighbors[slot];
+        if (target !== source && neighbors.has(target)) uniqueTargets.add(target);
+      }
+      closures += uniqueTargets.size;
+    }
+
+    triangleCounts[vertex] = closures;
+    clusteringCoefficients[vertex] = Math.fround(
+      closures / (neighbors.size * (neighbors.size - 1))
+    );
+  }
+
+  return {clusteringCoefficients, triangleCounts};
 }
 
 function evaluateLuGraphBenchmarkPageRank(
@@ -694,11 +900,15 @@ function getLuGraphBenchmarkCellCoordinate(position: number, size: number): numb
 
 function forEachBenchmarkEdge(
   dataset: LuGraphBenchmarkDataset,
-  visit: (source: number, target: number) => void
+  visit: (source: number, target: number, weight: number, edgeIndex: number) => void
 ): void {
+  let edgeIndex = 0;
   for (let chunkIndex = 0; chunkIndex < dataset.sourceChunks.length; chunkIndex++) {
     const sources = dataset.sourceChunks[chunkIndex];
     const targets = dataset.targetChunks[chunkIndex];
-    for (let row = 0; row < sources.length; row++) visit(sources[row], targets[row]);
+    const weights = dataset.weightChunks[chunkIndex];
+    for (let row = 0; row < sources.length; row++) {
+      visit(sources[row], targets[row], weights[row], edgeIndex++);
+    }
   }
 }

--- a/modules/experimental/src/lugraph/lu-graph-benchmark-data.ts
+++ b/modules/experimental/src/lugraph/lu-graph-benchmark-data.ts
@@ -160,6 +160,7 @@ type MeasuredLuGraphBenchmarkValue<Value> = {
 
 const UINT32_MAXIMUM = 0xffffffff;
 const MAXIMUM_VERTEX_COUNT = 0xfffffffe;
+const MAXIMUM_SHORTEST_PATH_ITERATIONS = 1024;
 const MINIMUM_REPULSION_DISTANCE_SQUARED = 0.0001;
 const PAGE_RANK_DAMPING = 0.85;
 /** @internal Fixed, honestly reported synchronous majority-vote workload. */
@@ -535,49 +536,49 @@ function evaluateLuGraphBenchmarkBreadthFirstSearch(
   return {distances, predecessors};
 }
 
-/** Independently evaluates positive float32 shortest paths without reusing GPU relaxation. */
-function evaluateLuGraphBenchmarkShortestPath(
+/** @internal Independently evaluates exactly the bounded GPU relaxation workload. */
+export function evaluateLuGraphBenchmarkShortestPath(
   adjacency: LuGraphBenchmarkAdjacency
 ): LuGraphBenchmarkShortestPath {
   const vertexCount = adjacency.forwardOffsets.length - 1;
   const weightedDistances = new Float32Array(vertexCount).fill(Number.POSITIVE_INFINITY);
   const weightedPredecessors = new Uint32Array(vertexCount).fill(UINT32_MAXIMUM);
-  const hopCounts = new Uint32Array(vertexCount).fill(UINT32_MAXIMUM);
-  const visited = new Uint8Array(vertexCount);
   weightedDistances[0] = 0;
-  hopCounts[0] = 0;
 
-  for (let iteration = 0; iteration < vertexCount; iteration++) {
-    let source = UINT32_MAXIMUM;
-    let nearestDistance = Number.POSITIVE_INFINITY;
-    for (let vertex = 0; vertex < vertexCount; vertex++) {
-      if (!visited[vertex] && weightedDistances[vertex] < nearestDistance) {
-        source = vertex;
-        nearestDistance = weightedDistances[vertex];
-      }
-    }
-    if (source === UINT32_MAXIMUM) break;
-    visited[source] = 1;
+  const maximumIterations = Math.min(
+    Math.max(vertexCount - 1, 0),
+    MAXIMUM_SHORTEST_PATH_ITERATIONS
+  );
+  for (let iteration = 0; iteration < maximumIterations; iteration++) {
+    const previousDistances = weightedDistances.slice();
+    let changed = false;
 
-    for (
-      let slot = adjacency.forwardOffsets[source];
-      slot < adjacency.forwardOffsets[source + 1];
-      slot++
-    ) {
-      const target = adjacency.forwardNeighbors[slot];
-      const distance = Math.fround(nearestDistance + adjacency.forwardWeights[slot]);
-      const hopCount = hopCounts[source] + 1;
-      if (
-        distance < weightedDistances[target] ||
-        (distance === weightedDistances[target] &&
-          (hopCount < hopCounts[target] ||
-            (hopCount === hopCounts[target] && source < weightedPredecessors[target])))
+    for (let source = 0; source < vertexCount; source++) {
+      const sourceDistance = previousDistances[source];
+      if (!Number.isFinite(sourceDistance)) continue;
+
+      for (
+        let slot = adjacency.forwardOffsets[source];
+        slot < adjacency.forwardOffsets[source + 1];
+        slot++
       ) {
-        weightedDistances[target] = distance;
-        weightedPredecessors[target] = source;
-        hopCounts[target] = hopCount;
+        const target = adjacency.forwardNeighbors[slot];
+        const distance = Math.fround(sourceDistance + adjacency.forwardWeights[slot]);
+        if (distance < weightedDistances[target]) {
+          weightedDistances[target] = distance;
+          weightedPredecessors[target] = source;
+          changed = true;
+        } else if (
+          distance === weightedDistances[target] &&
+          distance < previousDistances[target] &&
+          source < weightedPredecessors[target]
+        ) {
+          weightedPredecessors[target] = source;
+        }
       }
     }
+
+    if (!changed) break;
   }
 
   return {weightedDistances, weightedPredecessors};

--- a/modules/experimental/src/lugraph/lu-graph-benchmark.ts
+++ b/modules/experimental/src/lugraph/lu-graph-benchmark.ts
@@ -15,6 +15,7 @@ import {LuGraph} from './lu-graph';
 import {
   LU_GRAPH_BENCHMARK_BOUNDS,
   LU_GRAPH_BENCHMARK_FORCE_PROPS,
+  LU_GRAPH_BENCHMARK_LABEL_ITERATIONS,
   getLuGraphBenchmarkTime,
   prepareLuGraphBenchmark,
   summarizeLuGraphBenchmarkSamples,
@@ -29,12 +30,16 @@ import {
 import {LuGraphBreadthFirstSearch} from './lu-graph-breadth-first-search';
 import {LuGraphConnectedComponents} from './lu-graph-connected-components';
 import {LuGraphForceLayout} from './lu-graph-force-layout';
+import {LuGraphLabelPropagation} from './lu-graph-label-propagation';
+import {LuGraphLocalClusteringCoefficient} from './lu-graph-local-clustering-coefficient';
 import {LuGraphPageRank} from './lu-graph-page-rank';
+import {LuGraphSingleSourceShortestPath} from './lu-graph-single-source-shortest-path';
 import {LuGraphSpatialForceLayout} from './lu-graph-spatial-force-layout';
 import {LuGraphTopology, type LuGraphAdjacency} from './lu-graph-topology';
 
 const SCALAR_BYTE_LENGTH = 4;
 const PAGE_RANK_TOLERANCE = 0.0001;
+const CLUSTERING_TOLERANCE = 0.000001;
 const FORCE_LAYOUT_TOLERANCE = 0.0005;
 
 type BenchmarkScalarFormat = 'uint32' | 'float32';
@@ -89,7 +94,10 @@ export async function runLuGraphBenchmark(
     const contributors: [LuGraphBenchmarkAlgorithm, GPUCommandGraphContributor][] = [
       ['topology', resources.topology],
       ['breadth-first-search', resources.search],
+      ['single-source-shortest-path', resources.shortestPath],
       ['connected-components', resources.components],
+      ['label-propagation', resources.communities],
+      ['local-clustering-coefficient', resources.clustering],
       ['page-rank', resources.pageRank],
       ['exact-layout', resources.exactLayout],
       ['spatial-layout', resources.spatialLayout]
@@ -148,7 +156,15 @@ export async function runLuGraphBenchmark(
         algorithm: path.algorithm,
         ...(finalValidation.converged === undefined
           ? {}
-          : {iterations: resources.components.iterations, converged: finalValidation.converged}),
+          : {
+              iterations:
+                path.algorithm === 'connected-components'
+                  ? resources.components.iterations
+                  : path.algorithm === 'label-propagation'
+                    ? resources.communities.iterations
+                    : resources.shortestPath.maxIterations,
+              converged: finalValidation.converged
+            }),
         ...(finalValidation.residual === undefined
           ? {}
           : {iterations: resources.pageRank.iterations, residual: finalValidation.residual}),
@@ -209,7 +225,10 @@ class LuGraphBenchmarkResources {
   readonly graph: LuGraph;
   readonly topology: LuGraphTopology;
   readonly search: LuGraphBreadthFirstSearch;
+  readonly shortestPath: LuGraphSingleSourceShortestPath;
   readonly components: LuGraphConnectedComponents;
+  readonly communities: LuGraphLabelPropagation;
+  readonly clustering: LuGraphLocalClusteringCoefficient;
   readonly pageRank: LuGraphPageRank;
   readonly exactLayout: LuGraphForceLayout;
   readonly spatialLayout: LuGraphSpatialForceLayout;
@@ -224,8 +243,9 @@ class LuGraphBenchmarkResources {
     this.graph = new LuGraph({
       vertexCount,
       directed: true,
-      sourceVertices: this.createChunkedVector('sources', context.dataset.sourceChunks),
-      targetVertices: this.createChunkedVector('targets', context.dataset.targetChunks)
+      sourceVertices: this.createChunkedVector('sources', 'uint32', context.dataset.sourceChunks),
+      targetVertices: this.createChunkedVector('targets', 'uint32', context.dataset.targetChunks),
+      edgeWeights: this.createChunkedVector('weights', 'float32', context.dataset.weightChunks)
     });
     const forward = this.createAdjacency('forward', vertexCount, edgeCount);
     const reverse = this.createAdjacency('reverse', vertexCount, edgeCount);
@@ -245,11 +265,34 @@ class LuGraphBenchmarkResources {
       maxDepth: context.options.maxDepth,
       direction: 'outgoing'
     });
+    this.shortestPath = new LuGraphSingleSourceShortestPath({
+      id: 'lugraph-benchmark-shortest-path',
+      topology: this.topology,
+      sourceVertex: 0,
+      distances: this.createScalarVector('weighted-distances', 'float32', vertexCount),
+      predecessors: this.createScalarVector('weighted-predecessors', 'uint32', vertexCount),
+      converged: this.createScalarVector('shortest-path-convergence', 'uint32', 1),
+      invalidWeightCount: this.createScalarVector('invalid-edge-weights', 'uint32', 1),
+      direction: 'outgoing'
+    });
     this.components = new LuGraphConnectedComponents({
       id: 'lugraph-benchmark-components',
       topology: this.topology,
       output: this.createScalarVector('component-labels', 'uint32', vertexCount),
       converged: this.createScalarVector('component-convergence', 'uint32', 1)
+    });
+    this.communities = new LuGraphLabelPropagation({
+      id: 'lugraph-benchmark-communities',
+      topology: this.topology,
+      output: this.createScalarVector('community-labels', 'uint32', vertexCount),
+      iterations: LU_GRAPH_BENCHMARK_LABEL_ITERATIONS,
+      converged: this.createScalarVector('community-convergence', 'uint32', 1)
+    });
+    this.clustering = new LuGraphLocalClusteringCoefficient({
+      id: 'lugraph-benchmark-local-clustering',
+      topology: this.topology,
+      output: this.createScalarVector('local-clustering', 'float32', vertexCount),
+      triangles: this.createScalarVector('triangle-counts', 'uint32', vertexCount)
     });
     this.pageRank = new LuGraphPageRank({
       id: 'lugraph-benchmark-page-rank',
@@ -322,25 +365,34 @@ class LuGraphBenchmarkResources {
   }
 
   /** Preserves aligned original source batches, including the deterministic empty middle chunk. */
-  private createChunkedVector(name: string, chunks: Uint32Array[]): GPUVector<'uint32'> {
+  private createChunkedVector<Format extends BenchmarkScalarFormat>(
+    name: string,
+    format: Format,
+    chunks: Format extends 'uint32' ? Uint32Array[] : Float32Array[]
+  ): GPUVector<Format> {
     const data = chunks.map((values, chunkIndex) => {
       const buffer = this.device.createBuffer({
         id: `lugraph-benchmark-${name}-${chunkIndex}`,
-        data: values.length === 0 ? new Uint32Array(1) : values,
+        data:
+          values.length === 0
+            ? format === 'float32'
+              ? new Float32Array(1)
+              : new Uint32Array(1)
+            : values,
         usage: Buffer.STORAGE | Buffer.COPY_DST
       });
       this.buffers.push(buffer);
-      return new GPUData<'uint32'>({
+      return new GPUData<Format>({
         buffer,
-        format: 'uint32',
+        format,
         length: values.length,
         ownsBuffer: false
       });
     });
-    const vector = new GPUVector<'uint32'>({
+    const vector = new GPUVector<Format>({
       type: 'data',
       name,
-      format: 'uint32',
+      format,
       data,
       ownsData: false
     });
@@ -400,6 +452,7 @@ class LuGraphBenchmarkResources {
       offsets: this.createScalarVector(`${name}-offsets`, 'uint32', vertexCount + 1),
       neighbors: this.createScalarVector(`${name}-neighbors`, 'uint32', edgeCount),
       edgeIds: this.createScalarVector(`${name}-edge-ids`, 'uint32', edgeCount),
+      edgeWeights: this.createScalarVector(`${name}-edge-weights`, 'float32', edgeCount),
       count: this.createScalarVector(`${name}-count`, 'uint32', 1),
       overflow: this.createScalarVector(`${name}-overflow`, 'uint32', 1)
     };
@@ -548,14 +601,23 @@ async function readBenchmarkPath(
 
   switch (algorithm) {
     case 'topology': {
-      const [forwardOffsets, forwardNeighbors, reverseOffsets, reverseNeighbors, invalid] =
-        await readOutputs(
-          resources.topology.forward.offsets,
-          resources.topology.forward.neighbors,
-          resources.topology.reverse!.offsets,
-          resources.topology.reverse!.neighbors,
-          resources.topology.invalidEdgeCount
-        );
+      const [
+        forwardOffsets,
+        forwardNeighbors,
+        forwardWeights,
+        reverseOffsets,
+        reverseNeighbors,
+        reverseWeights,
+        invalid
+      ] = await readOutputs(
+        resources.topology.forward.offsets,
+        resources.topology.forward.neighbors,
+        resources.topology.forward.edgeWeights!,
+        resources.topology.reverse!.offsets,
+        resources.topology.reverse!.neighbors,
+        resources.topology.reverse!.edgeWeights!,
+        resources.topology.invalidEdgeCount
+      );
       maxAbsoluteError = Math.max(
         getMaximumAbsoluteError(forwardOffsets, context.reference.forwardOffsets),
         getMaximumAbsoluteError(reverseOffsets, context.reference.reverseOffsets),
@@ -563,13 +625,17 @@ async function readBenchmarkPath(
           forwardOffsets,
           forwardNeighbors,
           context.reference.forwardOffsets,
-          context.reference.forwardNeighbors
+          context.reference.forwardNeighbors,
+          forwardWeights,
+          context.reference.forwardWeights
         ),
         getMaximumAdjacencyError(
           reverseOffsets,
           reverseNeighbors,
           context.reference.reverseOffsets,
-          context.reference.reverseNeighbors
+          context.reference.reverseNeighbors,
+          reverseWeights,
+          context.reference.reverseWeights
         ),
         invalid[0]
       );
@@ -586,6 +652,21 @@ async function readBenchmarkPath(
       );
       break;
     }
+    case 'single-source-shortest-path': {
+      const [distances, predecessors, convergenceValues, invalidWeights] = await readOutputs(
+        resources.shortestPath.distances,
+        resources.shortestPath.predecessors,
+        resources.shortestPath.converged!,
+        resources.shortestPath.invalidWeightCount!
+      );
+      converged = convergenceValues[0] === 1;
+      maxAbsoluteError = Math.max(
+        getMaximumAbsoluteError(distances, context.reference.weightedDistances),
+        getMaximumAbsoluteError(predecessors, context.reference.weightedPredecessors),
+        invalidWeights[0]
+      );
+      break;
+    }
     case 'connected-components': {
       const [components, convergenceValues] = await readOutputs(
         resources.components.output,
@@ -595,6 +676,29 @@ async function readBenchmarkPath(
       maxAbsoluteError = Math.max(
         getMaximumAbsoluteError(components, context.reference.components),
         Math.abs(convergenceValues[0] - 1)
+      );
+      break;
+    }
+    case 'label-propagation': {
+      const [communities, convergenceValues] = await readOutputs(
+        resources.communities.output,
+        resources.communities.converged!
+      );
+      converged = convergenceValues[0] === 1;
+      maxAbsoluteError = Math.max(
+        getMaximumAbsoluteError(communities, context.reference.communities),
+        Math.abs(convergenceValues[0] - Number(context.reference.communityConverged))
+      );
+      break;
+    }
+    case 'local-clustering-coefficient': {
+      const [coefficients, triangles] = await readOutputs(
+        resources.clustering.output,
+        resources.clustering.triangles!
+      );
+      maxAbsoluteError = Math.max(
+        getMaximumAbsoluteError(coefficients, context.reference.clusteringCoefficients),
+        getMaximumAbsoluteError(triangles, context.reference.triangleCounts)
       );
       break;
     }
@@ -650,9 +754,11 @@ async function readBenchmarkPath(
   const tolerance =
     algorithm === 'page-rank'
       ? PAGE_RANK_TOLERANCE
-      : algorithm === 'exact-layout' || algorithm === 'spatial-layout'
-        ? FORCE_LAYOUT_TOLERANCE
-        : 0;
+      : algorithm === 'local-clustering-coefficient'
+        ? CLUSTERING_TOLERANCE
+        : algorithm === 'exact-layout' || algorithm === 'spatial-layout'
+          ? FORCE_LAYOUT_TOLERANCE
+          : 0;
   if (!Number.isFinite(maxAbsoluteError) || maxAbsoluteError > tolerance) {
     throw new Error(
       `luGraph benchmark ${algorithm} disagrees with its CPU oracle: ${maxAbsoluteError}`
@@ -687,18 +793,38 @@ function getMaximumAdjacencyError(
   actualOffsets: readonly number[],
   actualNeighbors: readonly number[],
   expectedOffsets: ArrayLike<number>,
-  expectedNeighbors: ArrayLike<number>
+  expectedNeighbors: ArrayLike<number>,
+  actualWeights?: readonly number[],
+  expectedWeights?: ArrayLike<number>
 ): number {
   let maximumError = 0;
   const expectedValues = Array.from(expectedNeighbors);
   for (let vertex = 0; vertex < expectedOffsets.length - 1; vertex++) {
     const actual = actualNeighbors
       .slice(actualOffsets[vertex], actualOffsets[vertex + 1])
-      .sort((left, right) => left - right);
+      .map((neighbor, row) => ({
+        neighbor,
+        weight: actualWeights?.[actualOffsets[vertex] + row] ?? 0
+      }))
+      .sort((left, right) => left.neighbor - right.neighbor || left.weight - right.weight);
     const expected = expectedValues
       .slice(expectedOffsets[vertex], expectedOffsets[vertex + 1])
-      .sort((left, right) => left - right);
-    maximumError = Math.max(maximumError, getMaximumAbsoluteError(actual, expected));
+      .map((neighbor, row) => ({
+        neighbor,
+        weight: expectedWeights?.[expectedOffsets[vertex] + row] ?? 0
+      }))
+      .sort((left, right) => left.neighbor - right.neighbor || left.weight - right.weight);
+    maximumError = Math.max(
+      maximumError,
+      getMaximumAbsoluteError(
+        actual.map(value => value.neighbor),
+        expected.map(value => value.neighbor)
+      ),
+      getMaximumAbsoluteError(
+        actual.map(value => value.weight),
+        expected.map(value => value.weight)
+      )
+    );
   }
   return maximumError;
 }
@@ -708,6 +834,7 @@ function getMaximumAbsoluteError(actual: ArrayLike<number>, expected: ArrayLike<
   if (actual.length !== expected.length) return Number.POSITIVE_INFINITY;
   let maximumError = 0;
   for (let index = 0; index < actual.length; index++) {
+    if (actual[index] === expected[index]) continue;
     const difference = Math.abs(actual[index] - expected[index]);
     if (!Number.isFinite(difference)) return Number.POSITIVE_INFINITY;
     maximumError = Math.max(maximumError, difference);

--- a/modules/experimental/src/lugraph/lu-graph-local-clustering-coefficient-internals.ts
+++ b/modules/experimental/src/lugraph/lu-graph-local-clustering-coefficient-internals.ts
@@ -1,0 +1,318 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuGraph.
+
+import {type Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import type {
+  GPUCommandGraph,
+  GraphBufferUse,
+  GraphDataView
+} from '../gpu-primitives/gpu-command-graph';
+import {
+  type GPUBoundedDispatchLayout,
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource
+} from '../gpu-primitives/gpu-dispatch-utils';
+import {getViewBinding, getViewElementOffset} from '../gpu-primitives/graph-data-view-utils';
+import type {LuGraphLocalClusteringCoefficient} from './lu-graph-local-clustering-coefficient';
+
+const LOCAL_CLUSTERING_WORKGROUP_SIZE = 256;
+const INVALID_TRIANGLE_COUNT = 0xffffffff;
+
+type ImportedLocalClustering = {
+  id: string;
+  vertexCount: number;
+  directed: boolean;
+  forwardOffsets: GraphDataView<'uint32'>;
+  forwardNeighbors: GraphDataView<'uint32'>;
+  forwardOverflow: GraphDataView<'uint32'>;
+  reverseOffsets?: GraphDataView<'uint32'>;
+  reverseNeighbors?: GraphDataView<'uint32'>;
+  reverseOverflow?: GraphDataView<'uint32'>;
+  output: GraphDataView<'float32'>;
+  triangles?: GraphDataView<'uint32'>;
+};
+
+type LocalClusteringBinding = {
+  view: GraphDataView<'uint32'> | GraphDataView<'float32'>;
+  usage: GraphBufferUse['usage'];
+};
+
+/** Declares exact Graphalytics clustering across existing unordered weak neighborhoods. @internal */
+export function addLuGraphLocalClusteringCoefficientToGraphWithDispatchLimit<Parameters>(
+  clustering: LuGraphLocalClusteringCoefficient,
+  commandGraph: GPUCommandGraph<Parameters>,
+  maxComputeWorkgroupsPerDimension: number
+): void {
+  const vertexCount = clustering.topology.graph.vertexCount;
+  if (vertexCount === 0) return;
+
+  const reverse = clustering.topology.graph.directed ? clustering.topology.reverse : undefined;
+  const state: ImportedLocalClustering = {
+    id: clustering.id,
+    vertexCount,
+    directed: clustering.topology.graph.directed,
+    forwardOffsets: commandGraph.importGPUVector(
+      `${clustering.id}-forward-offsets`,
+      clustering.topology.forward.offsets
+    ).data[0],
+    forwardNeighbors: commandGraph.importGPUVector(
+      `${clustering.id}-forward-neighbors`,
+      clustering.topology.forward.neighbors
+    ).data[0],
+    forwardOverflow: commandGraph.importGPUVector(
+      `${clustering.id}-forward-overflow`,
+      clustering.topology.forward.overflow
+    ).data[0],
+    ...(reverse
+      ? {
+          reverseOffsets: commandGraph.importGPUVector(
+            `${clustering.id}-reverse-offsets`,
+            reverse.offsets
+          ).data[0],
+          reverseNeighbors: commandGraph.importGPUVector(
+            `${clustering.id}-reverse-neighbors`,
+            reverse.neighbors
+          ).data[0],
+          reverseOverflow: commandGraph.importGPUVector(
+            `${clustering.id}-reverse-overflow`,
+            reverse.overflow
+          ).data[0]
+        }
+      : {}),
+    output: commandGraph.importGPUVector(`${clustering.id}-output`, clustering.output).data[0],
+    ...(clustering.triangles
+      ? {
+          triangles: commandGraph.importGPUVector(
+            `${clustering.id}-triangles`,
+            clustering.triangles
+          ).data[0]
+        }
+      : {})
+  };
+
+  const bindings: Record<string, LocalClusteringBinding> = {
+    forwardOffsets: {view: state.forwardOffsets, usage: 'storage-read'},
+    forwardNeighbors: {view: state.forwardNeighbors, usage: 'storage-read'},
+    forwardOverflow: {view: state.forwardOverflow, usage: 'storage-read'},
+    ...(state.reverseOffsets && state.reverseNeighbors && state.reverseOverflow
+      ? {
+          reverseOffsets: {view: state.reverseOffsets, usage: 'storage-read'},
+          reverseNeighbors: {view: state.reverseNeighbors, usage: 'storage-read'},
+          reverseOverflow: {view: state.reverseOverflow, usage: 'storage-read'}
+        }
+      : {}),
+    output: {view: state.output, usage: 'storage-write'},
+    ...(state.triangles ? {triangles: {view: state.triangles, usage: 'storage-write'}} : {})
+  };
+  const dispatchLayout = getLuGraphLocalClusteringCoefficientDispatchLayout(
+    vertexCount,
+    maxComputeWorkgroupsPerDimension
+  );
+  const source = getLocalClusteringSource(state, bindings, dispatchLayout);
+
+  commandGraph.addComputePass({
+    id: `${state.id}-calculate`,
+    resources: Object.values(bindings).map(({view, usage}) => ({buffer: view, usage})),
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id: `${state.id}-calculate`,
+        source,
+        shaderLayout: {
+          bindings: Object.keys(bindings).map((name, location) => ({
+            name,
+            type: 'storage' as const,
+            group: 0,
+            location
+          }))
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const shaderBindings: Record<string, Binding> = {};
+          for (const [name, binding] of Object.entries(bindings)) {
+            shaderBindings[name] = getViewBinding(binding.view, getBuffer);
+          }
+          computation.setBindings(shaderBindings);
+          computation.dispatch(computePass, dispatchLayout.x, dispatchLayout.y, dispatchLayout.z);
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+/** Generates one bounded pass using at most eight baseline WebGPU storage-buffer bindings. */
+function getLocalClusteringSource(
+  state: ImportedLocalClustering,
+  bindings: Record<string, LocalClusteringBinding>,
+  dispatchLayout: GPUBoundedDispatchLayout
+): string {
+  const hasReverse = Boolean(
+    state.reverseOffsets && state.reverseNeighbors && state.reverseOverflow
+  );
+  const reverseConstants = hasReverse
+    ? `const REVERSE_CAPACITY: u32 = ${state.reverseNeighbors!.length}u;
+const REVERSE_OFFSETS_OFFSET: u32 = ${getViewElementOffset(state.reverseOffsets!)}u;
+const REVERSE_NEIGHBORS_OFFSET: u32 = ${getViewElementOffset(state.reverseNeighbors!)}u;
+const REVERSE_OVERFLOW_OFFSET: u32 = ${getViewElementOffset(state.reverseOverflow!)}u;`
+    : '';
+  const reverseOverflow = hasReverse ? ' || reverseOverflow[REVERSE_OVERFLOW_OFFSET] != 0u' : '';
+  const reverseFirstSlot = hasReverse
+    ? `if (direction == 1u) {
+    return min(reverseOffsets[REVERSE_OFFSETS_OFFSET + vertex], REVERSE_CAPACITY);
+  }`
+    : '';
+  const reverseLastSlot = hasReverse
+    ? `if (direction == 1u) {
+    return min(reverseOffsets[REVERSE_OFFSETS_OFFSET + vertex + 1u], REVERSE_CAPACITY);
+  }`
+    : '';
+  const reverseNeighbor = hasReverse
+    ? `if (direction == 1u) {
+    return reverseNeighbors[REVERSE_NEIGHBORS_OFFSET + slot];
+  }`
+    : '';
+  const scanEarlierReverse = hasReverse
+    ? `if (direction == 1u) {
+    let reverseFirst = min(reverseOffsets[REVERSE_OFFSETS_OFFSET + vertex], REVERSE_CAPACITY);
+    for (var previous = reverseFirst; previous < slot; previous++) {
+      if (reverseNeighbors[REVERSE_NEIGHBORS_OFFSET + previous] == candidate) { return false; }
+    }
+  }`
+    : '';
+  const triangleOffset = state.triangles
+    ? `const TRIANGLES_OFFSET: u32 = ${getViewElementOffset(state.triangles)}u;`
+    : '';
+  const publishInvalidTriangles = state.triangles
+    ? `triangles[TRIANGLES_OFFSET + index] = ${INVALID_TRIANGLE_COUNT}u;`
+    : '';
+  const publishTriangles = state.triangles
+    ? `triangles[TRIANGLES_OFFSET + index] = ${state.directed ? 'closureCount' : 'closureCount / 2u'};`
+    : '';
+  const declarations = Object.entries(bindings)
+    .map(([name, binding], location) => {
+      const access = binding.usage === 'storage-read' ? 'read' : 'read_write';
+      const element = binding.view.format === 'float32' ? 'f32' : 'u32';
+      return `@group(0) @binding(${location}) var<storage, ${access}> ${name}: array<${element}>;`;
+    })
+    .join('\n');
+
+  return /* wgsl */ `
+const VERTEX_COUNT: u32 = ${state.vertexCount}u;
+const FORWARD_CAPACITY: u32 = ${state.forwardNeighbors.length}u;
+const FORWARD_OFFSETS_OFFSET: u32 = ${getViewElementOffset(state.forwardOffsets)}u;
+const FORWARD_NEIGHBORS_OFFSET: u32 = ${getViewElementOffset(state.forwardNeighbors)}u;
+const FORWARD_OVERFLOW_OFFSET: u32 = ${getViewElementOffset(state.forwardOverflow)}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(state.output)}u;
+const NEIGHBOR_DIRECTION_COUNT: u32 = ${hasReverse ? 2 : 1}u;
+${reverseConstants}
+${triangleOffset}
+${declarations}
+
+fn getFirstNeighborSlot(vertex: u32, direction: u32) -> u32 {
+  ${reverseFirstSlot}
+  return min(forwardOffsets[FORWARD_OFFSETS_OFFSET + vertex], FORWARD_CAPACITY);
+}
+
+fn getLastNeighborSlot(vertex: u32, direction: u32) -> u32 {
+  ${reverseLastSlot}
+  return min(forwardOffsets[FORWARD_OFFSETS_OFFSET + vertex + 1u], FORWARD_CAPACITY);
+}
+
+fn getNeighbor(direction: u32, slot: u32) -> u32 {
+  ${reverseNeighbor}
+  return forwardNeighbors[FORWARD_NEIGHBORS_OFFSET + slot];
+}
+
+fn isFirstDistinctNeighbor(vertex: u32, direction: u32, slot: u32, candidate: u32) -> bool {
+  if (candidate >= VERTEX_COUNT || candidate == vertex) { return false; }
+
+  let forwardFirst = min(forwardOffsets[FORWARD_OFFSETS_OFFSET + vertex], FORWARD_CAPACITY);
+  let forwardEnd = select(slot, min(forwardOffsets[FORWARD_OFFSETS_OFFSET + vertex + 1u], FORWARD_CAPACITY), direction != 0u);
+  for (var previous = forwardFirst; previous < forwardEnd; previous++) {
+    if (forwardNeighbors[FORWARD_NEIGHBORS_OFFSET + previous] == candidate) { return false; }
+  }
+  ${scanEarlierReverse}
+  return true;
+}
+
+fn containsForwardEdge(sourceVertex: u32, targetVertex: u32) -> bool {
+  let first = min(forwardOffsets[FORWARD_OFFSETS_OFFSET + sourceVertex], FORWARD_CAPACITY);
+  let last = min(forwardOffsets[FORWARD_OFFSETS_OFFSET + sourceVertex + 1u], FORWARD_CAPACITY);
+  for (var slot = first; slot < last; slot++) {
+    if (forwardNeighbors[FORWARD_NEIGHBORS_OFFSET + slot] == targetVertex) { return true; }
+  }
+  return false;
+}
+
+@compute @workgroup_size(${LOCAL_CLUSTERING_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getBoundedInvocationIndexSource(dispatchLayout, LOCAL_CLUSTERING_WORKGROUP_SIZE)}
+  if (index >= VERTEX_COUNT) { return; }
+  if (forwardOverflow[FORWARD_OVERFLOW_OFFSET] != 0u${reverseOverflow}) {
+    output[OUTPUT_OFFSET + index] = 0.0;
+    ${publishInvalidTriangles}
+    return;
+  }
+
+  var degree = 0u;
+  var closureCount = 0u;
+  for (var firstDirection = 0u; firstDirection < NEIGHBOR_DIRECTION_COUNT; firstDirection++) {
+    let firstStart = getFirstNeighborSlot(index, firstDirection);
+    let firstEnd = getLastNeighborSlot(index, firstDirection);
+    for (var firstSlot = firstStart; firstSlot < firstEnd; firstSlot++) {
+      let firstNeighbor = getNeighbor(firstDirection, firstSlot);
+      if (!isFirstDistinctNeighbor(index, firstDirection, firstSlot, firstNeighbor)) { continue; }
+      degree++;
+
+      for (var secondDirection = 0u; secondDirection < NEIGHBOR_DIRECTION_COUNT; secondDirection++) {
+        let secondStart = getFirstNeighborSlot(index, secondDirection);
+        let secondEnd = getLastNeighborSlot(index, secondDirection);
+        for (var secondSlot = secondStart; secondSlot < secondEnd; secondSlot++) {
+          let secondNeighbor = getNeighbor(secondDirection, secondSlot);
+          if (firstNeighbor >= secondNeighbor ||
+              !isFirstDistinctNeighbor(index, secondDirection, secondSlot, secondNeighbor)) {
+            continue;
+          }
+
+          let forwardClosure = select(0u, 1u, containsForwardEdge(firstNeighbor, secondNeighbor));
+          let reverseClosure = select(0u, 1u, containsForwardEdge(secondNeighbor, firstNeighbor));
+          let increment = forwardClosure + reverseClosure;
+          if (closureCount >= ${INVALID_TRIANGLE_COUNT}u - increment) {
+            output[OUTPUT_OFFSET + index] = 0.0;
+            ${publishInvalidTriangles}
+            return;
+          }
+          closureCount += increment;
+        }
+      }
+    }
+  }
+
+  output[OUTPUT_OFFSET + index] = select(
+    0.0,
+    f32(closureCount) / (f32(degree) * f32(degree - 1u)),
+    degree >= 2u
+  );
+  ${publishTriangles}
+}`;
+}
+
+/** Plans bounded true three-dimensional vertex-clustering dispatch. @internal */
+export function getLuGraphLocalClusteringCoefficientDispatchLayout(
+  elementCount: number,
+  maxComputeWorkgroupsPerDimension: number
+): GPUBoundedDispatchLayout {
+  return getBoundedDispatchLayout(
+    'LuGraphLocalClusteringCoefficient',
+    elementCount,
+    LOCAL_CLUSTERING_WORKGROUP_SIZE,
+    maxComputeWorkgroupsPerDimension
+  );
+}

--- a/modules/experimental/src/lugraph/lu-graph-local-clustering-coefficient.ts
+++ b/modules/experimental/src/lugraph/lu-graph-local-clustering-coefficient.ts
@@ -1,0 +1,178 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuGraph.
+
+import type {Buffer} from '@luma.gl/core';
+import {DynamicBuffer} from '@luma.gl/engine';
+import type {GPUData, GPUVector} from '@luma.gl/tables';
+import type {GPUCommandGraph} from '../gpu-primitives/gpu-command-graph';
+import {addLuGraphLocalClusteringCoefficientToGraphWithDispatchLimit} from './lu-graph-local-clustering-coefficient-internals';
+import type {LuGraphAdjacency, LuGraphTopology} from './lu-graph-topology';
+
+const SCALAR_BYTE_LENGTH = 4;
+
+/** Existing graph adjacency and caller-owned Graphalytics local-clustering outputs. */
+export type LuGraphLocalClusteringCoefficientProps = {
+  /** Prefix for generated command-graph nodes and imported-resource identifiers. */
+  id?: string;
+  /** Existing GPU graph adjacency; directed weak neighborhoods require reverse CSR. */
+  topology: LuGraphTopology;
+  /** One packed, caller-owned floating-point clustering coefficient per vertex. */
+  output: GPUVector<'float32'>;
+  /** Optional packed per-vertex triangle count or directed neighbor-edge closure count. */
+  triangles?: GPUVector<'uint32'>;
+};
+
+/**
+ * Computes exact Graphalytics local clustering directly from existing, unordered GPU CSR.
+ *
+ * A vertex's neighborhood is the distinct union of its incoming and outgoing neighbors. Self
+ * loops and duplicate edges are ignored. For directed graphs every distinct directed edge among
+ * those neighbors contributes separately; reciprocated edges therefore contribute twice. The
+ * coefficient is the directed closure count divided by `degree * (degree - 1)`. Undirected CSR
+ * is symmetric, so this is equivalently twice the unique incident triangle count divided by the
+ * same denominator. Vertices with fewer than two distinct neighbors receive zero.
+ *
+ * Optional triangle output contains directed neighbor-edge closures for directed graphs and
+ * unique incident triangles for undirected graphs. Required adjacency overflow or uint32
+ * closure-count overflow publishes zero coefficients and `0xffffffff` triangle sentinels.
+ *
+ * Existing adjacency is intentionally unordered and may contain duplicates, so exact GPU
+ * deduplication and membership scans have cubic worst-case work in vertex degree. No source
+ * vectors are sorted, repacked, read back, or implicitly destroyed.
+ */
+export class LuGraphLocalClusteringCoefficient {
+  /** Prefix for generated command-graph node and imported-resource identifiers. */
+  readonly id: string;
+  /** Existing caller-owned GPU graph topology. */
+  readonly topology: LuGraphTopology;
+  /** Caller-owned vertex-aligned floating-point local-clustering coefficients. */
+  readonly output: GPUVector<'float32'>;
+  /** Optional caller-owned unsigned incident-triangle or directed-closure counts. */
+  readonly triangles?: GPUVector<'uint32'>;
+
+  /** Validates caller metadata without allocating, submitting, reading, or destroying work. */
+  constructor(props: LuGraphLocalClusteringCoefficientProps) {
+    this.id = props.id ?? 'lu-graph-local-clustering-coefficient';
+    this.topology = props.topology;
+    this.output = props.output;
+    this.triangles = props.triangles;
+
+    if (this.topology.graph.directed && !this.topology.reverse) {
+      throw new Error(`${this.id} directed weak-neighbor clustering requires reverse adjacency`);
+    }
+
+    validateClusteringVector(
+      this.output,
+      'float32',
+      this.topology.graph.vertexCount,
+      `${this.id} output`
+    );
+    if (this.triangles) {
+      validateClusteringVector(
+        this.triangles,
+        'uint32',
+        this.topology.graph.vertexCount,
+        `${this.id} triangles`
+      );
+    }
+    validateDistinctClusteringOutputs(this);
+  }
+
+  /** Declares bounded GPU clustering without queue submission or CPU graph synchronization. */
+  addToGraph<Parameters>(commandGraph: GPUCommandGraph<Parameters>): void {
+    addLuGraphLocalClusteringCoefficientToGraphWithDispatchLimit(
+      this,
+      commandGraph,
+      commandGraph.device.limits.maxComputeWorkgroupsPerDimension
+    );
+  }
+}
+
+/** Requires one packed, aligned scalar output chunk with its exact logical vertex count. */
+function validateClusteringVector<Format extends 'uint32' | 'float32'>(
+  vector: GPUVector<Format>,
+  format: Format,
+  length: number,
+  name: string
+): void {
+  if (
+    vector.data.length !== 1 ||
+    vector.format !== format ||
+    vector.stride !== 1 ||
+    vector.byteStride !== SCALAR_BYTE_LENGTH ||
+    vector.rowByteLength !== SCALAR_BYTE_LENGTH ||
+    vector.valueLength !== vector.length ||
+    vector.bufferLayout
+  ) {
+    throw new Error(`${name} must contain exactly one packed ${format} chunk`);
+  }
+  if (vector.length !== length) {
+    throw new Error(`${name} must contain exactly ${length} ${format} rows`);
+  }
+
+  const chunk = vector.data[0];
+  if (
+    chunk.format !== format ||
+    chunk.length !== length ||
+    chunk.stride !== 1 ||
+    chunk.byteStride !== SCALAR_BYTE_LENGTH ||
+    chunk.rowByteLength !== SCALAR_BYTE_LENGTH ||
+    chunk.valueLength !== chunk.length ||
+    !Number.isSafeInteger(chunk.byteOffset) ||
+    chunk.byteOffset < 0 ||
+    chunk.byteOffset % SCALAR_BYTE_LENGTH !== 0
+  ) {
+    throw new Error(`${name} must contain one packed, ${format}-aligned chunk`);
+  }
+}
+
+/** Protects source graph, CSR/status allocations, and optional triangle output from alias. */
+function validateDistinctClusteringOutputs(clustering: LuGraphLocalClusteringCoefficient): void {
+  const {topology} = clustering;
+  const inputVectors = [
+    topology.graph.sourceVertices,
+    topology.graph.targetVertices,
+    ...(topology.graph.edgeWeights ? [topology.graph.edgeWeights] : []),
+    ...(topology.graph.edgeIds ? [topology.graph.edgeIds] : []),
+    ...getAdjacencyVectors(topology.forward),
+    ...(topology.reverse ? getAdjacencyVectors(topology.reverse) : []),
+    topology.invalidEdgeCount
+  ];
+  const allocations = new Set<Buffer>();
+  for (const vector of inputVectors) {
+    for (const chunk of vector.data) allocations.add(getPhysicalBuffer(chunk));
+  }
+
+  const outputs = [
+    {name: 'output', vector: clustering.output},
+    ...(clustering.triangles ? [{name: 'triangles', vector: clustering.triangles}] : [])
+  ];
+  for (const {name, vector} of outputs) {
+    const buffer = getPhysicalBuffer(vector.data[0]);
+    if (allocations.has(buffer)) {
+      throw new Error(`${clustering.id} ${name} must use a distinct physical buffer allocation`);
+    }
+    allocations.add(buffer);
+  }
+}
+
+/** Enumerates existing adjacency payloads and statuses without changing their chunk identity. */
+function getAdjacencyVectors(
+  adjacency: LuGraphAdjacency
+): (GPUVector<'uint32'> | GPUVector<'float32'>)[] {
+  return [
+    adjacency.offsets,
+    adjacency.neighbors,
+    adjacency.edgeIds,
+    ...(adjacency.edgeWeights ? [adjacency.edgeWeights] : []),
+    adjacency.count,
+    adjacency.overflow
+  ];
+}
+
+/** Resolves borrowed engine wrappers so slices cannot disguise physical allocation aliases. */
+function getPhysicalBuffer(chunk: GPUData<'uint32'> | GPUData<'float32'>): Buffer {
+  return chunk.buffer instanceof DynamicBuffer ? chunk.buffer.buffer : chunk.buffer;
+}

--- a/modules/experimental/src/lugraph/lu-graph-single-source-shortest-path-internals.ts
+++ b/modules/experimental/src/lugraph/lu-graph-single-source-shortest-path-internals.ts
@@ -1,0 +1,723 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuGraph.
+
+import {type Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import type {
+  GPUCommandGraph,
+  GraphBufferUse,
+  GraphDataView,
+  GraphVectorView
+} from '../gpu-primitives/gpu-command-graph';
+import {
+  type GPUBoundedDispatchLayout,
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource
+} from '../gpu-primitives/gpu-dispatch-utils';
+import {
+  createTransientView,
+  getViewBinding,
+  getViewElementOffset
+} from '../gpu-primitives/graph-data-view-utils';
+import type {LuGraphSingleSourceShortestPath} from './lu-graph-single-source-shortest-path';
+import type {LuGraphAdjacency} from './lu-graph-topology';
+
+const SHORTEST_PATH_WORKGROUP_SIZE = 256;
+const POSITIVE_INFINITY_BITS = 0x7f800000;
+const UNREACHABLE_PREDECESSOR = 0xffffffff;
+
+type ShortestPathDataView = GraphDataView<'uint32'> | GraphDataView<'float32'>;
+
+type ImportedShortestPathAdjacency = {
+  offsets: GraphDataView<'uint32'>;
+  neighbors: GraphDataView<'uint32'>;
+  edgeWeights?: GraphDataView<'float32'>;
+  overflow: GraphDataView<'uint32'>;
+};
+
+type ImportedShortestPathState = {
+  id: string;
+  vertexCount: number;
+  edgeCount: number;
+  sourceVertex: number;
+  maxIterations: number;
+  distances: GraphDataView<'float32'>;
+  predecessors: GraphDataView<'uint32'>;
+  converged: GraphDataView<'uint32'>;
+  invalidWeightCount: GraphDataView<'uint32'>;
+  previousDistances?: GraphDataView<'float32'>;
+  changed?: GraphDataView<'uint32'>;
+  sourceVertices?: GraphVectorView<'uint32'>;
+  targetVertices?: GraphVectorView<'uint32'>;
+  sourceWeights?: GraphVectorView<'float32'>;
+  primaryAdjacency: ImportedShortestPathAdjacency;
+  secondaryAdjacency?: ImportedShortestPathAdjacency;
+  maxComputeWorkgroupsPerDimension: number;
+};
+
+type ShortestPathBinding = {
+  view: ShortestPathDataView;
+  usage: GraphBufferUse['usage'];
+  atomic?: boolean;
+};
+
+type ShortestPathPassProps = {
+  id: string;
+  source: string;
+  bindings: Record<string, ShortestPathBinding>;
+  dispatchLayout: GPUBoundedDispatchLayout;
+};
+
+/** Adds GPU weighted Bellman-Ford passes using an explicit bounded dispatch limit. @internal */
+export function addLuGraphSingleSourceShortestPathToGraphWithDispatchLimit<Parameters>(
+  search: LuGraphSingleSourceShortestPath,
+  commandGraph: GPUCommandGraph<Parameters>,
+  maxComputeWorkgroupsPerDimension: number
+): void {
+  const directed = search.topology.graph.directed;
+  const useIncoming = directed && search.direction === 'incoming';
+  const primaryAdjacency = importShortestPathAdjacency(
+    commandGraph,
+    `${search.id}-${useIncoming ? 'incoming' : 'outgoing'}`,
+    useIncoming ? search.topology.reverse! : search.topology.forward
+  );
+  const state: ImportedShortestPathState = {
+    id: search.id,
+    vertexCount: search.topology.graph.vertexCount,
+    edgeCount: search.topology.graph.edgeCount,
+    sourceVertex: search.sourceVertex,
+    maxIterations: search.maxIterations,
+    distances: commandGraph.importGPUVector(`${search.id}-distances`, search.distances).data[0],
+    predecessors: commandGraph.importGPUVector(`${search.id}-predecessors`, search.predecessors)
+      .data[0],
+    converged: search.converged
+      ? commandGraph.importGPUVector(`${search.id}-converged`, search.converged).data[0]
+      : createTransientView(commandGraph, `${search.id}-converged-scratch`, 'uint32', 1),
+    invalidWeightCount: search.invalidWeightCount
+      ? commandGraph.importGPUVector(`${search.id}-invalid-weight-count`, search.invalidWeightCount)
+          .data[0]
+      : createTransientView(commandGraph, `${search.id}-invalid-weight-scratch`, 'uint32', 1),
+    ...(search.maxIterations > 0
+      ? {
+          previousDistances: createTransientView(
+            commandGraph,
+            `${search.id}-previous-distances`,
+            'float32',
+            search.topology.graph.vertexCount
+          ),
+          changed: createTransientView(commandGraph, `${search.id}-changed`, 'uint32', 1)
+        }
+      : {}),
+    ...(search.topology.graph.edgeWeights
+      ? {
+          sourceVertices: commandGraph.importGPUVector(
+            `${search.id}-source-vertices`,
+            search.topology.graph.sourceVertices
+          ),
+          targetVertices: commandGraph.importGPUVector(
+            `${search.id}-target-vertices`,
+            search.topology.graph.targetVertices
+          ),
+          sourceWeights: commandGraph.importGPUVector(
+            `${search.id}-source-weights`,
+            search.topology.graph.edgeWeights
+          )
+        }
+      : {}),
+    primaryAdjacency,
+    ...(directed && search.direction === 'both'
+      ? {
+          secondaryAdjacency: importShortestPathAdjacency(
+            commandGraph,
+            `${search.id}-incoming`,
+            search.topology.reverse!
+          )
+        }
+      : {}),
+    maxComputeWorkgroupsPerDimension
+  };
+
+  addInitializationPass(commandGraph, state);
+  for (const [chunkIndex, weights] of state.sourceWeights?.data.entries() ?? []) {
+    if (weights.length > 0) {
+      addWeightValidationPass(commandGraph, {
+        state,
+        weights,
+        sources: state.sourceVertices!.data[chunkIndex],
+        targets: state.targetVertices!.data[chunkIndex],
+        chunkIndex
+      });
+    }
+  }
+  addSourcePass(commandGraph, state);
+
+  for (let iteration = 0; iteration < state.maxIterations; iteration++) {
+    addSnapshotPass(commandGraph, state, iteration);
+    addRelaxationPass(commandGraph, {
+      state,
+      adjacency: state.primaryAdjacency,
+      iteration,
+      direction: useIncoming ? 'incoming' : 'outgoing'
+    });
+    if (state.secondaryAdjacency) {
+      addRelaxationPass(commandGraph, {
+        state,
+        adjacency: state.secondaryAdjacency,
+        iteration,
+        direction: 'incoming'
+      });
+    }
+    addPredecessorResetPass(commandGraph, state, iteration);
+    addPredecessorPass(commandGraph, {
+      state,
+      adjacency: state.primaryAdjacency,
+      iteration,
+      direction: useIncoming ? 'incoming' : 'outgoing'
+    });
+    if (state.secondaryAdjacency) {
+      addPredecessorPass(commandGraph, {
+        state,
+        adjacency: state.secondaryAdjacency,
+        iteration,
+        direction: 'incoming'
+      });
+    }
+    addConvergencePass(commandGraph, state, iteration);
+  }
+}
+
+/** Imports the capacity-bounded CSR and optional edge weights for one traversal direction. */
+function importShortestPathAdjacency<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  id: string,
+  adjacency: LuGraphAdjacency
+): ImportedShortestPathAdjacency {
+  return {
+    offsets: commandGraph.importGPUVector(`${id}-offsets`, adjacency.offsets).data[0],
+    neighbors: commandGraph.importGPUVector(`${id}-neighbors`, adjacency.neighbors).data[0],
+    ...(adjacency.edgeWeights
+      ? {
+          edgeWeights: commandGraph.importGPUVector(`${id}-edge-weights`, adjacency.edgeWeights)
+            .data[0]
+        }
+      : {}),
+    overflow: commandGraph.importGPUVector(`${id}-overflow`, adjacency.overflow).data[0]
+  };
+}
+
+/** Resets every caller-visible output and internal status before each graph encoding. */
+function addInitializationPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: ImportedShortestPathState
+): void {
+  const bindings: Record<string, ShortestPathBinding> = {
+    distances: {view: state.distances, usage: 'storage-write', atomic: true},
+    predecessors: {view: state.predecessors, usage: 'storage-write', atomic: true},
+    converged: {view: state.converged, usage: 'storage-write', atomic: true},
+    invalidWeightCount: {view: state.invalidWeightCount, usage: 'storage-write', atomic: true}
+  };
+  const source = /* wgsl */ `
+const VERTEX_COUNT: u32 = ${state.vertexCount}u;
+const DISTANCES_OFFSET: u32 = ${getViewElementOffset(state.distances)}u;
+const PREDECESSORS_OFFSET: u32 = ${getViewElementOffset(state.predecessors)}u;
+const CONVERGED_OFFSET: u32 = ${getViewElementOffset(state.converged)}u;
+const INVALID_WEIGHT_COUNT_OFFSET: u32 = ${getViewElementOffset(state.invalidWeightCount)}u;
+${getBindingDeclarations(bindings)}
+
+@compute @workgroup_size(${SHORTEST_PATH_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getInvocationIndexSource(state, Math.max(state.vertexCount, 1))}
+  if (index == 0u) {
+    atomicStore(&converged[CONVERGED_OFFSET], 0u);
+    atomicStore(&invalidWeightCount[INVALID_WEIGHT_COUNT_OFFSET], 0u);
+  }
+  if (index >= VERTEX_COUNT) { return; }
+  atomicStore(&distances[DISTANCES_OFFSET + index], ${POSITIVE_INFINITY_BITS}u);
+  atomicStore(&predecessors[PREDECESSORS_OFFSET + index], ${UNREACHABLE_PREDECESSOR}u);
+}`;
+  addShortestPathPass(commandGraph, {
+    id: `${state.id}-initialize`,
+    source,
+    bindings,
+    dispatchLayout: getDispatchLayout(state, Math.max(state.vertexCount, 1))
+  });
+}
+
+/** Counts every invalid original source edge exactly once, excluding invalid endpoint rows. */
+function addWeightValidationPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  props: {
+    state: ImportedShortestPathState;
+    sources: GraphDataView<'uint32'>;
+    targets: GraphDataView<'uint32'>;
+    weights: GraphDataView<'float32'>;
+    chunkIndex: number;
+  }
+): void {
+  const {state} = props;
+  const bindings: Record<string, ShortestPathBinding> = {
+    sources: {view: props.sources, usage: 'storage-read'},
+    targets: {view: props.targets, usage: 'storage-read'},
+    weights: {view: props.weights, usage: 'storage-read'},
+    invalidWeightCount: {view: state.invalidWeightCount, usage: 'storage-read-write', atomic: true}
+  };
+  const source = /* wgsl */ `
+const EDGE_COUNT: u32 = ${props.weights.length}u;
+const VERTEX_COUNT: u32 = ${state.vertexCount}u;
+const SOURCES_OFFSET: u32 = ${getViewElementOffset(props.sources)}u;
+const TARGETS_OFFSET: u32 = ${getViewElementOffset(props.targets)}u;
+const WEIGHTS_OFFSET: u32 = ${getViewElementOffset(props.weights)}u;
+const INVALID_WEIGHT_COUNT_OFFSET: u32 = ${getViewElementOffset(state.invalidWeightCount)}u;
+${getBindingDeclarations(bindings)}
+
+@compute @workgroup_size(${SHORTEST_PATH_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getInvocationIndexSource(state, props.weights.length)}
+  if (index >= EDGE_COUNT) { return; }
+  if (sources[SOURCES_OFFSET + index] >= VERTEX_COUNT ||
+      targets[TARGETS_OFFSET + index] >= VERTEX_COUNT) { return; }
+  let bits = bitcast<u32>(weights[WEIGHTS_OFFSET + index]);
+  let magnitude = bits & 0x7fffffffu;
+  let negative = (bits & 0x80000000u) != 0u && magnitude != 0u;
+  if (magnitude >= 0x7f800000u || negative) {
+    atomicAdd(&invalidWeightCount[INVALID_WEIGHT_COUNT_OFFSET], 1u);
+  }
+}`;
+  addShortestPathPass(commandGraph, {
+    id: `${state.id}-validate-weights-${props.chunkIndex}`,
+    source,
+    bindings,
+    dispatchLayout: getDispatchLayout(state, props.weights.length)
+  });
+}
+
+/** Publishes the source only after complete adjacency and weight status are known. */
+function addSourcePass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: ImportedShortestPathState
+): void {
+  const bindings: Record<string, ShortestPathBinding> = {
+    distances: {view: state.distances, usage: 'storage-read-write', atomic: true},
+    converged: {view: state.converged, usage: 'storage-read-write', atomic: true},
+    invalidWeightCount: {view: state.invalidWeightCount, usage: 'storage-read'},
+    ...getOverflowBindings(state)
+  };
+  const triviallyConverged = state.vertexCount <= 1 || state.edgeCount === 0;
+  const source = /* wgsl */ `
+const VERTEX_COUNT: u32 = ${state.vertexCount}u;
+const SOURCE_VERTEX: u32 = ${state.sourceVertex}u;
+const DISTANCES_OFFSET: u32 = ${getViewElementOffset(state.distances)}u;
+const CONVERGED_OFFSET: u32 = ${getViewElementOffset(state.converged)}u;
+const INVALID_WEIGHT_COUNT_OFFSET: u32 = ${getViewElementOffset(state.invalidWeightCount)}u;
+${getOverflowConstants(state)}
+${getBindingDeclarations(bindings)}
+
+@compute @workgroup_size(1)
+fn main() {
+  if (invalidWeightCount[INVALID_WEIGHT_COUNT_OFFSET] != 0u || ${getOverflowGuard(state)}) {
+    return;
+  }
+  if (VERTEX_COUNT > 0u) {
+    atomicStore(&distances[DISTANCES_OFFSET + SOURCE_VERTEX], 0u);
+  }
+  atomicStore(&converged[CONVERGED_OFFSET], ${triviallyConverged ? '1u' : '0u'});
+}`;
+  addShortestPathPass(commandGraph, {
+    id: `${state.id}-source`,
+    source,
+    bindings,
+    dispatchLayout: {x: 1, y: 1, z: 1}
+  });
+}
+
+/** Saves the previous round so parallel relaxations cannot cross multiple hops in one dispatch. */
+function addSnapshotPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: ImportedShortestPathState,
+  iteration: number
+): void {
+  const previousDistances = state.previousDistances!;
+  const changed = state.changed!;
+  const bindings: Record<string, ShortestPathBinding> = {
+    distances: {view: state.distances, usage: 'storage-read-write', atomic: true},
+    previousDistances: {view: previousDistances, usage: 'storage-write'},
+    changed: {view: changed, usage: 'storage-write', atomic: true},
+    converged: {view: state.converged, usage: 'storage-read'}
+  };
+  const source = /* wgsl */ `
+const VERTEX_COUNT: u32 = ${state.vertexCount}u;
+const DISTANCES_OFFSET: u32 = ${getViewElementOffset(state.distances)}u;
+const PREVIOUS_DISTANCES_OFFSET: u32 = ${getViewElementOffset(previousDistances)}u;
+const CHANGED_OFFSET: u32 = ${getViewElementOffset(changed)}u;
+const CONVERGED_OFFSET: u32 = ${getViewElementOffset(state.converged)}u;
+${getBindingDeclarations(bindings)}
+
+@compute @workgroup_size(${SHORTEST_PATH_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getInvocationIndexSource(state, Math.max(state.vertexCount, 1))}
+  if (index == 0u) { atomicStore(&changed[CHANGED_OFFSET], 0u); }
+  if (index >= VERTEX_COUNT || converged[CONVERGED_OFFSET] != 0u) { return; }
+  previousDistances[PREVIOUS_DISTANCES_OFFSET + index] =
+    bitcast<f32>(atomicLoad(&distances[DISTANCES_OFFSET + index]));
+}`;
+  addShortestPathPass(commandGraph, {
+    id: `${state.id}-iteration-${iteration}-snapshot`,
+    source,
+    bindings,
+    dispatchLayout: getDispatchLayout(state, Math.max(state.vertexCount, 1))
+  });
+}
+
+/** Computes one exact-hop parallel Bellman-Ford relaxation through aligned weighted CSR. */
+function addRelaxationPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  props: {
+    state: ImportedShortestPathState;
+    adjacency: ImportedShortestPathAdjacency;
+    iteration: number;
+    direction: 'outgoing' | 'incoming';
+  }
+): void {
+  const {state, adjacency} = props;
+  const previousDistances = state.previousDistances!;
+  const changed = state.changed!;
+  const bindings: Record<string, ShortestPathBinding> = {
+    offsets: {view: adjacency.offsets, usage: 'storage-read'},
+    neighbors: {view: adjacency.neighbors, usage: 'storage-read'},
+    ...(adjacency.edgeWeights
+      ? {edgeWeights: {view: adjacency.edgeWeights, usage: 'storage-read' as const}}
+      : {}),
+    previousDistances: {view: previousDistances, usage: 'storage-read'},
+    distances: {view: state.distances, usage: 'storage-read-write', atomic: true},
+    changed: {view: changed, usage: 'storage-read-write', atomic: true},
+    converged: {view: state.converged, usage: 'storage-read'}
+  };
+  const weightOffset = adjacency.edgeWeights
+    ? `const WEIGHTS_OFFSET: u32 = ${getViewElementOffset(adjacency.edgeWeights)}u;`
+    : '';
+  const weight = adjacency.edgeWeights ? 'edgeWeights[WEIGHTS_OFFSET + slot]' : '1.0';
+  const source = /* wgsl */ `
+const VERTEX_COUNT: u32 = ${state.vertexCount}u;
+const CAPACITY: u32 = ${adjacency.neighbors.length}u;
+const OFFSETS_OFFSET: u32 = ${getViewElementOffset(adjacency.offsets)}u;
+const NEIGHBORS_OFFSET: u32 = ${getViewElementOffset(adjacency.neighbors)}u;
+const PREVIOUS_DISTANCES_OFFSET: u32 = ${getViewElementOffset(previousDistances)}u;
+const DISTANCES_OFFSET: u32 = ${getViewElementOffset(state.distances)}u;
+const CHANGED_OFFSET: u32 = ${getViewElementOffset(changed)}u;
+const CONVERGED_OFFSET: u32 = ${getViewElementOffset(state.converged)}u;
+${weightOffset}
+${getBindingDeclarations(bindings)}
+
+@compute @workgroup_size(${SHORTEST_PATH_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getInvocationIndexSource(state, state.vertexCount)}
+  if (index >= VERTEX_COUNT || converged[CONVERGED_OFFSET] != 0u) { return; }
+  let distance = previousDistances[PREVIOUS_DISTANCES_OFFSET + index];
+  if (bitcast<u32>(distance) >= 0x7f800000u) { return; }
+  let first = min(offsets[OFFSETS_OFFSET + index], CAPACITY);
+  let last = min(offsets[OFFSETS_OFFSET + index + 1u], CAPACITY);
+  for (var slot = first; slot < last; slot++) {
+    let neighbor = neighbors[NEIGHBORS_OFFSET + slot];
+    if (neighbor >= VERTEX_COUNT) { continue; }
+    let candidate = distance + ${weight};
+    let candidateBits = bitcast<u32>(candidate);
+    if (candidateBits >= 0x7f800000u) { continue; }
+    let previous = atomicMin(&distances[DISTANCES_OFFSET + neighbor], candidateBits);
+    if (candidateBits < previous) { atomicStore(&changed[CHANGED_OFFSET], 1u); }
+  }
+}`;
+  addShortestPathPass(commandGraph, {
+    id: `${state.id}-iteration-${props.iteration}-relax-${props.direction}`,
+    source,
+    bindings,
+    dispatchLayout: getDispatchLayout(state, state.vertexCount)
+  });
+}
+
+/** Clears stale parents only where this synchronized round discovered a better distance. */
+function addPredecessorResetPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: ImportedShortestPathState,
+  iteration: number
+): void {
+  const previousDistances = state.previousDistances!;
+  const bindings: Record<string, ShortestPathBinding> = {
+    previousDistances: {view: previousDistances, usage: 'storage-read'},
+    distances: {view: state.distances, usage: 'storage-read-write', atomic: true},
+    predecessors: {view: state.predecessors, usage: 'storage-read-write', atomic: true},
+    converged: {view: state.converged, usage: 'storage-read'}
+  };
+  const source = /* wgsl */ `
+const VERTEX_COUNT: u32 = ${state.vertexCount}u;
+const SOURCE_VERTEX: u32 = ${state.sourceVertex}u;
+const PREVIOUS_DISTANCES_OFFSET: u32 = ${getViewElementOffset(previousDistances)}u;
+const DISTANCES_OFFSET: u32 = ${getViewElementOffset(state.distances)}u;
+const PREDECESSORS_OFFSET: u32 = ${getViewElementOffset(state.predecessors)}u;
+const CONVERGED_OFFSET: u32 = ${getViewElementOffset(state.converged)}u;
+${getBindingDeclarations(bindings)}
+
+@compute @workgroup_size(${SHORTEST_PATH_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getInvocationIndexSource(state, state.vertexCount)}
+  if (index >= VERTEX_COUNT || index == SOURCE_VERTEX || converged[CONVERGED_OFFSET] != 0u) {
+    return;
+  }
+  let previous = bitcast<u32>(previousDistances[PREVIOUS_DISTANCES_OFFSET + index]);
+  let current = atomicLoad(&distances[DISTANCES_OFFSET + index]);
+  if (current < previous) {
+    atomicStore(&predecessors[PREDECESSORS_OFFSET + index], ${UNREACHABLE_PREDECESSOR}u);
+  }
+}`;
+  addShortestPathPass(commandGraph, {
+    id: `${state.id}-iteration-${iteration}-reset-predecessors`,
+    source,
+    bindings,
+    dispatchLayout: getDispatchLayout(state, state.vertexCount)
+  });
+}
+
+/** Selects the lowest stable parent among equally short, same-hop newly discovered paths. */
+function addPredecessorPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  props: {
+    state: ImportedShortestPathState;
+    adjacency: ImportedShortestPathAdjacency;
+    iteration: number;
+    direction: 'outgoing' | 'incoming';
+  }
+): void {
+  const {state, adjacency} = props;
+  const previousDistances = state.previousDistances!;
+  const bindings: Record<string, ShortestPathBinding> = {
+    offsets: {view: adjacency.offsets, usage: 'storage-read'},
+    neighbors: {view: adjacency.neighbors, usage: 'storage-read'},
+    ...(adjacency.edgeWeights
+      ? {edgeWeights: {view: adjacency.edgeWeights, usage: 'storage-read' as const}}
+      : {}),
+    previousDistances: {view: previousDistances, usage: 'storage-read'},
+    distances: {view: state.distances, usage: 'storage-read-write', atomic: true},
+    predecessors: {view: state.predecessors, usage: 'storage-read-write', atomic: true},
+    converged: {view: state.converged, usage: 'storage-read'}
+  };
+  const weightOffset = adjacency.edgeWeights
+    ? `const WEIGHTS_OFFSET: u32 = ${getViewElementOffset(adjacency.edgeWeights)}u;`
+    : '';
+  const weight = adjacency.edgeWeights ? 'edgeWeights[WEIGHTS_OFFSET + slot]' : '1.0';
+  const source = /* wgsl */ `
+const VERTEX_COUNT: u32 = ${state.vertexCount}u;
+const SOURCE_VERTEX: u32 = ${state.sourceVertex}u;
+const CAPACITY: u32 = ${adjacency.neighbors.length}u;
+const OFFSETS_OFFSET: u32 = ${getViewElementOffset(adjacency.offsets)}u;
+const NEIGHBORS_OFFSET: u32 = ${getViewElementOffset(adjacency.neighbors)}u;
+const PREVIOUS_DISTANCES_OFFSET: u32 = ${getViewElementOffset(previousDistances)}u;
+const DISTANCES_OFFSET: u32 = ${getViewElementOffset(state.distances)}u;
+const PREDECESSORS_OFFSET: u32 = ${getViewElementOffset(state.predecessors)}u;
+const CONVERGED_OFFSET: u32 = ${getViewElementOffset(state.converged)}u;
+${weightOffset}
+${getBindingDeclarations(bindings)}
+
+@compute @workgroup_size(${SHORTEST_PATH_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getInvocationIndexSource(state, state.vertexCount)}
+  if (index >= VERTEX_COUNT || converged[CONVERGED_OFFSET] != 0u) { return; }
+  let sourceDistance = previousDistances[PREVIOUS_DISTANCES_OFFSET + index];
+  if (bitcast<u32>(sourceDistance) >= 0x7f800000u) { return; }
+  let first = min(offsets[OFFSETS_OFFSET + index], CAPACITY);
+  let last = min(offsets[OFFSETS_OFFSET + index + 1u], CAPACITY);
+  for (var slot = first; slot < last; slot++) {
+    let neighbor = neighbors[NEIGHBORS_OFFSET + slot];
+    if (neighbor >= VERTEX_COUNT || neighbor == SOURCE_VERTEX) { continue; }
+    let previousDistance = bitcast<u32>(previousDistances[PREVIOUS_DISTANCES_OFFSET + neighbor]);
+    let currentDistance = atomicLoad(&distances[DISTANCES_OFFSET + neighbor]);
+    let candidate = bitcast<u32>(sourceDistance + ${weight});
+    if (currentDistance < previousDistance && candidate == currentDistance) {
+      atomicMin(&predecessors[PREDECESSORS_OFFSET + neighbor], index);
+    }
+  }
+}`;
+  addShortestPathPass(commandGraph, {
+    id: `${state.id}-iteration-${props.iteration}-predecessors-${props.direction}`,
+    source,
+    bindings,
+    dispatchLayout: getDispatchLayout(state, state.vertexCount)
+  });
+}
+
+/** Publishes fixed-point convergence without synchronously reading status back to the CPU. */
+function addConvergencePass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: ImportedShortestPathState,
+  iteration: number
+): void {
+  const changed = state.changed!;
+  const bindings: Record<string, ShortestPathBinding> = {
+    changed: {view: changed, usage: 'storage-read'},
+    converged: {view: state.converged, usage: 'storage-read-write', atomic: true},
+    invalidWeightCount: {view: state.invalidWeightCount, usage: 'storage-read'},
+    ...getOverflowBindings(state)
+  };
+  const reachesSimplePathBound = iteration + 1 >= state.vertexCount - 1;
+  const source = /* wgsl */ `
+const CHANGED_OFFSET: u32 = ${getViewElementOffset(changed)}u;
+const CONVERGED_OFFSET: u32 = ${getViewElementOffset(state.converged)}u;
+const INVALID_WEIGHT_COUNT_OFFSET: u32 = ${getViewElementOffset(state.invalidWeightCount)}u;
+${getOverflowConstants(state)}
+${getBindingDeclarations(bindings)}
+
+@compute @workgroup_size(1)
+fn main() {
+  if (invalidWeightCount[INVALID_WEIGHT_COUNT_OFFSET] != 0u || ${getOverflowGuard(state)}) {
+    atomicStore(&converged[CONVERGED_OFFSET], 0u);
+    return;
+  }
+  if (changed[CHANGED_OFFSET] == 0u${reachesSimplePathBound ? ' || true' : ''}) {
+    atomicStore(&converged[CONVERGED_OFFSET], 1u);
+  }
+}`;
+  addShortestPathPass(commandGraph, {
+    id: `${state.id}-iteration-${iteration}-convergence`,
+    source,
+    bindings,
+    dispatchLayout: {x: 1, y: 1, z: 1}
+  });
+}
+
+/** Returns storage reads for every adjacency direction required by this traversal. */
+function getOverflowBindings(
+  state: ImportedShortestPathState
+): Record<string, ShortestPathBinding> {
+  return {
+    overflow: {view: state.primaryAdjacency.overflow, usage: 'storage-read'},
+    ...(state.secondaryAdjacency
+      ? {secondaryOverflow: {view: state.secondaryAdjacency.overflow, usage: 'storage-read'}}
+      : {})
+  };
+}
+
+/** Emits aligned component offsets for primary and optional secondary adjacency status. */
+function getOverflowConstants(state: ImportedShortestPathState): string {
+  return [
+    `const OVERFLOW_OFFSET: u32 = ${getViewElementOffset(state.primaryAdjacency.overflow)}u;`,
+    ...(state.secondaryAdjacency
+      ? [
+          `const SECONDARY_OVERFLOW_OFFSET: u32 = ${getViewElementOffset(state.secondaryAdjacency.overflow)}u;`
+        ]
+      : [])
+  ].join('\n');
+}
+
+/** Emits the fail-closed condition for every selected adjacency direction. */
+function getOverflowGuard(state: ImportedShortestPathState): string {
+  return `overflow[OVERFLOW_OFFSET] != 0u${
+    state.secondaryAdjacency ? ' || secondaryOverflow[SECONDARY_OVERFLOW_OFFSET] != 0u' : ''
+  }`;
+}
+
+/** Declares storage arrays, reinterpreting non-negative float32 distances as atomic uint32. */
+function getBindingDeclarations(bindings: Record<string, ShortestPathBinding>): string {
+  return Object.entries(bindings)
+    .map(([name, binding], location) => {
+      const access = binding.usage === 'storage-read' ? 'read' : 'read_write';
+      const element = binding.atomic
+        ? 'atomic<u32>'
+        : binding.view.format === 'float32'
+          ? 'f32'
+          : 'u32';
+      return `@group(0) @binding(${location}) var<storage, ${access}> ${name}: array<${element}>;`;
+    })
+    .join('\n');
+}
+
+/** Compiles one bounded GPU pass without submitting, reading back, or owning caller buffers. */
+function addShortestPathPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  props: ShortestPathPassProps
+): void {
+  commandGraph.addComputePass({
+    id: props.id,
+    resources: Object.values(props.bindings).map(({view, usage}) => ({buffer: view, usage})),
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id: props.id,
+        source: props.source,
+        shaderLayout: {
+          bindings: Object.keys(props.bindings).map((name, location) => ({
+            name,
+            type: 'storage' as const,
+            group: 0,
+            location
+          }))
+        }
+      });
+
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const bindings: Record<string, Binding> = {};
+          for (const [name, binding] of Object.entries(props.bindings)) {
+            bindings[name] = getViewBinding(binding.view, getBuffer);
+          }
+          computation.setBindings(bindings);
+          computation.dispatch(
+            computePass,
+            props.dispatchLayout.x,
+            props.dispatchLayout.y,
+            props.dispatchLayout.z
+          );
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+/** Plans one bounded vertex or source-edge dispatch using the owning adapter's limits. */
+function getDispatchLayout(
+  state: ImportedShortestPathState,
+  elementCount: number
+): GPUBoundedDispatchLayout {
+  return getLuGraphSingleSourceShortestPathDispatchLayout(
+    elementCount,
+    state.maxComputeWorkgroupsPerDimension
+  );
+}
+
+/** Emits a three-dimensional global invocation index for the planned bounded dispatch. */
+function getInvocationIndexSource(state: ImportedShortestPathState, elementCount: number): string {
+  return getBoundedInvocationIndexSource(
+    getDispatchLayout(state, elementCount),
+    SHORTEST_PATH_WORKGROUP_SIZE
+  );
+}
+
+/** Plans one bounded three-dimensional weighted shortest-path dispatch. @internal */
+export function getLuGraphSingleSourceShortestPathDispatchLayout(
+  elementCount: number,
+  maxComputeWorkgroupsPerDimension: number
+): GPUBoundedDispatchLayout {
+  return getBoundedDispatchLayout(
+    'LuGraphSingleSourceShortestPath',
+    elementCount,
+    SHORTEST_PATH_WORKGROUP_SIZE,
+    maxComputeWorkgroupsPerDimension
+  );
+}

--- a/modules/experimental/src/lugraph/lu-graph-single-source-shortest-path.ts
+++ b/modules/experimental/src/lugraph/lu-graph-single-source-shortest-path.ts
@@ -1,0 +1,232 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuGraph.
+
+import type {Buffer} from '@luma.gl/core';
+import {DynamicBuffer} from '@luma.gl/engine';
+import type {GPUData, GPUVector} from '@luma.gl/tables';
+import type {GPUCommandGraph} from '../gpu-primitives/gpu-command-graph';
+import {addLuGraphSingleSourceShortestPathToGraphWithDispatchLimit} from './lu-graph-single-source-shortest-path-internals';
+import type {LuGraphAdjacency, LuGraphTopology} from './lu-graph-topology';
+
+const MAXIMUM_SHORTEST_PATH_ITERATIONS = 1024;
+const SCALAR_BYTE_LENGTH = 4;
+
+/** Forward, reverse, or combined orientation for weighted shortest-path exploration. */
+export type LuGraphSingleSourceShortestPathDirection = 'outgoing' | 'incoming' | 'both';
+
+/** Existing topology, one source, and caller-owned weighted shortest-path destinations. */
+export type LuGraphSingleSourceShortestPathProps = {
+  /** Prefix for generated command-graph nodes and imported-resource identifiers. */
+  id?: string;
+  /** Existing GPU-resident compressed adjacency and its explicit overflow status. */
+  topology: LuGraphTopology;
+  /** Stable source vertex identifier; zero is also accepted for an empty graph. */
+  sourceVertex: number;
+  /** One caller-owned floating-point distance for every graph vertex. */
+  distances: GPUVector<'float32'>;
+  /** One caller-owned unsigned predecessor identifier for every graph vertex. */
+  predecessors: GPUVector<'uint32'>;
+  /** Maximum compiled relaxation rounds, between zero and 1,024 inclusive. */
+  maxIterations?: number;
+  /** Forward, reverse, or combined edge orientation. Defaults to outgoing. */
+  direction?: LuGraphSingleSourceShortestPathDirection;
+  /** Optional caller-owned scalar reporting whether all shortest distances are final. */
+  converged?: GPUVector<'uint32'>;
+  /** Optional caller-owned scalar receiving invalid, valid-endpoint source-edge weights. */
+  invalidWeightCount?: GPUVector<'uint32'>;
+};
+
+/**
+ * Computes bounded, non-negative weighted shortest paths without reading GPU graph data.
+ *
+ * Missing graph weights are treated as one. Negative, infinite, and NaN weights fail closed;
+ * invalid source endpoints are ignored. Unreachable vertices receive positive infinity, and
+ * unreachable vertices and the source receive the `0xffffffff` predecessor sentinel. Among
+ * equally short routes first discovered in the same relaxation round, the lowest parent wins.
+ */
+export class LuGraphSingleSourceShortestPath {
+  /** Prefix for generated command-graph nodes and imported resources. */
+  readonly id: string;
+  /** Existing caller-owned graph topology. */
+  readonly topology: LuGraphTopology;
+  /** Stable source vertex identifier. */
+  readonly sourceVertex: number;
+  /** Caller-owned, vertex-aligned weighted distance column. */
+  readonly distances: GPUVector<'float32'>;
+  /** Caller-owned, vertex-aligned deterministic predecessor column. */
+  readonly predecessors: GPUVector<'uint32'>;
+  /** Maximum compiled Bellman-Ford relaxation rounds. */
+  readonly maxIterations: number;
+  /** Selected graph edge orientation. */
+  readonly direction: LuGraphSingleSourceShortestPathDirection;
+  /** Optional caller-owned convergence status scalar. */
+  readonly converged?: GPUVector<'uint32'>;
+  /** Optional caller-owned invalid-source-edge-weight count scalar. */
+  readonly invalidWeightCount?: GPUVector<'uint32'>;
+
+  /** Validates caller-owned metadata without allocating, submitting, or reading GPU work. */
+  constructor(props: LuGraphSingleSourceShortestPathProps) {
+    this.id = props.id ?? 'lu-graph-single-source-shortest-path';
+    this.topology = props.topology;
+    this.sourceVertex = props.sourceVertex;
+    this.distances = props.distances;
+    this.predecessors = props.predecessors;
+    this.maxIterations =
+      props.maxIterations ??
+      Math.min(Math.max(this.topology.graph.vertexCount - 1, 0), MAXIMUM_SHORTEST_PATH_ITERATIONS);
+    this.direction = props.direction ?? 'outgoing';
+    this.converged = props.converged;
+    this.invalidWeightCount = props.invalidWeightCount;
+
+    const maximumSourceVertex = Math.max(this.topology.graph.vertexCount - 1, 0);
+    if (
+      !Number.isSafeInteger(this.sourceVertex) ||
+      this.sourceVertex < 0 ||
+      this.sourceVertex > maximumSourceVertex
+    ) {
+      throw new Error(`${this.id} sourceVertex must identify an existing graph vertex`);
+    }
+    if (!['outgoing', 'incoming', 'both'].includes(this.direction)) {
+      throw new Error(`${this.id} direction must be outgoing, incoming, or both`);
+    }
+    if (this.direction !== 'outgoing' && this.topology.graph.directed && !this.topology.reverse) {
+      throw new Error(
+        `${this.id} incoming or bidirectional directed paths require reverse adjacency`
+      );
+    }
+    if (
+      !Number.isSafeInteger(this.maxIterations) ||
+      this.maxIterations < 0 ||
+      this.maxIterations > MAXIMUM_SHORTEST_PATH_ITERATIONS
+    ) {
+      throw new Error(`${this.id} maxIterations must be a safe integer between zero and 1024`);
+    }
+
+    validateShortestPathVector(
+      this.distances,
+      'float32',
+      this.topology.graph.vertexCount,
+      `${this.id} distances`
+    );
+    validateShortestPathVector(
+      this.predecessors,
+      'uint32',
+      this.topology.graph.vertexCount,
+      `${this.id} predecessors`
+    );
+    if (this.converged) {
+      validateShortestPathVector(this.converged, 'uint32', 1, `${this.id} converged`);
+    }
+    if (this.invalidWeightCount) {
+      validateShortestPathVector(
+        this.invalidWeightCount,
+        'uint32',
+        1,
+        `${this.id} invalidWeightCount`
+      );
+    }
+    validateDistinctShortestPathOutputs(this);
+  }
+
+  /** Adds bounded weighted-path passes without submitting commands or reading GPU results. */
+  addToGraph<Parameters>(commandGraph: GPUCommandGraph<Parameters>): void {
+    addLuGraphSingleSourceShortestPathToGraphWithDispatchLimit(
+      this,
+      commandGraph,
+      commandGraph.device.limits.maxComputeWorkgroupsPerDimension
+    );
+  }
+}
+
+/** Requires exactly one packed, properly aligned caller-owned scalar output chunk. */
+function validateShortestPathVector<Format extends 'uint32' | 'float32'>(
+  vector: GPUVector<Format>,
+  format: Format,
+  length: number,
+  name: string
+): void {
+  if (
+    vector.format !== format ||
+    vector.data.length !== 1 ||
+    vector.length !== length ||
+    vector.stride !== 1 ||
+    vector.byteStride !== SCALAR_BYTE_LENGTH ||
+    vector.rowByteLength !== SCALAR_BYTE_LENGTH ||
+    vector.valueLength !== vector.length ||
+    vector.bufferLayout
+  ) {
+    throw new Error(`${name} must contain exactly ${length} packed ${format} rows in one chunk`);
+  }
+
+  const chunk = vector.data[0];
+  if (
+    chunk.format !== format ||
+    chunk.length !== length ||
+    chunk.stride !== 1 ||
+    chunk.byteStride !== SCALAR_BYTE_LENGTH ||
+    chunk.rowByteLength !== SCALAR_BYTE_LENGTH ||
+    chunk.valueLength !== chunk.length ||
+    !Number.isSafeInteger(chunk.byteOffset) ||
+    chunk.byteOffset < 0 ||
+    chunk.byteOffset % SCALAR_BYTE_LENGTH !== 0
+  ) {
+    throw new Error(`${name} must contain one packed, uint32-aligned ${format} chunk`);
+  }
+}
+
+/** Keeps writable shortest-path results physically disjoint from every graph input and peer. */
+function validateDistinctShortestPathOutputs(search: LuGraphSingleSourceShortestPath): void {
+  const topology = search.topology;
+  const inputVectors = [
+    topology.graph.sourceVertices,
+    topology.graph.targetVertices,
+    ...(topology.graph.edgeWeights ? [topology.graph.edgeWeights] : []),
+    ...(topology.graph.edgeIds ? [topology.graph.edgeIds] : []),
+    ...getAdjacencyVectors(topology.forward),
+    ...(topology.reverse ? getAdjacencyVectors(topology.reverse) : []),
+    topology.invalidEdgeCount
+  ];
+  const physicalAllocations = new Set<Buffer>();
+  for (const vector of inputVectors) {
+    for (const chunk of vector.data) {
+      physicalAllocations.add(getPhysicalBuffer(chunk));
+    }
+  }
+
+  const outputs = [
+    {name: 'distances', vector: search.distances},
+    {name: 'predecessors', vector: search.predecessors},
+    ...(search.converged ? [{name: 'converged', vector: search.converged}] : []),
+    ...(search.invalidWeightCount
+      ? [{name: 'invalidWeightCount', vector: search.invalidWeightCount}]
+      : [])
+  ];
+  for (const {name, vector} of outputs) {
+    const physicalBuffer = getPhysicalBuffer(vector.data[0]);
+    if (physicalAllocations.has(physicalBuffer)) {
+      throw new Error(`${search.id} ${name} must use a distinct physical buffer allocation`);
+    }
+    physicalAllocations.add(physicalBuffer);
+  }
+}
+
+/** Enumerates existing adjacency allocations without copying or changing source identity. */
+function getAdjacencyVectors(
+  adjacency: LuGraphAdjacency
+): (GPUVector<'uint32'> | GPUVector<'float32'>)[] {
+  return [
+    adjacency.offsets,
+    adjacency.neighbors,
+    adjacency.edgeIds,
+    ...(adjacency.edgeWeights ? [adjacency.edgeWeights] : []),
+    adjacency.count,
+    adjacency.overflow
+  ];
+}
+
+/** Resolves an engine wrapper to its current physical GPU allocation. */
+function getPhysicalBuffer(chunk: GPUData<'uint32'> | GPUData<'float32'>): Buffer {
+  return chunk.buffer instanceof DynamicBuffer ? chunk.buffer.buffer : chunk.buffer;
+}

--- a/modules/experimental/test/lugraph/lu-graph-benchmark.node.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-benchmark.node.spec.ts
@@ -16,6 +16,7 @@ import {
 import {describe, expect, expectTypeOf, test} from 'vitest';
 
 import {
+  evaluateLuGraphBenchmarkShortestPath,
   prepareLuGraphBenchmark,
   summarizeLuGraphBenchmarkSamples
 } from '../../src/lugraph/lu-graph-benchmark-data';
@@ -363,6 +364,31 @@ describe('luGraph benchmark independent CPU oracles', () => {
           Number.isFinite(distance) && distance !== context.reference.distances[vertex]
       )
     ).toBe(true);
+  });
+
+  test('bounds the shortest-path oracle to the same 1,024 GPU relaxation rounds', () => {
+    const vertexCount = 1030;
+    const edgeCount = vertexCount - 1;
+    const forwardOffsets = Uint32Array.from({length: vertexCount + 1}, (_, vertex) =>
+      Math.min(vertex, edgeCount)
+    );
+    const forwardNeighbors = Uint32Array.from({length: edgeCount}, (_, vertex) => vertex + 1);
+    const forwardWeights = new Float32Array(edgeCount).fill(1);
+
+    const reference = evaluateLuGraphBenchmarkShortestPath({
+      forwardOffsets,
+      forwardNeighbors,
+      forwardWeights,
+      reverseOffsets: new Uint32Array(vertexCount + 1),
+      reverseNeighbors: new Uint32Array(0),
+      reverseWeights: new Float32Array(0)
+    });
+
+    expect(reference.weightedDistances[1024]).toBe(1024);
+    expect(reference.weightedPredecessors[1024]).toBe(1023);
+    expect(reference.weightedDistances[1025]).toBe(Number.POSITIVE_INFINITY);
+    expect(reference.weightedPredecessors[1025]).toBe(0xffffffff);
+    expect(reference.weightedDistances[vertexCount - 1]).toBe(Number.POSITIVE_INFINITY);
   });
 
   test('counts distinct directed closures and normalizes complete graph neighborhoods', () => {

--- a/modules/experimental/test/lugraph/lu-graph-benchmark.node.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-benchmark.node.spec.ts
@@ -105,8 +105,10 @@ describe('luGraph benchmark deterministic source datasets', () => {
     expect(first.vertexCount).toBe(32);
     expect(first.sourceChunks).toHaveLength(3);
     expect(first.targetChunks).toHaveLength(3);
+    expect(first.weightChunks).toHaveLength(3);
     expect(first.sourceChunks[1]).toHaveLength(0);
     expect(first.targetChunks[1]).toHaveLength(0);
+    expect(first.weightChunks[1]).toHaveLength(0);
     expect(first.positions).toBeInstanceOf(Float32Array);
     expect(first.positions).toHaveLength(64);
     expect(first.positions).not.toBe(repeated.positions);
@@ -117,17 +119,24 @@ describe('luGraph benchmark deterministic source datasets', () => {
     let edgeCount = 0;
     for (const [chunkIndex, sources] of first.sourceChunks.entries()) {
       const targets = first.targetChunks[chunkIndex];
+      const weights = first.weightChunks[chunkIndex];
       expect(sources).toBeInstanceOf(Uint32Array);
       expect(targets).toBeInstanceOf(Uint32Array);
+      expect(weights).toBeInstanceOf(Float32Array);
       expect(targets.length).toBe(sources.length);
+      expect(weights.length).toBe(sources.length);
       expect(Array.from(sources)).toEqual(Array.from(repeated.sourceChunks[chunkIndex]));
       expect(Array.from(targets)).toEqual(Array.from(repeated.targetChunks[chunkIndex]));
+      expect(Array.from(weights)).toEqual(Array.from(repeated.weightChunks[chunkIndex]));
+      expect(weights).not.toBe(repeated.weightChunks[chunkIndex]);
       expect(Array.from(sources).every(vertex => vertex < first.vertexCount)).toBe(true);
       expect(Array.from(targets).every(vertex => vertex < first.vertexCount)).toBe(true);
+      expect(Array.from(weights).every(weight => Number.isFinite(weight) && weight > 0)).toBe(true);
       edgeCount += sources.length;
     }
     expect(first.edgeCount).toBe(edgeCount);
     expect(first.edgeCount).toBeGreaterThan(0);
+    expect(new Set(first.weightChunks.flatMap(chunk => Array.from(chunk))).size).toBeGreaterThan(1);
   });
 
   test('dense inputs contain every distinct ordered pair rather than synthetic edge counts', () => {
@@ -239,12 +248,13 @@ describe('luGraph benchmark deterministic source datasets', () => {
     expect(dataset.positions).toHaveLength(2);
     expect(dataset.sourceChunks).toHaveLength(3);
     expect(dataset.targetChunks).toHaveLength(3);
+    expect(dataset.weightChunks).toHaveLength(3);
     expect(dataset.edgeCount).toBe(0);
   });
 });
 
 describe('luGraph benchmark independent CPU oracles', () => {
-  test.each(DATASET_KINDS)('evaluates all six real CPU references for %s workloads', kind => {
+  test.each(DATASET_KINDS)('evaluates all nine real CPU references for %s workloads', kind => {
     const context = prepareLuGraphBenchmark({
       kind,
       vertexCount: 12,
@@ -264,12 +274,27 @@ describe('luGraph benchmark independent CPU oracles', () => {
     expect(reference.forwardOffsets[12]).toBe(context.dataset.edgeCount);
     expect(reference.reverseOffsets[12]).toBe(context.dataset.edgeCount);
     expect(reference.forwardNeighbors).toHaveLength(context.dataset.edgeCount);
+    expect(reference.forwardWeights).toHaveLength(context.dataset.edgeCount);
     expect(reference.reverseNeighbors).toHaveLength(context.dataset.edgeCount);
+    expect(reference.reverseWeights).toHaveLength(context.dataset.edgeCount);
     expect(reference.distances).toHaveLength(12);
     expect(reference.predecessors).toHaveLength(12);
     expect(reference.distances[0]).toBe(0);
     expect(reference.predecessors[0]).toBe(0xffffffff);
+    expect(reference.weightedDistances).toHaveLength(12);
+    expect(reference.weightedPredecessors).toHaveLength(12);
+    expect(reference.weightedDistances[0]).toBe(0);
+    expect(reference.weightedPredecessors[0]).toBe(0xffffffff);
     expect(reference.components).toHaveLength(12);
+    expect(reference.communities).toHaveLength(12);
+    expect(typeof reference.communityConverged).toBe('boolean');
+    expect(reference.clusteringCoefficients).toHaveLength(12);
+    expect(reference.triangleCounts).toHaveLength(12);
+    expect(
+      Array.from(reference.clusteringCoefficients).every(
+        coefficient => coefficient >= 0 && coefficient <= 1
+      )
+    ).toBe(true);
     expect(reference.pageRank).toHaveLength(12);
     expect(Array.from(reference.pageRank).reduce((sum, score) => sum + score, 0)).toBeCloseTo(1, 5);
     expect(reference.exactPositions).toHaveLength(24);
@@ -285,7 +310,10 @@ describe('luGraph benchmark independent CPU oracles', () => {
     expect(Object.keys(context.cpuTimeMilliseconds)).toEqual([
       'topology',
       'breadth-first-search',
+      'single-source-shortest-path',
       'connected-components',
+      'label-propagation',
+      'local-clustering-coefficient',
       'page-rank',
       'exact-layout',
       'spatial-layout'
@@ -314,6 +342,39 @@ describe('luGraph benchmark independent CPU oracles', () => {
     expect(context.reference.components[7]).toBe(7);
     expect(context.reference.distances[7]).toBe(0xffffffff);
     expect(context.reference.predecessors[7]).toBe(0xffffffff);
+    expect(context.reference.weightedDistances[7]).toBe(Number.POSITIVE_INFINITY);
+    expect(context.reference.weightedPredecessors[7]).toBe(0xffffffff);
+    expect(context.reference.clusteringCoefficients[7]).toBe(0);
+    expect(context.reference.triangleCounts[7]).toBe(0);
+  });
+
+  test('uses weighted routes rather than relabeling unweighted hop counts', () => {
+    const context = prepareLuGraphBenchmark({
+      kind: 'sparse',
+      vertexCount: 16,
+      seed: 42,
+      warmupIterations: 0,
+      measuredIterations: 1
+    });
+
+    expect(
+      Array.from(context.reference.weightedDistances).some(
+        (distance, vertex) =>
+          Number.isFinite(distance) && distance !== context.reference.distances[vertex]
+      )
+    ).toBe(true);
+  });
+
+  test('counts distinct directed closures and normalizes complete graph neighborhoods', () => {
+    const context = prepareLuGraphBenchmark({
+      kind: 'dense',
+      vertexCount: 8,
+      warmupIterations: 0,
+      measuredIterations: 1
+    });
+
+    expect(Array.from(context.reference.clusteringCoefficients)).toEqual(Array(8).fill(1));
+    expect(Array.from(context.reference.triangleCounts)).toEqual(Array(8).fill(42));
   });
 
   test.each([
@@ -368,6 +429,9 @@ describe('luGraph live documentation benchmark isolation', () => {
     expect(component).toContain("typeof navigator === 'undefined'");
     expect(component).toContain('spatialIndexBuildTimeMilliseconds');
     expect(component).toContain('approximationMaxAbsoluteError');
+    expect(component).toContain('Weighted shortest paths');
+    expect(component).toContain('Label-propagation communities');
+    expect(component).toContain('Local clustering coefficient');
     expect(component.match(/await runLuGraphBenchmark\(/g)).toHaveLength(1);
     expect(documentation).toContain('<LuGraphBenchmark />');
     expect(documentation).toContain('explicit completion fence');

--- a/modules/experimental/test/lugraph/lu-graph-benchmark.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-benchmark.spec.ts
@@ -18,7 +18,10 @@ import {vi} from 'vitest';
 const BENCHMARK_ALGORITHMS: LuGraphBenchmarkAlgorithm[] = [
   'topology',
   'breadth-first-search',
+  'single-source-shortest-path',
   'connected-components',
+  'label-propagation',
+  'local-clustering-coefficient',
   'page-rank',
   'exact-layout',
   'spatial-layout'
@@ -68,11 +71,11 @@ for (const kind of BENCHMARK_DATASETS) {
         pageRankIterations: 4
       });
       tapeTest.ok(
-        submitSpy.mock.calls.length >= 7,
+        submitSpy.mock.calls.length >= 10,
         'each real graph workload and independent spatial-index phase submits actual GPU work'
       );
       tapeTest.ok(
-        fenceSpy.mock.calls.length >= 7,
+        fenceSpy.mock.calls.length >= 10,
         'GPU operation and standalone spatial-index timers wait on real completion fences'
       );
       if (theta === 0) {
@@ -151,7 +154,7 @@ function assertBenchmarkReport(
   tapeTest.deepEqual(
     report.paths.map(path => path.algorithm),
     BENCHMARK_ALGORITHMS,
-    'six independently compiled CPU and WebGPU algorithms are actually benchmarked'
+    'nine independently compiled CPU and WebGPU algorithms are actually benchmarked'
   );
   for (const path of report.paths) {
     assertDistribution(tapeTest, path.cpuTimeMilliseconds, `${path.algorithm} CPU reference`);
@@ -176,12 +179,14 @@ function assertBenchmarkReport(
     if (
       path.algorithm === 'topology' ||
       path.algorithm === 'breadth-first-search' ||
-      path.algorithm === 'connected-components'
+      path.algorithm === 'single-source-shortest-path' ||
+      path.algorithm === 'connected-components' ||
+      path.algorithm === 'label-propagation'
     ) {
       tapeTest.equal(
         path.maxAbsoluteError,
         0,
-        `${path.algorithm} matches exact integer CPU results`
+        `${path.algorithm} matches its exact CPU reference outputs`
       );
     } else {
       tapeTest.ok(
@@ -199,7 +204,19 @@ function assertBenchmarkReport(
       assertDistribution(tapeTest, path.gpuTimeMilliseconds, `${path.algorithm} GPU timestamps`);
     }
 
-    if (path.algorithm === 'connected-components') {
+    if (path.algorithm === 'single-source-shortest-path') {
+      tapeTest.equal(
+        path.iterations,
+        expected.vertexCount - 1,
+        'weighted shortest paths report their actual bounded GPU relaxation passes'
+      );
+      tapeTest.equal(
+        typeof path.converged,
+        'boolean',
+        'weighted shortest paths expose the actual final GPU fixed-point status'
+      );
+      tapeTest.equal(path.residual, undefined, 'weighted paths never fabricate a residual');
+    } else if (path.algorithm === 'connected-components') {
       tapeTest.equal(path.iterations, 32, 'weak components report their actual bounded GPU passes');
       tapeTest.equal(
         path.converged,
@@ -211,6 +228,14 @@ function assertBenchmarkReport(
         undefined,
         'integer weak components never fabricate a residual'
       );
+    } else if (path.algorithm === 'label-propagation') {
+      tapeTest.equal(path.iterations, 8, 'community labels report their real bounded vote passes');
+      tapeTest.equal(
+        typeof path.converged,
+        'boolean',
+        'community labels expose their actual final GPU fixed-point status'
+      );
+      tapeTest.equal(path.residual, undefined, 'community labels never fabricate a residual');
     } else if (path.algorithm === 'page-rank') {
       tapeTest.equal(
         path.iterations,

--- a/modules/experimental/test/lugraph/lu-graph-local-clustering-coefficient.node.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-local-clustering-coefficient.node.spec.ts
@@ -1,0 +1,476 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer} from '@luma.gl/core';
+import {DynamicBuffer} from '@luma.gl/engine';
+import * as experimentalModule from '@luma.gl/experimental';
+import {
+  LuGraph,
+  LuGraphLocalClusteringCoefficient,
+  LuGraphTopology,
+  type LuGraphAdjacency,
+  type LuGraphLocalClusteringCoefficientProps
+} from '@luma.gl/experimental/lugraph';
+import {GPUData, GPUVector} from '@luma.gl/tables';
+import {NullDevice} from '@luma.gl/test-utils';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {getLuGraphLocalClusteringCoefficientDispatchLayout} from '../../src/lugraph/lu-graph-local-clustering-coefficient-internals';
+
+type ScalarFormat = 'uint32' | 'float32';
+type ScalarValues = Uint32Array | Float32Array;
+
+type ClusteringFixture = {
+  device: NullDevice;
+  buffers: Buffer[];
+  dynamicBuffers: DynamicBuffer[];
+  vectors: GPUVector[];
+};
+
+type VectorOptions = {
+  buffer?: Buffer | DynamicBuffer;
+  byteOffset?: number;
+  byteStride?: number;
+  rowByteLength?: number;
+  stride?: number;
+};
+
+const clusteringFixtures: ClusteringFixture[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const fixture of clusteringFixtures.splice(0)) {
+    for (const vector of fixture.vectors) vector.destroy();
+    for (const dynamicBuffer of fixture.dynamicBuffers) dynamicBuffer.destroy();
+    for (const buffer of fixture.buffers) buffer.destroy();
+    fixture.device.destroy();
+  }
+});
+
+describe('LuGraphLocalClusteringCoefficient public contract and ownership', () => {
+  test('keeps Graphalytics clustering isolated in the optional luGraph entry point', () => {
+    expect(typeof LuGraphLocalClusteringCoefficient).toBe('function');
+    expect('LuGraphLocalClusteringCoefficient' in experimentalModule).toBe(false);
+  });
+
+  test('borrows topology and both outputs without allocation, submission, or source readback', () => {
+    const fixture = createClusteringFixture();
+    const props = createClusteringProps(fixture, {weighted: true, triangles: true});
+    const createBufferSpy = vi.spyOn(fixture.device, 'createBuffer');
+    const createCommandEncoderSpy = vi.spyOn(fixture.device, 'createCommandEncoder');
+    const submitSpy = vi.spyOn(fixture.device, 'submit');
+    const readbackSpies = fixture.buffers.map(buffer => vi.spyOn(buffer, 'readAsync'));
+
+    const clustering = new LuGraphLocalClusteringCoefficient({...props, id: 'borrowed-triangles'});
+
+    expect(clustering.id).toBe('borrowed-triangles');
+    expect(clustering.topology).toBe(props.topology);
+    expect(clustering.output).toBe(props.output);
+    expect(clustering.triangles).toBe(props.triangles);
+    expect(clustering.topology.graph.sourceVertices.data.map(chunk => chunk.length)).toEqual([
+      2, 0, 3
+    ]);
+    expect(createBufferSpy).not.toHaveBeenCalled();
+    expect(createCommandEncoderSpy).not.toHaveBeenCalled();
+    expect(submitSpy).not.toHaveBeenCalled();
+    for (const readbackSpy of readbackSpies) expect(readbackSpy).not.toHaveBeenCalled();
+    expect(Reflect.has(clustering, 'destroy')).toBe(false);
+
+    for (const vector of fixture.vectors) vector.destroy();
+    expect(fixture.buffers.every(buffer => !buffer.destroyed)).toBe(true);
+  });
+
+  test('requires reverse adjacency for exact directed weak-neighbor clustering', () => {
+    const fixture = createClusteringFixture();
+    const props = createClusteringProps(fixture, {reverse: false});
+
+    expect(() => new LuGraphLocalClusteringCoefficient(props)).toThrow(/directed|reverse/);
+  });
+
+  test('accepts directed reverse CSR without optional triangle output', () => {
+    const fixture = createClusteringFixture();
+    const clustering = new LuGraphLocalClusteringCoefficient(createClusteringProps(fixture));
+
+    expect(clustering.id).toBe('lu-graph-local-clustering-coefficient');
+    expect(clustering.topology.graph.directed).toBe(true);
+    expect(clustering.topology.reverse).toBeDefined();
+    expect(clustering.triangles).toBeUndefined();
+  });
+
+  test('accepts symmetric undirected adjacency without reverse CSR', () => {
+    const fixture = createClusteringFixture();
+    const props = createClusteringProps(fixture, {directed: false, triangles: true});
+    const clustering = new LuGraphLocalClusteringCoefficient(props);
+
+    expect(clustering.topology.graph.directed).toBe(false);
+    expect(clustering.topology.reverse).toBeUndefined();
+    expect(clustering.triangles?.length).toBe(props.topology.graph.vertexCount);
+  });
+
+  test('accepts empty graph coefficient and optional triangle outputs', () => {
+    const fixture = createClusteringFixture();
+    const clustering = new LuGraphLocalClusteringCoefficient(
+      createClusteringProps(fixture, {vertexCount: 0, triangles: true})
+    );
+
+    expect(clustering.output.length).toBe(0);
+    expect(clustering.output.data).toHaveLength(1);
+    expect(clustering.triangles?.length).toBe(0);
+  });
+
+  test('plans bounded three-dimensional clustering dispatch without truncating vertices', () => {
+    expect(getLuGraphLocalClusteringCoefficientDispatchLayout(0, 2)).toEqual({x: 1, y: 1, z: 1});
+    expect(getLuGraphLocalClusteringCoefficientDispatchLayout(512, 2)).toEqual({
+      x: 2,
+      y: 1,
+      z: 1
+    });
+    expect(getLuGraphLocalClusteringCoefficientDispatchLayout(513, 2)).toEqual({
+      x: 2,
+      y: 2,
+      z: 1
+    });
+    expect(getLuGraphLocalClusteringCoefficientDispatchLayout(1025, 2)).toEqual({
+      x: 2,
+      y: 2,
+      z: 2
+    });
+    expect(() => getLuGraphLocalClusteringCoefficientDispatchLayout(2049, 2)).toThrow(
+      /3D dispatch limit/
+    );
+  });
+});
+
+describe('LuGraphLocalClusteringCoefficient output validation', () => {
+  test.each([5, 7])('requires exactly one coefficient row per vertex: %i', length => {
+    const fixture = createClusteringFixture();
+    const props = createClusteringProps(fixture);
+    const output = createVector(fixture, 'coefficient-length', 'float32', [
+      new Float32Array(length)
+    ]);
+
+    expect(() => new LuGraphLocalClusteringCoefficient({...props, output})).toThrow(
+      /output|float32|rows/
+    );
+  });
+
+  test('requires packed float32 coefficients instead of uint32', () => {
+    const fixture = createClusteringFixture();
+    const props = createClusteringProps(fixture);
+    const output = createVector(fixture, 'integer-coefficients', 'uint32', [
+      new Uint32Array(props.topology.graph.vertexCount)
+    ]) as unknown as GPUVector<'float32'>;
+
+    expect(() => new LuGraphLocalClusteringCoefficient({...props, output})).toThrow(
+      /output|float32|packed/
+    );
+  });
+
+  test.each([0, 2])('requires exactly one coefficient output chunk: %i', chunkCount => {
+    const fixture = createClusteringFixture();
+    const props = createClusteringProps(fixture);
+    const chunks = chunkCount === 0 ? [] : [new Float32Array(3), new Float32Array(3)];
+    const output = createVector(fixture, 'partitioned-coefficients', 'float32', chunks);
+
+    expect(() => new LuGraphLocalClusteringCoefficient({...props, output})).toThrow(
+      /output|one|chunk/
+    );
+  });
+
+  test.each([
+    ['misaligned byte offset', {byteOffset: 2}],
+    ['padded byte stride', {byteStride: 8}],
+    ['oversized row payload', {rowByteLength: 8}],
+    ['multi-component scalar stride', {stride: 2}]
+  ] as [string, VectorOptions][])('rejects unpacked coefficient output: %s', (_name, options) => {
+    const fixture = createClusteringFixture();
+    const props = createClusteringProps(fixture);
+    const output = createVector(
+      fixture,
+      'unpacked-coefficients',
+      'float32',
+      [new Float32Array(props.topology.graph.vertexCount)],
+      options
+    );
+
+    expect(() => new LuGraphLocalClusteringCoefficient({...props, output})).toThrow(
+      /output|float32|packed|aligned/
+    );
+  });
+
+  test.each([5, 7])('requires exactly one optional triangle count per vertex: %i', length => {
+    const fixture = createClusteringFixture();
+    const props = createClusteringProps(fixture);
+    const triangles = createVector(fixture, 'triangle-length', 'uint32', [new Uint32Array(length)]);
+
+    expect(() => new LuGraphLocalClusteringCoefficient({...props, triangles})).toThrow(
+      /triangles|uint32|rows/
+    );
+  });
+
+  test('requires packed uint32 triangle counts instead of float32', () => {
+    const fixture = createClusteringFixture();
+    const props = createClusteringProps(fixture);
+    const triangles = createVector(fixture, 'floating-triangles', 'float32', [
+      new Float32Array(props.topology.graph.vertexCount)
+    ]) as unknown as GPUVector<'uint32'>;
+
+    expect(() => new LuGraphLocalClusteringCoefficient({...props, triangles})).toThrow(
+      /triangles|uint32|packed/
+    );
+  });
+
+  test.each([0, 2])('requires exactly one triangle output chunk: %i', chunkCount => {
+    const fixture = createClusteringFixture();
+    const props = createClusteringProps(fixture);
+    const chunks = chunkCount === 0 ? [] : [new Uint32Array(3), new Uint32Array(3)];
+    const triangles = createVector(fixture, 'partitioned-triangles', 'uint32', chunks);
+
+    expect(() => new LuGraphLocalClusteringCoefficient({...props, triangles})).toThrow(
+      /triangles|one|chunk/
+    );
+  });
+
+  test('accepts both packed outputs at non-256-byte aligned storage-view offsets', () => {
+    const fixture = createClusteringFixture();
+    const props = createClusteringProps(fixture);
+    const output = createVector(
+      fixture,
+      'offset-coefficients',
+      'float32',
+      [new Float32Array(props.topology.graph.vertexCount)],
+      {byteOffset: 4}
+    );
+    const triangles = createVector(
+      fixture,
+      'offset-triangles',
+      'uint32',
+      [new Uint32Array(props.topology.graph.vertexCount)],
+      {byteOffset: 4}
+    );
+
+    const clustering = new LuGraphLocalClusteringCoefficient({...props, output, triangles});
+    expect(clustering.output.data[0].byteOffset).toBe(4);
+    expect(clustering.triangles?.data[0].byteOffset).toBe(4);
+  });
+
+  test.each([
+    'sourceVertices',
+    'targetVertices',
+    'edgeWeights',
+    'edgeIds',
+    'forward.offsets',
+    'forward.neighbors',
+    'forward.edgeIds',
+    'forward.edgeWeights',
+    'forward.count',
+    'forward.overflow',
+    'reverse.offsets',
+    'reverse.neighbors',
+    'reverse.edgeIds',
+    'reverse.edgeWeights',
+    'reverse.count',
+    'reverse.overflow',
+    'invalidEdgeCount'
+  ])('rejects coefficients aliasing an existing physical allocation: %s', vectorName => {
+    const fixture = createClusteringFixture();
+    const props = createClusteringProps(fixture, {vertexCount: 1, weighted: true});
+    const vector = getTopologyVector(props.topology, vectorName);
+    const output = createVector(fixture, 'aliased-coefficients', 'float32', [new Float32Array(1)], {
+      buffer: vector.data[0].buffer
+    });
+
+    expect(() => new LuGraphLocalClusteringCoefficient({...props, output})).toThrow(
+      /output|distinct|physical|allocation/
+    );
+  });
+
+  test('rejects optional triangle output aliasing coefficients or topology allocations', () => {
+    const fixture = createClusteringFixture();
+    const props = createClusteringProps(fixture, {vertexCount: 1, triangles: true});
+    const coefficientAlias = createVector(
+      fixture,
+      'coefficient-alias',
+      'uint32',
+      [new Uint32Array(1)],
+      {buffer: props.output.data[0].buffer}
+    );
+    const topologyAlias = createVector(fixture, 'topology-alias', 'uint32', [new Uint32Array(1)], {
+      buffer: props.topology.invalidEdgeCount.data[0].buffer
+    });
+
+    expect(
+      () => new LuGraphLocalClusteringCoefficient({...props, triangles: coefficientAlias})
+    ).toThrow(/triangles|distinct|physical|allocation/);
+    expect(
+      () => new LuGraphLocalClusteringCoefficient({...props, triangles: topologyAlias})
+    ).toThrow(/triangles|distinct|physical|allocation/);
+  });
+
+  test('unwraps borrowed DynamicBuffer wrappers when checking physical output aliases', () => {
+    const fixture = createClusteringFixture();
+    const props = createClusteringProps(fixture);
+    const concreteBuffer = props.topology.forward.offsets.data[0].buffer as Buffer;
+    const dynamicBuffer = new DynamicBuffer(fixture.device, {
+      id: 'borrowed-offset-wrapper',
+      buffer: concreteBuffer,
+      ownsBuffer: false
+    });
+    fixture.dynamicBuffers.push(dynamicBuffer);
+    const output = createVector(
+      fixture,
+      'dynamic-aliased-coefficients',
+      'float32',
+      [new Float32Array(props.topology.graph.vertexCount)],
+      {buffer: dynamicBuffer}
+    );
+
+    expect(() => new LuGraphLocalClusteringCoefficient({...props, output})).toThrow(
+      /distinct|physical|allocation/
+    );
+    expect(concreteBuffer.destroyed).toBe(false);
+  });
+});
+
+function createClusteringFixture(): ClusteringFixture {
+  const fixture = {device: new NullDevice({}), buffers: [], dynamicBuffers: [], vectors: []};
+  clusteringFixtures.push(fixture);
+  return fixture;
+}
+
+function createClusteringProps(
+  fixture: ClusteringFixture,
+  options: {
+    vertexCount?: number;
+    directed?: boolean;
+    reverse?: boolean;
+    weighted?: boolean;
+    triangles?: boolean;
+  } = {}
+): LuGraphLocalClusteringCoefficientProps {
+  const vertexCount = options.vertexCount ?? 6;
+  const sourceVertices = createVector(fixture, 'sourceVertices', 'uint32', [
+    Uint32Array.from([0, 2]),
+    new Uint32Array(0),
+    Uint32Array.from([2, 3, 4])
+  ]);
+  const targetVertices = createVector(fixture, 'targetVertices', 'uint32', [
+    Uint32Array.from([1, 4]),
+    new Uint32Array(0),
+    Uint32Array.from([3, 5, 1])
+  ]);
+  const edgeWeights = options.weighted
+    ? createVector(fixture, 'sourceWeights', 'float32', [
+        Float32Array.from([0.5, 2]),
+        new Float32Array(0),
+        Float32Array.from([1, 4, 8])
+      ])
+    : undefined;
+  const edgeIds = options.weighted
+    ? createVector(fixture, 'sourceEdgeIds', 'uint32', [
+        Uint32Array.from([10, 20]),
+        new Uint32Array(0),
+        Uint32Array.from([30, 40, 50])
+      ])
+    : undefined;
+  const graph = new LuGraph({
+    vertexCount,
+    sourceVertices,
+    targetVertices,
+    edgeWeights,
+    edgeIds,
+    directed: options.directed
+  });
+  const forward = createAdjacency(fixture, 'forward', vertexCount, 5, options.weighted);
+  const reverse =
+    (options.reverse ?? options.directed !== false)
+      ? createAdjacency(fixture, 'reverse', vertexCount, 5, options.weighted)
+      : undefined;
+  const invalidEdgeCount = createVector(fixture, 'invalidEdgeCount', 'uint32', [
+    new Uint32Array(1)
+  ]);
+  const topology = new LuGraphTopology({graph, forward, reverse, invalidEdgeCount});
+  const output = createVector(fixture, 'local-clustering', 'float32', [
+    new Float32Array(vertexCount)
+  ]);
+  const triangles = options.triangles
+    ? createVector(fixture, 'triangle-counts', 'uint32', [new Uint32Array(vertexCount)])
+    : undefined;
+  return {topology, output, triangles};
+}
+
+function createAdjacency(
+  fixture: ClusteringFixture,
+  name: string,
+  vertexCount: number,
+  capacity: number,
+  weighted = false
+): LuGraphAdjacency {
+  return {
+    offsets: createVector(fixture, `${name}-offsets`, 'uint32', [new Uint32Array(vertexCount + 1)]),
+    neighbors: createVector(fixture, `${name}-neighbors`, 'uint32', [new Uint32Array(capacity)]),
+    edgeIds: createVector(fixture, `${name}-edgeIds`, 'uint32', [new Uint32Array(capacity)]),
+    edgeWeights: weighted
+      ? createVector(fixture, `${name}-weights`, 'float32', [new Float32Array(capacity)])
+      : undefined,
+    count: createVector(fixture, `${name}-count`, 'uint32', [new Uint32Array(1)]),
+    overflow: createVector(fixture, `${name}-overflow`, 'uint32', [new Uint32Array(1)])
+  };
+}
+
+function getTopologyVector(topology: LuGraphTopology, name: string): GPUVector {
+  if (name === 'invalidEdgeCount') return topology.invalidEdgeCount;
+  if (name === 'sourceVertices') return topology.graph.sourceVertices;
+  if (name === 'targetVertices') return topology.graph.targetVertices;
+  if (name === 'edgeWeights') return topology.graph.edgeWeights!;
+  if (name === 'edgeIds') return topology.graph.edgeIds!;
+
+  const [direction, vectorName] = name.split('.');
+  const adjacency = direction === 'forward' ? topology.forward : topology.reverse!;
+  return adjacency[vectorName as keyof LuGraphAdjacency]!;
+}
+
+function createVector<Format extends ScalarFormat>(
+  fixture: ClusteringFixture,
+  name: string,
+  format: Format,
+  chunks: readonly ScalarValues[],
+  options: VectorOptions = {}
+): GPUVector<Format> {
+  const byteOffset = options.byteOffset ?? 0;
+  const byteStride = options.byteStride ?? Uint32Array.BYTES_PER_ELEMENT;
+  const rowByteLength = options.rowByteLength ?? Uint32Array.BYTES_PER_ELEMENT;
+  const stride = options.stride ?? 1;
+  const data = chunks.map((values, chunkIndex) => {
+    const buffer =
+      options.buffer ??
+      fixture.device.createBuffer({
+        id: `${name}-chunk-${chunkIndex}-${fixture.buffers.length}`,
+        byteLength: byteOffset + Math.max(Math.max(values.length, 1) * byteStride, rowByteLength),
+        usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC
+      });
+    if (!options.buffer) fixture.buffers.push(buffer as Buffer);
+    return new GPUData<Format>({
+      buffer,
+      format,
+      length: values.length,
+      byteOffset,
+      byteStride,
+      rowByteLength,
+      stride,
+      ownsBuffer: false
+    });
+  });
+  const vector = new GPUVector<Format>({
+    type: 'data',
+    name,
+    format,
+    data,
+    byteStride,
+    rowByteLength,
+    stride,
+    ownsData: false
+  });
+  fixture.vectors.push(vector);
+  return vector;
+}

--- a/modules/experimental/test/lugraph/lu-graph-local-clustering-coefficient.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-local-clustering-coefficient.spec.ts
@@ -1,0 +1,636 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {GPUCommandGraph} from '@luma.gl/experimental';
+import {
+  LuGraph,
+  LuGraphLocalClusteringCoefficient,
+  LuGraphTopology,
+  type LuGraphAdjacency
+} from '@luma.gl/experimental/lugraph';
+import {GPUData, GPUVector} from '@luma.gl/tables';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import test, {type Test} from 'test/utils/vitest-tape';
+import {vi} from 'vitest';
+import {addLuGraphLocalClusteringCoefficientToGraphWithDispatchLimit} from '../../src/lugraph/lu-graph-local-clustering-coefficient-internals';
+
+const INVALID_TRIANGLE_COUNT = 0xffffffff;
+
+type ScalarFormat = 'uint32' | 'float32';
+
+type ClusteringScenario = {
+  name: string;
+  vertexCount: number;
+  sourceChunks: number[][];
+  targetChunks: number[][];
+  weightChunks?: number[][];
+  directed?: boolean;
+  capacity?: number;
+  reverseCapacity?: number;
+  triangles?: boolean;
+  byteOffset?: number;
+  maximumWorkgroups?: number;
+  expectedCoefficients?: number[];
+  expectedTriangles?: number[];
+};
+
+type ExpectedClustering = {
+  coefficients: number[];
+  triangles: number[];
+  forwardCount: number;
+  reverseCount: number;
+  invalidEdgeCount: number;
+  forwardOverflow: boolean;
+  reverseOverflow: boolean;
+};
+
+type ClusteringExecutionFixture = {
+  device: Device;
+  buffers: Buffer[];
+  vectors: GPUVector[];
+  graph: LuGraph;
+  topology: LuGraphTopology;
+  clustering: LuGraphLocalClusteringCoefficient;
+  commandGraph: GPUCommandGraph;
+  compiled?: ReturnType<GPUCommandGraph['compile']>;
+};
+
+const clusteringScenarios: ClusteringScenario[] = [
+  {
+    name: 'empty directed graph preserves empty coefficient and triangle buffers',
+    vertexCount: 0,
+    sourceChunks: [[], []],
+    targetChunks: [[], []]
+  },
+  {
+    name: 'isolated vertices and degree-one neighborhoods have zero clustering',
+    vertexCount: 6,
+    sourceChunks: [[2], [], [4]],
+    targetChunks: [[1], [], [5]],
+    expectedCoefficients: [0, 0, 0, 0, 0, 0]
+  },
+  {
+    name: 'undirected triangle publishes three unit coefficients and one incident triangle each',
+    vertexCount: 4,
+    sourceChunks: [[2, 0], [], [1]],
+    targetChunks: [[0, 1], [], [2]],
+    directed: false,
+    expectedCoefficients: [1, 1, 1, 0],
+    expectedTriangles: [1, 1, 1, 0]
+  },
+  {
+    name: 'undirected square diagonal has two-thirds hub clustering and exact incident counts',
+    vertexCount: 4,
+    sourceChunks: [[3, 0], [], [0, 2, 1]],
+    targetChunks: [[0, 1], [], [2, 3, 2]],
+    directed: false,
+    expectedCoefficients: [2 / 3, 1, 2 / 3, 1],
+    expectedTriangles: [2, 1, 2, 1]
+  },
+  {
+    name: 'directed cycle counts one directed closure rather than one undirected neighbor link',
+    vertexCount: 4,
+    sourceChunks: [[2, 0], [], [1]],
+    targetChunks: [[0, 1], [], [2]],
+    expectedCoefficients: [0.5, 0.5, 0.5, 0],
+    expectedTriangles: [1, 1, 1, 0]
+  },
+  {
+    name: 'reciprocated directed neighbor edges contribute two distinct Graphalytics closures',
+    vertexCount: 3,
+    sourceChunks: [[0, 2], [], [0, 1]],
+    targetChunks: [[1, 1], [], [2, 2]],
+    expectedCoefficients: [1, 0.5, 0.5],
+    expectedTriangles: [2, 1, 1]
+  },
+  {
+    name: 'official directed Graphalytics validation graph reproduces published coefficients',
+    vertexCount: 10,
+    sourceChunks: [[0, 0, 1, 1, 1, 2], [], [2, 2, 2, 4, 4, 4, 5, 5, 6, 7, 8]],
+    targetChunks: [[2, 4, 3, 4, 9, 0], [], [4, 7, 9, 2, 3, 7, 2, 3, 3, 0, 3]],
+    expectedCoefficients: [2 / 3, 1 / 6, 0.15, 0.05, 0.25, 0, 0, 5 / 6, 0, 0],
+    expectedTriangles: [4, 1, 3, 1, 5, 0, 0, 5, 0, 0]
+  },
+  {
+    name: 'duplicate and reciprocated CSR neighbors collapse into one distinct weak neighbor',
+    vertexCount: 4,
+    sourceChunks: [[0, 0, 0], [], [1, 1, 2, 2, 1]],
+    targetChunks: [[1, 1, 2], [], [2, 2, 1, 1, 0]],
+    expectedCoefficients: [1, 0.5, 1, 0],
+    expectedTriangles: [2, 1, 2, 0]
+  },
+  {
+    name: 'self loops and duplicate edges neither create neighbors nor inflate triangle counts',
+    vertexCount: 4,
+    sourceChunks: [[0, 0, 1], [], [1, 2, 2, 0, 1]],
+    targetChunks: [[0, 1, 1], [], [2, 0, 2, 1, 2]],
+    expectedCoefficients: [0.5, 0.5, 0.5, 0],
+    expectedTriangles: [1, 1, 1, 0]
+  },
+  {
+    name: 'invalid source endpoints cannot create phantom closures or neighbors',
+    vertexCount: 4,
+    sourceChunks: [[0, 9], [], [1, 2, 7]],
+    targetChunks: [[1, 2], [], [2, 0, 8]],
+    expectedCoefficients: [0.5, 0.5, 0.5, 0],
+    expectedTriangles: [1, 1, 1, 0]
+  },
+  {
+    name: 'weighted graph chunks retain source boundaries while unweighted clustering ignores weights',
+    vertexCount: 4,
+    sourceChunks: [[2, 0], [], [1]],
+    targetChunks: [[0, 1], [], [2]],
+    weightChunks: [[0.5, 3], [], [9]],
+    directed: false,
+    expectedCoefficients: [1, 1, 1, 0]
+  },
+  {
+    name: 'optional triangle count may be omitted without changing exact coefficients',
+    vertexCount: 3,
+    sourceChunks: [[2, 0], [], [1]],
+    targetChunks: [[0, 1], [], [2]],
+    triangles: false,
+    expectedCoefficients: [0.5, 0.5, 0.5]
+  },
+  {
+    name: 'zero forward capacity fails closed across every coefficient and triangle count',
+    vertexCount: 4,
+    sourceChunks: [[0, 1]],
+    targetChunks: [[1, 2]],
+    capacity: 0
+  },
+  {
+    name: 'partially truncated forward adjacency never publishes misleading local clusters',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 0]],
+    capacity: 2
+  },
+  {
+    name: 'required reverse-adjacency overflow fails closed even when forward CSR is complete',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 0]],
+    reverseCapacity: 0
+  },
+  {
+    name: 'non-256-aligned CSR and coefficient and triangle storage views remain exact',
+    vertexCount: 4,
+    sourceChunks: [[2, 0], [], [1]],
+    targetChunks: [[0, 1], [], [2]],
+    byteOffset: 4,
+    expectedCoefficients: [0.5, 0.5, 0.5, 0]
+  },
+  {
+    name: 'bounded three-dimensional clustering dispatch reaches the last of 1025 vertices',
+    vertexCount: 1025,
+    sourceChunks: [[1024, 0, 1]],
+    targetChunks: [[0, 1, 1024]],
+    maximumWorkgroups: 2
+  }
+];
+
+for (const scenario of clusteringScenarios) {
+  test(`LuGraphLocalClusteringCoefficient GPU: ${scenario.name}`, async tapeTest => {
+    const device = await getWebGPUTestDevice();
+    if (!device) {
+      tapeTest.comment('WebGPU is not available');
+      tapeTest.end();
+      return;
+    }
+
+    const expected = calculateExpectedClustering(scenario);
+    const fixture = createExecutionFixture(device, scenario, expected);
+    try {
+      compileClustering(fixture, scenario.maximumWorkgroups);
+      executeClustering(fixture);
+      await assertClustering(tapeTest, fixture, expected);
+      tapeTest.deepEqual(
+        fixture.graph.sourceVertices.data.map(chunk => chunk.length),
+        scenario.sourceChunks.map(chunk => chunk.length),
+        'clustering preserves every original source chunk and its physical allocation'
+      );
+      if (scenario.expectedCoefficients) {
+        for (const [vertexIndex, coefficient] of scenario.expectedCoefficients.entries()) {
+          tapeTest.ok(
+            Math.abs(expected.coefficients[vertexIndex] - coefficient) < 1e-7,
+            `independent CPU oracle matches the explicit Graphalytics coefficient at vertex ${vertexIndex}`
+          );
+        }
+      }
+      if (scenario.expectedTriangles) {
+        tapeTest.deepEqual(
+          expected.triangles,
+          scenario.expectedTriangles,
+          'independent oracle matches explicit directed closures or undirected incident triangles'
+        );
+      }
+    } finally {
+      destroyExecutionFixture(tapeTest, fixture);
+    }
+
+    tapeTest.end();
+  });
+}
+
+test('LuGraphLocalClusteringCoefficient rebuilds exact triangles after source updates', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const original: ClusteringScenario = {
+    name: 'repeat exact triangle clustering',
+    vertexCount: 4,
+    sourceChunks: [[0, 1], [], [2]],
+    targetChunks: [[1, 2], [], [0]]
+  };
+  const fixture = createExecutionFixture(device, original, calculateExpectedClustering(original));
+  const submitSpy = vi.spyOn(device, 'submit');
+  const readbackSpies = [
+    ...fixture.graph.sourceVertices.data,
+    ...fixture.graph.targetVertices.data
+  ].map(chunk => vi.spyOn(chunk.buffer, 'readAsync'));
+
+  try {
+    compileClustering(fixture);
+    tapeTest.equal(
+      submitSpy.mock.calls.length,
+      0,
+      'construction and compilation never submit work'
+    );
+    tapeTest.ok(
+      readbackSpies.every(spy => spy.mock.calls.length === 0),
+      'exact local clustering never reads graph source buffers back'
+    );
+    submitSpy.mockRestore();
+    for (const readbackSpy of readbackSpies) readbackSpy.mockRestore();
+
+    executeClustering(fixture);
+    await assertClustering(tapeTest, fixture, calculateExpectedClustering(original));
+
+    const sourceBuffer = fixture.graph.sourceVertices.data[0].buffer as Buffer;
+    sourceBuffer.write(Uint32Array.from([3, 1]));
+    const updated = {...original, sourceChunks: [[3, 1], [], [2]]};
+    executeClustering(fixture);
+    await assertClustering(tapeTest, fixture, calculateExpectedClustering(updated));
+    tapeTest.equal(sourceBuffer, fixture.graph.sourceVertices.data[0].buffer);
+  } finally {
+    submitSpy.mockRestore();
+    for (const readbackSpy of readbackSpies) readbackSpy.mockRestore();
+    destroyExecutionFixture(tapeTest, fixture);
+  }
+
+  tapeTest.end();
+});
+
+/** Independently applies the official weak-neighbor, directed-edge Graphalytics definition. */
+function calculateExpectedClustering(scenario: ClusteringScenario): ExpectedClustering {
+  const directed = scenario.directed !== false;
+  const weakNeighbors: Set<number>[] = Array.from({length: scenario.vertexCount}, () => new Set());
+  const directedEdges = new Set<string>();
+  let validEdgeCount = 0;
+  let forwardCount = 0;
+  let invalidEdgeCount = 0;
+
+  for (const [chunkIndex, sources] of scenario.sourceChunks.entries()) {
+    for (const [rowIndex, source] of sources.entries()) {
+      const target = scenario.targetChunks[chunkIndex][rowIndex];
+      if (source >= scenario.vertexCount || target >= scenario.vertexCount) {
+        invalidEdgeCount++;
+        continue;
+      }
+      validEdgeCount++;
+      forwardCount += !directed && source !== target ? 2 : 1;
+      if (source === target) continue;
+      weakNeighbors[source].add(target);
+      weakNeighbors[target].add(source);
+      directedEdges.add(`${source}:${target}`);
+      if (!directed) directedEdges.add(`${target}:${source}`);
+    }
+  }
+
+  const reverseCount = directed ? validEdgeCount : 0;
+  const forwardOverflow = forwardCount > (scenario.capacity ?? forwardCount);
+  const reverseOverflow = directed && reverseCount > (scenario.reverseCapacity ?? reverseCount);
+  const failed = forwardOverflow || reverseOverflow;
+  const coefficients: number[] = [];
+  const triangles: number[] = [];
+
+  for (const neighbors of weakNeighbors) {
+    if (failed) {
+      coefficients.push(0);
+      triangles.push(INVALID_TRIANGLE_COUNT);
+      continue;
+    }
+
+    let closures = 0;
+    for (const firstNeighbor of neighbors) {
+      for (const secondNeighbor of neighbors) {
+        if (
+          firstNeighbor !== secondNeighbor &&
+          directedEdges.has(`${firstNeighbor}:${secondNeighbor}`)
+        ) {
+          closures++;
+        }
+      }
+    }
+    const degree = neighbors.size;
+    coefficients.push(degree < 2 ? 0 : closures / (degree * (degree - 1)));
+    triangles.push(directed ? closures : closures / 2);
+  }
+
+  return {
+    coefficients,
+    triangles,
+    forwardCount,
+    reverseCount,
+    invalidEdgeCount,
+    forwardOverflow,
+    reverseOverflow
+  };
+}
+
+function createExecutionFixture(
+  device: Device,
+  scenario: ClusteringScenario,
+  expected: ExpectedClustering
+): ClusteringExecutionFixture {
+  const buffers: Buffer[] = [];
+  const vectors: GPUVector[] = [];
+  const sourceVertices = createInputVector(
+    device,
+    buffers,
+    vectors,
+    'source-vertices',
+    'uint32',
+    scenario.sourceChunks
+  );
+  const targetVertices = createInputVector(
+    device,
+    buffers,
+    vectors,
+    'target-vertices',
+    'uint32',
+    scenario.targetChunks
+  );
+  const edgeWeights = scenario.weightChunks
+    ? createInputVector(device, buffers, vectors, 'weights', 'float32', scenario.weightChunks)
+    : undefined;
+  const graph = new LuGraph({
+    vertexCount: scenario.vertexCount,
+    sourceVertices,
+    targetVertices,
+    edgeWeights,
+    directed: scenario.directed
+  });
+  const forward = createOutputAdjacency(
+    device,
+    buffers,
+    vectors,
+    'forward',
+    scenario.vertexCount,
+    scenario.capacity ?? expected.forwardCount,
+    Boolean(edgeWeights),
+    scenario.byteOffset
+  );
+  const reverse =
+    scenario.directed !== false
+      ? createOutputAdjacency(
+          device,
+          buffers,
+          vectors,
+          'reverse',
+          scenario.vertexCount,
+          scenario.reverseCapacity ?? expected.reverseCount,
+          Boolean(edgeWeights),
+          scenario.byteOffset
+        )
+      : undefined;
+  const invalidEdgeCount = createOutputVector(
+    device,
+    buffers,
+    vectors,
+    'invalid-edges',
+    'uint32',
+    1
+  );
+  const topology = new LuGraphTopology({graph, forward, reverse, invalidEdgeCount});
+  const output = createOutputVector(
+    device,
+    buffers,
+    vectors,
+    'local-clustering',
+    'float32',
+    scenario.vertexCount,
+    scenario.byteOffset
+  );
+  const triangles =
+    scenario.triangles === false
+      ? undefined
+      : createOutputVector(
+          device,
+          buffers,
+          vectors,
+          'triangle-counts',
+          'uint32',
+          scenario.vertexCount,
+          scenario.byteOffset
+        );
+  const clustering = new LuGraphLocalClusteringCoefficient({topology, output, triangles});
+
+  return {
+    device,
+    buffers,
+    vectors,
+    graph,
+    topology,
+    clustering,
+    commandGraph: new GPUCommandGraph(device)
+  };
+}
+
+function createInputVector<Format extends ScalarFormat>(
+  device: Device,
+  buffers: Buffer[],
+  vectors: GPUVector[],
+  name: string,
+  format: Format,
+  chunks: readonly number[][]
+): GPUVector<Format> {
+  const data = chunks.map((chunk, chunkIndex) => {
+    const values = format === 'float32' ? Float32Array.from(chunk) : Uint32Array.from(chunk);
+    const buffer = device.createBuffer({
+      id: `${name}-chunk-${chunkIndex}`,
+      data: values.length > 0 ? values : new Uint32Array(1),
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+    buffers.push(buffer);
+    return new GPUData<Format>({buffer, format, length: values.length, ownsBuffer: false});
+  });
+  const vector = new GPUVector<Format>({type: 'data', name, format, data, ownsData: false});
+  vectors.push(vector);
+  return vector;
+}
+
+function createOutputAdjacency(
+  device: Device,
+  buffers: Buffer[],
+  vectors: GPUVector[],
+  name: string,
+  vertexCount: number,
+  capacity: number,
+  weighted: boolean,
+  byteOffset = 0
+): LuGraphAdjacency {
+  return {
+    offsets: createOutputVector(
+      device,
+      buffers,
+      vectors,
+      `${name}-offsets`,
+      'uint32',
+      vertexCount + 1,
+      byteOffset
+    ),
+    neighbors: createOutputVector(
+      device,
+      buffers,
+      vectors,
+      `${name}-neighbors`,
+      'uint32',
+      capacity
+    ),
+    edgeIds: createOutputVector(device, buffers, vectors, `${name}-edge-ids`, 'uint32', capacity),
+    edgeWeights: weighted
+      ? createOutputVector(device, buffers, vectors, `${name}-weights`, 'float32', capacity)
+      : undefined,
+    count: createOutputVector(device, buffers, vectors, `${name}-count`, 'uint32', 1),
+    overflow: createOutputVector(device, buffers, vectors, `${name}-overflow`, 'uint32', 1)
+  };
+}
+
+function createOutputVector<Format extends ScalarFormat>(
+  device: Device,
+  buffers: Buffer[],
+  vectors: GPUVector[],
+  name: string,
+  format: Format,
+  length: number,
+  byteOffset = 0
+): GPUVector<Format> {
+  const buffer = device.createBuffer({
+    id: name,
+    byteLength: byteOffset + Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  buffers.push(buffer);
+  const vector = new GPUVector<Format>({
+    type: 'buffer',
+    name,
+    format,
+    buffer,
+    length,
+    byteOffset,
+    ownsBuffer: false
+  });
+  vectors.push(vector);
+  return vector;
+}
+
+function compileClustering(fixture: ClusteringExecutionFixture, maximumWorkgroups?: number): void {
+  fixture.topology.addToGraph(fixture.commandGraph);
+  if (maximumWorkgroups === undefined) {
+    fixture.clustering.addToGraph(fixture.commandGraph);
+  } else {
+    addLuGraphLocalClusteringCoefficientToGraphWithDispatchLimit(
+      fixture.clustering,
+      fixture.commandGraph,
+      maximumWorkgroups
+    );
+  }
+  fixture.compiled = fixture.commandGraph.compile();
+}
+
+function executeClustering(fixture: ClusteringExecutionFixture): void {
+  const commandEncoder = fixture.device.createCommandEncoder({
+    id: 'lu-graph-local-clustering-test'
+  });
+  fixture.compiled!.encode(commandEncoder, {parameters: undefined});
+  fixture.device.submit(commandEncoder.finish());
+}
+
+async function assertClustering(
+  tapeTest: Test,
+  fixture: ClusteringExecutionFixture,
+  expected: ExpectedClustering
+): Promise<void> {
+  const [coefficients, triangles, invalidEdgeCount, forwardOverflow, reverseOverflow] =
+    await Promise.all([
+      readFloat32Vector(fixture.clustering.output),
+      fixture.clustering.triangles
+        ? readUint32Vector(fixture.clustering.triangles)
+        : Promise.resolve(undefined),
+      readUint32Vector(fixture.topology.invalidEdgeCount),
+      readUint32Vector(fixture.topology.forward.overflow),
+      fixture.topology.reverse
+        ? readUint32Vector(fixture.topology.reverse.overflow)
+        : Promise.resolve(undefined)
+    ]);
+
+  tapeTest.equal(coefficients.length, expected.coefficients.length);
+  for (const [vertexIndex, coefficient] of coefficients.entries()) {
+    tapeTest.ok(
+      Math.abs(coefficient - expected.coefficients[vertexIndex]) < 1e-6,
+      `vertex ${vertexIndex} coefficient matches the independent Graphalytics directed-edge oracle`
+    );
+  }
+  if (triangles) {
+    tapeTest.deepEqual(
+      triangles,
+      expected.triangles,
+      'unsigned counts distinguish directed closures from undirected incident triangles'
+    );
+  }
+  tapeTest.equal(invalidEdgeCount[0], expected.invalidEdgeCount);
+  tapeTest.equal(forwardOverflow[0], Number(expected.forwardOverflow));
+  if (reverseOverflow) tapeTest.equal(reverseOverflow[0], Number(expected.reverseOverflow));
+  if (expected.forwardOverflow || expected.reverseOverflow) {
+    tapeTest.ok(coefficients.every(coefficient => coefficient === 0));
+    if (triangles) tapeTest.ok(triangles.every(count => count === INVALID_TRIANGLE_COUNT));
+  }
+}
+
+async function readUint32Vector(vector: GPUVector<'uint32'>): Promise<number[]> {
+  if (vector.length === 0) return [];
+  const data = vector.data[0];
+  const bytes = await (data.buffer as Buffer).readAsync(
+    data.byteOffset,
+    vector.length * Uint32Array.BYTES_PER_ELEMENT
+  );
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, vector.length));
+}
+
+async function readFloat32Vector(vector: GPUVector<'float32'>): Promise<number[]> {
+  if (vector.length === 0) return [];
+  const data = vector.data[0];
+  const bytes = await (data.buffer as Buffer).readAsync(
+    data.byteOffset,
+    vector.length * Float32Array.BYTES_PER_ELEMENT
+  );
+  return Array.from(new Float32Array(bytes.buffer, bytes.byteOffset, vector.length));
+}
+
+function destroyExecutionFixture(tapeTest: Test, fixture: ClusteringExecutionFixture): void {
+  fixture.compiled?.destroy();
+  for (const vector of fixture.vectors) vector.destroy();
+  tapeTest.ok(
+    fixture.buffers.every(buffer => !buffer.destroyed),
+    'compiled clustering graphs and borrowed vectors never destroy caller-owned buffers'
+  );
+  for (const buffer of fixture.buffers) buffer.destroy();
+}

--- a/modules/experimental/test/lugraph/lu-graph-single-source-shortest-path.node.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-single-source-shortest-path.node.spec.ts
@@ -1,0 +1,413 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer} from '@luma.gl/core';
+import {DynamicBuffer} from '@luma.gl/engine';
+import * as experimentalModule from '@luma.gl/experimental';
+import {
+  LuGraph,
+  LuGraphSingleSourceShortestPath,
+  LuGraphTopology,
+  type LuGraphAdjacency,
+  type LuGraphSingleSourceShortestPathDirection,
+  type LuGraphSingleSourceShortestPathProps
+} from '@luma.gl/experimental/lugraph';
+import {GPUData, GPUVector} from '@luma.gl/tables';
+import {NullDevice} from '@luma.gl/test-utils';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {getLuGraphSingleSourceShortestPathDispatchLayout} from '../../src/lugraph/lu-graph-single-source-shortest-path-internals';
+
+type ScalarFormat = 'uint32' | 'float32';
+type ScalarValues = Uint32Array | Float32Array;
+
+type ShortestPathFixture = {
+  device: NullDevice;
+  buffers: Buffer[];
+  dynamicBuffers: DynamicBuffer[];
+  vectors: GPUVector[];
+};
+
+type VectorOptions = {buffer?: Buffer | DynamicBuffer; byteOffset?: number; byteStride?: number};
+
+const shortestPathFixtures: ShortestPathFixture[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const fixture of shortestPathFixtures.splice(0)) {
+    for (const vector of fixture.vectors) vector.destroy();
+    for (const dynamicBuffer of fixture.dynamicBuffers) dynamicBuffer.destroy();
+    for (const buffer of fixture.buffers) buffer.destroy();
+    fixture.device.destroy();
+  }
+});
+
+describe('LuGraphSingleSourceShortestPath public GPU-resident API', () => {
+  test('exports weighted paths exclusively through the optional LuGraph subpath', () => {
+    expect(typeof LuGraphSingleSourceShortestPath).toBe('function');
+    expect('LuGraphSingleSourceShortestPath' in experimentalModule).toBe(false);
+  });
+
+  test('preserves weighted topology and caller-owned outputs without submitting or reading', () => {
+    const fixture = createShortestPathFixture();
+    const props = createShortestPathProps(fixture, {weighted: true, statuses: true, reverse: true});
+    const submit = vi.spyOn(fixture.device, 'submit');
+    const search = new LuGraphSingleSourceShortestPath(props);
+
+    expect(search.id).toBe('lu-graph-single-source-shortest-path');
+    expect(search.topology).toBe(props.topology);
+    expect(search.sourceVertex).toBe(props.sourceVertex);
+    expect(search.distances).toBe(props.distances);
+    expect(search.predecessors).toBe(props.predecessors);
+    expect(search.converged).toBe(props.converged);
+    expect(search.invalidWeightCount).toBe(props.invalidWeightCount);
+    expect(search.direction).toBe('outgoing');
+    expect(search.maxIterations).toBe(props.topology.graph.vertexCount - 1);
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  test('caps the default relaxation count while allowing explicitly source-only results', () => {
+    const fixture = createShortestPathFixture();
+    const props = createShortestPathProps(fixture, {vertexCount: 2048});
+
+    expect(new LuGraphSingleSourceShortestPath(props).maxIterations).toBe(1024);
+    expect(new LuGraphSingleSourceShortestPath({...props, maxIterations: 0}).maxIterations).toBe(0);
+  });
+
+  test('accepts source zero and empty vertex-aligned destinations for an empty graph', () => {
+    const fixture = createShortestPathFixture();
+    const props = createShortestPathProps(fixture, {vertexCount: 0});
+    const search = new LuGraphSingleSourceShortestPath(props);
+
+    expect(search.sourceVertex).toBe(0);
+    expect(search.maxIterations).toBe(0);
+    expect(search.distances.length).toBe(0);
+  });
+
+  test.each([
+    -1,
+    4,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY
+  ])('rejects an invalid source vertex: %s', sourceVertex => {
+    const fixture = createShortestPathFixture();
+    const props = createShortestPathProps(fixture);
+
+    expect(() => new LuGraphSingleSourceShortestPath({...props, sourceVertex})).toThrow(
+      /sourceVertex|vertex/
+    );
+  });
+
+  test.each([
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    1025
+  ])('rejects invalid compiled iteration counts: %s', maxIterations => {
+    const fixture = createShortestPathFixture();
+    const props = createShortestPathProps(fixture);
+
+    expect(() => new LuGraphSingleSourceShortestPath({...props, maxIterations})).toThrow(
+      /maxIterations|1024/
+    );
+  });
+
+  test.each([
+    'incoming',
+    'both'
+  ] as const)('requires reverse CSR for directed %s traversal', direction => {
+    const fixture = createShortestPathFixture();
+    const props = createShortestPathProps(fixture);
+
+    expect(() => new LuGraphSingleSourceShortestPath({...props, direction})).toThrow(/reverse/);
+    const reversible = createShortestPathProps(fixture, {reverse: true});
+    expect(new LuGraphSingleSourceShortestPath({...reversible, direction}).direction).toBe(
+      direction
+    );
+  });
+
+  test.each([
+    'incoming',
+    'both'
+  ] as const)('reuses symmetric forward CSR for undirected %s traversal', direction => {
+    const fixture = createShortestPathFixture();
+    const props = createShortestPathProps(fixture, {directed: false});
+
+    expect(new LuGraphSingleSourceShortestPath({...props, direction}).direction).toBe(direction);
+  });
+
+  test.each(['reverse', '', 'OUTGOING'])('rejects unsupported direction: %s', invalidDirection => {
+    const fixture = createShortestPathFixture();
+    const props = createShortestPathProps(fixture, {reverse: true});
+    const direction = invalidDirection as LuGraphSingleSourceShortestPathDirection;
+
+    expect(() => new LuGraphSingleSourceShortestPath({...props, direction})).toThrow(/direction/);
+  });
+});
+
+describe('LuGraphSingleSourceShortestPath output validation and physical ownership', () => {
+  test('requires exactly one packed float32 distance and uint32 predecessor row per vertex', () => {
+    const fixture = createShortestPathFixture();
+    const props = createShortestPathProps(fixture);
+    const wrongDistances = createVector(fixture, 'wrong-distances', 'uint32', [
+      new Uint32Array(4)
+    ]) as unknown as GPUVector<'float32'>;
+    const wrongPredecessors = createVector(fixture, 'wrong-predecessors', 'float32', [
+      new Float32Array(4)
+    ]) as unknown as GPUVector<'uint32'>;
+    const shortDistances = createVector(fixture, 'short-distances', 'float32', [
+      new Float32Array(3)
+    ]);
+
+    expect(
+      () => new LuGraphSingleSourceShortestPath({...props, distances: wrongDistances})
+    ).toThrow(/distances|float32/);
+    expect(
+      () => new LuGraphSingleSourceShortestPath({...props, predecessors: wrongPredecessors})
+    ).toThrow(/predecessors|uint32/);
+    expect(
+      () => new LuGraphSingleSourceShortestPath({...props, distances: shortDistances})
+    ).toThrow(/distances|rows/);
+  });
+
+  test.each([
+    'converged',
+    'invalidWeightCount'
+  ] as const)('requires exactly one packed uint32 %s status row', statusName => {
+    const fixture = createShortestPathFixture();
+    const props = createShortestPathProps(fixture, {statuses: true});
+    const invalidStatus = createVector(fixture, `wrong-${statusName}`, 'uint32', [
+      new Uint32Array(2)
+    ]);
+
+    expect(
+      () => new LuGraphSingleSourceShortestPath({...props, [statusName]: invalidStatus})
+    ).toThrow(new RegExp(`${statusName}|rows`));
+  });
+
+  test('accepts legal non-256-aligned scalar views without copying caller-owned data', () => {
+    const fixture = createShortestPathFixture();
+    const props = createShortestPathProps(fixture, {statuses: true, byteOffset: 4});
+    const search = new LuGraphSingleSourceShortestPath(props);
+
+    expect(search.distances.data[0].byteOffset).toBe(4);
+    expect(search.predecessors.data[0].byteOffset).toBe(4);
+    expect(search.converged?.data[0].byteOffset).toBe(4);
+  });
+
+  test.each([
+    'sourceVertices',
+    'forward.offsets',
+    'forward.edgeWeights',
+    'reverse.neighbors'
+  ])('rejects distance aliases with existing graph allocations: %s', vectorName => {
+    const fixture = createShortestPathFixture();
+    const props = createShortestPathProps(fixture, {weighted: true, reverse: true});
+    const source = getInputVector(props, vectorName);
+    const distances = createVector(fixture, 'aliased-distances', 'float32', [new Float32Array(4)], {
+      buffer: source.data[0].buffer
+    });
+
+    expect(() => new LuGraphSingleSourceShortestPath({...props, distances})).toThrow(
+      /distinct|physical|allocation/
+    );
+  });
+
+  test('rejects aliases between caller-visible result and status allocations', () => {
+    const fixture = createShortestPathFixture();
+    const props = createShortestPathProps(fixture, {vertexCount: 1, statuses: true});
+    const predecessors = createVector(
+      fixture,
+      'aliased-predecessors',
+      'uint32',
+      [new Uint32Array(1)],
+      {buffer: props.distances.data[0].buffer}
+    );
+
+    expect(() => new LuGraphSingleSourceShortestPath({...props, predecessors})).toThrow(
+      /distinct|physical|allocation/
+    );
+  });
+
+  test('unwraps DynamicBuffer wrappers before validating borrowed physical allocations', () => {
+    const fixture = createShortestPathFixture();
+    const props = createShortestPathProps(fixture);
+    const concreteBuffer = props.topology.forward.offsets.data[0].buffer as Buffer;
+    const wrapper = new DynamicBuffer(fixture.device, {
+      id: 'borrowed-adjacency-wrapper',
+      buffer: concreteBuffer,
+      ownsBuffer: false
+    });
+    fixture.dynamicBuffers.push(wrapper);
+    const distances = createVector(fixture, 'wrapped-distances', 'float32', [new Float32Array(4)], {
+      buffer: wrapper
+    });
+
+    expect(() => new LuGraphSingleSourceShortestPath({...props, distances})).toThrow(
+      /distinct|physical|allocation/
+    );
+  });
+
+  test('plans bounded three-dimensional weighted-path dispatch', () => {
+    expect(getLuGraphSingleSourceShortestPathDispatchLayout(0, 2)).toEqual({x: 1, y: 1, z: 1});
+    expect(getLuGraphSingleSourceShortestPathDispatchLayout(512, 2)).toEqual({x: 2, y: 1, z: 1});
+    expect(getLuGraphSingleSourceShortestPathDispatchLayout(513, 2)).toEqual({x: 2, y: 2, z: 1});
+    expect(getLuGraphSingleSourceShortestPathDispatchLayout(1025, 2)).toEqual({x: 2, y: 2, z: 2});
+    expect(() => getLuGraphSingleSourceShortestPathDispatchLayout(2049, 2)).toThrow(
+      /3D dispatch limit/
+    );
+  });
+});
+
+function createShortestPathFixture(): ShortestPathFixture {
+  const fixture = {device: new NullDevice({}), buffers: [], dynamicBuffers: [], vectors: []};
+  shortestPathFixtures.push(fixture);
+  return fixture;
+}
+
+function createShortestPathProps(
+  fixture: ShortestPathFixture,
+  options: {
+    vertexCount?: number;
+    directed?: boolean;
+    reverse?: boolean;
+    weighted?: boolean;
+    statuses?: boolean;
+    byteOffset?: number;
+  } = {}
+): LuGraphSingleSourceShortestPathProps {
+  const vertexCount = options.vertexCount ?? 4;
+  const sourceVertices = createVector(fixture, 'sourceVertices', 'uint32', [
+    Uint32Array.from([0, 1]),
+    new Uint32Array(0),
+    Uint32Array.from([1, 2])
+  ]);
+  const targetVertices = createVector(fixture, 'targetVertices', 'uint32', [
+    Uint32Array.from([1, 2]),
+    new Uint32Array(0),
+    Uint32Array.from([2, 3])
+  ]);
+  const edgeWeights = options.weighted
+    ? createVector(fixture, 'edgeWeights', 'float32', [
+        Float32Array.from([1.5, 0]),
+        new Float32Array(0),
+        Float32Array.from([2, 4])
+      ])
+    : undefined;
+  const graph = new LuGraph({
+    vertexCount,
+    sourceVertices,
+    targetVertices,
+    edgeWeights,
+    directed: options.directed
+  });
+  const forward = createAdjacency(fixture, 'forward', vertexCount, 4, Boolean(edgeWeights));
+  const reverse = options.reverse
+    ? createAdjacency(fixture, 'reverse', vertexCount, 4, Boolean(edgeWeights))
+    : undefined;
+  const invalidEdgeCount = createVector(fixture, 'invalidEdgeCount', 'uint32', [
+    new Uint32Array(1)
+  ]);
+  const topology = new LuGraphTopology({graph, forward, reverse, invalidEdgeCount});
+  const vectorOptions = {byteOffset: options.byteOffset};
+  return {
+    topology,
+    sourceVertex: 0,
+    distances: createVector(
+      fixture,
+      'distances',
+      'float32',
+      [new Float32Array(vertexCount)],
+      vectorOptions
+    ),
+    predecessors: createVector(
+      fixture,
+      'predecessors',
+      'uint32',
+      [new Uint32Array(vertexCount)],
+      vectorOptions
+    ),
+    ...(options.statuses
+      ? {
+          converged: createVector(
+            fixture,
+            'converged',
+            'uint32',
+            [new Uint32Array(1)],
+            vectorOptions
+          ),
+          invalidWeightCount: createVector(
+            fixture,
+            'invalidWeightCount',
+            'uint32',
+            [new Uint32Array(1)],
+            vectorOptions
+          )
+        }
+      : {})
+  };
+}
+
+function createAdjacency(
+  fixture: ShortestPathFixture,
+  name: string,
+  vertexCount: number,
+  capacity: number,
+  weighted: boolean
+): LuGraphAdjacency {
+  return {
+    offsets: createVector(fixture, `${name}-offsets`, 'uint32', [new Uint32Array(vertexCount + 1)]),
+    neighbors: createVector(fixture, `${name}-neighbors`, 'uint32', [new Uint32Array(capacity)]),
+    edgeIds: createVector(fixture, `${name}-edgeIds`, 'uint32', [new Uint32Array(capacity)]),
+    ...(weighted
+      ? {
+          edgeWeights: createVector(fixture, `${name}-weights`, 'float32', [
+            new Float32Array(capacity)
+          ])
+        }
+      : {}),
+    count: createVector(fixture, `${name}-count`, 'uint32', [new Uint32Array(1)]),
+    overflow: createVector(fixture, `${name}-overflow`, 'uint32', [new Uint32Array(1)])
+  };
+}
+
+function getInputVector(props: LuGraphSingleSourceShortestPathProps, name: string): GPUVector {
+  if (name === 'sourceVertices') return props.topology.graph.sourceVertices;
+  const [direction, vectorName] = name.split('.');
+  const adjacency = direction === 'forward' ? props.topology.forward : props.topology.reverse!;
+  return adjacency[vectorName as keyof LuGraphAdjacency]!;
+}
+
+function createVector<Format extends ScalarFormat>(
+  fixture: ShortestPathFixture,
+  name: string,
+  format: Format,
+  chunks: readonly ScalarValues[],
+  options: VectorOptions = {}
+): GPUVector<Format> {
+  const byteOffset = options.byteOffset ?? 0;
+  const byteStride = options.byteStride ?? Uint32Array.BYTES_PER_ELEMENT;
+  const data = chunks.map((values, chunkIndex) => {
+    const buffer =
+      options.buffer ??
+      fixture.device.createBuffer({
+        id: `${name}-${chunkIndex}-${fixture.buffers.length}`,
+        byteLength: byteOffset + Math.max(values.length, 1) * byteStride,
+        usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC
+      });
+    if (!options.buffer) fixture.buffers.push(buffer as Buffer);
+    return new GPUData<Format>({
+      buffer,
+      format,
+      length: values.length,
+      byteOffset,
+      byteStride,
+      ownsBuffer: false
+    });
+  });
+  const vector = new GPUVector<Format>({type: 'data', name, format, data, ownsData: false});
+  fixture.vectors.push(vector);
+  return vector;
+}

--- a/modules/experimental/test/lugraph/lu-graph-single-source-shortest-path.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-single-source-shortest-path.spec.ts
@@ -1,0 +1,773 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {GPUCommandGraph} from '@luma.gl/experimental';
+import {
+  LuGraph,
+  LuGraphSingleSourceShortestPath,
+  LuGraphTopology,
+  type LuGraphAdjacency,
+  type LuGraphSingleSourceShortestPathDirection
+} from '@luma.gl/experimental/lugraph';
+import {GPUData, GPUVector} from '@luma.gl/tables';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import test, {type Test} from 'test/utils/vitest-tape';
+import {vi} from 'vitest';
+import {
+  addLuGraphSingleSourceShortestPathToGraphWithDispatchLimit,
+  getLuGraphSingleSourceShortestPathDispatchLayout
+} from '../../src/lugraph/lu-graph-single-source-shortest-path-internals';
+
+const UNREACHABLE_PREDECESSOR = 0xffffffff;
+
+type ScalarFormat = 'uint32' | 'float32';
+
+type ShortestPathScenario = {
+  name: string;
+  vertexCount: number;
+  sourceChunks: number[][];
+  targetChunks: number[][];
+  weightChunks?: number[][];
+  sourceVertex?: number;
+  directed?: boolean;
+  reverse?: boolean;
+  direction?: LuGraphSingleSourceShortestPathDirection;
+  maxIterations?: number;
+  capacity?: number;
+  reverseCapacity?: number;
+  byteOffset?: number;
+  maximumWorkgroups?: number;
+};
+
+type WeightedNeighbor = {vertex: number; weight: number};
+
+type ExpectedShortestPath = {
+  distances: number[];
+  predecessors: number[];
+  converged: boolean;
+  invalidWeightCount: number;
+  invalidEdgeCount: number;
+  forwardCount: number;
+  reverseCount: number;
+  forwardOverflow: boolean;
+  reverseOverflow: boolean;
+};
+
+type ShortestPathExecutionFixture = {
+  device: Device;
+  buffers: Buffer[];
+  vectors: GPUVector[];
+  graph: LuGraph;
+  topology: LuGraphTopology;
+  search: LuGraphSingleSourceShortestPath;
+  commandGraph: GPUCommandGraph;
+  compiled?: ReturnType<GPUCommandGraph['compile']>;
+};
+
+const shortestPathScenarios: ShortestPathScenario[] = [
+  {
+    name: 'empty graphs preserve empty results and report a trivially converged search',
+    vertexCount: 0,
+    sourceChunks: [[], []],
+    targetChunks: [[], []]
+  },
+  {
+    name: 'isolated vertices remain positive infinity with sentinel predecessors',
+    vertexCount: 4,
+    sourceChunks: [[], []],
+    targetChunks: [[], []],
+    sourceVertex: 2
+  },
+  {
+    name: 'weighted cheaper two-hop routes replace expensive direct edges',
+    vertexCount: 5,
+    sourceChunks: [[0, 0], [], [2, 1]],
+    targetChunks: [[1, 2], [], [1, 3]],
+    weightChunks: [[9, 1], [], [2, 4]]
+  },
+  {
+    name: 'float32 decimal accumulation follows GPU precision rather than JavaScript doubles',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 3]],
+    weightChunks: [[0.1, 0.2, 0.3]]
+  },
+  {
+    name: 'parallel duplicate edges retain the cheapest source-aligned CSR weight',
+    vertexCount: 3,
+    sourceChunks: [[0, 0, 1]],
+    targetChunks: [[1, 1, 2]],
+    weightChunks: [[8, 1.5, 2]]
+  },
+  {
+    name: 'same-hop equal-cost diamonds choose the numerically lowest stable parent',
+    vertexCount: 5,
+    sourceChunks: [[0, 3], [], [0, 1]],
+    targetChunks: [[3, 4], [], [1, 4]],
+    weightChunks: [[2, 2], [], [2, 2]]
+  },
+  {
+    name: 'zero-weight cycles preserve source sentinel and acyclic first-discovery parents',
+    vertexCount: 4,
+    sourceChunks: [[0, 3, 1, 2]],
+    targetChunks: [[3, 1, 2, 1]],
+    weightChunks: [[0, 0, 0, 0]]
+  },
+  {
+    name: 'negative zero is a valid zero-weight edge',
+    vertexCount: 2,
+    sourceChunks: [[0]],
+    targetChunks: [[1]],
+    weightChunks: [[-0]]
+  },
+  {
+    name: 'graphs without explicit weight columns use unit-cost edges',
+    vertexCount: 5,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 3]]
+  },
+  {
+    name: 'zero compiled iterations publish the source only without claiming convergence',
+    vertexCount: 3,
+    sourceChunks: [[0, 1]],
+    targetChunks: [[1, 2]],
+    weightChunks: [[1, 1]],
+    maxIterations: 0
+  },
+  {
+    name: 'bounded weighted routes expose partial distances and a non-converged GPU status',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 3]],
+    weightChunks: [[1, 1, 1]],
+    maxIterations: 1
+  },
+  {
+    name: 'incoming directed routes use transposed CSR and its aligned edge weights',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 3]],
+    weightChunks: [[1, 2, 4]],
+    sourceVertex: 3,
+    reverse: true,
+    direction: 'incoming'
+  },
+  {
+    name: 'bidirectional directed routes combine outgoing and incoming weighted neighbors',
+    vertexCount: 5,
+    sourceChunks: [[0, 2, 2, 4]],
+    targetChunks: [[1, 1, 3, 3]],
+    weightChunks: [[1, 2, 4, 8]],
+    sourceVertex: 1,
+    reverse: true,
+    direction: 'both'
+  },
+  {
+    name: 'undirected graphs reuse mirrored forward adjacency for incoming traversal',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 3]],
+    weightChunks: [[1, 2, 4]],
+    sourceVertex: 3,
+    directed: false,
+    direction: 'incoming'
+  },
+  {
+    name: 'invalid endpoints and their invalid weights are excluded before path validation',
+    vertexCount: 3,
+    sourceChunks: [[0, 9], [], [1]],
+    targetChunks: [[1, 2], [], [2]],
+    weightChunks: [[2, -5], [], [3]]
+  },
+  {
+    name: 'negative valid-endpoint weights fail closed and count each source edge once',
+    vertexCount: 3,
+    sourceChunks: [[0, 1]],
+    targetChunks: [[1, 2]],
+    weightChunks: [[1, -2]],
+    reverse: true,
+    direction: 'both'
+  },
+  {
+    name: 'NaN and positive and negative infinity fail closed with exact invalid counts',
+    vertexCount: 4,
+    sourceChunks: [[0, 1], [], [2, 0]],
+    targetChunks: [[1, 2], [], [3, 3]],
+    weightChunks: [[Number.NaN, Number.POSITIVE_INFINITY], [], [Number.NEGATIVE_INFINITY, 1]]
+  },
+  {
+    name: 'outgoing CSR overflow leaves all distances unreachable and status unconverged',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 3]],
+    weightChunks: [[1, 2, 3]],
+    capacity: 1
+  },
+  {
+    name: 'incoming traversal fails closed on required reverse adjacency overflow',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 3]],
+    weightChunks: [[1, 2, 3]],
+    sourceVertex: 3,
+    reverse: true,
+    reverseCapacity: 0,
+    direction: 'incoming'
+  },
+  {
+    name: 'outgoing traversal ignores overflow in unused reverse adjacency',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 3]],
+    weightChunks: [[1, 2, 3]],
+    reverse: true,
+    reverseCapacity: 0
+  },
+  {
+    name: 'bidirectional traversal fails closed when either selected direction overflows',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 3]],
+    weightChunks: [[1, 2, 3]],
+    reverse: true,
+    reverseCapacity: 1,
+    direction: 'both'
+  },
+  {
+    name: 'non-256-aligned CSR, output, and status views preserve their logical offsets',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 3]],
+    weightChunks: [[1, 2, 3]],
+    byteOffset: 4
+  },
+  {
+    name: 'bounded three-dimensional dispatch reaches the final weighted source vertex',
+    vertexCount: 1025,
+    sourceChunks: [[1024]],
+    targetChunks: [[512]],
+    weightChunks: [[2.5]],
+    sourceVertex: 1024,
+    maxIterations: 1,
+    maximumWorkgroups: 2
+  }
+];
+
+test('LuGraphSingleSourceShortestPath plans bounded three-dimensional GPU work', tapeTest => {
+  tapeTest.deepEqual(getLuGraphSingleSourceShortestPathDispatchLayout(0, 2), {x: 1, y: 1, z: 1});
+  tapeTest.deepEqual(getLuGraphSingleSourceShortestPathDispatchLayout(513, 2), {x: 2, y: 2, z: 1});
+  tapeTest.deepEqual(getLuGraphSingleSourceShortestPathDispatchLayout(1025, 2), {x: 2, y: 2, z: 2});
+  tapeTest.throws(() => getLuGraphSingleSourceShortestPathDispatchLayout(2049, 2), /3D dispatch/);
+  tapeTest.end();
+});
+
+for (const scenario of shortestPathScenarios) {
+  test(`LuGraphSingleSourceShortestPath GPU traversal: ${scenario.name}`, async tapeTest => {
+    const device = await getWebGPUTestDevice();
+    if (!device) {
+      tapeTest.comment('WebGPU is not available');
+      tapeTest.end();
+      return;
+    }
+
+    const expected = calculateExpectedShortestPath(scenario);
+    const fixture = createExecutionFixture(device, scenario, expected);
+    try {
+      compileShortestPath(fixture, scenario.maximumWorkgroups);
+      executeShortestPath(fixture);
+      await assertShortestPath(tapeTest, fixture, expected);
+    } finally {
+      destroyExecutionFixture(tapeTest, fixture);
+    }
+    tapeTest.end();
+  });
+}
+
+test('LuGraphSingleSourceShortestPath schedules work without submission or source readback', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const scenario: ShortestPathScenario = {
+    name: 'command ownership',
+    vertexCount: 3,
+    sourceChunks: [[0, 1]],
+    targetChunks: [[1, 2]],
+    weightChunks: [[2, 3]]
+  };
+  const expected = calculateExpectedShortestPath(scenario);
+  const fixture = createExecutionFixture(device, scenario, expected);
+  const submit = vi.spyOn(device, 'submit');
+  const sourceBuffers = [
+    ...fixture.graph.sourceVertices.data,
+    ...fixture.graph.targetVertices.data,
+    ...fixture.graph.edgeWeights!.data
+  ];
+  const readbacks = sourceBuffers.map(chunk => vi.spyOn(chunk.buffer as Buffer, 'readAsync'));
+  try {
+    compileShortestPath(fixture);
+    tapeTest.equal(
+      submit.mock.calls.length,
+      0,
+      'constructing and compiling never submits GPU work'
+    );
+    executeShortestPath(fixture);
+    await assertShortestPath(tapeTest, fixture, expected);
+    tapeTest.ok(
+      readbacks.every(readback => readback.mock.calls.length === 0),
+      'weighted graph source buffers are never read back by the GPU operation'
+    );
+  } finally {
+    submit.mockRestore();
+    for (const readback of readbacks) readback.mockRestore();
+    destroyExecutionFixture(tapeTest, fixture);
+  }
+  tapeTest.end();
+});
+
+/** Computes the same synchronized float32 Bellman-Ford rounds as the GPU implementation. */
+function calculateExpectedShortestPath(scenario: ShortestPathScenario): ExpectedShortestPath {
+  const outgoing = Array.from({length: scenario.vertexCount}, () => [] as WeightedNeighbor[]);
+  const incoming = Array.from({length: scenario.vertexCount}, () => [] as WeightedNeighbor[]);
+  let invalidEdgeCount = 0;
+  let invalidWeightCount = 0;
+
+  for (const [chunkIndex, sources] of scenario.sourceChunks.entries()) {
+    for (const [edgeIndex, source] of sources.entries()) {
+      const target = scenario.targetChunks[chunkIndex][edgeIndex];
+      if (source >= scenario.vertexCount || target >= scenario.vertexCount) {
+        invalidEdgeCount++;
+        continue;
+      }
+      const weight = Math.fround(scenario.weightChunks?.[chunkIndex][edgeIndex] ?? 1);
+      if (!Number.isFinite(weight) || weight < 0) invalidWeightCount++;
+      outgoing[source].push({vertex: target, weight});
+      if (scenario.directed === false) {
+        if (source !== target) outgoing[target].push({vertex: source, weight});
+      } else {
+        incoming[target].push({vertex: source, weight});
+      }
+    }
+  }
+
+  const forwardCount = outgoing.reduce((count, neighbors) => count + neighbors.length, 0);
+  const reverseCount = incoming.reduce((count, neighbors) => count + neighbors.length, 0);
+  const forwardOverflow = forwardCount > (scenario.capacity ?? forwardCount);
+  const reverseOverflow = Boolean(
+    scenario.reverse && reverseCount > (scenario.reverseCapacity ?? reverseCount)
+  );
+  const direction = scenario.direction ?? 'outgoing';
+  const requiredOverflow =
+    scenario.directed === false || direction === 'outgoing'
+      ? forwardOverflow
+      : direction === 'incoming'
+        ? reverseOverflow
+        : forwardOverflow || reverseOverflow;
+  const distances = new Array<number>(scenario.vertexCount).fill(Number.POSITIVE_INFINITY);
+  const predecessors = new Array<number>(scenario.vertexCount).fill(UNREACHABLE_PREDECESSOR);
+  let converged = false;
+
+  if (!requiredOverflow && invalidWeightCount === 0) {
+    const sourceVertex = scenario.sourceVertex ?? 0;
+    if (scenario.vertexCount > 0) distances[sourceVertex] = 0;
+    const edgeCount = scenario.sourceChunks.reduce((count, chunk) => count + chunk.length, 0);
+    converged = scenario.vertexCount <= 1 || edgeCount === 0;
+    const maximumIterations =
+      scenario.maxIterations ?? Math.min(Math.max(scenario.vertexCount - 1, 0), 1024);
+
+    for (let iteration = 0; iteration < maximumIterations && !converged; iteration++) {
+      const previous = [...distances];
+      for (let vertex = 0; vertex < scenario.vertexCount; vertex++) {
+        if (!Number.isFinite(previous[vertex])) continue;
+        for (const neighbor of getSelectedNeighbors(scenario, outgoing, incoming, vertex)) {
+          const candidate = Math.fround(previous[vertex] + neighbor.weight);
+          if (Number.isFinite(candidate) && candidate < distances[neighbor.vertex]) {
+            distances[neighbor.vertex] = candidate;
+          }
+        }
+      }
+
+      let changed = false;
+      for (let vertex = 0; vertex < scenario.vertexCount; vertex++) {
+        if (distances[vertex] < previous[vertex]) {
+          changed = true;
+          if (vertex !== sourceVertex) predecessors[vertex] = UNREACHABLE_PREDECESSOR;
+        }
+      }
+      for (let vertex = 0; vertex < scenario.vertexCount; vertex++) {
+        if (!Number.isFinite(previous[vertex])) continue;
+        for (const neighbor of getSelectedNeighbors(scenario, outgoing, incoming, vertex)) {
+          const candidate = Math.fround(previous[vertex] + neighbor.weight);
+          if (
+            neighbor.vertex !== sourceVertex &&
+            distances[neighbor.vertex] < previous[neighbor.vertex] &&
+            candidate === distances[neighbor.vertex]
+          ) {
+            predecessors[neighbor.vertex] = Math.min(predecessors[neighbor.vertex], vertex);
+          }
+        }
+      }
+      converged = !changed || iteration + 1 >= scenario.vertexCount - 1;
+    }
+  }
+
+  return {
+    distances,
+    predecessors,
+    converged,
+    invalidWeightCount,
+    invalidEdgeCount,
+    forwardCount,
+    reverseCount,
+    forwardOverflow,
+    reverseOverflow
+  };
+}
+
+function getSelectedNeighbors(
+  scenario: ShortestPathScenario,
+  outgoing: WeightedNeighbor[][],
+  incoming: WeightedNeighbor[][],
+  vertex: number
+): WeightedNeighbor[] {
+  if (scenario.directed === false || !scenario.direction || scenario.direction === 'outgoing') {
+    return outgoing[vertex];
+  }
+  return scenario.direction === 'incoming'
+    ? incoming[vertex]
+    : [...outgoing[vertex], ...incoming[vertex]];
+}
+
+function createExecutionFixture(
+  device: Device,
+  scenario: ShortestPathScenario,
+  expected: ExpectedShortestPath
+): ShortestPathExecutionFixture {
+  const buffers: Buffer[] = [];
+  const vectors: GPUVector[] = [];
+  const sourceVertices = createInputVector(
+    device,
+    buffers,
+    vectors,
+    'source-vertices',
+    'uint32',
+    scenario.sourceChunks
+  );
+  const targetVertices = createInputVector(
+    device,
+    buffers,
+    vectors,
+    'target-vertices',
+    'uint32',
+    scenario.targetChunks
+  );
+  const edgeWeights = scenario.weightChunks
+    ? createInputVector(device, buffers, vectors, 'edge-weights', 'float32', scenario.weightChunks)
+    : undefined;
+  const graph = new LuGraph({
+    vertexCount: scenario.vertexCount,
+    sourceVertices,
+    targetVertices,
+    edgeWeights,
+    directed: scenario.directed
+  });
+  const forward = createOutputAdjacency(
+    device,
+    buffers,
+    vectors,
+    'forward',
+    scenario.vertexCount,
+    scenario.capacity ?? expected.forwardCount,
+    Boolean(edgeWeights),
+    scenario.byteOffset
+  );
+  const reverse = scenario.reverse
+    ? createOutputAdjacency(
+        device,
+        buffers,
+        vectors,
+        'reverse',
+        scenario.vertexCount,
+        scenario.reverseCapacity ?? expected.reverseCount,
+        Boolean(edgeWeights),
+        scenario.byteOffset
+      )
+    : undefined;
+  const invalidEdgeCount = createOutputVector(
+    device,
+    buffers,
+    vectors,
+    'invalid-edges',
+    'uint32',
+    1
+  );
+  const topology = new LuGraphTopology({graph, forward, reverse, invalidEdgeCount});
+  const distances = createOutputVector(
+    device,
+    buffers,
+    vectors,
+    'distances',
+    'float32',
+    scenario.vertexCount,
+    scenario.byteOffset
+  );
+  const predecessors = createOutputVector(
+    device,
+    buffers,
+    vectors,
+    'predecessors',
+    'uint32',
+    scenario.vertexCount,
+    scenario.byteOffset
+  );
+  const converged = createOutputVector(
+    device,
+    buffers,
+    vectors,
+    'converged',
+    'uint32',
+    1,
+    scenario.byteOffset
+  );
+  const invalidWeightCount = createOutputVector(
+    device,
+    buffers,
+    vectors,
+    'invalid-weights',
+    'uint32',
+    1,
+    scenario.byteOffset
+  );
+  const search = new LuGraphSingleSourceShortestPath({
+    topology,
+    sourceVertex: scenario.sourceVertex ?? 0,
+    distances,
+    predecessors,
+    maxIterations: scenario.maxIterations,
+    direction: scenario.direction,
+    converged,
+    invalidWeightCount
+  });
+
+  return {
+    device,
+    buffers,
+    vectors,
+    graph,
+    topology,
+    search,
+    commandGraph: new GPUCommandGraph(device)
+  };
+}
+
+function createInputVector<Format extends ScalarFormat>(
+  device: Device,
+  buffers: Buffer[],
+  vectors: GPUVector[],
+  name: string,
+  format: Format,
+  chunks: readonly number[][]
+): GPUVector<Format> {
+  const data = chunks.map((chunk, chunkIndex) => {
+    const values = format === 'float32' ? Float32Array.from(chunk) : Uint32Array.from(chunk);
+    const buffer = device.createBuffer({
+      id: `${name}-${chunkIndex}`,
+      byteLength: Math.max(values.length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+    if (values.length > 0) buffer.write(values);
+    buffers.push(buffer);
+    return new GPUData<Format>({buffer, format, length: values.length, ownsBuffer: false});
+  });
+  const vector = new GPUVector<Format>({type: 'data', name, format, data, ownsData: false});
+  vectors.push(vector);
+  return vector;
+}
+
+function createOutputAdjacency(
+  device: Device,
+  buffers: Buffer[],
+  vectors: GPUVector[],
+  name: string,
+  vertexCount: number,
+  capacity: number,
+  weighted: boolean,
+  byteOffset = 0
+): LuGraphAdjacency {
+  return {
+    offsets: createOutputVector(
+      device,
+      buffers,
+      vectors,
+      `${name}-offsets`,
+      'uint32',
+      vertexCount + 1,
+      byteOffset
+    ),
+    neighbors: createOutputVector(
+      device,
+      buffers,
+      vectors,
+      `${name}-neighbors`,
+      'uint32',
+      capacity
+    ),
+    edgeIds: createOutputVector(device, buffers, vectors, `${name}-edge-ids`, 'uint32', capacity),
+    ...(weighted
+      ? {
+          edgeWeights: createOutputVector(
+            device,
+            buffers,
+            vectors,
+            `${name}-edge-weights`,
+            'float32',
+            capacity
+          )
+        }
+      : {}),
+    count: createOutputVector(device, buffers, vectors, `${name}-count`, 'uint32', 1),
+    overflow: createOutputVector(device, buffers, vectors, `${name}-overflow`, 'uint32', 1)
+  };
+}
+
+function createOutputVector<Format extends ScalarFormat>(
+  device: Device,
+  buffers: Buffer[],
+  vectors: GPUVector[],
+  name: string,
+  format: Format,
+  length: number,
+  byteOffset = 0
+): GPUVector<Format> {
+  const buffer = device.createBuffer({
+    id: name,
+    byteLength: byteOffset + Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  buffers.push(buffer);
+  const vector = new GPUVector<Format>({
+    type: 'buffer',
+    name,
+    format,
+    buffer,
+    length,
+    byteOffset,
+    ownsBuffer: false
+  });
+  vectors.push(vector);
+  return vector;
+}
+
+function compileShortestPath(
+  fixture: ShortestPathExecutionFixture,
+  maximumWorkgroups?: number
+): void {
+  fixture.topology.addToGraph(fixture.commandGraph);
+  if (maximumWorkgroups === undefined) {
+    fixture.search.addToGraph(fixture.commandGraph);
+  } else {
+    addLuGraphSingleSourceShortestPathToGraphWithDispatchLimit(
+      fixture.search,
+      fixture.commandGraph,
+      maximumWorkgroups
+    );
+  }
+  fixture.compiled = fixture.commandGraph.compile();
+}
+
+function executeShortestPath(fixture: ShortestPathExecutionFixture): void {
+  const encoder = fixture.device.createCommandEncoder({id: 'lu-graph-weighted-shortest-path-test'});
+  fixture.compiled!.encode(encoder, {parameters: undefined});
+  fixture.device.submit(encoder.finish());
+}
+
+async function assertShortestPath(
+  tapeTest: Test,
+  fixture: ShortestPathExecutionFixture,
+  expected: ExpectedShortestPath
+): Promise<void> {
+  const [
+    distances,
+    predecessors,
+    converged,
+    invalidWeightCount,
+    invalidEdgeCount,
+    forwardOverflow
+  ] = await Promise.all([
+    readScalarVector(fixture.search.distances),
+    readScalarVector(fixture.search.predecessors),
+    readScalarVector(fixture.search.converged!),
+    readScalarVector(fixture.search.invalidWeightCount!),
+    readScalarVector(fixture.topology.invalidEdgeCount),
+    readScalarVector(fixture.topology.forward.overflow)
+  ]);
+  tapeTest.deepEqual(
+    distances,
+    expected.distances,
+    'weighted float32 distances match the CPU oracle'
+  );
+  tapeTest.deepEqual(
+    predecessors,
+    expected.predecessors,
+    'same-hop shortest routes choose the lowest stable predecessor'
+  );
+  tapeTest.equal(
+    converged[0],
+    Number(expected.converged),
+    'GPU convergence status remains truthful'
+  );
+  tapeTest.equal(
+    invalidWeightCount[0],
+    expected.invalidWeightCount,
+    'each invalid source-edge weight is counted once'
+  );
+  tapeTest.equal(
+    invalidEdgeCount[0],
+    expected.invalidEdgeCount,
+    'invalid endpoints remain excluded'
+  );
+  tapeTest.equal(
+    forwardOverflow[0],
+    Number(expected.forwardOverflow),
+    'forward overflow is explicit'
+  );
+  if (fixture.topology.reverse) {
+    const reverseOverflow = await readScalarVector(fixture.topology.reverse.overflow);
+    tapeTest.equal(
+      reverseOverflow[0],
+      Number(expected.reverseOverflow),
+      'reverse overflow remains explicit'
+    );
+  }
+}
+
+async function readScalarVector(
+  vector: GPUVector<'uint32'> | GPUVector<'float32'>
+): Promise<number[]> {
+  if (vector.length === 0) return [];
+  const data = vector.data[0];
+  const bytes = await (data.buffer as Buffer).readAsync(
+    data.byteOffset,
+    vector.length * Uint32Array.BYTES_PER_ELEMENT
+  );
+  return Array.from(
+    vector.format === 'float32'
+      ? new Float32Array(bytes.buffer, bytes.byteOffset, vector.length)
+      : new Uint32Array(bytes.buffer, bytes.byteOffset, vector.length)
+  );
+}
+
+function destroyExecutionFixture(tapeTest: Test, fixture: ShortestPathExecutionFixture): void {
+  fixture.compiled?.destroy();
+  for (const vector of fixture.vectors) vector.destroy();
+  tapeTest.ok(
+    fixture.buffers.every(buffer => !buffer.destroyed),
+    'destroying the compiled operation preserves every caller-owned GPU buffer'
+  );
+  for (const buffer of fixture.buffers) buffer.destroy();
+}

--- a/test/examples/lugraph-docs.node.spec.ts
+++ b/test/examples/lugraph-docs.node.spec.ts
@@ -163,7 +163,11 @@ describe('luGraph GPU-resident graph analytics documentation', () => {
 
     expect(graphDocumentation).toContain('`V × (V - 1)` edges');
     expect(graphDocumentation).toContain('including an intentionally empty');
-    expect(graphDocumentation).toContain('six genuine GPU algorithms');
+    expect(graphDocumentation).toContain('nine genuine GPU');
+    expect(graphDocumentation).toContain('weighted single-source shortest paths');
+    expect(graphDocumentation).toContain('local clustering coefficients');
+    expect(graphDocumentation).toContain('label-propagation communities');
+    expect(graphDocumentation).toContain('six Graphalytics workload families');
     expect(graphDocumentation).toContain('not\nmillion-vertex benchmarks');
     expect(graphDocumentation).toContain("from '@luma.gl/experimental/lugraph/benchmarks';");
     expect(graphDocumentation).toContain('makeLuGraphBenchmarkDataset');
@@ -205,7 +209,9 @@ describe('luGraph GPU-resident graph analytics documentation', () => {
     expect(graphDocumentation).toContain('Knowledge and citation graphs');
     expect(graphDocumentation).toContain('A small, CPU-resident, one-off analysis');
     expect(graphDocumentation).toContain('**Question: How many direct relationships');
+    expect(graphDocumentation).toContain("**Question: Do this vertex's neighbors actually connect");
     expect(graphDocumentation).toContain('**Question: Which entities can I reach');
+    expect(graphDocumentation).toContain('**Question: Which route from my starting vertex costs');
     expect(graphDocumentation).toContain('**Question: Which vertices belong to the same connected');
     expect(graphDocumentation).toContain('**Question: Which vertices form closely connected');
     expect(graphDocumentation).toContain('**Question: Which vertices receive influence');
@@ -217,7 +223,9 @@ describe('luGraph GPU-resident graph analytics documentation', () => {
       'LuGraph',
       'LuGraphTopology',
       'LuGraphDegree',
+      'LuGraphLocalClusteringCoefficient',
       'LuGraphBreadthFirstSearch',
+      'LuGraphSingleSourceShortestPath',
       'LuGraphConnectedComponents',
       'LuGraphLabelPropagation',
       'LuGraphPageRank',
@@ -230,6 +238,10 @@ describe('luGraph GPU-resident graph analytics documentation', () => {
     expect(packageDocumentation).toContain('compressed adjacency');
     expect(packageDocumentation).toContain('vertex-degree queries');
     expect(packageDocumentation).toContain('breadth-first shortest paths');
+    expect(packageDocumentation).toContain('nonnegative weighted single-source routes');
+    expect(packageDocumentation).toContain('LuGraphSingleSourceShortestPath');
+    expect(packageDocumentation).toContain('local clustering coefficients');
+    expect(packageDocumentation).toContain('LuGraphLocalClusteringCoefficient');
     expect(packageDocumentation).toContain('weakly connected components');
     expect(packageDocumentation).toContain('deterministic label-propagation communities');
     expect(packageDocumentation).toContain('LuGraphLabelPropagation');
@@ -238,12 +250,103 @@ describe('luGraph GPU-resident graph analytics documentation', () => {
     expect(packageDocumentation).toContain('LuGraphSpatialForceLayout');
     expect(packageDocumentation).toContain('## Overview');
     expect(packageDocumentation).toContain('## When to use luGraph');
+    expect(packageDocumentation).toContain('## Weighted routes and local neighborhoods');
     expect(packageDocumentation).toContain('flat-grid approximation');
     expect(graphDocumentation).toContain("from '@luma.gl/experimental/lugraph';");
     expect(graphDocumentation).toContain('topology.addToGraph(workflow);');
     expect(graphDocumentation).toContain('const compiled = workflow.compile();');
     expect(graphDocumentation).toContain('compiled.encode(encoder, {parameters: undefined});');
     expect(graphDocumentation).toContain('device.submit(encoder.finish());');
+  });
+
+  test('explains complete Graphalytics workload coverage without overstating benchmark conformance', () => {
+    expect(graphDocumentation).toContain(
+      '## What does complete Graphalytics workload coverage mean?'
+    );
+    expect(graphDocumentation).toContain('breadth-first search (BFS)');
+    expect(graphDocumentation).toContain('single-source shortest');
+    expect(graphDocumentation).toContain('paths (SSSP)');
+    expect(graphDocumentation).toContain('weakly connected components (WCC)');
+    expect(graphDocumentation).toContain('community detection by label propagation');
+    expect(graphDocumentation).toContain('(CDLP)');
+    expect(graphDocumentation).toContain('local clustering coefficient (LCC)');
+    expect(graphDocumentation).toContain('PageRank (PR)');
+    expect(graphDocumentation).toContain('not a claim of official Graphalytics certification');
+    expect(graphDocumentation).toContain('comparable published scores');
+    expect(packageDocumentation).toContain('Graphalytics workload');
+    expect(packageDocumentation).toContain('does not');
+    expect(packageDocumentation).toContain('official benchmark certification');
+  });
+
+  test('explains unique weak-neighborhood triangles and honest local clustering complexity', () => {
+    expect(graphDocumentation).toContain(
+      '## Measure neighborhood density with LuGraphLocalClusteringCoefficient'
+    );
+    expect(graphDocumentation).toContain('tightly connected friend circle');
+    expect(graphDocumentation).toContain('mutually connected transaction accounts');
+    expect(graphDocumentation).toContain('new LuGraphLocalClusteringCoefficient({');
+    expect(graphDocumentation).toContain('output: clusteringCoefficients');
+    expect(graphDocumentation).toContain('triangles: incidentTriangleCounts');
+    expect(graphDocumentation).toContain("GPUVector<'float32'>");
+    expect(graphDocumentation).toContain("GPUVector<'uint32'>");
+    expect(graphDocumentation).toContain('`2 × T / (d × (d - 1))`');
+    expect(graphDocumentation).toContain('fewer than two distinct neighbors');
+    expect(graphDocumentation).toContain('**weak**, neighborhood');
+    expect(graphDocumentation).toContain('both forward and reverse CSR');
+    expect(graphDocumentation).toContain('Self-loops never make a vertex its own neighbor');
+    expect(graphDocumentation).toContain('`C / (d × (d - 1))`');
+    expect(graphDocumentation).toContain('Reciprocal neighbor relationships count as two');
+    expect(graphDocumentation).toContain('repeated copies of the');
+    expect(graphDocumentation).toContain('not silently collapsed');
+    expect(graphDocumentation).toContain('cannot fit in `uint32`');
+    expect(graphDocumentation).toContain('allocating a graph-owned scratch buffer');
+    expect(graphDocumentation).toContain('fails closed to zero');
+    expect(graphDocumentation).toContain('triangle counts become `0xffffffff`');
+    expect(graphDocumentation).toContain('`O(sum(degree³))`');
+    expect(graphDocumentation).toContain('not a claim of constant-time triangle counting');
+  });
+
+  test('distinguishes nonnegative weighted routes from unweighted hops and documents failures', () => {
+    expect(graphDocumentation).toContain(
+      '## Find least-cost routes with LuGraphSingleSourceShortestPath'
+    );
+    expect(graphDocumentation).toContain('40 minutes');
+    expect(graphDocumentation).toContain('20 minutes');
+    expect(graphDocumentation).toContain('travel-time maps');
+    expect(graphDocumentation).toContain('communication latency');
+    expect(graphDocumentation).toContain('service-dependency recovery costs');
+    expect(graphDocumentation).toContain('new LuGraphSingleSourceShortestPath({');
+    expect(graphDocumentation).toContain('sourceVertex: selectedVertex');
+    expect(graphDocumentation).toContain('distances: routeCosts');
+    expect(graphDocumentation).toContain('predecessors: routeParents');
+    expect(graphDocumentation).toContain('maxIterations: 64');
+    expect(graphDocumentation).toContain('converged: shortestPathsConverged');
+    expect(graphDocumentation).toContain('invalidWeightCount');
+    expect(graphDocumentation).toContain('positive infinity (`+Infinity`)');
+    expect(graphDocumentation).toContain('predecessor `0xffffffff`');
+    expect(graphDocumentation).toContain('the one with fewer hops wins');
+    expect(graphDocumentation).toContain('lowest stable predecessor identifier wins');
+    expect(graphDocumentation).toContain('Zero-weight edges are\nvalid');
+    expect(graphDocumentation).toContain('every edge then costs one');
+    expect(graphDocumentation).toContain('Negative weights, `NaN`, positive infinity');
+    expect(graphDocumentation).toContain('number of invalid **source edges**');
+    expect(graphDocumentation).toContain(
+      'Directed `incoming` or `both` routing requires reverse CSR'
+    );
+    expect(graphDocumentation).toContain('bounded Bellman–Ford-style synchronized relaxation');
+    expect(graphDocumentation).toContain('from `0` through `1024`');
+    expect(graphDocumentation).toContain('`min(max(vertexCount - 1, 0), 1024)`');
+    expect(graphDocumentation).toContain('partially relaxed routes');
+    expect(graphDocumentation).toContain('`O(K × (V + E))`');
+    expect(graphDocumentation).toContain('`O(V)` graph-owned scratch');
+    expect(graphDocumentation).toContain('new LuGraphLocalClusteringCoefficient({');
+    expect(graphDocumentation).toContain('}).addToGraph(workflow);');
+    expect(graphDocumentation).not.toContain(
+      'Choose another tool when the application needs weighted shortest paths'
+    );
+    expect(graphDocumentation).not.toContain(
+      'weighted shortest paths, or a CPU execution fallback'
+    );
   });
 
   test('explains deterministic GPU communities, practical use cases, and honest limitations', () => {

--- a/website/src/components/docs/lugraph-benchmark.tsx
+++ b/website/src/components/docs/lugraph-benchmark.tsx
@@ -78,7 +78,7 @@ export function LuGraphBenchmark(): ReactNode {
 
       <LiveBenchmarkPanel
         title="Live CPU versus WebGPU graph analytics"
-        description="Run the same deterministic graph through real CPU and GPU adjacency, neighborhood search, weak components, PageRank, exact force layout, and explicitly approximate spatial force layout."
+        description="Run the same weighted graph through real CPU and GPU adjacency, neighborhood search, shortest paths, weak components, communities, local clustering, PageRank, and two force layouts."
         runLabel="Run graph benchmark on this device"
         unsupportedReason={
           webGPUUnavailable
@@ -176,9 +176,9 @@ function LuGraphBenchmarkResults({
       </p>
 
       <p style={{fontSize: 12, margin: '8px 0 0'}}>
-        Weak-component convergence is read from its final GPU status after the stated bounded pass
-        count. PageRank reports its actual final GPU L₁ residual after its separately stated pass
-        count; neither metric changes the measured timing or implies early termination.
+        Shortest-path, weak-component, and community convergence are read from their actual final
+        GPU statuses after the stated bounded pass counts. PageRank reports its real final GPU L₁
+        residual; none of these measurements imply early termination.
       </p>
     </div>
   );
@@ -223,7 +223,10 @@ function formatAlgorithm(algorithm: LuGraphBenchmarkAlgorithm): string {
   const labels: Record<LuGraphBenchmarkAlgorithm, string> = {
     topology: 'CSR adjacency',
     'breadth-first-search': 'Neighborhood search',
+    'single-source-shortest-path': 'Weighted shortest paths',
     'connected-components': 'Weak components',
+    'label-propagation': 'Label-propagation communities',
+    'local-clustering-coefficient': 'Local clustering coefficient',
     'page-rank': 'PageRank',
     'exact-layout': 'Exact force layout',
     'spatial-layout': 'Approximate spatial layout'
@@ -244,7 +247,12 @@ function formatError(error: number): string {
 }
 
 function formatConvergence(path: LuGraphBenchmarkPathReport): string {
-  if (path.algorithm === 'connected-components' && path.iterations !== undefined) {
+  if (
+    (path.algorithm === 'connected-components' ||
+      path.algorithm === 'label-propagation' ||
+      path.algorithm === 'single-source-shortest-path') &&
+    path.iterations !== undefined
+  ) {
     const status =
       path.converged === undefined
         ? 'status unavailable'


### PR DESCRIPTION
## Goals

- Complete all six Graphalytics workload families directly on browser WebGPU without adding CPU graph readback, deck.gl dependencies, or new package boundaries.
- Extend the existing honest live benchmark so every new algorithm is checked against an independent CPU oracle before timings are shown.

## Changes

- Add `LuGraphSingleSourceShortestPath` for nonnegative float32 weighted routes, deterministic predecessor ties, incoming/outgoing/bidirectional traversal, bounded convergence, invalid-weight detection, and fail-closed adjacency overflow.
- Add `LuGraphLocalClusteringCoefficient` with exact Graphalytics directed-neighborhood semantics, duplicate/self-loop handling, optional per-vertex triangle or directed-closure counts, and portable WebGPU binding limits.
- Upgrade deterministic benchmark datasets to preserve three aligned source, target, and float32 weight batches; expand live GPU-versus-CPU coverage from six to nine paths, including weighted shortest paths, label propagation, and local clustering.
- Preserve the million-node native/deck.gl showcases while documenting eleven optional graph operations, all six Graphalytics workload families, bounded complexity, and existing advanced-analytics opportunities.
- Add extensive real WebGPU and Node coverage for weighted directions, float32 precision, zero weights/cycles, invalid inputs, predecessor ties, CSR overflow, exact directed and undirected coefficients, source-batch preservation, and browser benchmark correctness.

## Verification

- `yarn lint fix`
- `yarn build`
- `CI=1 yarn test`: **1,968 Node tests passed** and **1,974 headless WebGPU tests passed**; existing skips remained unchanged.
- `yarn website:build`
- Focused post-rebase SwiftShader validation: **52 real WebGPU tests passed**, including all five nine-path benchmark datasets and the existing raster backend regression.
- Focused post-rebase Node coverage: **170 tests passed** across both algorithms, benchmarks, documentation, capabilities, SPDX, and RAPIDS attribution.

## Scope and limitations

- Coverage refers to implementation of the six Graphalytics workload families; this does not claim official Graphalytics certification.
- Weighted routes support nonnegative float32 costs and at most 1,024 explicit relaxation rounds; local clustering is exact but can require cubic work in vertex degree on unsorted CSR.
- Execution remains single-device WebGPU; GPU ownership, queue submission, and optional readback stay controlled by the caller.