### PR TITLE
feat(examples): benchmark million-row GPU dataframe workloads

### DIFF
--- a/docs/api-reference/experimental/ludf.md
+++ b/docs/api-reference/experimental/ludf.md
@@ -386,6 +386,18 @@ durations for:
 5. Explicitly reading only the outputs required for validation.
 6. Computing the corresponding CPU reference results.
 
+Choose a source size between **1,024 and 1,048,576 rows** and one, three, or five measured samples.
+Fixtures use packed typed arrays and genuine sliced nullable Arrow dictionary batches rather than
+allocating one JavaScript object per row. Every workload performs an excluded warmup before the
+measured samples; the reported filter, grouping, stable top-K, and join comparisons use median
+CPU and completion-fenced GPU durations, observed GPU rows per second, and measured speedup.
+
+The example records an overall GPU crossover only when a size actually measured on the current
+device has lower aggregate execution time than the equivalent CPU workloads. Upload, compilation,
+explicit validation readback, and the separately measured index are intentionally not hidden inside
+that execution-only comparison. Browser devices, available memory, and adapter limits still
+determine which selected sizes can complete.
+
 GPU durations wait for `device.createFence().signaled` rather than measuring command submission
 alone. The separately reported index-build phase is an equivalent standalone measurement; the
 complete join execution still includes construction of its own index. Timings must not be added or

--- a/examples/experimental/gpu-data-analysis/src/app-shell.ts
+++ b/examples/experimental/gpu-data-analysis/src/app-shell.ts
@@ -134,9 +134,27 @@ export const GPU_DATA_ANALYSIS_TEMPLATE = `
             nullable, dictionary-encoded Arrow batches. Nothing runs until you ask.
           </p>
         </div>
-        <button id="analysis-ludf-benchmark-run" class="benchmark-button" data-ludf-benchmark disabled>
-          Run verified benchmark <span>→</span>
-        </button>
+        <div class="benchmark-controls">
+          <label>Benchmark rows
+            <select data-ludf-benchmark-rows>
+              <option value="1024">1,024 rows</option>
+              <option value="4096">4,096 rows</option>
+              <option value="65536" selected>65,536 rows</option>
+              <option value="262144">262,144 rows</option>
+              <option value="1048576">1,048,576 rows</option>
+            </select>
+          </label>
+          <label>Measured samples
+            <select data-ludf-benchmark-iterations>
+              <option value="1">1 sample</option>
+              <option value="3" selected>3 samples</option>
+              <option value="5">5 samples</option>
+            </select>
+          </label>
+          <button id="analysis-ludf-benchmark-run" class="benchmark-button" data-ludf-benchmark disabled>
+            Run verified benchmark <span>→</span>
+          </button>
+        </div>
       </div>
       <p id="analysis-ludf-benchmark-status" class="benchmark-status" data-ludf-benchmark-status>
         Filter, group, stable top-K, and unique-key joins remain GPU-resident.
@@ -458,13 +476,19 @@ export const GPU_DATA_ANALYSIS_STYLES = `
   .benchmark-heading .eyebrow { color: var(--blue); }
   .benchmark-heading h2 { margin: 0 0 7px; font-size: 21px; letter-spacing: -0.4px; }
   .benchmark-heading > div > p:last-child { max-width: 680px; margin: 0; color: var(--muted); }
-  .analysis-example .benchmark-button { width: 230px; border-color: rgba(115, 170, 250, 0.5); color: var(--blue); }
+  .benchmark-controls { display: grid; min-width: 260px; grid-template-columns: 1fr 1fr; gap: 9px; }
+  .analysis-example .benchmark-button { grid-column: 1 / -1; width: 100%; border-color: rgba(115, 170, 250, 0.5); color: var(--blue); }
   .benchmark-status { margin: 16px 0 0; color: var(--muted); font-size: 11px; }
   .benchmark-results table { width: 100%; margin-top: 13px; border-collapse: collapse; }
   .benchmark-results th, .benchmark-results td { padding: 10px; border-bottom: 1px solid var(--border); text-align: left; }
   .benchmark-results thead th { color: var(--muted); font-size: 10px; letter-spacing: 0.5px; }
   .benchmark-results tbody th { color: var(--text); font-size: 12px; font-weight: 500; }
   .benchmark-results td { color: var(--green); text-align: right; font-variant-numeric: tabular-nums; }
