### PR TITLE
feat(experimental): scale dataframe dispatch across workgroup dimensions

### DIFF
--- a/docs/api-reference/experimental/ludf.md
+++ b/docs/api-reference/experimental/ludf.md
@@ -296,6 +296,25 @@ Sorting and top-K are performed independently within every original source batch
 implicit global cross-batch materialization or global top-K. Compiled results expose the original
 table, sorted `rowIndices`, updated `selectionMask`, and one selected count per preserved batch.
 
+### Scaling beyond one-dimensional workgroup limits
+
+WebGPU limits the number of workgroups in each individual dispatch dimension, but that does not
+limit a dataframe batch to one dimension. luDF maps linear source rows and dense result rows across
+bounded three-dimensional workgroup layouts while preserving their original row order and batch
+boundaries. Filtering, derived expressions, visibility compaction, grouped statistics, scalar
+reductions, histograms, stable sorting, and join preparation all use the same overflow-safe linear
+indexing scheme.
+
+For example, an adapter limited to two workgroups per dimension can still process 1,025 rows with
+256-thread workgroups by dispatching a `2 × 2 × 2` grid. The shader converts each workgroup's
+three-dimensional coordinate back into its original linear row index and ignores padded lanes.
+Dense histogram bins and categorical group outputs are initialized and finalized the same way.
+
+Actual dataset capacity remains constrained by unsigned 32-bit row indices, the full
+three-dimensional workgroup capacity, and adapter storage-buffer size limits. Dispatch scaling
+does not concatenate batches, make per-batch sorting global, or transfer GPU-resident rows back to
+the CPU.
+
 ## Join or look up unique right-side keys
 
 luDF supports bounded, unique-right-key `uint32` inner joins and source-aligned left lookups. Left

--- a/modules/experimental/src/gpu-primitives/gpu-group-aggregation.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-group-aggregation.ts
@@ -11,6 +11,11 @@ import {
   type GraphDataView
 } from './gpu-command-graph';
 import {
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource,
+  type GPUBoundedDispatchLayout
+} from './gpu-dispatch-utils';
+import {
   createTransientView,
   getViewBinding,
   getViewElementOffset,
@@ -22,7 +27,7 @@ import {
 const GROUP_AGGREGATION_WORKGROUP_SIZE = 256;
 const MAXIMUM_LOCAL_GROUP_COUNT = 256;
 
-type GPUGroupAggregationDispatchLayout = {x: number; y: number; z: number};
+type GPUGroupAggregationDispatchLayout = GPUBoundedDispatchLayout;
 
 /** One packed group-key chunk or an ordered vector of packed group-key chunks. */
 export type GPUGroupAggregationKeys = GraphDataView<'uint32'> | GraphVectorView<'uint32'>;
@@ -250,15 +255,23 @@ function addClearGroupsPass<Parameters>(
   id: string,
   output: GraphDataView<'uint32'>
 ): void {
+  const dispatchLayout = getGPUGroupAggregationDispatchLayout(
+    output.length,
+    graph.device.limits.maxComputeWorkgroupsPerDimension
+  );
   const source = /* wgsl */ `
 const GROUP_COUNT: u32 = ${output.length}u;
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(output)}u;
 @group(0) @binding(0) var<storage, read_write> outputCounts: array<atomic<u32>>;
 
 @compute @workgroup_size(${GROUP_AGGREGATION_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  if (globalId.x < GROUP_COUNT) {
-    atomicStore(&outputCounts[OUTPUT_OFFSET + globalId.x], 0u);
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getBoundedInvocationIndexSource(dispatchLayout, GROUP_AGGREGATION_WORKGROUP_SIZE)}
+  if (index < GROUP_COUNT) {
+    atomicStore(&outputCounts[OUTPUT_OFFSET + index], 0u);
   }
 }`;
   addComputationPass(graph, {
@@ -266,7 +279,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
     source,
     resources: [{buffer: output, usage: 'storage-write'}],
     bindings: {outputCounts: output},
-    dispatchCount: Math.ceil(output.length / GROUP_AGGREGATION_WORKGROUP_SIZE)
+    dispatchSize: dispatchLayout
   });
 }
 
@@ -348,6 +361,10 @@ function addInitializeGroupStatisticsPass<Parameters>(
   operation: Exclude<GPUGroupAggregationOperation, 'count'>,
   counts?: GraphDataView<'uint32'>
 ): void {
+  const dispatchLayout = getGPUGroupAggregationDispatchLayout(
+    output.length,
+    graph.device.limits.maxComputeWorkgroupsPerDimension
+  );
   const initialBits = operation === 'min' ? '0xffffffffu' : '0u';
   const countBinding = counts
     ? '@group(0) @binding(1) var<storage, read_write> outputCounts: array<atomic<u32>>;'
@@ -361,9 +378,10 @@ const OUTPUT_OFFSET: u32 = ${getViewElementOffset(output)}u;
 @group(0) @binding(0) var<storage, read_write> outputValues: array<atomic<u32>>;
 ${countBinding}
 @compute @workgroup_size(${GROUP_AGGREGATION_WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) globalId: vec3<u32>
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
 ) {
-  let index = globalId.x;
+  ${getBoundedInvocationIndexSource(dispatchLayout, GROUP_AGGREGATION_WORKGROUP_SIZE)}
   if (index < GROUP_COUNT) {
     atomicStore(&outputValues[OUTPUT_OFFSET + index], ${initialBits});
     ${countInitialization}
@@ -377,7 +395,7 @@ ${countBinding}
       ...(counts ? ([{buffer: counts, usage: 'storage-write'}] as GraphBufferUse[]) : [])
     ],
     bindings: {outputValues: output, ...(counts ? {outputCounts: counts} : {})},
-    dispatchCount: Math.ceil(output.length / GROUP_AGGREGATION_WORKGROUP_SIZE)
+    dispatchSize: dispatchLayout
   });
 }
 
@@ -467,6 +485,10 @@ function addFinalizeGroupStatisticsPass<Parameters>(
   operation: 'min' | 'max' | 'mean',
   counts?: GraphDataView<'uint32'>
 ): void {
+  const dispatchLayout = getGPUGroupAggregationDispatchLayout(
+    output.length,
+    graph.device.limits.maxComputeWorkgroupsPerDimension
+  );
   const countBinding = counts
     ? '@group(0) @binding(1) var<storage, read> outputCounts: array<u32>;'
     : '';
@@ -499,9 +521,10 @@ const OUTPUT_OFFSET: u32 = ${getViewElementOffset(output)}u;
 ${countBinding}
 ${decodeFunction}
 @compute @workgroup_size(${GROUP_AGGREGATION_WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) globalId: vec3<u32>
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
 ) {
-  let index = globalId.x;
+  ${getBoundedInvocationIndexSource(dispatchLayout, GROUP_AGGREGATION_WORKGROUP_SIZE)}
   if (index < GROUP_COUNT) {
     ${finalizeStatement}
   }
@@ -514,7 +537,7 @@ ${decodeFunction}
       ...(counts ? ([{buffer: counts, usage: 'storage-read'}] as GraphBufferUse[]) : [])
     ],
     bindings: {outputValues: output, ...(counts ? {outputCounts: counts} : {})},
-    dispatchCount: Math.ceil(output.length / GROUP_AGGREGATION_WORKGROUP_SIZE)
+    dispatchSize: dispatchLayout
   });
 }
 
