### PR TITLE
Scale GPU trace focus storage for 100M spans

### DIFF
--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -185,9 +185,9 @@ type TraceGraphResources = {
   dependencyBatchIndex: Buffer;
   candidateDependencyBatchIds: Buffer;
   parentSpans: Buffer;
-  outgoingOffsets: Buffer;
+  outgoingTopology: Buffer;
   outgoingNeighbors: Buffer;
-  incomingOffsets: Buffer;
+  incomingTopology: Buffer;
   incomingNeighbors: Buffer;
   processStates: Buffer;
   threadStates: Buffer;
@@ -230,9 +230,9 @@ function getTraceResourceBuffers(resources: TraceGraphResources): Array<{byteLen
     resources.dependencyBatchIndex,
     resources.candidateDependencyBatchIds,
     resources.parentSpans,
-    resources.outgoingOffsets,
+    resources.outgoingTopology,
     resources.outgoingNeighbors,
-    resources.incomingOffsets,
+    resources.incomingTopology,
     resources.incomingNeighbors,
     resources.processStates,
     resources.threadStates,
@@ -590,9 +590,16 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     );
     const dependencyMaskByteLength = Math.max(dataset.dependencyCount, 1) * UINT32_BYTE_LENGTH;
     const densityBinCount = TRACE_LANE_COUNT * TRACE_DENSITY_BIN_COUNT;
-    const topologyChunkLengths = getTopologyChunkLengths(dataset.spanCount);
-    const outgoingOffsets = makePartitionedOffsets(dataset.outgoing.offsets, topologyChunkLengths);
-    const incomingOffsets = makePartitionedOffsets(dataset.incoming.offsets, topologyChunkLengths);
+    const outgoingTopologyChunkLengths = getTopologyChunkLengths(dataset.outgoing.nodes.length);
+    const incomingTopologyChunkLengths = getTopologyChunkLengths(dataset.incoming.nodes.length);
+    const outgoingTopology = makeSparseTopologyRows(
+      dataset.outgoing.nodes,
+      makePartitionedOffsets(dataset.outgoing.offsets, outgoingTopologyChunkLengths)
+    );
+    const incomingTopology = makeSparseTopologyRows(
+      dataset.incoming.nodes,
+      makePartitionedOffsets(dataset.incoming.offsets, incomingTopologyChunkLengths)
+    );
     const maximumDirectSpanByteLength = Math.min(
       this.device.limits.maxStorageBufferBindingSize,
       this.device.limits.maxBufferSize
@@ -726,12 +733,12 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         Buffer.COPY_SRC
       ),
       parentSpans: this.createDataBuffer('gpu-trace-parent-spans', dataset.parentSpans),
-      outgoingOffsets: this.createDataBuffer('gpu-trace-outgoing-offsets', outgoingOffsets),
+      outgoingTopology: this.createDataBuffer('gpu-trace-outgoing-topology', outgoingTopology),
       outgoingNeighbors: this.createDataBuffer(
         'gpu-trace-outgoing-neighbors',
         dataset.outgoing.neighbors
       ),
-      incomingOffsets: this.createDataBuffer('gpu-trace-incoming-offsets', incomingOffsets),
+      incomingTopology: this.createDataBuffer('gpu-trace-incoming-topology', incomingTopology),
       incomingNeighbors: this.createDataBuffer(
         'gpu-trace-incoming-neighbors',
         dataset.incoming.neighbors
@@ -882,13 +889,13 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         resources.candidateDependencyDispatchCommands.buffer
       ),
       parentSpans: importTraceBuffer(graph, 'parent-spans', resources.parentSpans),
-      outgoingOffsets: importTraceBuffer(graph, 'outgoing-offsets', resources.outgoingOffsets),
+      outgoingTopology: importTraceBuffer(graph, 'outgoing-topology', resources.outgoingTopology),
       outgoingNeighbors: importTraceBuffer(
         graph,
         'outgoing-neighbors',
         resources.outgoingNeighbors
       ),
-      incomingOffsets: importTraceBuffer(graph, 'incoming-offsets', resources.incomingOffsets),
+      incomingTopology: importTraceBuffer(graph, 'incoming-topology', resources.incomingTopology),
       incomingNeighbors: importTraceBuffer(
         graph,
         'incoming-neighbors',
@@ -951,14 +958,15 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       TRACE_THREADS_PER_PROCESS + 1,
       TRACE_THREAD_COUNT - TRACE_THREADS_PER_PROCESS - 1
     ];
-    const topologyChunkLengths = getTopologyChunkLengths(resources.spanCount);
+    const outgoingTopologyChunkLengths = getTopologyChunkLengths(dataset.outgoing.nodes.length);
+    const incomingTopologyChunkLengths = getTopologyChunkLengths(dataset.incoming.nodes.length);
     const outgoingNeighborChunkLengths = getNeighborChunkLengths(
       dataset.outgoing.offsets,
-      topologyChunkLengths
+      outgoingTopologyChunkLengths
     );
     const incomingNeighborChunkLengths = getNeighborChunkLengths(
       dataset.incoming.offsets,
-      topologyChunkLengths
+      incomingTopologyChunkLengths
     );
 
     const candidateBatchFlags = graph.createTransientBuffer({
@@ -1105,41 +1113,44 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         length: 1,
         workgroupSize: 1
       });
-      let sourceNodeBase = 0;
-      let offsetWordBase = 0;
-      let outgoingNeighborWordBase = 0;
-      let incomingNeighborWordBase = 0;
-      for (const [partitionIndex, sourceNodeCount] of topologyChunkLengths.entries()) {
-        for (const direction of [
-          {
-            name: 'outgoing',
-            offsets: handles.outgoingOffsets,
-            neighbors: handles.outgoingNeighbors,
-            neighborWordBase: outgoingNeighborWordBase,
-            neighborCount: outgoingNeighborChunkLengths[partitionIndex]
-          },
-          {
-            name: 'incoming',
-            offsets: handles.incomingOffsets,
-            neighbors: handles.incomingNeighbors,
-            neighborWordBase: incomingNeighborWordBase,
-            neighborCount: incomingNeighborChunkLengths[partitionIndex]
-          }
-        ]) {
+      for (const direction of [
+        {
+          name: 'outgoing',
+          topology: handles.outgoingTopology,
+          neighbors: handles.outgoingNeighbors,
+          nodeChunkLengths: outgoingTopologyChunkLengths,
+          neighborChunkLengths: outgoingNeighborChunkLengths
+        },
+        {
+          name: 'incoming',
+          topology: handles.incomingTopology,
+          neighbors: handles.incomingNeighbors,
+          nodeChunkLengths: incomingTopologyChunkLengths,
+          neighborChunkLengths: incomingNeighborChunkLengths
+        }
+      ]) {
+        let nodeWordBase = 0;
+        let offsetWordBase = direction.nodeChunkLengths.reduce(
+          (total, nodeCount) => total + nodeCount,
+          0
+        );
+        let neighborWordBase = 0;
+        for (const [partitionIndex, sourceNodeCount] of direction.nodeChunkLengths.entries()) {
+          const neighborCount = direction.neighborChunkLengths[partitionIndex];
           addTraceIndirectComputePass(graph, {
             id: `trace-focus-frontier-${depth}-${direction.name}-${partitionIndex}`,
             source: getFocusFrontierExpansionShader({
               spanCount: resources.spanCount,
               frontierCapacity: resources.focusFrontierCapacity,
-              sourceNodeBase,
+              nodeWordBase,
               sourceNodeCount,
               offsetWordBase,
-              neighborWordBase: direction.neighborWordBase,
-              neighborCount: direction.neighborCount,
+              neighborWordBase,
+              neighborCount,
               depth
             }),
             bindings: [
-              storageRead('offsets', direction.offsets),
+              storageRead('topology', direction.topology),
               storageRead('neighbors', direction.neighbors),
               storageRead('frontier', focusFrontiers[currentFrontierIndex]),
               storageRead('frontierCount', focusFrontierCounts[currentFrontierIndex]),
@@ -1150,11 +1161,10 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
             ],
             dispatchBuffer: focusDispatchCommands[currentFrontierIndex]
           });
+          nodeWordBase += sourceNodeCount;
+          offsetWordBase += sourceNodeCount + 1;
+          neighborWordBase += neighborCount;
         }
-        sourceNodeBase += sourceNodeCount;
-        offsetWordBase += sourceNodeCount + 1;
-        outgoingNeighborWordBase += outgoingNeighborChunkLengths[partitionIndex];
-        incomingNeighborWordBase += incomingNeighborChunkLengths[partitionIndex];
       }
       addTraceComputePass(graph, {
         id: `trace-focus-frontier-${depth}-publish`,
@@ -1660,9 +1670,9 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       resources.dependencyBatchIndex,
       resources.candidateDependencyBatchIds,
       resources.parentSpans,
-      resources.outgoingOffsets,
+      resources.outgoingTopology,
       resources.outgoingNeighbors,
-      resources.incomingOffsets,
+      resources.incomingTopology,
       resources.incomingNeighbors,
       resources.processStates,
       resources.threadStates,
@@ -2162,7 +2172,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
   };
 }
 
-/** Splits source-aligned topology into two stable global-ID partitions. */
+/** Splits sparse adjacency rows into two stable global-ID partitions. */
 function getTopologyChunkLengths(length: number): number[] {
   if (length < 2) {
     return [length];
@@ -2199,6 +2209,14 @@ function makePartitionedOffsets(
     nodeBase += nodeCount;
   }
   return Uint32Array.from(partitionedOffsets);
+}
+
+/** Packs sparse owner IDs and partition-local CSR offsets into one portable shader binding. */
+function makeSparseTopologyRows(nodes: Uint32Array, offsets: Uint32Array): Uint32Array {
+  const topology = new Uint32Array(nodes.length + offsets.length);
+  topology.set(nodes);
+  topology.set(offsets, nodes.length);
+  return topology;
 }
 
 /** Adapts consecutive subranges of one caller-owned allocation as a chunk-preserving vector. */

--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -81,6 +81,7 @@ import {
   getFocusFrontierDispatchShader,
   getFocusFrontierExpansionShader,
   getFocusFrontierSeedShader,
+  getFocusReachabilityClearShader,
   getPickClearShader,
   getTraceDrawCommandsShader,
   TRACE_DENSITY_RENDER_SHADER,
@@ -383,7 +384,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     }
     const pick = this.pendingPick;
     const visibilityGeneration = (this.frameIndex % 0xfffffffe) + 1;
-    resources.focusTraversalState.write(Uint32Array.of(this.focusDepth, visibilityGeneration));
+    resources.focusTraversalState.write(Uint32Array.of(this.focusDepth));
     this.writeViewUniforms(width, height, pick, visibilityGeneration, resources.dependencyCount);
     const encoding = this.graphObservation?.encode(device.commandEncoder, {
       parameters: this.view
@@ -580,6 +581,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       firstSpanIndex: group.firstSpanIndex
     }));
     const spanMaskByteLength = Math.max(dataset.spanCount, 1) * UINT32_BYTE_LENGTH;
+    const focusMaskWordCount = Math.max(Math.ceil(dataset.spanCount / 32), 1);
     const dependencyMaskByteLength = Math.max(dataset.dependencyCount, 1) * UINT32_BYTE_LENGTH;
     const densityBinCount = TRACE_LANE_COUNT * TRACE_DENSITY_BIN_COUNT;
     const topologyChunkLengths = getTopologyChunkLengths(dataset.spanCount);
@@ -742,11 +744,11 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       selectedSeedCount: this.createDataBuffer('gpu-trace-selected-seed-count', new Uint32Array(1)),
       focusTraversalState: this.createDataBuffer(
         'gpu-trace-focus-traversal-state',
-        Uint32Array.of(this.focusDepth, 1)
+        Uint32Array.of(this.focusDepth)
       ),
       reachedSpans: this.createStorageBuffer(
         'gpu-trace-reached-spans',
-        spanMaskByteLength,
+        focusMaskWordCount * UINT32_BYTE_LENGTH,
         Buffer.COPY_SRC
       ),
       dependencyResults: this.createStorageBuffer(
@@ -1060,6 +1062,14 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         usage: Buffer.STORAGE | Buffer.INDIRECT
       })
     );
+    const focusMaskWordCount = Math.max(Math.ceil(resources.spanCount / 32), 1);
+    addTraceComputePass(graph, {
+      id: 'trace-focus-reachability-clear',
+      source: getFocusReachabilityClearShader(focusMaskWordCount),
+      bindings: [storageWrite('reachedSpans', handles.reachedSpans)],
+      length: focusMaskWordCount,
+      workgroupSize: TRACE_WORKGROUP_SIZE
+    });
     addTraceComputePass(graph, {
       id: 'trace-focus-frontier-seed',
       source: getFocusFrontierSeedShader(resources.spanCount),

--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -41,6 +41,7 @@ import {
 import {
   getTraceCapacityOptions,
   getTraceDependencyCapacityOptions,
+  getTraceFocusFrontierCapacity,
   isTraceDensityMode,
   makeTraceDataset,
   makeTraceSpanChunks,
@@ -206,6 +207,7 @@ type TraceGraphResources = {
   spanBatchCount: number;
   dependencyBatchCount: number;
   dependencyCount: number;
+  focusFrontierCapacity: number;
 };
 
 function getTraceResourceBuffers(resources: TraceGraphResources): Array<{byteLength: number}> {
@@ -582,6 +584,10 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     }));
     const spanMaskByteLength = Math.max(dataset.spanCount, 1) * UINT32_BYTE_LENGTH;
     const focusMaskWordCount = Math.max(Math.ceil(dataset.spanCount / 32), 1);
+    const focusFrontierCapacity = getTraceFocusFrontierCapacity(
+      dataset.spanCount,
+      dataset.dependencyCount
+    );
     const dependencyMaskByteLength = Math.max(dataset.dependencyCount, 1) * UINT32_BYTE_LENGTH;
     const densityBinCount = TRACE_LANE_COUNT * TRACE_DENSITY_BIN_COUNT;
     const topologyChunkLengths = getTopologyChunkLengths(dataset.spanCount);
@@ -783,7 +789,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       spanCount: dataset.spanCount,
       spanBatchCount: dataset.spanBatches.length,
       dependencyBatchCount: dataset.dependencyBatches.length,
-      dependencyCount: dataset.dependencyCount
+      dependencyCount: dataset.dependencyCount,
+      focusFrontierCapacity
     };
   }
 
@@ -1044,7 +1051,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     const focusFrontiers = [0, 1].map(index =>
       graph.createTransientBuffer({
         id: `trace-focus-frontier-${index}`,
-        byteLength: Math.max(resources.spanCount, 1) * UINT32_BYTE_LENGTH,
+        byteLength: resources.focusFrontierCapacity * UINT32_BYTE_LENGTH,
         usage: Buffer.STORAGE
       })
     );
@@ -1123,6 +1130,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
             id: `trace-focus-frontier-${depth}-${direction.name}-${partitionIndex}`,
             source: getFocusFrontierExpansionShader({
               spanCount: resources.spanCount,
+              frontierCapacity: resources.focusFrontierCapacity,
               sourceNodeBase,
               sourceNodeCount,
               offsetWordBase,

--- a/examples/experimental/gpu-trace-viewer/trace-data.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-data.ts
@@ -83,6 +83,17 @@ export function getTraceDependencyCapacityOptions(
   ];
 }
 
+/**
+ * Returns the maximum number of unique spans that one dependency traversal can discover.
+ *
+ * Every reached span after the seed requires at least one dependency, so sparse traces do not
+ * need span-sized frontier allocations. One word is retained for an empty trace because WebGPU
+ * buffers cannot be empty.
+ */
+export function getTraceFocusFrontierCapacity(spanCount: number, dependencyCount: number): number {
+  return Math.max(Math.min(spanCount, dependencyCount + 1), 1);
+}
+
 /** Matches the GPU's adaptive exact-span versus density-rendering decision. */
 export function isTraceDensityMode(
   timeMin: number,

--- a/examples/experimental/gpu-trace-viewer/trace-data.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-data.ts
@@ -150,13 +150,21 @@ export type TraceDependencyBatchData = {
   familyMask: number;
 };
 
-/** Compact forward or reverse compressed sparse dependency adjacency. */
+/** Compact forward or reverse adjacency containing rows only for nodes that own edges. */
 export type TraceAdjacencyData = {
-  /** One stable offset per source node plus the final edge count. */
+  /** Sorted stable global span IDs for rows that own at least one edge. */
+  nodes: Uint32Array;
+  /** One stable offset per sparse row plus the final edge count. */
   offsets: Uint32Array;
   /** Stable destination span indices in source edge order. */
   neighbors: Uint32Array;
 };
+
+/** Worst-case storage for both sparse adjacency directions at a dependency capacity. */
+export function getMaximumTraceAdjacencyByteLength(dependencyCount: number): number {
+  const maximumWordCount = dependencyCount * 6 + 2;
+  return maximumWordCount * Uint32Array.BYTES_PER_ELEMENT;
+}
 
 /** GPU-upload-ready trace source data and hierarchy-preserving graph topology. */
 export type TraceDatasetData = {
@@ -256,8 +264,8 @@ export function makeTraceDataset(
     dependencyBatches,
     dependencyBatchIndex,
     parentSpans: topology.parentSpans,
-    outgoing: buildTraceAdjacency(totalSpanCount, topology.dependencies, 'outgoing'),
-    incoming: buildTraceAdjacency(totalSpanCount, topology.dependencies, 'incoming'),
+    outgoing: buildTraceAdjacency(topology.dependencies, 'outgoing'),
+    incoming: buildTraceAdjacency(topology.dependencies, 'incoming'),
     spanCount: totalSpanCount,
     dependencyCount,
     processCount: TRACE_PROCESS_COUNT,
@@ -628,29 +636,35 @@ function writeTraceDependency(
 
 /** Builds stable compressed sparse rows without materializing per-node edge arrays. */
 function buildTraceAdjacency(
-  nodeCount: number,
   dependencies: Uint32Array,
   direction: 'outgoing' | 'incoming'
 ): TraceAdjacencyData {
-  const offsets = new Uint32Array(nodeCount + 1);
   const edgeCount = dependencies.length / TRACE_DEPENDENCY_RECORD_WORD_LENGTH;
   const sourceWord = direction === 'outgoing' ? 0 : 1;
   const destinationWord = direction === 'outgoing' ? 1 : 0;
+  const edgeCounts = new Map<number, number>();
 
   for (let edgeIndex = 0; edgeIndex < edgeCount; edgeIndex++) {
     const source = dependencies[edgeIndex * TRACE_DEPENDENCY_RECORD_WORD_LENGTH + sourceWord];
-    offsets[source + 1]++;
+    edgeCounts.set(source, (edgeCounts.get(source) || 0) + 1);
   }
-  for (let nodeIndex = 0; nodeIndex < nodeCount; nodeIndex++) {
-    offsets[nodeIndex + 1] += offsets[nodeIndex];
+
+  const nodes = Uint32Array.from(edgeCounts.keys()).sort();
+  const offsets = new Uint32Array(nodes.length + 1);
+  const rowByNode = new Map<number, number>();
+  for (let rowIndex = 0; rowIndex < nodes.length; rowIndex++) {
+    const node = nodes[rowIndex];
+    rowByNode.set(node, rowIndex);
+    offsets[rowIndex + 1] = offsets[rowIndex] + (edgeCounts.get(node) || 0);
   }
 
   const neighbors = new Uint32Array(edgeCount);
-  const cursors = offsets.slice(0, nodeCount);
+  const cursors = offsets.slice(0, nodes.length);
   for (let edgeIndex = 0; edgeIndex < edgeCount; edgeIndex++) {
     const wordOffset = edgeIndex * TRACE_DEPENDENCY_RECORD_WORD_LENGTH;
     const source = dependencies[wordOffset + sourceWord];
-    neighbors[cursors[source]++] = dependencies[wordOffset + destinationWord];
+    const rowIndex = rowByNode.get(source)!;
+    neighbors[cursors[rowIndex]++] = dependencies[wordOffset + destinationWord];
   }
-  return {offsets, neighbors};
+  return {nodes, offsets, neighbors};
 }

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -182,7 +182,8 @@ struct VertexOutput {
   let laneY = 1.0 - ((f32(lane) - viewUniforms.laneMin) / laneRange) * 2.0;
   let pulse = 0.84 + 0.16 * sin(span.start * 0.13 + f32(lane) * 0.31);
   let isSelected = sourceIndex == viewUniforms.selectedSpanIndex;
-  let isReached = reachedSpans[sourceIndex] == viewUniforms.visibilityGeneration;
+  let isReached =
+    (reachedSpans[sourceIndex >> 5u] & (1u << (sourceIndex & 31u))) != 0u;
   let hasSelection = viewUniforms.selectedSpanIndex != 0xffffffffu;
   let focusOpacity = select(1.0, select(0.22, 1.0, isReached), hasSelection);
   let baseColor = getGroupColor(span.group) * pulse;
@@ -365,7 +366,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
 }`;
 }
 
-/** Seeds a generation-tagged compact focus frontier and its first indirect dispatch. */
+/** Seeds a bit-packed compact focus frontier and its first indirect dispatch. */
 export function getFocusFrontierSeedShader(spanCount: number): string {
   return /* wgsl */ `
 const SPAN_COUNT: u32 = ${spanCount}u;
@@ -383,7 +384,7 @@ fn main() {
   var count = 0u;
   let seed = selectedSeeds[0];
   if (activeSeedCount[0] != 0u && seed < SPAN_COUNT) {
-    atomicStore(&reachedSpans[seed], focusTraversalState[1]);
+    atomicOr(&reachedSpans[seed >> 5u], 1u << (seed & 31u));
     frontier[0] = seed;
     count = 1u;
   }
@@ -391,6 +392,20 @@ fn main() {
   dispatchCommand[0] = (count + WORKGROUP_SIZE - 1u) / WORKGROUP_SIZE;
   dispatchCommand[1] = 1u;
   dispatchCommand[2] = 1u;
+}`;
+}
+
+/** Clears the compact focus-reachability bitset before the next traversal. */
+export function getFocusReachabilityClearShader(wordCount: number): string {
+  return /* wgsl */ `
+const WORD_COUNT: u32 = ${wordCount}u;
+@group(0) @binding(0) var<storage, read_write> reachedSpans: array<u32>;
+
+@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  if (globalId.x < WORD_COUNT) {
+    reachedSpans[globalId.x] = 0u;
+  }
 }`;
 }
 
@@ -409,7 +424,7 @@ fn main() {
 }`;
 }
 
-/** Expands one CSR partition from a compact frontier into a generation-tagged next frontier. */
+/** Expands one CSR partition from a compact frontier into a bit-packed next frontier. */
 export function getFocusFrontierExpansionShader(options: {
   spanCount: number;
   sourceNodeBase: number;
@@ -451,9 +466,9 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let lastNeighbor = min(offsets[OFFSET_WORD_BASE + localSourceIndex + 1u], NEIGHBOR_COUNT);
   for (var neighborIndex = firstNeighbor; neighborIndex < lastNeighbor; neighborIndex++) {
     let neighbor = neighbors[NEIGHBOR_WORD_BASE + neighborIndex];
+    let reachedMask = 1u << (neighbor & 31u);
     if (neighbor < SPAN_COUNT &&
-      atomicExchange(&reachedSpans[neighbor], focusTraversalState[1]) !=
-        focusTraversalState[1]) {
+      (atomicOr(&reachedSpans[neighbor >> 5u], reachedMask) & reachedMask) == 0u) {
       let nextIndex = atomicAdd(&nextFrontierCount[0], 1u);
       if (nextIndex < SPAN_COUNT) {
         nextFrontier[nextIndex] = neighbor;
@@ -579,7 +594,7 @@ fn main(
   let focusEnabled =
     viewUniforms.focusMode != 0u && viewUniforms.selectedSpanIndex != 0xffffffffu;
   let focusVisible = !focusEnabled ||
-    reachedSpans[sourceIndex] == viewUniforms.visibilityGeneration;
+    (reachedSpans[sourceIndex >> 5u] & (1u << (sourceIndex & 31u))) != 0u;
   let densityVisible = sourceVisible && (isDensityMode() || !processExpanded);
   if (densityVisible && focusVisible) {
     let timeRange = max(viewUniforms.timeMax - viewUniforms.timeMin, 0.0001);
@@ -677,7 +692,7 @@ fn main(
   let focusEnabled =
     viewUniforms.focusMode != 0u && viewUniforms.selectedSpanIndex != 0xffffffffu;
   let focusVisible = !focusEnabled ||
-    reachedSpans[sourceIndex] == viewUniforms.visibilityGeneration;
+    (reachedSpans[sourceIndex >> 5u] & (1u << (sourceIndex & 31u))) != 0u;
   visibilityFlags[sourceIndex - CHUNK_FIRST_SPAN_INDEX] = select(
     0u,
     viewUniforms.visibilityGeneration,

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -428,7 +428,7 @@ fn main() {
 export function getFocusFrontierExpansionShader(options: {
   spanCount: number;
   frontierCapacity: number;
-  sourceNodeBase: number;
+  nodeWordBase: number;
   sourceNodeCount: number;
   offsetWordBase: number;
   neighborWordBase: number;
@@ -438,13 +438,13 @@ export function getFocusFrontierExpansionShader(options: {
   return /* wgsl */ `
 const SPAN_COUNT: u32 = ${options.spanCount}u;
 const FRONTIER_CAPACITY: u32 = ${options.frontierCapacity}u;
-const SOURCE_NODE_BASE: u32 = ${options.sourceNodeBase}u;
+const NODE_WORD_BASE: u32 = ${options.nodeWordBase}u;
 const SOURCE_NODE_COUNT: u32 = ${options.sourceNodeCount}u;
 const OFFSET_WORD_BASE: u32 = ${options.offsetWordBase}u;
 const NEIGHBOR_WORD_BASE: u32 = ${options.neighborWordBase}u;
 const NEIGHBOR_COUNT: u32 = ${options.neighborCount}u;
 const DEPTH: u32 = ${options.depth}u;
-@group(0) @binding(0) var<storage, read> offsets: array<u32>;
+@group(0) @binding(0) var<storage, read> topology: array<u32>;
 @group(0) @binding(1) var<storage, read> neighbors: array<u32>;
 @group(0) @binding(2) var<storage, read> frontier: array<u32>;
 @group(0) @binding(3) var<storage, read> frontierCount: array<u32>;
@@ -453,6 +453,24 @@ const DEPTH: u32 = ${options.depth}u;
 @group(0) @binding(6) var<storage, read_write> reachedSpans: array<atomic<u32>>;
 @group(0) @binding(7) var<storage, read> focusTraversalState: array<u32>;
 
+fn findSparseRow(sourceIndex: u32) -> u32 {
+  var low = 0u;
+  var high = SOURCE_NODE_COUNT;
+  while (low < high) {
+    let middle = low + (high - low) / 2u;
+    let node = topology[NODE_WORD_BASE + middle];
+    if (node < sourceIndex) {
+      low = middle + 1u;
+    } else {
+      high = middle;
+    }
+  }
+  if (low < SOURCE_NODE_COUNT && topology[NODE_WORD_BASE + low] == sourceIndex) {
+    return low;
+  }
+  return 0xffffffffu;
+}
+
 @compute @workgroup_size(${TRACE_FOCUS_FRONTIER_WORKGROUP_SIZE})
 fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let frontierIndex = globalId.x;
@@ -460,12 +478,12 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
     return;
   }
   let sourceIndex = frontier[frontierIndex];
-  if (sourceIndex < SOURCE_NODE_BASE || sourceIndex - SOURCE_NODE_BASE >= SOURCE_NODE_COUNT) {
+  let localSourceIndex = findSparseRow(sourceIndex);
+  if (localSourceIndex == 0xffffffffu) {
     return;
   }
-  let localSourceIndex = sourceIndex - SOURCE_NODE_BASE;
-  let firstNeighbor = min(offsets[OFFSET_WORD_BASE + localSourceIndex], NEIGHBOR_COUNT);
-  let lastNeighbor = min(offsets[OFFSET_WORD_BASE + localSourceIndex + 1u], NEIGHBOR_COUNT);
+  let firstNeighbor = min(topology[OFFSET_WORD_BASE + localSourceIndex], NEIGHBOR_COUNT);
+  let lastNeighbor = min(topology[OFFSET_WORD_BASE + localSourceIndex + 1u], NEIGHBOR_COUNT);
   for (var neighborIndex = firstNeighbor; neighborIndex < lastNeighbor; neighborIndex++) {
     let neighbor = neighbors[NEIGHBOR_WORD_BASE + neighborIndex];
     let reachedMask = 1u << (neighbor & 31u);

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -427,6 +427,7 @@ fn main() {
 /** Expands one CSR partition from a compact frontier into a bit-packed next frontier. */
 export function getFocusFrontierExpansionShader(options: {
   spanCount: number;
+  frontierCapacity: number;
   sourceNodeBase: number;
   sourceNodeCount: number;
   offsetWordBase: number;
@@ -436,6 +437,7 @@ export function getFocusFrontierExpansionShader(options: {
 }): string {
   return /* wgsl */ `
 const SPAN_COUNT: u32 = ${options.spanCount}u;
+const FRONTIER_CAPACITY: u32 = ${options.frontierCapacity}u;
 const SOURCE_NODE_BASE: u32 = ${options.sourceNodeBase}u;
 const SOURCE_NODE_COUNT: u32 = ${options.sourceNodeCount}u;
 const OFFSET_WORD_BASE: u32 = ${options.offsetWordBase}u;
@@ -470,7 +472,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
     if (neighbor < SPAN_COUNT &&
       (atomicOr(&reachedSpans[neighbor >> 5u], reachedMask) & reachedMask) == 0u) {
       let nextIndex = atomicAdd(&nextFrontierCount[0], 1u);
-      if (nextIndex < SPAN_COUNT) {
+      if (nextIndex < FRONTIER_CAPACITY) {
         nextFrontier[nextIndex] = neighbor;
       }
     }

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -50,6 +50,7 @@ import {
   getFocusFrontierDispatchShader,
   getFocusFrontierExpansionShader,
   getFocusFrontierSeedShader,
+  getFocusReachabilityClearShader,
   getPickClearShader,
   getTraceDrawCommandsShader,
   TRACE_DENSITY_RENDER_SHADER,
@@ -292,6 +293,7 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
     getDependencyEndpointResolveShader(endpointRouting, 0),
     getDependencyEndpointResolveShader(endpointRouting, 1),
     getCandidateDependencyVisibilityShader(endpointRouting),
+    getFocusReachabilityClearShader(1),
     getFocusFrontierSeedShader(11),
     getFocusFrontierClearShader(),
     getFocusFrontierExpansionShader({

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -15,6 +15,7 @@ import {
 import {
   getTraceCapacityOptions,
   getTraceDependencyCapacityOptions,
+  getTraceFocusFrontierCapacity,
   isTraceDensityMode,
   makeTraceDataset,
   makeTraceDependencyBatches,
@@ -110,6 +111,25 @@ test('GPU trace capacity options adapt to negotiated WebGPU buffer limits', t =>
     getTraceCapacityOptions(1024 * 1024 * 1024, 1024 * 1024 * 1024),
     [250_000, 1_000_000, 4_000_000, 10_000_000],
     'maximum adapters expose the ten-million-span demonstration'
+  );
+  t.end();
+});
+
+test('GPU trace focus frontiers scale with reachable dependency population', t => {
+  t.equal(
+    getTraceFocusFrontierCapacity(100_000_000, 250_000),
+    250_001,
+    'a sparse 100M-span trace allocates one frontier entry per dependency plus its seed'
+  );
+  t.equal(
+    getTraceFocusFrontierCapacity(100_000_000, 100_000_000),
+    100_000_000,
+    'a dense trace retains enough capacity to reach every span'
+  );
+  t.equal(
+    getTraceFocusFrontierCapacity(0, 0),
+    1,
+    'an empty trace retains one allocation-safe frontier word'
   );
   t.end();
 });
@@ -298,6 +318,7 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
     getFocusFrontierClearShader(),
     getFocusFrontierExpansionShader({
       spanCount: 11,
+      frontierCapacity: 5,
       sourceNodeBase: 0,
       sourceNodeCount: 6,
       offsetWordBase: 0,

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -13,6 +13,7 @@ import {
   TRACE_BENCHMARK_SCENARIOS
 } from '../../examples/experimental/gpu-trace-viewer/trace-benchmark';
 import {
+  getMaximumTraceAdjacencyByteLength,
   getTraceCapacityOptions,
   getTraceDependencyCapacityOptions,
   getTraceFocusFrontierCapacity,
@@ -35,7 +36,8 @@ import {
   TRACE_SPAN_CHUNK_TARGET_BYTE_LENGTH,
   TRACE_SPAN_RECORD_WORD_LENGTH,
   TRACE_THREAD_COUNT,
-  TRACE_THREADS_PER_PROCESS
+  TRACE_THREADS_PER_PROCESS,
+  type TraceAdjacencyData
 } from '../../examples/experimental/gpu-trace-viewer/trace-data';
 import {
   getBatchVisibilityShader,
@@ -319,7 +321,7 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
     getFocusFrontierExpansionShader({
       spanCount: 11,
       frontierCapacity: 5,
-      sourceNodeBase: 0,
+      nodeWordBase: 0,
       sourceNodeCount: 6,
       offsetWordBase: 0,
       neighborWordBase: 0,
@@ -505,33 +507,49 @@ test('GPU trace data publishes stable forward and reverse dependency adjacency',
   t.ok(dataset.dependencyCount > 0, 'generates realistic sparse dependencies');
   t.equal(
     dataset.outgoing.offsets.length,
-    dataset.spanCount + 1,
-    'forward CSR owns one offset per span plus its sentinel'
+    dataset.outgoing.nodes.length + 1,
+    'forward CSR owns one offset per active source plus its sentinel'
   );
   t.equal(
     dataset.incoming.offsets.length,
-    dataset.spanCount + 1,
-    'reverse CSR owns one offset per span plus its sentinel'
+    dataset.incoming.nodes.length + 1,
+    'reverse CSR owns one offset per active destination plus its sentinel'
   );
   t.equal(
-    dataset.outgoing.offsets[dataset.spanCount],
+    dataset.outgoing.offsets[dataset.outgoing.nodes.length],
     dataset.dependencyCount,
     'forward sentinel equals the canonical dependency count'
   );
   t.equal(
-    dataset.incoming.offsets[dataset.spanCount],
+    dataset.incoming.offsets[dataset.incoming.nodes.length],
     dataset.dependencyCount,
     'reverse sentinel equals the canonical dependency count'
   );
+  t.ok(
+    dataset.outgoing.nodes.length <= dataset.dependencyCount &&
+      dataset.incoming.nodes.length <= dataset.dependencyCount,
+    'both directions allocate rows only for nodes that own edges'
+  );
+  for (const adjacency of [dataset.outgoing, dataset.incoming]) {
+    for (let rowIndex = 0; rowIndex < adjacency.nodes.length; rowIndex++) {
+      if (rowIndex > 0) {
+        t.ok(
+          adjacency.nodes[rowIndex] > adjacency.nodes[rowIndex - 1],
+          'sparse owner rows preserve strict global-ID order for GPU binary search'
+        );
+      }
+      t.ok(
+        adjacency.offsets[rowIndex + 1] > adjacency.offsets[rowIndex],
+        'every sparse owner row contains at least one dependency'
+      );
+    }
+  }
   for (let spanIndex = 0; spanIndex < dataset.spanCount; spanIndex++) {
     const parentSpanIndex = dataset.parentSpans[spanIndex];
     if (parentSpanIndex === TRACE_INVALID_SPAN_INDEX) {
       continue;
     }
-    const incoming = dataset.incoming.neighbors.subarray(
-      dataset.incoming.offsets[spanIndex],
-      dataset.incoming.offsets[spanIndex + 1]
-    );
+    const incoming = getTraceAdjacencyNeighbors(dataset.incoming, spanIndex);
     t.ok(incoming.includes(parentSpanIndex), 'canonical ancestry is backed by a real parent edge');
   }
 
@@ -543,14 +561,8 @@ test('GPU trace data publishes stable forward and reverse dependency adjacency',
     const destination = dataset.dependencies[wordOffset + 1];
     const family = dataset.dependencies[wordOffset + 2];
     const metadata = dataset.dependencies[wordOffset + 3];
-    const outgoing = dataset.outgoing.neighbors.subarray(
-      dataset.outgoing.offsets[source],
-      dataset.outgoing.offsets[source + 1]
-    );
-    const incoming = dataset.incoming.neighbors.subarray(
-      dataset.incoming.offsets[destination],
-      dataset.incoming.offsets[destination + 1]
-    );
+    const outgoing = getTraceAdjacencyNeighbors(dataset.outgoing, source);
+    const incoming = getTraceAdjacencyNeighbors(dataset.incoming, destination);
     t.ok(outgoing.includes(destination), 'forward CSR contains the canonical destination');
     t.ok(incoming.includes(source), 'reverse CSR contains the canonical source');
     t.equal(metadata & 0xff, TRACE_PARENT_DEPENDENCY_FLAG, 'parent classification remains numeric');
@@ -572,6 +584,16 @@ test('GPU trace data publishes stable forward and reverse dependency adjacency',
   }
   t.ok(sameProcessCount > 0, 'includes same-thread parent dependencies');
   t.ok(crossProcessCount > 0, 'includes cross-process parent dependencies');
+  t.equal(
+    getMaximumTraceAdjacencyByteLength(250_000),
+    6_000_008,
+    '250K dependencies need at most 6 MB of bidirectional sparse adjacency at any span count'
+  );
+  t.ok(
+    getMaximumTraceAdjacencyByteLength(250_000) * 100 <
+      2 * (100_000_000 + 1 + 250_000) * Uint32Array.BYTES_PER_ELEMENT,
+    '100M spans with 250K dependencies use over 100x less adjacency storage than dense CSR'
+  );
   t.end();
 });
 
@@ -588,7 +610,9 @@ test('GPU trace data handles empty inputs and rejects invalid capacities', t => 
     0,
     'empty traces have no dependency batch index records'
   );
+  t.deepEqual(Array.from(dataset.outgoing.nodes), [], 'empty forward CSR has no active rows');
   t.deepEqual(Array.from(dataset.outgoing.offsets), [0], 'empty forward CSR has a sentinel');
+  t.deepEqual(Array.from(dataset.incoming.nodes), [], 'empty reverse CSR has no active rows');
   t.deepEqual(Array.from(dataset.incoming.offsets), [0], 'empty reverse CSR has a sentinel');
   t.throws(() => makeTraceDataset(-1), /nonnegative uint32/, 'negative capacity is rejected');
   t.throws(() => makeTraceDataset(1.5), /nonnegative uint32/, 'fractional capacity is rejected');
@@ -599,3 +623,10 @@ test('GPU trace data handles empty inputs and rejects invalid capacities', t => 
   );
   t.end();
 });
+
+function getTraceAdjacencyNeighbors(adjacency: TraceAdjacencyData, node: number): Uint32Array {
+  const rowIndex = adjacency.nodes.indexOf(node);
+  return rowIndex < 0
+    ? adjacency.neighbors.subarray(0, 0)
+    : adjacency.neighbors.subarray(adjacency.offsets[rowIndex], adjacency.offsets[rowIndex + 1]);
+}

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -55,6 +55,7 @@ describe('GPU hierarchical trace viewer', () => {
           dependencyResults: {readAsync: () => Promise<Uint8Array>};
           densityBins: {readAsync: () => Promise<Uint8Array>};
           reachedSpans: {
+            byteLength: number;
             readAsync: (byteOffset?: number, byteLength?: number) => Promise<Uint8Array>;
           };
           dependencyCount: number;
@@ -321,13 +322,15 @@ describe('GPU hierarchical trace viewer', () => {
       expect(focusedCounts[1] + focusedCounts[5] + focusedCounts[9]).toBeLessThanOrEqual(
         firstCounts[1] + firstCounts[5] + firstCounts[9]
       );
+      expect(state.resources.reachedSpans.byteLength).toBe(
+        Math.ceil(state.resources.spanCount / 32) * Uint32Array.BYTES_PER_ELEMENT
+      );
       const reachedBytes = await state.resources.reachedSpans.readAsync(
-        29 * Uint32Array.BYTES_PER_ELEMENT,
+        0,
         Uint32Array.BYTES_PER_ELEMENT
       );
-      expect(new Uint32Array(reachedBytes.buffer, reachedBytes.byteOffset, 1)[0]).toBe(
-        state.frameIndex
-      );
+      const reachedWord = new Uint32Array(reachedBytes.buffer, reachedBytes.byteOffset, 1)[0];
+      expect(reachedWord & (1 << 29)).not.toBe(0);
       focusOnly!.checked = false;
       focusOnly!.dispatchEvent(new Event('change', {bubbles: true}));
       expect(state.focusOnly).toBe(false);

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -7,6 +7,7 @@ import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import {describe, expect, test} from 'vitest';
 import GPUTraceViewerAnimationLoopTemplate from '../../examples/experimental/gpu-trace-viewer/app';
 import {
+  getTraceFocusFrontierCapacity,
   TRACE_COLLAPSED_STATE,
   TRACE_DENSITY_BIN_COUNT,
   TRACE_FILTER_HIDE_OVERLAPPING_CHILDREN,
@@ -59,6 +60,7 @@ describe('GPU hierarchical trace viewer', () => {
             readAsync: (byteOffset?: number, byteLength?: number) => Promise<Uint8Array>;
           };
           dependencyCount: number;
+          focusFrontierCapacity: number;
           spanCount: number;
           spanBatchCount: number;
           dependencyBatchCount: number;
@@ -86,6 +88,12 @@ describe('GPU hierarchical trace viewer', () => {
       expect(state.resources.spanCount).toBe(4096);
       expect(state.resources.spanBatchCount).toBeGreaterThan(0);
       expect(state.resources.dependencyCount).toBeGreaterThan(0);
+      expect(state.resources.focusFrontierCapacity).toBe(
+        getTraceFocusFrontierCapacity(
+          state.resources.spanCount,
+          state.resources.dependencyCount
+        )
+      );
       expect(state.resources.dependencyBatchCount).toBeGreaterThan(0);
       expect(host.querySelectorAll('[data-process]')).toHaveLength(TRACE_PROCESS_COUNT);
       expect(host.querySelectorAll('[data-thread]')).toHaveLength(TRACE_THREAD_COUNT);

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -89,10 +89,7 @@ describe('GPU hierarchical trace viewer', () => {
       expect(state.resources.spanBatchCount).toBeGreaterThan(0);
       expect(state.resources.dependencyCount).toBeGreaterThan(0);
       expect(state.resources.focusFrontierCapacity).toBe(
-        getTraceFocusFrontierCapacity(
-          state.resources.spanCount,
-          state.resources.dependencyCount
-        )
+        getTraceFocusFrontierCapacity(state.resources.spanCount, state.resources.dependencyCount)
       );
       expect(state.resources.dependencyBatchCount).toBeGreaterThan(0);
       expect(host.querySelectorAll('[data-process]')).toHaveLength(TRACE_PROCESS_COUNT);


### PR DESCRIPTION
## Goals

- Keep dependency focus practical as logical trace capacity approaches 100 million spans.
- Remove focus allocations that scale with all spans when the dependency graph is sparse.
- Preserve stable source IDs, bidirectional traversal, filtering, compaction, and indirect rendering.

## Changes

- Store focus reachability as a packed bitset instead of one generation word per span.
- Bound both compact focus frontiers by `min(spanCount, dependencyCount + 1)`.
- Replace dense incoming and outgoing CSR rows with sorted sparse owner rows.
- Pack sparse owner IDs and partition-local offsets into one topology binding so traversal remains within portable WebGPU limits.
- Use partition-local GPU binary search to resolve stable global span IDs.
- Add behavioral, empty-input, shader-reflection, portability, and 100M-span memory-contract coverage.

At 100 million spans and 250,000 dependencies, the focus frontier reservation falls from roughly 800 MB to about 2 MB, while bidirectional adjacency falls from roughly 802 MB to at most 6.1 MB.

## Verification

- `nvm use`
- Direct Biome formatting of the affected files with the repository's formatting conventions
- Strict TypeScript check of the changed trace data and shader modules
- WGSL reflection, including the portable eight-storage-binding limit
- Exhaustive forward/reverse validation of every generated dependency edge
- `git diff --check`

The root Yarn gates could not run locally because this worktree lacks a current `node_modules` install state, and the configured registry rejected the missing dependency artifacts. GitHub CI is expected to run the complete repository gates.
