### PR TITLE
test(splats): restore browser coverage

### DIFF
--- a/modules/splats/test/splat-browser-coverage.spec.ts
+++ b/modules/splats/test/splat-browser-coverage.spec.ts
@@ -1,0 +1,7 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import './gpu-splat-graph-interaction.node.spec';
+import './splat-gltf.node.spec';
+import './splat-hierarchy.node.spec';


### PR DESCRIPTION
## Goals

- Restore the master Coveralls gate after hierarchical splat code landed with browser coverage below the repository baseline.
- Reuse the existing deterministic tests instead of duplicating assertions or changing production behavior.

## Changes

- Add one browser test entry that imports the existing browser-safe `NullDevice` suites for splat hierarchy, glTF conversion, and graph interaction.
- Keep the original `.node.spec.ts` files as the node-project entries; browser/headless discovery executes the new bridge exactly once.

## Root cause

Master build 81043054 dropped from 73.870% to 73.189%. The three newly measured splat files contributed only 13 covered line/branch sites out of 895 because their substantive tests were node-only and therefore absent from the uploaded browser LCOV.

## Verification

- Focused headless Chromium: 26/26 tests passed in four consecutive runs.
- Focused Istanbul coverage: affected files improved from 13/895 to 808/895 covered line/branch sites.
- Exact master-LCOV projection: 58,323/78,595 = 74.207%, 0.337 percentage points above the prior green baseline.
- Biome 2.4.8 formatting and lint checks passed with repository rules; `git diff --check` passed.
- The repository `yarn lint fix` wrapper was attempted but the borrowed local install lacks `ocular-lint`; the direct current-Biome checks produced the canonical seven-line file.

## Risks

- Test-only change; no shipped code or public API changes.
- The imported suites use browser-safe typed arrays, promises, WGSL reflection, and `NullDevice`; they do not depend on Node built-ins or shared GPU state.