@@ -556,17 +579,12 @@ export function getGPUGroupAggregationDispatchLayout(
   elementCount: number,
   maxComputeWorkgroupsPerDimension: number
 ): GPUGroupAggregationDispatchLayout {
-  const maximum = Math.floor(maxComputeWorkgroupsPerDimension);
-  const workgroupCount = Math.max(1, Math.ceil(elementCount / GROUP_AGGREGATION_WORKGROUP_SIZE));
-  const x = Math.min(workgroupCount, maximum);
-  const y = Math.min(Math.ceil(workgroupCount / x), maximum);
-  const z = Math.ceil(workgroupCount / x / y);
-  if (z > maximum) {
-    throw new Error(
-      `GPUGroupAggregation requires ${workgroupCount} workgroups, exceeding the 3D dispatch limit of ${maximum} per dimension`
-    );
-  }
-  return {x, y, z};
+  return getBoundedDispatchLayout(
+    'GPUGroupAggregation',
+    elementCount,
+    GROUP_AGGREGATION_WORKGROUP_SIZE,
+    maxComputeWorkgroupsPerDimension
+  );
 }
 
 /** Wraps generated WGSL in one graph compute node with deferred physical buffer resolution. */

--- a/modules/experimental/src/gpu-primitives/gpu-histogram.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-histogram.ts
@@ -11,6 +11,11 @@ import {
   type GraphDataView
 } from './gpu-command-graph';
 import {
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource,
+  type GPUBoundedDispatchLayout
+} from './gpu-dispatch-utils';
+import {
   createTransientView,
   getViewBinding,
   getViewElementOffset,
@@ -265,21 +270,24 @@ function addClearHistogramPass<Parameters>(
   output: GraphDataView<'uint32'>
 ): void {
   const passId = `${id}-clear`;
+  const dispatchLayout = getHistogramDispatchLayout(graph, output.length);
   const source = /* wgsl */ `
 const BIN_COUNT: u32 = ${output.length}u;
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(output)}u;
 @group(0) @binding(0) var<storage, read_write> outputCounts: array<atomic<u32>>;
 @compute @workgroup_size(${HISTOGRAM_WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) globalId: vec3<u32>
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
 ) {
-  if (globalId.x < BIN_COUNT) { atomicStore(&outputCounts[OUTPUT_OFFSET + globalId.x], 0u); }
+  ${getBoundedInvocationIndexSource(dispatchLayout, HISTOGRAM_WORKGROUP_SIZE)}
+  if (index < BIN_COUNT) { atomicStore(&outputCounts[OUTPUT_OFFSET + index], 0u); }
 }`;
   addComputationPass(graph, {
     id: passId,
     source,
     resources: [{buffer: output, usage: 'storage-write'}],
     bindings: {outputCounts: output},
-    dispatchCount: Math.ceil(output.length / HISTOGRAM_WORKGROUP_SIZE)
+    dispatchLayout
   });
 }
 
@@ -342,6 +350,7 @@ function addIrregularHistogramPass<Parameters, T extends GPUScalarFormat>(
     edgeValidity?: GraphDataView<'uint32'>;
   }
 ): void {
+  const dispatchLayout = getHistogramDispatchLayout(graph, props.input.length);
   const local = props.output.length <= MAXIMUM_LOCAL_BIN_COUNT;
   const shaderType = getShaderType(props.input.format);
   const gpuEdges = isGPUHistogramEdgesView(props.edges);
@@ -393,11 +402,11 @@ ${local ? `var<workgroup> localCounts: array<atomic<u32>, ${props.output.length}
 ${edgeAccessor}
 
 @compute @workgroup_size(${HISTOGRAM_WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) globalId: vec3<u32>,
-  @builtin(local_invocation_id) localId: vec3<u32>
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
 ) {
-  let index = globalId.x;
-  let lane = localId.x;
+  ${getBoundedInvocationIndexSource(dispatchLayout, HISTOGRAM_WORKGROUP_SIZE)}
+  let lane = localInvocationIndex;
   ${local ? 'if (lane < BIN_COUNT) { atomicStore(&localCounts[lane], 0u); }\n  workgroupBarrier();' : ''}
   var accepted = false;
   var binIndex = 0u;
@@ -447,7 +456,7 @@ ${edgeAccessor}
       ...(props.mask ? {selectionMask: props.mask} : {}),
       outputCounts: props.output
     },
-    dispatchCount: Math.ceil(props.input.length / HISTOGRAM_WORKGROUP_SIZE)
+    dispatchLayout
   });
 }
 
@@ -462,6 +471,7 @@ function addHistogramPass<Parameters, T extends GPUScalarFormat>(
     domain: readonly [number, number] | GraphDataView<T>;
   }
 ): void {
+  const dispatchLayout = getHistogramDispatchLayout(graph, props.input.length);
   const local = props.output.length <= MAXIMUM_LOCAL_BIN_COUNT;
   const shaderType = getShaderType(props.input.format);
   const gpuDomain = isGPUHistogramDomainView(props.domain);
@@ -549,11 +559,11 @@ ${local ? `var<workgroup> localCounts: array<atomic<u32>, ${props.output.length}
 ${integerBinningFunction}
 
 @compute @workgroup_size(${HISTOGRAM_WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) globalId: vec3<u32>,
-  @builtin(local_invocation_id) localId: vec3<u32>
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
 ) {
-  let index = globalId.x;
-  let lane = localId.x;
+  ${getBoundedInvocationIndexSource(dispatchLayout, HISTOGRAM_WORKGROUP_SIZE)}
+  let lane = localInvocationIndex;
   ${domainInitialization}
   ${local ? 'if (lane < BIN_COUNT) { atomicStore(&localCounts[lane], 0u); }\n  workgroupBarrier();' : ''}
   var accepted = false;
@@ -595,7 +605,7 @@ ${integerBinningFunction}
       ...(props.mask ? {selectionMask: props.mask} : {}),
       outputCounts: props.output
     },
-    dispatchCount: Math.ceil(props.input.length / HISTOGRAM_WORKGROUP_SIZE)
+    dispatchLayout
   });
 }
 
