### PR TITLE
feat(splats): add camera-driven out-of-core RAD rendering

### DIFF
--- a/docs/api-reference/splats/README.md
+++ b/docs/api-reference/splats/README.md
@@ -202,17 +202,64 @@ Train scene, the primary renderer buffers use approximately 45.3 MiB and graph s
 approximately 19.8 MiB; packed source columns add approximately 36.8 MiB separately.
 
 The projected-record allocation must fit the device's `maxStorageBufferBindingSize`. A 128 MiB
-storage-binding limit supports at most 2,796,202 splats in one graph. Larger active frontiers or
-constrained adapters require a different rendering strategy. Hierarchy and RAD integrations must
-limit their simultaneously resident frontier to this device-dependent capacity; the complete
-source hierarchy may contain many more rows. The showcase falls back to `SplatRenderer` when graph
-compilation fails synchronously.
+storage-binding limit supports at most 2,796,202 splats in one `GPUSplatGraphRenderer` graph. Use
+`GPUPagedSplatRenderer` when independent source pages or a larger active hierarchy frontier would
+exceed that projected-record limit. The original progressive graph remains useful when one known
+scene fits its single allocation.
 
 Reserving the final scene size avoids repeated graph compilation, but the global radix sort processes
 the entire reserved capacity on every dirty progressive frame, even while most source rows are
 still inactive. Oversized hints therefore trade higher early GPU work and memory for stable graph
 identity. The radix sort intentionally processes 16 significant depth bits; stable equal-key ties
 may be less precise than the CPU renderer's higher-precision depth ordering.
+
+## Segmented paged WebGPU rendering
+
+`GPUPagedSplatRenderer` projects independently owned source pages into bounded GPU segments while
+preserving one globally correct depth order across the entire active frontier:
+
+```ts
+import {GPUPagedSplatRenderer} from '@luma.gl/splats';
+
+const renderer = new GPUPagedSplatRenderer(webgpuDevice, {
+  viewportSize: [width, height],
+  pages: [
+    {id: 'rad:0', data: rootPage, activeRows: new Uint32Array([0, 4, 12])},
+    {id: 'rad:8', data: detailPage, activeRows: new Uint32Array([2, 7])}
+  ]
+});
+
+renderer.setFrontier(cameraSelectedSourcePages);
+const encoding = renderer.encode(commandEncoder);
+if (encoding) webgpuDevice.submit(commandEncoder.finish());
+
+console.log(renderer.stats.segmentCount, renderer.stats.activeRowCount);
+```
+
+`activeRows` contains original batch-local row indices; omit it to render every row in one source
+page. No source page or GPU column is concatenated, rewritten, or transferred to the renderer.
+Each sparse source segment projects only its selected rows, evaluates degree-one through
+degree-three directional harmonics, and applies GPU semantic include/exclude selections. Source
+bindings, including large harmonic columns, are split into legal device-sized ranges while every
+compute shader stays within the standard eight-storage-binding WebGPU guarantee.
+
+A global GPU radix sort orders compact four-byte source-row references across every page. The
+sorted permutation is scattered into separate 48-byte projected output segments, and one shared
+render pass draws those segments in global depth order using GPU-written indirect commands. This
+preserves transparency ordering even when rows from different pages overlap or interleave in
+depth; sorting pages independently would not.
+
+On a device with a 128 MiB storage-binding limit, the previous single-record graph supports at
+most 2,796,202 active rows; the paged renderer instead supports up to 33,554,432 simultaneously
+active four-byte global-sort references. Source datasets may be larger because original pages can
+enter and leave bounded residency. The four-byte global sort still has its own binding limit, and
+this renderer does not yet provide a dedicated segmented GPU picker or mixed-mesh helper.
+
+`maxProjectedSplatsPerSegment` can tighten the per-segment limit explicitly. `renderer.stats`
+reports original versus active rows, source/output segment counts, global sort capacity, exact
+borrowed-source and renderer-owned GPU bytes, and one indirect draw per output segment. The
+caller owns command submission and every source batch; destroy the renderer before releasing
+source pages.
 
 ## Source columns and rendering
 