+  .benchmark-results .workload-title { margin: 20px 0 3px; color: var(--blue); font-size: 11px; letter-spacing: 0.7px; }
+  .benchmark-results .workload-metadata { margin: 0 0 8px; color: var(--muted); font-size: 11px; }
+  .benchmark-results .workload-table td { color: var(--text); }
+  .benchmark-results .workload-table td:last-child { color: var(--green); font-weight: 700; }
+  .benchmark-results .benchmark-crossover { margin-top: 13px; color: var(--amber); font-size: 11px; }
   .benchmark-results[data-state="error"] { color: #ff8585; }
 
   .visualizations {
@@ -541,6 +565,7 @@ export const GPU_DATA_ANALYSIS_STYLES = `
     .dataframe-lab { padding: 15px; }
     .benchmark-lab { padding: 15px; }
     .benchmark-heading { align-items: flex-start; flex-direction: column; }
+    .benchmark-controls { width: 100%; }
     .analysis-example .benchmark-button { width: 100%; }
     .visualizations { grid-template-columns: 1fr; }
     .heatmap-card { grid-column: auto; }

--- a/examples/experimental/gpu-data-analysis/src/app.ts
+++ b/examples/experimental/gpu-data-analysis/src/app.ts
@@ -63,7 +63,9 @@ type ExampleElements = {
   luDataFrameSelected: HTMLElement;
   luDataFrameThreshold: HTMLInputElement;
   ludfBenchmark: HTMLButtonElement;
+  ludfBenchmarkIterations: HTMLSelectElement;
   ludfBenchmarkResults: HTMLElement;
+  ludfBenchmarkRows: HTMLSelectElement;
   ludfBenchmarkStatus: HTMLElement;
   nodes: HTMLElement;
   reuse: HTMLElement;
@@ -91,6 +93,7 @@ class GPUDataAnalysisExample {
   private device: Device | null = null;
   private resources: ExampleResources | null = null;
   private benchmarkController: AbortController | null = null;
+  private readonly benchmarkHistory: LuDataFrameBenchmarkResult[] = [];
   private destroyed = false;
   private hasRunLuDataFrameDemo = false;
   private runVersion = 0;
@@ -740,16 +743,20 @@ class GPUDataAnalysisExample {
     this.elements.ludfBenchmark.disabled = true;
     this.elements.ludfBenchmarkResults.dataset.state = 'running';
     this.elements.ludfBenchmarkResults.dataset.validated = 'false';
-    this.elements.ludfBenchmarkStatus.textContent =
-      'Uploading a nullable Arrow dictionary dataset and validating GPU dataframe queries...';
+    const rowCount = Number(this.elements.ludfBenchmarkRows.value);
+    const iterations = Number(this.elements.ludfBenchmarkIterations.value);
+    this.elements.ludfBenchmarkStatus.textContent = `Preparing ${rowCount.toLocaleString()} nullable Arrow rows and ${iterations} measured samples...`;
 
     try {
       const result = await runLuDataFrameBenchmark(this.device, {
-        rowCount: 384,
+        rowCount,
+        iterations,
+        warmupIterations: 1,
         signal: controller.signal
       });
       if (this.destroyed || controller.signal.aborted) return;
-      renderLuDataFrameBenchmark(this.elements, result);
+      this.benchmarkHistory.push(result);
+      renderLuDataFrameBenchmark(this.elements, result, this.benchmarkHistory);
     } catch (error) {
       if (this.destroyed || controller.signal.aborted) return;
       this.elements.ludfBenchmarkResults.dataset.state = 'error';
@@ -1047,7 +1054,9 @@ function getElements(root: HTMLElement): ExampleElements {
     luDataFrameSelected: get('[data-ludf-selected]'),
     luDataFrameThreshold: get('[data-ludf-threshold]'),
     ludfBenchmark: get('[data-ludf-benchmark]'),
+    ludfBenchmarkIterations: get('[data-ludf-benchmark-iterations]'),
     ludfBenchmarkResults: get('[data-ludf-benchmark-phases]'),
+    ludfBenchmarkRows: get('[data-ludf-benchmark-rows]'),
     ludfBenchmarkStatus: get('[data-ludf-benchmark-status]'),
     nodes: get('[data-nodes]'),
     reuse: get('[data-reuse]'),
@@ -1068,7 +1077,8 @@ function ensureStyles(): void {
 /** Renders only bounded, independently fenced phase timings and explicit CPU-oracle validation. */
 function renderLuDataFrameBenchmark(
   elements: ExampleElements,
-  result: LuDataFrameBenchmarkResult
+  result: LuDataFrameBenchmarkResult,
+  history: readonly LuDataFrameBenchmarkResult[]
 ): void {
   const timingRows = [
     ['upload', 'Arrow upload', result.timings.uploadMilliseconds],
@@ -1078,18 +1088,43 @@ function renderLuDataFrameBenchmark(
     ['readback', 'Bounded result readback', result.timings.readbackMilliseconds],
     ['cpu', 'Equivalent CPU reference', result.timings.cpuMilliseconds]
   ] as const;
-  elements.ludfBenchmarkResults.innerHTML = `<table><thead><tr><th scope="col">Phase</th><th scope="col">Milliseconds</th></tr></thead><tbody>${timingRows
+  const phaseTable = `<table><thead><tr><th scope="col">Phase</th><th scope="col">Milliseconds</th></tr></thead><tbody>${timingRows
     .map(
       ([phase, label, milliseconds]) =>
         `<tr data-ludf-phase="${phase}"><th scope="row">${label}</th><td>${milliseconds.toFixed(2)}</td></tr>`
     )
     .join('')}</tbody></table>`;
+  const workloadRows = Object.entries(result.workloads)
+    .map(
+      ([name, workload]) =>
+        `<tr data-ludf-workload="${name}"><th scope="row">${name}</th><td>${workload.cpuMilliseconds.toFixed(2)}</td><td>${workload.gpuMilliseconds.toFixed(2)}</td><td>${formatBenchmarkThroughput(workload.gpuRowsPerSecond)}</td><td>${workload.speedup.toFixed(2)}×</td></tr>`
+    )
+    .join('');
+  const crossover = [...history]
+    .sort((left, right) => left.rowCount - right.rowCount)
+    .find(
+      measurement => measurement.timings.cpuMilliseconds > measurement.timings.executionMilliseconds
+    );
+  const crossoverMessage = crossover
+    ? `Measured end-to-end GPU crossover: ${crossover.rowCount.toLocaleString()} rows.`
+    : 'No GPU crossover observed yet; compare larger datasets on this device.';
+  elements.ludfBenchmarkResults.innerHTML = `${phaseTable}
+    <p class="workload-title">MEDIAN OPERATION COMPARISONS</p>
+    <p class="workload-metadata">${result.measurement.warmupIterations} warmup · ${result.measurement.iterations} measured sample${result.measurement.iterations === 1 ? '' : 's'} · GPU durations include completion fences</p>
+    <table class="workload-table"><thead><tr><th scope="col">Operation</th><th scope="col">CPU ms</th><th scope="col">GPU ms</th><th scope="col">GPU rows/s</th><th scope="col">GPU speedup</th></tr></thead><tbody>${workloadRows}</tbody></table>
+    <p class="benchmark-crossover" data-ludf-crossover>${crossoverMessage}</p>`;
   const validated = Object.values(result.validation).every(Boolean);
   elements.ludfBenchmarkResults.dataset.state = validated ? 'ok' : 'error';
   elements.ludfBenchmarkResults.dataset.validated = String(validated);
   elements.ludfBenchmarkStatus.textContent = validated
     ? `${result.rowCount.toLocaleString()} Arrow rows · batches ${result.batchRowCounts.join(' / ')} · filter, grouping, sorting, and joins match the CPU reference · ${result.readbackBytes.toLocaleString()} summary bytes read`
     : 'GPU dataframe results did not match their equivalent CPU reference.';
+}
+
+function formatBenchmarkThroughput(rowsPerSecond: number): string {
+  if (rowsPerSecond >= 1_000_000) return `${(rowsPerSecond / 1_000_000).toFixed(2)}M`;
+  if (rowsPerSecond >= 1_000) return `${(rowsPerSecond / 1_000).toFixed(1)}K`;
+  return rowsPerSecond.toFixed(0);
 }
 
 function getErrorMessage(error: unknown): string {

--- a/examples/experimental/gpu-data-analysis/src/ludf-benchmark.ts
+++ b/examples/experimental/gpu-data-analysis/src/ludf-benchmark.ts
@@ -24,8 +24,11 @@ import {
 import {GPUVector, type GPUData} from '@luma.gl/tables';
 import * as arrow from 'apache-arrow';
 
-const DEFAULT_ROW_COUNT = 512;
-const MAXIMUM_ROW_COUNT = 4096;
+const DEFAULT_ROW_COUNT = 65_536;
+const MAXIMUM_ROW_COUNT = 1_048_576;
+const DEFAULT_MEASUREMENT_ITERATIONS = 3;
+const DEFAULT_WARMUP_ITERATIONS = 1;
+const MAXIMUM_MEASUREMENT_ITERATIONS = 9;
 const SLICE_OFFSET = 9;
 const CATEGORY_LABELS = ['North', 'East', 'South', 'West'] as const;
 const MINIMUM_FARE = 20;
@@ -64,16 +67,20 @@ type BenchmarkRightColumns = {
 type BenchmarkDataset = {
   left: arrow.Table<BenchmarkArrowColumns>;
   right: arrow.Table<BenchmarkRightArrowColumns>;
-  rows: readonly BenchmarkSourceRow[];
+  rows: BenchmarkSourceRows;
   batchRowCounts: readonly number[];
 };
 
-type BenchmarkSourceRow = {
-  rowId: number;
-  batchIndex: number;
-  fare: number | null;
-  category: number | null;
+type BenchmarkSourceRows = {
+  fares: Float32Array;
+  categories: Uint32Array;
+  fareValidity: Uint8Array;
+  categoryValidity: Uint8Array;
+  rowCount: number;
+  sliceOffset: number;
 };
+
+type BenchmarkWorkloadName = 'filter' | 'groups' | 'sorting' | 'join';
 
 type BenchmarkReference = {
   filterCounts: number[];
@@ -113,6 +120,21 @@ export type LuDataFrameBenchmarkTimings = {
   cpuMilliseconds: number;
 };
 
+/** Median fence-synchronized GPU and equivalent CPU measurements for one dataframe operation. */
+export type LuDataFrameBenchmarkWorkload = {
+  cpuMilliseconds: number;
+  gpuMilliseconds: number;
+  cpuRowsPerSecond: number;
+  gpuRowsPerSecond: number;
+  speedup: number;
+};
+
+/** Repetition policy used to prevent a single cold submission from masquerading as throughput. */
+export type LuDataFrameBenchmarkMeasurement = {
+  iterations: number;
+  warmupIterations: number;
+};
+
 /** Small independently verified outputs; full Arrow columns are never read back from the GPU. */
 export type LuDataFrameBenchmarkSummaries = {
   filterCount: number;
@@ -128,6 +150,8 @@ export type LuDataFrameBenchmarkResult = {
   rowCount: number;
   batchRowCounts: number[];
   timings: LuDataFrameBenchmarkTimings;
+  workloads: Record<BenchmarkWorkloadName, LuDataFrameBenchmarkWorkload>;
+  measurement: LuDataFrameBenchmarkMeasurement;
   validation: {
     filter: boolean;
     groups: boolean;
@@ -141,7 +165,17 @@ export type LuDataFrameBenchmarkResult = {
 /** Runs real Arrow uploads and correctness-gated dataframe workloads only when explicitly invoked. */
 export async function runLuDataFrameBenchmark(
   device: Device,
-  {rowCount = DEFAULT_ROW_COUNT, signal}: {rowCount?: number; signal?: AbortSignal} = {}
+  {
+    rowCount = DEFAULT_ROW_COUNT,
+    iterations = DEFAULT_MEASUREMENT_ITERATIONS,
+    warmupIterations = DEFAULT_WARMUP_ITERATIONS,
+    signal
+  }: {
+    rowCount?: number;
+    iterations?: number;
+    warmupIterations?: number;
+    signal?: AbortSignal;
+  } = {}
 ): Promise<LuDataFrameBenchmarkResult> {
   if (device.type !== 'webgpu') {
     throw new Error('The luDF benchmark requires a WebGPU device');
@@ -149,12 +183,39 @@ export async function runLuDataFrameBenchmark(
   if (!Number.isSafeInteger(rowCount) || rowCount < 2 || rowCount > MAXIMUM_ROW_COUNT) {
     throw new Error(`The luDF benchmark requires between 2 and ${MAXIMUM_ROW_COUNT} rows`);
   }
+  if (
+    !Number.isSafeInteger(iterations) ||
+    iterations < 1 ||
+    iterations > MAXIMUM_MEASUREMENT_ITERATIONS
+  ) {
+    throw new Error(
+      `The luDF benchmark requires between 1 and ${MAXIMUM_MEASUREMENT_ITERATIONS} measured iterations`
+    );
+  }
+  if (
+    !Number.isSafeInteger(warmupIterations) ||
+    warmupIterations < 0 ||
+    warmupIterations > MAXIMUM_MEASUREMENT_ITERATIONS
+  ) {
+    throw new Error(
+      `The luDF benchmark requires between 0 and ${MAXIMUM_MEASUREMENT_ITERATIONS} warmup iterations`
+    );
+  }
   signal?.throwIfAborted();
 
   const dataset = createBenchmarkDataset(rowCount);
-  const cpuStarted = performance.now();
   const reference = createBenchmarkReference(dataset.rows, dataset.batchRowCounts);
-  const cpuMilliseconds = performance.now() - cpuStarted;
+  const cpuSamples = measureBenchmarkCPUWorkloads(
+    dataset.rows,
+    dataset.batchRowCounts,
+    iterations,
+    warmupIterations,
+    signal
+  );
+  const cpuMilliseconds = Object.values(cpuSamples).reduce(
+    (sum, samples) => sum + getBenchmarkMedian(samples),
+    0
+  );
 
   const ownedBuffers: Buffer[] = [];
   let left: LuDataFrame<BenchmarkColumns> | undefined;
@@ -193,20 +254,32 @@ export async function runLuDataFrameBenchmark(
       'ludf-benchmark-standalone-index',
       signal
     );
-    let executionMilliseconds = 0;
+    const gpuSamples: Record<BenchmarkWorkloadName, number[]> = {
+      filter: [],
+      groups: [],
+      sorting: [],
+      join: []
+    };
     for (const [name, graph] of [
       ['filter', graphs.filter],
       ['groups', graphs.groups],
       ['sorting', graphs.sorting],
       ['join', graphs.join]
     ] as const) {
-      executionMilliseconds += await executeBenchmarkGraph(
-        device,
-        graph,
-        `ludf-benchmark-${name}`,
-        signal
-      );
+      for (let iteration = 0; iteration < warmupIterations + iterations; iteration++) {
+        const milliseconds = await executeBenchmarkGraph(
+          device,
+          graph,
+          `ludf-benchmark-${name}-${iteration}`,
+          signal
+        );
+        if (iteration >= warmupIterations) gpuSamples[name].push(milliseconds);
+      }
     }
+    const executionMilliseconds = Object.values(gpuSamples).reduce(
+      (sum, samples) => sum + getBenchmarkMedian(samples),
+      0
+    );
 
     const readbackStarted = performance.now();
     const bytes = {value: 0};
@@ -269,7 +342,16 @@ export async function runLuDataFrameBenchmark(
       compareNestedNumberArrays(joinRightRowIds, reference.joinRightRowIds);
 
     if (!filter || !groups || !sorting || !join) {
-      throw new Error('The luDF benchmark GPU outputs do not match the shared CPU reference');
+      const failedWorkloads = Object.entries({filter, groups, sorting, join})
+        .filter(([, valid]) => !valid)
+        .map(([name]) => name)
+        .join(', ');
+      throw new Error(
+        `The luDF benchmark GPU outputs do not match the CPU reference: ${failedWorkloads}` +
+          (!groups
+            ? ` (GPU sums ${groupSums.join(', ')}; CPU sums ${reference.groupSums.join(', ')})`
+            : '')
+      );
     }
     signal?.throwIfAborted();
     return {
@@ -283,6 +365,25 @@ export async function runLuDataFrameBenchmark(
         readbackMilliseconds,
         cpuMilliseconds
       },
+      workloads: {
+        filter: summarizeLuDataFrameBenchmarkSamples(
+          rowCount,
+          cpuSamples.filter,
+          gpuSamples.filter
+        ),
+        groups: summarizeLuDataFrameBenchmarkSamples(
+          rowCount,
+          cpuSamples.groups,
+          gpuSamples.groups
+        ),
+        sorting: summarizeLuDataFrameBenchmarkSamples(
+          rowCount,
+          cpuSamples.sorting,
+          gpuSamples.sorting
+        ),
+        join: summarizeLuDataFrameBenchmarkSamples(rowCount, cpuSamples.join, gpuSamples.join)
+      },
+      measurement: {iterations, warmupIterations},
       validation: {filter, groups, sorting, join},
       summaries: {
         filterCount: filterCounts.reduce((total, count) => total + count, 0),
@@ -311,14 +412,22 @@ export async function runLuDataFrameBenchmark(
 /** Constructs sliced nullable Arrow columns and dictionary-compatible independent right batches. */
 function createBenchmarkDataset(rowCount: number): BenchmarkDataset {
   const totalRows = rowCount + SLICE_OFFSET;
-  const fares: (number | null)[] = [];
+  const fares = new Float32Array(totalRows);
   const categories = new Uint32Array(totalRows);
   const tripIds = new Uint32Array(totalRows);
+  const fareBitmap = new Uint8Array(Math.ceil(totalRows / 8));
   const categoryBitmap = new Uint8Array(Math.ceil(totalRows / 8));
+  let fareNullCount = 0;
   let categoryNullCount = 0;
 
   for (let index = 0; index < totalRows; index++) {
-    fares.push(index % 13 === 0 ? null : Math.fround(((index * 37) % 121) - 30 + (index % 7) / 10));
+    // Half-integer fares and the half-integer adjustment keep million-row sums exactly representable.
+    fares[index] = Math.fround(((index * 37) % 121) - 30 + 0.5);
+    if (index % 13 === 0) {
+      fareNullCount++;
+    } else {
+      fareBitmap[index >> 3] |= 1 << (index & 7);
+    }
     categories[index] = index % CATEGORY_LABELS.length;
     tripIds[index] = index - SLICE_OFFSET >= 0 ? index - SLICE_OFFSET : 0;
     if (index % 11 === 0) {
@@ -339,7 +448,15 @@ function createBenchmarkDataset(rowCount: number): BenchmarkDataset {
     dictionary
   });
   const categoryVector = new arrow.Vector([categoryData]);
-  const fareVector = arrow.vectorFromArray(fares, new arrow.Float32());
+  const fareVector = new arrow.Vector([
+    arrow.makeData({
+      type: new arrow.Float32(),
+      length: totalRows,
+      data: fares,
+      nullBitmap: fareBitmap,
+      nullCount: fareNullCount
+    })
+  ]);
   const tripIdVector = arrow.makeVector(tripIds);
   const fields = [
     new arrow.Field('fare', new arrow.Float32(), true, new Map([['unit', 'USD']])),
@@ -415,70 +532,173 @@ function createBenchmarkDataset(rowCount: number): BenchmarkDataset {
     );
   });
 
-  const rows: BenchmarkSourceRow[] = [];
-  for (let rowId = 0; rowId < rowCount; rowId++) {
-    const sourceIndex = rowId + SLICE_OFFSET;
-    rows.push({
-      rowId,
-      batchIndex: rowId < midpoint ? 0 : 2,
-      fare: fares[sourceIndex],
-      category: sourceIndex % 11 === 0 ? null : categories[sourceIndex]
-    });
-  }
   return {
     left: new arrow.Table(schema, batches),
     right: new arrow.Table(rightSchema, rightBatches),
-    rows,
+    rows: {
+      fares,
+      categories,
+      fareValidity: fareBitmap,
+      categoryValidity: categoryBitmap,
+      rowCount,
+      sliceOffset: SLICE_OFFSET
+    },
     batchRowCounts: [midpoint, 0, rowCount - midpoint]
   };
 }
 
 /** Computes exact source-batch-aware CPU oracles for every independent GPU workload. */
 function createBenchmarkReference(
-  rows: readonly BenchmarkSourceRow[],
+  rows: BenchmarkSourceRows,
   batchRowCounts: readonly number[]
 ): BenchmarkReference {
-  const filterCounts = batchRowCounts.map(() => 0);
+  return {
+    filterCounts: createBenchmarkFilterReference(rows, batchRowCounts),
+    ...createBenchmarkGroupReference(rows),
+    topKRowIds: createBenchmarkSortingReference(rows, batchRowCounts),
+    ...createBenchmarkJoinReference(rows, batchRowCounts)
+  };
+}
+
+/** Times equivalent CPU operations independently so fused JavaScript work cannot bias comparisons. */
+function measureBenchmarkCPUWorkloads(
+  rows: BenchmarkSourceRows,
+  batchRowCounts: readonly number[],
+  iterations: number,
+  warmupIterations: number,
+  signal: AbortSignal | undefined
+): Record<BenchmarkWorkloadName, number[]> {
+  const samples: Record<BenchmarkWorkloadName, number[]> = {
+    filter: [],
+    groups: [],
+    sorting: [],
+    join: []
+  };
+  const workloads = {
+    filter: () => createBenchmarkFilterReference(rows, batchRowCounts),
+    groups: () => createBenchmarkGroupReference(rows),
+    sorting: () => createBenchmarkSortingReference(rows, batchRowCounts),
+    join: () => createBenchmarkJoinReference(rows, batchRowCounts)
+  };
+  for (const name of ['filter', 'groups', 'sorting', 'join'] as const) {
+    for (let iteration = 0; iteration < warmupIterations + iterations; iteration++) {
+      signal?.throwIfAborted();
+      const started = performance.now();
+      workloads[name]();
+      const milliseconds = performance.now() - started;
+      if (iteration >= warmupIterations) samples[name].push(milliseconds);
+    }
+  }
+  return samples;
+}
+
+/** Checks packed nullable Arrow bitmaps without allocating one JavaScript object per source row. */
+function isBenchmarkRowSelected(rows: BenchmarkSourceRows, rowId: number): boolean {
+  const sourceIndex = rowId + rows.sliceOffset;
+  const mask = 1 << (sourceIndex & 7);
+  return (
+    (rows.fareValidity[sourceIndex >> 3] & mask) !== 0 &&
+    (rows.categoryValidity[sourceIndex >> 3] & mask) !== 0 &&
+    rows.fares[sourceIndex] > MINIMUM_FARE
+  );
+}
+
+function createBenchmarkFilterReference(
+  rows: BenchmarkSourceRows,
+  batchRowCounts: readonly number[]
+): number[] {
+  const counts = batchRowCounts.map(() => 0);
+  const midpoint = batchRowCounts[0];
+  for (let rowId = 0; rowId < rows.rowCount; rowId++) {
+    if (isBenchmarkRowSelected(rows, rowId)) counts[rowId < midpoint ? 0 : 2]++;
+  }
+  return counts;
+}
+
+function createBenchmarkGroupReference(rows: BenchmarkSourceRows): {
+  groupCounts: number[];
+  groupSums: number[];
+} {
   const groupCounts = CATEGORY_LABELS.map(() => 0);
   const groupSums = CATEGORY_LABELS.map(() => 0);
-  const selectedByBatch = batchRowCounts.map(
-    () => [] as Array<{rowId: number; adjusted: number; category: number}>
-  );
-
-  for (const row of rows) {
-    if (row.fare === null || row.fare <= MINIMUM_FARE || row.category === null) {
-      continue;
-    }
-    const adjusted = Math.fround(row.fare + DRIVER_TIP);
-    filterCounts[row.batchIndex]++;
-    groupCounts[row.category]++;
-    groupSums[row.category] += adjusted;
-    selectedByBatch[row.batchIndex].push({rowId: row.rowId, adjusted, category: row.category});
+  for (let rowId = 0; rowId < rows.rowCount; rowId++) {
+    if (!isBenchmarkRowSelected(rows, rowId)) continue;
+    const sourceIndex = rowId + rows.sliceOffset;
+    const category = rows.categories[sourceIndex];
+    groupCounts[category]++;
+    groupSums[category] += Math.fround(rows.fares[sourceIndex] + DRIVER_TIP);
   }
+  return {groupCounts, groupSums};
+}
 
-  const topKRowIds = selectedByBatch.map(values =>
-    [...values]
-      .sort((left, right) => right.adjusted - left.adjusted || left.rowId - right.rowId)
+function createBenchmarkSortingReference(
+  rows: BenchmarkSourceRows,
+  batchRowCounts: readonly number[]
+): number[][] {
+  const midpoint = batchRowCounts[0];
+  const selectedByBatch: number[][] = batchRowCounts.map(() => []);
+  for (let rowId = 0; rowId < rows.rowCount; rowId++) {
+    if (isBenchmarkRowSelected(rows, rowId)) {
+      selectedByBatch[rowId < midpoint ? 0 : 2].push(rowId);
+    }
+  }
+  return selectedByBatch.map(rowIds =>
+    rowIds
+      .sort(
+        (left, right) =>
+          rows.fares[right + rows.sliceOffset] - rows.fares[left + rows.sliceOffset] || left - right
+      )
       .slice(0, TOP_K_LIMIT)
-      .map(row => row.rowId)
   );
-  const joinRequiredCounts = selectedByBatch.map(values => values.length);
-  const joinLeftRowIds = selectedByBatch.map(values =>
-    values.slice(0, JOIN_CAPACITY).map(row => row.rowId)
-  );
-  const joinRightRowIds = selectedByBatch.map(values =>
-    values.slice(0, JOIN_CAPACITY).map(row => row.category)
-  );
+}
 
+function createBenchmarkJoinReference(
+  rows: BenchmarkSourceRows,
+  batchRowCounts: readonly number[]
+): Pick<BenchmarkReference, 'joinRequiredCounts' | 'joinLeftRowIds' | 'joinRightRowIds'> {
+  const joinRequiredCounts = batchRowCounts.map(() => 0);
+  const joinLeftRowIds: number[][] = batchRowCounts.map(() => []);
+  const joinRightRowIds: number[][] = batchRowCounts.map(() => []);
+  const midpoint = batchRowCounts[0];
+  for (let rowId = 0; rowId < rows.rowCount; rowId++) {
+    if (!isBenchmarkRowSelected(rows, rowId)) continue;
+    const batchIndex = rowId < midpoint ? 0 : 2;
+    joinRequiredCounts[batchIndex]++;
+    if (joinLeftRowIds[batchIndex].length < JOIN_CAPACITY) {
+      joinLeftRowIds[batchIndex].push(rowId);
+      joinRightRowIds[batchIndex].push(rows.categories[rowId + rows.sliceOffset]);
+    }
+  }
+  return {joinRequiredCounts, joinLeftRowIds, joinRightRowIds};
+}
+
+/** Summarizes observed CPU/GPU samples without inventing a crossover or including setup phases. */
+export function summarizeLuDataFrameBenchmarkSamples(
+  rowCount: number,
+  cpuSamples: readonly number[],
+  gpuSamples: readonly number[]
+): LuDataFrameBenchmarkWorkload {
+  if (!Number.isSafeInteger(rowCount) || rowCount < 1) {
+    throw new Error('Benchmark throughput requires a positive row count');
+  }
+  const cpuMilliseconds = getBenchmarkMedian(cpuSamples);
+  const gpuMilliseconds = getBenchmarkMedian(gpuSamples);
   return {
-    filterCounts,
-    groupCounts,
-    groupSums,
-    topKRowIds,
-    joinRequiredCounts,
-    joinLeftRowIds,
-    joinRightRowIds
+    cpuMilliseconds,
+    gpuMilliseconds,
+    cpuRowsPerSecond: cpuMilliseconds > 0 ? (rowCount * 1000) / cpuMilliseconds : 0,
+    gpuRowsPerSecond: gpuMilliseconds > 0 ? (rowCount * 1000) / gpuMilliseconds : 0,
+    speedup: gpuMilliseconds > 0 ? cpuMilliseconds / gpuMilliseconds : 0
   };
+}
+
+function getBenchmarkMedian(samples: readonly number[]): number {
+  if (samples.length === 0 || samples.some(sample => !Number.isFinite(sample) || sample < 0)) {
+    throw new Error('Benchmark samples must contain finite nonnegative durations');
+  }
+  const sorted = [...samples].sort((left, right) => left - right);
+  const midpoint = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[midpoint - 1] + sorted[midpoint]) / 2 : sorted[midpoint];
 }
 
 /** Compiles four reusable dataframe workloads plus one truthful, standalone equivalent index. */

--- a/examples/experimental/gpu-data-analysis/src/ludf-benchmark.ts
+++ b/examples/experimental/gpu-data-analysis/src/ludf-benchmark.ts
@@ -204,7 +204,7 @@ export async function runLuDataFrameBenchmark(
   signal?.throwIfAborted();
 
   const dataset = createBenchmarkDataset(rowCount);
-  const reference = createBenchmarkReference(dataset.rows, dataset.batchRowCounts);
+  const reference = createLuDataFrameBenchmarkReference(dataset.rows, dataset.batchRowCounts);
   const cpuSamples = measureBenchmarkCPUWorkloads(
     dataset.rows,
     dataset.batchRowCounts,
@@ -547,8 +547,8 @@ function createBenchmarkDataset(rowCount: number): BenchmarkDataset {
   };
 }
 
-/** Computes exact source-batch-aware CPU oracles for every independent GPU workload. */
-function createBenchmarkReference(
+/** @internal Computes equivalent projected CPU work for every independent GPU workload. */
+export function createLuDataFrameBenchmarkReference(
   rows: BenchmarkSourceRows,
   batchRowCounts: readonly number[]
 ): BenchmarkReference {
@@ -603,10 +603,20 @@ function isBenchmarkRowSelected(rows: BenchmarkSourceRows, rowId: number): boole
   );
 }
 
+/** Materializes the same complete float32 projection present in every compiled GPU query. */
+function createBenchmarkAdjustedFares(rows: BenchmarkSourceRows): Float32Array {
+  const adjustedFares = new Float32Array(rows.rowCount);
+  for (let rowId = 0; rowId < rows.rowCount; rowId++) {
+    adjustedFares[rowId] = Math.fround(rows.fares[rowId + rows.sliceOffset] + DRIVER_TIP);
+  }
+  return adjustedFares;
+}
+
 function createBenchmarkFilterReference(
   rows: BenchmarkSourceRows,
   batchRowCounts: readonly number[]
 ): number[] {
+  createBenchmarkAdjustedFares(rows);
   const counts = batchRowCounts.map(() => 0);
   const midpoint = batchRowCounts[0];
   for (let rowId = 0; rowId < rows.rowCount; rowId++) {
@@ -619,6 +629,7 @@ function createBenchmarkGroupReference(rows: BenchmarkSourceRows): {
   groupCounts: number[];
   groupSums: number[];
 } {
+  const adjustedFares = createBenchmarkAdjustedFares(rows);
   const groupCounts = CATEGORY_LABELS.map(() => 0);
   const groupSums = CATEGORY_LABELS.map(() => 0);
   for (let rowId = 0; rowId < rows.rowCount; rowId++) {
@@ -626,7 +637,7 @@ function createBenchmarkGroupReference(rows: BenchmarkSourceRows): {
     const sourceIndex = rowId + rows.sliceOffset;
     const category = rows.categories[sourceIndex];
     groupCounts[category]++;
-    groupSums[category] += Math.fround(rows.fares[sourceIndex] + DRIVER_TIP);
+    groupSums[category] += adjustedFares[rowId];
   }
   return {groupCounts, groupSums};
 }
@@ -635,6 +646,7 @@ function createBenchmarkSortingReference(
   rows: BenchmarkSourceRows,
   batchRowCounts: readonly number[]
 ): number[][] {
+  const adjustedFares = createBenchmarkAdjustedFares(rows);
   const midpoint = batchRowCounts[0];
   const selectedByBatch: number[][] = batchRowCounts.map(() => []);
   for (let rowId = 0; rowId < rows.rowCount; rowId++) {
@@ -644,10 +656,7 @@ function createBenchmarkSortingReference(
   }
   return selectedByBatch.map(rowIds =>
     rowIds
-      .sort(
-        (left, right) =>
-          rows.fares[right + rows.sliceOffset] - rows.fares[left + rows.sliceOffset] || left - right
-      )
+      .sort((left, right) => adjustedFares[right] - adjustedFares[left] || left - right)
       .slice(0, TOP_K_LIMIT)
   );
 }
@@ -656,6 +665,7 @@ function createBenchmarkJoinReference(
   rows: BenchmarkSourceRows,
   batchRowCounts: readonly number[]
 ): Pick<BenchmarkReference, 'joinRequiredCounts' | 'joinLeftRowIds' | 'joinRightRowIds'> {
+  createBenchmarkAdjustedFares(rows);
   const joinRequiredCounts = batchRowCounts.map(() => 0);
   const joinLeftRowIds: number[][] = batchRowCounts.map(() => []);
   const joinRightRowIds: number[][] = batchRowCounts.map(() => []);

--- a/test/examples/ludf-analysis.node.spec.ts
+++ b/test/examples/ludf-analysis.node.spec.ts
@@ -98,7 +98,12 @@ describe('luDF dataframe documentation and opt-in Arrow benchmark integration', 
     expect(exampleShell).toContain('data-validated="false"');
     expect(example).toContain("addEventListener('click', this.handleLuDataFrameBenchmark)");
     expect(example).toContain('this.benchmarkController?.abort()');
-    expect(example).toContain('rowCount: 384');
+    expect(exampleShell).toContain('data-ludf-benchmark-rows');
+    expect(exampleShell).toContain('data-ludf-benchmark-iterations');
+    expect(exampleShell).toContain('1,048,576 rows');
+    expect(example).toContain('warmupIterations: 1');
+    expect(example).toContain('MEDIAN OPERATION COMPARISONS');
+    expect(example).toContain('data-ludf-crossover');
 
     for (const phase of ['upload', 'compile', 'index', 'execution', 'readback', 'cpu']) {
       expect(example).toContain(`['${phase}',`);
@@ -124,6 +129,9 @@ describe('luDF dataframe documentation and opt-in Arrow benchmark integration', 
     expect(benchmark).toContain('createFence');
     expect(benchmark).toContain('readbackBytes');
     expect(benchmark).toContain('signal');
+    expect(benchmark).toContain('MAXIMUM_ROW_COUNT = 1_048_576');
+    expect(benchmark).toContain('summarizeLuDataFrameBenchmarkSamples');
+    expect(benchmark).not.toContain('BenchmarkSourceRow[]');
     expect(tablesPackage.dependencies?.['apache-arrow']).toBeUndefined();
     expect(gpuPackage.dependencies?.['apache-arrow']).toBeUndefined();
   });

--- a/test/examples/ludf-analysis.spec.ts
+++ b/test/examples/ludf-analysis.spec.ts
@@ -20,7 +20,11 @@ describe('Arrow-driven luDF dataframe example', () => {
       return;
     }
 
-    const result = await runLuDataFrameBenchmark(device, {rowCount: 128});
+    const result = await runLuDataFrameBenchmark(device, {
+      rowCount: 128,
+      iterations: 2,
+      warmupIterations: 1
+    });
 
     expect(result.rowCount).toBe(128);
     expect(result.batchRowCounts).toHaveLength(3);
@@ -42,6 +46,15 @@ describe('Arrow-driven luDF dataframe example', () => {
     expect(result.summaries.joinRightRowIds[1]).toEqual([]);
     expect(result.readbackBytes).toBeGreaterThan(0);
     expect(result.readbackBytes).toBeLessThanOrEqual(1024);
+    expect(result.measurement).toEqual({iterations: 2, warmupIterations: 1});
+
+    for (const workload of Object.values(result.workloads)) {
+      expect(workload.cpuMilliseconds).toBeGreaterThanOrEqual(0);
+      expect(workload.gpuMilliseconds).toBeGreaterThanOrEqual(0);
+      expect(workload.cpuRowsPerSecond).toBeGreaterThanOrEqual(0);
+      expect(workload.gpuRowsPerSecond).toBeGreaterThanOrEqual(0);
+      expect(workload.speedup).toBeGreaterThanOrEqual(0);
+    }
 
     for (const phase of [
       result.timings.uploadMilliseconds,
@@ -55,6 +68,23 @@ describe('Arrow-driven luDF dataframe example', () => {
       expect(phase).toBeGreaterThanOrEqual(0);
     }
   }, 30_000);
+
+  test('executes datasets larger than the former 4,096-row benchmark ceiling', async () => {
+    const device = await getWebGPUTestDevice();
+    if (!device) return;
+
+    const result = await runLuDataFrameBenchmark(device, {
+      rowCount: 8192,
+      iterations: 1,
+      warmupIterations: 0
+    });
+
+    expect(result.rowCount).toBe(8192);
+    expect(result.batchRowCounts).toEqual([4096, 0, 4096]);
+    expect(result.validation).toEqual({filter: true, groups: true, sorting: true, join: true});
+    expect(result.readbackBytes).toBeLessThanOrEqual(1024);
+    expect(result.workloads.sorting.gpuRowsPerSecond).toBeGreaterThan(0);
+  }, 45_000);
 
   test('runs the real WebGPU benchmark only after an explicit interactive request', async () => {
     const availableDevice = await getWebGPUTestDevice();
@@ -74,6 +104,14 @@ describe('Arrow-driven luDF dataframe example', () => {
       dataset.value = 'small';
 
       const button = getRequiredElement<HTMLButtonElement>(root, '#analysis-ludf-benchmark-run');
+      const benchmarkRows = getRequiredElement<HTMLSelectElement>(
+        root,
+        '[data-ludf-benchmark-rows]'
+      );
+      const benchmarkIterations = getRequiredElement<HTMLSelectElement>(
+        root,
+        '[data-ludf-benchmark-iterations]'
+      );
       const status = getRequiredElement<HTMLElement>(root, '#analysis-ludf-benchmark-status');
       const results = getRequiredElement<HTMLElement>(root, '#analysis-ludf-benchmark-results');
 
@@ -83,6 +121,9 @@ describe('Arrow-driven luDF dataframe example', () => {
       expect(results.dataset.state).toBe('idle');
       expect(results.dataset.validated).toBe('false');
       expect(results.querySelectorAll('[data-ludf-phase]')).toHaveLength(0);
+      expect(Array.from(benchmarkRows.options, option => option.value)).toContain('1048576');
+      benchmarkRows.value = '1024';
+      benchmarkIterations.value = '1';
 
       await vi.waitFor(
         () => {
@@ -116,9 +157,11 @@ describe('Arrow-driven luDF dataframe example', () => {
         expect(Number.isFinite(milliseconds)).toBe(true);
         expect(milliseconds).toBeGreaterThanOrEqual(0);
       }
-      expect(status.textContent).toContain('384');
+      expect(status.textContent).toContain('1,024');
       expect(status.textContent).toMatch(/filter, grouping, sorting, and joins match/i);
       expect(status.textContent).toMatch(/summary bytes read/i);
+      expect(results.querySelectorAll('[data-ludf-workload]')).toHaveLength(4);
+      expect(results.querySelector('[data-ludf-crossover]')?.textContent).toMatch(/crossover/i);
     } finally {
       example?.destroy();
       root.remove();

--- a/test/examples/ludf-million-row-benchmark.node.spec.ts
+++ b/test/examples/ludf-million-row-benchmark.node.spec.ts
@@ -1,0 +1,42 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {summarizeLuDataFrameBenchmarkSamples} from '../../examples/experimental/gpu-data-analysis/src/ludf-benchmark';
+
+describe('million-row luDF benchmark measurements', () => {
+  test('reports median CPU/GPU durations, observed throughput, and honest speedup', () => {
+    expect(summarizeLuDataFrameBenchmarkSamples(1_000_000, [24, 8, 12], [10, 4, 6])).toEqual({
+      cpuMilliseconds: 12,
+      gpuMilliseconds: 6,
+      cpuRowsPerSecond: 1_000_000_000 / 12,
+      gpuRowsPerSecond: 1_000_000_000 / 6,
+      speedup: 2
+    });
+  });
+
+  test('averages the middle observations for an even number of samples', () => {
+    const result = summarizeLuDataFrameBenchmarkSamples(4096, [14, 6, 18, 10], [9, 3, 7, 5]);
+    expect(result.cpuMilliseconds).toBe(12);
+    expect(result.gpuMilliseconds).toBe(6);
+    expect(result.speedup).toBe(2);
+  });
+
+  test('does not invent throughput or speedup from zero-duration observations', () => {
+    expect(summarizeLuDataFrameBenchmarkSamples(1024, [0], [0])).toEqual({
+      cpuMilliseconds: 0,
+      gpuMilliseconds: 0,
+      cpuRowsPerSecond: 0,
+      gpuRowsPerSecond: 0,
+      speedup: 0
+    });
+  });
+
+  test('rejects invalid row counts and invalid timing observations', () => {
+    expect(() => summarizeLuDataFrameBenchmarkSamples(0, [1], [1])).toThrow(/row count/i);
+    expect(() => summarizeLuDataFrameBenchmarkSamples(1024, [], [1])).toThrow(/samples/i);
+    expect(() => summarizeLuDataFrameBenchmarkSamples(1024, [1], [Number.NaN])).toThrow(/samples/i);
+    expect(() => summarizeLuDataFrameBenchmarkSamples(1024, [-1], [1])).toThrow(/samples/i);
+  });
+});

--- a/test/examples/ludf-million-row-benchmark.node.spec.ts
+++ b/test/examples/ludf-million-row-benchmark.node.spec.ts
@@ -2,10 +2,42 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import {describe, expect, test} from 'vitest';
-import {summarizeLuDataFrameBenchmarkSamples} from '../../examples/experimental/gpu-data-analysis/src/ludf-benchmark';
+import {describe, expect, test, vi} from 'vitest';
+import {
+  createLuDataFrameBenchmarkReference,
+  summarizeLuDataFrameBenchmarkSamples
+} from '../../examples/experimental/gpu-data-analysis/src/ludf-benchmark';
 
 describe('million-row luDF benchmark measurements', () => {
+  test('materializes adjusted fares for every row of all four CPU workloads', () => {
+    const roundFloat32 = vi.spyOn(Math, 'fround');
+
+    try {
+      const reference = createLuDataFrameBenchmarkReference(
+        {
+          fares: Float32Array.from([999, 21, 30, 50, 10]),
+          categories: Uint32Array.from([0, 0, 1, 2, 3]),
+          fareValidity: Uint8Array.from([0xff]),
+          categoryValidity: Uint8Array.from([0xff]),
+          rowCount: 4,
+          sliceOffset: 1
+        },
+        [2, 0, 2]
+      );
+
+      expect(roundFloat32).toHaveBeenCalledTimes(16);
+      expect(roundFloat32.mock.calls.map(([fare]) => fare)).toEqual(
+        Array.from({length: 4}, () => [23.5, 32.5, 52.5, 12.5]).flat()
+      );
+      expect(reference.filterCounts).toEqual([2, 0, 1]);
+      expect(reference.groupSums).toEqual([23.5, 32.5, 52.5, 0]);
+      expect(reference.topKRowIds).toEqual([[1, 0], [], [2]]);
+      expect(reference.joinRequiredCounts).toEqual([2, 0, 1]);
+    } finally {
+      roundFloat32.mockRestore();
+    }
+  });
+
   test('reports median CPU/GPU durations, observed throughput, and honest speedup', () => {
     expect(summarizeLuDataFrameBenchmarkSamples(1_000_000, [24, 8, 12], [10, 4, 6])).toEqual({
       cpuMilliseconds: 12,


### PR DESCRIPTION
## Goals

Establish an honest, reproducible performance baseline for WebGPU data-frame workloads before tackling scalable dispatch, global ordering, and richer joins in subsequent tranches.

## Changes

- Scale the existing opt-in Arrow/luDF benchmark from its previous 4,096-row ceiling to selectable datasets of 1,024, 4,096, 65,536, 262,144, and 1,048,576 rows.
- Build genuine sliced, nullable, dictionary-backed Arrow record batches using packed typed arrays instead of allocating one JavaScript object per source row.
- Measure filtering, grouped aggregation, stable per-batch top-K, and bounded unique-right joins independently against equivalent CPU implementations.
- Exclude configurable warmup runs, summarize repeated CPU and fence-synchronized GPU samples by their median, and report rows/second, measured speedup, and observed crossover points.
- Preserve distinct upload, compile, standalone hash-index construction, GPU execution, bounded readback, and CPU timing phases without claiming index-build time can be subtracted from join execution.
- Use exactly representable half-integer fixture values so million-row GPU grouped sums remain directly comparable with the exact CPU oracle; validate filtering, grouping, sorting, joins, and compact readback for every execution.
- Document benchmark controls, statistical methodology, hardware limitations, and truthful performance interpretation.
- Add focused Node regressions for median calculation, invalid measurements, source/UI contracts, and real-WebGPU coverage above the former hard limit.

## Verification

- `yarn lint fix` — passed; 1,821 files checked.
- `yarn build` — passed for the complete monorepo after final formatting.
- `CI=1 yarn test` — passed: 1,942 Node tests and 1,941 Chromium/WebGPU tests; existing skips unchanged.
- `yarn website:build` — passed; 483 documentation pages validated.
- `(cd website && yarn build)` — passed; 483 documentation pages validated.
- `yarn examples:typecheck` — passed for 47 example workspaces.
- Dedicated real-WebGPU stress execution at exactly **1,048,576 rows** — passed with all four CPU-equivalent validation checks and bounded result readback.
- Git pre-commit hooks independently reran formatting checks and all 1,942 Node tests successfully.
- Dependencies were reused from an existing local worktree; `yarn install` was not required.

## Follow-up tranches

1. Scale remaining data-frame command-graph dispatch paths.
2. Add globally ordered sorting and top-K across preserved batches.
3. Expand GPU join capabilities while maintaining explicit diagnostics, ownership, and batching guarantees.

## Risks and limitations

- Performance crossover is hardware- and browser-dependent; the example reports only measured observations and does not claim an unconditional GPU speedup.
- Sorting remains per source batch, joins remain unique-right, and million-row execution still depends on the device's available storage and compute limits.
- The one-million-row stress case is intentionally run explicitly instead of imposing its resource requirements on every CI runner.