@@ -607,7 +617,8 @@ function addComputationPass<Parameters>(
     source: string;
     resources: GraphBufferUse[];
     bindings: Record<string, GraphDataView>;
-    dispatchCount: number;
+    dispatchCount?: number;
+    dispatchLayout?: GPUBoundedDispatchLayout;
   }
 ): void {
   graph.addComputePass({
@@ -633,12 +644,34 @@ function addComputationPass<Parameters>(
             bindings[name] = getViewBinding(view, getBuffer);
           }
           computation.setBindings(bindings);
-          computation.dispatch(computePass, props.dispatchCount);
+          if (props.dispatchLayout) {
+            computation.dispatch(
+              computePass,
+              props.dispatchLayout.x,
+              props.dispatchLayout.y,
+              props.dispatchLayout.z
+            );
+          } else {
+            computation.dispatch(computePass, props.dispatchCount ?? 1);
+          }
         },
         destroy: () => computation.destroy()
       };
     }
   });
+}
+
+/** Plans histogram accumulation and output clearing across bounded workgroup dimensions. */
+function getHistogramDispatchLayout<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  elementCount: number
+): GPUBoundedDispatchLayout {
+  return getBoundedDispatchLayout(
+    'GPUHistogram',
+    elementCount,
+    HISTOGRAM_WORKGROUP_SIZE,
+    graph.device.limits.maxComputeWorkgroupsPerDimension
+  );
 }
 
 /** Validates literal or GPU-resident irregular histogram boundaries. */