@@ -449,6 +496,55 @@ or loader-owned. Prepared pages remain caller-owned by default; set `node.ownsDa
 the hierarchy should destroy an asynchronously decoded page on eviction or shutdown. An externally
 supplied residency manager is always borrowed and must be destroyed by its original owner.
 
+### Spark RAD row hierarchies
+
+Spark RAD hierarchy links belong to individual source rows, not whole source pages.
+`SplatRADHierarchyManager` preserves this distinction using the original page-local `childCounts`
+and source-global `childStarts` arrays:
+
+```ts
+import {GPUPagedSplatRenderer, SplatRADHierarchyManager} from '@luma.gl/splats';
+
+const renderer = new GPUPagedSplatRenderer(device, {viewportSize: [width, height]});
+const hierarchy = new SplatRADHierarchyManager({
+  pageSize: 65_536,
+  maximumActiveRows: 1_000_000,
+  residencyBudget: {maxResidentSplats: 1_000_000},
+  maximumScreenSpaceError: 8,
+  onFrontierChange: frontier => renderer.setFrontier(frontier),
+  onPageRequest: request => scheduleSourcePage(request.rowIndex, request.priority),
+  onPageCancel: request => cancelSourcePage(request.rowIndex)
+});
+
+hierarchy.registerPage({
+  id: 'rad:0',
+  data: preparedRootPage,
+  childCounts: rootLoaderData.childCounts,
+  childStarts: rootLoaderData.childStarts,
+  ownsData: true
+});
+
+hierarchy.update({
+  cameraPosition,
+  modelViewProjectionMatrix,
+  viewportSize: [width, height],
+  foveation: {center: [0.5, 0.5], radius: 0.2, strength: 2}
+});
+```
+
+Traversal starts at Spark's single authored root row, retains every unrefined or childless leaf,
+and replaces an individual parent only after all of its selected child rows become resident.
+Mixed parent-and-leaf source pages therefore remain correct. Each frontier entry exposes the
+intact original `data`, batch-local `activeRows`, `activeMask`, bounds, priority, and fallback
+state. Camera frustum changes cancel obsolete page requests, and protected parents remain visible
+when the residency budget cannot admit every required child.
+
+Top-level RAD metadata contains source page ranges, but not spatial page bounds. Bounds are
+derived conservatively after a page is decoded; missing-page requests use authored global child
+row links. Transport, parsing, asynchronous worker bridges, and GPU upload remain application- or
+loader-owned. Supply residency estimates before initiating page fetch and preparation when a hard
+window must prevent both unnecessary requests and transient GPU overcommit.
+
 ## Khronos Gaussian splats, 3D Tiles, and SPZ
 
 Decoded glTF primitives declaring `KHR_gaussian_splatting` can be prepared directly without adding
@@ -525,11 +621,18 @@ same Hugging Face catalog used by the loaders.gl Gaussian splat example. Use
 scenes. If the Hugging Face CDN is unavailable, Train automatically falls back to its two
 GitHub-hosted PLY segments; `scene=train-github` selects those segments directly.
 
-`?scene=coit` selects Spark's 50,937,127-splat Coit Tower RAD source. Its metadata and independent
-pages are fetched with HTTP range requests and bounded to a one-million-splat resident preview by
-default; set `&residentSplats=250000` to choose another whole-page source budget. The overlay keeps
-reporting the complete authored source count, and unneeded RAD pages are never fetched or uploaded.
-This is a bounded page window, not a claim that all 50 million rows fit inside one WebGPU graph.
+`?scene=coit` selects Spark's 50,937,127-splat Coit Tower RAD source. On WebGPU, the showcase
+first range-fetches the root page, then uses the live camera and authored per-row child links to
+request, cancel, and evict only the source pages needed by its current hierarchy frontier.
+`GPUPagedSplatRenderer` projects the selected original rows and sorts them globally across bounded
+GPU segments. The default residency window retains at most one million original source rows; set
+`&residentSplats=250000` to choose another whole-page source budget. The overlay reports the
+complete authored source count, current selected rows, and resident pages.
+
+Page requests are bounded and prioritized, but the published loaders.gl RAD decoder currently
+runs on the main thread. Applications can inject an actual asynchronous or worker-backed decoder
+through the demand-driven source adapter; the showcase does not imply that such a worker ships by
+default. Explicit CPU and non-hierarchical RAD sources retain their bounded whole-page path.
 
 Use `?loaders=local&scene=fixture` for the lightweight 1,000-splat parser fixture, or provide
 `source` to select a custom `.ply`, `.splat`, `.ksplat`, `.spz`, or `.rad` file. Full PLY scenes

--- a/docs/capabilities.mdx
+++ b/docs/capabilities.mdx
@@ -593,6 +593,7 @@ Read the [ANARI ray-tracing renderer](/docs/api-reference/anari/anari-rendering)
 | GPU projection and culling | Experimental | WebGPU | `@luma.gl/splats` | Project visible splats and apply supported frustum, opacity, and size thresholds. |
 | GPU depth sorting | Experimental | WebGPU | `@luma.gl/splats` | Execute supported command-graph-native global depth ordering. |
 | Indirect splat drawing | Experimental | WebGPU | `@luma.gl/splats` | Generate one bounded indirect draw from the visible GPU-resident set. |
+| Segmented paged splat rendering | Experimental | WebGPU | `@luma.gl/splats` | Project sparse original source rows into bounded GPU segments and draw them in one globally sorted cross-page depth order. |
 | HDR spherical-harmonic DC | Experimental | WebGPU | `@luma.gl/splats` | Preserve supported floating-point source radiance on compatible presentation targets. |
 | Standard-dynamic-range fallback | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Apply supported display mapping when extended HDR output is unavailable. |
 | View-dependent harmonics | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Evaluate degree-one through degree-three spherical harmonics in reusable WebGPU graphs or portable splat models. |
@@ -602,8 +603,9 @@ Read the [ANARI ray-tracing renderer](/docs/api-reference/anari/anari-rendering)
 | Mixed mesh and splat rendering | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Composite depth-tested Gaussian splats between caller-owned opaque and transparent meshes. |
 | Bounded splat residency | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Reserve upload capacity and evict prioritized, unpinned source tiles within byte, row, and chunk budgets. |
 | Hierarchical splat refinement | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Select frustum-culled, foveated source-page frontiers with parent fallback and bounded asynchronous loading. |
+| Row-accurate RAD hierarchy | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Traverse authored global child-row links while retaining mixed page leaves, parent fallback, and sparse source-row identity. |
 | Khronos glTF splat attributes | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Render decoded `KHR_gaussian_splatting` attributes, feature IDs, and externally decoded SPZ v2 content. |
-| Progressive RAD page sources | Experimental | WebGPU + WebGL2 | `@luma.gl/arrow` and `@luma.gl/splats` | Preserve independently range-fetched RAD chunk boundaries and authored global source identities. |
+| Camera-driven RAD page sources | Experimental | WebGPU + WebGL2 | `@luma.gl/arrow` and `@luma.gl/splats` | Demand, prioritize, cancel, and evict independently range-fetched source pages while preserving authored global row identities. |
 
 Higher-order harmonics, semantic filtering, dedicated picking, and mixed-scene composition are
 available through the portable `SplatRenderer` and the WebGPU-only `GPUSplatGraphRenderer`. The
@@ -653,7 +655,7 @@ commitments to release dates.
 | Massive geometry visualization | Opportunity | WebGPU | `@luma.gl/experimental` | Extend procedural virtual geometry toward imported mesh clusters and occlusion-aware residency. |
 | Motion-aware temporal reconstruction | Opportunity | WebGPU | `@luma.gl/effects` and `@luma.gl/anari` | Extend camera-reprojection antialiasing with animated-object motion vectors, compatible denoising, and temporal upscaling. |
 | GPU-resident crowd animation | Opportunity | WebGPU | `@luma.gl/gltf` | Extend existing instanced skeletal crowds toward GPU clip sampling, independent actor morph deformation, and material variation. |
-| Massive captured-scene parity | Opportunity | WebGPU | `@luma.gl/splats` | Add shared segmented page tables, worker-driven RAD row traversal, cross-page global sorting, and verified 50-million-splat Spark parity. |
+| Massive captured-scene parity | Opportunity | WebGPU | `@luma.gl/splats` | Extend segmented RAD rendering with shipped worker decoding, segmented GPU picking, larger global-sort domains, and measured 50-million-splat Spark visual/performance parity. |
 | Production-ready module boundaries | Opportunity | WebGPU + WebGL2 | `@luma.gl/engine`, `@luma.gl/tables`, and `@luma.gl/gpgpu` | Graduate reusable scheduling, data adapters, and algorithms into their natural published packages. |
 
 `@luma.gl/experimental`, `@luma.gl/anari`, `@luma.gl/splats`, `@luma.gl/arrow`,

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -155,8 +155,10 @@ Target Release Date: Q3, 2026
 - **Dynamic splats and mixed scenes** - Update existing GPU source rows in place and composite depth-tested Gaussian splats between opaque and transparent mesh draws.
 - **Bounded splat residency** - Prioritized, pinned, least-recently-used source batches remain within configurable GPU byte, row, and chunk budgets.
 - **Hierarchical source paging** - Frustum-aware, foveated screen-space-error traversal preserves parent fallback, bounds asynchronous page decoding, and reserves GPU capacity before upload.
+- **Row-accurate RAD refinement** - Authored Spark child links select sparse source rows, preserve mixed parent-and-leaf pages, retain coarse fallback, and cancel camera-obsolete demand.
+- **Segmented out-of-core GPU rendering** - Independently bounded source and projected segments preserve exact cross-page global GPU depth ordering beyond the single-storage-buffer limit.
 - **Khronos glTF and 3D Tiles primitives** - Structural `KHR_gaussian_splatting` adapters retain feature IDs, complete spherical harmonics, stable tile identities, and externally decoded SPZ v2 compression.
-- **Progressive RAD sources** - Range-fetch independently owned Spark RAD pages, preserve authored source-global row identities, and cap interactive resident windows for large captures.
+- **Camera-driven RAD sources** - Range-fetch, prioritize, cancel, and evict independently owned Spark RAD pages while retaining authored global row identities and a hard interactive residency window.
 - **Incremental splat streaming** - New prepared batches append without concatenating source data, rebuilding previous batches, or transferring ownership to the renderer.
 - **Layered adapters** - File parsing stays in loaders.gl, Apache Arrow conversion stays in `@luma.gl/arrow`, and deck.gl integration stays in downstream applications.
 

--- a/examples/showcase/gaussian-splats/app.ts
+++ b/examples/showcase/gaussian-splats/app.ts
@@ -8,10 +8,12 @@ import type {Device} from '@luma.gl/core';
 import {AnimationLoopTemplate, OrbitControls, type AnimationProps} from '@luma.gl/engine';
 import {GPUCommandGraphInspector, type GPUCommandGraphInspectorGraph} from '@luma.gl/experimental';
 import {
+  GPUPagedSplatRenderer,
   GPUSplatGraphRenderer,
   makeGPUSplatData,
   SplatRenderer,
   type GPUSplatData,
+  type SplatHierarchyView,
   type SplatRendererProps,
   type SplatSortMode
 } from '@luma.gl/splats';
@@ -27,9 +29,11 @@ import {
   GAUSSIAN_SPLAT_SOURCE_CATALOG,
   getLocalGaussianSplatLoadersConfiguration,
   loadLocalGaussianSplatArrowSources,
+  openLocalGaussianSplatRADPageSource,
   type LocalGaussianSplatLoadProgress,
   type LocalGaussianSplatLoadersConfiguration
 } from './local-loaders';
+import {GaussianSplatRADSceneController} from './rad-scene';
 
 export const title = 'Gaussian Splats';
 export const description =
@@ -149,7 +153,7 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
   static props = {useDevicePixels: true};
 
   readonly device: Device;
-  renderer: SplatRenderer | GPUSplatGraphRenderer;
+  renderer: SplatRenderer | GPUSplatGraphRenderer | GPUPagedSplatRenderer;
   readonly batches: GPUSplatData[];
 
   private readonly executionMode: GaussianSplatExecutionMode;
@@ -179,6 +183,8 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
   private autoOrbit = true;
   private orbitControls: OrbitControls | null = null;
   private loadAbortController: AbortController | null = null;
+  private radSceneController: GaussianSplatRADSceneController | null = null;
+  private hierarchyView: SplatHierarchyView | undefined;
   private loadingProgress: LocalGaussianSplatLoadProgress | undefined;
   private loadingError: string | undefined;
   private isLoading = false;
@@ -253,14 +259,16 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
     };
     this.renderer =
       this.executionMode === 'graph'
-        ? new GPUSplatGraphRenderer(device, {
-            ...rendererProps,
-            clearColor: CLEAR_COLOR,
-            expectedSplatCount:
-              this.localLoadersConfiguration?.maxResidentSplatCount ??
-              this.localLoadersConfiguration?.expectedSplatCount,
-            expectedBatchCount: this.localLoadersConfiguration?.expectedBatchCount
-          })
+        ? this.localLoadersConfiguration?.sourceFormat === 'RAD'
+          ? new GPUPagedSplatRenderer(device, {...rendererProps, clearColor: CLEAR_COLOR})
+          : new GPUSplatGraphRenderer(device, {
+              ...rendererProps,
+              clearColor: CLEAR_COLOR,
+              expectedSplatCount:
+                this.localLoadersConfiguration?.maxResidentSplatCount ??
+                this.localLoadersConfiguration?.expectedSplatCount,
+              expectedBatchCount: this.localLoadersConfiguration?.expectedBatchCount
+            })
         : new SplatRenderer(device, rendererProps);
   }
 
@@ -318,7 +326,7 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
       while (this.sourceBatchIndex < requestedBatchCount) {
         const nextBatch = makeGPUSplatData(device, makeGaussianSplatSource(this.sourceBatchIndex));
         this.batches.push(nextBatch);
-        this.renderer.appendData(nextBatch);
+        this.appendRendererBatch(nextBatch);
         this.requestRedraw();
         this.loadedSplatCount += nextBatch.length;
         this.sourceBatchIndex++;
@@ -355,7 +363,10 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
 
     let graphChanged = false;
     const activeRenderer = this.renderer;
-    if (activeRenderer instanceof GPUSplatGraphRenderer) {
+    if (
+      activeRenderer instanceof GPUSplatGraphRenderer ||
+      activeRenderer instanceof GPUPagedSplatRenderer
+    ) {
       try {
         const encoding = activeRenderer.encode(device.commandEncoder);
         if (!encoding) {
@@ -372,7 +383,15 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
           this.graphInspector.recordEncoding(compiledGraph.id, encoding);
         }
       } catch (error) {
-        this.activateCpuRendererFallback(error);
+        if (activeRenderer instanceof GPUSplatGraphRenderer) {
+          this.activateCpuRendererFallback(error);
+        } else {
+          this.loadingError =
+            error instanceof Error ? error.message : 'The segmented RAD renderer is unavailable.';
+          this.needsRedraw = false;
+          this.updatePanel();
+          return;
+        }
       }
     }
     if (this.renderer instanceof SplatRenderer) {
@@ -411,8 +430,12 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
 
     // Rendering resources borrow the caller-owned source batches.
     this.renderer.destroy();
+    this.radSceneController?.destroy();
+    this.radSceneController = null;
     for (const batch of this.batches) {
-      batch.destroy();
+      if (!batch.destroyed) {
+        batch.destroy();
+      }
     }
   }
 
@@ -420,6 +443,12 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
     configuration: LocalGaussianSplatLoadersConfiguration
   ): Promise<void> {
     this.loadAbortController = new AbortController();
+    if (configuration.sourceFormat === 'RAD' && this.renderer instanceof GPUPagedSplatRenderer) {
+      if (await this.loadAdaptiveRADScene(configuration)) {
+        return;
+      }
+    }
+
     const source = loadLocalGaussianSplatArrowSources(configuration, {
       signal: this.loadAbortController.signal,
       onProgress: progress => {
@@ -442,7 +471,7 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
       this.batches.push(batch);
       this.loadedSplatCount += batch.length;
       this.expectedSplatCount = Math.max(this.expectedSplatCount, this.loadedSplatCount);
-      this.renderer.appendData(batch);
+      this.appendRendererBatch(batch);
       this.requestRedraw();
       if (this.batches.length === 1 && !this.hasManualCameraInteraction) {
         this.fitCameraToBatches();
@@ -471,6 +500,100 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
     this.expectedBatchCount = configuration.expectedBatchCount ?? this.batches.length;
     this.expectedSplatCount = configuration.expectedSplatCount ?? this.loadedSplatCount;
     this.updatePanel();
+  }
+
+  /** Keeps Spark's authored RAD hierarchy out-of-core and driven by the live camera frontier. */
+  private async loadAdaptiveRADScene(
+    configuration: LocalGaussianSplatLoadersConfiguration
+  ): Promise<boolean> {
+    const loadAbortController = this.loadAbortController;
+    if (!loadAbortController || !(this.renderer instanceof GPUPagedSplatRenderer)) {
+      return false;
+    }
+
+    const pageSource = await openLocalGaussianSplatRADPageSource(configuration, {
+      signal: loadAbortController.signal,
+      maxConcurrentLoads: 4,
+      onProgress: progress => {
+        if (!this.isFinalized) {
+          this.loadingProgress = progress;
+          this.expectedSplatCount = progress.expectedSplatCount ?? this.expectedSplatCount;
+          this.expectedBatchCount = progress.expectedBatchCount ?? this.expectedBatchCount;
+          this.updatePanel();
+        }
+      }
+    });
+    if (this.isFinalized || loadAbortController.signal.aborted) {
+      pageSource.destroy();
+      return true;
+    }
+    if (!pageSource.metadata.lodTree) {
+      pageSource.destroy();
+      return false;
+    }
+
+    this.expectedSplatCount = pageSource.metadata.count;
+    this.expectedBatchCount = pageSource.metadata.chunks.length;
+    this.radSceneController = new GaussianSplatRADSceneController({
+      device: this.device,
+      source: pageSource,
+      maxResidentSplatCount:
+        configuration.maxResidentSplatCount ?? Math.max(pageSource.metadata.count, 1),
+      onFrontierChange: (frontier, stats) => {
+        if (this.isFinalized || !(this.renderer instanceof GPUPagedSplatRenderer)) {
+          return;
+        }
+        this.renderer.setFrontier(frontier);
+        this.batches.splice(0, this.batches.length, ...frontier.map(entry => entry.data));
+        this.loadedSplatCount = stats.activeRowCount;
+        this.requestRedraw();
+        this.updatePanel();
+      },
+      onPageLoad: (page, stats) => {
+        if (this.isFinalized) {
+          return;
+        }
+        if (stats.pageCount === 1 && !this.hasManualCameraInteraction) {
+          this.batches.splice(0, this.batches.length, page.data);
+          this.loadedSplatCount = page.data.length;
+          this.fitCameraToBatches();
+          const frontierBatches = this.radSceneController?.hierarchy.frontierBatches;
+          if (stats.activePageCount > 0 && frontierBatches) {
+            this.batches.splice(0, this.batches.length, ...frontierBatches);
+            this.loadedSplatCount = stats.activeRowCount;
+          }
+        }
+        this.requestRedraw();
+        this.updatePanel();
+      },
+      onError: error => {
+        if (!this.isFinalized && !isAbortError(error)) {
+          this.loadingError = error instanceof Error ? error.message : 'RAD page loading failed.';
+          this.updatePanel();
+        }
+      }
+    });
+
+    await this.radSceneController.start(this.hierarchyView);
+    if (this.isFinalized || loadAbortController.signal.aborted) {
+      return true;
+    }
+    this.isLoading = false;
+    this.requestRedraw();
+    this.updatePanel();
+    return true;
+  }
+
+  /** Retains the source batch unchanged across portable, graph, and segmented GPU pipelines. */
+  private appendRendererBatch(batch: GPUSplatData): void {
+    if (this.renderer instanceof GPUPagedSplatRenderer) {
+      this.renderer.setFrontier([
+        ...this.renderer.pages,
+        {id: `source:${batch.sourceBatchIndex}:${batch.rowIndexBase}`, data: batch}
+      ]);
+      return;
+    }
+    this.renderer.appendData(batch);
   }
 
   /** Keeps a captured scene usable when the selected WebGPU adapter cannot compile its graph. */
@@ -534,6 +657,13 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
       viewportSize: [cameraState.viewportWidth, cameraState.viewportHeight]
     };
     this.renderer.setProps({...cameraProps, cameraPosition});
+    this.hierarchyView = {
+      cameraPosition,
+      modelViewProjectionMatrix,
+      viewportSize: [cameraState.viewportWidth, cameraState.viewportHeight],
+      verticalFieldOfView: CAMERA_FIELD_OF_VIEW
+    };
+    this.radSceneController?.update(this.hierarchyView);
   }
 
   private fitCameraToBatches(): void {
@@ -839,13 +969,19 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
     )) {
       pipelineElement.textContent = this.graphFallbackReason
         ? 'CPU fallback · graph unavailable'
-        : this.renderer instanceof GPUSplatGraphRenderer
+        : this.renderer instanceof GPUPagedSplatRenderer
           ? this.renderer.compiledGraph
-            ? 'GPU command graph'
-            : 'Compiling GPU graph…'
-          : this.device.type === 'webgpu'
-            ? 'CPU depth ordering'
-            : 'WebGL2 fallback';
+            ? `Segmented GPU · ${this.renderer.stats.segmentCount.toLocaleString()} segment${
+                this.renderer.stats.segmentCount === 1 ? '' : 's'
+              }`
+            : 'Preparing segmented GPU graph…'
+          : this.renderer instanceof GPUSplatGraphRenderer
+            ? this.renderer.compiledGraph
+              ? 'GPU command graph'
+              : 'Compiling GPU graph…'
+            : this.device.type === 'webgpu'
+              ? 'CPU depth ordering'
+              : 'WebGL2 fallback';
     }
     for (const pipelineErrorElement of document.querySelectorAll<HTMLElement>(
       '[data-gaussian-splats-pipeline-error]'
@@ -894,9 +1030,11 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
         statusElement.textContent = this.loadingError
           ? 'Unable to load scene'
           : !this.isLoading
-            ? this.loadedSplatCount < this.expectedSplatCount
-              ? 'Resident page window ready'
-              : 'Scene loaded'
+            ? this.radSceneController
+              ? 'Camera-driven RAD paging'
+              : this.loadedSplatCount < this.expectedSplatCount
+                ? 'Resident page window ready'
+                : 'Scene loaded'
             : progress?.fallbackActive
               ? 'Loading GitHub scene fallback…'
               : progress?.phase === 'loaded'
@@ -918,7 +1056,13 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
           );
         }
         if (this.loadedSplatCount > 0) {
-          detailParts.push(`${this.loadedSplatCount.toLocaleString()} splats ready`);
+          detailParts.push(
+            this.radSceneController
+              ? `${this.loadedSplatCount.toLocaleString()} active rows · ${
+                  this.radSceneController.hierarchy.residencyManager.stats.residentChunkCount
+                } resident pages`
+              : `${this.loadedSplatCount.toLocaleString()} splats ready`
+          );
         }
         detailElement.textContent = detailParts.join(' · ');
       }

--- a/examples/showcase/gaussian-splats/local-loaders.ts
+++ b/examples/showcase/gaussian-splats/local-loaders.ts
@@ -70,6 +70,68 @@ export type LocalGaussianSplatLoadOptions = {
   onProgress?: (progress: LocalGaussianSplatLoadProgress) => void;
 };
 
+/** One independently addressable RAD source page, retaining its source-global row interval. */
+export type LocalGaussianSplatRADChunkMetadata = {
+  chunkIndex: number;
+  base: number;
+  count: number;
+  bytes: number;
+  offset?: number;
+  filename?: string;
+};
+
+/** One intact loader-owned Arrow page with exact source-global identity and row hierarchy. */
+export type LocalGaussianSplatRADPage = {
+  readonly data: GPUSplatArrowRecordBatchLike;
+  readonly shape?: string;
+  readonly loaderData: {
+    readonly base: number;
+    readonly chunkIndex: number;
+    readonly childCounts?: Uint16Array;
+    readonly childStarts?: Uint32Array;
+    readonly [metadataName: string]: unknown;
+  };
+};
+
+/** Source metadata needed to demand, estimate, and traverse independent RAD pages. */
+export type LocalGaussianSplatRADMetadata = {
+  count: number;
+  chunks: readonly LocalGaussianSplatRADChunkMetadata[];
+  allChunkBytes?: number;
+  chunkSize?: number;
+  maxSh?: number;
+  lodTree?: boolean;
+};
+
+/** Current camera-driven interest in one RAD page; larger priorities are serviced first. */
+export type LocalGaussianSplatRADPageDemand = {
+  chunkIndex: number;
+  priority?: number;
+};
+
+/** Input for an injected asynchronous or worker-backed RAD page decoder. */
+export type LocalGaussianSplatRADPageDecodeContext = {
+  chunkIndex: number;
+  sourceUrl: string;
+  metadata: LocalGaussianSplatRADMetadata;
+  signal: AbortSignal;
+  /** Published RADSourceLoader performs this decoder synchronously after the range fetch. */
+  decodeDefault: () => Promise<unknown>;
+};
+
+/** Cancellation, bounded demand, and optional real worker bridge for RAD page loading. */
+export type LocalGaussianSplatRADPageSourceOptions = LocalGaussianSplatLoadOptions & {
+  maxConcurrentLoads?: number;
+  /** Override with an actual worker bridge; the published RAD source has no worker parser. */
+  decodePage?: (context: LocalGaussianSplatRADPageDecodeContext) => Promise<unknown>;
+};
+
+/** Optional request-local cancellation and camera priority for one RAD page. */
+export type LocalGaussianSplatRADPageLoadOptions = {
+  priority?: number;
+  signal?: AbortSignal;
+};
+
 type LocalGaussianSplatLoaderModules = {
   coreModule: Record<string, any>;
   loader: unknown;
@@ -85,8 +147,17 @@ type LocalGaussianSplatLoadState = {
 type LocalGaussianSplatRADSource = {
   getMetadata(): Promise<{
     count: number;
-    chunks: readonly {base?: number; count?: number; bytes?: number}[];
+    chunks: readonly {
+      base?: number;
+      count?: number;
+      bytes?: number;
+      offset?: number;
+      filename?: string;
+    }[];
     allChunkBytes?: number;
+    chunkSize?: number;
+    maxSh?: number;
+    lodTree?: boolean;
   }>;
   getChunkTable(
     chunkIndex: number,
@@ -97,9 +168,29 @@ type LocalGaussianSplatRADSource = {
   ): Promise<unknown>;
 };
 
+type LocalGaussianSplatRADPageRequest = {
+  chunkIndex: number;
+  priority: number;
+  sequence: number;
+  controller: AbortController;
+  promise: Promise<LocalGaussianSplatRADPage>;
+  resolve: (page: LocalGaussianSplatRADPage) => void;
+  reject: (error: unknown) => void;
+  removeAbortListener?: () => void;
+  started: boolean;
+  settled: boolean;
+};
+
+type LocalGaussianSplatRADProgressState = {
+  loadedBytes: number;
+  loadedSplatCount: number;
+  totalBytes?: number;
+};
+
 const DEFAULT_GAUSSIAN_PLY_PATH = 'modules/ply/test/data/gaussian/train-1000.ply';
 const GAUSSIAN_SPLAT_ARROW_BATCH_SIZE = 65_536;
 const DEFAULT_RAD_RESIDENT_SPLAT_COUNT = 1_000_000;
+const DEFAULT_RAD_MAX_CONCURRENT_PAGE_LOADS = 4;
 const DOWNLOAD_PROGRESS_INTERVAL_MILLISECONDS = 125;
 const HUGGING_FACE_GAUSSIAN_SPLAT_BASE_URL =
   'https://huggingface.co/datasets/Voxel51/gaussian_splatting/resolve/main/FO_dataset';
@@ -260,6 +351,446 @@ export function getLocalGaussianSplatLoadersConfiguration():
     up: scene.up,
     camera: scene.camera
   };
+}
+
+/**
+ * Demand-driven RAD source whose decoded pages remain separate and caller-owned.
+ *
+ * Setting demand only updates priorities and cancels stale requests. Pages are never fetched until
+ * `loadPage` is explicitly called, and completed Arrow pages are not cached or repacked.
+ */
+export class LocalGaussianSplatRADPageSource {
+  readonly metadata: LocalGaussianSplatRADMetadata;
+
+  private readonly source: LocalGaussianSplatRADSource;
+  private readonly configuration: LocalGaussianSplatLoadersConfiguration;
+  private readonly options: LocalGaussianSplatRADPageSourceOptions;
+  private readonly sourceAbortController: AbortController;
+  private readonly progressState: LocalGaussianSplatRADProgressState;
+  private readonly requests = new Map<number, LocalGaussianSplatRADPageRequest>();
+  private readonly queue: LocalGaussianSplatRADPageRequest[] = [];
+  private readonly demand = new Map<number, number>();
+  private readonly maxConcurrentLoads: number;
+  private readonly handleSourceAbort = (): void => this.destroy();
+  private activeLoadCount = 0;
+  private nextRequestSequence = 0;
+  private destroyed = false;
+
+  constructor(
+    source: LocalGaussianSplatRADSource,
+    metadata: LocalGaussianSplatRADMetadata,
+    configuration: LocalGaussianSplatLoadersConfiguration,
+    options: LocalGaussianSplatRADPageSourceOptions,
+    sourceAbortController: AbortController,
+    progressState: LocalGaussianSplatRADProgressState
+  ) {
+    this.source = source;
+    this.metadata = metadata;
+    this.configuration = configuration;
+    this.options = options;
+    this.sourceAbortController = sourceAbortController;
+    this.progressState = progressState;
+    this.maxConcurrentLoads = Math.max(
+      1,
+      Math.floor(options.maxConcurrentLoads ?? DEFAULT_RAD_MAX_CONCURRENT_PAGE_LOADS)
+    );
+    sourceAbortController.signal.addEventListener('abort', this.handleSourceAbort, {once: true});
+  }
+
+  /** Returns already-fetched top-level metadata without issuing another range request. */
+  getMetadata(): LocalGaussianSplatRADMetadata {
+    return this.metadata;
+  }
+
+  /** Resolves a source-global LoD child row to its original, independently fetchable page. */
+  getChunkForRow(rowIndex: number): number | undefined {
+    if (!Number.isSafeInteger(rowIndex) || rowIndex < 0) {
+      return undefined;
+    }
+
+    const nominalChunkSize = this.metadata.chunkSize;
+    if (nominalChunkSize && nominalChunkSize > 0) {
+      const nominalChunk = this.metadata.chunks[Math.floor(rowIndex / nominalChunkSize)];
+      if (
+        nominalChunk &&
+        rowIndex >= nominalChunk.base &&
+        rowIndex < nominalChunk.base + nominalChunk.count
+      ) {
+        return nominalChunk.chunkIndex;
+      }
+    }
+
+    let firstChunkIndex = 0;
+    let lastChunkIndex = this.metadata.chunks.length - 1;
+    while (firstChunkIndex <= lastChunkIndex) {
+      const chunk = this.metadata.chunks[Math.floor((firstChunkIndex + lastChunkIndex) / 2)]!;
+      if (rowIndex >= chunk.base && rowIndex < chunk.base + chunk.count) {
+        return chunk.chunkIndex;
+      }
+      if (rowIndex < chunk.base) {
+        lastChunkIndex = chunk.chunkIndex - 1;
+      } else {
+        firstChunkIndex = chunk.chunkIndex + 1;
+      }
+    }
+    return undefined;
+  }
+
+  /** Updates camera demand without implicitly starting requests or retaining decoded pages. */
+  setPageDemand(
+    demands: readonly LocalGaussianSplatRADPageDemand[],
+    options: {cancelUndemanded?: boolean} = {}
+  ): void {
+    this.demand.clear();
+    for (const pageDemand of demands) {
+      this.demand.set(pageDemand.chunkIndex, pageDemand.priority ?? 0);
+    }
+    for (const request of [...this.requests.values()]) {
+      const priority = this.demand.get(request.chunkIndex);
+      if (priority === undefined && options.cancelUndemanded !== false) {
+        this.cancelPage(request.chunkIndex);
+      } else if (priority !== undefined) {
+        request.priority = priority;
+      }
+    }
+    this.sortQueue();
+  }
+
+  /** Fetches only the requested original source page with deduplication and bounded concurrency. */
+  loadPage(
+    chunkIndex: number,
+    options: LocalGaussianSplatRADPageLoadOptions = {}
+  ): Promise<LocalGaussianSplatRADPage> {
+    if (this.destroyed || this.sourceAbortController.signal.aborted) {
+      return Promise.reject(getGaussianSplatRADAbortReason(this.sourceAbortController.signal));
+    }
+    if (options.signal?.aborted) {
+      return Promise.reject(getGaussianSplatRADAbortReason(options.signal));
+    }
+
+    const chunk = this.metadata.chunks[chunkIndex];
+    if (!chunk || chunk.chunkIndex !== chunkIndex) {
+      return Promise.reject(new RangeError('The requested RAD page does not exist.'));
+    }
+    if (
+      this.configuration.maxResidentSplatCount !== undefined &&
+      chunk.count > this.configuration.maxResidentSplatCount
+    ) {
+      return Promise.reject(
+        new RangeError('The RAD page exceeds residentSplats; increase the budget.')
+      );
+    }
+
+    const existingRequest = this.requests.get(chunkIndex);
+    if (existingRequest) {
+      if (options.priority !== undefined) {
+        existingRequest.priority = options.priority;
+        this.sortQueue();
+      }
+      return existingRequest.promise;
+    }
+
+    let resolvePage!: (page: LocalGaussianSplatRADPage) => void;
+    let rejectPage!: (error: unknown) => void;
+    const promise = new Promise<LocalGaussianSplatRADPage>((resolve, reject) => {
+      resolvePage = resolve;
+      rejectPage = reject;
+    });
+    const request: LocalGaussianSplatRADPageRequest = {
+      chunkIndex,
+      priority: options.priority ?? this.demand.get(chunkIndex) ?? 0,
+      sequence: this.nextRequestSequence++,
+      controller: new AbortController(),
+      promise,
+      resolve: resolvePage,
+      reject: rejectPage,
+      started: false,
+      settled: false
+    };
+
+    if (options.signal) {
+      const handleAbort = (): void => {
+        this.cancelPage(chunkIndex, options.signal?.reason);
+      };
+      options.signal.addEventListener('abort', handleAbort, {once: true});
+      request.removeAbortListener = () => options.signal?.removeEventListener('abort', handleAbort);
+    }
+
+    this.requests.set(chunkIndex, request);
+    this.queue.push(request);
+    this.sortQueue();
+    this.startQueuedPages();
+    return promise;
+  }
+
+  /** Aborts a queued or in-flight request without destroying any caller-owned decoded page. */
+  cancelPage(chunkIndex: number, reason?: unknown): boolean {
+    const request = this.requests.get(chunkIndex);
+    if (!request) {
+      return false;
+    }
+    request.controller.abort(reason);
+    if (!request.started) {
+      const queueIndex = this.queue.indexOf(request);
+      if (queueIndex >= 0) {
+        this.queue.splice(queueIndex, 1);
+      }
+    }
+    this.finishRequest(request, getGaussianSplatRADAbortReason(request.controller.signal));
+    return true;
+  }
+
+  /** Cancels queued and in-flight work; already returned Arrow pages remain caller-owned. */
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+    this.sourceAbortController.signal.removeEventListener('abort', this.handleSourceAbort);
+    if (!this.sourceAbortController.signal.aborted) {
+      this.sourceAbortController.abort();
+    }
+    for (const request of [...this.requests.values()]) {
+      this.cancelPage(request.chunkIndex, this.sourceAbortController.signal.reason);
+    }
+    this.demand.clear();
+  }
+
+  private sortQueue(): void {
+    this.queue.sort(
+      (left, right) => right.priority - left.priority || left.sequence - right.sequence
+    );
+  }
+
+  private startQueuedPages(): void {
+    while (!this.destroyed && this.activeLoadCount < this.maxConcurrentLoads && this.queue.length) {
+      const request = this.queue.shift()!;
+      request.started = true;
+      this.activeLoadCount++;
+      void this.decodeRequestedPage(request);
+    }
+  }
+
+  private async decodeRequestedPage(request: LocalGaussianSplatRADPageRequest): Promise<void> {
+    try {
+      const signal = request.controller.signal;
+      signal.throwIfAborted();
+      const decodeDefault = async (): Promise<unknown> =>
+        await this.source.getChunkTable(request.chunkIndex, {
+          signal,
+          radChunk: {includeLoDTree: true, includeSphericalHarmonics: true}
+        });
+      const arrowSource = this.options.decodePage
+        ? await this.options.decodePage({
+            chunkIndex: request.chunkIndex,
+            sourceUrl: this.configuration.sourceUrl,
+            metadata: this.metadata,
+            signal,
+            decodeDefault
+          })
+        : await decodeDefault();
+      signal.throwIfAborted();
+
+      if (!isGaussianSplatArrowSource(arrowSource)) {
+        throw new Error('RADSourceLoader did not return a Gaussian Arrow page.');
+      }
+      if (
+        this.configuration.maxResidentSplatCount !== undefined &&
+        arrowSource.data.numRows > this.configuration.maxResidentSplatCount
+      ) {
+        throw new RangeError('The RAD page exceeds residentSplats; increase the budget.');
+      }
+
+      const sourceLoaderData =
+        'loaderData' in arrowSource &&
+        typeof arrowSource.loaderData === 'object' &&
+        arrowSource.loaderData !== null
+          ? arrowSource.loaderData
+          : {};
+      const chunk = this.metadata.chunks[request.chunkIndex]!;
+      const base = typeof sourceLoaderData.base === 'number' ? sourceLoaderData.base : chunk.base;
+      chunk.base = base;
+      chunk.count = arrowSource.data.numRows;
+      const page: LocalGaussianSplatRADPage = {
+        data: arrowSource.data,
+        ...(arrowSource.shape ? {shape: arrowSource.shape} : {}),
+        loaderData: {...sourceLoaderData, base, chunkIndex: request.chunkIndex}
+      };
+      this.progressState.loadedSplatCount += arrowSource.data.numRows;
+      reportGaussianSplatRADProgress(
+        this.configuration,
+        this.options,
+        this.progressState,
+        'loaded'
+      );
+      this.finishRequest(request, undefined, page);
+    } catch (error) {
+      this.finishRequest(request, error);
+    } finally {
+      this.activeLoadCount--;
+      this.startQueuedPages();
+    }
+  }
+
+  private finishRequest(
+    request: LocalGaussianSplatRADPageRequest,
+    error?: unknown,
+    page?: LocalGaussianSplatRADPage
+  ): void {
+    if (request.settled) {
+      return;
+    }
+    request.settled = true;
+    request.removeAbortListener?.();
+    if (this.requests.get(request.chunkIndex) === request) {
+      this.requests.delete(request.chunkIndex);
+    }
+    if (page) {
+      request.resolve(page);
+    } else {
+      request.reject(error);
+    }
+  }
+}
+
+/** Opens only RAD metadata; source pages are fetched later in explicit camera-demand order. */
+export async function openLocalGaussianSplatRADPageSource(
+  configuration: LocalGaussianSplatLoadersConfiguration,
+  options: LocalGaussianSplatRADPageSourceOptions = {}
+): Promise<LocalGaussianSplatRADPageSource> {
+  if (configuration.sourceFormat !== 'RAD') {
+    throw new Error('A demand-driven RAD page source requires a RAD scene.');
+  }
+  options.signal?.throwIfAborted();
+  const loaderModules = await loadLocalGaussianSplatLoaderModules(configuration);
+  const sourceAbortController = new AbortController();
+  const handleExternalAbort = (): void => sourceAbortController.abort(options.signal?.reason);
+  options.signal?.addEventListener('abort', handleExternalAbort, {once: true});
+  if (options.signal?.aborted) {
+    handleExternalAbort();
+  }
+  sourceAbortController.signal.addEventListener(
+    'abort',
+    () => options.signal?.removeEventListener('abort', handleExternalAbort),
+    {once: true}
+  );
+
+  const progressState: LocalGaussianSplatRADProgressState = {
+    loadedBytes: 0,
+    loadedSplatCount: 0
+  };
+  reportGaussianSplatRADProgress(configuration, options, progressState, 'loading');
+
+  try {
+    const fetchSource = async (url: string, requestOptions?: RequestInit): Promise<Response> => {
+      const {signal, cleanup} = combineGaussianSplatRADAbortSignals(
+        sourceAbortController.signal,
+        requestOptions?.signal ?? undefined
+      );
+      let response: Response;
+      try {
+        response = await fetch(url, {...requestOptions, signal});
+      } catch (error) {
+        cleanup();
+        throw error;
+      }
+      if (!response.ok) {
+        cleanup();
+        throw new Error(`Unable to load Gaussian splat source (${response.status}).`);
+      }
+      if (!response.body) {
+        cleanup();
+        return response;
+      }
+
+      const reader = response.body.getReader();
+      const progressStream = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          try {
+            const {done, value} = await reader.read();
+            if (done) {
+              cleanup();
+              controller.close();
+              return;
+            }
+            progressState.loadedBytes += value.byteLength;
+            reportGaussianSplatRADProgress(configuration, options, progressState, 'loading');
+            controller.enqueue(value);
+          } catch (error) {
+            cleanup();
+            controller.error(error);
+          }
+        },
+        async cancel(reason) {
+          cleanup();
+          await reader.cancel(reason);
+        }
+      });
+
+      return new Response(progressStream, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers
+      });
+    };
+    const source: unknown = await loaderModules.coreModule.load(
+      configuration.sourceUrl,
+      loaderModules.loader,
+      {
+        worker: false,
+        fetch: fetchSource,
+        core: {batchSize: GAUSSIAN_SPLAT_ARROW_BATCH_SIZE},
+        splats: {shape: 'arrow-table'}
+      }
+    );
+    if (!isGaussianSplatRADSource(source)) {
+      throw new Error('RADSourceLoader did not return a paged Gaussian source.');
+    }
+
+    const sourceMetadata = await source.getMetadata();
+    sourceAbortController.signal.throwIfAborted();
+    const nominalChunkSize = sourceMetadata.chunkSize ?? GAUSSIAN_SPLAT_ARROW_BATCH_SIZE;
+    const metadata: LocalGaussianSplatRADMetadata = {
+      count: sourceMetadata.count,
+      chunks: sourceMetadata.chunks.map((chunk, chunkIndex) => ({
+        chunkIndex,
+        base: chunk.base ?? chunkIndex * nominalChunkSize,
+        count:
+          chunk.count ??
+          Math.min(
+            nominalChunkSize,
+            Math.max(0, sourceMetadata.count - chunkIndex * nominalChunkSize)
+          ),
+        bytes: chunk.bytes ?? 0,
+        ...(chunk.offset === undefined ? {} : {offset: chunk.offset}),
+        ...(chunk.filename === undefined ? {} : {filename: chunk.filename})
+      })),
+      ...(sourceMetadata.allChunkBytes === undefined
+        ? {}
+        : {allChunkBytes: sourceMetadata.allChunkBytes}),
+      ...(sourceMetadata.chunkSize === undefined ? {} : {chunkSize: sourceMetadata.chunkSize}),
+      ...(sourceMetadata.maxSh === undefined ? {} : {maxSh: sourceMetadata.maxSh}),
+      ...(sourceMetadata.lodTree === undefined ? {} : {lodTree: sourceMetadata.lodTree})
+    };
+    configuration.expectedSplatCount = metadata.count;
+    configuration.expectedBatchCount = metadata.chunks.length;
+    progressState.totalBytes =
+      metadata.allChunkBytes ||
+      metadata.chunks.reduce((totalByteLength, chunk) => totalByteLength + chunk.bytes, 0) ||
+      undefined;
+    reportGaussianSplatRADProgress(configuration, options, progressState, 'loading');
+    return new LocalGaussianSplatRADPageSource(
+      source,
+      metadata,
+      configuration,
+      options,
+      sourceAbortController,
+      progressState
+    );
+  } catch (error) {
+    sourceAbortController.abort();
+    throw error;
+  }
 }
 
 /** Progressively loads Arrow batches through an isolated loaders.gl 5 bundle or checkout. */
@@ -655,9 +1186,11 @@ function makeLocalLoadersFileUrl(loadersRoot: string, relativePath: string): str
   return `/@fs${loadersRoot}/${relativePath}`;
 }
 
-function isGaussianSplatArrowSource(
-  value: unknown
-): value is {readonly data: GPUSplatArrowRecordBatchLike; readonly shape?: string} {
+function isGaussianSplatArrowSource(value: unknown): value is {
+  readonly data: GPUSplatArrowRecordBatchLike;
+  readonly shape?: string;
+  readonly loaderData?: Record<string, unknown>;
+} {
   if (typeof value !== 'object' || value === null || !('data' in value)) {
     return false;
   }
@@ -681,5 +1214,59 @@ function isGaussianSplatRADSource(value: unknown): value is LocalGaussianSplatRA
     typeof value.getMetadata === 'function' &&
     'getChunkTable' in value &&
     typeof value.getChunkTable === 'function'
+  );
+}
+
+function reportGaussianSplatRADProgress(
+  configuration: LocalGaussianSplatLoadersConfiguration,
+  options: LocalGaussianSplatRADPageSourceOptions,
+  state: LocalGaussianSplatRADProgressState,
+  phase: LocalGaussianSplatLoadProgress['phase']
+): void {
+  options.onProgress?.({
+    phase,
+    loadedBytes: state.loadedBytes,
+    totalBytes: state.totalBytes,
+    sourceIndex: 0,
+    sourceCount: 1,
+    sourceLabel: configuration.sourceLabel,
+    fallbackActive: false,
+    loadedSplatCount: state.loadedSplatCount,
+    expectedSplatCount: configuration.expectedSplatCount,
+    expectedBatchCount: configuration.expectedBatchCount
+  });
+}
+
+function combineGaussianSplatRADAbortSignals(
+  sourceSignal: AbortSignal,
+  requestSignal?: AbortSignal
+): {signal: AbortSignal; cleanup: () => void} {
+  if (!requestSignal || sourceSignal === requestSignal) {
+    return {signal: sourceSignal, cleanup: () => {}};
+  }
+
+  const controller = new AbortController();
+  const abortFromSource = (): void => controller.abort(sourceSignal.reason);
+  const abortFromRequest = (): void => controller.abort(requestSignal.reason);
+  const cleanup = (): void => {
+    sourceSignal.removeEventListener('abort', abortFromSource);
+    requestSignal.removeEventListener('abort', abortFromRequest);
+  };
+  if (sourceSignal.aborted) {
+    abortFromSource();
+  } else if (requestSignal.aborted) {
+    abortFromRequest();
+  } else {
+    sourceSignal.addEventListener('abort', abortFromSource, {once: true});
+    requestSignal.addEventListener('abort', abortFromRequest, {once: true});
+    controller.signal.addEventListener('abort', cleanup, {once: true});
+  }
+  return {signal: controller.signal, cleanup};
+}
+
+function getGaussianSplatRADAbortReason(signal: AbortSignal): unknown {
+  return (
+    signal.reason ??
+    new DOMException('The Gaussian splat RAD page request was aborted.', 'AbortError')
   );
 }

--- a/examples/showcase/gaussian-splats/rad-scene.ts
+++ b/examples/showcase/gaussian-splats/rad-scene.ts
@@ -1,0 +1,263 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {makeGPUSplatDataFromArrow, type GPUSplatArrowSource} from '@luma.gl/arrow';
+import type {Device} from '@luma.gl/core';
+import {
+  SplatRADHierarchyManager,
+  type SplatHierarchyView,
+  type SplatRADHierarchyFrontierEntry,
+  type SplatRADHierarchyPage,
+  type SplatRADHierarchyStats
+} from '@luma.gl/splats';
+import {
+  type LocalGaussianSplatRADPage,
+  type LocalGaussianSplatRADPageDemand,
+  type LocalGaussianSplatRADPageSource
+} from './local-loaders';
+
+/** Integrates independent loader-owned RAD pages with row-level source residency. */
+export type GaussianSplatRADSceneControllerProps = {
+  /** Device receiving each independently decoded, source-faithful Gaussian page. */
+  device: Device;
+  /** Metadata-only, demand-driven source opened by the isolated loaders.gl adapter. */
+  source: LocalGaussianSplatRADPageSource;
+  /** Hard limit across intact, independently uploaded source pages. */
+  maxResidentSplatCount: number;
+  /** Maximum accepted projected error before requesting finer source rows. */
+  maximumScreenSpaceError?: number;
+  /** Receives original source pages and batch-local active-row selections. */
+  onFrontierChange?: (
+    frontier: readonly SplatRADHierarchyFrontierEntry[],
+    stats: SplatRADHierarchyStats
+  ) => void;
+  /** Reports successful admission of one independently prepared source page. */
+  onPageLoad?: (page: SplatRADHierarchyPage, stats: SplatRADHierarchyStats) => void;
+  /** Reports a genuine range, decode, or upload failure outside cancelled camera demand. */
+  onError?: (error: unknown) => void;
+};
+
+/**
+ * Loads only camera-requested RAD pages and preserves their original row hierarchy.
+ *
+ * The source owns transport and decoding; the hierarchy owns complete GPU source pages. Parent
+ * rows remain visible until every required child page is resident, and camera motion cancels
+ * obsolete demand without concatenating pages or replacing mixed parent-and-leaf source chunks.
+ */
+export class GaussianSplatRADSceneController {
+  /** Original demand-driven range source; completed Arrow pages are never retained here. */
+  readonly source: LocalGaussianSplatRADPageSource;
+  /** Loader-neutral row frontier and bounded, explicitly owned GPU source residency. */
+  readonly hierarchy: SplatRADHierarchyManager;
+
+  private readonly device: Device;
+  private readonly onPageLoad?: GaussianSplatRADSceneControllerProps['onPageLoad'];
+  private readonly onError?: GaussianSplatRADSceneControllerProps['onError'];
+  private readonly pendingPageLoads = new Map<number, Promise<void>>();
+  private readonly rejectedPageIndices = new Set<number>();
+  private currentView?: SplatHierarchyView;
+  private demandRefreshScheduled = false;
+  private isDestroyed = false;
+
+  constructor(props: GaussianSplatRADSceneControllerProps) {
+    this.device = props.device;
+    this.source = props.source;
+    this.onPageLoad = props.onPageLoad;
+    this.onError = props.onError;
+    this.hierarchy = new SplatRADHierarchyManager({
+      pageSize: props.source.metadata.chunkSize ?? 65_536,
+      residencyBudget: {maxResidentSplats: props.maxResidentSplatCount},
+      maximumActiveRows: props.maxResidentSplatCount,
+      maximumScreenSpaceError: props.maximumScreenSpaceError,
+      onFrontierChange: props.onFrontierChange,
+      onPageRequest: () => this.scheduleDemandRefresh(),
+      onPageCancel: request => {
+        const chunkIndex = this.source.getChunkForRow(request.rowIndex);
+        if (chunkIndex !== undefined) {
+          this.source.cancelPage(chunkIndex);
+        }
+      }
+    });
+  }
+
+  /** Fetches exactly the Spark root page, then starts camera-prioritized row refinement. */
+  async start(view?: SplatHierarchyView): Promise<void> {
+    if (view) {
+      this.currentView = view;
+    }
+    const admitted = await this.loadSourcePage(0, Number.MAX_SAFE_INTEGER);
+    if (!admitted && !this.isDestroyed) {
+      throw new RangeError('The RAD root page exceeds the resident source budget.');
+    }
+    if (this.currentView && !this.isDestroyed) {
+      this.hierarchy.update(this.currentView);
+      this.scheduleDemandRefresh();
+    }
+  }
+
+  /** Updates the row-level camera frontier and schedules only newly relevant source pages. */
+  update(view: SplatHierarchyView): readonly SplatRADHierarchyFrontierEntry[] {
+    if (this.isDestroyed) {
+      return [];
+    }
+    this.currentView = view;
+    this.rejectedPageIndices.clear();
+    const frontier = this.hierarchy.update(view);
+    this.scheduleDemandRefresh();
+    return frontier;
+  }
+
+  /** Waits for the currently requested page queue; useful for deterministic integration tests. */
+  async waitForIdle(): Promise<void> {
+    while (!this.isDestroyed && (this.demandRefreshScheduled || this.pendingPageLoads.size > 0)) {
+      await Promise.resolve();
+      const pendingPageLoads = [...this.pendingPageLoads.values()];
+      if (pendingPageLoads.length > 0) {
+        await Promise.allSettled(pendingPageLoads);
+      }
+    }
+  }
+
+  /** Cancels transport before releasing every hierarchy-owned independent GPU source page. */
+  destroy(): void {
+    if (this.isDestroyed) {
+      return;
+    }
+    this.isDestroyed = true;
+    this.source.destroy();
+    this.hierarchy.destroy();
+    this.pendingPageLoads.clear();
+    this.rejectedPageIndices.clear();
+  }
+
+  private scheduleDemandRefresh(): void {
+    if (this.isDestroyed || this.demandRefreshScheduled) {
+      return;
+    }
+    this.demandRefreshScheduled = true;
+    queueMicrotask(() => {
+      this.demandRefreshScheduled = false;
+      if (!this.isDestroyed) {
+        this.refreshDemand();
+      }
+    });
+  }
+
+  private refreshDemand(): void {
+    const demandByChunkIndex = new Map<number, LocalGaussianSplatRADPageDemand>();
+    for (const request of this.hierarchy.requests) {
+      const chunkIndex = this.source.getChunkForRow(request.rowIndex);
+      if (chunkIndex === undefined || this.rejectedPageIndices.has(chunkIndex)) {
+        continue;
+      }
+      const previousDemand = demandByChunkIndex.get(chunkIndex);
+      if (!previousDemand || request.priority > (previousDemand.priority ?? 0)) {
+        demandByChunkIndex.set(chunkIndex, {chunkIndex, priority: request.priority});
+      }
+    }
+
+    const demands = [...demandByChunkIndex.values()].sort(
+      (left, right) => (right.priority ?? 0) - (left.priority ?? 0)
+    );
+    this.source.setPageDemand(demands);
+    for (const demand of demands) {
+      if (this.pendingPageLoads.has(demand.chunkIndex)) {
+        continue;
+      }
+      const pageLoad = this.loadSourcePage(demand.chunkIndex, demand.priority ?? 0)
+        .then(admitted => {
+          if (!admitted && !this.isDestroyed) {
+            this.rejectedPageIndices.add(demand.chunkIndex);
+          }
+        })
+        .catch(error => {
+          if (!this.isDestroyed && !isRADPageAbortError(error)) {
+            this.rejectedPageIndices.add(demand.chunkIndex);
+            this.onError?.(error);
+          }
+        })
+        .finally(() => {
+          if (this.pendingPageLoads.get(demand.chunkIndex) === pageLoad) {
+            this.pendingPageLoads.delete(demand.chunkIndex);
+            if (
+              !this.isDestroyed &&
+              !this.rejectedPageIndices.has(demand.chunkIndex) &&
+              this.hierarchy.requests.some(
+                request => this.source.getChunkForRow(request.rowIndex) === demand.chunkIndex
+              )
+            ) {
+              this.scheduleDemandRefresh();
+            }
+          }
+        });
+      this.pendingPageLoads.set(demand.chunkIndex, pageLoad);
+    }
+  }
+
+  private async loadSourcePage(chunkIndex: number, priority: number): Promise<boolean> {
+    const sourceChunk = this.source.metadata.chunks[chunkIndex];
+    if (!sourceChunk) {
+      return false;
+    }
+
+    const sourcePageId = `rad:${chunkIndex}`;
+    const sourceHarmonicDegree = Math.min(Math.max(this.source.metadata.maxSh ?? 0, 0), 3);
+    const coefficientCount = ((sourceHarmonicDegree + 1) ** 2 - 1) * 3;
+    const sourceBytesPerRow = 68 + coefficientCount * Float32Array.BYTES_PER_ELEMENT;
+    let arrowSource: LocalGaussianSplatRADPage | undefined;
+    const residentChunk = await this.hierarchy.residencyManager.load(
+      sourcePageId,
+      async () => {
+        arrowSource = await this.source.loadPage(chunkIndex, {priority});
+        return makeSingleGPUSplatPage(this.device, arrowSource);
+      },
+      {
+        priority,
+        estimatedGpuBytes: sourceChunk.count * sourceBytesPerRow,
+        estimatedSplatCount: sourceChunk.count,
+        ownsData: true
+      }
+    );
+    if (!residentChunk || !arrowSource || this.isDestroyed) {
+      return false;
+    }
+
+    const {childCounts, childStarts} = arrowSource.loaderData;
+    const page: SplatRADHierarchyPage = {
+      id: sourcePageId,
+      data: residentChunk.data,
+      ...(childCounts ? {childCounts} : {}),
+      ...(childStarts ? {childStarts} : {}),
+      ownsData: true
+    };
+
+    if (!this.hierarchy.registerPage(page)) {
+      this.hierarchy.residencyManager.remove(sourcePageId);
+      return false;
+    }
+
+    this.onPageLoad?.(page, this.hierarchy.stats);
+    if (this.currentView) {
+      this.hierarchy.update(this.currentView);
+    }
+    this.scheduleDemandRefresh();
+    return true;
+  }
+}
+
+/** Keeps one RAD source page intact and releases every batch on malformed multi-batch input. */
+function makeSingleGPUSplatPage(device: Device, source: GPUSplatArrowSource) {
+  const batches = makeGPUSplatDataFromArrow(device, source);
+  if (batches.length === 1) {
+    return batches[0];
+  }
+  for (const batch of batches) {
+    batch.destroy();
+  }
+  throw new Error('A RAD source page must contain exactly one independent Arrow record batch.');
+}
+
+function isRADPageAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}

--- a/modules/splats/README.md
+++ b/modules/splats/README.md
@@ -5,7 +5,9 @@ loaders.gl, or deck.gl.
 
 `makeGPUSplatData(...)` prepares caller-owned GPU data. `SplatRenderer` supports WebGPU and WebGL2;
 `GPUSplatGraphRenderer` progressively streams preserved batches through reusable WebGPU command
-graphs, global GPU sorting, and one indirect draw.
+graphs, global GPU sorting, and one indirect draw. `GPUPagedSplatRenderer` projects sparse rows
+from independently owned source pages into bounded GPU segments while preserving one global
+cross-page depth order.
 
 Prepared batches support degree-one through degree-three spherical harmonics, semantic class IDs,
 and in-place row updates. Both rendering paths evaluate view-dependent radiance and filter semantic
@@ -13,7 +15,9 @@ classes. `SplatPicker` and `GPUSplatGraphPicker` resolve original source rows; t
 mixed-scene helpers compose splats with caller-owned depth-tested meshes.
 
 `SplatHierarchyManager` traverses frustum-culled, foveated source hierarchies while preserving
-coarse parent fallback and bounded asynchronous loading. `SplatResidencyManager` bounds intact
+coarse parent fallback and bounded asynchronous loading. `SplatRADHierarchyManager` follows
+Spark's authored per-row global child links, retaining mixed source-page leaves and parent
+fallback until the complete child frontier is resident. `SplatResidencyManager` bounds intact
 streamed batches by GPU bytes, rows, or chunks. Structural glTF adapters accept decoded
 `KHR_gaussian_splatting` attributes, mesh feature IDs, and caller-owned SPZ v2 decoder handoffs.
 

--- a/modules/splats/src/gpu-paged-splat-renderer.ts
+++ b/modules/splats/src/gpu-paged-splat-renderer.ts
@@ -1,0 +1,1562 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  assert,
+  Buffer,
+  type Binding,
+  type CommandEncoder,
+  type Device,
+  type ShaderLayout
+} from '@luma.gl/core';
+import {Computation, Model} from '@luma.gl/engine';
+import {
+  DrawCommandBuffer,
+  GPUCommandGraph,
+  GPUCommandGraphEncoding,
+  GPUSort,
+  type CompiledGPUCommandGraph,
+  type GPUCommandGraphStats,
+  type GraphBufferHandle,
+  type GraphDataView
+} from '@luma.gl/experimental';
+import type {GPUSplatGraphRendererProps} from './gpu-splat-graph-renderer';
+import {
+  GPU_SPLAT_GRAPH_FEATURE_UNIFORM_BYTE_LENGTH,
+  GPU_SPLAT_GRAPH_UNIFORM_BYTE_LENGTH,
+  GPU_SPLAT_INVALID_DEPTH_KEY,
+  GPU_SPLAT_PROJECTED_RECORD_BYTE_LENGTH
+} from './gpu-splat-graph-shaders';
+import {
+  GPU_PAGED_SPLAT_FEATURE_SHADER,
+  GPU_PAGED_SPLAT_FEATURE_SHADER_LAYOUT,
+  GPU_PAGED_SPLAT_PROJECTION_SHADER,
+  GPU_PAGED_SPLAT_PROJECTION_SHADER_LAYOUT,
+  GPU_PAGED_SPLAT_RENDER_SHADER,
+  GPU_PAGED_SPLAT_RENDER_SHADER_LAYOUT
+} from './gpu-paged-splat-shaders';
+import {GPUSplatData} from './splat-data';
+import type {SplatSemanticFilter, SplatSemanticSelection} from './splat-filter';
+import type {SplatResidencyBounds} from './splat-residency';
+import type {SplatRendererStats} from './splat-renderer';
+import {
+  getSplatSphericalHarmonicCoefficientCount,
+  type SplatSphericalHarmonicsDegree
+} from './splat-spherical-harmonics';
+
+const WORKGROUP_SIZE = 256;
+const MINIMUM_SEMANTIC_SELECTION_CAPACITY = 64;
+
+/** One intact caller-owned source page and its optional batch-local active-row frontier. */
+export type GPUPagedSplatPage = {
+  /** Stable page identity used to retain source topology and renderer-owned index buffers. */
+  id: string;
+  /** Original caller-owned prepared source allocation, never rewritten or destroyed here. */
+  data: GPUSplatData;
+  /** Optional compact, batch-local row selection; omitted pages render all original rows. */
+  activeRows?: Uint32Array;
+  /** Optional source bounds retained for hierarchy and application diagnostics. */
+  bounds?: SplatResidencyBounds;
+};
+
+/** Shared camera/style controls plus independently projected page and output segment limits. */
+export type GPUPagedSplatRendererProps = Omit<
+  GPUSplatGraphRendererProps,
+  'expectedSplatCount' | 'expectedBatchCount'
+> & {
+  /** Intact source pages and optional per-page sparse row selections. */
+  pages?: readonly GPUPagedSplatPage[];
+  /** Optional tighter projected-segment row bound; useful for bounded memory and regression tests. */
+  maxProjectedSplatsPerSegment?: number;
+};
+
+/** Active-frontier, segmented working-set, and original borrowed-source memory diagnostics. */
+export type GPUPagedSplatRendererStats = SplatRendererStats & {
+  /** Number of independently retained caller-owned source pages. */
+  pageCount: number;
+  /** Number of bounded source projection segments. */
+  sourceSegmentCount: number;
+  /** Number of bounded globally ordered projected output segments. */
+  segmentCount: number;
+  /** Number of explicitly active source rows entering sparse GPU projection. */
+  activeRowCount: number;
+  /** Number of rows in the global four-byte GPU depth/index sorting domain. */
+  globalSortCapacity: number;
+  /** Maximum rows allowed in one 48-byte projected storage binding. */
+  maxProjectedSplatsPerSegment: number;
+};
+
+type ResolvedPagedSplatProps = {
+  modelViewProjectionMatrix: [
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number
+  ];
+  viewportSize: [number, number];
+  cameraPosition: [number, number, number];
+  sphericalHarmonicsDegree: SplatSphericalHarmonicsDegree;
+  semanticFilter?: SplatSemanticFilter;
+  sortMode: 'global';
+  alphaCutoff: number;
+  screenSizeCutoffPixels: number;
+  gaussianSupportRadius: number;
+  kernel2DSize: number;
+  maxScreenSpaceSplatSize: number;
+  radiusScale: number;
+  alphaScale: number;
+  exposure: number;
+  toneMapping: 'none' | 'reinhard';
+};
+
+type PlannedSourceSegment = {
+  id: string;
+  page: GPUPagedSplatPage;
+  activeRows?: Uint32Array;
+  activeRowCount: number;
+  sourceRowOffset: number;
+  sourceBindingRowOffset: number;
+  sourceRowCount: number;
+  usesSourceRanges: boolean;
+  globalRowOffset: number;
+};
+
+type SourceSegment = PlannedSourceSegment & {
+  activeRowBuffer: Buffer;
+  projectedRecordBuffer: Buffer;
+  uniformBuffer: Buffer;
+  featureUniformBuffer: Buffer;
+  graphUniforms: GraphBufferHandle;
+  graphFeatureUniforms: GraphBufferHandle;
+  graphActiveRows: GraphBufferHandle;
+  graphProjectedRecords: GraphBufferHandle;
+};
+
+type OutputSegment = {
+  index: number;
+  globalRowOffset: number;
+  rowCount: number;
+  projectedRecordBuffer: Buffer;
+  graphProjectedRecords: GraphBufferHandle;
+};
+
+const SOURCE_COLUMNS = [
+  {name: 'positions', rowByteLength: 12},
+  {name: 'scales', rowByteLength: 12},
+  {name: 'rotations', rowByteLength: 16},
+  {name: 'colors', rowByteLength: 4},
+  {name: 'opacities', rowByteLength: 4}
+] as const;
+
+const INITIALIZE_LAYOUT = {
+  attributes: [],
+  bindings: [
+    {name: 'values', type: 'storage', group: 0, location: 0},
+    {name: 'depthKeys', type: 'storage', group: 0, location: 1},
+    {name: 'drawCommands', type: 'storage', group: 0, location: 2}
+  ]
+} satisfies ShaderLayout;
+
+const INVERSE_LAYOUT = {
+  attributes: [],
+  bindings: [
+    {name: 'sortedIndices', type: 'read-only-storage', group: 0, location: 0},
+    {name: 'inverseIndices', type: 'storage', group: 0, location: 1}
+  ]
+} satisfies ShaderLayout;
+
+const SCATTER_LAYOUT = {
+  attributes: [],
+  bindings: [
+    {name: 'sourceRecords', type: 'read-only-storage', group: 0, location: 0},
+    {name: 'inverseIndices', type: 'read-only-storage', group: 0, location: 1},
+    {name: 'outputRecords', type: 'storage', group: 0, location: 2},
+    {name: 'graphUniforms', type: 'uniform', group: 0, location: 3}
+  ]
+} satisfies ShaderLayout;
+
+const SEGMENT_DRAW_LAYOUT = {
+  attributes: [],
+  bindings: [{name: 'drawCommands', type: 'storage', group: 0, location: 0}]
+} satisfies ShaderLayout;
+
+/**
+ * Globally ordered WebGPU Gaussian rendering across independently bounded projected segments.
+ *
+ * Original page buffers remain borrowed. Sparse hierarchy rows are projected directly from their
+ * original source columns, all pages share one exact GPU radix depth ordering, and globally ordered
+ * projected records are gathered into independently bound <= device-limit output segments.
+ */
+export class GPUPagedSplatRenderer {
+  /** WebGPU device shared with all caller-owned source pages. */
+  readonly device: Device;
+  /** Resolved camera, Gaussian visibility, source-semantic, and HDR presentation controls. */
+  readonly props: ResolvedPagedSplatProps;
+  /** Intact caller-selected pages, retaining their independently owned source allocations. */
+  readonly pages: GPUPagedSplatPage[] = [];
+  /** Global visible instance count plus one indirect draw command per ordered output segment. */
+  drawCommands: DrawCommandBuffer;
+  /** Current reusable page-aware command graph, available after its first nonempty encoding. */
+  compiledGraph?: CompiledGPUCommandGraph;
+  /** Immediate CPU/node diagnostics from the latest globally ordered graph encoding. */
+  lastEncoding?: GPUCommandGraphEncoding;
+
+  private readonly clearColor: [number, number, number, number];
+  private readonly requestedSegmentCapacity?: number;
+  private readonly ownedBuffers: Buffer[] = [];
+  private readonly sourceSegments: SourceSegment[] = [];
+  private readonly outputSegments: OutputSegment[] = [];
+  private readonly pageRevisions = new Map<string, number>();
+  private plannedSegments: PlannedSourceSegment[] = [];
+  private model?: Model;
+  private sortedValuesBuffer?: Buffer;
+  private semanticSelectionBuffer?: Buffer;
+  private semanticSelectionValues = new Uint32Array(0);
+  private semanticIncludeCount = 0;
+  private semanticExcludeCount = 0;
+  private semanticSelectionCapacity = 0;
+  private globalSortCapacity = 0;
+  private requiresGraphRebuild = true;
+  private requiresEncoding = true;
+  private hasPresentedContent = false;
+  private hasExplicitToneMapping = false;
+  private isDestroyed = false;
+
+  /** Retains intact source pages lazily without projecting, sorting, or copying source rows. */
+  constructor(device: Device, props: GPUPagedSplatRendererProps = {}) {
+    if (device.type !== 'webgpu') {
+      throw new Error('GPUPagedSplatRenderer requires a WebGPU device');
+    }
+    assert(
+      props.maxProjectedSplatsPerSegment === undefined ||
+        (Number.isSafeInteger(props.maxProjectedSplatsPerSegment) &&
+          props.maxProjectedSplatsPerSegment > 0)
+    );
+
+    this.device = device;
+    this.requestedSegmentCapacity = props.maxProjectedSplatsPerSegment;
+    this.clearColor = [...(props.clearColor ?? [0, 0, 0, 0])];
+    this.props = {
+      modelViewProjectionMatrix: toPagedSplatMatrix(props.modelViewProjectionMatrix),
+      viewportSize: [...(props.viewportSize ?? [1, 1])],
+      cameraPosition: [...(props.cameraPosition ?? [0, 0, 0])],
+      sphericalHarmonicsDegree: props.sphericalHarmonicsDegree ?? 3,
+      ...(props.semanticFilter ? {semanticFilter: props.semanticFilter} : {}),
+      sortMode: 'global',
+      alphaCutoff: props.alphaCutoff ?? props.opacityThreshold ?? 1 / 255,
+      screenSizeCutoffPixels: props.screenSizeCutoffPixels ?? 0,
+      gaussianSupportRadius: props.gaussianSupportRadius ?? 3,
+      kernel2DSize: props.kernel2DSize ?? 0.3,
+      maxScreenSpaceSplatSize: props.maxScreenSpaceSplatSize ?? 1024,
+      radiusScale: props.radiusScale ?? props.pointSize ?? 1,
+      alphaScale: props.alphaScale ?? 1,
+      exposure: props.exposure ?? 1,
+      toneMapping: props.toneMapping ?? 'none'
+    };
+    this.hasExplicitToneMapping = props.toneMapping !== undefined;
+    this.updateSemanticSelections(props.semanticFilter);
+    this.drawCommands = this.createDrawCommands(1);
+
+    if (props.pages) {
+      this.setFrontier(props.pages);
+    } else if (props.data) {
+      const batches = props.data instanceof GPUSplatData ? [props.data] : props.data;
+      this.setFrontier(
+        batches.map(batch => ({
+          id: `${batch.sourceBatchIndex}:${batch.rowIndexBase}`,
+          data: batch
+        }))
+      );
+    }
+  }
+
+  /** Independent caller-owned source batches in the same order as the selected page frontier. */
+  get batches(): GPUSplatData[] {
+    return this.pages.map(page => page.data);
+  }
+
+  /** Renderer-owned globally sorted sparse-row identities, available after graph compilation. */
+  get sortedIndexBuffer(): Buffer | undefined {
+    return this.sortedValuesBuffer;
+  }
+
+  /** Ordered projected segment allocations; no single segment exceeds a storage binding limit. */
+  get projectedRecordBuffers(): readonly Buffer[] {
+    return this.outputSegments.map(segment => segment.projectedRecordBuffer);
+  }
+
+  /** Shared presentation uniforms for integrations that draw ordered segments externally. */
+  get uniformBuffer(): Buffer | undefined {
+    return this.sourceSegments[0]?.uniformBuffer;
+  }
+
+  /** Compiled node order, hazard ordering, and physically allocated graph scratch diagnostics. */
+  get graphStats(): GPUCommandGraphStats | undefined {
+    return this.compiledGraph?.stats;
+  }
+
+  /** Loaded source, sparse active row, segmented output, and GPU-memory diagnostics. */
+  get stats(): GPUPagedSplatRendererStats {
+    return this.getStats();
+  }
+
+  /** Whether owned graph, working allocations, and indirect draw records have been released. */
+  get destroyed(): boolean {
+    return this.isDestroyed;
+  }
+
+  /** Replaces the active row frontier while retaining all caller-owned source allocations. */
+  setFrontier(pages: readonly GPUPagedSplatPage[]): void {
+    if (this.isDestroyed) {
+      throw new Error('Cannot update a destroyed paged Gaussian splat renderer');
+    }
+    const pageIds = new Set<string>();
+    for (const page of pages) {
+      if (!page.id || pageIds.has(page.id)) {
+        throw new Error('Paged Gaussian splats require unique nonempty page identifiers');
+      }
+      if (page.data.destroyed || page.data.device !== this.device) {
+        throw new Error('Paged Gaussian splats require live data prepared on their own device');
+      }
+      pageIds.add(page.id);
+    }
+
+    const nextSegments = this.planSourceSegments(pages);
+    const canReuseGraph =
+      this.compiledGraph !== undefined &&
+      nextSegments.length === this.sourceSegments.length &&
+      nextSegments.every((segment, index) => {
+        const previousSegment = this.sourceSegments[index];
+        return (
+          segment.id === previousSegment.id &&
+          segment.page.data === previousSegment.page.data &&
+          segment.activeRowCount === previousSegment.activeRowCount &&
+          segment.sourceRowOffset === previousSegment.sourceRowOffset &&
+          segment.sourceBindingRowOffset === previousSegment.sourceBindingRowOffset &&
+          segment.sourceRowCount === previousSegment.sourceRowCount &&
+          segment.usesSourceRanges === previousSegment.usesSourceRanges
+        );
+      });
+    if (!canReuseGraph && nextSegments.length > 0) {
+      this.releaseCompiledGraph();
+    }
+    this.pages.splice(0, this.pages.length, ...pages);
+    this.plannedSegments = nextSegments;
+    for (const page of pages) {
+      this.pageRevisions.set(page.id, page.data.revision);
+      if (
+        !this.hasExplicitToneMapping &&
+        page.data.colors.format === 'float32x4' &&
+        !hasPagedHighDynamicRangePresentation(this.device)
+      ) {
+        this.props.toneMapping = 'reinhard';
+      }
+    }
+    for (const pageId of this.pageRevisions.keys()) {
+      if (!pageIds.has(pageId)) {
+        this.pageRevisions.delete(pageId);
+      }
+    }
+    if (canReuseGraph) {
+      for (let segmentIndex = 0; segmentIndex < this.sourceSegments.length; segmentIndex++) {
+        Object.assign(this.sourceSegments[segmentIndex], nextSegments[segmentIndex]);
+      }
+    } else if (nextSegments.length > 0) {
+      this.requiresGraphRebuild = true;
+    }
+    this.requiresEncoding = true;
+  }
+
+  /** Alias for page-oriented callers that do not expose a hierarchy-specific frontier name. */
+  setPages(pages: readonly GPUPagedSplatPage[]): void {
+    this.setFrontier(pages);
+  }
+
+  /** Updates borrowed pages, camera matrices, sparse semantic selections, or display uniforms. */
+  setProps(props: Partial<GPUPagedSplatRendererProps>): void {
+    if (props.pages) {
+      this.setFrontier(props.pages);
+    } else if (props.data !== undefined) {
+      const batches = props.data instanceof GPUSplatData ? [props.data] : props.data;
+      this.setFrontier(
+        batches.map(batch => ({id: `${batch.sourceBatchIndex}:${batch.rowIndexBase}`, data: batch}))
+      );
+    }
+    if (
+      props.modelViewProjectionMatrix &&
+      !arePagedSplatValuesEqual(
+        this.props.modelViewProjectionMatrix,
+        props.modelViewProjectionMatrix
+      )
+    ) {
+      this.props.modelViewProjectionMatrix = toPagedSplatMatrix(props.modelViewProjectionMatrix);
+      this.requiresEncoding = true;
+    }
+    if (
+      props.viewportSize &&
+      !arePagedSplatValuesEqual(this.props.viewportSize, props.viewportSize)
+    ) {
+      this.props.viewportSize = [...props.viewportSize];
+      this.requiresEncoding = true;
+    }
+    if (
+      props.cameraPosition &&
+      !arePagedSplatValuesEqual(this.props.cameraPosition, props.cameraPosition)
+    ) {
+      this.props.cameraPosition = [...props.cameraPosition];
+      this.requiresEncoding = true;
+    }
+    if (
+      props.sphericalHarmonicsDegree !== undefined &&
+      this.props.sphericalHarmonicsDegree !== props.sphericalHarmonicsDegree
+    ) {
+      this.props.sphericalHarmonicsDegree = props.sphericalHarmonicsDegree;
+      this.requiresEncoding = true;
+    }
+    if ('semanticFilter' in props && !Object.is(this.props.semanticFilter, props.semanticFilter)) {
+      this.updateSemanticSelections(props.semanticFilter);
+      this.props.semanticFilter = props.semanticFilter;
+      this.requiresEncoding = true;
+    }
+
+    const updates: Partial<ResolvedPagedSplatProps> = {
+      ...(props.alphaCutoff !== undefined || props.opacityThreshold !== undefined
+        ? {alphaCutoff: props.alphaCutoff ?? props.opacityThreshold}
+        : {}),
+      ...(props.radiusScale !== undefined || props.pointSize !== undefined
+        ? {radiusScale: props.radiusScale ?? props.pointSize}
+        : {}),
+      ...(props.screenSizeCutoffPixels !== undefined
+        ? {screenSizeCutoffPixels: props.screenSizeCutoffPixels}
+        : {}),
+      ...(props.gaussianSupportRadius !== undefined
+        ? {gaussianSupportRadius: props.gaussianSupportRadius}
+        : {}),
+      ...(props.kernel2DSize !== undefined ? {kernel2DSize: props.kernel2DSize} : {}),
+      ...(props.maxScreenSpaceSplatSize !== undefined
+        ? {maxScreenSpaceSplatSize: props.maxScreenSpaceSplatSize}
+        : {}),
+      ...(props.alphaScale !== undefined ? {alphaScale: props.alphaScale} : {}),
+      ...(props.exposure !== undefined ? {exposure: props.exposure} : {}),
+      ...(props.toneMapping !== undefined ? {toneMapping: props.toneMapping} : {})
+    };
+    if (props.toneMapping !== undefined) {
+      this.hasExplicitToneMapping = true;
+    }
+    for (const [propertyName, value] of Object.entries(updates)) {
+      if (this.props[propertyName as keyof ResolvedPagedSplatProps] !== value) {
+        Object.assign(this.props, {[propertyName]: value});
+        this.requiresEncoding = true;
+      }
+    }
+  }
+
+  /** Encodes sparse projection, exact cross-page ordering, segmented gather, and one render pass. */
+  encode(commandEncoder: CommandEncoder): GPUCommandGraphEncoding | undefined {
+    if (this.isDestroyed) {
+      return undefined;
+    }
+    if (this.plannedSegments.length === 0) {
+      if (!this.requiresEncoding || !this.hasPresentedContent) {
+        return undefined;
+      }
+      this.drawCommands.buffer.write(
+        new Uint32Array([0]),
+        this.drawCommands.getInstanceCountByteOffset(0)
+      );
+      const renderPass = commandEncoder.beginRenderPass({
+        id: 'paged-gaussian-splat-clear-pass',
+        clearColor: this.clearColor,
+        clearDepth: 1,
+        clearStencil: false
+      });
+      renderPass.end();
+      this.lastEncoding = new GPUCommandGraphEncoding(
+        [
+          {
+            stats: {
+              id: 'paged-gaussian-splat-clear',
+              type: 'render',
+              cpuEncodeTimeMilliseconds: 0,
+              hasGPUTimestamps: false
+            }
+          }
+        ],
+        0
+      );
+      this.hasPresentedContent = false;
+      this.requiresEncoding = false;
+      return this.lastEncoding;
+    }
+    for (const page of this.pages) {
+      if (page.data.revision !== this.pageRevisions.get(page.id)) {
+        this.pageRevisions.set(page.id, page.data.revision);
+        this.requiresEncoding = true;
+      }
+    }
+    if (!this.requiresEncoding) {
+      return undefined;
+    }
+    if (this.requiresGraphRebuild) {
+      this.rebuildGraph();
+    }
+    if (!this.compiledGraph) {
+      return undefined;
+    }
+    this.writeSourceUniforms();
+    this.lastEncoding = this.compiledGraph.encode(commandEncoder, {parameters: undefined});
+    this.hasPresentedContent = true;
+    this.requiresEncoding = false;
+    return this.lastEncoding;
+  }
+
+  /** Counts unique caller-owned pages separately from renderer-owned bounded working storage. */
+  getStats(): GPUPagedSplatRendererStats {
+    const uniqueSourceBatches = new Set(this.pages.map(page => page.data));
+    const sourceGpuByteLength = Array.from(uniqueSourceBatches).reduce(
+      (totalByteLength, batch) => totalByteLength + batch.byteLength,
+      0
+    );
+    const rendererGpuByteLength =
+      this.drawCommands.buffer.byteLength +
+      this.ownedBuffers.reduce(
+        (totalByteLength, buffer) => totalByteLength + buffer.byteLength,
+        0
+      ) +
+      (this.compiledGraph?.stats.physicalTransientBytes ?? 0);
+    const activeRowCount = this.plannedSegments.reduce(
+      (totalRowCount, segment) => totalRowCount + segment.activeRowCount,
+      0
+    );
+    const loadedRowCount = this.pages.reduce(
+      (totalRowCount, page) => totalRowCount + page.data.length,
+      0
+    );
+    return {
+      splatCount: activeRowCount,
+      rowCount: loadedRowCount,
+      visibleSplatCount: activeRowCount,
+      batchCount: this.pages.length,
+      pageCount: this.pages.length,
+      sourceSegmentCount: this.plannedSegments.length,
+      segmentCount: this.outputSegments.length,
+      activeRowCount,
+      globalSortCapacity: this.globalSortCapacity,
+      maxProjectedSplatsPerSegment: this.getMaximumProjectedSegmentRows(),
+      sortMode: 'global',
+      sourceGpuByteLength,
+      rendererGpuByteLength,
+      gpuByteLength: sourceGpuByteLength + rendererGpuByteLength,
+      drawCallCount: this.outputSegments.length
+    };
+  }
+
+  /** Releases graph-owned scratch and renderer-owned allocations without touching source pages. */
+  destroy(): void {
+    if (this.isDestroyed) {
+      return;
+    }
+    this.releaseCompiledGraph();
+    this.drawCommands.destroy();
+    this.pages.length = 0;
+    this.plannedSegments.length = 0;
+    this.pageRevisions.clear();
+    this.isDestroyed = true;
+  }
+
+  private rebuildGraph(): void {
+    this.releaseCompiledGraph();
+    const activeRowCount = this.plannedSegments.reduce(
+      (totalRowCount, segment) => totalRowCount + segment.activeRowCount,
+      0
+    );
+    if (activeRowCount === 0) {
+      this.requiresGraphRebuild = false;
+      return;
+    }
+    const maximumStorageByteLength = this.device.limits.maxStorageBufferBindingSize;
+    if (
+      maximumStorageByteLength > 0 &&
+      activeRowCount * Uint32Array.BYTES_PER_ELEMENT > maximumStorageByteLength
+    ) {
+      throw new Error('Paged Gaussian global sorting exceeds the device storage binding limit');
+    }
+    this.globalSortCapacity = activeRowCount;
+    const graph = new GPUCommandGraph(this.device, {id: 'paged-gaussian-splat-render-graph'});
+    const outputSegmentCount = Math.ceil(activeRowCount / this.getMaximumProjectedSegmentRows());
+    if (this.drawCommands.capacity < outputSegmentCount + 1) {
+      this.drawCommands.destroy();
+      this.drawCommands = this.createDrawCommands(outputSegmentCount + 1);
+    }
+
+    const depthKeys = this.importUint32Buffer(
+      graph,
+      this.createOwnedBuffer('paged-gaussian-depth-keys', activeRowCount * 4),
+      activeRowCount
+    );
+    const sourceIndices = this.importUint32Buffer(
+      graph,
+      this.createOwnedBuffer('paged-gaussian-source-indices', activeRowCount * 4),
+      activeRowCount
+    );
+    const sortedKeys = this.importUint32Buffer(
+      graph,
+      this.createOwnedBuffer('paged-gaussian-sorted-depths', activeRowCount * 4),
+      activeRowCount
+    );
+    this.sortedValuesBuffer = this.createOwnedBuffer(
+      'paged-gaussian-sorted-indices',
+      activeRowCount * 4
+    );
+    const sortedIndices = this.importUint32Buffer(graph, this.sortedValuesBuffer, activeRowCount);
+    const inverseIndices = this.importUint32Buffer(
+      graph,
+      this.createOwnedBuffer('paged-gaussian-inverse-indices', activeRowCount * 4),
+      activeRowCount
+    );
+    this.semanticSelectionCapacity = Math.max(
+      MINIMUM_SEMANTIC_SELECTION_CAPACITY,
+      this.semanticSelectionValues.length
+    );
+    this.semanticSelectionBuffer = this.createOwnedBuffer(
+      'paged-gaussian-semantic-selections',
+      this.semanticSelectionCapacity * 4
+    );
+    const semanticSelections = this.importOwnedBuffer(graph, this.semanticSelectionBuffer);
+    const drawCommandViews = this.drawCommands.importToGraph(graph, 'paged-gaussian-draw-commands');
+
+    this.addInitializationPass(graph, sourceIndices, depthKeys, drawCommandViews.buffer);
+    for (const plannedSegment of this.plannedSegments) {
+      const segment = this.createSourceSegment(graph, plannedSegment);
+      this.sourceSegments.push(segment);
+      this.addProjectionPass(graph, segment, depthKeys);
+      this.addFeaturePass(graph, segment, depthKeys, drawCommandViews.buffer, semanticSelections);
+    }
+
+    new GPUSort({
+      id: 'paged-gaussian-global-depth-sort',
+      keys: depthKeys,
+      values: sourceIndices,
+      outputKeys: sortedKeys,
+      outputValues: sortedIndices,
+      algorithm: 'radix',
+      direction: 'ascending',
+      keyBits: 16
+    }).addToGraph(graph);
+    this.addInversePermutationPass(graph, sortedIndices, inverseIndices);
+
+    for (let segmentIndex = 0; segmentIndex < outputSegmentCount; segmentIndex++) {
+      const globalRowOffset = segmentIndex * this.getMaximumProjectedSegmentRows();
+      const rowCount = Math.min(
+        activeRowCount - globalRowOffset,
+        this.getMaximumProjectedSegmentRows()
+      );
+      const projectedRecordBuffer = this.createOwnedBuffer(
+        `paged-gaussian-sorted-records-${segmentIndex}`,
+        rowCount * GPU_SPLAT_PROJECTED_RECORD_BYTE_LENGTH
+      );
+      const outputSegment: OutputSegment = {
+        index: segmentIndex,
+        globalRowOffset,
+        rowCount,
+        projectedRecordBuffer,
+        graphProjectedRecords: this.importOwnedBuffer(graph, projectedRecordBuffer)
+      };
+      this.outputSegments.push(outputSegment);
+      for (const sourceSegment of this.sourceSegments) {
+        this.addScatterPass(graph, sourceSegment, outputSegment, inverseIndices);
+      }
+      this.addSegmentDrawCountPass(graph, outputSegment, drawCommandViews.buffer);
+    }
+    this.addRenderPass(graph, drawCommandViews.buffer);
+    this.compiledGraph = graph.compile();
+    this.requiresGraphRebuild = false;
+  }
+
+  private createSourceSegment(
+    graph: GPUCommandGraph,
+    planned: PlannedSourceSegment
+  ): SourceSegment {
+    const activeRowBuffer = this.createOwnedBuffer(
+      `paged-gaussian-active-rows-${planned.id}`,
+      Math.max(planned.activeRows?.byteLength ?? 0, 4)
+    );
+    const projectedRecordBuffer = this.createOwnedBuffer(
+      `paged-gaussian-projected-${planned.id}`,
+      planned.activeRowCount * GPU_SPLAT_PROJECTED_RECORD_BYTE_LENGTH
+    );
+    const uniformBuffer = this.createUniformBuffer(
+      `paged-gaussian-uniforms-${planned.id}`,
+      GPU_SPLAT_GRAPH_UNIFORM_BYTE_LENGTH
+    );
+    const featureUniformBuffer = this.createUniformBuffer(
+      `paged-gaussian-features-${planned.id}`,
+      GPU_SPLAT_GRAPH_FEATURE_UNIFORM_BYTE_LENGTH
+    );
+    return {
+      ...planned,
+      activeRowBuffer,
+      projectedRecordBuffer,
+      uniformBuffer,
+      featureUniformBuffer,
+      graphUniforms: this.importOwnedBuffer(graph, uniformBuffer),
+      graphFeatureUniforms: this.importOwnedBuffer(graph, featureUniformBuffer),
+      graphActiveRows: this.importOwnedBuffer(graph, activeRowBuffer),
+      graphProjectedRecords: this.importOwnedBuffer(graph, projectedRecordBuffer)
+    };
+  }
+
+  private addInitializationPass(
+    graph: GPUCommandGraph,
+    values: GraphDataView<'uint32'>,
+    depthKeys: GraphDataView<'uint32'>,
+    drawCommands: GraphBufferHandle
+  ): void {
+    const dispatch = getPagedDispatch(this.globalSortCapacity, this.device);
+    const shader = /* wgsl */ `
+const ROW_COUNT: u32 = ${this.globalSortCapacity}u;
+const WORKGROUPS_X: u32 = ${dispatch.x}u;
+const INVALID_DEPTH_KEY: u32 = ${GPU_SPLAT_INVALID_DEPTH_KEY}u;
+@group(0) @binding(0) var<storage, read_write> values: array<u32>;
+@group(0) @binding(1) var<storage, read_write> depthKeys: array<u32>;
+@group(0) @binding(2) var<storage, read_write> drawCommands: array<atomic<u32>>;
+@compute @workgroup_size(${WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
+  let rowIndex = invocation.x + invocation.y * WORKGROUPS_X * ${WORKGROUP_SIZE}u;
+  if (rowIndex < ROW_COUNT) {
+    values[rowIndex] = rowIndex;
+    depthKeys[rowIndex] = INVALID_DEPTH_KEY;
+  }
+  if (rowIndex == 0u) {
+    atomicStore(&drawCommands[1u], 0u);
+  }
+}`;
+    graph.addComputePass({
+      id: 'paged-gaussian-initialize',
+      resources: [
+        {buffer: values, usage: 'storage-write'},
+        {buffer: depthKeys, usage: 'storage-write'},
+        {buffer: drawCommands, usage: 'storage-write'}
+      ],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: 'paged-gaussian-initialize',
+          source: shader,
+          shaderLayout: INITIALIZE_LAYOUT
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            computation.setBindings({
+              values: getBuffer(values),
+              depthKeys: getBuffer(depthKeys),
+              drawCommands: getBuffer(drawCommands)
+            });
+            computation.dispatch(computePass, dispatch.x, dispatch.y);
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+  }
+
+  private addProjectionPass(
+    graph: GPUCommandGraph,
+    segment: SourceSegment,
+    depthKeys: GraphDataView<'uint32'>
+  ): void {
+    const sourceHandles = this.importSourceBuffers(graph, segment);
+    graph.addComputePass({
+      id: `paged-gaussian-project-${segment.id}`,
+      resources: [
+        ...SOURCE_COLUMNS.map(({name}) => ({
+          buffer: sourceHandles[name],
+          usage: 'storage-read' as const
+        })),
+        {buffer: segment.graphProjectedRecords, usage: 'storage-write'},
+        {buffer: depthKeys, usage: 'storage-write'},
+        {buffer: segment.graphActiveRows, usage: 'storage-read'},
+        {buffer: segment.graphUniforms, usage: 'uniform'}
+      ],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: `paged-gaussian-project-${segment.id}`,
+          source: GPU_PAGED_SPLAT_PROJECTION_SHADER,
+          shaderLayout: GPU_PAGED_SPLAT_PROJECTION_SHADER_LAYOUT
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            computation.setBindings({
+              positions: this.getSourceBinding(
+                segment,
+                'positions',
+                getBuffer(sourceHandles.positions)
+              ),
+              scales: this.getSourceBinding(segment, 'scales', getBuffer(sourceHandles.scales)),
+              rotations: this.getSourceBinding(
+                segment,
+                'rotations',
+                getBuffer(sourceHandles.rotations)
+              ),
+              colors: this.getSourceBinding(segment, 'colors', getBuffer(sourceHandles.colors)),
+              opacities: this.getSourceBinding(
+                segment,
+                'opacities',
+                getBuffer(sourceHandles.opacities)
+              ),
+              projectedRecords: getBuffer(segment.graphProjectedRecords),
+              depthKeys: getBuffer(depthKeys),
+              activeRows: getBuffer(segment.graphActiveRows),
+              graphUniforms: getBuffer(segment.graphUniforms)
+            });
+            computation.dispatch(computePass, Math.ceil(segment.activeRowCount / WORKGROUP_SIZE));
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+  }
+
+  private addFeaturePass(
+    graph: GPUCommandGraph,
+    segment: SourceSegment,
+    depthKeys: GraphDataView<'uint32'>,
+    drawCommands: GraphBufferHandle,
+    semanticSelections: GraphBufferHandle
+  ): void {
+    const sourceHandles = this.importFeatureBuffers(graph, segment);
+    graph.addComputePass({
+      id: `paged-gaussian-features-${segment.id}`,
+      resources: [
+        {buffer: sourceHandles.positions, usage: 'storage-read'},
+        {buffer: sourceHandles.sphericalHarmonics, usage: 'storage-read'},
+        {buffer: sourceHandles.semanticIds, usage: 'storage-read'},
+        {buffer: semanticSelections, usage: 'storage-read'},
+        {buffer: segment.graphProjectedRecords, usage: 'storage-read-write'},
+        {buffer: depthKeys, usage: 'storage-read-write'},
+        {buffer: drawCommands, usage: 'storage-read-write'},
+        {buffer: segment.graphActiveRows, usage: 'storage-read'},
+        {buffer: segment.graphUniforms, usage: 'uniform'},
+        {buffer: segment.graphFeatureUniforms, usage: 'uniform'}
+      ],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: `paged-gaussian-features-${segment.id}`,
+          source: GPU_PAGED_SPLAT_FEATURE_SHADER,
+          shaderLayout: GPU_PAGED_SPLAT_FEATURE_SHADER_LAYOUT
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            computation.setBindings({
+              positions: this.getSourceBinding(
+                segment,
+                'positions',
+                getBuffer(sourceHandles.positions)
+              ),
+              sphericalHarmonics: this.getSourceBinding(
+                segment,
+                'sphericalHarmonics',
+                getBuffer(sourceHandles.sphericalHarmonics)
+              ),
+              semanticIds: this.getSourceBinding(
+                segment,
+                'semanticIds',
+                getBuffer(sourceHandles.semanticIds)
+              ),
+              semanticSelections: getBuffer(semanticSelections),
+              projectedRecords: getBuffer(segment.graphProjectedRecords),
+              depthKeys: getBuffer(depthKeys),
+              drawCommands: getBuffer(drawCommands),
+              activeRows: getBuffer(segment.graphActiveRows),
+              graphUniforms: getBuffer(segment.graphUniforms),
+              featureUniforms: getBuffer(segment.graphFeatureUniforms)
+            });
+            computation.dispatch(computePass, Math.ceil(segment.activeRowCount / WORKGROUP_SIZE));
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+  }
+
+  private addInversePermutationPass(
+    graph: GPUCommandGraph,
+    sortedIndices: GraphDataView<'uint32'>,
+    inverseIndices: GraphDataView<'uint32'>
+  ): void {
+    const dispatch = getPagedDispatch(this.globalSortCapacity, this.device);
+    const shader = /* wgsl */ `
+const ROW_COUNT: u32 = ${this.globalSortCapacity}u;
+const WORKGROUPS_X: u32 = ${dispatch.x}u;
+@group(0) @binding(0) var<storage, read> sortedIndices: array<u32>;
+@group(0) @binding(1) var<storage, read_write> inverseIndices: array<u32>;
+@compute @workgroup_size(${WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
+  let sortedRow = invocation.x + invocation.y * WORKGROUPS_X * ${WORKGROUP_SIZE}u;
+  if (sortedRow < ROW_COUNT) {
+    inverseIndices[sortedIndices[sortedRow]] = sortedRow;
+  }
+}`;
+    graph.addComputePass({
+      id: 'paged-gaussian-inverse-permutation',
+      resources: [
+        {buffer: sortedIndices, usage: 'storage-read'},
+        {buffer: inverseIndices, usage: 'storage-write'}
+      ],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: 'paged-gaussian-inverse-permutation',
+          source: shader,
+          shaderLayout: INVERSE_LAYOUT
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            computation.setBindings({
+              sortedIndices: getBuffer(sortedIndices),
+              inverseIndices: getBuffer(inverseIndices)
+            });
+            computation.dispatch(computePass, dispatch.x, dispatch.y);
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+  }
+
+  private addScatterPass(
+    graph: GPUCommandGraph,
+    sourceSegment: SourceSegment,
+    outputSegment: OutputSegment,
+    inverseIndices: GraphDataView<'uint32'>
+  ): void {
+    const shader = /* wgsl */ `
+struct ProjectedSplat {
+  clipCenter: vec4<f32>,
+  axis0: vec2<f32>,
+  axis1: vec2<f32>,
+  color: vec4<f32>,
+};
+struct GraphSplatUniforms {
+  modelViewProjectionMatrix: mat4x4<f32>,
+  viewportSize: vec2<f32>,
+  radiusScale: f32,
+  alphaScale: f32,
+  alphaCutoff: f32,
+  screenSizeCutoffPixels: f32,
+  gaussianSupportRadius: f32,
+  kernel2DSize: f32,
+  maxScreenSpaceSplatSize: f32,
+  exposure: f32,
+  toneMapping: u32,
+  batchOffset: u32,
+  rowCount: u32,
+  isFloatColor: u32,
+  hasActiveRows: u32,
+  sourceRowOffset: u32,
+};
+const DESTINATION_OFFSET: u32 = ${outputSegment.globalRowOffset}u;
+const DESTINATION_LENGTH: u32 = ${outputSegment.rowCount}u;
+@group(0) @binding(0) var<storage, read> sourceRecords: array<ProjectedSplat>;
+@group(0) @binding(1) var<storage, read> inverseIndices: array<u32>;
+@group(0) @binding(2) var<storage, read_write> outputRecords: array<ProjectedSplat>;
+@group(0) @binding(3) var<uniform> graphUniforms: GraphSplatUniforms;
+@compute @workgroup_size(${WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
+  let sourceRow = invocation.x;
+  if (sourceRow >= graphUniforms.rowCount) {
+    return;
+  }
+  let sortedRow = inverseIndices[graphUniforms.batchOffset + sourceRow];
+  if (sortedRow >= DESTINATION_OFFSET && sortedRow < DESTINATION_OFFSET + DESTINATION_LENGTH) {
+    outputRecords[sortedRow - DESTINATION_OFFSET] = sourceRecords[sourceRow];
+  }
+}`;
+    const passId = `paged-gaussian-gather-${sourceSegment.id}-into-${outputSegment.index}`;
+    graph.addComputePass({
+      id: passId,
+      resources: [
+        {buffer: sourceSegment.graphProjectedRecords, usage: 'storage-read'},
+        {buffer: inverseIndices, usage: 'storage-read'},
+        {buffer: outputSegment.graphProjectedRecords, usage: 'storage-write'},
+        {buffer: sourceSegment.graphUniforms, usage: 'uniform'}
+      ],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: passId,
+          source: shader,
+          shaderLayout: SCATTER_LAYOUT
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            computation.setBindings({
+              sourceRecords: getBuffer(sourceSegment.graphProjectedRecords),
+              inverseIndices: getBuffer(inverseIndices),
+              outputRecords: getBuffer(outputSegment.graphProjectedRecords),
+              graphUniforms: getBuffer(sourceSegment.graphUniforms)
+            });
+            computation.dispatch(
+              computePass,
+              Math.ceil(sourceSegment.activeRowCount / WORKGROUP_SIZE)
+            );
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+  }
+
+  private addSegmentDrawCountPass(
+    graph: GPUCommandGraph,
+    segment: OutputSegment,
+    drawCommands: GraphBufferHandle
+  ): void {
+    const shader = /* wgsl */ `
+const SEGMENT_OFFSET: u32 = ${segment.globalRowOffset}u;
+const SEGMENT_LENGTH: u32 = ${segment.rowCount}u;
+const COMMAND_OFFSET: u32 = ${(segment.index + 1) * 4}u;
+@group(0) @binding(0) var<storage, read_write> drawCommands: array<u32>;
+@compute @workgroup_size(1)
+fn main() {
+  let visibleCount = drawCommands[1u];
+  drawCommands[COMMAND_OFFSET] = 4u;
+  drawCommands[COMMAND_OFFSET + 1u] = select(
+    0u,
+    min(visibleCount - SEGMENT_OFFSET, SEGMENT_LENGTH),
+    visibleCount > SEGMENT_OFFSET
+  );
+  drawCommands[COMMAND_OFFSET + 2u] = 0u;
+  drawCommands[COMMAND_OFFSET + 3u] = 0u;
+}`;
+    const passId = `paged-gaussian-indirect-count-${segment.index}`;
+    graph.addComputePass({
+      id: passId,
+      resources: [{buffer: drawCommands, usage: 'storage-read-write'}],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: passId,
+          source: shader,
+          shaderLayout: SEGMENT_DRAW_LAYOUT
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            computation.setBindings({drawCommands: getBuffer(drawCommands)});
+            computation.dispatch(computePass, 1);
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+  }
+
+  private addRenderPass(graph: GPUCommandGraph, drawCommands: GraphBufferHandle): void {
+    const firstUniform = this.sourceSegments[0].graphUniforms;
+    const firstUniformBuffer = this.sourceSegments[0].uniformBuffer;
+    const firstOutput = this.outputSegments[0];
+    this.model = new Model(this.device, {
+      id: 'paged-gaussian-render-model',
+      source: GPU_PAGED_SPLAT_RENDER_SHADER,
+      shaderLayout: GPU_PAGED_SPLAT_RENDER_SHADER_LAYOUT,
+      isInstanced: true,
+      instanceCount: this.getMaximumProjectedSegmentRows(),
+      vertexCount: 4,
+      topology: 'triangle-strip',
+      bindings: {
+        graphUniforms: firstUniformBuffer,
+        projectedRecords: firstOutput.projectedRecordBuffer
+      },
+      parameters: {
+        depthWriteEnabled: false,
+        depthCompare: 'less-equal',
+        blend: true,
+        blendColorOperation: 'add',
+        blendAlphaOperation: 'add',
+        blendColorSrcFactor: 'src-alpha',
+        blendColorDstFactor: 'one-minus-src-alpha',
+        blendAlphaSrcFactor: 'one',
+        blendAlphaDstFactor: 'one-minus-src-alpha'
+      }
+    });
+    graph.addRenderPass({
+      id: 'paged-gaussian-segmented-render',
+      resources: [
+        ...this.outputSegments.map(segment => ({
+          buffer: segment.graphProjectedRecords,
+          usage: 'storage-read' as const
+        })),
+        {buffer: firstUniform, usage: 'uniform'},
+        {buffer: drawCommands, usage: 'indirect'}
+      ],
+      compile: () => ({
+        getRenderPassProps: () => ({
+          id: 'paged-gaussian-render-pass',
+          clearColor: this.clearColor,
+          clearDepth: 1,
+          clearStencil: false
+        }),
+        encode: ({renderPass, getBuffer}) => {
+          if (!this.model) {
+            return;
+          }
+          renderPass.setPipeline(this.model.pipeline);
+          renderPass.setVertexArray(this.model.vertexArray);
+          for (const segment of this.outputSegments) {
+            renderPass.setBindings({
+              graphUniforms: getBuffer(firstUniform),
+              projectedRecords: getBuffer(segment.graphProjectedRecords)
+            });
+            this.drawCommands.draw(renderPass, segment.index + 1);
+          }
+        }
+      })
+    });
+  }
+
+  private importSourceBuffers(
+    graph: GPUCommandGraph,
+    segment: SourceSegment
+  ): Record<(typeof SOURCE_COLUMNS)[number]['name'], GraphBufferHandle> {
+    const handles = {} as Record<(typeof SOURCE_COLUMNS)[number]['name'], GraphBufferHandle>;
+    for (const {name, rowByteLength} of SOURCE_COLUMNS) {
+      const buffer = segment.page.data[name].data[0].buffer;
+      handles[name] = graph.importBuffer(
+        {
+          id: `paged-gaussian-source-${segment.id}-${name}`,
+          byteLength: Math.min(rowByteLength, buffer.byteLength),
+          usage: Buffer.STORAGE
+        },
+        buffer
+      );
+    }
+    return handles;
+  }
+
+  private importFeatureBuffers(
+    graph: GPUCommandGraph,
+    segment: SourceSegment
+  ): {
+    positions: GraphBufferHandle;
+    sphericalHarmonics: GraphBufferHandle;
+    semanticIds: GraphBufferHandle;
+  } {
+    const positions = graph.importBuffer(
+      {
+        id: `paged-gaussian-feature-${segment.id}-positions`,
+        byteLength: 12,
+        usage: Buffer.STORAGE
+      },
+      segment.page.data.positions.data[0].buffer
+    );
+    const sphericalHarmonicsBuffer =
+      segment.page.data.sphericalHarmonics?.data[0].buffer ?? segment.activeRowBuffer;
+    const semanticIdsBuffer =
+      segment.page.data.semanticIds?.data[0].buffer ?? segment.activeRowBuffer;
+    const sphericalHarmonics = graph.importBuffer(
+      {
+        id: `paged-gaussian-feature-${segment.id}-harmonics`,
+        byteLength: 4,
+        usage: Buffer.STORAGE
+      },
+      sphericalHarmonicsBuffer
+    );
+    const semanticIds = graph.importBuffer(
+      {
+        id: `paged-gaussian-feature-${segment.id}-semantics`,
+        byteLength: 4,
+        usage: Buffer.STORAGE
+      },
+      semanticIdsBuffer
+    );
+    return {positions, sphericalHarmonics, semanticIds};
+  }
+
+  private getSourceBinding(
+    segment: SourceSegment,
+    name: (typeof SOURCE_COLUMNS)[number]['name'] | 'sphericalHarmonics' | 'semanticIds',
+    buffer: Buffer
+  ): Binding {
+    if (!segment.usesSourceRanges || !segment.page.data[name]) {
+      return buffer;
+    }
+    const rowByteLength = getPagedSourceRowByteLength(segment.page.data, name);
+    const byteOffset = segment.sourceBindingRowOffset * rowByteLength;
+    const byteLength = Math.min(
+      segment.sourceRowCount * rowByteLength,
+      buffer.byteLength - byteOffset
+    );
+    return {buffer, offset: byteOffset, size: byteLength};
+  }
+
+  private writeSourceUniforms(): void {
+    if (this.semanticSelectionValues.length > 0) {
+      this.semanticSelectionBuffer?.write(this.semanticSelectionValues);
+    }
+    for (const segment of this.sourceSegments) {
+      if (segment.activeRows) {
+        segment.activeRowBuffer.write(segment.activeRows);
+      }
+      const uniformData = new ArrayBuffer(GPU_SPLAT_GRAPH_UNIFORM_BYTE_LENGTH);
+      const floatValues = new Float32Array(uniformData);
+      const integerValues = new Uint32Array(uniformData);
+      floatValues.set(this.props.modelViewProjectionMatrix, 0);
+      floatValues.set(this.props.viewportSize, 16);
+      floatValues[18] = this.props.radiusScale;
+      floatValues[19] = this.props.alphaScale;
+      floatValues[20] = this.props.alphaCutoff;
+      floatValues[21] = this.props.screenSizeCutoffPixels;
+      floatValues[22] = this.props.gaussianSupportRadius;
+      floatValues[23] = this.props.kernel2DSize;
+      floatValues[24] = this.props.maxScreenSpaceSplatSize;
+      floatValues[25] = this.props.exposure;
+      integerValues[26] = this.props.toneMapping === 'reinhard' ? 1 : 0;
+      integerValues[27] = segment.globalRowOffset;
+      integerValues[28] = segment.activeRowCount;
+      integerValues[29] = segment.page.data.colors.format === 'float32x4' ? 1 : 0;
+      integerValues[30] = segment.activeRows ? 1 : 0;
+      integerValues[31] = segment.sourceRowOffset - segment.sourceBindingRowOffset;
+      segment.uniformBuffer.write(new Uint8Array(uniformData));
+
+      const featureData = new ArrayBuffer(GPU_SPLAT_GRAPH_FEATURE_UNIFORM_BYTE_LENGTH);
+      const featureFloatValues = new Float32Array(featureData);
+      const featureIntegerValues = new Uint32Array(featureData);
+      const batch = segment.page.data;
+      const degree =
+        batch.sphericalHarmonics && this.props.sphericalHarmonicsDegree > 0
+          ? Math.min(batch.sphericalHarmonicsDegree, this.props.sphericalHarmonicsDegree)
+          : 0;
+      featureFloatValues.set(this.props.cameraPosition, 0);
+      featureIntegerValues[3] = degree;
+      featureIntegerValues[4] = getSplatSphericalHarmonicCoefficientCount(
+        batch.sphericalHarmonicsDegree
+      );
+      featureIntegerValues[5] = batch.semanticIds ? 1 : 0;
+      featureIntegerValues[6] = this.semanticIncludeCount;
+      featureIntegerValues[7] = this.semanticExcludeCount;
+      featureIntegerValues[8] = this.props.semanticFilter?.include ? 1 : 0;
+      featureIntegerValues[9] =
+        (this.props.semanticFilter?.includeUnlabeled ?? !this.props.semanticFilter?.include)
+          ? 1
+          : 0;
+      featureIntegerValues[10] = this.props.semanticFilter ? 1 : 0;
+      segment.featureUniformBuffer.write(new Uint8Array(featureData));
+    }
+  }
+
+  private planSourceSegments(pages: readonly GPUPagedSplatPage[]): PlannedSourceSegment[] {
+    const plannedSegments: PlannedSourceSegment[] = [];
+    let globalRowOffset = 0;
+    for (const page of pages) {
+      if (page.activeRows?.length === 0 || page.data.length === 0) {
+        continue;
+      }
+      const maximumStorageByteLength = this.device.limits.maxStorageBufferBindingSize;
+      const maximumSourceRowByteLength = Math.max(
+        ...SOURCE_COLUMNS.map(({name}) => getPagedSourceRowByteLength(page.data, name)),
+        page.data.sphericalHarmonics
+          ? getPagedSourceRowByteLength(page.data, 'sphericalHarmonics')
+          : 0,
+        page.data.semanticIds ? Uint32Array.BYTES_PER_ELEMENT : 0
+      );
+      const usesSourceRanges =
+        maximumStorageByteLength > 0 &&
+        [
+          ...SOURCE_COLUMNS.map(({name}) => page.data[name].data[0].buffer),
+          page.data.sphericalHarmonics?.data[0].buffer,
+          page.data.semanticIds?.data[0].buffer
+        ].some(buffer => buffer !== undefined && buffer.byteLength > maximumStorageByteLength);
+      const alignmentRows = getPagedSourceAlignmentRows(this.device, page.data);
+      const rawSourceRowCapacity =
+        maximumStorageByteLength > 0
+          ? Math.floor(maximumStorageByteLength / maximumSourceRowByteLength)
+          : Number.MAX_SAFE_INTEGER;
+      const sourceWindowCapacity = usesSourceRanges
+        ? Math.floor(rawSourceRowCapacity / alignmentRows) * alignmentRows
+        : page.data.length;
+      if (sourceWindowCapacity <= 0) {
+        throw new Error('Paged Gaussian source columns exceed device storage range alignment');
+      }
+      let pageSegmentIndex = 0;
+      if (page.activeRows) {
+        let activeRows: number[] = [];
+        let sourceWindowStart = -1;
+        const appendSparseSegment = (): void => {
+          if (activeRows.length === 0) {
+            return;
+          }
+          const offset = usesSourceRanges ? sourceWindowStart : 0;
+          const selectedRows = Uint32Array.from(activeRows, rowIndex => rowIndex - offset);
+          const sourceRowCount = usesSourceRanges
+            ? Math.min(sourceWindowCapacity, page.data.length - sourceWindowStart)
+            : page.data.length;
+          plannedSegments.push({
+            id: `${page.id}-${pageSegmentIndex++}`,
+            page,
+            activeRows: selectedRows,
+            activeRowCount: selectedRows.length,
+            sourceRowOffset: offset,
+            sourceBindingRowOffset: offset,
+            sourceRowCount,
+            usesSourceRanges,
+            globalRowOffset
+          });
+          globalRowOffset += selectedRows.length;
+          activeRows = [];
+        };
+        for (const rowIndex of page.activeRows) {
+          if (rowIndex >= page.data.length) {
+            throw new RangeError('Paged Gaussian active rows must be source-page-local indices');
+          }
+          const nextWindowStart = usesSourceRanges
+            ? Math.floor(rowIndex / sourceWindowCapacity) * sourceWindowCapacity
+            : 0;
+          if (
+            activeRows.length > 0 &&
+            (nextWindowStart !== sourceWindowStart ||
+              activeRows.length >= this.getMaximumProjectedSegmentRows())
+          ) {
+            appendSparseSegment();
+          }
+          sourceWindowStart = nextWindowStart;
+          activeRows.push(rowIndex);
+        }
+        appendSparseSegment();
+        continue;
+      }
+
+      for (let sourceRowOffset = 0; sourceRowOffset < page.data.length; ) {
+        const sourceWindowStart = usesSourceRanges
+          ? Math.floor(sourceRowOffset / sourceWindowCapacity) * sourceWindowCapacity
+          : sourceRowOffset;
+        const sourceWindowEnd = usesSourceRanges
+          ? Math.min(sourceWindowStart + sourceWindowCapacity, page.data.length)
+          : page.data.length;
+        const activeRowCount = Math.min(
+          sourceWindowEnd - sourceRowOffset,
+          this.getMaximumProjectedSegmentRows()
+        );
+        plannedSegments.push({
+          id: `${page.id}-${pageSegmentIndex++}`,
+          page,
+          activeRowCount,
+          sourceRowOffset,
+          sourceBindingRowOffset: usesSourceRanges ? sourceWindowStart : 0,
+          sourceRowCount: usesSourceRanges ? sourceWindowEnd - sourceWindowStart : activeRowCount,
+          usesSourceRanges,
+          globalRowOffset
+        });
+        sourceRowOffset += activeRowCount;
+        globalRowOffset += activeRowCount;
+      }
+    }
+    return plannedSegments;
+  }
+
+  private updateSemanticSelections(filter: SplatSemanticFilter | undefined): void {
+    if (filter?.predicate) {
+      throw new Error('Paged GPU Gaussian semantic filters cannot evaluate JavaScript predicates');
+    }
+    const includedIds = getPagedSemanticValues(filter?.include);
+    const excludedIds = getPagedSemanticValues(filter?.exclude);
+    this.semanticIncludeCount = includedIds.length;
+    this.semanticExcludeCount = excludedIds.length;
+    this.semanticSelectionValues = Uint32Array.from([...includedIds, ...excludedIds]);
+    if (
+      this.compiledGraph &&
+      this.semanticSelectionValues.length > this.semanticSelectionCapacity
+    ) {
+      this.requiresGraphRebuild = true;
+    }
+  }
+
+  private getMaximumProjectedSegmentRows(): number {
+    const maximumStorageByteLength = this.device.limits.maxStorageBufferBindingSize;
+    const deviceRows =
+      maximumStorageByteLength > 0
+        ? Math.floor(maximumStorageByteLength / GPU_SPLAT_PROJECTED_RECORD_BYTE_LENGTH)
+        : Number.MAX_SAFE_INTEGER;
+    if (deviceRows < 1) {
+      throw new Error('Paged Gaussian projected records exceed the device storage binding limit');
+    }
+    return Math.min(deviceRows, this.requestedSegmentCapacity ?? Number.MAX_SAFE_INTEGER);
+  }
+
+  private createDrawCommands(capacity: number): DrawCommandBuffer {
+    return new DrawCommandBuffer(this.device, {
+      id: 'paged-gaussian-indirect-draws',
+      type: 'draw',
+      capacity,
+      commands: Array.from({length: capacity}, () => ({vertexCount: 4, instanceCount: 0}))
+    });
+  }
+
+  private createOwnedBuffer(id: string, byteLength: number): Buffer {
+    const buffer = this.device.createBuffer({
+      id,
+      byteLength,
+      usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+    });
+    this.ownedBuffers.push(buffer);
+    return buffer;
+  }
+
+  private createUniformBuffer(id: string, byteLength: number): Buffer {
+    const buffer = this.device.createBuffer({
+      id,
+      byteLength,
+      usage: Buffer.UNIFORM | Buffer.COPY_DST
+    });
+    this.ownedBuffers.push(buffer);
+    return buffer;
+  }
+
+  private importOwnedBuffer(graph: GPUCommandGraph, buffer: Buffer): GraphBufferHandle {
+    return graph.importBuffer(
+      {id: buffer.id, byteLength: buffer.byteLength, usage: buffer.usage},
+      buffer
+    );
+  }
+
+  private importUint32Buffer(
+    graph: GPUCommandGraph,
+    buffer: Buffer,
+    length: number
+  ): GraphDataView<'uint32'> {
+    return graph.createDataView(this.importOwnedBuffer(graph, buffer), {format: 'uint32', length});
+  }
+
+  private releaseCompiledGraph(): void {
+    this.compiledGraph?.destroy();
+    this.compiledGraph = undefined;
+    this.lastEncoding = undefined;
+    this.model?.destroy();
+    this.model = undefined;
+    for (const buffer of this.ownedBuffers) {
+      buffer.destroy();
+    }
+    this.ownedBuffers.length = 0;
+    this.sourceSegments.length = 0;
+    this.outputSegments.length = 0;
+    this.sortedValuesBuffer = undefined;
+    this.semanticSelectionBuffer = undefined;
+    this.semanticSelectionCapacity = 0;
+    this.globalSortCapacity = 0;
+    this.requiresGraphRebuild = true;
+  }
+}
+
+function getPagedDispatch(rowCount: number, device: Device): {x: number; y: number} {
+  const workgroups = Math.ceil(rowCount / WORKGROUP_SIZE);
+  const maximumDimension = device.limits.maxComputeWorkgroupsPerDimension || 65535;
+  const x = Math.min(workgroups, maximumDimension);
+  return {x, y: Math.ceil(workgroups / x)};
+}
+
+function getPagedSourceRowByteLength(
+  batch: GPUSplatData,
+  name: (typeof SOURCE_COLUMNS)[number]['name'] | 'sphericalHarmonics' | 'semanticIds'
+): number {
+  if (name === 'sphericalHarmonics') {
+    return getSplatSphericalHarmonicCoefficientCount(batch.sphericalHarmonicsDegree) * 4;
+  }
+  if (name === 'colors') {
+    return batch.colors.format === 'float32x4' ? 16 : 4;
+  }
+  if (name === 'semanticIds') {
+    return 4;
+  }
+  return SOURCE_COLUMNS.find(column => column.name === name)?.rowByteLength ?? 4;
+}
+
+function getPagedSourceAlignmentRows(device: Device, batch: GPUSplatData): number {
+  const alignment = Math.max(device.limits.minStorageBufferOffsetAlignment || 1, 1);
+  let rows = 1;
+  for (const name of [
+    ...SOURCE_COLUMNS.map(column => column.name),
+    ...(batch.sphericalHarmonics ? (['sphericalHarmonics'] as const) : []),
+    ...(batch.semanticIds ? (['semanticIds'] as const) : [])
+  ]) {
+    const stride = getPagedSourceRowByteLength(batch, name);
+    const requiredRows = alignment / getPagedGreatestCommonDivisor(alignment, stride);
+    rows = (rows * requiredRows) / getPagedGreatestCommonDivisor(rows, requiredRows);
+  }
+  return rows;
+}
+
+function getPagedGreatestCommonDivisor(first: number, second: number): number {
+  while (second !== 0) {
+    [first, second] = [second, first % second];
+  }
+  return first;
+}
+
+function getPagedSemanticValues(selection: SplatSemanticSelection | undefined): number[] {
+  if (!selection) {
+    return [];
+  }
+  const values = Array.from(selection);
+  for (const value of values) {
+    if (!Number.isSafeInteger(value) || value < 0 || value > 0xffff_ffff) {
+      throw new RangeError('Paged Gaussian semantic IDs must fit unsigned 32-bit integers');
+    }
+  }
+  return values;
+}
+
+function hasPagedHighDynamicRangePresentation(device: Device): boolean {
+  return (
+    device.preferredColorFormat === 'rgba16float' &&
+    device.canvasContext?.props.toneMapping === 'extended'
+  );
+}
+
+function arePagedSplatValuesEqual(left: ArrayLike<number>, right: ArrayLike<number>): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let index = 0; index < left.length; index++) {
+    if (!Object.is(left[index], right[index])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function toPagedSplatMatrix(
+  matrix: ArrayLike<number> | undefined
+): ResolvedPagedSplatProps['modelViewProjectionMatrix'] {
+  if (!matrix) {
+    return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+  }
+  if (matrix.length !== 16) {
+    throw new Error('GPUPagedSplatRenderer requires a 16-element camera matrix');
+  }
+  return [
+    matrix[0],
+    matrix[1],
+    matrix[2],
+    matrix[3],
+    matrix[4],
+    matrix[5],
+    matrix[6],
+    matrix[7],
+    matrix[8],
+    matrix[9],
+    matrix[10],
+    matrix[11],
+    matrix[12],
+    matrix[13],
+    matrix[14],
+    matrix[15]
+  ];
+}

--- a/modules/splats/src/gpu-paged-splat-shaders.ts
+++ b/modules/splats/src/gpu-paged-splat-shaders.ts
@@ -1,0 +1,168 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {ShaderLayout} from '@luma.gl/core';
+import {
+  GPU_SPLAT_FEATURE_SHADER,
+  GPU_SPLAT_PROJECTION_SHADER,
+  GPU_SPLAT_RENDER_SHADER
+} from './gpu-splat-graph-shaders';
+
+/** Sparse source projection retains every original column within eight storage bindings. */
+export const GPU_PAGED_SPLAT_PROJECTION_SHADER_LAYOUT = {
+  attributes: [],
+  bindings: [
+    {name: 'positions', type: 'read-only-storage', group: 0, location: 0},
+    {name: 'scales', type: 'read-only-storage', group: 0, location: 1},
+    {name: 'rotations', type: 'read-only-storage', group: 0, location: 2},
+    {name: 'colors', type: 'read-only-storage', group: 0, location: 3},
+    {name: 'opacities', type: 'read-only-storage', group: 0, location: 4},
+    {name: 'projectedRecords', type: 'storage', group: 0, location: 5},
+    {name: 'depthKeys', type: 'storage', group: 0, location: 6},
+    {name: 'activeRows', type: 'read-only-storage', group: 0, location: 7},
+    {name: 'graphUniforms', type: 'uniform', group: 0, location: 8}
+  ]
+} satisfies ShaderLayout;
+
+/** Sparse SH, semantics, and global visibility also honor the portable eight-buffer limit. */
+export const GPU_PAGED_SPLAT_FEATURE_SHADER_LAYOUT = {
+  attributes: [],
+  bindings: [
+    {name: 'positions', type: 'read-only-storage', group: 0, location: 0},
+    {name: 'sphericalHarmonics', type: 'read-only-storage', group: 0, location: 1},
+    {name: 'semanticIds', type: 'read-only-storage', group: 0, location: 2},
+    {name: 'semanticSelections', type: 'read-only-storage', group: 0, location: 3},
+    {name: 'projectedRecords', type: 'storage', group: 0, location: 4},
+    {name: 'depthKeys', type: 'storage', group: 0, location: 5},
+    {name: 'drawCommands', type: 'storage', group: 0, location: 6},
+    {name: 'activeRows', type: 'read-only-storage', group: 0, location: 7},
+    {name: 'graphUniforms', type: 'uniform', group: 0, location: 8},
+    {name: 'featureUniforms', type: 'uniform', group: 0, location: 9}
+  ]
+} satisfies ShaderLayout;
+
+/** Already gathered global-order segments require one uniform and one projected storage buffer. */
+export const GPU_PAGED_SPLAT_RENDER_SHADER_LAYOUT = {
+  attributes: [],
+  bindings: [
+    {name: 'graphUniforms', type: 'uniform', group: 0, location: 0},
+    {name: 'projectedRecords', type: 'read-only-storage', group: 0, location: 1}
+  ]
+} satisfies ShaderLayout;
+
+const PAGED_UNIFORM_FIELDS = `  isFloatColor: u32,
+  hasActiveRows: u32,
+  sourceRowOffset: u32,
+};`;
+
+/** Original Gaussian projection with sparse source rows and a separate global depth domain. */
+export const GPU_PAGED_SPLAT_PROJECTION_SHADER = replacePagedShaderSource(
+  replacePagedShaderSource(
+    replacePagedShaderSource(
+      replacePagedShaderSource(
+        replacePagedShaderSource(
+          replacePagedShaderSource(
+            GPU_SPLAT_PROJECTION_SHADER,
+            '  isFloatColor: u32,\n};',
+            PAGED_UNIFORM_FIELDS
+          ),
+          '@group(0) @binding(7) var<storage, read_write> drawCommands: array<atomic<u32>>;',
+          '@group(0) @binding(7) var<storage, read> activeRows: array<u32>;'
+        ),
+        '  depthKeys[rowIndex] = INVALID_DEPTH_KEY;',
+        '  depthKeys[graphUniforms.batchOffset + rowIndex] = INVALID_DEPTH_KEY;'
+      ),
+      `  let batchRowIndex = globalInvocationId.x;
+  if (batchRowIndex >= graphUniforms.rowCount) {
+    return;
+  }
+
+  let projectedRowIndex = graphUniforms.batchOffset + batchRowIndex;`,
+      `  let projectedRowIndex = globalInvocationId.x;
+  if (projectedRowIndex >= graphUniforms.rowCount) {
+    return;
+  }
+  var batchRowIndex = projectedRowIndex + graphUniforms.sourceRowOffset;
+  if (graphUniforms.hasActiveRows != 0u) {
+    batchRowIndex = activeRows[projectedRowIndex];
+  }`
+    ),
+    '  depthKeys[projectedRowIndex] = MAXIMUM_VALID_DEPTH_KEY - quantizedDepth;',
+    '  depthKeys[graphUniforms.batchOffset + projectedRowIndex] = MAXIMUM_VALID_DEPTH_KEY - quantizedDepth;'
+  ),
+  '  atomicAdd(&drawCommands[1u], 1u);\n',
+  ''
+);
+
+/** Sparse source feature evaluation publishes the exact globally visible indirect count. */
+export const GPU_PAGED_SPLAT_FEATURE_SHADER = replacePagedShaderSource(
+  replacePagedShaderSource(
+    replacePagedShaderSource(
+      replacePagedShaderSource(
+        replacePagedShaderSource(
+          replacePagedShaderSource(
+            GPU_SPLAT_FEATURE_SHADER,
+            '  isFloatColor: u32,\n};',
+            PAGED_UNIFORM_FIELDS
+          ),
+          `@group(0) @binding(7) var<uniform> graphUniforms: GraphSplatUniforms;
+@group(0) @binding(8) var<uniform> featureUniforms: GraphSplatFeatureUniforms;`,
+          `@group(0) @binding(7) var<storage, read> activeRows: array<u32>;
+@group(0) @binding(8) var<uniform> graphUniforms: GraphSplatUniforms;
+@group(0) @binding(9) var<uniform> featureUniforms: GraphSplatFeatureUniforms;`
+        ),
+        `  let batchRowIndex = globalInvocationId.x;
+  if (batchRowIndex >= graphUniforms.rowCount) {
+    return;
+  }
+
+  let projectedRowIndex = graphUniforms.batchOffset + batchRowIndex;`,
+        `  let projectedRowIndex = globalInvocationId.x;
+  if (projectedRowIndex >= graphUniforms.rowCount) {
+    return;
+  }
+  var batchRowIndex = projectedRowIndex + graphUniforms.sourceRowOffset;
+  if (graphUniforms.hasActiveRows != 0u) {
+    batchRowIndex = activeRows[projectedRowIndex];
+  }
+  let globalRowIndex = graphUniforms.batchOffset + projectedRowIndex;`
+      ),
+      '  if (depthKeys[projectedRowIndex] == INVALID_FEATURE_DEPTH_KEY) {',
+      '  if (depthKeys[globalRowIndex] == INVALID_FEATURE_DEPTH_KEY) {'
+    ),
+    `    depthKeys[projectedRowIndex] = INVALID_FEATURE_DEPTH_KEY;
+    atomicSub(&drawCommands[1u], 1u);`,
+    '    depthKeys[globalRowIndex] = INVALID_FEATURE_DEPTH_KEY;'
+  ),
+  `      projectedColor.a
+    );
+  }
+}
+`,
+  `      projectedColor.a
+    );
+  }
+  atomicAdd(&drawCommands[1u], 1u);
+}
+`
+);
+
+/** Final gathered records already occupy exact global painter order. */
+export const GPU_PAGED_SPLAT_RENDER_SHADER = replacePagedShaderSource(
+  replacePagedShaderSource(
+    GPU_SPLAT_RENDER_SHADER,
+    '@group(0) @binding(2) var<storage, read> sortedIds: array<u32>;\n',
+    ''
+  ),
+  '  let projected = projectedRecords[sortedIds[instanceIndex]];',
+  '  let projected = projectedRecords[instanceIndex];'
+);
+
+/** Prevent upstream shader edits from silently removing sparse-source projection invariants. */
+function replacePagedShaderSource(source: string, search: string, replacement: string): string {
+  if (!source.includes(search)) {
+    throw new Error('Paged Gaussian shader source no longer matches its shared graph shader');
+  }
+  return source.replace(search, replacement);
+}

--- a/modules/splats/src/index.ts
+++ b/modules/splats/src/index.ts
@@ -70,6 +70,15 @@ export {
   type SplatHierarchyView
 } from './splat-hierarchy';
 export {
+  SplatRADHierarchyManager,
+  getSplatRADPageBounds,
+  type SplatRADHierarchyFrontierEntry,
+  type SplatRADHierarchyManagerProps,
+  type SplatRADHierarchyPage,
+  type SplatRADHierarchyRequest,
+  type SplatRADHierarchyStats
+} from './splat-rad-hierarchy';
+export {
   getCovarianceEllipseAxes,
   getQuaternionScaledAxes,
   projectSplatCovarianceToScreen,
@@ -100,6 +109,12 @@ export {
   GPUSplatGraphRenderer,
   type GPUSplatGraphRendererProps
 } from './gpu-splat-graph-renderer';
+export {
+  GPUPagedSplatRenderer,
+  type GPUPagedSplatPage,
+  type GPUPagedSplatRendererProps,
+  type GPUPagedSplatRendererStats
+} from './gpu-paged-splat-renderer';
 export {
   GPUSplatGraphMixedRenderer,
   GPUSplatGraphPicker,

--- a/modules/splats/src/splat-rad-hierarchy.ts
+++ b/modules/splats/src/splat-rad-hierarchy.ts
@@ -1,0 +1,797 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {GPUSplatData} from './splat-data';
+import {
+  getSplatHierarchyFoveatedPriority,
+  getSplatHierarchyScreenSpaceError,
+  isSplatHierarchyNodeVisible,
+  type SplatHierarchyFoveation,
+  type SplatHierarchyNode,
+  type SplatHierarchyView
+} from './splat-hierarchy';
+import {
+  SplatResidencyManager,
+  type SplatResidencyBounds,
+  type SplatResidencyBudget,
+  type SplatResidencyChunk
+} from './splat-residency';
+
+const DEFAULT_RAD_PAGE_SIZE = 65_536;
+const GAUSSIAN_SUPPORT_RADIUS = 3;
+
+/** One independently prepared source page and its untouched per-row hierarchy metadata. */
+export type SplatRADHierarchyPage = {
+  /** Stable source-page identity used for residency and renderer page slots. */
+  id: string;
+  /** Original independently prepared batch; source buffers are never copied or repacked. */
+  data: GPUSplatData;
+  /** Number of child source rows represented by each original batch-local parent row. */
+  childCounts?: Uint16Array;
+  /** Global source-row index of the first child of each original batch-local parent row. */
+  childStarts?: Uint32Array;
+  /** Optional source-provided page bounds; otherwise conservative decoded bounds are derived. */
+  bounds?: SplatResidencyBounds;
+  /** Optional world-space error overriding the individual Gaussian source scales. */
+  geometricError?: number;
+  /** Whether the residency manager owns and destroys this independently decoded source batch. */
+  ownsData?: boolean;
+};
+
+/** One source page with only its currently selected, original batch-local hierarchy rows. */
+export type SplatRADHierarchyFrontierEntry = {
+  /** Stable original source-page identity. */
+  id: string;
+  /** Original independently prepared source batch and all of its intact GPU buffers. */
+  data: GPUSplatData;
+  /** Original batch-local source-row offsets selected for the current camera view. */
+  activeRows: Uint32Array;
+  /** One byte per original batch-local row; selected rows contain one. */
+  activeMask: Uint8Array;
+  /** Conservative authored or decoded source-page bounds. */
+  bounds: SplatResidencyBounds;
+  /** Largest selected source-row geometric approximation error. */
+  geometricError: number;
+  /** Highest selected foveation-adjusted source-row priority. */
+  priority: number;
+  /** Whether at least one selected parent is covering missing or incomplete child pages. */
+  isFallback: boolean;
+};
+
+/** Camera-prioritized request for the original source page containing a missing global row. */
+export type SplatRADHierarchyRequest = {
+  /** Stable original global source row required by the active hierarchy traversal. */
+  rowIndex: number;
+  /** Nominal original source-page index, derived from the configured source page size. */
+  pageIndex: number;
+  /** Global source parent retained while this missing child page is requested. */
+  parentRowIndex?: number;
+  /** Foveation- and screen-space-error-adjusted source-page request priority. */
+  priority: number;
+};
+
+/** Camera-selected source rows, fallback coverage, demand requests, and residency diagnostics. */
+export type SplatRADHierarchyStats = {
+  /** Number of independently registered original source pages. */
+  pageCount: number;
+  /** Source pages intersecting at least one selected camera-visible hierarchy row. */
+  activePageCount: number;
+  /** Original source rows selected without repacking their owning source pages. */
+  activeRowCount: number;
+  /** Source rows traversed inside the conservative camera frustum. */
+  visibleRowCount: number;
+  /** Source rows omitted because their complete conservative sphere is outside the camera. */
+  culledRowCount: number;
+  /** Coarse parent source rows retained until every required child page becomes available. */
+  fallbackRowCount: number;
+  /** Independently requested, not-yet-resident original source pages. */
+  requestedPageCount: number;
+  /** Configured maximum number of simultaneously selected source rows. */
+  maximumActiveRows: number;
+};
+
+/** Loader-neutral row-hierarchy traversal, source-page residency, and integration callbacks. */
+export type SplatRADHierarchyManagerProps = {
+  /** Optional initially resident source pages, preserving their original row boundaries. */
+  pages?: readonly SplatRADHierarchyPage[];
+  /** Global source hierarchy roots; Spark RAD sources default to the root at row zero. */
+  rootRows?: readonly number[];
+  /** Nominal source rows per independently fetchable page; Spark defaults to 65,536. */
+  pageSize?: number;
+  /** Optional borrowed source residency window, never destroyed by this hierarchy. */
+  residencyManager?: SplatResidencyManager;
+  /** Limits used when this hierarchy creates its own source residency window. */
+  residencyBudget?: SplatResidencyBudget;
+  /** Maximum accepted projected source-row geometric error in physical pixels. */
+  maximumScreenSpaceError?: number;
+  /** Maximum simultaneously selected original source rows across every active page. */
+  maximumActiveRows?: number;
+  /** Default gaze-aware priority controls for views without an explicit override. */
+  foveation?: SplatHierarchyFoveation;
+  /** Receives intact source pages plus original batch-local active-row indirection. */
+  onFrontierChange?: (
+    frontier: readonly SplatRADHierarchyFrontierEntry[],
+    stats: SplatRADHierarchyStats
+  ) => void;
+  /** Requests a missing source page; transport, decoding, workers, and upload remain external. */
+  onPageRequest?: (request: SplatRADHierarchyRequest) => void;
+  /** Cancels a previously requested page after it leaves the selected camera frontier. */
+  onPageCancel?: (request: SplatRADHierarchyRequest) => void;
+};
+
+type RegisteredSplatRADPage = {
+  page: SplatRADHierarchyPage;
+  bounds: SplatResidencyBounds;
+  endRowIndex: number;
+};
+
+type SelectedSplatRADPage = {
+  registeredPage: RegisteredSplatRADPage;
+  activeRows: number[];
+  activeMask: Uint8Array;
+  geometricError: number;
+  priority: number;
+  isFallback: boolean;
+};
+
+type SplatRADTraversalState = {
+  selectedPages: Map<string, SelectedSplatRADPage>;
+  protectedPageIds: Set<string>;
+  requestedPages: Map<number, SplatRADHierarchyRequest>;
+  ancestorRows: Set<number>;
+  allocatedRowCount: number;
+};
+
+/**
+ * Selects a coherent row-level frontier from independently resident Gaussian source pages.
+ *
+ * Each decoded row can own global child rows in any page. Parent rows stay visible until every
+ * required child exists, while unrelated leaf rows in the same source page remain selected.
+ * Original source pages and their GPU allocations stay intact; only batch-local visibility masks
+ * and active-row indirection change as the camera or residency window changes.
+ */
+export class SplatRADHierarchyManager {
+  /** Borrowed or independently owned residency window for untouched decoded source pages. */
+  readonly residencyManager: SplatResidencyManager;
+
+  private readonly pagesById = new Map<string, RegisteredSplatRADPage>();
+  private readonly ownedPinnedIds = new Set<string>();
+  private readonly pendingRequests = new Map<number, SplatRADHierarchyRequest>();
+  private readonly onFrontierChange?: SplatRADHierarchyManagerProps['onFrontierChange'];
+  private readonly onPageRequest?: SplatRADHierarchyManagerProps['onPageRequest'];
+  private readonly onPageCancel?: SplatRADHierarchyManagerProps['onPageCancel'];
+  private readonly ownsResidencyManager: boolean;
+  private readonly maximumScreenSpaceError: number;
+  private readonly maximumActiveRows: number;
+  private readonly pageSize: number;
+  private readonly foveation?: SplatHierarchyFoveation;
+
+  private sortedPages: RegisteredSplatRADPage[] = [];
+  private rootRows: readonly number[];
+  private currentView?: SplatHierarchyView;
+  private currentFrontier: SplatRADHierarchyFrontierEntry[] = [];
+  private visibleRowCount = 0;
+  private culledRowCount = 0;
+  private fallbackRowCount = 0;
+  private isDestroyed = false;
+
+  /** Creates a loader-neutral global-row hierarchy without fetching or decoding source pages. */
+  constructor(props: SplatRADHierarchyManagerProps = {}) {
+    this.residencyManager =
+      props.residencyManager ?? new SplatResidencyManager(props.residencyBudget);
+    this.ownsResidencyManager = !props.residencyManager;
+    this.rootRows = [...(props.rootRows ?? [0])];
+    this.pageSize = props.pageSize ?? DEFAULT_RAD_PAGE_SIZE;
+    this.maximumScreenSpaceError = Math.max(props.maximumScreenSpaceError ?? 8, 0);
+    this.maximumActiveRows = props.maximumActiveRows ?? Number.POSITIVE_INFINITY;
+    this.foveation = props.foveation;
+    this.onFrontierChange = props.onFrontierChange;
+    this.onPageRequest = props.onPageRequest;
+    this.onPageCancel = props.onPageCancel;
+
+    if (!Number.isSafeInteger(this.pageSize) || this.pageSize <= 0) {
+      throw new RangeError('Gaussian source page size must be a positive safe integer');
+    }
+    if (
+      this.maximumActiveRows !== Number.POSITIVE_INFINITY &&
+      (!Number.isSafeInteger(this.maximumActiveRows) || this.maximumActiveRows <= 0)
+    ) {
+      throw new RangeError('Gaussian active-row capacity must be a positive safe integer');
+    }
+    this.validateRootRows(this.rootRows);
+    for (const page of props.pages ?? []) {
+      this.registerPage(page);
+    }
+  }
+
+  /** Whether this hierarchy has released its own pins, requests, and optional residency window. */
+  get destroyed(): boolean {
+    return this.isDestroyed;
+  }
+
+  /** Current intact source pages and original batch-local active-row visibility masks. */
+  get frontier(): readonly SplatRADHierarchyFrontierEntry[] {
+    return this.currentFrontier;
+  }
+
+  /** Original independently prepared batches participating in the current row frontier. */
+  get frontierBatches(): GPUSplatData[] {
+    return this.currentFrontier.map(entry => entry.data);
+  }
+
+  /** Global source rows belonging to the missing pages currently requested by this view. */
+  get requestedRows(): number[] {
+    return Array.from(this.pendingRequests.values(), request => request.rowIndex);
+  }
+
+  /** Original global-row requests and their current camera-dependent source priorities. */
+  get requests(): SplatRADHierarchyRequest[] {
+    return Array.from(this.pendingRequests.values());
+  }
+
+  /** Selected source-row, fallback, request, visibility, and independent-page diagnostics. */
+  get stats(): SplatRADHierarchyStats {
+    return {
+      pageCount: this.pagesById.size,
+      activePageCount: this.currentFrontier.length,
+      activeRowCount: this.currentFrontier.reduce(
+        (totalRowCount, entry) => totalRowCount + entry.activeRows.length,
+        0
+      ),
+      visibleRowCount: this.visibleRowCount,
+      culledRowCount: this.culledRowCount,
+      fallbackRowCount: this.fallbackRowCount,
+      requestedPageCount: this.pendingRequests.size,
+      maximumActiveRows: this.maximumActiveRows
+    };
+  }
+
+  /** Returns the original metadata and intact GPU allocation for one registered source page. */
+  getPage(id: string): SplatRADHierarchyPage | undefined {
+    return this.pagesById.get(id)?.page;
+  }
+
+  /** Resolves the independently resident source page containing one original global source row. */
+  getPageForRow(rowIndex: number): SplatRADHierarchyPage | undefined {
+    return this.getRegisteredPageForRow(rowIndex)?.page;
+  }
+
+  /** Replaces the original hierarchy roots and immediately refreshes any active camera view. */
+  setRootRows(rootRows: readonly number[]): void {
+    this.assertLive();
+    this.validateRootRows(rootRows);
+    this.rootRows = [...rootRows];
+    this.refresh();
+  }
+
+  /**
+   * Admits one original prepared page and preserves its complete source-row child metadata.
+   *
+   * Returns false when bounded residency cannot accept the page while protecting existing
+   * fallback coverage. Ownership remains with the caller when an incoming page is rejected.
+   */
+  registerPage(page: SplatRADHierarchyPage): boolean {
+    this.assertLive();
+    this.validatePage(page);
+    const existingPage = this.pagesById.get(page.id);
+    if (existingPage && existingPage.page.data !== page.data) {
+      throw new Error('Gaussian source page identity already belongs to another batch');
+    }
+    if (existingPage) {
+      return true;
+    }
+
+    const bounds = getSplatRADPageBounds(page);
+    const priority = this.getPagePriority(page, bounds);
+    const chunk = this.residencyManager.add(page.data, {
+      id: page.id,
+      priority,
+      bounds,
+      ...(page.ownsData !== undefined ? {ownsData: page.ownsData} : {})
+    });
+    if (!chunk) {
+      return false;
+    }
+
+    const registeredPage: RegisteredSplatRADPage = {
+      page,
+      bounds,
+      endRowIndex: page.data.rowIndexBase + page.data.length
+    };
+    this.pagesById.set(page.id, registeredPage);
+    this.sortedPages.push(registeredPage);
+    this.sortedPages.sort(
+      (firstPage, secondPage) =>
+        firstPage.page.data.rowIndexBase - secondPage.page.data.rowIndexBase
+    );
+    this.pruneEvictedPages();
+    this.pendingRequests.delete(Math.floor(page.data.rowIndexBase / this.pageSize));
+    this.refresh();
+    return true;
+  }
+
+  /** Removes one registered source page and immediately restores any available parent coverage. */
+  removePage(id: string): boolean {
+    this.assertLive();
+    const page = this.pagesById.get(id);
+    if (!page) {
+      return false;
+    }
+    if (this.ownedPinnedIds.delete(id)) {
+      this.residencyManager.unpin(id);
+    }
+    this.pagesById.delete(id);
+    this.sortedPages = this.sortedPages.filter(candidate => candidate !== page);
+    this.residencyManager.remove(id);
+    this.refresh();
+    return true;
+  }
+
+  /** Allows an externally cancelled or failed source-page request to be retried by the view. */
+  clearRequestedPage(pageIndex: number): void {
+    this.pendingRequests.delete(pageIndex);
+  }
+
+  /** Computes coherent camera-selected original source rows without copying source page buffers. */
+  update(view: SplatHierarchyView): readonly SplatRADHierarchyFrontierEntry[] {
+    this.assertLive();
+    this.currentView = view;
+    this.refresh();
+    return this.currentFrontier;
+  }
+
+  /** Cancels irrelevant demand, releases hierarchy-owned pins, and preserves borrowed windows. */
+  destroy(): void {
+    if (this.isDestroyed) {
+      return;
+    }
+    this.isDestroyed = true;
+    for (const request of this.pendingRequests.values()) {
+      this.onPageCancel?.(request);
+    }
+    this.pendingRequests.clear();
+    this.releaseInactivePins(new Set());
+    this.pagesById.clear();
+    this.sortedPages = [];
+    this.currentFrontier = [];
+    if (this.ownsResidencyManager) {
+      this.residencyManager.destroy();
+    }
+  }
+
+  private refresh(): void {
+    if (this.isDestroyed || !this.currentView) {
+      return;
+    }
+
+    this.pruneEvictedPages();
+    this.visibleRowCount = 0;
+    this.culledRowCount = 0;
+    this.fallbackRowCount = 0;
+    const rootRows = this.rootRows.slice(0, this.maximumActiveRows);
+    const state: SplatRADTraversalState = {
+      selectedPages: new Map(),
+      protectedPageIds: new Set(),
+      requestedPages: new Map(),
+      ancestorRows: new Set(),
+      allocatedRowCount: rootRows.length
+    };
+
+    for (const rootRow of rootRows) {
+      const rootPage = this.getRegisteredPageForRow(rootRow);
+      if (!rootPage) {
+        this.requestRow(state, rootRow, Number.MAX_SAFE_INTEGER);
+        continue;
+      }
+      this.traverseRow(rootPage, rootRow, state);
+    }
+
+    const selectedFrontier = this.makeFrontier(state);
+    const activePageIds = new Set([
+      ...state.protectedPageIds,
+      ...selectedFrontier.map(entry => entry.id)
+    ]);
+    for (const entry of selectedFrontier) {
+      const chunk = this.residencyManager.getChunk(entry.id);
+      if (chunk) {
+        this.protectChunk(chunk);
+        this.residencyManager.setPriority(chunk, entry.priority);
+      }
+    }
+    this.releaseInactivePins(activePageIds);
+    this.updateFrontier(selectedFrontier);
+    this.synchronizeRequests(state.requestedPages);
+  }
+
+  private traverseRow(
+    registeredPage: RegisteredSplatRADPage,
+    globalRowIndex: number,
+    state: SplatRADTraversalState
+  ): boolean {
+    const page = registeredPage.page;
+    const localRowIndex = globalRowIndex - page.data.rowIndexBase;
+    const node = this.makeRowNode(registeredPage, localRowIndex);
+    if (!isSplatHierarchyNodeVisible(node, this.currentView?.modelViewProjectionMatrix)) {
+      this.culledRowCount++;
+      return false;
+    }
+    this.visibleRowCount++;
+
+    const view = this.currentView;
+    if (!view) {
+      return false;
+    }
+    const screenSpaceError = getSplatHierarchyScreenSpaceError(node, view);
+    const priority = getSplatHierarchyFoveatedPriority(
+      node,
+      view,
+      view.foveation ?? this.foveation,
+      screenSpaceError
+    );
+    const childCount = page.childCounts?.[localRowIndex] ?? 0;
+    const childStart = page.childStarts?.[localRowIndex] ?? 0;
+    if (
+      childCount === 0 ||
+      priority <= this.maximumScreenSpaceError ||
+      state.allocatedRowCount + childCount - 1 > this.maximumActiveRows ||
+      !Number.isSafeInteger(childStart + childCount) ||
+      childStart + childCount > 0x8000_0000
+    ) {
+      this.selectRow(registeredPage, localRowIndex, node.geometricError, priority, false, state);
+      return true;
+    }
+
+    state.ancestorRows.add(globalRowIndex);
+    const childPages: RegisteredSplatRADPage[] = [];
+    let allChildrenResident = true;
+    for (let childOffset = 0; childOffset < childCount; childOffset++) {
+      const childRowIndex = childStart + childOffset;
+      const childPage = this.getRegisteredPageForRow(childRowIndex);
+      if (state.ancestorRows.has(childRowIndex)) {
+        allChildrenResident = false;
+        continue;
+      }
+      if (!childPage) {
+        allChildrenResident = false;
+        this.requestRow(state, childRowIndex, priority, globalRowIndex);
+        continue;
+      }
+      childPages.push(childPage);
+      if (childPage.page.id !== page.id) {
+        const chunk = this.residencyManager.getChunk(childPage.page.id);
+        if (chunk) {
+          this.protectChunk(chunk);
+          state.protectedPageIds.add(chunk.id);
+        }
+      }
+    }
+
+    if (!allChildrenResident || childPages.length !== childCount) {
+      this.selectRow(registeredPage, localRowIndex, node.geometricError, priority, true, state);
+      state.ancestorRows.delete(globalRowIndex);
+      return true;
+    }
+
+    state.allocatedRowCount += childCount - 1;
+    let hasVisibleChild = false;
+    for (let childOffset = 0; childOffset < childCount; childOffset++) {
+      hasVisibleChild =
+        this.traverseRow(childPages[childOffset], childStart + childOffset, state) ||
+        hasVisibleChild;
+    }
+    state.ancestorRows.delete(globalRowIndex);
+    if (!hasVisibleChild) {
+      state.allocatedRowCount -= childCount - 1;
+      this.selectRow(registeredPage, localRowIndex, node.geometricError, priority, false, state);
+    }
+    return true;
+  }
+
+  private selectRow(
+    registeredPage: RegisteredSplatRADPage,
+    localRowIndex: number,
+    geometricError: number,
+    priority: number,
+    isFallback: boolean,
+    state: SplatRADTraversalState
+  ): void {
+    const page = registeredPage.page;
+    let selectedPage = state.selectedPages.get(page.id);
+    if (!selectedPage) {
+      selectedPage = {
+        registeredPage,
+        activeRows: [],
+        activeMask: new Uint8Array(page.data.length),
+        geometricError: 0,
+        priority: 0,
+        isFallback: false
+      };
+      state.selectedPages.set(page.id, selectedPage);
+    }
+    if (!selectedPage.activeMask[localRowIndex]) {
+      selectedPage.activeRows.push(localRowIndex);
+      selectedPage.activeMask[localRowIndex] = 1;
+      if (isFallback) {
+        this.fallbackRowCount++;
+      }
+    }
+    selectedPage.geometricError = Math.max(selectedPage.geometricError, geometricError);
+    selectedPage.priority = Math.max(selectedPage.priority, priority);
+    selectedPage.isFallback ||= isFallback;
+  }
+
+  private requestRow(
+    state: SplatRADTraversalState,
+    rowIndex: number,
+    priority: number,
+    parentRowIndex?: number
+  ): void {
+    const pageIndex = Math.floor(rowIndex / this.pageSize);
+    const previousRequest = state.requestedPages.get(pageIndex);
+    if (previousRequest && previousRequest.priority >= priority) {
+      return;
+    }
+    state.requestedPages.set(pageIndex, {
+      rowIndex,
+      pageIndex,
+      ...(parentRowIndex === undefined ? {} : {parentRowIndex}),
+      priority
+    });
+  }
+
+  private synchronizeRequests(nextRequests: Map<number, SplatRADHierarchyRequest>): void {
+    for (const [pageIndex, request] of this.pendingRequests) {
+      if (!nextRequests.has(pageIndex)) {
+        this.pendingRequests.delete(pageIndex);
+        this.onPageCancel?.(request);
+      }
+    }
+    for (const [pageIndex, request] of nextRequests) {
+      const previousRequest = this.pendingRequests.get(pageIndex);
+      this.pendingRequests.set(pageIndex, request);
+      if (!previousRequest) {
+        this.onPageRequest?.(request);
+      }
+    }
+  }
+
+  private makeFrontier(state: SplatRADTraversalState): SplatRADHierarchyFrontierEntry[] {
+    return Array.from(state.selectedPages.values())
+      .sort(
+        (firstPage, secondPage) =>
+          firstPage.registeredPage.page.data.rowIndexBase -
+          secondPage.registeredPage.page.data.rowIndexBase
+      )
+      .map(selectedPage => {
+        selectedPage.activeRows.sort((firstRow, secondRow) => firstRow - secondRow);
+        return {
+          id: selectedPage.registeredPage.page.id,
+          data: selectedPage.registeredPage.page.data,
+          activeRows: Uint32Array.from(selectedPage.activeRows),
+          activeMask: selectedPage.activeMask,
+          bounds: selectedPage.registeredPage.bounds,
+          geometricError: selectedPage.geometricError,
+          priority: selectedPage.priority,
+          isFallback: selectedPage.isFallback
+        };
+      });
+  }
+
+  private updateFrontier(selectedFrontier: SplatRADHierarchyFrontierEntry[]): void {
+    const hasChanged =
+      selectedFrontier.length !== this.currentFrontier.length ||
+      selectedFrontier.some((entry, entryIndex) => {
+        const previousEntry = this.currentFrontier[entryIndex];
+        return (
+          entry.id !== previousEntry.id ||
+          entry.data !== previousEntry.data ||
+          entry.isFallback !== previousEntry.isFallback ||
+          entry.activeRows.length !== previousEntry.activeRows.length ||
+          entry.activeRows.some(
+            (rowIndex, rowOffset) => rowIndex !== previousEntry.activeRows[rowOffset]
+          )
+        );
+      });
+    if (hasChanged) {
+      this.currentFrontier = selectedFrontier;
+      this.onFrontierChange?.(selectedFrontier, this.stats);
+      return;
+    }
+    for (let entryIndex = 0; entryIndex < selectedFrontier.length; entryIndex++) {
+      this.currentFrontier[entryIndex].priority = selectedFrontier[entryIndex].priority;
+      this.currentFrontier[entryIndex].geometricError = selectedFrontier[entryIndex].geometricError;
+    }
+  }
+
+  private makeRowNode(
+    registeredPage: RegisteredSplatRADPage,
+    localRowIndex: number
+  ): SplatHierarchyNode {
+    const {data, geometricError} = registeredPage.page;
+    const componentOffset = localRowIndex * 3;
+    const center = [
+      data.source.positions[componentOffset],
+      data.source.positions[componentOffset + 1],
+      data.source.positions[componentOffset + 2]
+    ] as const;
+    const maximumScale = Math.max(
+      Math.abs(data.source.scales[componentOffset]),
+      Math.abs(data.source.scales[componentOffset + 1]),
+      Math.abs(data.source.scales[componentOffset + 2])
+    );
+    return {
+      id: `${registeredPage.page.id}:${localRowIndex}`,
+      bounds: {center, radius: maximumScale * GAUSSIAN_SUPPORT_RADIUS},
+      geometricError: geometricError ?? maximumScale
+    };
+  }
+
+  private getPagePriority(page: SplatRADHierarchyPage, bounds: SplatResidencyBounds): number {
+    if (!this.currentView) {
+      return 0;
+    }
+    const node: SplatHierarchyNode = {
+      id: page.id,
+      bounds,
+      geometricError: page.geometricError ?? Math.max(bounds.radius ?? 0, Number.EPSILON)
+    };
+    return getSplatHierarchyFoveatedPriority(
+      node,
+      this.currentView,
+      this.currentView.foveation ?? this.foveation
+    );
+  }
+
+  private getRegisteredPageForRow(rowIndex: number): RegisteredSplatRADPage | undefined {
+    let lowerIndex = 0;
+    let upperIndex = this.sortedPages.length - 1;
+    while (lowerIndex <= upperIndex) {
+      const middleIndex = lowerIndex + Math.floor((upperIndex - lowerIndex) / 2);
+      const page = this.sortedPages[middleIndex];
+      if (rowIndex < page.page.data.rowIndexBase) {
+        upperIndex = middleIndex - 1;
+      } else if (rowIndex >= page.endRowIndex) {
+        lowerIndex = middleIndex + 1;
+      } else if (!page.page.data.destroyed && this.residencyManager.has(page.page.id)) {
+        return page;
+      } else {
+        return undefined;
+      }
+    }
+    return undefined;
+  }
+
+  private protectChunk(chunk: SplatResidencyChunk): void {
+    if (!chunk.pinned && this.residencyManager.pin(chunk)) {
+      this.ownedPinnedIds.add(chunk.id);
+    }
+  }
+
+  private releaseInactivePins(activePageIds: ReadonlySet<string>): void {
+    for (const pageId of this.ownedPinnedIds) {
+      if (!activePageIds.has(pageId)) {
+        this.ownedPinnedIds.delete(pageId);
+        this.residencyManager.unpin(pageId);
+      }
+    }
+  }
+
+  private pruneEvictedPages(): void {
+    let removedPage = false;
+    for (const [pageId, registeredPage] of this.pagesById) {
+      if (registeredPage.page.data.destroyed || !this.residencyManager.has(pageId)) {
+        this.pagesById.delete(pageId);
+        this.ownedPinnedIds.delete(pageId);
+        removedPage = true;
+      }
+    }
+    if (removedPage) {
+      this.sortedPages = this.sortedPages.filter(page => this.pagesById.has(page.page.id));
+    }
+  }
+
+  private validateRootRows(rootRows: readonly number[]): void {
+    if (
+      rootRows.some(
+        rowIndex => !Number.isSafeInteger(rowIndex) || rowIndex < 0 || rowIndex > 0x7fff_ffff
+      )
+    ) {
+      throw new RangeError('Gaussian hierarchy roots must be nonnegative signed GPU row indices');
+    }
+  }
+
+  private validatePage(page: SplatRADHierarchyPage): void {
+    if (!page.id || page.data.destroyed || page.data.length === 0) {
+      throw new Error('Gaussian source pages require a stable identity and live prepared batch');
+    }
+    if (
+      Boolean(page.childCounts) !== Boolean(page.childStarts) ||
+      (page.childCounts && page.childCounts.length !== page.data.length) ||
+      (page.childStarts && page.childStarts.length !== page.data.length)
+    ) {
+      throw new Error('Gaussian source hierarchy arrays must match original source-row counts');
+    }
+    const endRowIndex = page.data.rowIndexBase + page.data.length;
+    if (
+      this.sortedPages.some(
+        registeredPage =>
+          registeredPage.page.id !== page.id &&
+          page.data.rowIndexBase < registeredPage.endRowIndex &&
+          endRowIndex > registeredPage.page.data.rowIndexBase
+      )
+    ) {
+      throw new Error('Gaussian source page global row ranges must not overlap');
+    }
+  }
+
+  private assertLive(): void {
+    if (this.isDestroyed || this.residencyManager.destroyed) {
+      throw new Error('Gaussian row hierarchy or its residency manager has been destroyed');
+    }
+  }
+}
+
+/** Derives a conservative sphere from original decoded page positions and Gaussian source scales. */
+export function getSplatRADPageBounds(
+  page: Pick<SplatRADHierarchyPage, 'data' | 'bounds'>
+): SplatResidencyBounds {
+  if (page.bounds) {
+    return page.bounds;
+  }
+
+  const positions = page.data.source.positions;
+  const scales = page.data.source.scales;
+  let minimumX = Number.POSITIVE_INFINITY;
+  let minimumY = Number.POSITIVE_INFINITY;
+  let minimumZ = Number.POSITIVE_INFINITY;
+  let maximumX = Number.NEGATIVE_INFINITY;
+  let maximumY = Number.NEGATIVE_INFINITY;
+  let maximumZ = Number.NEGATIVE_INFINITY;
+
+  for (let rowIndex = 0; rowIndex < page.data.length; rowIndex++) {
+    const componentOffset = rowIndex * 3;
+    const positionX = positions[componentOffset];
+    const positionY = positions[componentOffset + 1];
+    const positionZ = positions[componentOffset + 2];
+    if (!Number.isFinite(positionX + positionY + positionZ)) {
+      continue;
+    }
+    minimumX = Math.min(minimumX, positionX);
+    minimumY = Math.min(minimumY, positionY);
+    minimumZ = Math.min(minimumZ, positionZ);
+    maximumX = Math.max(maximumX, positionX);
+    maximumY = Math.max(maximumY, positionY);
+    maximumZ = Math.max(maximumZ, positionZ);
+  }
+
+  if (!Number.isFinite(minimumX)) {
+    return {center: [0, 0, 0], radius: 0};
+  }
+  const center = [
+    (minimumX + maximumX) / 2,
+    (minimumY + maximumY) / 2,
+    (minimumZ + maximumZ) / 2
+  ] as const;
+  let radius = 0;
+  for (let rowIndex = 0; rowIndex < page.data.length; rowIndex++) {
+    const componentOffset = rowIndex * 3;
+    const positionX = positions[componentOffset];
+    const positionY = positions[componentOffset + 1];
+    const positionZ = positions[componentOffset + 2];
+    if (!Number.isFinite(positionX + positionY + positionZ)) {
+      continue;
+    }
+    const maximumScale = Math.max(
+      Math.abs(scales[componentOffset]),
+      Math.abs(scales[componentOffset + 1]),
+      Math.abs(scales[componentOffset + 2])
+    );
+    radius = Math.max(
+      radius,
+      Math.hypot(positionX - center[0], positionY - center[1], positionZ - center[2]) +
+        maximumScale * GAUSSIAN_SUPPORT_RADIUS
+    );
+  }
+  return {center, radius};
+}

--- a/modules/splats/test/gpu-paged-splat-renderer.node.spec.ts
+++ b/modules/splats/test/gpu-paged-splat-renderer.node.spec.ts
@@ -1,0 +1,313 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {WgslReflect} from 'wgsl_reflect';
+import {makeGPUSplatData, type SplatSource} from '@luma.gl/splats';
+import {NullDevice} from '@luma.gl/test-utils';
+import {GPUPagedSplatRenderer} from '../src/gpu-paged-splat-renderer';
+import {
+  GPU_PAGED_SPLAT_FEATURE_SHADER,
+  GPU_PAGED_SPLAT_FEATURE_SHADER_LAYOUT,
+  GPU_PAGED_SPLAT_PROJECTION_SHADER,
+  GPU_PAGED_SPLAT_PROJECTION_SHADER_LAYOUT,
+  GPU_PAGED_SPLAT_RENDER_SHADER,
+  GPU_PAGED_SPLAT_RENDER_SHADER_LAYOUT
+} from '../src/gpu-paged-splat-shaders';
+
+test('paged Gaussian GPU shaders preserve sparse source rows within baseline storage limits', t => {
+  const projection = new WgslReflect(GPU_PAGED_SPLAT_PROJECTION_SHADER);
+  const features = new WgslReflect(GPU_PAGED_SPLAT_FEATURE_SHADER);
+  const render = new WgslReflect(GPU_PAGED_SPLAT_RENDER_SHADER);
+
+  for (const [name, reflection, layout] of [
+    ['projection', projection, GPU_PAGED_SPLAT_PROJECTION_SHADER_LAYOUT],
+    ['features', features, GPU_PAGED_SPLAT_FEATURE_SHADER_LAYOUT]
+  ] as const) {
+    t.equal(reflection.storage.length, 8, `${name} uses only eight portable storage bindings`);
+    t.deepEqual(
+      reflection.storage.map(resource => ({name: resource.name, location: resource.binding})),
+      layout.bindings
+        .filter(binding => binding.type !== 'uniform')
+        .map(binding => ({name: binding.name, location: binding.location})),
+      `${name} retains separate caller-owned source storage and renderer-owned sparse indices`
+    );
+    const uniforms = reflection.uniforms.find(uniform => uniform.name === 'graphUniforms');
+    t.equal(uniforms?.size, 128, `${name} reuses the existing 128-byte camera uniform allocation`);
+    t.deepEqual(
+      uniforms?.members?.slice(-2).map(member => ({name: member.name, offset: member.offset})),
+      [
+        {name: 'hasActiveRows', offset: 120},
+        {name: 'sourceRowOffset', offset: 124}
+      ],
+      `${name} fills previously unused source-index uniform padding`
+    );
+  }
+
+  t.equal(render.storage.length, 1, 'globally gathered presentation binds one projected segment');
+  t.deepEqual(
+    [
+      ...render.uniforms.map(resource => ({name: resource.name, location: resource.binding})),
+      ...render.storage.map(resource => ({name: resource.name, location: resource.binding}))
+    ],
+    GPU_PAGED_SPLAT_RENDER_SHADER_LAYOUT.bindings.map(binding => ({
+      name: binding.name,
+      location: binding.location
+    })),
+    'ordered output segments need no duplicated source or sorted-index presentation bindings'
+  );
+  t.equal(
+    projection.structs.find(struct => struct.name === 'ProjectedSplat')?.size,
+    48,
+    'preserves shared 48-byte anisotropic HDR projected records'
+  );
+  t.match(
+    GPU_PAGED_SPLAT_PROJECTION_SHADER,
+    /batchRowIndex = activeRows\[projectedRowIndex\]/,
+    'projects only compact selected page-local source rows'
+  );
+  t.match(
+    GPU_PAGED_SPLAT_PROJECTION_SHADER,
+    /depthKeys\[graphUniforms\.batchOffset \+ projectedRowIndex\]/,
+    'publishes every page into one exact global depth-key domain'
+  );
+  t.match(
+    GPU_PAGED_SPLAT_FEATURE_SHADER,
+    /atomicAdd\(&drawCommands\[1u\], 1u\)/,
+    'counts only sparse rows surviving projection, semantic filtering, and SH evaluation'
+  );
+  t.match(
+    GPU_PAGED_SPLAT_RENDER_SHADER,
+    /projectedRecords\[instanceIndex\]/,
+    'consumes already globally ordered projected output segments directly'
+  );
+  t.end();
+});
+
+test('GPUPagedSplatRenderer rejects devices without WebGPU compute graphs', t => {
+  const device = new NullDevice({});
+  t.throws(
+    () => new GPUPagedSplatRenderer(device),
+    /requires a WebGPU device/,
+    'keeps WebGL source drawing on the existing fallback renderer'
+  );
+  t.end();
+});
+
+test('GPUPagedSplatRenderer retains sparse independent pages and bounded source segments lazily', t => {
+  const device = makePagedWebGPUNullDevice();
+  const firstSource = makePagedSplatSource([0.9, 0.1, 0.6, 0.2, 0.4], 100, 7);
+  const secondSource = makePagedSplatSource([0.8, 0.3], 500, 8);
+  const firstPage = makeGPUSplatData(device, firstSource);
+  const secondPage = makeGPUSplatData(device, secondSource);
+  const selectedFirstRows = new Uint32Array([4, 1, 3]);
+  const selectedSecondRows = new Uint32Array([0]);
+  const renderer = new GPUPagedSplatRenderer(device, {
+    pages: [
+      {id: 'first-source-page', data: firstPage, activeRows: selectedFirstRows},
+      {id: 'second-source-page', data: secondPage, activeRows: selectedSecondRows}
+    ],
+    viewportSize: [32, 24],
+    maxProjectedSplatsPerSegment: 2
+  });
+
+  t.equal(renderer.pages[0]?.data, firstPage, 'retains the first intact original source page');
+  t.equal(renderer.pages[1]?.data, secondPage, 'retains the independent second source page');
+  t.equal(renderer.pages[0]?.activeRows, selectedFirstRows, 'retains caller-owned sparse row IDs');
+  t.equal(renderer.compiledGraph, undefined, 'defers all compute graph compilation until encoding');
+  t.equal(renderer.sortedIndexBuffer, undefined, 'allocates no global permutation eagerly');
+  t.equal(renderer.uniformBuffer, undefined, 'allocates no presentation uniforms eagerly');
+  t.deepEqual(renderer.projectedRecordBuffers, [], 'allocates no gathered output segment eagerly');
+  t.equal(renderer.stats.pageCount, 2, 'tracks independently retained source pages');
+  t.equal(renderer.stats.rowCount, 7, 'reports the complete borrowed loaded source row count');
+  t.equal(renderer.stats.activeRowCount, 4, 'projects only four caller-selected page-local rows');
+  t.equal(renderer.stats.splatCount, 4, 'reports the actual sparse visible-work upper bound');
+  t.equal(renderer.stats.sourceSegmentCount, 3, 'splits sources into bounded projection segments');
+  t.equal(renderer.stats.maxProjectedSplatsPerSegment, 2, 'honors the forced segment limit');
+  t.equal(renderer.stats.segmentCount, 0, 'keeps output segment allocation deferred');
+  t.equal(renderer.stats.sortMode, 'global', 'plans one exact cross-page global depth ordering');
+  t.equal(
+    renderer.stats.sourceGpuByteLength,
+    firstPage.byteLength + secondPage.byteLength,
+    'accounts for borrowed GPU source pages independently of renderer-owned storage'
+  );
+
+  const originalFirstPositions = firstPage.positions.data[0].buffer;
+  const originalSecondPositions = secondPage.positions.data[0].buffer;
+  const rendererIndirectCommands = renderer.drawCommands.buffer;
+  renderer.destroy();
+  renderer.destroy();
+  t.ok(renderer.destroyed, 'renderer destruction is idempotent');
+  t.ok(rendererIndirectCommands.destroyed, 'releases its owned indirect command allocation');
+  t.notOk(originalFirstPositions.destroyed, 'never destroys the first borrowed source allocation');
+  t.notOk(originalSecondPositions.destroyed, 'never destroys the second source allocation');
+  firstPage.destroy();
+  secondPage.destroy();
+  t.end();
+});
+
+test('GPUPagedSplatRenderer validates page-local sparse ownership and source identities', t => {
+  const device = makePagedWebGPUNullDevice();
+  const foreignDevice = makePagedWebGPUNullDevice();
+  const localPage = makeGPUSplatData(device, makePagedSplatSource([0.1, 0.8], 700, 4));
+  const foreignPage = makeGPUSplatData(foreignDevice, makePagedSplatSource([0.2], 1, 5));
+  const renderer = new GPUPagedSplatRenderer(device);
+
+  t.equal(renderer.stats.activeRowCount, 0, 'starts safely with an empty streaming frontier');
+  t.throws(
+    () => renderer.setFrontier([{id: 'foreign', data: foreignPage}]),
+    /own device/,
+    'rejects pages borrowed from another WebGPU device'
+  );
+  t.throws(
+    () =>
+      renderer.setFrontier([
+        {id: 'repeated', data: localPage},
+        {id: 'repeated', data: localPage}
+      ]),
+    /unique nonempty/,
+    'requires stable unique source page identities'
+  );
+  t.throws(
+    () =>
+      renderer.setFrontier([
+        {id: 'outside-source', data: localPage, activeRows: new Uint32Array([2])}
+      ]),
+    /source-page-local/,
+    'rejects global row offsets in a batch-local active-row frontier'
+  );
+
+  renderer.setFrontier([{id: 'source', data: localPage, activeRows: new Uint32Array([1])}]);
+  t.equal(renderer.stats.activeRowCount, 1, 'accepts a valid original source-row selection');
+  renderer.setPages([{id: 'source', data: localPage}]);
+  t.equal(renderer.stats.activeRowCount, 2, 'accepts page-oriented aliases without row copies');
+  renderer.setProps({data: localPage});
+  t.equal(renderer.batches[0], localPage, 'accepts existing graph-style borrowed source props');
+  renderer.setFrontier([]);
+  t.equal(renderer.stats.pageCount, 0, 'supports empty hierarchy frontiers safely');
+  t.notOk(localPage.destroyed, 'frontier replacement never destroys caller-owned source pages');
+
+  renderer.destroy();
+  localPage.destroy();
+  foreignPage.destroy();
+  t.end();
+});
+
+test('GPUPagedSplatRenderer plans aligned source ranges beyond one storage binding', t => {
+  const device = makePagedWebGPUNullDevice();
+  device.limits.maxStorageBufferBindingSize = 1_024;
+  device.limits.minStorageBufferOffsetAlignment = 256;
+  const depths = Array.from({length: 130}, (_, rowIndex) => rowIndex / 130);
+  const sourcePage = makeGPUSplatData(device, makePagedSplatSource(depths, 70_000, 12));
+  const renderer = new GPUPagedSplatRenderer(device, {
+    pages: [{id: 'oversized-source', data: sourcePage}],
+    maxProjectedSplatsPerSegment: 20
+  });
+
+  t.ok(
+    sourcePage.positions.data[0].buffer.byteLength > device.limits.maxStorageBufferBindingSize,
+    'retains the original caller allocation even when it exceeds one storage binding'
+  );
+  t.equal(renderer.stats.maxProjectedSplatsPerSegment, 20, 'respects bounded output capacity');
+  t.equal(renderer.stats.sourceSegmentCount, 9, 'splits two aligned 64-row windows and a tail');
+  t.equal(renderer.stats.activeRowCount, 130, 'retains every original source row exactly once');
+
+  renderer.setFrontier([
+    {
+      id: 'oversized-source',
+      data: sourcePage,
+      activeRows: new Uint32Array([65, 127, 3, 128])
+    }
+  ]);
+  t.equal(renderer.stats.sourceSegmentCount, 3, 'groups sparse rows by aligned source windows');
+  t.equal(renderer.stats.activeRowCount, 4, 'keeps sparse work proportional to active rows');
+  renderer.destroy();
+  t.notOk(sourcePage.destroyed, 'never destroys the oversized borrowed source allocation');
+  sourcePage.destroy();
+  t.end();
+});
+
+test('GPUPagedSplatRenderer retains directional SH, semantic controls, and HDR source ownership', t => {
+  const device = makePagedWebGPUNullDevice();
+  const source = makePagedSplatSource([0.4, 0.8], 90, 3);
+  source.colors = new Float32Array([4, 1, 0.5, 1, 2, 0.5, 0.25, 1]);
+  source.semanticIds = new Uint32Array([4, 9]);
+  source.sphericalHarmonics = new Float32Array(90);
+  source.sphericalHarmonicsDegree = 3;
+  const sourcePage = makeGPUSplatData(device, source);
+  const filter = {include: new Set([4, 9]), exclude: [9], includeUnlabeled: true};
+  const renderer = new GPUPagedSplatRenderer(device, {
+    pages: [{id: 'directional-source', data: sourcePage}],
+    cameraPosition: [1, 2, 3],
+    sphericalHarmonicsDegree: 2,
+    semanticFilter: filter
+  });
+
+  t.equal(sourcePage.colors.format, 'float32x4', 'preserves original source HDR radiance');
+  t.equal(renderer.props.toneMapping, 'reinhard', 'adapts HDR source pages for SDR presentation');
+  t.deepEqual(renderer.props.cameraPosition, [1, 2, 3], 'keeps source SH camera direction');
+  t.equal(renderer.props.sphericalHarmonicsDegree, 2, 'preserves requested higher-order SH bands');
+  t.equal(renderer.props.semanticFilter, filter, 'preserves source semantic selection controls');
+  renderer.setProps({
+    cameraPosition: [3, 2, 1],
+    sphericalHarmonicsDegree: 3,
+    semanticFilter: undefined,
+    toneMapping: 'none',
+    opacityThreshold: 0.2,
+    pointSize: 1.5
+  });
+  t.deepEqual(renderer.props.cameraPosition, [3, 2, 1], 'updates source SH lighting direction');
+  t.equal(renderer.props.sphericalHarmonicsDegree, 3, 'supports all three Khronos SH bands');
+  t.equal(renderer.props.semanticFilter, undefined, 'restores unfiltered source visibility');
+  t.equal(renderer.props.toneMapping, 'none', 'respects explicit display tone-map controls');
+  t.equal(renderer.props.alphaCutoff, 0.2, 'preserves opacity-threshold compatibility');
+  t.equal(renderer.props.radiusScale, 1.5, 'preserves point-size compatibility');
+  t.throws(
+    () => renderer.setProps({semanticFilter: {predicate: () => true}}),
+    /JavaScript predicates/,
+    'rejects CPU callbacks incompatible with sparse GPU-native source traversal'
+  );
+  t.throws(
+    () => renderer.setProps({semanticFilter: {include: [-1]}}),
+    /unsigned 32-bit/,
+    'rejects classes unrepresentable in caller-owned source semantic buffers'
+  );
+
+  const sphericalHarmonics = sourcePage.sphericalHarmonics!.data[0].buffer;
+  const semanticIdentifiers = sourcePage.semanticIds!.data[0].buffer;
+  renderer.destroy();
+  t.notOk(sphericalHarmonics.destroyed, 'preserves independently borrowed source SH storage');
+  t.notOk(semanticIdentifiers.destroyed, 'preserves independently borrowed source class storage');
+  sourcePage.destroy();
+  t.end();
+});
+
+function makePagedWebGPUNullDevice(): NullDevice {
+  const device = new NullDevice({});
+  Object.defineProperties(device, {
+    type: {value: 'webgpu'},
+    info: {value: {...device.info, type: 'webgpu', shadingLanguage: 'wgsl'}}
+  });
+  return device;
+}
+
+function makePagedSplatSource(
+  depths: readonly number[],
+  rowIndexBase: number,
+  sourceBatchIndex: number
+): SplatSource {
+  const positions = new Float32Array(depths.length * 3);
+  const scales = new Float32Array(depths.length * 3);
+  const rotations = new Float32Array(depths.length * 4);
+  const colors = new Uint8Array(depths.length * 4);
+  const opacities = new Float32Array(depths.length);
+  for (const [rowIndex, depth] of depths.entries()) {
+    positions[rowIndex * 3 + 2] = depth;
+    scales.set([0.3, 0.2, 0.1], rowIndex * 3);
+    rotations[rowIndex * 4] = 1;
+    colors.set([255, 128, 32, 255], rowIndex * 4);
+    opacities[rowIndex] = 1;
+  }
+  return {positions, scales, rotations, colors, opacities, rowIndexBase, sourceBatchIndex};
+}

--- a/modules/splats/test/gpu-paged-splat-renderer.spec.ts
+++ b/modules/splats/test/gpu-paged-splat-renderer.spec.ts
@@ -6,12 +6,201 @@ import test from 'test/utils/vitest-tape';
 import {Buffer, Texture, type Device} from '@luma.gl/core';
 import {Model} from '@luma.gl/engine';
 import {makeGPUSplatData, type SplatSource} from '@luma.gl/splats';
-import {getTestDevices} from '@luma.gl/test-utils';
+import {getTestDevices, NullDevice} from '@luma.gl/test-utils';
 import {GPUPagedSplatRenderer} from '../src/gpu-paged-splat-renderer';
 import {
   GPU_PAGED_SPLAT_RENDER_SHADER,
   GPU_PAGED_SPLAT_RENDER_SHADER_LAYOUT
 } from '../src/gpu-paged-splat-shaders';
+import './gpu-paged-splat-renderer.node.spec';
+
+test('GPUPagedSplatRenderer executes sparse source lifecycle on every browser WebGPU adapter', async t => {
+  const devices = await getTestDevices(['webgpu']);
+  t.ok(devices.length > 0, 'a browser WebGPU adapter is available, including software adapters');
+  const unsupportedDevice = new NullDevice({});
+  t.throws(
+    () => new GPUPagedSplatRenderer(unsupportedDevice),
+    /requires a WebGPU device/,
+    'rejects unsupported graphics backends without accessing source data'
+  );
+
+  for (const device of devices) {
+    const firstSource = makeBrowserPagedSplatSource([0.9, 0.1, 0.6, 0.3], 100, 17);
+    firstSource.colors = new Float32Array([
+      2, 0.5, 0.25, 1, 1, 0.75, 0.5, 1, 0.75, 1, 0.25, 1, 0.5, 0.25, 1, 1
+    ]);
+    firstSource.semanticIds = new Uint32Array([4, 9, 4, 7]);
+    firstSource.sphericalHarmonics = new Float32Array(4 * 45);
+    firstSource.sphericalHarmonicsDegree = 3;
+    firstSource.sphericalHarmonics[2 * 3] = 0.25;
+    const secondSource = makeBrowserPagedSplatSource([0.8, 0.2, 0.4], 200, 18);
+    secondSource.semanticIds = new Uint32Array([4, 9, 7]);
+    const firstPage = makeGPUSplatData(device, firstSource);
+    const secondPage = makeGPUSplatData(device, secondSource);
+    const initialPages = [
+      {id: 'browser-directional-page', data: firstPage, activeRows: new Uint32Array([0, 2, 3])},
+      {id: 'browser-semantic-page', data: secondPage, activeRows: new Uint32Array([0, 1])}
+    ];
+    const renderer = new GPUPagedSplatRenderer(device, {
+      pages: initialPages,
+      viewportSize: [16, 16],
+      cameraPosition: [-1, 0, 0.9],
+      sphericalHarmonicsDegree: 2,
+      semanticFilter: {include: [4, 9], exclude: [7], includeUnlabeled: true},
+      maxProjectedSplatsPerSegment: 2,
+      clearColor: [0, 0, 0, 0]
+    });
+
+    t.equal(renderer.batches[0], firstPage, 'retains the first independent original source page');
+    t.equal(renderer.batches[1], secondPage, 'retains the second independent source allocation');
+    t.equal(renderer.props.toneMapping, 'reinhard', 'automatically maps Float32 source radiance');
+    t.equal(renderer.stats.activeRowCount, 5, 'retains only requested original sparse source rows');
+    t.equal(renderer.stats.sourceSegmentCount, 3, 'splits independent bounded source projections');
+    t.ok(renderer.encode(device.commandEncoder), 'encodes the real device command graph');
+    t.ok(renderer.compiledGraph, 'compiles GPU projection, global sorting, and ordered gather');
+    t.ok(renderer.graphStats, 'exposes real graph diagnostics without mapping a GPU buffer');
+    t.ok(renderer.lastEncoding, 'records the current sparse GPU graph encoding');
+    t.ok(renderer.uniformBuffer, 'retains shared GPU camera presentation uniforms');
+    t.ok(renderer.sortedIndexBuffer, 'retains one compact global GPU source permutation');
+    t.equal(renderer.projectedRecordBuffers.length, 3, 'allocates three ordered bounded outputs');
+    t.equal(renderer.stats.segmentCount, 3, 'tracks output segments independently of source pages');
+    t.equal(renderer.stats.globalSortCapacity, 5, 'sorts exactly five active cross-page rows');
+    t.ok(
+      renderer.stats.rendererGpuByteLength > 0 && renderer.stats.sourceGpuByteLength > 0,
+      'separates owned graph storage from original caller-owned source bytes'
+    );
+    device.submit();
+
+    const originalGraph = renderer.compiledGraph;
+    t.equal(
+      renderer.encode(device.commandEncoder),
+      undefined,
+      'avoids work when no source, camera, or sparse visibility changed'
+    );
+    const updatedMatrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.1, 0, 0, 1];
+    renderer.setProps({
+      modelViewProjectionMatrix: updatedMatrix,
+      viewportSize: [24, 24],
+      cameraPosition: [1, 0, 0.9],
+      sphericalHarmonicsDegree: 3,
+      semanticFilter: {include: new Set([4, 7, 9]), exclude: [7]},
+      opacityThreshold: 0.02,
+      pointSize: 1.25,
+      screenSizeCutoffPixels: 0.1,
+      gaussianSupportRadius: 2.75,
+      kernel2DSize: 0.4,
+      maxScreenSpaceSplatSize: 256,
+      alphaScale: 0.8,
+      exposure: 1.1,
+      toneMapping: 'none'
+    });
+    t.ok(renderer.encode(device.commandEncoder), 'updates camera, semantics, SH, and presentation');
+    t.equal(
+      renderer.compiledGraph,
+      originalGraph,
+      'reuses its existing GPU graph for style changes'
+    );
+    device.submit();
+
+    renderer.setFrontier([
+      {id: 'browser-directional-page', data: firstPage, activeRows: new Uint32Array([1, 2, 3])},
+      {id: 'browser-semantic-page', data: secondPage, activeRows: new Uint32Array([1, 2])}
+    ]);
+    t.ok(renderer.encode(device.commandEncoder), 'updates compact sparse original source offsets');
+    t.equal(renderer.compiledGraph, originalGraph, 'reuses stable-cardinality source projections');
+    device.submit();
+
+    firstPage.updateRows(1, {opacities: new Float32Array([0.75])});
+    t.ok(renderer.encode(device.commandEncoder), 'detects in-place caller-owned source revisions');
+    t.equal(renderer.compiledGraph, originalGraph, 'reuses its graph for original source updates');
+    device.submit();
+
+    renderer.setProps({semanticFilter: {include: Array.from({length: 70}, (_, index) => index)}});
+    t.ok(renderer.encode(device.commandEncoder), 'grows GPU-owned semantic-selection capacity');
+    t.notEqual(
+      renderer.compiledGraph,
+      originalGraph,
+      'rebuilds only for expanded semantic storage'
+    );
+    device.submit();
+
+    const replacementGraph = renderer.compiledGraph;
+    renderer.setFrontier([]);
+    t.ok(renderer.encode(device.commandEncoder), 'clears an empty hierarchy frontier exactly once');
+    t.equal(renderer.compiledGraph, replacementGraph, 'retains graph allocations while empty');
+    device.submit();
+    t.equal(
+      renderer.encode(device.commandEncoder),
+      undefined,
+      'does not clear a clean scene twice'
+    );
+    renderer.setPages([
+      {id: 'browser-directional-page', data: firstPage, activeRows: new Uint32Array([1, 2, 3])},
+      {id: 'browser-semantic-page', data: secondPage, activeRows: new Uint32Array([1, 2])}
+    ]);
+    t.ok(renderer.encode(device.commandEncoder), 'reactivates original sparse page allocations');
+    t.equal(renderer.compiledGraph, replacementGraph, 'restores the original bounded graph');
+    device.submit();
+
+    renderer.setProps({pages: [{id: 'replacement-page', data: secondPage}]});
+    t.ok(renderer.encode(device.commandEncoder), 'rebuilds for a different independent page set');
+    t.equal(renderer.stats.activeRowCount, 3, 'renders complete original replacement page rows');
+    device.submit();
+    renderer.setProps({data: firstPage, semanticFilter: undefined});
+    t.ok(renderer.encode(device.commandEncoder), 'supports existing graph-compatible source props');
+    device.submit();
+
+    t.throws(
+      () =>
+        renderer.setFrontier([{id: 'invalid', data: firstPage, activeRows: new Uint32Array([4])}]),
+      /source-page-local/,
+      'rejects sparse source offsets outside the original borrowed page'
+    );
+    t.throws(
+      () => renderer.setProps({semanticFilter: {predicate: () => true}}),
+      /JavaScript predicates/,
+      'rejects host callbacks that cannot execute inside the GPU graph'
+    );
+    t.throws(
+      () => renderer.setProps({semanticFilter: {include: [-1]}}),
+      /unsigned 32-bit/,
+      'rejects classes incompatible with original unsigned semantic storage'
+    );
+
+    const firstPositions = firstPage.positions.data[0].buffer;
+    const secondPositions = secondPage.positions.data[0].buffer;
+    const drawCommands = renderer.drawCommands.buffer;
+    renderer.destroy();
+    renderer.destroy();
+    t.ok(renderer.destroyed, 'makes renderer destruction safe and idempotent');
+    t.ok(drawCommands.destroyed, 'destroys renderer-owned indirect command storage');
+    t.notOk(firstPositions.destroyed, 'preserves independently borrowed first-page source storage');
+    t.notOk(
+      secondPositions.destroyed,
+      'preserves independently borrowed second-page source storage'
+    );
+    t.equal(renderer.encode(device.commandEncoder), undefined, 'does not encode destroyed graphs');
+    t.throws(
+      () => renderer.setFrontier([{id: 'destroyed', data: firstPage}]),
+      /destroyed/,
+      'rejects further source updates after destruction'
+    );
+
+    const compatibleRenderer = new GPUPagedSplatRenderer(device, {data: [firstPage, secondPage]});
+    t.deepEqual(
+      compatibleRenderer.batches,
+      [firstPage, secondPage],
+      'preserves graph-compatible streamed batch arrays without copying source rows'
+    );
+    compatibleRenderer.setProps({data: secondPage});
+    compatibleRenderer.destroy();
+    firstPage.destroy();
+    secondPage.destroy();
+  }
+
+  unsupportedDevice.destroy();
+  t.end();
+});
 
 test('GPUPagedSplatRenderer globally sorts overlapping real WebGPU pages across bounded segments', async t => {
   const devices = await getTestDevices(['webgpu']);

--- a/modules/splats/test/gpu-paged-splat-renderer.spec.ts
+++ b/modules/splats/test/gpu-paged-splat-renderer.spec.ts
@@ -1,0 +1,504 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {Buffer, Texture, type Device} from '@luma.gl/core';
+import {Model} from '@luma.gl/engine';
+import {makeGPUSplatData, type SplatSource} from '@luma.gl/splats';
+import {getTestDevices} from '@luma.gl/test-utils';
+import {GPUPagedSplatRenderer} from '../src/gpu-paged-splat-renderer';
+import {
+  GPU_PAGED_SPLAT_RENDER_SHADER,
+  GPU_PAGED_SPLAT_RENDER_SHADER_LAYOUT
+} from '../src/gpu-paged-splat-shaders';
+
+test('GPUPagedSplatRenderer globally sorts overlapping real WebGPU pages across bounded segments', async t => {
+  const devices = await getTestDevices(['webgpu']);
+  t.ok(devices.length > 0, 'a browser WebGPU adapter is available');
+
+  for (const device of devices) {
+    if (isSoftwareBackedPagedDevice(device)) {
+      t.comment('Skipping globally ordered segmented splat readback on a software-backed adapter');
+      continue;
+    }
+
+    const textureSize = 16;
+    const firstSource = makeBrowserPagedSplatSource([0.9, 0.1], 100, 4);
+    firstSource.colors.set([255, 0, 0, 255, 0, 0, 255, 255]);
+    firstSource.opacities.fill(0.5);
+    const secondSource = makeBrowserPagedSplatSource([0.7, 0.3], 800, 9);
+    secondSource.colors.set([0, 255, 0, 255, 255, 255, 0, 255]);
+    secondSource.opacities.fill(0.5);
+    const firstPage = makeGPUSplatData(device, firstSource);
+    const secondPage = makeGPUSplatData(device, secondSource);
+    const renderer = new GPUPagedSplatRenderer(device, {
+      pages: [
+        {id: 'red-blue-page', data: firstPage},
+        {id: 'green-yellow-page', data: secondPage}
+      ],
+      viewportSize: [textureSize, textureSize],
+      maxProjectedSplatsPerSegment: 2,
+      alphaCutoff: 0
+    });
+
+    t.ok(renderer.encode(device.commandEncoder), 'encodes the globally ordered segmented graph');
+    t.equal(renderer.stats.pageCount, 2, 'preserves two independently allocated source pages');
+    t.equal(renderer.stats.sourceSegmentCount, 2, 'projects each preserved source page separately');
+    t.equal(renderer.stats.segmentCount, 2, 'gathers exact global order into two bounded outputs');
+    t.equal(
+      renderer.stats.globalSortCapacity,
+      4,
+      'sorts all active pages in one global GPU domain'
+    );
+    t.ok(
+      renderer.compiledGraph?.stats.nodeOrder.some(nodeId =>
+        nodeId.includes('paged-gaussian-global-depth-sort')
+      ),
+      'schedules a single cross-page GPU radix ordering'
+    );
+    t.ok(
+      renderer.compiledGraph?.stats.nodeOrder.includes('paged-gaussian-segmented-render'),
+      'presents ordered segments within one final render pass'
+    );
+    device.submit();
+
+    const sortedBytes = await renderer.sortedIndexBuffer!.readAsync();
+    const sortedIndices = new Uint32Array(
+      sortedBytes.buffer,
+      sortedBytes.byteOffset,
+      sortedBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+    );
+    t.deepEqual(
+      Array.from(sortedIndices),
+      [0, 2, 3, 1],
+      'interleaves overlapping page depths in exact global far-to-near order'
+    );
+
+    const indirectBytes = await renderer.drawCommands.buffer.readAsync();
+    const indirectCommands = new Uint32Array(
+      indirectBytes.buffer,
+      indirectBytes.byteOffset,
+      indirectBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+    );
+    t.deepEqual(
+      Array.from(indirectCommands),
+      [4, 4, 0, 0, 4, 2, 0, 0, 4, 2, 0, 0],
+      'publishes global visibility and exact GPU-driven counts for each bounded segment'
+    );
+
+    const firstOutputBytes = await renderer.projectedRecordBuffers[0].readAsync();
+    const firstOutput = new Float32Array(
+      firstOutputBytes.buffer,
+      firstOutputBytes.byteOffset,
+      firstOutputBytes.byteLength / Float32Array.BYTES_PER_ELEMENT
+    );
+    const secondOutputBytes = await renderer.projectedRecordBuffers[1].readAsync();
+    const secondOutput = new Float32Array(
+      secondOutputBytes.buffer,
+      secondOutputBytes.byteOffset,
+      secondOutputBytes.byteLength / Float32Array.BYTES_PER_ELEMENT
+    );
+    t.deepEqual(
+      [
+        Array.from(firstOutput.slice(8, 11)),
+        Array.from(firstOutput.slice(20, 23)),
+        Array.from(secondOutput.slice(8, 11)),
+        Array.from(secondOutput.slice(20, 23))
+      ],
+      [
+        [1, 0, 0],
+        [0, 1, 0],
+        [1, 1, 0],
+        [0, 0, 1]
+      ],
+      'gathers only renderer-owned projected records into exact cross-page depth order'
+    );
+
+    const colorTexture = device.createTexture({
+      format: 'rgba8unorm',
+      width: textureSize,
+      height: textureSize,
+      usage: Texture.RENDER_ATTACHMENT | Texture.COPY_SRC
+    });
+    const framebuffer = device.createFramebuffer({
+      width: textureSize,
+      height: textureSize,
+      colorAttachments: [colorTexture],
+      depthStencilAttachment: 'depth24plus'
+    });
+    const presentationModel = new Model(device, {
+      id: 'paged-gaussian-global-order-readback',
+      source: GPU_PAGED_SPLAT_RENDER_SHADER,
+      shaderLayout: GPU_PAGED_SPLAT_RENDER_SHADER_LAYOUT,
+      colorAttachmentFormats: ['rgba8unorm'],
+      depthStencilAttachmentFormat: 'depth24plus',
+      isInstanced: true,
+      instanceCount: 2,
+      vertexCount: 4,
+      topology: 'triangle-strip',
+      bindings: {
+        graphUniforms: renderer.uniformBuffer!,
+        projectedRecords: renderer.projectedRecordBuffers[0]
+      },
+      parameters: {
+        depthWriteEnabled: false,
+        depthCompare: 'less-equal',
+        blend: true,
+        blendColorOperation: 'add',
+        blendAlphaOperation: 'add',
+        blendColorSrcFactor: 'src-alpha',
+        blendColorDstFactor: 'one-minus-src-alpha',
+        blendAlphaSrcFactor: 'one',
+        blendAlphaDstFactor: 'one-minus-src-alpha'
+      }
+    });
+    presentationModel.predraw(device.commandEncoder);
+    const renderPass = device.beginRenderPass({
+      framebuffer,
+      clearColor: [0, 0, 0, 0],
+      clearDepth: 1
+    });
+    renderPass.setPipeline(presentationModel.pipeline);
+    renderPass.setVertexArray(presentationModel.vertexArray);
+    for (const [segmentIndex, projectedRecords] of renderer.projectedRecordBuffers.entries()) {
+      renderPass.setBindings({graphUniforms: renderer.uniformBuffer!, projectedRecords});
+      renderer.drawCommands.draw(renderPass, segmentIndex + 1);
+    }
+    renderPass.end();
+    device.submit();
+
+    const pixelLayout = colorTexture.computeMemoryLayout({width: textureSize, height: textureSize});
+    const pixelReadback = device.createBuffer({
+      byteLength: pixelLayout.byteLength,
+      usage: Buffer.COPY_DST | Buffer.MAP_READ
+    });
+    colorTexture.readBuffer({width: textureSize, height: textureSize}, pixelReadback);
+    const pixels = await pixelReadback.readAsync(0, pixelLayout.byteLength);
+    const centerPixelOffset =
+      Math.floor(textureSize / 2) * pixelLayout.bytesPerRow + Math.floor(textureSize / 2) * 4;
+    const pixel = pixels.slice(centerPixelOffset, centerPixelOffset + 4);
+    t.ok(
+      pixel[2] > pixel[1] && pixel[1] > pixel[0] && pixel[0] > 60,
+      `real pixel [${Array.from(pixel)}] blends red→green→yellow→blue globally across page and segment boundaries`
+    );
+    t.notOk(presentationModel.pipeline.isErrored, 'compiles the real segmented splat pipeline');
+
+    const originalFirstSource = firstPage.positions.data[0].buffer;
+    const originalSecondSource = secondPage.positions.data[0].buffer;
+    pixelReadback.destroy();
+    presentationModel.destroy();
+    framebuffer.destroy();
+    colorTexture.destroy();
+    renderer.destroy();
+    t.notOk(originalFirstSource.destroyed, 'preserves the first original borrowed GPU source');
+    t.notOk(originalSecondSource.destroyed, 'preserves the second original borrowed GPU source');
+    firstPage.destroy();
+    secondPage.destroy();
+  }
+
+  t.end();
+});
+
+test('GPUPagedSplatRenderer reuses sparse real WebGPU graphs for semantic and row-frontier updates', async t => {
+  const devices = await getTestDevices(['webgpu']);
+
+  for (const device of devices) {
+    if (isSoftwareBackedPagedDevice(device)) {
+      t.comment('Skipping sparse semantic paged splat readback on a software-backed adapter');
+      continue;
+    }
+
+    const firstSource = makeBrowserPagedSplatSource([0.9, 0.1, 0.6], 100, 7);
+    firstSource.semanticIds = new Uint32Array([4, 9, 4]);
+    firstSource.sphericalHarmonics = new Float32Array(27);
+    firstSource.sphericalHarmonicsDegree = 1;
+    firstSource.sphericalHarmonics[2 * 3] = 0.5;
+    const secondSource = makeBrowserPagedSplatSource([0.8, 0.2], 200, 8);
+    secondSource.semanticIds = new Uint32Array([4, 9]);
+    const firstPage = makeGPUSplatData(device, firstSource);
+    const secondPage = makeGPUSplatData(device, secondSource);
+    const renderer = new GPUPagedSplatRenderer(device, {
+      pages: [
+        {id: 'directional-page', data: firstPage, activeRows: new Uint32Array([0, 1])},
+        {id: 'semantic-page', data: secondPage, activeRows: new Uint32Array([0, 1])}
+      ],
+      viewportSize: [16, 16],
+      cameraPosition: [-1, 0, 0.9],
+      sphericalHarmonicsDegree: 1,
+      maxProjectedSplatsPerSegment: 2,
+      semanticFilter: {include: [4]}
+    });
+
+    t.ok(renderer.encode(device.commandEncoder), 'projects sparse original GPU row selections');
+    device.submit();
+    const originalGraph = renderer.compiledGraph;
+    const originalSortedIndices = renderer.sortedIndexBuffer;
+    const originalOutput = renderer.projectedRecordBuffers[0];
+    const initialCommandBytes = await renderer.drawCommands.buffer.readAsync();
+    const initialCommands = new Uint32Array(
+      initialCommandBytes.buffer,
+      initialCommandBytes.byteOffset,
+      initialCommandBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+    );
+    t.deepEqual(
+      [initialCommands[1], initialCommands[5], initialCommands[9]],
+      [2, 2, 0],
+      'keeps only two semantically selected sparse rows in globally ordered indirect segments'
+    );
+
+    const initialProjectedBytes = await originalOutput.readAsync();
+    const initialProjected = new Float32Array(
+      initialProjectedBytes.buffer,
+      initialProjectedBytes.byteOffset,
+      initialProjectedBytes.byteLength / Float32Array.BYTES_PER_ELEMENT
+    );
+    const initialDirectionalRed = initialProjected[8];
+    renderer.setProps({cameraPosition: [1, 0, 0.9], semanticFilter: {include: [4, 9]}});
+    t.ok(
+      renderer.encode(device.commandEncoder),
+      'updates sparse semantic and directional controls'
+    );
+    t.equal(renderer.compiledGraph, originalGraph, 'reuses the same compiled cross-page graph');
+    t.equal(renderer.sortedIndexBuffer, originalSortedIndices, 'reuses the global GPU permutation');
+    device.submit();
+    const updatedCommandBytes = await renderer.drawCommands.buffer.readAsync();
+    const updatedCommands = new Uint32Array(
+      updatedCommandBytes.buffer,
+      updatedCommandBytes.byteOffset,
+      updatedCommandBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+    );
+    t.deepEqual(
+      [updatedCommands[1], updatedCommands[5], updatedCommands[9]],
+      [4, 2, 2],
+      'restores all included sparse rows and splits GPU visibility over ordered output segments'
+    );
+    const updatedProjectedBytes = await originalOutput.readAsync();
+    const updatedProjected = new Float32Array(
+      updatedProjectedBytes.buffer,
+      updatedProjectedBytes.byteOffset,
+      updatedProjectedBytes.byteLength / Float32Array.BYTES_PER_ELEMENT
+    );
+    t.ok(
+      Math.abs(initialDirectionalRed - updatedProjected[8]) > 0.2,
+      'evaluates original page-owned higher-order SH against the updated camera direction'
+    );
+
+    renderer.setFrontier([
+      {id: 'directional-page', data: firstPage, activeRows: new Uint32Array([2, 1])},
+      {id: 'semantic-page', data: secondPage, activeRows: new Uint32Array([0, 1])}
+    ]);
+    t.ok(renderer.encode(device.commandEncoder), 'replaces sparse page-local row selections');
+    t.equal(renderer.compiledGraph, originalGraph, 'retains graph identity for stable cardinality');
+    t.equal(renderer.projectedRecordBuffers[0], originalOutput, 'retains bounded output storage');
+    device.submit();
+    const frontierSortedBytes = await renderer.sortedIndexBuffer!.readAsync();
+    const frontierSorted = new Uint32Array(
+      frontierSortedBytes.buffer,
+      frontierSortedBytes.byteOffset,
+      frontierSortedBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+    );
+    t.deepEqual(
+      Array.from(frontierSorted),
+      [2, 0, 3, 1],
+      'resorts replaced original source offsets exactly across overlapping page depths'
+    );
+
+    renderer.setFrontier([]);
+    t.ok(renderer.encode(device.commandEncoder), 'encodes one clear when a hierarchy empties');
+    t.equal(renderer.compiledGraph, originalGraph, 'preserves graph allocations while empty');
+    device.submit();
+    renderer.setFrontier([
+      {id: 'directional-page', data: firstPage, activeRows: new Uint32Array([2, 1])},
+      {id: 'semantic-page', data: secondPage, activeRows: new Uint32Array([0, 1])}
+    ]);
+    t.ok(renderer.encode(device.commandEncoder), 'reactivates the preserved sparse page frontier');
+    t.equal(renderer.compiledGraph, originalGraph, 'restores the original reusable graph');
+    device.submit();
+
+    const sourceHarmonics = firstPage.sphericalHarmonics!.data[0].buffer;
+    const sourceSemantics = secondPage.semanticIds!.data[0].buffer;
+    renderer.destroy();
+    t.notOk(sourceHarmonics.destroyed, 'never destroys borrowed original higher-order SH buffers');
+    t.notOk(sourceSemantics.destroyed, 'never destroys borrowed original semantic source buffers');
+    firstPage.destroy();
+    secondPage.destroy();
+  }
+
+  t.end();
+});
+
+test('GPUPagedSplatRenderer binds aligned real WebGPU source ranges across sparse degree-three pages', async t => {
+  const devices = await getTestDevices(['webgpu']);
+
+  for (const device of devices) {
+    if (isSoftwareBackedPagedDevice(device)) {
+      t.comment('Skipping aligned source-range paged splat readback on a software-backed adapter');
+      continue;
+    }
+
+    const rowCount = 130;
+    const firstSource = makeBrowserPagedSplatSource(
+      Array.from({length: rowCount}, (_, rowIndex) => rowIndex / rowCount),
+      2_000,
+      22
+    );
+    firstSource.sphericalHarmonics = new Float32Array(rowCount * 45);
+    firstSource.sphericalHarmonicsDegree = 3;
+    firstSource.semanticIds = new Uint32Array(rowCount).fill(4);
+    const secondSource = makeBrowserPagedSplatSource(
+      Array.from({length: rowCount}, (_, rowIndex) => (rowCount - rowIndex) / (rowCount + 1)),
+      8_000,
+      23
+    );
+    secondSource.colors = new Float32Array(rowCount * 4);
+    secondSource.sphericalHarmonics = new Float32Array(rowCount * 45);
+    secondSource.sphericalHarmonicsDegree = 3;
+    secondSource.semanticIds = new Uint32Array(rowCount).fill(9);
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      firstSource.sphericalHarmonics[rowIndex * 45 + 2 * 3] = 0.25;
+      secondSource.sphericalHarmonics[rowIndex * 45 + 2 * 3] = 0.25;
+      secondSource.colors.set([2, 0.25, 0.125, 1], rowIndex * 4);
+    }
+    const firstPage = makeGPUSplatData(device, firstSource);
+    const secondPage = makeGPUSplatData(device, secondSource);
+    const originalLimits = device.limits;
+    const forcedBindingByteLength = 12_288;
+    Object.defineProperty(device, 'limits', {
+      configurable: true,
+      value: new Proxy(originalLimits, {
+        get(target, property) {
+          if (property === 'maxStorageBufferBindingSize') {
+            return forcedBindingByteLength;
+          }
+          return Reflect.get(target, property);
+        }
+      })
+    });
+    let renderer: GPUPagedSplatRenderer | undefined;
+
+    try {
+      renderer = new GPUPagedSplatRenderer(device, {
+        pages: [{id: 'aligned-packed-page', data: firstPage}],
+        viewportSize: [16, 16],
+        cameraPosition: [1, 0, 0.5],
+        sphericalHarmonicsDegree: 3,
+        maxProjectedSplatsPerSegment: 20,
+        toneMapping: 'none',
+        semanticFilter: {include: [4, 9]}
+      });
+      t.ok(
+        firstPage.sphericalHarmonics!.data[0].buffer.byteLength > forcedBindingByteLength,
+        'retains a degree-three source allocation larger than the simulated device binding limit'
+      );
+      t.equal(
+        renderer.stats.sourceSegmentCount,
+        9,
+        'projects source rows through two aligned 64-row windows and one original tail'
+      );
+      t.ok(
+        renderer.encode(device.commandEncoder),
+        'encodes aligned original source storage ranges'
+      );
+      t.equal(renderer.stats.segmentCount, 7, 'splits complete output into seven bounded segments');
+      device.submit();
+      const completeSortedBytes = await renderer.sortedIndexBuffer!.readAsync();
+      const completeSortedIndices = new Uint32Array(
+        completeSortedBytes.buffer,
+        completeSortedBytes.byteOffset,
+        completeSortedBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+      );
+      t.deepEqual(
+        Array.from(completeSortedIndices),
+        Array.from({length: rowCount}, (_, sortedRow) => rowCount - sortedRow - 1),
+        'retains exact global ordering across every aligned source and output window'
+      );
+
+      renderer.setFrontier([
+        {
+          id: 'aligned-packed-page',
+          data: firstPage,
+          activeRows: new Uint32Array([63, 64, 129])
+        },
+        {
+          id: 'aligned-float-page',
+          data: secondPage,
+          activeRows: new Uint32Array([0, 65, 128])
+        }
+      ]);
+      t.equal(renderer.stats.sourceSegmentCount, 6, 'separates sparse rows at aligned range edges');
+      t.equal(
+        renderer.stats.activeRowCount,
+        6,
+        'dispatches only six selected original source rows'
+      );
+      t.ok(
+        renderer.encode(device.commandEncoder),
+        'binds original Uint8 and Float32 source columns without uploading merged row buffers'
+      );
+      device.submit();
+      const sparseSortedBytes = await renderer.sortedIndexBuffer!.readAsync();
+      const sparseSortedIndices = new Uint32Array(
+        sparseSortedBytes.buffer,
+        sparseSortedBytes.byteOffset,
+        sparseSortedBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+      );
+      t.deepEqual(
+        Array.from(sparseSortedIndices),
+        [3, 2, 4, 1, 0, 5],
+        'globally interleaves preserved sparse page rows across three source-binding windows'
+      );
+      const projectedBytes = await renderer.projectedRecordBuffers[0].readAsync();
+      const projectedRecords = new Float32Array(
+        projectedBytes.buffer,
+        projectedBytes.byteOffset,
+        projectedBytes.byteLength / Float32Array.BYTES_PER_ELEMENT
+      );
+      t.ok(
+        projectedRecords[8] > 1.5,
+        'retains unquantized Float32 page radiance while evaluating degree-three source SH'
+      );
+    } finally {
+      renderer?.destroy();
+      Object.defineProperty(device, 'limits', {configurable: true, value: originalLimits});
+      t.notOk(
+        firstPage.sphericalHarmonics!.data[0].buffer.destroyed,
+        'never destroys an oversized borrowed Uint8-page SH source allocation'
+      );
+      t.notOk(
+        secondPage.colors.data[0].buffer.destroyed,
+        'never destroys an independently borrowed Float32 source color allocation'
+      );
+      firstPage.destroy();
+      secondPage.destroy();
+    }
+  }
+
+  t.end();
+});
+
+function makeBrowserPagedSplatSource(
+  depths: readonly number[],
+  rowIndexBase: number,
+  sourceBatchIndex: number
+): SplatSource {
+  const positions = new Float32Array(depths.length * 3);
+  const scales = new Float32Array(depths.length * 3);
+  const rotations = new Float32Array(depths.length * 4);
+  const colors = new Uint8Array(depths.length * 4);
+  const opacities = new Float32Array(depths.length);
+  for (const [rowIndex, depth] of depths.entries()) {
+    positions[rowIndex * 3 + 2] = depth;
+    scales.set([0.8, 0.8, 0.1], rowIndex * 3);
+    rotations[rowIndex * 4] = 1;
+    colors.set([128, 64, 32, 255], rowIndex * 4);
+    opacities[rowIndex] = 1;
+  }
+  return {positions, scales, rotations, colors, opacities, rowIndexBase, sourceBatchIndex};
+}
+
+function isSoftwareBackedPagedDevice(device: Device): boolean {
+  return (
+    device.info.gpu === 'software' || device.info.gpuType === 'cpu' || Boolean(device.info.fallback)
+  );
+}

--- a/modules/splats/test/index.ts
+++ b/modules/splats/test/index.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
+import './gpu-paged-splat-renderer.node.spec';
+import './gpu-paged-splat-renderer.spec';
 import './gpu-splat-graph-interaction.node.spec';
 import './gpu-splat-graph-interaction.spec';
 import './splat-data.node.spec';
@@ -10,6 +12,7 @@ import './splat-hierarchy.node.spec';
 import './splat-interaction.node.spec';
 import './splat-interaction.spec';
 import './splat-mixed-renderer.node.spec';
+import './splat-rad-hierarchy.node.spec';
 import './splat-residency.node.spec';
 import './splat-renderer.node.spec';
 import './splat-renderer.spec';

--- a/modules/splats/test/index.ts
+++ b/modules/splats/test/index.ts
@@ -13,6 +13,7 @@ import './splat-interaction.node.spec';
 import './splat-interaction.spec';
 import './splat-mixed-renderer.node.spec';
 import './splat-rad-hierarchy.node.spec';
+import './splat-rad-hierarchy.spec';
 import './splat-residency.node.spec';
 import './splat-renderer.node.spec';
 import './splat-renderer.spec';

--- a/modules/splats/test/splat-rad-hierarchy.node.spec.ts
+++ b/modules/splats/test/splat-rad-hierarchy.node.spec.ts
@@ -1,0 +1,700 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {makeGPUSplatData, SplatResidencyManager, type GPUSplatData} from '@luma.gl/splats';
+import {NullDevice} from '@luma.gl/test-utils';
+import {GPUPagedSplatRenderer} from '../src/gpu-paged-splat-renderer';
+import type {SplatHierarchyView} from '../src/splat-hierarchy';
+import {
+  getSplatRADPageBounds,
+  SplatRADHierarchyManager,
+  type SplatRADHierarchyFrontierEntry,
+  type SplatRADHierarchyPage,
+  type SplatRADHierarchyRequest
+} from '../src/splat-rad-hierarchy';
+
+const IDENTITY_MATRIX = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1] as const;
+
+test('SplatRADHierarchyManager conservatively derives original decoded source-page bounds', t => {
+  const device = new NullDevice({});
+  const page = makeRADPage(device, {
+    id: 'root',
+    rowIndexBase: 20,
+    positions: [-1, 0, 0, 1, 2, 0],
+    scales: [0.1, 0.2, 0.1, 0.25, 0.1, 0.1]
+  });
+  const bounds = getSplatRADPageBounds(page);
+
+  t.deepEqual(bounds.center, [0, 1, 0], 'centers the proxy sphere on original page extrema');
+  t.ok(
+    (bounds.radius ?? 0) >= Math.SQRT2 + 0.75,
+    'covers the farthest decoded position and its complete three-sigma Gaussian support'
+  );
+  const authoredBounds = {center: [9, 8, 7] as const, radius: 5};
+  t.equal(
+    getSplatRADPageBounds({...page, bounds: authoredBounds}),
+    authoredBounds,
+    'retains authored source bounds without creating replacement metadata'
+  );
+
+  page.data.destroy();
+  t.end();
+});
+
+test('SplatRADHierarchyManager requests the single global Spark root only once', t => {
+  const device = new NullDevice({});
+  const requests: SplatRADHierarchyRequest[] = [];
+  const manager = new SplatRADHierarchyManager({
+    pageSize: 16,
+    onPageRequest: request => requests.push(request)
+  });
+
+  manager.update(makeRADView());
+  manager.update(makeRADView());
+  t.deepEqual(
+    requests.map(request => [request.rowIndex, request.pageIndex]),
+    [[0, 0]],
+    'deduplicates repeated camera updates into one root source-page request'
+  );
+  t.deepEqual(manager.requestedRows, [0], 'exposes the original missing global source row');
+
+  const root = makeRADPage(device, {id: 'root', rowIndexBase: 0, positions: [0, 0, 0]});
+  t.ok(manager.registerPage(root), 'admits the independently decoded root source page');
+  t.deepEqual(
+    getFrontierSourceRows(manager.frontier),
+    [[0]],
+    'selects the one Spark root source row after registration'
+  );
+  t.equal(manager.getPage('root'), root, 'preserves exact caller-owned source metadata');
+  t.equal(manager.getPageForRow(0), root, 'resolves the global source row without page packing');
+  t.equal(manager.stats.requestedPageCount, 0, 'clears the resolved root source-page request');
+
+  manager.destroy();
+  t.notOk(root.data.destroyed, 'does not destroy caller-owned prepared source data');
+  root.data.destroy();
+  t.end();
+});
+
+test('SplatRADHierarchyManager refines mixed parent and childless rows independently', t => {
+  const device = new NullDevice({});
+  const requests: SplatRADHierarchyRequest[] = [];
+  const events: number[][][] = [];
+  const root = makeRADPage(device, {
+    id: 'root',
+    sourceBatchIndex: 4,
+    rowIndexBase: 0,
+    positions: [0, 0, 0, 0.25, 0, 0],
+    childCounts: [2, 0],
+    childStarts: [4, 0]
+  });
+  const children = makeRADPage(device, {
+    id: 'children',
+    sourceBatchIndex: 9,
+    rowIndexBase: 4,
+    positions: [-0.15, 0, 0, 0.15, 0, 0]
+  });
+  const manager = new SplatRADHierarchyManager({
+    pages: [root],
+    rootRows: [0, 1],
+    pageSize: 2,
+    maximumScreenSpaceError: 1,
+    onPageRequest: request => requests.push(request),
+    onFrontierChange: frontier => events.push(getFrontierSourceRows(frontier))
+  });
+
+  manager.update(makeRADView());
+  t.deepEqual(
+    getFrontierSourceRows(manager.frontier),
+    [[0, 1]],
+    'retains the coarse parent and unrelated childless row in their original source page'
+  );
+  t.deepEqual(
+    Array.from(manager.frontier[0].activeMask),
+    [1, 1],
+    'marks original batch-local parent and leaf source rows without copying source buffers'
+  );
+  t.equal(
+    manager.frontier[0].isFallback,
+    true,
+    'marks only the containing source page as fallback'
+  );
+  t.equal(
+    manager.stats.fallbackRowCount,
+    1,
+    'counts the unresolved parent, not the unrelated leaf'
+  );
+  t.deepEqual(
+    requests.map(request => [request.pageIndex, request.parentRowIndex]),
+    [[2, 0]],
+    'maps global child rows to one deduplicated, stable source-page request'
+  );
+
+  manager.registerPage(children);
+  t.deepEqual(
+    getFrontierSourceRows(manager.frontier),
+    [[1], [4, 5]],
+    'removes only the refined parent while preserving its childless sibling and both child rows'
+  );
+  t.deepEqual(
+    Array.from(manager.frontier[0].activeRows),
+    [1],
+    'keeps page-local source offsets rather than replacing or repacking the mixed parent page'
+  );
+  t.deepEqual(
+    Array.from(manager.frontier[0].activeMask),
+    [0, 1],
+    'updates only the source-row visibility mask for the original parent page'
+  );
+  t.equal(manager.frontier[0].data, root.data, 'retains the original mixed parent-page GPU batch');
+  t.equal(manager.frontier[1].data, children.data, 'retains the original child-page GPU batch');
+  t.deepEqual(
+    manager.frontier.map(entry => entry.data.sourceBatchIndex),
+    [4, 9],
+    'preserves independent source-batch identities for picking and semantic filtering'
+  );
+  t.deepEqual(
+    events,
+    [[[0, 1]], [[1], [4, 5]]],
+    'notifies renderers only when atomic original-row coverage changes'
+  );
+
+  manager.destroy();
+  root.data.destroy();
+  children.data.destroy();
+  t.end();
+});
+
+test('SplatRADHierarchyManager pins partial child pages until all replacing rows exist', t => {
+  const device = new NullDevice({});
+  const residency = new SplatResidencyManager({maxResidentChunks: 3});
+  const requests: SplatRADHierarchyRequest[] = [];
+  const parent = makeRADPage(device, {
+    id: 'parent',
+    rowIndexBase: 0,
+    positions: [0, 0, 0],
+    childCounts: [2],
+    childStarts: [2]
+  });
+  const firstChild = makeRADPage(device, {
+    id: 'first-child',
+    rowIndexBase: 2,
+    positions: [-0.1, 0, 0]
+  });
+  const secondChild = makeRADPage(device, {
+    id: 'second-child',
+    rowIndexBase: 3,
+    positions: [0.1, 0, 0]
+  });
+  const manager = new SplatRADHierarchyManager({
+    pages: [parent],
+    pageSize: 1,
+    residencyManager: residency,
+    maximumScreenSpaceError: 1,
+    onPageRequest: request => requests.push(request)
+  });
+
+  manager.update(makeRADView());
+  t.deepEqual(
+    requests.map(request => request.pageIndex),
+    [2, 3],
+    'requests both globally addressed child source pages'
+  );
+  t.ok(residency.getChunk('parent')?.pinned, 'pins the active coarse fallback source page');
+
+  manager.registerPage(firstChild);
+  t.deepEqual(
+    getFrontierSourceRows(manager.frontier),
+    [[0]],
+    'keeps the coarse source parent visible until the final child page is ready'
+  );
+  t.ok(
+    residency.getChunk('first-child')?.pinned,
+    'protects an already decoded child page from residency thrashing'
+  );
+  t.deepEqual(manager.requestedRows, [3], 'keeps only the still-missing source child request');
+
+  manager.registerPage(secondChild);
+  t.deepEqual(
+    getFrontierSourceRows(manager.frontier),
+    [[2], [3]],
+    'atomically replaces one parent with its original children across page boundaries'
+  );
+  t.notOk(residency.getChunk('parent')?.pinned, 'releases the obsolete parent fallback pin');
+  t.ok(residency.getChunk('first-child')?.pinned, 'pins the first active child source page');
+  t.ok(residency.getChunk('second-child')?.pinned, 'pins the second active child source page');
+  t.equal(manager.stats.fallbackRowCount, 0, 'removes fallback coverage after atomic replacement');
+
+  manager.destroy();
+  t.notOk(residency.destroyed, 'borrows the externally managed source residency window');
+  residency.destroy();
+  parent.data.destroy();
+  firstChild.data.destroy();
+  secondChild.data.destroy();
+  t.end();
+});
+
+test('SplatRADHierarchyManager sends exact sparse source-page frontiers to the GPU renderer', t => {
+  const device = new NullDevice({});
+  Object.defineProperties(device, {
+    type: {value: 'webgpu'},
+    info: {value: {...device.info, type: 'webgpu', shadingLanguage: 'wgsl'}}
+  });
+  const parent = makeRADPage(device, {
+    id: 'parent',
+    sourceBatchIndex: 4,
+    rowIndexBase: 0,
+    positions: [0, 0, 0, 0.25, 0, 0],
+    childCounts: [1, 0],
+    childStarts: [5, 0]
+  });
+  const child = makeRADPage(device, {
+    id: 'child',
+    sourceBatchIndex: 11,
+    rowIndexBase: 5,
+    positions: [-0.1, 0, 0]
+  });
+  const renderer = new GPUPagedSplatRenderer(device, {viewportSize: [256, 256]});
+  const manager = new SplatRADHierarchyManager({
+    pages: [parent],
+    rootRows: [0, 1],
+    maximumScreenSpaceError: 1,
+    onFrontierChange: frontier => renderer.setFrontier(frontier)
+  });
+
+  manager.update(makeRADView());
+  t.deepEqual(
+    renderer.pages.map(page => Array.from(page.activeRows ?? [])),
+    [[0, 1]],
+    'passes the parent fallback and childless sibling as original batch-local offsets'
+  );
+  t.equal(renderer.pages[0].data, parent.data, 'borrows the untouched parent GPU source batch');
+
+  manager.registerPage(child);
+  t.deepEqual(
+    renderer.pages.map(page => Array.from(page.activeRows ?? [])),
+    [[1], [0]],
+    'updates only sparse local source-row indirection during atomic parent replacement'
+  );
+  t.deepEqual(
+    renderer.pages.map(page => [page.data.sourceBatchIndex, page.data.rowIndexBase]),
+    [
+      [4, 0],
+      [11, 5]
+    ],
+    'preserves stable original page and global source-row picking identities'
+  );
+  t.equal(
+    renderer.pages[0].data.positions.data[0].buffer,
+    parent.data.positions.data[0].buffer,
+    'keeps the original independently allocated source position buffer'
+  );
+  t.equal(renderer.compiledGraph, undefined, 'keeps GPU graph compilation lazy during traversal');
+
+  manager.update({
+    ...makeRADView(),
+    modelViewProjectionMatrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -5, 0, 0, 1]
+  });
+  t.equal(renderer.pages.length, 0, 'detaches every borrowed source when the frontier is empty');
+  manager.update(makeRADView());
+  t.equal(renderer.pages[0].data, parent.data, 'restores the original mixed source page');
+  t.equal(renderer.pages[1].data, child.data, 'restores the original child source page');
+
+  renderer.destroy();
+  manager.destroy();
+  t.notOk(parent.data.destroyed, 'neither borrowing component destroys parent source data');
+  t.notOk(child.data.destroyed, 'neither borrowing component destroys child source data');
+  parent.data.destroy();
+  child.data.destroy();
+  t.end();
+});
+
+test('SplatRADHierarchyManager respects active-row budgets and missing-page backpressure', t => {
+  const device = new NullDevice({});
+  const parent = makeRADPage(device, {
+    id: 'parent',
+    rowIndexBase: 0,
+    positions: [0, 0, 0],
+    childCounts: [2],
+    childStarts: [2]
+  });
+  const children = makeRADPage(device, {
+    id: 'children',
+    rowIndexBase: 2,
+    positions: [-0.2, 0, 0, 0.2, 0, 0]
+  });
+  const requests: number[] = [];
+  const activeBudget = new SplatRADHierarchyManager({
+    pages: [parent, children],
+    maximumScreenSpaceError: 0,
+    maximumActiveRows: 1,
+    onPageRequest: request => requests.push(request.pageIndex)
+  });
+
+  activeBudget.update(makeRADView());
+  t.deepEqual(
+    getFrontierSourceRows(activeBudget.frontier),
+    [[0]],
+    'keeps one coarse parent when its child replacement would exceed the active-row budget'
+  );
+  t.notOk(activeBudget.frontier[0].isFallback, 'does not mislabel an intentional budgeted level');
+  t.equal(activeBudget.stats.activeRowCount, 1, 'never exceeds the configured visible-row budget');
+  t.deepEqual(requests, [], 'does not request unreachable detail outside the active-row budget');
+
+  activeBudget.destroy();
+  parent.data.destroy();
+  children.data.destroy();
+  t.end();
+});
+
+test('SplatRADHierarchyManager retains fallback when protected page budgets deny child admission', t => {
+  const device = new NullDevice({});
+  const residency = new SplatResidencyManager({maxResidentChunks: 2});
+  const requests: number[] = [];
+  const parent = makeRADPage(device, {
+    id: 'parent',
+    rowIndexBase: 0,
+    positions: [0, 0, 0],
+    childCounts: [2],
+    childStarts: [2]
+  });
+  const firstChild = makeRADPage(device, {
+    id: 'first-child',
+    rowIndexBase: 2,
+    positions: [-0.1, 0, 0]
+  });
+  const secondChild = makeRADPage(device, {
+    id: 'second-child',
+    rowIndexBase: 3,
+    positions: [0.1, 0, 0]
+  });
+  const manager = new SplatRADHierarchyManager({
+    pages: [parent],
+    pageSize: 1,
+    residencyManager: residency,
+    maximumScreenSpaceError: 1,
+    onPageRequest: request => requests.push(request.pageIndex)
+  });
+
+  manager.update(makeRADView());
+  t.ok(manager.registerPage(firstChild), 'admits one child inside the independent page budget');
+  t.notOk(
+    manager.registerPage(secondChild),
+    'rejects the final child when the protected parent and first sibling exhaust residency'
+  );
+  t.deepEqual(
+    getFrontierSourceRows(manager.frontier),
+    [[0]],
+    'retains exact parent fallback when atomic child replacement cannot fit'
+  );
+  t.equal(residency.stats.residentChunkCount, 2, 'never exceeds the independent source-page cap');
+  t.ok(residency.getChunk('parent')?.pinned, 'does not evict the original visible parent');
+  t.ok(residency.getChunk('first-child')?.pinned, 'does not thrash the completed child sibling');
+  t.notOk(secondChild.data.destroyed, 'leaves a rejected caller-owned source page untouched');
+
+  manager.update(makeRADView());
+  t.deepEqual(requests, [2, 3], 'does not repeatedly request the unadmittable child source page');
+  t.deepEqual(manager.requestedRows, [3], 'keeps one stable pending request for future capacity');
+
+  manager.destroy();
+  residency.destroy();
+  parent.data.destroy();
+  firstChild.data.destroy();
+  secondChild.data.destroy();
+  t.end();
+});
+
+test('SplatRADHierarchyManager culls rows and concentrates detail around camera foveation', t => {
+  const device = new NullDevice({});
+  const parents = makeRADPage(device, {
+    id: 'parents',
+    rowIndexBase: 0,
+    positions: [0, 0, 0, 0.8, 0, 0],
+    childCounts: [1, 1],
+    childStarts: [2, 3]
+  });
+  const children = makeRADPage(device, {
+    id: 'children',
+    rowIndexBase: 2,
+    positions: [0.1, 0, 0, 0.8, 0, 0]
+  });
+  const manager = new SplatRADHierarchyManager({
+    pages: [parents, children],
+    rootRows: [0, 1],
+    maximumScreenSpaceError: 20,
+    foveation: {center: [0.5, 0.5], radius: 0.05, strength: 10}
+  });
+
+  manager.update(makeRADView());
+  t.deepEqual(
+    getFrontierSourceRows(manager.frontier),
+    [[1], [2]],
+    'refines the centered parent while preserving a coarse peripheral source row'
+  );
+  t.ok(
+    (manager.frontier.find(entry => entry.id === 'children')?.priority ?? 0) >
+      (manager.frontier.find(entry => entry.id === 'parents')?.priority ?? 0),
+    'prioritizes original source rows near the camera gaze'
+  );
+
+  manager.update({
+    ...makeRADView(),
+    modelViewProjectionMatrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -4, 0, 0, 1]
+  });
+  t.equal(
+    manager.frontier.length,
+    0,
+    'removes source rows outside the conservative camera frustum'
+  );
+  t.ok(manager.stats.culledRowCount > 0, 'reports conservatively rejected original source rows');
+  t.equal(
+    manager.residencyManager.stats.pinnedChunkCount,
+    0,
+    'releases hierarchy-owned page pins when the camera no longer needs them'
+  );
+
+  manager.destroy();
+  parents.data.destroy();
+  children.data.destroy();
+  t.end();
+});
+
+test('SplatRADHierarchyManager cancels stale page demand and restores evicted parent coverage', t => {
+  const device = new NullDevice({});
+  const requested: number[] = [];
+  const cancelled: number[] = [];
+  const parent = makeRADPage(device, {
+    id: 'parent',
+    rowIndexBase: 0,
+    positions: [0, 0, 0],
+    childCounts: [1],
+    childStarts: [4]
+  });
+  const child = makeRADPage(device, {
+    id: 'child',
+    rowIndexBase: 4,
+    positions: [0, 0, 0]
+  });
+  const manager = new SplatRADHierarchyManager({
+    pages: [parent],
+    pageSize: 2,
+    maximumScreenSpaceError: 1,
+    onPageRequest: request => requested.push(request.pageIndex),
+    onPageCancel: request => cancelled.push(request.pageIndex)
+  });
+
+  manager.update(makeRADView());
+  t.deepEqual(requested, [2], 'requests the source page containing a missing global child');
+  manager.update({
+    ...makeRADView(),
+    modelViewProjectionMatrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -5, 0, 0, 1]
+  });
+  t.deepEqual(cancelled, [2], 'cancels the loader-owned page after the camera leaves its parent');
+  t.equal(manager.stats.requestedPageCount, 0, 'drops the no-longer-relevant source page demand');
+
+  manager.update(makeRADView());
+  manager.registerPage(child);
+  t.deepEqual(getFrontierSourceRows(manager.frontier), [[4]], 'selects the restored child page');
+  manager.removePage('child');
+  t.deepEqual(
+    getFrontierSourceRows(manager.frontier),
+    [[0]],
+    'restores the original parent row when its refined source child is removed'
+  );
+  t.ok(manager.frontier[0].isFallback, 'marks the restored parent as replacement fallback');
+  t.deepEqual(
+    requested,
+    [2, 2, 2],
+    'requests the page again only after explicit view/eviction changes'
+  );
+
+  manager.destroy();
+  parent.data.destroy();
+  child.data.destroy();
+  t.end();
+});
+
+test('SplatRADHierarchyManager reuses caller-reserved residency and preserves external pins', async t => {
+  const device = new NullDevice({});
+  const residency = new SplatResidencyManager({maxResidentChunks: 1});
+  const root = makeRADPage(device, {id: 'root', rowIndexBase: 0, positions: [0, 0, 0]});
+  const chunk = await residency.load('root', () => root.data, {
+    estimatedGpuBytes: root.data.byteLength,
+    estimatedSplatCount: root.data.length
+  });
+  t.ok(chunk, 'reserves and admits the source page before hierarchy registration');
+  residency.pin('root');
+  const manager = new SplatRADHierarchyManager({residencyManager: residency});
+
+  t.ok(manager.registerPage(root), 'reuses the existing caller-reserved source residency chunk');
+  manager.update(makeRADView());
+  t.equal(residency.stats.residentChunkCount, 1, 'never duplicates source residency allocations');
+  t.equal(manager.frontier[0].data, root.data, 'passes the original prepared batch to rendering');
+
+  manager.destroy();
+  t.ok(residency.getChunk('root')?.pinned, 'does not release a pin owned by the source caller');
+  t.notOk(residency.destroyed, 'does not destroy the caller-owned source residency manager');
+  residency.unpin('root');
+  residency.destroy();
+  root.data.destroy();
+  t.end();
+});
+
+test('SplatRADHierarchyManager traverses a large mixed-page global row tree', t => {
+  const device = new NullDevice({});
+  const pageSize = 64;
+  const totalRowCount = 2_047;
+  const pages: SplatRADHierarchyPage[] = [];
+  for (let rowIndexBase = 0; rowIndexBase < totalRowCount; rowIndexBase += pageSize) {
+    const rowCount = Math.min(pageSize, totalRowCount - rowIndexBase);
+    const positions: number[] = [];
+    const childCounts: number[] = [];
+    const childStarts: number[] = [];
+    for (let rowOffset = 0; rowOffset < rowCount; rowOffset++) {
+      const globalRowIndex = rowIndexBase + rowOffset;
+      positions.push((globalRowIndex % 32) / 64 - 0.25, 0, 0);
+      childCounts.push(globalRowIndex < 1_023 ? 2 : 0);
+      childStarts.push(globalRowIndex < 1_023 ? globalRowIndex * 2 + 1 : 0);
+    }
+    pages.push(
+      makeRADPage(device, {
+        id: `page-${rowIndexBase / pageSize}`,
+        sourceBatchIndex: rowIndexBase / pageSize,
+        rowIndexBase,
+        positions,
+        childCounts,
+        childStarts
+      })
+    );
+  }
+
+  const manager = new SplatRADHierarchyManager({
+    pages,
+    pageSize,
+    maximumScreenSpaceError: 0,
+    maximumActiveRows: 1_024
+  });
+  manager.update(makeRADView());
+
+  t.equal(manager.stats.activeRowCount, 1_024, 'selects exactly the binary tree leaf frontier');
+  t.equal(manager.stats.fallbackRowCount, 0, 'never overlays resident ancestors over leaf rows');
+  t.equal(manager.stats.requestedPageCount, 0, 'resolves every child through its original page');
+  t.deepEqual(
+    getFrontierSourceRows(manager.frontier).flat(),
+    Array.from({length: 1_024}, (_, rowOffset) => rowOffset + 1_023),
+    'retains every global leaf source identity across all independently resident source pages'
+  );
+  for (const entry of manager.frontier) {
+    t.equal(entry.data, manager.getPage(entry.id)?.data, 'borrows the exact original source page');
+    t.ok(
+      entry.activeRows.every(rowIndex => rowIndex < entry.data.length),
+      'keeps all selected source offsets batch-local'
+    );
+  }
+
+  manager.destroy();
+  for (const page of pages) {
+    page.data.destroy();
+  }
+  t.end();
+});
+
+test('SplatRADHierarchyManager rejects inconsistent child metadata and overlapping row ranges', t => {
+  const device = new NullDevice({});
+  const root = makeRADPage(device, {id: 'root', rowIndexBase: 0, positions: [0, 0, 0]});
+  const overlap = makeRADPage(device, {id: 'overlap', rowIndexBase: 0, positions: [0, 0, 0]});
+  const manager = new SplatRADHierarchyManager({pages: [root]});
+
+  t.throws(
+    () => manager.registerPage(overlap),
+    /must not overlap/,
+    'rejects source pages with ambiguous global source-row identities'
+  );
+  t.throws(
+    () =>
+      manager.registerPage({
+        ...overlap,
+        id: 'invalid-tree',
+        childCounts: new Uint16Array([1])
+      }),
+    /hierarchy arrays/,
+    'rejects incomplete source child metadata before modifying residency'
+  );
+  t.throws(
+    () => manager.setRootRows([-1]),
+    /hierarchy roots/,
+    'rejects global roots outside the stable GPU source-row domain'
+  );
+  t.throws(
+    () => new SplatRADHierarchyManager({pageSize: 0}),
+    /page size/,
+    'rejects invalid original source-page sizes'
+  );
+  t.throws(
+    () => new SplatRADHierarchyManager({maximumActiveRows: 0}),
+    /active-row capacity/,
+    'rejects empty source-row visibility budgets'
+  );
+
+  manager.destroy();
+  t.throws(
+    () => manager.update(makeRADView()),
+    /destroyed/,
+    'rejects camera updates after destroy'
+  );
+  root.data.destroy();
+  overlap.data.destroy();
+  t.end();
+});
+
+function makeRADPage(
+  device: NullDevice,
+  options: {
+    id: string;
+    rowIndexBase: number;
+    sourceBatchIndex?: number;
+    positions: number[];
+    scales?: number[];
+    childCounts?: number[];
+    childStarts?: number[];
+  }
+): SplatRADHierarchyPage {
+  const rowCount = options.positions.length / 3;
+  const scales = options.scales ?? Array.from({length: rowCount * 3}, () => 0.1);
+  const rotations = new Float32Array(rowCount * 4);
+  const colors = new Uint8Array(rowCount * 4);
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+    rotations[rowIndex * 4] = 1;
+    colors.set([255, 255, 255, 255], rowIndex * 4);
+  }
+  const data: GPUSplatData = makeGPUSplatData(device, {
+    positions: Float32Array.from(options.positions),
+    scales: Float32Array.from(scales),
+    rotations,
+    colors,
+    opacities: new Float32Array(rowCount).fill(1),
+    sourceBatchIndex: options.sourceBatchIndex ?? options.rowIndexBase,
+    rowIndexBase: options.rowIndexBase
+  });
+  return {
+    id: options.id,
+    data,
+    ...(options.childCounts ? {childCounts: Uint16Array.from(options.childCounts)} : {}),
+    ...(options.childStarts ? {childStarts: Uint32Array.from(options.childStarts)} : {})
+  };
+}
+
+function makeRADView(): SplatHierarchyView {
+  return {
+    cameraPosition: [0, 0, 2],
+    viewportSize: [1_000, 1_000],
+    modelViewProjectionMatrix: IDENTITY_MATRIX
+  };
+}
+
+function getFrontierSourceRows(frontier: readonly SplatRADHierarchyFrontierEntry[]): number[][] {
+  return frontier.map(entry =>
+    Array.from(entry.activeRows, rowOffset => entry.data.rowIndexBase + rowOffset)
+  );
+}

--- a/modules/splats/test/splat-rad-hierarchy.spec.ts
+++ b/modules/splats/test/splat-rad-hierarchy.spec.ts
@@ -1,0 +1,7 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+// The authored-row hierarchy uses only NullDevice resources, so run its complete source-fidelity
+// suite in headless/browser coverage as well as the separate Node-only test project.
+import './splat-rad-hierarchy.node.spec';

--- a/test/examples/gaussian-splat-viewer.node.spec.ts
+++ b/test/examples/gaussian-splat-viewer.node.spec.ts
@@ -7,7 +7,14 @@ import path from 'node:path';
 import {pathToFileURL} from 'node:url';
 import {afterEach, describe, expect, test, vi} from 'vitest';
 import type {AnimationProps} from '@luma.gl/engine';
-import {GPUSplatGraphRenderer, SplatRenderer, type GPUSplatData} from '@luma.gl/splats';
+import {
+  GPUPagedSplatRenderer,
+  GPUSplatGraphRenderer,
+  SplatRenderer,
+  makeGPUSplatData,
+  type GPUSplatData,
+  type SplatHierarchyView
+} from '@luma.gl/splats';
 import {NullDevice} from '@luma.gl/test-utils';
 import {
   default as GaussianSplatsAnimationLoopTemplate,
@@ -18,8 +25,11 @@ import {
   GAUSSIAN_SPLAT_SOURCE_CATALOG,
   getLocalGaussianSplatLoadersConfiguration,
   loadLocalGaussianSplatArrowSources,
-  type LocalGaussianSplatLoadProgress
+  openLocalGaussianSplatRADPageSource,
+  type LocalGaussianSplatLoadProgress,
+  type LocalGaussianSplatLoadersConfiguration
 } from '../../examples/showcase/gaussian-splats/local-loaders';
+import {GaussianSplatRADSceneController} from '../../examples/showcase/gaussian-splats/rad-scene';
 import {getExampleThumbnailPath} from '../../website/src/example-thumbnails';
 
 const WEBSITE_VIEWER_ROUTE = '/examples/showcase/gaussian-splat-viewer';
@@ -74,6 +84,43 @@ describe('published Gaussian splat viewer', () => {
 
     animation.renderer.destroy();
     device.destroy();
+  });
+
+  test('selects segmented WebGPU RAD rendering while preserving CPU and WebGL fallback', () => {
+    installViewerWindow('?scene=coit');
+    const webgpuDevice = makeViewerWebGPUDevice();
+    const adaptiveAnimation = new GaussianSplatsAnimationLoopTemplate({
+      device: webgpuDevice,
+      width: 640,
+      height: 480
+    } as AnimationProps);
+
+    expect(adaptiveAnimation.renderer).toBeInstanceOf(GPUPagedSplatRenderer);
+    expect(adaptiveAnimation.renderer).not.toBeInstanceOf(GPUSplatGraphRenderer);
+    adaptiveAnimation.renderer.destroy();
+    webgpuDevice.destroy();
+
+    installViewerWindow('?scene=coit&renderer=cpu');
+    const cpuComparisonDevice = makeViewerWebGPUDevice();
+    const cpuAnimation = new GaussianSplatsAnimationLoopTemplate({
+      device: cpuComparisonDevice,
+      width: 640,
+      height: 480
+    } as AnimationProps);
+    expect(cpuAnimation.renderer).toBeInstanceOf(SplatRenderer);
+    cpuAnimation.renderer.destroy();
+    cpuComparisonDevice.destroy();
+
+    installViewerWindow('?scene=coit');
+    const webglDevice = new NullDevice({});
+    const webglAnimation = new GaussianSplatsAnimationLoopTemplate({
+      device: webglDevice,
+      width: 640,
+      height: 480
+    } as AnimationProps);
+    expect(webglAnimation.renderer).toBeInstanceOf(SplatRenderer);
+    webglAnimation.renderer.destroy();
+    webglDevice.destroy();
   });
 
   test('exposes the execution selector and graph diagnostics in the shared viewer panel', () => {
@@ -351,6 +398,521 @@ describe('published Gaussian splat viewer', () => {
     );
   });
 
+  test('opens RAD metadata without fetching pages and follows nonsequential camera demand', async () => {
+    const source = makeGaussianRADFixture();
+    const {configuration, requestedRanges} = installGaussianRADPageSourceFixture(
+      source,
+      '&residentSplats=1'
+    );
+    const progressUpdates: LocalGaussianSplatLoadProgress[] = [];
+
+    const pageSource = await openLocalGaussianSplatRADPageSource(configuration, {
+      onProgress: progress => progressUpdates.push(progress)
+    });
+
+    expect(requestedRanges).toHaveLength(1);
+    expect(pageSource.getMetadata()).toMatchObject({
+      count: 2,
+      chunkSize: 1,
+      maxSh: 0,
+      chunks: [
+        {chunkIndex: 0, base: 0, count: 1},
+        {chunkIndex: 1, base: 10, count: 1}
+      ]
+    });
+    expect(pageSource.getChunkForRow(0)).toBe(0);
+    expect(pageSource.getChunkForRow(10)).toBe(1);
+    expect(pageSource.getChunkForRow(1)).toBeUndefined();
+
+    pageSource.setPageDemand([{chunkIndex: 1, priority: 100}]);
+    expect(requestedRanges).toHaveLength(1);
+    const fartherPage = await pageSource.loadPage(1);
+    expect(fartherPage).toMatchObject({loaderData: {base: 10, chunkIndex: 1}});
+
+    pageSource.setPageDemand([{chunkIndex: 0, priority: 200}]);
+    const nearerPage = await pageSource.loadPage(0);
+    expect(nearerPage).toMatchObject({loaderData: {base: 0, chunkIndex: 0}});
+    expect(requestedRanges).toHaveLength(3);
+    expect(configuration).toMatchObject({expectedSplatCount: 2, expectedBatchCount: 2});
+    expect(progressUpdates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({phase: 'loaded', loadedSplatCount: 1}),
+        expect.objectContaining({phase: 'loaded', loadedSplatCount: 2})
+      ])
+    );
+
+    const reloadedPage = await pageSource.loadPage(1);
+    expect(reloadedPage).toMatchObject({loaderData: {base: 10, chunkIndex: 1}});
+    expect(requestedRanges).toHaveLength(4);
+
+    pageSource.destroy();
+  });
+
+  test('bounds concurrent RAD decodes, deduplicates demand, and prioritizes queued pages', async () => {
+    const source = makeGaussianRADFixture(1, {chunkCount: 3});
+    const {configuration, requestedRanges} = installGaussianRADPageSourceFixture(source);
+    const startedChunks: number[] = [];
+    const releaseDecoders = new Map<number, () => void>();
+    let activeDecoderCount = 0;
+    let maximumActiveDecoderCount = 0;
+    const pageSource = await openLocalGaussianSplatRADPageSource(configuration, {
+      maxConcurrentLoads: 1,
+      decodePage: async context => {
+        startedChunks.push(context.chunkIndex);
+        activeDecoderCount++;
+        maximumActiveDecoderCount = Math.max(maximumActiveDecoderCount, activeDecoderCount);
+        await new Promise<void>(resolve => releaseDecoders.set(context.chunkIndex, resolve));
+        try {
+          return await context.decodeDefault();
+        } finally {
+          activeDecoderCount--;
+        }
+      }
+    });
+
+    pageSource.setPageDemand([
+      {chunkIndex: 0, priority: 1},
+      {chunkIndex: 1, priority: 2},
+      {chunkIndex: 2, priority: 100}
+    ]);
+    const firstPage = pageSource.loadPage(0);
+    const lowPriorityPage = pageSource.loadPage(1);
+    const highPriorityPage = pageSource.loadPage(2);
+
+    expect(pageSource.loadPage(2)).toBe(highPriorityPage);
+    expect(startedChunks).toEqual([0]);
+    expect(requestedRanges).toHaveLength(1);
+
+    releaseDecoders.get(0)?.();
+    await firstPage;
+    await vi.waitFor(() => expect(startedChunks).toEqual([0, 2]));
+    releaseDecoders.get(2)?.();
+    await highPriorityPage;
+    await vi.waitFor(() => expect(startedChunks).toEqual([0, 2, 1]));
+    releaseDecoders.get(1)?.();
+    await lowPriorityPage;
+
+    expect(maximumActiveDecoderCount).toBe(1);
+    expect(requestedRanges).toHaveLength(4);
+    pageSource.destroy();
+  });
+
+  test('preserves RAD child arrays and resolves child starts as source-global rows', async () => {
+    const source = makeGaussianRADFixture(1, {includeLoDTree: true});
+    const {configuration} = installGaussianRADPageSourceFixture(source);
+    const pageSource = await openLocalGaussianSplatRADPageSource(configuration);
+
+    expect(pageSource.metadata.lodTree).toBe(true);
+    const parentPage = await pageSource.loadPage(0);
+    if (!('loaderData' in parentPage)) {
+      throw new Error('RAD hierarchy metadata was detached from its source-owned page.');
+    }
+    expect(parentPage.loaderData?.childCounts).toBeInstanceOf(Uint16Array);
+    expect(parentPage.loaderData?.childStarts).toBeInstanceOf(Uint32Array);
+    expect(Array.from(parentPage.loaderData?.childCounts as Uint16Array)).toEqual([1]);
+    expect(Array.from(parentPage.loaderData?.childStarts as Uint32Array)).toEqual([10]);
+    expect(pageSource.getChunkForRow(10)).toBe(1);
+
+    const childPage = await pageSource.loadPage(1);
+    expect(childPage).toMatchObject({loaderData: {base: 10, chunkIndex: 1}});
+    pageSource.destroy();
+  });
+
+  test('infers original page intervals from nominal chunk size when RAD ranges omit them', async () => {
+    const source = makeGaussianRADFixture(1, {
+      chunkBaseStride: 1,
+      omitChunkRowRanges: true
+    });
+    const {configuration} = installGaussianRADPageSourceFixture(source);
+    const pageSource = await openLocalGaussianSplatRADPageSource(configuration);
+
+    expect(pageSource.metadata.chunks).toMatchObject([
+      {chunkIndex: 0, base: 0, count: 1},
+      {chunkIndex: 1, base: 1, count: 1}
+    ]);
+    expect(pageSource.getChunkForRow(1)).toBe(1);
+    expect(await pageSource.loadPage(1)).toMatchObject({loaderData: {base: 1, chunkIndex: 1}});
+
+    pageSource.destroy();
+  });
+
+  test('cancels stale camera demand and queued requests without aborting current demand', async () => {
+    const source = makeGaussianRADFixture();
+    const {configuration, requestedRanges, pendingPageResponses, requestedPageSignals} =
+      installGaussianRADPageSourceFixture(source, '', {delayPages: true});
+    const pageSource = await openLocalGaussianSplatRADPageSource(configuration, {
+      maxConcurrentLoads: 1
+    });
+
+    pageSource.setPageDemand([
+      {chunkIndex: 0, priority: 1},
+      {chunkIndex: 1, priority: 2}
+    ]);
+    const stalePage = pageSource.loadPage(0);
+    const staleResult = stalePage.catch(error => error);
+    const currentPage = pageSource.loadPage(1);
+    await vi.waitFor(() => expect(pendingPageResponses).toHaveLength(1));
+
+    pageSource.setPageDemand([{chunkIndex: 1, priority: 100}]);
+    const staleError = await staleResult;
+    expect(staleError).toMatchObject({name: 'AbortError'});
+    expect(requestedPageSignals[0]?.aborted).toBe(true);
+    await vi.waitFor(() => expect(pendingPageResponses).toHaveLength(2));
+
+    pendingPageResponses[1]?.();
+    await expect(currentPage).resolves.toMatchObject({loaderData: {base: 10, chunkIndex: 1}});
+    expect(requestedPageSignals[1]?.aborted).toBe(false);
+
+    pageSource.setPageDemand([
+      {chunkIndex: 0, priority: 1},
+      {chunkIndex: 1, priority: 2}
+    ]);
+    const activePage = pageSource.loadPage(0).catch(error => error);
+    const queuedPage = pageSource.loadPage(1).catch(error => error);
+    await vi.waitFor(() => expect(pendingPageResponses).toHaveLength(3));
+    pageSource.destroy();
+
+    expect(await activePage).toMatchObject({name: 'AbortError'});
+    expect(await queuedPage).toMatchObject({name: 'AbortError'});
+    expect(requestedPageSignals[2]?.aborted).toBe(true);
+    expect(requestedRanges).toHaveLength(4);
+    expect(pageSource.cancelPage(1)).toBe(false);
+    await expect(pageSource.loadPage(0)).rejects.toMatchObject({name: 'AbortError'});
+  });
+
+  test('combines request-local and scene cancellation while allowing immediate retry', async () => {
+    const source = makeGaussianRADFixture();
+    const {configuration, pendingPageResponses, requestedPageSignals} =
+      installGaussianRADPageSourceFixture(source, '', {delayPages: true});
+    const sceneAbortController = new AbortController();
+    const pageSource = await openLocalGaussianSplatRADPageSource(configuration, {
+      signal: sceneAbortController.signal,
+      maxConcurrentLoads: 1
+    });
+
+    const requestAbortController = new AbortController();
+    const canceledPage = pageSource
+      .loadPage(0, {signal: requestAbortController.signal})
+      .catch(error => error);
+    await vi.waitFor(() => expect(pendingPageResponses).toHaveLength(1));
+    requestAbortController.abort();
+    expect(await canceledPage).toMatchObject({name: 'AbortError'});
+    expect(requestedPageSignals[0]?.aborted).toBe(true);
+    expect(sceneAbortController.signal.aborted).toBe(false);
+
+    const retriedPage = pageSource.loadPage(0);
+    await vi.waitFor(() => expect(pendingPageResponses).toHaveLength(2));
+    pendingPageResponses[1]?.();
+    await expect(retriedPage).resolves.toMatchObject({loaderData: {base: 0, chunkIndex: 0}});
+
+    const finalPage = pageSource.loadPage(1).catch(error => error);
+    await vi.waitFor(() => expect(pendingPageResponses).toHaveLength(3));
+    sceneAbortController.abort();
+    expect(await finalPage).toMatchObject({name: 'AbortError'});
+    expect(requestedPageSignals[2]?.aborted).toBe(true);
+
+    pageSource.destroy();
+    await expect(pageSource.loadPage(0)).rejects.toMatchObject({name: 'AbortError'});
+  });
+
+  test('allows failed RAD decoders to retry without retaining rejected page promises', async () => {
+    const source = makeGaussianRADFixture();
+    const {configuration, requestedRanges} = installGaussianRADPageSourceFixture(source);
+    let attemptCount = 0;
+    const pageSource = await openLocalGaussianSplatRADPageSource(configuration, {
+      decodePage: async context => {
+        attemptCount++;
+        if (attemptCount === 1) {
+          throw new Error('The injected RAD decoder failed.');
+        }
+        return await context.decodeDefault();
+      }
+    });
+
+    await expect(pageSource.loadPage(0)).rejects.toThrow('injected RAD decoder failed');
+    expect(requestedRanges).toHaveLength(1);
+    await expect(pageSource.loadPage(0)).resolves.toMatchObject({
+      loaderData: {base: 0, chunkIndex: 0}
+    });
+    expect(attemptCount).toBe(2);
+    expect(requestedRanges).toHaveLength(2);
+
+    pageSource.destroy();
+  });
+
+  test('rejects oversized RAD pages before fetching without blocking smaller demanded pages', async () => {
+    const source = makeGaussianRADFixture(2);
+    const {configuration, requestedRanges} = installGaussianRADPageSourceFixture(
+      source,
+      '&residentSplats=1'
+    );
+    const pageSource = await openLocalGaussianSplatRADPageSource(configuration);
+
+    await expect(pageSource.loadPage(0)).rejects.toThrow('exceeds residentSplats');
+    expect(requestedRanges).toHaveLength(1);
+    await expect(pageSource.loadPage(1)).resolves.toMatchObject({
+      loaderData: {base: 10, chunkIndex: 1}
+    });
+    expect(requestedRanges).toHaveLength(2);
+
+    pageSource.destroy();
+  });
+
+  test('refines mixed RAD source rows out of order while preserving fallback, budget, and ownership', async () => {
+    const source = makeGaussianRADFixture(3, {
+      chunkCount: 3,
+      chunkSize: 10,
+      includeLoDTree: true,
+      hierarchyRows: [
+        [
+          {childCount: 2, childStart: 1},
+          {childCount: 0, childStart: 0},
+          {childCount: 1, childStart: 20}
+        ],
+        [{childCount: 0, childStart: 0}],
+        [{childCount: 0, childStart: 0}]
+      ]
+    });
+    const {configuration, requestedRanges, pendingPageResponses} =
+      installGaussianRADPageSourceFixture(source, '&residentSplats=4', {delayPages: true});
+    const pageSource = await openLocalGaussianSplatRADPageSource(configuration);
+    const device = new NullDevice({});
+    const loadedPages: GPUSplatData[] = [];
+    const selectedFrontiers: number[][][] = [];
+    const scene = new GaussianSplatRADSceneController({
+      device,
+      source: pageSource,
+      maxResidentSplatCount: 4,
+      maximumScreenSpaceError: 1,
+      onPageLoad: page => loadedPages.push(page.data),
+      onFrontierChange: frontier =>
+        selectedFrontiers.push(
+          frontier.map(entry =>
+            Array.from(entry.activeRows, rowIndex => entry.data.rowIndexBase + rowIndex)
+          )
+        )
+    });
+
+    const evictablePage = makeGPUSplatData(device, {
+      positions: new Float32Array([100, 0, 0]),
+      scales: new Float32Array([1, 1, 1]),
+      rotations: new Float32Array([1, 0, 0, 0]),
+      colors: new Uint8Array([255, 255, 255, 255]),
+      opacities: new Float32Array([1]),
+      sourceBatchIndex: 9,
+      rowIndexBase: 100
+    });
+    const admittedEvictablePage = scene.hierarchy.residencyManager.add(evictablePage, {
+      id: 'unused-source-page',
+      priority: Number.NEGATIVE_INFINITY,
+      ownsData: true
+    });
+    expect(admittedEvictablePage).toBeDefined();
+    expect(scene.hierarchy.residencyManager.stats.residentSplatCount).toBe(1);
+
+    const sceneStart = scene.start(makeGaussianRADHierarchyView());
+    await vi.waitFor(() => expect(pendingPageResponses).toHaveLength(1));
+    pendingPageResponses[0]?.();
+    await sceneStart;
+    await vi.waitFor(() => expect(pendingPageResponses).toHaveLength(2));
+
+    expect(scene.hierarchy.frontier).toHaveLength(1);
+    expect(Array.from(scene.hierarchy.frontier[0].activeRows)).toEqual([1, 2]);
+    expect(Array.from(scene.hierarchy.frontier[0].activeMask)).toEqual([0, 1, 1]);
+    expect(scene.hierarchy.stats.fallbackRowCount).toBe(1);
+    expect(pageSource.getChunkForRow(20)).toBe(2);
+    expect(requestedRanges).toHaveLength(3);
+    expect(evictablePage.destroyed).toBe(true);
+    expect(scene.hierarchy.residencyManager.stats.residentSplatCount).toBe(3);
+
+    pendingPageResponses[1]?.();
+    await scene.waitForIdle();
+
+    expect(evictablePage.destroyed).toBe(true);
+    expect(loadedPages.map(page => page.sourceBatchIndex)).toEqual([0, 2]);
+    expect(loadedPages.map(page => page.rowIndexBase)).toEqual([0, 20]);
+    expect(scene.hierarchy.frontier.map(entry => entry.data)).toEqual(loadedPages);
+    expect(scene.hierarchy.frontier.map(entry => Array.from(entry.activeRows))).toEqual([[1], [0]]);
+    expect(selectedFrontiers).toContainEqual([[1, 2]]);
+    expect(selectedFrontiers).toContainEqual([[1], [20]]);
+    expect(scene.hierarchy.stats.fallbackRowCount).toBe(0);
+    expect(scene.hierarchy.residencyManager.stats.residentSplatCount).toBe(4);
+    expect(scene.hierarchy.residencyManager.stats.evictedChunkCount).toBe(1);
+    expect(requestedRanges).toHaveLength(3);
+
+    scene.destroy();
+    expect(loadedPages.every(page => page.destroyed)).toBe(true);
+    expect(scene.hierarchy.residencyManager.destroyed).toBe(true);
+    device.destroy();
+  });
+
+  test('cancels obsolete RAD hierarchy requests and restores demand after camera return', async () => {
+    const source = makeGaussianRADFixture(1, {
+      chunkSize: 10,
+      includeLoDTree: true
+    });
+    const {configuration, pendingPageResponses, requestedPageSignals} =
+      installGaussianRADPageSourceFixture(source, '&residentSplats=2', {delayPages: true});
+    const pageSource = await openLocalGaussianSplatRADPageSource(configuration);
+    const device = new NullDevice({});
+    const loadedPages: GPUSplatData[] = [];
+    const scene = new GaussianSplatRADSceneController({
+      device,
+      source: pageSource,
+      maxResidentSplatCount: 2,
+      maximumScreenSpaceError: 1,
+      onPageLoad: page => loadedPages.push(page.data)
+    });
+    const visibleView = makeGaussianRADHierarchyView();
+
+    const sceneStart = scene.start(visibleView);
+    await vi.waitFor(() => expect(pendingPageResponses).toHaveLength(1));
+    pendingPageResponses[0]?.();
+    await sceneStart;
+    await vi.waitFor(() => expect(pendingPageResponses).toHaveLength(2));
+    expect(scene.hierarchy.stats.fallbackRowCount).toBe(1);
+
+    scene.update({
+      ...visibleView,
+      modelViewProjectionMatrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -100, 0, 0, 1]
+    });
+    await scene.waitForIdle();
+    expect(requestedPageSignals[1]?.aborted).toBe(true);
+    expect(scene.hierarchy.frontier).toHaveLength(0);
+
+    scene.update(visibleView);
+    await vi.waitFor(() => expect(pendingPageResponses).toHaveLength(3));
+    pendingPageResponses[2]?.();
+    await scene.waitForIdle();
+
+    expect(scene.hierarchy.frontier.map(entry => entry.data.rowIndexBase)).toEqual([10]);
+    expect(scene.hierarchy.residencyManager.stats.residentSplatCount).toBe(2);
+    expect(loadedPages.map(page => page.sourceBatchIndex)).toEqual([0, 1]);
+
+    scene.destroy();
+    expect(loadedPages.every(page => page.destroyed)).toBe(true);
+    device.destroy();
+  });
+
+  test('restarts canceled RAD page demand when the camera returns before request cleanup', async () => {
+    const source = makeGaussianRADFixture(1, {
+      chunkSize: 10,
+      includeLoDTree: true
+    });
+    const {configuration, pendingPageResponses, requestedPageSignals} =
+      installGaussianRADPageSourceFixture(source, '&residentSplats=2', {delayPages: true});
+    const pageSource = await openLocalGaussianSplatRADPageSource(configuration);
+    const device = new NullDevice({});
+    const scene = new GaussianSplatRADSceneController({
+      device,
+      source: pageSource,
+      maxResidentSplatCount: 2,
+      maximumScreenSpaceError: 1
+    });
+    const visibleView = makeGaussianRADHierarchyView();
+
+    const sceneStart = scene.start(visibleView);
+    await vi.waitFor(() => expect(pendingPageResponses).toHaveLength(1));
+    pendingPageResponses[0]?.();
+    await sceneStart;
+    await vi.waitFor(() => expect(pendingPageResponses).toHaveLength(2));
+
+    scene.update({
+      ...visibleView,
+      modelViewProjectionMatrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -100, 0, 0, 1]
+    });
+    scene.update(visibleView);
+    expect(requestedPageSignals[1]?.aborted).toBe(true);
+    expect(scene.hierarchy.stats.fallbackRowCount).toBe(1);
+
+    await vi.waitFor(() => expect(pendingPageResponses).toHaveLength(3));
+    pendingPageResponses[2]?.();
+    await scene.waitForIdle();
+
+    expect(scene.hierarchy.frontier.map(entry => entry.data.rowIndexBase)).toEqual([10]);
+    expect(scene.hierarchy.stats.fallbackRowCount).toBe(0);
+    expect(scene.hierarchy.residencyManager.stats.residentSplatCount).toBe(2);
+
+    scene.destroy();
+    device.destroy();
+  });
+
+  test('rejects protected RAD child pages before starting their source range request', async () => {
+    const source = makeGaussianRADFixture(1, {
+      chunkSize: 10,
+      includeLoDTree: true
+    });
+    const {configuration, requestedRanges} = installGaussianRADPageSourceFixture(
+      source,
+      '&residentSplats=1'
+    );
+    const pageSource = await openLocalGaussianSplatRADPageSource(configuration);
+    const device = new NullDevice({});
+    const errors: unknown[] = [];
+    const scene = new GaussianSplatRADSceneController({
+      device,
+      source: pageSource,
+      maxResidentSplatCount: 1,
+      maximumScreenSpaceError: 1,
+      onError: error => errors.push(error)
+    });
+
+    await scene.start(makeGaussianRADHierarchyView());
+    await scene.waitForIdle();
+
+    expect(requestedRanges).toHaveLength(2);
+    expect(scene.hierarchy.frontier.map(entry => entry.data.rowIndexBase)).toEqual([0]);
+    expect(scene.hierarchy.stats.fallbackRowCount).toBe(1);
+    expect(scene.hierarchy.residencyManager.stats.rejectedChunkCount).toBe(1);
+    expect(scene.hierarchy.residencyManager.stats.residentSplatCount).toBe(1);
+    expect(errors).toEqual([]);
+
+    scene.destroy();
+    device.destroy();
+  });
+
+  test('falls back to complete source pages when a RAD scene has no authored LoD hierarchy', async () => {
+    const source = makeGaussianRADFixture();
+    const {configuration, requestedRanges} = installGaussianRADPageSourceFixture(
+      source,
+      '&residentSplats=1'
+    );
+    vi.stubGlobal('window', {
+      location: {
+        search: '?source=https%3A%2F%2Fexample.test%2Fscene.rad&residentSplats=1',
+        href: 'file:///gaussian-splat-viewer.html',
+        origin: 'null'
+      },
+      __lumaGaussianSplatsLoaderBundleUrl: configuration.loaderBundleUrl
+    });
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback): number => {
+      queueMicrotask(() => callback(0));
+      return 1;
+    });
+    const device = makeViewerWebGPUDevice();
+    const animation = new GaussianSplatsAnimationLoopTemplate({
+      device,
+      width: 640,
+      height: 480
+    } as AnimationProps);
+
+    expect(animation.renderer).toBeInstanceOf(GPUPagedSplatRenderer);
+    await animation['loadLocalSplatData'](configuration);
+
+    expect(requestedRanges).toHaveLength(3);
+    expect(animation.batches).toHaveLength(1);
+    expect(animation.batches[0].rowIndexBase).toBe(0);
+    expect(animation.renderer).toBeInstanceOf(GPUPagedSplatRenderer);
+    if (animation.renderer instanceof GPUPagedSplatRenderer) {
+      expect(animation.renderer.pages).toHaveLength(1);
+      expect(animation.renderer.pages[0].data).toBe(animation.batches[0]);
+    }
+
+    animation.onFinalize();
+    expect(animation.batches[0].destroyed).toBe(true);
+    device.destroy();
+  });
+
   test('stops RAD page requests at the caller-selected resident source-row budget', async () => {
     installViewerWindow('?source=https%3A%2F%2Fexample.test%2Fscene.rad&residentSplats=1');
     const configuration = getLocalGaussianSplatLoadersConfiguration();
@@ -470,6 +1032,13 @@ function makeViewerWebGPUDevice(): NullDevice {
   return device;
 }
 
+function makeGaussianRADHierarchyView(): SplatHierarchyView {
+  return {
+    cameraPosition: [0, 0, 12],
+    viewportSize: [800, 600]
+  };
+}
+
 function installViewerWindow(
   search = '',
   overrides: {
@@ -486,6 +1055,71 @@ function installViewerWindow(
     __lumaGaussianSplatsLoaderBundleUrl: DEPLOYED_LOADER_BUNDLE_URL,
     ...overrides
   });
+}
+
+function installGaussianRADPageSourceFixture(
+  source: ArrayBuffer,
+  search = '',
+  options: {delayPages?: boolean} = {}
+): {
+  configuration: LocalGaussianSplatLoadersConfiguration;
+  requestedRanges: string[];
+  pendingPageResponses: Array<() => void>;
+  requestedPageSignals: Array<AbortSignal | undefined>;
+} {
+  installViewerWindow(`?source=https%3A%2F%2Fexample.test%2Fscene.rad${search}`);
+  const configuration = getLocalGaussianSplatLoadersConfiguration();
+  if (!configuration) {
+    throw new Error('The isolated RAD loader configuration was not created.');
+  }
+  configuration.loaderBundleUrl = pathToFileURL(
+    path.join(process.cwd(), 'website/static/standalone-examples/gaussian-splats/loaders-gl.mjs')
+  ).href;
+  vi.stubGlobal('window', {
+    location: {href: 'file:///gaussian-splat-viewer.html', origin: 'null'}
+  });
+
+  const requestedRanges: string[] = [];
+  const pendingPageResponses: Array<() => void> = [];
+  const requestedPageSignals: Array<AbortSignal | undefined> = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_input: string | URL | Request, requestOptions?: RequestInit) => {
+      const range = new Headers(requestOptions?.headers).get('Range');
+      if (range) {
+        requestedRanges.push(range);
+      }
+      const match = range?.match(/^bytes=(\d+)-(\d+)$/);
+      const start = Number(match?.[1] ?? 0);
+      const end = Math.min(Number(match?.[2] ?? source.byteLength - 1) + 1, source.byteLength);
+      const makeResponse = (): Response =>
+        new Response(source.slice(start, end), {
+          status: range ? 206 : 200,
+          headers: {'content-length': String(end - start)}
+        });
+
+      if (!options.delayPages || requestedRanges.length === 1) {
+        return makeResponse();
+      }
+
+      const signal = requestOptions?.signal ?? undefined;
+      requestedPageSignals.push(signal);
+      return await new Promise<Response>((resolve, reject) => {
+        if (signal?.aborted) {
+          reject(signal.reason);
+          return;
+        }
+        const handleAbort = (): void => reject(signal?.reason);
+        signal?.addEventListener('abort', handleAbort, {once: true});
+        pendingPageResponses.push(() => {
+          signal?.removeEventListener('abort', handleAbort);
+          resolve(makeResponse());
+        });
+      });
+    })
+  );
+
+  return {configuration, requestedRanges, pendingPageResponses, requestedPageSignals};
 }
 
 function makeGaussianSplatPLYFixture(): string {
@@ -513,23 +1147,51 @@ function makeGaussianSplatPLYFixture(): string {
   ].join('\n');
 }
 
-function makeGaussianRADFixture(firstChunkRowCount = 1): ArrayBuffer {
-  const chunks = [
-    makeGaussianRADChunkFixture(0, 1, firstChunkRowCount),
-    makeGaussianRADChunkFixture(10, 2)
-  ];
+function makeGaussianRADFixture(
+  firstChunkRowCount = 1,
+  options: {
+    chunkCount?: number;
+    chunkBaseStride?: number;
+    chunkSize?: number;
+    hierarchyRows?: readonly (readonly {childCount: number; childStart: number}[])[];
+    includeLoDTree?: boolean;
+    omitChunkRowRanges?: boolean;
+  } = {}
+): ArrayBuffer {
+  const chunkCount = options.chunkCount ?? 2;
+  const chunkBaseStride = options.chunkBaseStride ?? 10;
+  const chunks = Array.from({length: chunkCount}, (_, chunkIndex) =>
+    makeGaussianRADChunkFixture(
+      chunkIndex * chunkBaseStride,
+      chunkIndex + 1,
+      chunkIndex === 0 ? firstChunkRowCount : 1,
+      options.includeLoDTree
+        ? {
+            childCount: chunkIndex + 1 < chunkCount ? 1 : 0,
+            childStart: chunkIndex + 1 < chunkCount ? (chunkIndex + 1) * chunkBaseStride : 0,
+            ...(options.hierarchyRows?.[chunkIndex]
+              ? {rows: options.hierarchyRows[chunkIndex]}
+              : {})
+          }
+        : undefined
+    )
+  );
   const metadata = {
     version: 1,
     type: 'gsplat',
-    count: firstChunkRowCount + 1,
+    count: firstChunkRowCount + chunkCount - 1,
     maxSh: 0,
-    chunkSize: 1,
+    chunkSize: options.chunkSize ?? 1,
+    ...(options.includeLoDTree ? {lodTree: true} : {}),
     allChunkBytes: chunks.reduce((byteLength, chunk) => byteLength + chunk.byteLength, 0),
     chunks: chunks.map((chunk, index) => ({
-      offset: index === 0 ? 0 : chunks[0].byteLength,
+      offset: chunks
+        .slice(0, index)
+        .reduce((byteLength, previous) => byteLength + previous.byteLength, 0),
       bytes: chunk.byteLength,
-      base: index * 10,
-      count: index === 0 ? firstChunkRowCount : 1
+      ...(options.omitChunkRowRanges
+        ? {}
+        : {base: index * chunkBaseStride, count: index === 0 ? firstChunkRowCount : 1})
     }))
   };
   const metadataBytes = new TextEncoder().encode(JSON.stringify(metadata));
@@ -548,12 +1210,36 @@ function makeGaussianRADFixture(firstChunkRowCount = 1): ArrayBuffer {
   return data;
 }
 
-function makeGaussianRADChunkFixture(base: number, coordinate: number, rowCount = 1): ArrayBuffer {
+function makeGaussianRADChunkFixture(
+  base: number,
+  coordinate: number,
+  rowCount = 1,
+  hierarchy?: {
+    childCount: number;
+    childStart: number;
+    rows?: readonly {childCount: number; childStart: number}[];
+  }
+): ArrayBuffer {
   const position = Float32Array.from(
     {length: rowCount * 3},
     (_, componentIndex) => coordinate + componentIndex
   );
-  const payloadByteLength = alignGaussianRADBytes(position.byteLength);
+  const childCounts = new Uint16Array(rowCount);
+  const childStarts = new Uint32Array(rowCount);
+  if (hierarchy) {
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      const rowHierarchy = hierarchy.rows?.[rowIndex];
+      childCounts[rowIndex] =
+        rowHierarchy?.childCount ?? (rowIndex === 0 ? hierarchy.childCount : 0);
+      childStarts[rowIndex] =
+        rowHierarchy?.childStart ?? (rowIndex === 0 ? hierarchy.childStart : 0);
+    }
+  }
+  const childCountByteOffset = alignGaussianRADBytes(position.byteLength);
+  const childStartByteOffset = childCountByteOffset + alignGaussianRADBytes(childCounts.byteLength);
+  const payloadByteLength = hierarchy
+    ? childStartByteOffset + alignGaussianRADBytes(childStarts.byteLength)
+    : alignGaussianRADBytes(position.byteLength);
   const metadataBytes = new TextEncoder().encode(
     JSON.stringify({
       version: 1,
@@ -561,8 +1247,26 @@ function makeGaussianRADChunkFixture(base: number, coordinate: number, rowCount 
       count: rowCount,
       payloadBytes: payloadByteLength,
       maxSh: 0,
-      lodTree: false,
-      properties: [{offset: 0, bytes: position.byteLength, property: 'center', encoding: 'f32'}]
+      lodTree: Boolean(hierarchy),
+      properties: [
+        {offset: 0, bytes: position.byteLength, property: 'center', encoding: 'f32'},
+        ...(hierarchy
+          ? [
+              {
+                offset: childCountByteOffset,
+                bytes: childCounts.byteLength,
+                property: 'child_count',
+                encoding: 'u16'
+              },
+              {
+                offset: childStartByteOffset,
+                bytes: childStarts.byteLength,
+                property: 'child_start',
+                encoding: 'u32'
+              }
+            ]
+          : [])
+      ]
     })
   );
   const payloadByteLengthOffset = 8 + alignGaussianRADBytes(metadataBytes.byteLength);
@@ -575,6 +1279,10 @@ function makeGaussianRADChunkFixture(base: number, coordinate: number, rowCount 
   bytes.set(metadataBytes, 8);
   view.setBigUint64(payloadByteLengthOffset, BigInt(payloadByteLength), true);
   bytes.set(new Uint8Array(position.buffer), payloadByteOffset);
+  if (hierarchy) {
+    bytes.set(new Uint8Array(childCounts.buffer), payloadByteOffset + childCountByteOffset);
+    bytes.set(new Uint8Array(childStarts.buffer), payloadByteOffset + childStartByteOffset);
+  }
   return data;
 }
 

--- a/website/content/examples/showcase/gaussian-splat-viewer.mdx
+++ b/website/content/examples/showcase/gaussian-splat-viewer.mdx
@@ -31,15 +31,21 @@ On WebGPU, every streamed batch renders through a compiled **GPU command graph**
 arrives. Projection, visibility, depth ordering, and rendering remain GPU work from the first
 visible splats rather than reprojecting source rows on the main thread while the scene loads.
 Directional spherical harmonics remain GPU-native and update as the camera moves.
+Large RAD captures use bounded projected segments and one shared global GPU depth order, keeping
+overlapping source pages correctly blended beyond a single storage-buffer limit.
 Expand **GPU graph inspector** to see the real graph nodes, encoding timings, and transient-memory
 reuse. Choose **CPU depth ordering** in the execution selector, or append `?renderer=cpu`, to
 compare against the original renderer. WebGL2 always retains its compatible CPU-ordered fallback.
 
 Append `?scene=truck`, `?scene=drjohnson`, `?scene=playroom`, or `?scene=train-github` to select a
 capture directly. `?scene=coit` selects the **50,937,127-splat Coit Tower RAD source** and retains
-a bounded one-million-splat page window; use `&residentSplats=250000` to choose a different
-whole-page residency limit. Provide `?source=https://example.com/scene.ply` for another compatible public
-file. Choose **Synthetic chromatic showcase** in the scene selector or visit the separate
+a camera-driven, one-million-splat source-page window. The viewer starts at Spark's authored root
+row, keeps coarse parents visible until their children arrive, and range-fetches, cancels, or
+evicts independent pages as the camera changes; use `&residentSplats=250000` to choose a different
+whole-page residency limit. Published loaders.gl currently decodes RAD pages on the main thread;
+applications can supply their own worker-backed decoder bridge. Provide
+`?source=https://example.com/scene.ply` for another compatible public file.
+Choose **Synthetic chromatic showcase** in the scene selector or visit the separate
 [Gaussian Splats showcase](/examples/showcase/gaussian-splats) for the deterministic generated
 scene.
 