--- a/modules/experimental/src/gpu-primitives/gpu-reduction.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-reduction.ts
@@ -11,6 +11,11 @@ import {
   type GraphDataView
 } from './gpu-command-graph';
 import {
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource,
+  type GPUBoundedDispatchLayout
+} from './gpu-dispatch-utils';
+import {
   createTransientView,
   getViewBinding,
   getViewElementOffset,
@@ -370,6 +375,12 @@ function addReductionLevelPass<Parameters, T extends GPUScalarFormat>(
     firstLevel: boolean;
   }
 ): void {
+  const dispatchLayout = getBoundedDispatchLayout(
+    'GPUReduction',
+    props.inputLength,
+    REDUCTION_WORKGROUP_SIZE,
+    graph.device.limits.maxComputeWorkgroupsPerDimension
+  );
   const shaderType = getShaderType(props.format);
   const zero = getZeroLiteral(props.format);
   const isSum = props.operation === 'sum';
@@ -426,12 +437,14 @@ var<workgroup> secondScratch: array<${shaderType}, ${REDUCTION_WORKGROUP_SIZE}>;
 var<workgroup> validityScratch: array<u32, ${REDUCTION_WORKGROUP_SIZE}>;
 
 @compute @workgroup_size(${REDUCTION_WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) globalId: vec3<u32>,
-  @builtin(local_invocation_id) localId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32,
   @builtin(workgroup_id) workgroupId: vec3<u32>
 ) {
-  let index = globalId.x;
-  let lane = localId.x;
+  ${getBoundedInvocationIndexSource(dispatchLayout, REDUCTION_WORKGROUP_SIZE)}
+  if (workgroupIndex >= ${Math.ceil(props.inputLength / REDUCTION_WORKGROUP_SIZE)}u) {
+    return;
+  }
+  let lane = localInvocationIndex;
   var value = ${zero};
   var secondValue = ${zero};
   var valid = 0u;
@@ -452,9 +465,9 @@ var<workgroup> validityScratch: array<u32, ${REDUCTION_WORKGROUP_SIZE}>;
     stride = stride / 2u;
   }
   if (lane == 0u) {
-    outputValues[OUTPUT_OFFSET + workgroupId.x * VALUES_PER_ROW] = firstScratch[0];
-    ${isExtent ? 'outputValues[OUTPUT_OFFSET + workgroupId.x * VALUES_PER_ROW + 1u] = secondScratch[0];' : ''}
-    ${props.outputValidity ? 'outputValidity[OUTPUT_VALIDITY_OFFSET + workgroupId.x] = validityScratch[0];' : ''}
+    outputValues[OUTPUT_OFFSET + workgroupIndex * VALUES_PER_ROW] = firstScratch[0];
+    ${isExtent ? 'outputValues[OUTPUT_OFFSET + workgroupIndex * VALUES_PER_ROW + 1u] = secondScratch[0];' : ''}
+    ${props.outputValidity ? 'outputValidity[OUTPUT_VALIDITY_OFFSET + workgroupIndex] = validityScratch[0];' : ''}
   }
 }`;
 
@@ -477,7 +490,7 @@ var<workgroup> validityScratch: array<u32, ${REDUCTION_WORKGROUP_SIZE}>;
     source,
     resources,
     bindings,
-    dispatchCount: Math.ceil(props.inputLength / REDUCTION_WORKGROUP_SIZE)
+    dispatchLayout
   });
 }
 
@@ -559,7 +572,8 @@ function addComputationPass<Parameters>(
     source: string;
     resources: GraphBufferUse[];
     bindings: Record<string, GraphDataView>;
-    dispatchCount: number;
+    dispatchCount?: number;
+    dispatchLayout?: GPUBoundedDispatchLayout;
   }
 ): void {
   graph.addComputePass({
@@ -586,7 +600,16 @@ function addComputationPass<Parameters>(
             bindings[name] = getViewBinding(view, getBuffer);
           }
           computation.setBindings(bindings);
-          computation.dispatch(computePass, props.dispatchCount);
+          if (props.dispatchLayout) {
+            computation.dispatch(
+              computePass,
+              props.dispatchLayout.x,
+              props.dispatchLayout.y,
+              props.dispatchLayout.z
+            );
+          } else {
+            computation.dispatch(computePass, props.dispatchCount ?? 1);
+          }
         },
         destroy: () => computation.destroy()
       };

--- a/modules/experimental/src/ludf/lu-analytics-compiler-utils.ts
+++ b/modules/experimental/src/ludf/lu-analytics-compiler-utils.ts
@@ -19,6 +19,10 @@ import {
   type GraphBufferUse,
   type GraphDataView
 } from '../gpu-primitives/gpu-command-graph';
+import {
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource
+} from '../gpu-primitives/gpu-dispatch-utils';
 import {GPUMask} from '../gpu-primitives/gpu-mask';
 import {
   createTransientVectorView,
@@ -63,7 +67,7 @@ export function validateLuAnalyticsSource<Source extends GPUTypeMap>(
   }
 }
 
-/** Validates dense output storage and existing one-dimensional histogram dispatch constraints. */
+/** Validates dense output storage and bounded multidimensional dispatch capacity. */
 export function validateLuAnalyticsOutputLength(
   graph: GPUCommandGraph<LuDataFrameQueryParameters>,
   length: number
@@ -71,9 +75,7 @@ export function validateLuAnalyticsOutputLength(
   if (!Number.isSafeInteger(length) || length <= 0 || length > MAXIMUM_UINT32) {
     throw new Error('LuDataFrame analytics output requires a positive uint32 length');
   }
-  if (length > graph.device.limits.maxComputeWorkgroupsPerDimension * LU_ANALYTICS_WORKGROUP_SIZE) {
-    throw new Error('LuDataFrame analytics output exceeds the supported dispatch capacity');
-  }
+  getLuAnalyticsDispatchLayout(graph, length);
   const byteLength = length * UINT32_BYTE_LENGTH;
   if (
     byteLength > graph.device.limits.maxBufferSize ||
@@ -252,6 +254,7 @@ export function addLuAnalyticsComputePass(
     length: number;
   }
 ): void {
+  const dispatchLayout = getLuAnalyticsDispatchLayout(graph, props.length);
   graph.addComputePass({
     id: props.id,
     resources: [...props.resources],
@@ -275,15 +278,36 @@ export function addLuAnalyticsComputePass(
             bindings[name] = getViewBinding(view, getBuffer);
           }
           computation.setBindings(bindings);
-          computation.dispatch(
-            computePass,
-            Math.max(1, Math.ceil(props.length / LU_ANALYTICS_WORKGROUP_SIZE))
-          );
+          computation.dispatch(computePass, dispatchLayout.x, dispatchLayout.y, dispatchLayout.z);
         },
         destroy: () => computation.destroy()
       };
     }
   });
+}
+
+/** Maps bounded three-dimensional analytics workgroups to overflow-safe source-row indices. */
+export function getLuAnalyticsInvocationIndexSource(
+  graph: GPUCommandGraph<LuDataFrameQueryParameters>,
+  length: number
+): string {
+  return getBoundedInvocationIndexSource(
+    getLuAnalyticsDispatchLayout(graph, length),
+    LU_ANALYTICS_WORKGROUP_SIZE
+  );
+}
+
+/** Keeps analytics shaders and their actual command dispatch on the identical 3D layout. */
+function getLuAnalyticsDispatchLayout(
+  graph: GPUCommandGraph<LuDataFrameQueryParameters>,
+  length: number
+) {
+  return getBoundedDispatchLayout(
+    'LuDataFrame analytics',
+    length,
+    LU_ANALYTICS_WORKGROUP_SIZE,
+    graph.device.limits.maxComputeWorkgroupsPerDimension
+  );
 }
 
 /** Maps only closed scalar storage formats to native WGSL scalar names. */

--- a/modules/experimental/src/ludf/lu-global-aggregation-compiler.ts
+++ b/modules/experimental/src/ludf/lu-global-aggregation-compiler.ts
@@ -19,6 +19,7 @@ import {
   createLuAnalyticsResultTable,
   createLuAnalyticsTransientVector,
   getLuAnalyticsSelectionMask,
+  getLuAnalyticsInvocationIndexSource,
   getLuAnalyticsShaderType,
   getLuAnalyticsVector,
   validateLuAnalyticsSource,
@@ -241,8 +242,11 @@ const OUTPUT_OFFSET: u32 = ${getViewElementOffset(mask)}u;
 @group(0) @binding(2) var<storage, read_write> outputMask: array<u32>;
 
 @compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  let index = globalId.x;
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, mask.length)}
   if (index < ELEMENT_COUNT) {
     let value = inputValues[INPUT_OFFSET + index];
     let finite = value == value && abs(value) <= 3.402823466e+38;
@@ -307,8 +311,11 @@ const OUTPUT_OFFSET: u32 = ${getViewElementOffset(destination)}u;
 @group(0) @binding(2) var<storage, read_write> outputValues: array<${outputType}>;
 
 @compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  let index = globalId.x;
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(context.graph, destination.length)}
   if (index < ELEMENT_COUNT) {
     let value = ${outputType}(inputValues[INPUT_OFFSET + index]);
     outputValues[OUTPUT_OFFSET + index] = select(

--- a/modules/experimental/src/ludf/lu-group-aggregation-compiler.ts
+++ b/modules/experimental/src/ludf/lu-group-aggregation-compiler.ts
@@ -3,8 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 // SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuDF.
 
-import {Buffer, type Binding, type Device} from '@luma.gl/core';
-import {Computation} from '@luma.gl/engine';
+import {Buffer, type Device} from '@luma.gl/core';
 import {
   GPUData,
   GPURecordBatch,
@@ -16,16 +15,20 @@ import {
 import {
   GraphVectorView,
   type GPUCommandGraph,
-  type GraphBufferUse,
   type GraphDataView
 } from '../gpu-primitives/gpu-command-graph';
 import {GPUGroupAggregation} from '../gpu-primitives/gpu-group-aggregation';
 import {GPUMask} from '../gpu-primitives/gpu-mask';
 import {
   createTransientVectorView,
-  getViewBinding,
   getViewElementOffset
 } from '../gpu-primitives/graph-data-view-utils';
+import {
+  LU_ANALYTICS_WORKGROUP_SIZE,
+  addLuAnalyticsComputePass,
+  getLuAnalyticsInvocationIndexSource,
+  validateLuAnalyticsOutputLength
+} from './lu-analytics-compiler-utils';
 import type {LuDataFrame, LuDataFrameDictionaries, LuDataFrameValidity} from './lu-data-frame';
 import type {LuDataFrameDerivedColumn} from './lu-data-frame-query';
 import type {LuExpression} from './lu-expression';
@@ -39,7 +42,6 @@ import {
   type LuDataFrameQueryParameters
 } from './lu-query-compiler';
 
-const LU_GROUP_WORKGROUP_SIZE = 256;
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 const MAXIMUM_UINT32 = 0xffffffff;
 
@@ -125,9 +127,7 @@ function validateLuGroupingCapacity<Source extends GPUTypeMap>(
   if (source.numRows > MAXIMUM_UINT32) {
     throw new Error('LuDataFrame group counts cannot represent more than uint32 source rows');
   }
-  if (groupCount > graph.device.limits.maxComputeWorkgroupsPerDimension * LU_GROUP_WORKGROUP_SIZE) {
-    throw new Error('LuDataFrame group count exceeds the supported dispatch capacity');
-  }
+  validateLuAnalyticsOutputLength(graph, groupCount);
   const byteLength = groupCount * UINT32_BYTE_LENGTH;
   if (
     byteLength > graph.device.limits.maxStorageBufferBindingSize ||
@@ -430,13 +430,17 @@ const ELEMENT_COUNT: u32 = ${output.length}u;
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(output)}u;
 @group(0) @binding(0) var<storage, read_write> outputValues: array<u32>;
 
-@compute @workgroup_size(${LU_GROUP_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  if (globalId.x < ELEMENT_COUNT) {
-    outputValues[OUTPUT_OFFSET + globalId.x] = globalId.x;
+@compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, output.length)}
+  if (index < ELEMENT_COUNT) {
+    outputValues[OUTPUT_OFFSET + index] = index;
   }
 }`;
-  addLuGroupingComputePass(graph, {
+  addLuAnalyticsComputePass(graph, {
     id,
     source,
     resources: [{buffer: output, usage: 'storage-write'}],
@@ -468,19 +472,23 @@ const OUTPUT_OFFSET: u32 = ${getViewElementOffset(mask)}u;
 @group(0) @binding(1) var<storage, read> inputMask: array<u32>;
 @group(0) @binding(2) var<storage, read_write> outputMask: array<u32>;
 
-@compute @workgroup_size(${LU_GROUP_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  if (globalId.x < ELEMENT_COUNT) {
-    let value = inputValues[VALUE_OFFSET + globalId.x];
+@compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, mask.length)}
+  if (index < ELEMENT_COUNT) {
+    let value = inputValues[VALUE_OFFSET + index];
     let finite = value == value && abs(value) <= 3.402823466e+38;
-    outputMask[OUTPUT_OFFSET + globalId.x] = select(
+    outputMask[OUTPUT_OFFSET + index] = select(
       0u,
       1u,
-      inputMask[INPUT_OFFSET + globalId.x] != 0u && finite
+      inputMask[INPUT_OFFSET + index] != 0u && finite
     );
   }
 }`;
-    addLuGroupingComputePass(graph, {
+    addLuAnalyticsComputePass(graph, {
       id: `${id}-chunk-${chunkIndex}`,
       source,
       resources: [
@@ -505,60 +513,22 @@ const ELEMENT_COUNT: u32 = ${validity.length}u;
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(validity)}u;
 @group(0) @binding(0) var<storage, read_write> outputValidity: array<u32>;
 
-@compute @workgroup_size(${LU_GROUP_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  if (globalId.x < ELEMENT_COUNT) {
-    let offset = OUTPUT_OFFSET + globalId.x;
+@compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, validity.length)}
+  if (index < ELEMENT_COUNT) {
+    let offset = OUTPUT_OFFSET + index;
     outputValidity[offset] = select(0u, 1u, outputValidity[offset] != 0u);
   }
 }`;
-  addLuGroupingComputePass(graph, {
+  addLuAnalyticsComputePass(graph, {
     id,
     source,
     resources: [{buffer: validity, usage: 'storage-read-write'}],
     bindings: {outputValidity: validity},
     length: validity.length
-  });
-}
-
-/** Owns one small grouping computation while preserving typed graph buffer hazard declarations. */
-function addLuGroupingComputePass(
-  graph: GPUCommandGraph<LuDataFrameQueryParameters>,
-  props: {
-    id: string;
-    source: string;
-    resources: readonly GraphBufferUse[];
-    bindings: Readonly<Record<string, GraphDataView>>;
-    length: number;
-  }
-): void {
-  graph.addComputePass({
-    id: props.id,
-    resources: [...props.resources],
-    compile: ({device}) => {
-      const computation = new Computation(device, {
-        id: props.id,
-        source: props.source,
-        shaderLayout: {
-          bindings: Object.keys(props.bindings).map((name, location) => ({
-            name,
-            type: 'storage' as const,
-            group: 0,
-            location
-          }))
-        }
-      });
-      return {
-        encode: ({computePass, getBuffer}) => {
-          const resolvedBindings: Record<string, Binding> = {};
-          for (const [name, view] of Object.entries(props.bindings)) {
-            resolvedBindings[name] = getViewBinding(view, getBuffer);
-          }
-          computation.setBindings(resolvedBindings);
-          computation.dispatch(computePass, Math.ceil(props.length / LU_GROUP_WORKGROUP_SIZE));
-        },
-        destroy: () => computation.destroy()
-      };
-    }
   });
 }

--- a/modules/experimental/src/ludf/lu-histogram-compiler.ts
+++ b/modules/experimental/src/ludf/lu-histogram-compiler.ts
@@ -13,6 +13,7 @@ import {
   createLuAnalyticsOutputVector,
   createLuAnalyticsResultTable,
   getLuAnalyticsSelectionMask,
+  getLuAnalyticsInvocationIndexSource,
   getLuAnalyticsVector,
   validateLuAnalyticsOutputLength,
   validateLuAnalyticsSource,
@@ -175,9 +176,13 @@ const OUTPUT_OFFSET: u32 = ${getViewElementOffset(output)}u;
 @group(0) @binding(0) var<storage, read_write> outputBins: array<u32>;
 
 @compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  if (globalId.x < ELEMENT_COUNT) {
-    outputBins[OUTPUT_OFFSET + globalId.x] = globalId.x;
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, output.length)}
+  if (index < ELEMENT_COUNT) {
+    outputBins[OUTPUT_OFFSET + index] = index;
   }
 }`;
   addLuAnalyticsComputePass(graph, {

--- a/modules/experimental/src/ludf/lu-join-compiler.ts
+++ b/modules/experimental/src/ludf/lu-join-compiler.ts
@@ -28,6 +28,7 @@ import {
 import {
   LU_ANALYTICS_WORKGROUP_SIZE,
   addLuAnalyticsComputePass,
+  getLuAnalyticsInvocationIndexSource,
   getLuAnalyticsVector,
   validateLuAnalyticsSource
 } from './lu-analytics-compiler-utils';
@@ -642,8 +643,11 @@ ${validityBinding}
 @group(0) @binding(${firstTailBinding + 1}) var<storage, read_write> preparedKeys: array<u32>;
 
 @compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  let index = globalId.x;
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, props.input.length)}
   if (index < ELEMENT_COUNT) {
     let selected = selectionMask[SELECTION_OFFSET + index] != 0u;
     let valid = ${isValid};
@@ -716,8 +720,11 @@ const OUTPUT_CAPACITY: u32 = ${props.capacity}u;
 @group(0) @binding(6) var<storage, read_write> selectedCounts: array<u32>;
 
 @compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  let index = globalId.x;
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, props.matches.length)}
   let published = min(requiredCounts[REQUIRED_OFFSET], OUTPUT_CAPACITY);
   if (index == 0u) {
     selectedCounts[PUBLISHED_OFFSET] = published;

--- a/modules/experimental/src/ludf/lu-query-compiler.ts
+++ b/modules/experimental/src/ludf/lu-query-compiler.ts
@@ -397,18 +397,18 @@ export function compileLuDataFrameQuery<
   }
 }
 
-/** Keeps legacy visibility identity/scatter dispatches within the device's 1D workgroup limit. */
+/** Rejects source batches only when even bounded three-dimensional dispatch cannot represent them. */
 function validateLuQueryBatchCapacity<T extends GPUTypeMap>(
   source: LuDataFrame<T>,
   graph: GPUCommandGraph<LuDataFrameQueryParameters>
 ): void {
-  const maximum = graph.device.limits.maxComputeWorkgroupsPerDimension * LU_QUERY_WORKGROUP_SIZE;
   for (const [batchIndex, batch] of source.batches.entries()) {
-    if (batch.numRows > maximum) {
-      throw new Error(
-        `LuDataFrame source batch ${batchIndex} exceeds visibility dispatch capacity`
-      );
-    }
+    getBoundedDispatchLayout(
+      `LuDataFrame source batch ${batchIndex}`,
+      batch.numRows,
+      LU_QUERY_WORKGROUP_SIZE,
+      graph.device.limits.maxComputeWorkgroupsPerDimension
+    );
   }
 }
 

--- a/modules/experimental/src/ludf/lu-sort-compiler.ts
+++ b/modules/experimental/src/ludf/lu-sort-compiler.ts
@@ -18,6 +18,7 @@ import {
   LU_ANALYTICS_WORKGROUP_SIZE,
   addLuAnalyticsComputePass,
   getLuAnalyticsShaderType,
+  getLuAnalyticsInvocationIndexSource,
   getLuAnalyticsVector,
   validateLuAnalyticsSource,
   type LuAnalyticsScalarFormat
@@ -264,8 +265,11 @@ ${validityBinding}
 @group(0) @binding(${keyBindingIndex + 1}) var<storage, read_write> outputIndices: array<u32>;
 
 @compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  let index = globalId.x;
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, chunk.input.length)}
   if (index < ELEMENT_COUNT) {
     let value = inputValues[INPUT_OFFSET + index];
     let isNull = ${isNull};
@@ -357,8 +361,11 @@ ${validityBinding}
 @group(0) @binding(${outputBindingIndex}) var<storage, read_write> outputClasses: array<u32>;
 
 @compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  let index = globalId.x;
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, chunk.input.length)}
   if (index < ELEMENT_COUNT) {
     let localIndex = sortedIndices[INDEX_OFFSET + index];
     let value = inputValues[INPUT_OFFSET + localIndex];
@@ -426,8 +433,11 @@ const ROW_LIMIT: u32 = ${props.limit}u;
 @group(0) @binding(4) var<storage, read_write> selectedCounts: array<u32>;
 
 @compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  let index = globalId.x;
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, props.sortedIndices.length)}
   if (index < ELEMENT_COUNT) {
     let localIndex = sortedIndices[LOCAL_INDEX_OFFSET + index];
     let selected = sortedClasses[CLASS_OFFSET + index] != 3u && index < ROW_LIMIT;

--- a/modules/experimental/test/ludf/lu-scalable-dispatch.node.spec.ts
+++ b/modules/experimental/test/ludf/lu-scalable-dispatch.node.spec.ts
@@ -1,0 +1,133 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer} from '@luma.gl/core';
+import {
+  GPUCommandGraph,
+  GPUGroupAggregation,
+  GPUHistogram,
+  GPUReduction
+} from '@luma.gl/experimental';
+import {NullDevice} from '@luma.gl/test-utils';
+import {describe, expect, test, vi} from 'vitest';
+import {
+  getLuAnalyticsInvocationIndexSource,
+  validateLuAnalyticsOutputLength
+} from '../../src/ludf/lu-analytics-compiler-utils';
+
+const WORKGROUP_SIZE = 256;
+
+describe('bounded LuDataFrame analytics dispatch', () => {
+  test('expands dense output layouts across three dimensions and rejects real 3D overflow', () => {
+    const {device, graph} = createBoundedGraph();
+
+    try {
+      expect(() => validateLuAnalyticsOutputLength(graph, 4 * WORKGROUP_SIZE + 1)).not.toThrow();
+      expect(() => validateLuAnalyticsOutputLength(graph, 8 * WORKGROUP_SIZE + 1)).toThrow(
+        /3D dispatch limit/i
+      );
+
+      const source = getLuAnalyticsInvocationIndexSource(graph, 4 * WORKGROUP_SIZE + 1);
+      expect(source).toContain('workgroupId.z * 2u + workgroupId.y');
+      expect(source).toContain('* 2u + workgroupId.x');
+      expect(source.indexOf('workgroupIndex >= 16777216u')).toBeLessThan(
+        source.indexOf('workgroupIndex * 256u + localInvocationIndex')
+      );
+    } finally {
+      device.destroy();
+    }
+  });
+
+  test('declares bounded hierarchical reduction work beyond the legacy one-dimensional ceiling', () => {
+    const {device, graph} = createBoundedGraph();
+    const input = createView(graph, 'reduction-input', 'float32', 1_025);
+    const output = createView(graph, 'reduction-output', 'float32', 1);
+    const addComputePass = vi.spyOn(graph, 'addComputePass');
+
+    try {
+      expect(() =>
+        new GPUReduction({id: 'bounded-reduction', input, output, operation: 'sum'}).addToGraph(
+          graph
+        )
+      ).not.toThrow();
+      expect(addComputePass.mock.calls.map(([pass]) => pass.id)).toEqual(
+        expect.arrayContaining(['bounded-reduction-level-0', 'bounded-reduction-level-1'])
+      );
+    } finally {
+      addComputePass.mockRestore();
+      device.destroy();
+    }
+  });
+
+  test('declares bounded histogram accumulation and dense output initialization', () => {
+    const {device, graph} = createBoundedGraph();
+    const input = createView(graph, 'histogram-input', 'uint32', 1_025);
+    const output = createView(graph, 'histogram-output', 'uint32', 1_025);
+    const addComputePass = vi.spyOn(graph, 'addComputePass');
+
+    try {
+      expect(() =>
+        new GPUHistogram({id: 'bounded-histogram', input, output, domain: [0, 1_025]}).addToGraph(
+          graph
+        )
+      ).not.toThrow();
+      expect(addComputePass.mock.calls.map(([pass]) => pass.id)).toEqual([
+        'bounded-histogram-clear',
+        'bounded-histogram-global'
+      ]);
+    } finally {
+      addComputePass.mockRestore();
+      device.destroy();
+    }
+  });
+
+  test('initializes and finalizes dense groups beyond one-dimensional workgroup capacity', () => {
+    const {device, graph} = createBoundedGraph();
+    const keys = createView(graph, 'group-keys', 'uint32', 1_025);
+    const values = createView(graph, 'group-values', 'float32', 1_025);
+    const output = createView(graph, 'group-output', 'float32', 1_025);
+    const addComputePass = vi.spyOn(graph, 'addComputePass');
+
+    try {
+      expect(() =>
+        new GPUGroupAggregation({
+          id: 'bounded-groups',
+          keys,
+          values,
+          output,
+          operation: 'mean'
+        }).addToGraph(graph)
+      ).not.toThrow();
+      expect(addComputePass.mock.calls.map(([pass]) => pass.id)).toEqual(
+        expect.arrayContaining(['bounded-groups-initialize', 'bounded-groups-finalize'])
+      );
+    } finally {
+      addComputePass.mockRestore();
+      device.destroy();
+    }
+  });
+});
+
+function createBoundedGraph(): {device: NullDevice; graph: GPUCommandGraph} {
+  const device = new NullDevice({id: 'ludf-scalable-dispatch-node-device'});
+  Object.defineProperty(device, 'type', {value: 'webgpu'});
+  device.limits.maxComputeWorkgroupsPerDimension = 2;
+  device.limits.maxBufferSize = 65_536;
+  device.limits.maxStorageBufferBindingSize = 65_536;
+  return {device, graph: new GPUCommandGraph(device, {id: 'ludf-scalable-dispatch-node-graph'})};
+}
+
+function createView<Format extends 'float32' | 'uint32'>(
+  graph: GPUCommandGraph,
+  id: string,
+  format: Format,
+  length: number
+) {
+  const buffer = graph.createTransientBuffer({
+    id,
+    byteLength: Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE
+  });
+  return graph.createDataView(buffer, {format, length});
+}

--- a/modules/experimental/test/ludf/lu-scalable-dispatch.spec.ts
+++ b/modules/experimental/test/ludf/lu-scalable-dispatch.spec.ts
@@ -1,0 +1,163 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph} from '@luma.gl/experimental';
+import {
+  LuDataFrame,
+  column,
+  literal,
+  type LuDataFrameQueryParameters
+} from '@luma.gl/experimental/ludf';
+import {GPUData, GPURecordBatch, GPUTable, type GPUVector} from '@luma.gl/tables';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import {expect, test, vi} from 'vitest';
+
+type ScalableSource = {value: 'float32'; category: 'uint32'};
+
+test('LuDataFrame filters, reduces, groups, bins, sorts, and joins across bounded 3D dispatches', async () => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    return;
+  }
+
+  const originalLimits = device.limits;
+  Object.defineProperty(device, 'limits', {
+    configurable: true,
+    value: new Proxy(originalLimits, {
+      get(target, property) {
+        return property === 'maxComputeWorkgroupsPerDimension'
+          ? 2
+          : Reflect.get(target, property, target);
+      }
+    })
+  });
+  const dispatch = vi.spyOn(Computation.prototype, 'dispatch');
+  const left = createScalableFrame(device, 1_025, 100);
+  const right = createScalableFrame(device, 3, 500, Uint32Array.from([0, 512, 1_024]));
+  const ownedQueries: {destroy(): void}[] = [];
+
+  try {
+    const filter = left
+      .withColumn('adjusted', column('value').add(literal(1)), {format: 'float32'})
+      .filter(column('adjusted').greaterThan(literal(0)))
+      .compile(new GPUCommandGraph<LuDataFrameQueryParameters>(device, {id: 'bounded-filter'}));
+    ownedQueries.push(filter);
+    const reduction = left
+      .aggregate({count: 'count', total: {sum: 'value'}, maximum: {max: 'value'}})
+      .compile(new GPUCommandGraph<LuDataFrameQueryParameters>(device, {id: 'bounded-reduction'}));
+    ownedQueries.push(reduction);
+    const groups = left
+      .groupBy('category', {groupCount: 1_025})
+      .aggregate({count: 'count', mean: {mean: 'value'}})
+      .compile(new GPUCommandGraph<LuDataFrameQueryParameters>(device, {id: 'bounded-groups'}));
+    ownedQueries.push(groups);
+    const histogram = left
+      .histogram('value', {bins: 1_025, domain: [0, 1_025]})
+      .compile(new GPUCommandGraph<LuDataFrameQueryParameters>(device, {id: 'bounded-histogram'}));
+    ownedQueries.push(histogram);
+    const sorting = left
+      .topK('value', 3)
+      .compile(new GPUCommandGraph<LuDataFrameQueryParameters>(device, {id: 'bounded-sorting'}));
+    ownedQueries.push(sorting);
+    const join = left
+      .innerJoin(right, {leftOn: 'category', rightOn: 'category', capacity: 3})
+      .compile(new GPUCommandGraph<LuDataFrameQueryParameters>(device, {id: 'bounded-join'}));
+    ownedQueries.push(join);
+
+    const encoder = device.createCommandEncoder({id: 'bounded-dataframe-workloads'});
+    for (const compiled of [filter, reduction, groups, histogram, sorting, join]) {
+      compiled.encode(encoder);
+    }
+    device.submit(encoder.finish());
+
+    expect(await readUnsigned(filter.selectedCounts)).toEqual([1_025]);
+    expect(await readUnsigned(reduction.table.gpuVectors.count)).toEqual([1_025]);
+    expect(await readFloating(reduction.table.gpuVectors.total)).toEqual([524_800]);
+    expect(await readFloating(reduction.table.gpuVectors.maximum)).toEqual([1_024]);
+
+    const groupedCounts = await readUnsigned(groups.table.gpuVectors.count);
+    expect(groupedCounts).toHaveLength(1_025);
+    expect(groupedCounts.every(count => count === 1)).toBe(true);
+    expect(await readUnsigned(groups.table.gpuVectors.category, 5)).toEqual([0, 1, 2, 3, 4]);
+
+    const histogramCounts = await readUnsigned(histogram.table.gpuVectors.count);
+    expect(histogramCounts).toHaveLength(1_025);
+    expect(histogramCounts.every(count => count === 1)).toBe(true);
+    expect(await readUnsigned(histogram.table.gpuVectors.bin, 5)).toEqual([0, 1, 2, 3, 4]);
+
+    expect(await readUnsigned(sorting.selectedCounts)).toEqual([3]);
+    expect(await readUnsigned(sorting.rowIndices, 3)).toEqual([1_124, 1_123, 1_122]);
+    expect(await readUnsigned(join.selectedCounts)).toEqual([3]);
+    expect(await readUnsigned(join.rowIndices, 3)).toEqual([100, 612, 1_124]);
+    expect(await readUnsigned(join.rightRowIndices, 3)).toEqual([500, 501, 502]);
+
+    const boundedPasses = dispatch.mock.calls.filter(
+      ([, horizontal, vertical, depth]) => horizontal === 2 && vertical === 2 && depth === 2
+    );
+    expect(boundedPasses.length).toBeGreaterThan(10);
+  } finally {
+    for (const query of ownedQueries) {
+      query.destroy();
+    }
+    left.destroy();
+    right.destroy();
+    dispatch.mockRestore();
+    Object.defineProperty(device, 'limits', {configurable: true, value: originalLimits});
+  }
+}, 60_000);
+
+function createScalableFrame(
+  device: Device,
+  rowCount: number,
+  sourceRowIndexOffset: number,
+  keys = Uint32Array.from({length: rowCount}, (_, index) => index)
+): LuDataFrame<ScalableSource> {
+  const values = Float32Array.from(keys);
+  const batch = new GPURecordBatch<ScalableSource>({
+    gpuData: {
+      value: createScalableData(device, values, 'float32'),
+      category: createScalableData(device, keys, 'uint32')
+    },
+    fields: [
+      {name: 'value', format: 'float32', nullable: false},
+      {name: 'category', format: 'uint32', nullable: false}
+    ],
+    sourceInfo: {sourceBatchIndex: 0, sourceRowIndexOffset, sourceRowCount: rowCount}
+  });
+  return new LuDataFrame({table: new GPUTable({batches: [batch]}), ownership: 'owned'});
+}
+
+function createScalableData<Format extends 'float32' | 'uint32'>(
+  device: Device,
+  values: Float32Array | Uint32Array,
+  format: Format
+): GPUData<Format> {
+  const buffer = device.createBuffer({
+    data: values,
+    usage: Buffer.STORAGE | Buffer.VERTEX | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+  return new GPUData({buffer, format, length: values.length, ownsBuffer: true});
+}
+
+async function readUnsigned(
+  vector: GPUVector<'uint32'>,
+  length = vector.length
+): Promise<number[]> {
+  const data = vector.data[0];
+  const buffer = data.buffer instanceof Buffer ? data.buffer : data.buffer.buffer;
+  const bytes = await buffer.readAsync(0, length * Uint32Array.BYTES_PER_ELEMENT);
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, length));
+}
+
+async function readFloating(
+  vector: GPUVector<'float32'>,
+  length = vector.length
+): Promise<number[]> {
+  const data = vector.data[0];
+  const buffer = data.buffer instanceof Buffer ? data.buffer : data.buffer.buffer;
+  const bytes = await buffer.readAsync(0, length * Float32Array.BYTES_PER_ELEMENT);
+  return Array.from(new Float32Array(bytes.buffer, bytes.byteOffset, length));
+}


### PR DESCRIPTION
## Goals

Remove the remaining one-dimensional WebGPU workgroup ceiling from luDF so preserved source batches and dense analytics results can expand across all three bounded dispatch dimensions without changing dataframe APIs, ownership, or batch topology.

## Changes

- Replace the stale dataframe source-batch `maxComputeWorkgroupsPerDimension * 256` rejection with validation against the complete overflow-safe three-dimensional dispatch capacity.
- Centralize bounded analytics dispatch planning and guarded WGSL linear-index generation for derived filters, global aggregations, grouped statistics, histogram identities, per-batch sorting/top-K, and unique-right joins.
- Scale `GPUReduction` hierarchies across bounded 3D grids and explicitly skip padded whole workgroups before they can write outside graph-suballocated partial buffers.
- Scale `GPUHistogram` output clearing, equal-width accumulation, and irregular-edge accumulation while preserving local/global atomics, masks, source chunks, and explicit domains.
- Scale `GPUGroupAggregation` dense clears, floating-point initialization, and finalization; reuse the same central planner for dense dataframe grouping instead of maintaining a duplicate one-dimensional compute helper.
- Retain exact original batch boundaries, stable source row identifiers, nullable validity, owned outputs, graph resource hazards, and existing public interfaces.
- Document why multidimensional dispatch is needed, how a 1,025-row workload maps to a `2 × 2 × 2` grid, and which genuine uint32/storage-buffer limitations still apply.
- Add synthetic-limit Node regressions for complete 3D capacity, overflow rejection, reduction hierarchies, histogram bins, and dense group initialization.
- Add an actual WebGPU integration that forces a synthetic two-workgroup-per-dimension limit and validates filter/derived, global reductions, dense grouping, 1,025-bin histograms, stable top-K, and joins against exact expected results.

## Verification

- `yarn lint fix` — passed; 1,843 files checked.
- `yarn build` — passed for the full monorepo after final source/formatting changes.
- `CI=1 yarn test` — passed: **2,037 Node tests** and **2,009 actual Chromium/WebGPU tests**, with existing skips unchanged.
- Focused luDF/GPU primitive Node regressions — 90 tests passed.
- Focused real-WebGPU dataframe, reduction, histogram, and command-graph regressions — 64 tests passed.
- Dedicated synthetic-limit WebGPU integration observed more than ten actual `dispatchWorkgroups(2, 2, 2)` workloads and validated every output.
- `yarn website:build` — passed; 483 documentation pages validated.
- `(cd website && yarn build)` — passed; 483 documentation pages validated.
- `yarn examples:typecheck` — passed for 47 example workspaces.
- Git pre-commit hooks independently reran formatting and all 2,037 Node tests.
- Dependencies were reused from the existing benchmark worktree; `yarn install` was unnecessary.

## Risks and follow-up

- Hardware storage/binding limits and unsigned 32-bit source-row identities still cap practical batch size; the implementation does not claim unbounded datasets.
- Workgroup padding is explicitly guarded before hierarchical partial writes to protect shared graph scratch allocations.
- Sorting remains intentionally per source batch. Global sorting/top-K is the next independent tranche, followed by richer joins.