### PR DESCRIPTION
## Goals

- Make Spark RAD captures navigable out of core instead of loading a static prefix of source pages.
- Preserve globally correct Gaussian transparency beyond a single WebGPU storage-buffer binding.
- Keep loaders, Apache Arrow conversion, original page ownership, and GPU rendering in their existing package boundaries.

## Changes

- Add `SplatRADHierarchyManager` for authored per-row RAD child links, camera-dependent screen-space refinement, frustum/foveated prioritization, mixed leaf/parent pages, atomic parent fallback, cancellation, and bounded independent source-page residency.
- Add `GPUPagedSplatRenderer` with sparse original-row projection, aligned device-sized source bindings, degree-1–3 spherical harmonics, GPU semantic filtering, one cross-page radix ordering, segmented globally ordered projected outputs, and GPU-written indirect draws.
- Add a demand-driven RAD page source with metadata-only initialization, original source-global row/chunk identities, prioritized bounded requests, abort/retry handling, an injectable asynchronous decoder bridge, and pre-fetch/pre-upload residency reservations.
- Switch WebGPU Coit Tower scenes to the new camera-driven row frontier and segmented renderer while preserving the original progressive graph for other scenes and CPU/WebGL or non-hierarchical RAD fallbacks.
- Document actual ownership rules, storage limits, camera-driven residency, decoder boundaries, and remaining feature gaps.

## Verification

- `yarn lint fix` — passed; 1,834 files checked.
- `yarn build` — passed across every workspace package.
- `yarn test-node` — passed: 2,007 tests.
- `yarn test` — passed: 2,007 Node tests and 1,953 Chromium browser/WebGPU/WebGL tests.
- `yarn examples:typecheck` — passed across all 47 example workspaces.
- `yarn website:build` — passed, including generated API documentation, the production website, and 483 raw documentation pages.
- Hardware WebGPU regressions verify interleaved cross-page transparency, exact global depth ordering, multiple indirect output segments, forced 12-KiB binding limits, 256-byte-aligned source windows, sparse semantic filtering, floating-point HDR colors, and degree-three harmonic columns.
- End-to-end RAD regressions verify nonsequential range requests, mixed parent/leaf source pages, atomic refinement, cancellation and immediate camera-return retries, pre-fetch rejection at a protected residency limit, eviction, stable global identities, CPU/WebGL fallbacks, and source destruction.
- `nvm use` and `yarn install` were not rerun; the existing Node 22.22.1 installation and installed workspace dependencies were used. `(cd website && yarn build)` was not run separately because the root `yarn website:build` executed that workspace build.

## Limits and follow-up

- The 50,937,127-row Coit source is traversed through a bounded one-million-source-row default residency window; this does not claim all authored rows fit in memory or that Spark visual/performance parity has been benchmarked.
- A 128-MiB binding limit supports roughly 2.8 million rows in the existing contiguous renderer and up to 33,554,432 simultaneously active four-byte global-sort references in the segmented renderer.
- Published loaders.gl currently decodes RAD pages on the main thread; applications may provide a real worker-backed decoder through the explicit bridge.
- The segmented renderer does not yet expose a dedicated GPU picker or mixed-mesh helper. Its gather currently schedules source-segment × output-segment passes, and frontier topology/cardinality changes rebuild its graph; optimizing both is follow-up work.