### PR TITLE
feat(experimental): add GPU graph core numbers and modularity

### DIFF
--- a/docs/api-reference/experimental/README.md
+++ b/docs/api-reference/experimental/README.md
@@ -144,14 +144,20 @@ visibility, flat scenes, and indirect rendering without adding trace concepts to
 [`@luma.gl/experimental/lugraph`](/docs/api-reference/experimental/lugraph) turns existing GPU
 edge columns into reusable compressed adjacency, vertex degrees, unweighted and nonnegative
 weighted shortest paths, weakly connected components, label-propagation communities, local
-clustering coefficients, and dangling-aware PageRank scores. Social networks, dependency graphs,
-transaction investigations, and infrastructure maps can compose those operations into one WebGPU
-command graph without copying source batches or reading complete results back to JavaScript.
+clustering coefficients, durable core numbers, community modularity scores, and dangling-aware
+PageRank scores. Social networks, dependency graphs, transaction investigations, and
+infrastructure maps can compose those operations into one WebGPU command graph without copying
+source batches or reading complete results back to JavaScript.
 The [interactive graph explorer](/examples/experimental/lugraph-explorer) adds directly renderable
 exact force-layout coordinates, neighborhood highlighting, stable GPU picking, dragging, and pinning.
 An opt-in live benchmark compares nine actual CPU and WebGPU graph workloads across five graph
-families, covering all six Graphalytics workload families while reporting command encoding,
-completion fences, setup costs, and layout accuracy.
+families, covering all six
+[LDBC Graphalytics algorithm families](https://ldbcouncil.org/benchmarks/graphalytics/algorithms/)
+defined by the [Graph Data Council (GDC)](https://ldbcouncil.org/) while reporting command
+encoding, completion fences, setup costs, and layout accuracy. The council was formerly the Linked
+Data Benchmark Council (LDBC); its benchmark name remains LDBC Graphalytics. Core numbers and
+modularity extend beyond those six families. Feature coverage and the local benchmark do not
+claim an official submission, certification, or published result.
 
 ## GPU-Resident Dataframes
 

--- a/docs/api-reference/experimental/lugraph.md
+++ b/docs/api-reference/experimental/lugraph.md
@@ -11,16 +11,19 @@ import {LuGraphExplorerExample} from '@site/src/examples';
 A graph answers questions that individual table rows cannot: which accounts share a transaction,
 which services depend on a failed service, which people are two introductions apart, which tightly
 connected groups exist inside a wider network, which route has the lowest actual travel cost, how
-closely somebody's friends know one another, and which pages matter because other important pages
-link to them. Vertices represent those entities; edges represent their relationships.
+closely somebody's friends know one another, which network members form a durable structural
+backbone, whether a proposed community grouping is actually meaningful, and which pages matter
+because other important pages link to them. Vertices represent those entities; edges represent
+their relationships.
 
 `@luma.gl/experimental/lugraph` answers these questions directly on a browser WebGPU device. It
 describes caller-owned GPU edge columns, builds reusable compressed adjacency, and publishes vertex
 degrees, unweighted shortest-path neighborhoods, weighted least-cost routes, weakly connected
-groups, densely connected communities, per-vertex local clustering, PageRank importance, and
-progressive two-dimensional graph layouts into caller-owned GPU buffers. Layout can evaluate every
-repulsive interaction exactly or explicitly approximate distant groups through a caller-owned
-uniform grid. Every operation composes with the existing `GPUCommandGraph`.
+groups, densely connected communities, per-vertex local clustering, structural core numbers,
+community modularity scores, PageRank importance, and progressive two-dimensional graph layouts
+into caller-owned GPU buffers. Layout can evaluate every repulsive interaction exactly or
+explicitly approximate distant groups through a caller-owned uniform grid. Every operation
+composes with the existing `GPUCommandGraph`.
 
 This is an experimental, headless graph analytics API, not a graph database, visualization
 framework, file importer, or general-purpose dataframe. Applications decide how data reaches the
@@ -71,7 +74,8 @@ buffer, which is simultaneously writable storage and a render vertex attribute. 
 shaders consume the actual community, component, PageRank, and degree buffers. Original source
 edge batches, including the intentionally empty middle batch, are never concatenated or repacked.
 Weighted shortest paths and local clustering are separate reusable graph operations and benchmark
-workloads; the existing example does not claim to expose them as additional explorer controls.
+workloads. Core decomposition and modularity scoring are additional reusable operations beyond
+the benchmark; the existing example does not claim to expose any of them as explorer controls.
 
 Automatic layout selects distinct, honestly bounded GPU workloads:
 
@@ -180,7 +184,9 @@ local clustering coefficients, PageRank, exact force layout, and explicitly appr
 uniform-grid force layout. The six Graphalytics workload families are represented, alongside
 adjacency construction and two visualization-oriented layouts. These bounded demonstrations are not
 million-vertex benchmarks; dense graphs, local triangle counting, and exact force layout can
-require much more work than sparse traversal.
+require much more work than sparse traversal. Structural core decomposition and partition
+modularity extend the reusable graph API beyond these six standardized families and nine measured
+paths; they are not silently counted as additional benchmark results.
 
 ### Read each timing without hiding its costs
 
@@ -258,7 +264,8 @@ luGraph keeps the complete intermediate pipeline on one WebGPU device:
 ```text
 Existing GPU edge columns
     -> compressed adjacency
-    -> degree / weighted paths / local clustering / communities / PageRank / force layout
+    -> degree / core numbers / weighted paths / local clustering / communities / PageRank
+    -> partition modularity / directly renderable force-layout positions
     -> caller-owned GPU result columns and directly renderable positions
 ```
 
@@ -279,14 +286,17 @@ combine graph analytics with further GPU work:
 
 - **Social and communication networks:** count contacts, highlight friends within a bounded number
   of introductions, distinguish friend circles within connected networks, measure whether each
-  person's friends also know one another, group disconnected networks, rank influential accounts,
-  and arrange connected people into a readable map.
+  person's friends also know one another, identify mutually supported network cores, compare
+  proposed community partitions, group disconnected networks, rank influential accounts, and
+  arrange connected people into a readable map.
 - **Software and service dependencies:** follow incoming or outgoing dependency chains, find
   isolated dependency islands, reveal tightly linked ownership groups, identify unusually closed
   service clusters, and compare dependency paths by latency, risk, or recovery cost.
 - **Transaction and fraud investigations:** follow transfers around a selected account, identify
   coordinated clusters inside a larger connected group of counterparties, distinguish locally
-  interlinked transaction rings from simple hubs, and prioritize structurally important entities.
+  interlinked transaction rings from simple hubs, expose resilient fraud-ring backbones, compare
+  whether suggested groups retain more transaction weight than expected, and prioritize
+  structurally important entities.
 - **Transport and infrastructure maps:** inspect junction degree, compare routes by nonnegative
   travel time or distance, distinguish cheapest routes from fewest transfers, and find disconnected
   subnetworks and relationship-driven importance across a network.
@@ -304,20 +314,43 @@ other unsupported features above.
 
 ## What does complete Graphalytics workload coverage mean?
 
-Graphalytics describes six widely recognized graph-analysis workload families. luGraph now supplies
-an actual browser-GPU contributor for each: **breadth-first search (BFS)**, **single-source shortest
-paths (SSSP)**, **weakly connected components (WCC)**, **community detection by label propagation
-(CDLP)**, **local clustering coefficient (LCC)**, and **PageRank (PR)**. This is useful because the
-same resident adjacency can answer reachability, least-cost routing, connectivity, community,
-neighborhood-density, and influence questions without a CPU round trip between operations.
+The [Graph Data Council (GDC)](https://ldbcouncil.org/) is a nonprofit graph-data community that
+defines reproducible graph benchmarks and contributes to graph standards. Before 2025 it was
+called the **Linked Data Benchmark Council (LDBC)**; its established benchmark suite still retains
+the LDBC name. Its [LDBC Graphalytics benchmark](https://ldbcouncil.org/benchmarks/graphalytics/)
+compares graph-analysis platforms using clearly defined algorithms, reference datasets, expected
+outputs, and published execution rules.
+
+The council's [six official Graphalytics algorithm families](https://ldbcouncil.org/benchmarks/graphalytics/algorithms/)
+cover **breadth-first search (BFS)**, **single-source shortest paths (SSSP)**,
+**weakly connected components (WCC)**, **community detection by label propagation (CDLP)**,
+**local clustering coefficient (LCC)**, and **PageRank (PR)**. luGraph supplies an actual
+browser-GPU contributor for each. This is useful because the same resident adjacency can answer
+reachability, least-cost routing, connectivity, community, neighborhood-density, and influence
+questions without a CPU round trip between operations. Its core decomposition and modularity scoring
+add useful graph analysis **beyond** those six standardized workload families; they are not
+additional Graphalytics workloads.
+
+To understand what a formal comparison additionally requires, consult the council's
+[real and synthetic reference datasets](https://ldbcouncil.org/benchmarks/graphalytics/datasets/),
+[open-source Graphalytics driver](https://github.com/ldbc/ldbc_graphalytics),
+[benchmark specification and algorithm definitions](https://github.com/ldbc/ldbc_graphalytics_docs),
+and [competition and validation rules](https://ldbcouncil.org/benchmarks/graphalytics/rules/).
+The published datasets include small directed and undirected reference fixtures as well as much
+larger real and synthetic graphs; vertex and edge data are also available in Parquet format.
+Formal benchmark comparisons require the prescribed datasets and reference outputs, documented
+algorithm and hardware configurations, repeated runs, and organizer review and reproducibility.
+The rules permit single-node, GPU-based, and partial implementations, so browser WebGPU can
+meaningfully join the same technical conversation without becoming an official result by default.
 
 Workload-family coverage is not a claim of official Graphalytics certification, identical reference
 configuration, distributed execution, comparable published scores, or performance parity with
 another framework. Each operation retains its actual WebGPU contracts: routing accepts nonnegative
 single-precision weights, label propagation is a bounded deterministic heuristic, clustering
 counts distinct directed weak-neighborhood closures, and fixed iteration budgets do not
-automatically prove convergence. Use the live benchmark to inspect real bounded CPU/GPU runs on
-your own device.
+automatically prove convergence. The embedded local benchmark uses its own deterministic graph
+families and CPU references; it is not the official driver, an audited submission, or a
+published Graphalytics score. Use it to inspect real bounded CPU/GPU runs on your own device.
 
 ## Choose the right graph operation
 
@@ -326,11 +359,13 @@ your own device.
 | `LuGraph` | Which GPU columns describe the graph? | Borrowed graph metadata and original chunks | Metadata only; no GPU dispatch |
 | `LuGraphTopology` | Which vertices are adjacent? | Forward and optional reverse compressed adjacency | `O(V + E)` |
 | `LuGraphDegree` | How many relationships touch each vertex in one direction? | One `uint32` degree per vertex | `O(V)` after adjacency exists |
+| `LuGraphCoreNumber` | Which vertices remain inside increasingly cohesive network backbones? | One `uint32` core number per vertex and an optional maximum | At most `O(K × sum(degree² × log(degree + 1)))` for `K` bounded rounds |
 | `LuGraphLocalClusteringCoefficient` | How closely are each vertex's neighbors connected to one another? | One `float32` coefficient and optional triangle count per vertex | At most `O(sum(degree³))` with unsorted adjacency |
 | `LuGraphBreadthFirstSearch` | Which vertices are within a chosen number of unweighted hops? | Distances, deterministic predecessors, and an optional selection mask | At most `O(D × (V + E))` for `D` compiled hops |
 | `LuGraphSingleSourceShortestPath` | Which routes have the lowest nonnegative total edge cost from a selected source? | One `float32` distance and deterministic predecessor per vertex | At most `O(K × (V + E))` for `K` bounded relaxations |
 | `LuGraphConnectedComponents` | Which vertices belong to the same weakly connected group? | One `uint32` component identifier per vertex | At most `O(K × (V + E))` for `K` bounded iterations |
 | `LuGraphLabelPropagation` | Which densely connected communities exist inside a connected network? | One deterministic `uint32` community label per vertex | At most `O(K × sum(degree²))` for `K` bounded iterations |
+| `LuGraphModularity` | Does an existing partition contain more internal relationship weight than chance predicts? | One `float32` partition-quality score and optional per-community contributions | `O(V + E)` |
 | `LuGraphPageRank` | Which vertices receive influence from other important vertices? | One normalized `float32` score per vertex | `O(K × (V + E))` for `K` iterations |
 | `LuGraphForceLayout` | How can related vertices be positioned as a readable network? | Directly renderable `float32x2` positions and persistent velocities | `O(V² + E)` per exact force iteration |
 | `LuGraphSpatialForceLayout` | Can distant graph regions be approximated while nearby relationships remain exact? | The existing renderable layout positions plus explicit uniform-grid diagnostics | `Θ(V × G + P + E)` per spatial force iteration |
@@ -416,9 +451,10 @@ Every shown output is an existing, caller-owned, single-chunk `GPUVector<'uint32
 each configured adjacency also requires a matching `float32` edge-weight output.
 
 Build reverse adjacency when a directed graph needs incoming-degree queries, incoming or
-bidirectional breadth-first search, weak-neighborhood community or local-clustering analysis, or
-PageRank. Directed weak components use forward adjacency alone, as do outgoing weighted shortest
-paths. Undirected graphs use one symmetric forward adjacency and must not provide reverse adjacency.
+bidirectional breadth-first search, weak-neighborhood community, core-number, or local-clustering
+analysis, or PageRank. Directed weak components use forward adjacency alone, as do outgoing
+weighted shortest paths. Modularity reads original edge columns directly and needs no adjacency.
+Undirected graphs use one symmetric forward adjacency and must not provide reverse adjacency.
 
 Invalid endpoints are excluded and counted. `count` reports the complete number of accepted
 adjacency entries even if neighbor capacity is insufficient; `overflow` makes truncation explicit.
@@ -450,6 +486,66 @@ Degrees come from complete CSR offsets rather than the capacity-bounded neighbor
 remain exact even when the corresponding adjacency reports neighbor overflow. Degree is useful
 when raw connectivity is the question; it does not account for whether a vertex's neighbors are
 themselves important.
+
+## Find durable network backbones with LuGraphCoreNumber
+
+**Question: Which vertices stay connected to a mutually supportive group after peripheral
+relationships disappear?**
+
+`LuGraphCoreNumber` separates a genuinely cohesive network backbone from a vertex that merely has
+many fragile spokes. A vertex belongs to the **k-core** when it remains in a largest subgraph where
+every remaining vertex has at least `k` other remaining neighbors; its core number is the highest
+such `k`. An isolated vertex has core number zero.
+
+Consider a popular account with 100 followers who do not follow one another. Its degree is 100,
+but the account and every follower have core number one: remove the leaves and no mutually
+supporting dense group remains. A four-person clique instead has core number three for each
+member. Use core decomposition to find resilient social backbones, tightly sustained fraud rings,
+interdependent service groups, or the stable center of a citation network. Choose vertex degree
+for immediate popularity, local clustering for connections among one vertex's neighbors, community
+labels for a proposed group assignment, and core numbers for repeated structural support.
+
+```ts
+import {LuGraphCoreNumber} from '@luma.gl/experimental/lugraph';
+
+const cores = new LuGraphCoreNumber({
+  topology,
+  output: coreNumbers,
+  iterations: 32,
+  converged: coresConverged,
+  degeneracy: maximumCoreNumber
+});
+
+cores.addToGraph(workflow);
+```
+
+`output` is a caller-owned, packed `GPUVector<'uint32'>` with exactly one row per vertex. The
+optional one-row `converged` output becomes one only when the final synchronized refinement proves
+that no core estimate changed. The optional one-row `degeneracy` output receives the maximum
+published core number, describing the deepest available graph core. When convergence is zero,
+both the per-vertex values and the maximum are **upper bounds**, not proven exact answers.
+
+The operation explicitly projects all relationships into a **simple undirected weak graph**. A
+distinct incoming or outgoing neighbor counts once; reciprocal directed edges and parallel edges
+do not increase support, self-loops do not make a vertex support itself, and edge weights do not
+change structural core membership. This directed convention is not interchangeable with an
+in-degree-plus-out-degree convention that counts reciprocal incidences separately. Directed
+graphs require complete forward and reverse CSR; undirected graphs reuse symmetric forward CSR.
+
+Each vertex starts at its distinct weak-neighbor degree. Every bounded round simultaneously
+replaces that upper estimate with the H-index of its neighbors' preceding estimates: the largest
+`k` for which at least `k` distinct neighbors still have estimates of at least `k`. The default is
+`32` rounds; `iterations` may be any integer from `0` through `1024`. Zero rounds publish the
+initial unique-neighbor degrees and conservatively leave convergence unproven unless the graph has
+no edges. An empty graph has no core rows, convergence one, and optional degeneracy zero. There
+is no automatic early termination, CPU synchronization, or implicit result readback.
+
+If either required CSR neighbor allocation overflows, every core number and the optional
+degeneracy become `0xffffffff`, and optional convergence becomes zero. For `K` configured rounds
+and distinct weak degree `d`, unsorted CSR deduplication and H-index selection require worst-case
+`O(K × sum(d² × log(d + 1)))` work. The implementation needs `O(V)` graph-owned scratch, plus an
+optional bounded reduction workspace when reporting degeneracy; large hubs or insufficient round
+budgets require explicit measurement rather than assumed convergence.
 
 ## Measure neighborhood density with LuGraphLocalClusteringCoefficient
 
@@ -705,6 +801,73 @@ neighborhood; a high-degree hub can therefore be disproportionately expensive. T
 label-propagation heuristic is not Louvain or Leiden, does not optimize modularity, and does not
 guarantee objectively correct communities or a particular clustering quality.
 
+## Evaluate community quality with LuGraphModularity
+
+**Question: Does an existing community grouping keep more relationship weight inside its groups
+than a degree-matched random network would predict?**
+
+`LuGraphModularity` scores a partition that the application already owns; it does not create or
+improve that partition. Use it to compare rival social-network groupings, check whether a detected
+fraud ring concentrates transaction weight, evaluate whether service ownership labels follow real
+dependency structure, or monitor whether an evolving document grouping is more meaningful than
+chance. Feed it labels from `LuGraphLabelPropagation`, an external clustering method, or any other
+caller-owned assignment.
+
+A high positive score means the specified partition keeps more relationship weight within its
+groups than the corresponding degree-preserving random baseline predicts; a score near zero
+suggests little advantage over that baseline. A negative score means the partition keeps less
+internal weight than expected. Scores depend on the graph and resolution parameter: they are not
+universal quality percentages or proof that one partition is objectively correct.
+
+```ts
+import {LuGraphModularity} from '@luma.gl/experimental/lugraph';
+
+const partitionQuality = new LuGraphModularity({
+  graph,
+  communities: communityIds,
+  output: modularityScore,
+  resolution: 1,
+  communityContributions,
+  valid: modularityValid
+});
+
+partitionQuality.addToGraph(workflow);
+```
+
+`communities` is a caller-owned, packed `GPUVector<'uint32'>` containing exactly one stable
+community identifier per vertex. Every label must be in the range from zero through
+`vertexCount - 1`. `output` is a separate caller-owned, packed one-row `GPUVector<'float32'>`.
+The optional `communityContributions` result has one `float32` row per possible community label;
+unused identifiers receive zero. The optional one-row `GPUVector<'uint32'>` `valid` distinguishes
+a successfully evaluated partition from a zeroed failure result. Outputs may not physically alias
+the graph's original buffers, community labels, or one another.
+
+Let `W` be the total weight of all valid-endpoint original source edges and let `Lc` be the
+internal original edge weight for community `c`. A missing weight column gives every edge weight
+one. Directed graphs use the weighted directed modularity formula
+`Q = Σc [Lc / W - γ × Kout,c × Kin,c / W²]`, where `Kout,c` and `Kin,c` are that community's
+outgoing and incoming weighted volumes. Undirected graphs use
+`Q = Σc [Lc / W - γ × (Kc / (2W))²]`, where `Kc` is the community's weighted degree volume. An
+undirected self-loop contributes once to `W` and `Lc` but twice to `Kc`. Parallel source edges
+and reciprocal directed source edges retain their original multiplicity; modularity deliberately
+does not apply the simple-graph deduplication used by core numbers.
+
+`resolution`, written `γ` above, defaults to one and must be a finite, nonnegative value that
+remains finite as `float32`; it adjusts the degree-matched expectation without changing the input
+partition. An invalid community identifier, a negative or nonfinite weight on an edge with valid
+endpoints, an empty graph, total valid edge weight of zero, or floating-point accumulation
+overflow publishes score zero, zero per-community contributions, and optional `valid` zero.
+Edges with invalid endpoints are excluded entirely, including their weights. Existing source edge
+batches remain separate, ordered, and borrowed; the operation reads them directly without
+constructing or requiring forward or reverse CSR.
+
+Weighted contributions, community volumes, and the final score use ordinary GPU `float32`
+arithmetic; concurrent atomic accumulation can make the final low-order rounding vary across
+execution orders or devices. Work is bounded by `O(V + E)`, with `O(V)` graph-owned community
+volume scratch and bounded reduction storage. This contributor measures a supplied partition; it
+is **not** Louvain, Leiden, automatic community optimization, hierarchical coarsening, or a
+guarantee that label propagation converged.
+
 ## Rank incoming influence with LuGraphPageRank
 
 **Question: Which vertices receive influence from other important vertices?**
@@ -949,10 +1112,12 @@ import {
   LuGraph,
   LuGraphBreadthFirstSearch,
   LuGraphConnectedComponents,
+  LuGraphCoreNumber,
   LuGraphDegree,
   LuGraphForceLayout,
   LuGraphLabelPropagation,
   LuGraphLocalClusteringCoefficient,
+  LuGraphModularity,
   LuGraphPageRank,
   LuGraphSingleSourceShortestPath,
   LuGraphSpatialForceLayout,
@@ -992,6 +1157,13 @@ const workflow = new GPUCommandGraph(device);
 
 topology.addToGraph(workflow);
 new LuGraphDegree({topology, output: outgoingDegrees}).addToGraph(workflow);
+new LuGraphCoreNumber({
+  topology,
+  output: coreNumbers,
+  iterations: 32,
+  converged: coresConverged,
+  degeneracy: maximumCoreNumber
+}).addToGraph(workflow);
 new LuGraphLocalClusteringCoefficient({
   topology,
   output: clusteringCoefficients,
@@ -1026,6 +1198,14 @@ new LuGraphLabelPropagation({
   output: communityIds,
   iterations: 32,
   converged: communitiesConverged
+}).addToGraph(workflow);
+new LuGraphModularity({
+  graph,
+  communities: communityIds,
+  output: modularityScore,
+  resolution: 1,
+  communityContributions,
+  valid: modularityValid
 }).addToGraph(workflow);
 new LuGraphPageRank({
   topology,
@@ -1076,20 +1256,22 @@ when exact all-pairs repulsion is the better fit.
   `DynamicBuffer` wrapper exposes the same underlying allocation through different views.
 - Adjacency capacities and overflow statuses are explicit. Breadth-first search fails closed to
   unreachable distances, weighted routing publishes `+Infinity` and `0xffffffff` predecessors,
-  weak components and community detection publish `0xffffffff`, local clustering publishes zero
-  coefficients and optional `0xffffffff` triangle statuses, and PageRank publishes zero scores
-  when a required neighbor list overflowed. Force layout preserves its existing positions and
-  clears velocities on required adjacency overflow.
+  weak components, community detection, and core numbers publish `0xffffffff`, local clustering
+  publishes zero coefficients and optional `0xffffffff` triangle statuses, and PageRank publishes
+  zero scores when a required neighbor list overflowed. Force layout preserves its existing
+  positions and clears velocities on required adjacency overflow.
 - Invalid negative or nonfinite edge weights also fail weighted routing closed; optional
   `invalidWeightCount` reports invalid original source edges without double-counting reverse CSR.
+- Partition modularity reads original source edges independently of adjacency overflow; invalid
+  labels, invalid accepted edge weights, or zero total weight publish zero score and validity.
 - Spatial layout also preserves positions and clears velocities when its accepted count excludes
   any out-of-domain vertex or its explicit vertex-ID capacity overflows.
 - Degree remains exact under neighbor overflow because its input is the complete CSR offset range.
 - Renderable layout positions require both `Buffer.STORAGE` and `Buffer.VERTEX` usage on their
   original caller-owned allocation; position readback or repacking is never implicit.
-- Fixed weighted-routing, component, community, and PageRank iteration budgets do not imply
-  convergence. Their optional status and final-change outputs remain GPU-resident until an
-  application explicitly requests readback.
+- Fixed weighted-routing, component, community, core-number, and PageRank iteration budgets do
+  not imply convergence. Their optional status, degeneracy, and final-change outputs remain
+  GPU-resident until an application explicitly requests readback.
 - Work uses bounded WebGPU dispatch and portable storage bindings on one device. Original chunk
   preservation does not imply distributed or multi-GPU execution.
 - The optional graph subpath does not supply automatic Arrow import, rendering, graph persistence,

--- a/docs/capabilities.mdx
+++ b/docs/capabilities.mdx
@@ -323,13 +323,15 @@ primitives](/docs/api-reference/experimental/gpu-primitives).
 | Chunk-preserving graph inputs | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Preserve independently owned source batches and caller-controlled graph resource lifetimes. |
 | Compressed graph adjacency | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Build reusable forward and optional reverse compressed sparse row (CSR) adjacency for supported graph operations. |
 | Directional vertex degree | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Compute supported incoming or outgoing degree values directly into GPU result columns. |
+| Structural graph core numbers | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Find bounded simple weak-graph k-core values, convergence, and maximum degeneracy without counting loops or duplicate neighbors. |
 | Breadth-first graph search | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Traverse bounded unweighted neighborhoods and generate deterministic predecessor or selection results. |
 | Weighted single-source shortest paths | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Find least-cost routes over nonnegative single-precision edge weights with bounded relaxation and deterministic predecessors. |
 | Weakly connected components | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Label supported connected groups within an explicit iteration budget and expose convergence information. |
 | Deterministic graph communities | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | `LuGraphLabelPropagation` assigns communities through bounded unweighted majority votes and deterministic label tie-breaking. |
+| Weighted community modularity | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Score existing directed or undirected community partitions, preserving original edge weights and multiplicity without claiming Louvain optimization. |
 | Local clustering coefficients | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Measure exact weak-neighborhood closure with distinct directed links or optional undirected triangle counts. |
 | GPU PageRank | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Rank vertices using iterative GPU execution with supported dangling-node redistribution. |
-| Six Graphalytics workload families | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Implement BFS, weighted SSSP, weak components, label propagation, local clustering, and PageRank without claiming official benchmark certification. |
+| Six Graphalytics workload families | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Implement the [Graph Data Council's six LDBC Graphalytics algorithms](https://ldbcouncil.org/benchmarks/graphalytics/algorithms/) without claiming official validation, certification, or published benchmark results. |
 | Exact force-directed layout | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Generate directly renderable graph positions through supported pairwise attraction and repulsion. |
 | Spatially accelerated layout | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Approximate supported distant forces through a flat GPU spatial grid; this is not hierarchical Barnes-Hut. |
 | Interactive graph exploration | Experimental | WebGPU | `@luma.gl/experimental/lugraph` | Coordinate layout, neighborhood highlighting, GPU picking, dragging, and pinned graph vertices. |
@@ -339,6 +341,12 @@ primitives](/docs/api-reference/experimental/gpu-primitives).
 Read the [GPU-resident graph analytics reference](/docs/api-reference/experimental/lugraph),
 the [interactive luGraph explorer](/examples/experimental/lugraph-explorer), or the
 [deck.gl graph explorer](/examples/deck/lugraph-explorer).
+
+The [Graph Data Council (GDC)](https://ldbcouncil.org/), formerly the Linked Data Benchmark
+Council, maintains the [LDBC Graphalytics benchmark](https://ldbcouncil.org/benchmarks/graphalytics/).
+Its formal reference datasets, correctness outputs, driver, and competition rules are separate
+from luGraph's local demonstrations. Structural core numbers and modularity scoring go beyond its
+six standardized workload families.
 
 ### GPU raster and satellite analysis
 
@@ -649,7 +657,7 @@ commitments to release dates.
 | Advanced dataframe analytics | Opportunity | WebGPU | `@luma.gl/experimental/ludf` | Extend existing grouped analytics, joins, lookups, sorting, and top-K toward non-unique/outer joins, temporal windows, and incremental updates. |
 | GPU vector similarity search | Opportunity | WebGPU | `@luma.gl/experimental` | Add embedding similarity, nearest-neighbor indexes, top-K distance queries, and compatible metadata filtering. |
 | Seam-safe multi-tile raster analysis | Opportunity | WebGPU | `@luma.gl/experimental/luraster` | Build on existing tile residency and graph reuse with assembled cross-tile halos, stitched contours, global aggregates, and generated analytical overviews. |
-| Advanced GPU graph analytics | Opportunity | WebGPU | `@luma.gl/experimental/lugraph` | Build on existing weighted shortest paths, local clustering, all six Graphalytics workload families, PageRank, communities, and layouts with Louvain/Leiden modularity optimization and dynamic graph updates. |
+| Advanced GPU graph analytics | Opportunity | WebGPU | `@luma.gl/experimental/lugraph` | Build on existing core numbers, weighted shortest paths, local clustering, community modularity scoring, all six Graphalytics families, and layouts with Louvain/Leiden partition optimization and dynamic graph updates. |
 | Hierarchical spatial indexes | Opportunity | WebGPU | `@luma.gl/experimental/geospatial` | Extend supported spatial queries toward tiled indexing, nearest neighbors, and spatial joins. |
 | High-precision geospatial pipelines | Opportunity | WebGPU | `@luma.gl/experimental/luproj` | Broaden projection, local-origin precision, coordinate systems, and streamed map-scale workflows. |
 | Cross-view GPU-native provenance | Opportunity | WebGPU | `@luma.gl/experimental/luxfilter` | Extend existing linked filters and histograms with shared picking, provenance, and selection across more charts, maps, and scene views. |

--- a/modules/experimental/src/lugraph/README.md
+++ b/modules/experimental/src/lugraph/README.md
@@ -8,9 +8,11 @@ identifiers, optional properties, and original GPU vector chunks without uploadi
 
 Reusable compressed adjacency supports vertex-degree queries, bounded breadth-first shortest paths,
 nonnegative weighted single-source routes, weakly connected components,
-deterministic label-propagation communities, local clustering coefficients, normalized PageRank
-with dangling-vertex redistribution, and progressive exact force-directed layout with directly
-renderable GPU positions. An optional `LuGraphSpatialForceLayout` can approximate distant
+deterministic label-propagation communities, local clustering coefficients, structural core
+numbers, and normalized PageRank with dangling-vertex redistribution. Partition modularity scores
+caller-owned community assignments directly against the original weighted source edges, and
+progressive exact force-directed layout produces directly renderable GPU positions. An optional
+`LuGraphSpatialForceLayout` can approximate distant
 uniform-grid cells while keeping nearby forces exact; it preserves the same positions, explicit
 bounds, caller-owned indexing buffers, and observable overflow status. These operations contribute
 work to a caller-owned `GPUCommandGraph`; applications retain ownership of their buffers,
@@ -26,6 +28,13 @@ latencies, or transaction costs and the cheapest route matters more than the few
 `LuGraphLocalClusteringCoefficient` when a vertex's neighbor count alone cannot distinguish a
 tightly connected friend circle or transaction ring from a loose hub.
 
+Choose `LuGraphCoreNumber` when you need to find a genuinely resilient network backbone: a star
+hub with 100 unconnected followers has degree 100 but core number one, whereas each member of a
+four-person clique has core number three. Choose `LuGraphModularity` when you already have
+community labels and need to measure whether those groups retain more relationship weight than a
+degree-matched random network would predict. It scores a proposed partition; it does not discover
+or optimize communities.
+
 Weakly connected components find disconnected
 islands; `LuGraphLabelPropagation` can expose friend circles, related service groups, or
 coordinated accounts inside a connected island. Its deterministic, bounded majority-vote heuristic
@@ -39,6 +48,27 @@ components, label propagation, local clustering, and PageRank cover the six **Gr
 families**. This means those analysis types have real browser-GPU implementations; it does not
 claim official benchmark certification, matching reference settings, distributed execution,
 published performance scores, or feature parity with another graph system.
+
+## Graph Data Council and Graphalytics
+
+The [Graph Data Council (GDC)](https://ldbcouncil.org/) maintains the
+[LDBC Graphalytics benchmark](https://ldbcouncil.org/benchmarks/graphalytics/). Before 2025, the
+nonprofit organization was named the **Linked Data Benchmark Council (LDBC)**; the benchmark
+suite retains its established LDBC name. Its
+[six graph-analysis algorithm families](https://ldbcouncil.org/benchmarks/graphalytics/algorithms/)
+cover breadth-first search, weighted shortest paths, weak components, label-propagation
+communities, local clustering, and PageRank.
+
+The council also publishes
+[real and synthetic reference datasets, including Parquet vertex and edge data](https://ldbcouncil.org/benchmarks/graphalytics/datasets/),
+an [open-source benchmark driver](https://github.com/ldbc/ldbc_graphalytics), its
+[algorithm specification and reference definitions](https://github.com/ldbc/ldbc_graphalytics_docs),
+and [competition and validation rules](https://ldbcouncil.org/benchmarks/graphalytics/rules/).
+Its rules allow single-node, GPU-based, and partial submissions, but formal results still require
+the prescribed datasets, reference outputs, repeated runs, system disclosures, and reproducible
+validation. luGraph's local CPU/WebGPU benchmark is not that official driver, an audited
+submission, or a published Graphalytics score. Core numbers and modularity are additional
+capabilities **beyond** the six Graphalytics workload families.
 
 ## Weighted routes and local neighborhoods
 
@@ -56,6 +86,29 @@ Self-loops and duplicate edges do not inflate the result. The caller receives on
 coefficient per vertex and can optionally request `uint32` directed-closure or triangle counts.
 Unsorted CSR makes exact neighbor matching up to `O(sum(degree³))`, so dense hubs need careful
 measurement.
+
+## Durable cores and community quality
+
+`LuGraphCoreNumber` finds each vertex's highest supported `k` in the **simple undirected weak
+graph**. Directed incoming and outgoing neighbors are united and deduplicated; reciprocal edges,
+parallel edges, and self-loops never inflate the result, and edge weights are ignored. Directed
+graphs require complete forward and reverse CSR. The caller supplies one `uint32` output per
+vertex and can request one-row convergence and maximum-core, or degeneracy, outputs. Its default
+32 synchronous refinement rounds can be set from zero through 1024; values are exact only when
+convergence is established, otherwise both core numbers and degeneracy are upper bounds. Required
+CSR overflow publishes `0xffffffff` outputs and zero convergence. Worst-case work with unordered
+adjacency is `O(K × sum(degree² × log(degree + 1)))` over `K` rounds.
+
+`LuGraphModularity` consumes existing `uint32` community identifiers and publishes one `float32`
+partition-quality score, optionally including `float32` contributions per possible label and a
+one-row validity result. It evaluates directed or undirected weighted original source edges in
+`O(V + E)` work without building CSR; missing weights mean one. Unlike core decomposition,
+parallel edges, reciprocal relationships, and self-loops retain their original multiplicity.
+Invalid labels, negative or nonfinite accepted weights, zero total edge weight, and floating-point
+accumulation overflow publish a zero score and zero validity. A finite nonnegative resolution
+adjusts the degree-matched baseline; the default is one.
+This is a community-quality measurement, not Louvain, Leiden, hierarchical coarsening, or
+automatic modularity optimization.
 
 Exact layout suits smaller graphs and accuracy-sensitive workflows; the optional
 flat-grid approximation suits applications that can trade some far-field accuracy for fewer

--- a/modules/experimental/src/lugraph/index.ts
+++ b/modules/experimental/src/lugraph/index.ts
@@ -21,8 +21,12 @@ export type {
 } from './lu-graph-single-source-shortest-path';
 export {LuGraphConnectedComponents} from './lu-graph-connected-components';
 export type {LuGraphConnectedComponentsProps} from './lu-graph-connected-components';
+export {LuGraphCoreNumber} from './lu-graph-core-number';
+export type {LuGraphCoreNumberProps} from './lu-graph-core-number';
 export {LuGraphLabelPropagation} from './lu-graph-label-propagation';
 export type {LuGraphLabelPropagationProps} from './lu-graph-label-propagation';
+export {LuGraphModularity} from './lu-graph-modularity';
+export type {LuGraphModularityProps} from './lu-graph-modularity';
 export {LuGraphLocalClusteringCoefficient} from './lu-graph-local-clustering-coefficient';
 export type {LuGraphLocalClusteringCoefficientProps} from './lu-graph-local-clustering-coefficient';
 export {LuGraphPageRank} from './lu-graph-page-rank';

--- a/modules/experimental/src/lugraph/lu-graph-core-number-internals.ts
+++ b/modules/experimental/src/lugraph/lu-graph-core-number-internals.ts
@@ -1,0 +1,542 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuGraph.
+
+import {type Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import type {
+  GPUCommandGraph,
+  GraphBufferUse,
+  GraphDataView
+} from '../gpu-primitives/gpu-command-graph';
+import {
+  type GPUBoundedDispatchLayout,
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource
+} from '../gpu-primitives/gpu-dispatch-utils';
+import {GPUReduction} from '../gpu-primitives/gpu-reduction';
+import {
+  createTransientView,
+  getViewBinding,
+  getViewElementOffset
+} from '../gpu-primitives/graph-data-view-utils';
+import type {LuGraphCoreNumber} from './lu-graph-core-number';
+
+const CORE_NUMBER_WORKGROUP_SIZE = 256;
+const INVALID_CORE_NUMBER = 0xffffffff;
+
+type ImportedCoreNumber = {
+  id: string;
+  vertexCount: number;
+  edgeCount: number;
+  iterations: number;
+  forwardOffsets: GraphDataView<'uint32'>;
+  forwardNeighbors: GraphDataView<'uint32'>;
+  forwardOverflow: GraphDataView<'uint32'>;
+  reverseOffsets?: GraphDataView<'uint32'>;
+  reverseNeighbors?: GraphDataView<'uint32'>;
+  reverseOverflow?: GraphDataView<'uint32'>;
+  output: GraphDataView<'uint32'>;
+  converged: GraphDataView<'uint32'>;
+  degeneracy?: GraphDataView<'uint32'>;
+  scratch?: GraphDataView<'uint32'>;
+  changed?: GraphDataView<'uint32'>;
+  maxComputeWorkgroupsPerDimension: number;
+};
+
+type CoreNumberBinding = {
+  view: GraphDataView<'uint32'>;
+  usage: GraphBufferUse['usage'];
+  atomic?: boolean;
+};
+
+type CoreNumberPassProps = {
+  id: string;
+  source: string;
+  bindings: Record<string, CoreNumberBinding>;
+  dispatchLayout: GPUBoundedDispatchLayout;
+};
+
+/** Adds bounded, exact simple-weak-graph k-core refinement with explicit dispatch limits. */
+export function addLuGraphCoreNumberToGraphWithDispatchLimit<Parameters>(
+  coreNumber: LuGraphCoreNumber,
+  commandGraph: GPUCommandGraph<Parameters>,
+  maxComputeWorkgroupsPerDimension: number
+): void {
+  const graph = coreNumber.topology.graph;
+  const reverse = graph.directed ? coreNumber.topology.reverse : undefined;
+  const output = commandGraph.importGPUVector(`${coreNumber.id}-output`, coreNumber.output).data[0];
+  const state: ImportedCoreNumber = {
+    id: coreNumber.id,
+    vertexCount: graph.vertexCount,
+    edgeCount: graph.edgeCount,
+    iterations: coreNumber.iterations,
+    forwardOffsets: commandGraph.importGPUVector(
+      `${coreNumber.id}-forward-offsets`,
+      coreNumber.topology.forward.offsets
+    ).data[0],
+    forwardNeighbors: commandGraph.importGPUVector(
+      `${coreNumber.id}-forward-neighbors`,
+      coreNumber.topology.forward.neighbors
+    ).data[0],
+    forwardOverflow: commandGraph.importGPUVector(
+      `${coreNumber.id}-forward-overflow`,
+      coreNumber.topology.forward.overflow
+    ).data[0],
+    ...(reverse
+      ? {
+          reverseOffsets: commandGraph.importGPUVector(
+            `${coreNumber.id}-reverse-offsets`,
+            reverse.offsets
+          ).data[0],
+          reverseNeighbors: commandGraph.importGPUVector(
+            `${coreNumber.id}-reverse-neighbors`,
+            reverse.neighbors
+          ).data[0],
+          reverseOverflow: commandGraph.importGPUVector(
+            `${coreNumber.id}-reverse-overflow`,
+            reverse.overflow
+          ).data[0]
+        }
+      : {}),
+    output,
+    converged: coreNumber.converged
+      ? commandGraph.importGPUVector(`${coreNumber.id}-converged`, coreNumber.converged).data[0]
+      : createTransientView(commandGraph, `${coreNumber.id}-convergence-scratch`, 'uint32', 1),
+    ...(coreNumber.degeneracy
+      ? {
+          degeneracy: commandGraph.importGPUVector(
+            `${coreNumber.id}-degeneracy`,
+            coreNumber.degeneracy
+          ).data[0]
+        }
+      : {}),
+    ...(graph.vertexCount > 0 && coreNumber.iterations > 0
+      ? {
+          scratch: createTransientView(
+            commandGraph,
+            `${coreNumber.id}-next-core-numbers`,
+            'uint32',
+            graph.vertexCount
+          ),
+          changed: createTransientView(commandGraph, `${coreNumber.id}-changed`, 'uint32', 1)
+        }
+      : {}),
+    maxComputeWorkgroupsPerDimension
+  };
+
+  addInitializationPass(commandGraph, state);
+  if (state.vertexCount > 0) {
+    for (let iteration = 0; iteration < state.iterations; iteration++) {
+      addChangeResetPass(commandGraph, state, iteration);
+      addRefinementPass(commandGraph, state, iteration);
+      addPublishPass(commandGraph, state, iteration);
+      addConvergencePass(commandGraph, state, iteration);
+    }
+  }
+
+  if (state.degeneracy) {
+    new GPUReduction({
+      id: `${state.id}-degeneracy`,
+      input: state.output,
+      output: state.degeneracy,
+      operation: 'max'
+    }).addToGraph(commandGraph);
+  }
+}
+
+/** Publishes distinct weak-neighbor degree upper bounds or fail-closed overflow sentinels. */
+function addInitializationPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: ImportedCoreNumber
+): void {
+  const bindings: Record<string, CoreNumberBinding> = {
+    output: {view: state.output, usage: 'storage-write'},
+    forwardOffsets: {view: state.forwardOffsets, usage: 'storage-read'},
+    forwardNeighbors: {view: state.forwardNeighbors, usage: 'storage-read'},
+    forwardOverflow: {view: state.forwardOverflow, usage: 'storage-read'},
+    ...(state.reverseOffsets && state.reverseNeighbors && state.reverseOverflow
+      ? {
+          reverseOffsets: {view: state.reverseOffsets, usage: 'storage-read' as const},
+          reverseNeighbors: {view: state.reverseNeighbors, usage: 'storage-read' as const},
+          reverseOverflow: {view: state.reverseOverflow, usage: 'storage-read' as const}
+        }
+      : {}),
+    converged: {view: state.converged, usage: 'storage-write', atomic: true}
+  };
+  const dispatchLayout = getDispatchLayout(state, Math.max(state.vertexCount, 1));
+  const noEdges = state.vertexCount === 0 || state.edgeCount === 0;
+  const source = /* wgsl */ `
+${getNeighborhoodConstants(state)}
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(state.output)}u;
+const FORWARD_OVERFLOW_OFFSET: u32 = ${getViewElementOffset(state.forwardOverflow)}u;
+const CONVERGED_OFFSET: u32 = ${getViewElementOffset(state.converged)}u;
+${state.reverseOverflow ? `const REVERSE_OVERFLOW_OFFSET: u32 = ${getViewElementOffset(state.reverseOverflow)}u;` : ''}
+${getBindingDeclarations(bindings)}
+${getNeighborhoodFunctions(state)}
+
+@compute @workgroup_size(${CORE_NUMBER_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getBoundedInvocationIndexSource(dispatchLayout, CORE_NUMBER_WORKGROUP_SIZE)}
+  let hasOverflow = forwardOverflow[FORWARD_OVERFLOW_OFFSET] != 0u${
+    state.reverseOverflow ? ' || reverseOverflow[REVERSE_OVERFLOW_OFFSET] != 0u' : ''
+  };
+  if (index == 0u) {
+    atomicStore(&converged[CONVERGED_OFFSET], select(0u, ${noEdges ? '1u' : '0u'}, !hasOverflow));
+  }
+  if (index >= VERTEX_COUNT) { return; }
+  if (hasOverflow) {
+    output[OUTPUT_OFFSET + index] = ${INVALID_CORE_NUMBER}u;
+    return;
+  }
+
+  var degree = 0u;
+  for (var direction = 0u; direction < NEIGHBOR_DIRECTION_COUNT; direction++) {
+    let first = getFirstNeighborSlot(index, direction);
+    let last = getLastNeighborSlot(index, direction);
+    for (var slot = first; slot < last; slot++) {
+      let neighbor = getNeighbor(direction, slot);
+      if (isFirstDistinctNeighbor(index, direction, slot, neighbor)) { degree++; }
+    }
+  }
+  output[OUTPUT_OFFSET + index] = degree;
+}`;
+  addCoreNumberPass(commandGraph, {id: `${state.id}-initialize`, source, bindings, dispatchLayout});
+}
+
+/** Clears one graph-owned atomic modification flag before the next synchronized round. */
+function addChangeResetPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: ImportedCoreNumber,
+  iteration: number
+): void {
+  const changed = state.changed!;
+  const bindings: Record<string, CoreNumberBinding> = {
+    changed: {view: changed, usage: 'storage-write', atomic: true}
+  };
+  const source = /* wgsl */ `
+const CHANGED_OFFSET: u32 = ${getViewElementOffset(changed)}u;
+${getBindingDeclarations(bindings)}
+
+@compute @workgroup_size(1)
+fn main() {
+  atomicStore(&changed[CHANGED_OFFSET], 0u);
+}`;
+  addCoreNumberPass(commandGraph, {
+    id: `${state.id}-iteration-${iteration}-reset`,
+    source,
+    bindings,
+    dispatchLayout: {x: 1, y: 1, z: 1}
+  });
+}
+
+/** Computes a monotone, synchronized neighborhood H-index using at most eight storage buffers. */
+function addRefinementPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: ImportedCoreNumber,
+  iteration: number
+): void {
+  const scratch = state.scratch!;
+  const changed = state.changed!;
+  const bindings: Record<string, CoreNumberBinding> = {
+    output: {view: state.output, usage: 'storage-read'},
+    scratch: {view: scratch, usage: 'storage-write'},
+    forwardOffsets: {view: state.forwardOffsets, usage: 'storage-read'},
+    forwardNeighbors: {view: state.forwardNeighbors, usage: 'storage-read'},
+    ...(state.reverseOffsets && state.reverseNeighbors
+      ? {
+          reverseOffsets: {view: state.reverseOffsets, usage: 'storage-read' as const},
+          reverseNeighbors: {view: state.reverseNeighbors, usage: 'storage-read' as const}
+        }
+      : {}),
+    changed: {view: changed, usage: 'storage-read-write', atomic: true},
+    converged: {view: state.converged, usage: 'storage-read'}
+  };
+  const dispatchLayout = getDispatchLayout(state, state.vertexCount);
+  const source = /* wgsl */ `
+${getNeighborhoodConstants(state)}
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(state.output)}u;
+const SCRATCH_OFFSET: u32 = ${getViewElementOffset(scratch)}u;
+const CHANGED_OFFSET: u32 = ${getViewElementOffset(changed)}u;
+const CONVERGED_OFFSET: u32 = ${getViewElementOffset(state.converged)}u;
+${getBindingDeclarations(bindings)}
+${getNeighborhoodFunctions(state)}
+
+fn countSupportingNeighbors(vertex: u32, candidate: u32) -> u32 {
+  var supporters = 0u;
+  for (var direction = 0u; direction < NEIGHBOR_DIRECTION_COUNT; direction++) {
+    let first = getFirstNeighborSlot(vertex, direction);
+    let last = getLastNeighborSlot(vertex, direction);
+    for (var slot = first; slot < last; slot++) {
+      let neighbor = getNeighbor(direction, slot);
+      if (!isFirstDistinctNeighbor(vertex, direction, slot, neighbor)) { continue; }
+      let neighborCore = output[OUTPUT_OFFSET + neighbor];
+      if (neighborCore != ${INVALID_CORE_NUMBER}u && neighborCore >= candidate) {
+        supporters++;
+      }
+    }
+  }
+  return supporters;
+}
+
+@compute @workgroup_size(${CORE_NUMBER_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getBoundedInvocationIndexSource(dispatchLayout, CORE_NUMBER_WORKGROUP_SIZE)}
+  if (index >= VERTEX_COUNT || converged[CONVERGED_OFFSET] != 0u) { return; }
+  let previous = output[OUTPUT_OFFSET + index];
+  if (previous == ${INVALID_CORE_NUMBER}u) {
+    scratch[SCRATCH_OFFSET + index] = ${INVALID_CORE_NUMBER}u;
+    return;
+  }
+
+  var lower = 0u;
+  var upper = previous;
+  while (lower < upper) {
+    let candidate = lower + (upper - lower + 1u) / 2u;
+    if (countSupportingNeighbors(index, candidate) >= candidate) {
+      lower = candidate;
+    } else {
+      upper = candidate - 1u;
+    }
+  }
+  scratch[SCRATCH_OFFSET + index] = lower;
+  if (lower != previous) { atomicStore(&changed[CHANGED_OFFSET], 1u); }
+}`;
+  addCoreNumberPass(commandGraph, {
+    id: `${state.id}-iteration-${iteration}-refine`,
+    source,
+    bindings,
+    dispatchLayout
+  });
+}
+
+/** Publishes the fully synchronized round without exposing a partially updated neighbor field. */
+function addPublishPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: ImportedCoreNumber,
+  iteration: number
+): void {
+  const scratch = state.scratch!;
+  const bindings: Record<string, CoreNumberBinding> = {
+    output: {view: state.output, usage: 'storage-write'},
+    scratch: {view: scratch, usage: 'storage-read'},
+    converged: {view: state.converged, usage: 'storage-read'}
+  };
+  const dispatchLayout = getDispatchLayout(state, state.vertexCount);
+  const source = /* wgsl */ `
+const VERTEX_COUNT: u32 = ${state.vertexCount}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(state.output)}u;
+const SCRATCH_OFFSET: u32 = ${getViewElementOffset(scratch)}u;
+const CONVERGED_OFFSET: u32 = ${getViewElementOffset(state.converged)}u;
+${getBindingDeclarations(bindings)}
+
+@compute @workgroup_size(${CORE_NUMBER_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getBoundedInvocationIndexSource(dispatchLayout, CORE_NUMBER_WORKGROUP_SIZE)}
+  if (index >= VERTEX_COUNT || converged[CONVERGED_OFFSET] != 0u) { return; }
+  output[OUTPUT_OFFSET + index] = scratch[SCRATCH_OFFSET + index];
+}`;
+  addCoreNumberPass(commandGraph, {
+    id: `${state.id}-iteration-${iteration}-publish`,
+    source,
+    bindings,
+    dispatchLayout
+  });
+}
+
+/** Reports fixed-point convergence while preserving explicit selected-adjacency failure status. */
+function addConvergencePass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: ImportedCoreNumber,
+  iteration: number
+): void {
+  const changed = state.changed!;
+  const bindings: Record<string, CoreNumberBinding> = {
+    changed: {view: changed, usage: 'storage-read'},
+    converged: {view: state.converged, usage: 'storage-read-write', atomic: true},
+    forwardOverflow: {view: state.forwardOverflow, usage: 'storage-read'},
+    ...(state.reverseOverflow
+      ? {reverseOverflow: {view: state.reverseOverflow, usage: 'storage-read' as const}}
+      : {})
+  };
+  const source = /* wgsl */ `
+const CHANGED_OFFSET: u32 = ${getViewElementOffset(changed)}u;
+const CONVERGED_OFFSET: u32 = ${getViewElementOffset(state.converged)}u;
+const FORWARD_OVERFLOW_OFFSET: u32 = ${getViewElementOffset(state.forwardOverflow)}u;
+${state.reverseOverflow ? `const REVERSE_OVERFLOW_OFFSET: u32 = ${getViewElementOffset(state.reverseOverflow)}u;` : ''}
+${getBindingDeclarations(bindings)}
+
+@compute @workgroup_size(1)
+fn main() {
+  let hasOverflow = forwardOverflow[FORWARD_OVERFLOW_OFFSET] != 0u${
+    state.reverseOverflow ? ' || reverseOverflow[REVERSE_OVERFLOW_OFFSET] != 0u' : ''
+  };
+  atomicStore(&converged[CONVERGED_OFFSET], select(0u, 1u, !hasOverflow && changed[CHANGED_OFFSET] == 0u));
+}`;
+  addCoreNumberPass(commandGraph, {
+    id: `${state.id}-iteration-${iteration}-convergence`,
+    source,
+    bindings,
+    dispatchLayout: {x: 1, y: 1, z: 1}
+  });
+}
+
+/** Emits bounded CSR storage offsets shared by initialization and synchronous refinement. */
+function getNeighborhoodConstants(state: ImportedCoreNumber): string {
+  return [
+    `const VERTEX_COUNT: u32 = ${state.vertexCount}u;`,
+    `const FORWARD_CAPACITY: u32 = ${state.forwardNeighbors.length}u;`,
+    `const FORWARD_OFFSETS_OFFSET: u32 = ${getViewElementOffset(state.forwardOffsets)}u;`,
+    `const FORWARD_NEIGHBORS_OFFSET: u32 = ${getViewElementOffset(state.forwardNeighbors)}u;`,
+    `const NEIGHBOR_DIRECTION_COUNT: u32 = ${state.reverseOffsets ? 2 : 1}u;`,
+    ...(state.reverseOffsets && state.reverseNeighbors
+      ? [
+          `const REVERSE_CAPACITY: u32 = ${state.reverseNeighbors.length}u;`,
+          `const REVERSE_OFFSETS_OFFSET: u32 = ${getViewElementOffset(state.reverseOffsets)}u;`,
+          `const REVERSE_NEIGHBORS_OFFSET: u32 = ${getViewElementOffset(state.reverseNeighbors)}u;`
+        ]
+      : [])
+  ].join('\n');
+}
+
+/** Enumerates each distinct non-self weak neighbor exactly once across unsorted CSR directions. */
+function getNeighborhoodFunctions(state: ImportedCoreNumber): string {
+  const hasReverse = Boolean(state.reverseOffsets && state.reverseNeighbors);
+  const reverseFirst = hasReverse
+    ? `if (direction == 1u) {
+    return min(reverseOffsets[REVERSE_OFFSETS_OFFSET + vertex], REVERSE_CAPACITY);
+  }`
+    : '';
+  const reverseLast = hasReverse
+    ? `if (direction == 1u) {
+    return min(reverseOffsets[REVERSE_OFFSETS_OFFSET + vertex + 1u], REVERSE_CAPACITY);
+  }`
+    : '';
+  const reverseNeighbor = hasReverse
+    ? `if (direction == 1u) {
+    return reverseNeighbors[REVERSE_NEIGHBORS_OFFSET + slot];
+  }`
+    : '';
+  const scanReverse = hasReverse
+    ? `if (direction == 1u) {
+    let reverseFirst = min(reverseOffsets[REVERSE_OFFSETS_OFFSET + vertex], REVERSE_CAPACITY);
+    for (var previous = reverseFirst; previous < slot; previous++) {
+      if (reverseNeighbors[REVERSE_NEIGHBORS_OFFSET + previous] == candidate) { return false; }
+    }
+  }`
+    : '';
+
+  return /* wgsl */ `
+fn getFirstNeighborSlot(vertex: u32, direction: u32) -> u32 {
+  ${reverseFirst}
+  return min(forwardOffsets[FORWARD_OFFSETS_OFFSET + vertex], FORWARD_CAPACITY);
+}
+
+fn getLastNeighborSlot(vertex: u32, direction: u32) -> u32 {
+  ${reverseLast}
+  return min(forwardOffsets[FORWARD_OFFSETS_OFFSET + vertex + 1u], FORWARD_CAPACITY);
+}
+
+fn getNeighbor(direction: u32, slot: u32) -> u32 {
+  ${reverseNeighbor}
+  return forwardNeighbors[FORWARD_NEIGHBORS_OFFSET + slot];
+}
+
+fn isFirstDistinctNeighbor(vertex: u32, direction: u32, slot: u32, candidate: u32) -> bool {
+  if (candidate >= VERTEX_COUNT || candidate == vertex) { return false; }
+  let forwardFirst = min(forwardOffsets[FORWARD_OFFSETS_OFFSET + vertex], FORWARD_CAPACITY);
+  let forwardEnd = select(
+    slot,
+    min(forwardOffsets[FORWARD_OFFSETS_OFFSET + vertex + 1u], FORWARD_CAPACITY),
+    direction != 0u
+  );
+  for (var previous = forwardFirst; previous < forwardEnd; previous++) {
+    if (forwardNeighbors[FORWARD_NEIGHBORS_OFFSET + previous] == candidate) { return false; }
+  }
+  ${scanReverse}
+  return true;
+}`;
+}
+
+/** Declares ordinary or atomic unsigned storage arrays in deterministic binding order. */
+function getBindingDeclarations(bindings: Record<string, CoreNumberBinding>): string {
+  return Object.entries(bindings)
+    .map(([name, binding], location) => {
+      const access = binding.usage === 'storage-read' ? 'read' : 'read_write';
+      const element = binding.atomic ? 'atomic<u32>' : 'u32';
+      return `@group(0) @binding(${location}) var<storage, ${access}> ${name}: array<${element}>;`;
+    })
+    .join('\n');
+}
+
+/** Compiles one portable bounded pass without owning, submitting, or mapping caller buffers. */
+function addCoreNumberPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  props: CoreNumberPassProps
+): void {
+  commandGraph.addComputePass({
+    id: props.id,
+    resources: Object.values(props.bindings).map(({view, usage}) => ({buffer: view, usage})),
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id: props.id,
+        source: props.source,
+        shaderLayout: {
+          bindings: Object.keys(props.bindings).map((name, location) => ({
+            name,
+            type: 'storage' as const,
+            group: 0,
+            location
+          }))
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const bindings: Record<string, Binding> = {};
+          for (const [name, binding] of Object.entries(props.bindings)) {
+            bindings[name] = getViewBinding(binding.view, getBuffer);
+          }
+          computation.setBindings(bindings);
+          computation.dispatch(
+            computePass,
+            props.dispatchLayout.x,
+            props.dispatchLayout.y,
+            props.dispatchLayout.z
+          );
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+/** Plans a portable one-, two-, or three-dimensional scalar dispatch. */
+function getDispatchLayout(
+  state: ImportedCoreNumber,
+  elementCount: number
+): GPUBoundedDispatchLayout {
+  return getLuGraphCoreNumberDispatchLayout(elementCount, state.maxComputeWorkgroupsPerDimension);
+}
+
+/** Plans one bounded three-dimensional k-core initialization or refinement dispatch. @internal */
+export function getLuGraphCoreNumberDispatchLayout(
+  elementCount: number,
+  maxComputeWorkgroupsPerDimension: number
+): GPUBoundedDispatchLayout {
+  return getBoundedDispatchLayout(
+    'LuGraphCoreNumber',
+    elementCount,
+    CORE_NUMBER_WORKGROUP_SIZE,
+    maxComputeWorkgroupsPerDimension
+  );
+}

--- a/modules/experimental/src/lugraph/lu-graph-core-number.ts
+++ b/modules/experimental/src/lugraph/lu-graph-core-number.ts
@@ -1,0 +1,180 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuGraph.
+
+import type {Buffer} from '@luma.gl/core';
+import {DynamicBuffer} from '@luma.gl/engine';
+import type {GPUData, GPUVector} from '@luma.gl/tables';
+import type {GPUCommandGraph} from '../gpu-primitives/gpu-command-graph';
+import {addLuGraphCoreNumberToGraphWithDispatchLimit} from './lu-graph-core-number-internals';
+import type {LuGraphAdjacency, LuGraphTopology} from './lu-graph-topology';
+
+const DEFAULT_CORE_NUMBER_ITERATIONS = 32;
+const MAXIMUM_CORE_NUMBER_ITERATIONS = 1024;
+const SCALAR_BYTE_LENGTH = 4;
+
+/** Existing graph topology and caller-owned k-core decomposition destinations. */
+export type LuGraphCoreNumberProps = {
+  /** Prefix for generated command-graph nodes and imported-resource identifiers. */
+  id?: string;
+  /** Existing compressed adjacency; directed weak neighborhoods require reverse CSR. */
+  topology: LuGraphTopology;
+  /** One caller-owned unsigned core-number row per graph vertex. */
+  output: GPUVector<'uint32'>;
+  /** Maximum synchronized core-refinement rounds; defaults to 32 and is bounded by 1,024. */
+  iterations?: number;
+  /** Optional caller-owned scalar reporting whether the core numbers reached a fixed point. */
+  converged?: GPUVector<'uint32'>;
+  /** Optional caller-owned scalar receiving the maximum currently published core number. */
+  degeneracy?: GPUVector<'uint32'>;
+};
+
+/**
+ * Computes the standard simple, undirected k-core numbers of GPU-resident weak neighborhoods.
+ *
+ * Directed graphs require reverse adjacency and are interpreted as undirected. Reciprocal and
+ * duplicate edges are deduplicated, self-loops are ignored, and edge weights have no effect.
+ * Synchronous H-index refinements monotonically lower distinct-degree upper bounds until the
+ * exact core numbers are reached. If the bounded rounds stop first, outputs are valid upper
+ * bounds and the optional convergence scalar remains zero.
+ *
+ * An isolated vertex has core number zero. Overflow in either required adjacency publishes
+ * `0xffffffff` output and optional degeneracy sentinels and leaves convergence at zero.
+ */
+export class LuGraphCoreNumber {
+  /** Prefix for generated command-graph nodes and imported resources. */
+  readonly id: string;
+  /** Existing caller-owned GPU graph topology. */
+  readonly topology: LuGraphTopology;
+  /** Caller-owned, vertex-aligned unsigned core numbers. */
+  readonly output: GPUVector<'uint32'>;
+  /** Maximum number of compiled, globally synchronized refinement rounds. */
+  readonly iterations: number;
+  /** Optional caller-owned fixed-point convergence status. */
+  readonly converged?: GPUVector<'uint32'>;
+  /** Optional caller-owned maximum currently published core number. */
+  readonly degeneracy?: GPUVector<'uint32'>;
+
+  /** Validates caller-owned metadata without allocating, submitting, or reading GPU work. */
+  constructor(props: LuGraphCoreNumberProps) {
+    this.id = props.id ?? 'lu-graph-core-number';
+    this.topology = props.topology;
+    this.output = props.output;
+    this.iterations = props.iterations ?? DEFAULT_CORE_NUMBER_ITERATIONS;
+    this.converged = props.converged;
+    this.degeneracy = props.degeneracy;
+
+    if (this.topology.graph.directed && !this.topology.reverse) {
+      throw new Error(`${this.id} directed weak-neighbor core numbers require reverse adjacency`);
+    }
+    if (
+      !Number.isSafeInteger(this.iterations) ||
+      this.iterations < 0 ||
+      this.iterations > MAXIMUM_CORE_NUMBER_ITERATIONS
+    ) {
+      throw new Error(`${this.id} iterations must be a safe integer between zero and 1024`);
+    }
+
+    validateCoreNumberVector(this.output, this.topology.graph.vertexCount, `${this.id} output`);
+    if (this.converged) {
+      validateCoreNumberVector(this.converged, 1, `${this.id} converged`);
+    }
+    if (this.degeneracy) {
+      validateCoreNumberVector(this.degeneracy, 1, `${this.id} degeneracy`);
+    }
+    validateDistinctCoreNumberOutputs(this);
+  }
+
+  /** Declares bounded GPU core refinement without queue submission or CPU synchronization. */
+  addToGraph<Parameters>(commandGraph: GPUCommandGraph<Parameters>): void {
+    addLuGraphCoreNumberToGraphWithDispatchLimit(
+      this,
+      commandGraph,
+      commandGraph.device.limits.maxComputeWorkgroupsPerDimension
+    );
+  }
+}
+
+/** Requires exactly one packed, uint32-aligned caller-owned scalar output chunk. */
+function validateCoreNumberVector(vector: GPUVector<'uint32'>, length: number, name: string): void {
+  if (
+    vector.format !== 'uint32' ||
+    vector.data.length !== 1 ||
+    vector.length !== length ||
+    vector.stride !== 1 ||
+    vector.byteStride !== SCALAR_BYTE_LENGTH ||
+    vector.rowByteLength !== SCALAR_BYTE_LENGTH ||
+    vector.valueLength !== vector.length ||
+    vector.bufferLayout
+  ) {
+    throw new Error(`${name} must contain exactly ${length} packed uint32 rows in one chunk`);
+  }
+
+  const chunk = vector.data[0];
+  if (
+    chunk.format !== 'uint32' ||
+    chunk.length !== length ||
+    chunk.stride !== 1 ||
+    chunk.byteStride !== SCALAR_BYTE_LENGTH ||
+    chunk.rowByteLength !== SCALAR_BYTE_LENGTH ||
+    chunk.valueLength !== chunk.length ||
+    !Number.isSafeInteger(chunk.byteOffset) ||
+    chunk.byteOffset < 0 ||
+    chunk.byteOffset % SCALAR_BYTE_LENGTH !== 0
+  ) {
+    throw new Error(`${name} must contain one packed, uint32-aligned chunk`);
+  }
+}
+
+/** Keeps caller-visible core outputs disjoint from graph sources, CSR, status, and peers. */
+function validateDistinctCoreNumberOutputs(coreNumber: LuGraphCoreNumber): void {
+  const {topology} = coreNumber;
+  const inputVectors = [
+    topology.graph.sourceVertices,
+    topology.graph.targetVertices,
+    ...(topology.graph.edgeWeights ? [topology.graph.edgeWeights] : []),
+    ...(topology.graph.edgeIds ? [topology.graph.edgeIds] : []),
+    ...getAdjacencyVectors(topology.forward),
+    ...(topology.reverse ? getAdjacencyVectors(topology.reverse) : []),
+    topology.invalidEdgeCount
+  ];
+  const physicalAllocations = new Set<Buffer>();
+  for (const vector of inputVectors) {
+    for (const chunk of vector.data) {
+      physicalAllocations.add(getPhysicalBuffer(chunk));
+    }
+  }
+
+  const outputs = [
+    {name: 'output', vector: coreNumber.output},
+    ...(coreNumber.converged ? [{name: 'converged', vector: coreNumber.converged}] : []),
+    ...(coreNumber.degeneracy ? [{name: 'degeneracy', vector: coreNumber.degeneracy}] : [])
+  ];
+  for (const {name, vector} of outputs) {
+    const physicalBuffer = getPhysicalBuffer(vector.data[0]);
+    if (physicalAllocations.has(physicalBuffer)) {
+      throw new Error(`${coreNumber.id} ${name} must use a distinct physical buffer allocation`);
+    }
+    physicalAllocations.add(physicalBuffer);
+  }
+}
+
+/** Enumerates caller-owned adjacency payloads and statuses without changing source identity. */
+function getAdjacencyVectors(
+  adjacency: LuGraphAdjacency
+): (GPUVector<'uint32'> | GPUVector<'float32'>)[] {
+  return [
+    adjacency.offsets,
+    adjacency.neighbors,
+    adjacency.edgeIds,
+    ...(adjacency.edgeWeights ? [adjacency.edgeWeights] : []),
+    adjacency.count,
+    adjacency.overflow
+  ];
+}
+
+/** Resolves borrowed engine wrappers to the actual physical allocation. */
+function getPhysicalBuffer(chunk: GPUData<'uint32'> | GPUData<'float32'>): Buffer {
+  return chunk.buffer instanceof DynamicBuffer ? chunk.buffer.buffer : chunk.buffer;
+}

--- a/modules/experimental/src/lugraph/lu-graph-modularity-internals.ts
+++ b/modules/experimental/src/lugraph/lu-graph-modularity-internals.ts
@@ -1,0 +1,527 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuGraph.
+
+import {type Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import type {
+  GPUCommandGraph,
+  GraphBufferUse,
+  GraphDataView,
+  GraphVectorView
+} from '../gpu-primitives/gpu-command-graph';
+import {
+  type GPUBoundedDispatchLayout,
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource
+} from '../gpu-primitives/gpu-dispatch-utils';
+import {GPUReduction} from '../gpu-primitives/gpu-reduction';
+import {
+  createTransientView,
+  getViewBinding,
+  getViewElementOffset
+} from '../gpu-primitives/graph-data-view-utils';
+import type {LuGraphModularity} from './lu-graph-modularity';
+
+const MODULARITY_WORKGROUP_SIZE = 256;
+
+type ModularityView = GraphDataView<'uint32'> | GraphDataView<'float32'>;
+
+type ImportedModularity = {
+  id: string;
+  vertexCount: number;
+  directed: boolean;
+  resolution: number;
+  sourceVertices: GraphVectorView<'uint32'>;
+  targetVertices: GraphVectorView<'uint32'>;
+  edgeWeights?: GraphVectorView<'float32'>;
+  communities: GraphDataView<'uint32'>;
+  outgoingVolumes: GraphDataView<'float32'>;
+  incomingVolumes?: GraphDataView<'float32'>;
+  internalWeights: GraphDataView<'float32'>;
+  contributions: GraphDataView<'float32'>;
+  totalVolume: GraphDataView<'float32'>;
+  status: GraphDataView<'uint32'>;
+  output: GraphDataView<'float32'>;
+  valid?: GraphDataView<'uint32'>;
+  maxComputeWorkgroupsPerDimension: number;
+};
+
+type ModularityBinding = {
+  view: ModularityView;
+  usage: GraphBufferUse['usage'];
+  atomic?: boolean;
+};
+
+type ModularityPass = {
+  id: string;
+  source: string;
+  bindings: Record<string, ModularityBinding>;
+  dispatchLayout: GPUBoundedDispatchLayout;
+};
+
+/** Composes weighted Newman modularity directly over original ordered edge batches. @internal */
+export function addLuGraphModularityToGraphWithDispatchLimit<Parameters>(
+  modularity: LuGraphModularity,
+  commandGraph: GPUCommandGraph<Parameters>,
+  maxComputeWorkgroupsPerDimension: number
+): void {
+  const vertexCount = modularity.graph.vertexCount;
+  const state: ImportedModularity = {
+    id: modularity.id,
+    vertexCount,
+    directed: modularity.graph.directed,
+    resolution: Math.fround(modularity.resolution),
+    sourceVertices: commandGraph.importGPUVector(
+      `${modularity.id}-source-vertices`,
+      modularity.graph.sourceVertices
+    ),
+    targetVertices: commandGraph.importGPUVector(
+      `${modularity.id}-target-vertices`,
+      modularity.graph.targetVertices
+    ),
+    ...(modularity.graph.edgeWeights
+      ? {
+          edgeWeights: commandGraph.importGPUVector(
+            `${modularity.id}-source-weights`,
+            modularity.graph.edgeWeights
+          )
+        }
+      : {}),
+    communities: commandGraph.importGPUVector(
+      `${modularity.id}-communities`,
+      modularity.communities
+    ).data[0],
+    outgoingVolumes: createTransientView(
+      commandGraph,
+      `${modularity.id}-outgoing-volumes`,
+      'float32',
+      vertexCount
+    ),
+    ...(modularity.graph.directed
+      ? {
+          incomingVolumes: createTransientView(
+            commandGraph,
+            `${modularity.id}-incoming-volumes`,
+            'float32',
+            vertexCount
+          )
+        }
+      : {}),
+    internalWeights: createTransientView(
+      commandGraph,
+      `${modularity.id}-internal-weights`,
+      'float32',
+      vertexCount
+    ),
+    contributions: modularity.communityContributions
+      ? commandGraph.importGPUVector(
+          `${modularity.id}-community-contributions`,
+          modularity.communityContributions
+        ).data[0]
+      : createTransientView(
+          commandGraph,
+          `${modularity.id}-contribution-scratch`,
+          'float32',
+          vertexCount
+        ),
+    totalVolume: createTransientView(commandGraph, `${modularity.id}-total-volume`, 'float32', 1),
+    status: createTransientView(commandGraph, `${modularity.id}-invalid-status`, 'uint32', 1),
+    output: commandGraph.importGPUVector(`${modularity.id}-output`, modularity.output).data[0],
+    ...(modularity.valid
+      ? {valid: commandGraph.importGPUVector(`${modularity.id}-valid`, modularity.valid).data[0]}
+      : {}),
+    maxComputeWorkgroupsPerDimension
+  };
+
+  addStatusInitializationPass(commandGraph, state);
+  if (vertexCount > 0) addCommunityInitializationPass(commandGraph, state);
+
+  for (const [chunkIndex, sources] of state.sourceVertices.data.entries()) {
+    if (sources.length === 0) continue;
+    addEdgeAccumulationPass(commandGraph, {
+      state,
+      chunkIndex,
+      sources,
+      targets: state.targetVertices.data[chunkIndex],
+      weights: state.edgeWeights?.data[chunkIndex]
+    });
+  }
+
+  new GPUReduction({
+    id: `${state.id}-total-volume-reduction`,
+    input: state.outgoingVolumes,
+    output: state.totalVolume,
+    operation: 'sum'
+  }).addToGraph(commandGraph);
+
+  if (vertexCount > 0) addContributionPass(commandGraph, state);
+
+  new GPUReduction({
+    id: `${state.id}-score-reduction`,
+    input: state.contributions,
+    output: state.output,
+    operation: 'sum'
+  }).addToGraph(commandGraph);
+
+  addValidityFinalizationPass(commandGraph, state);
+}
+
+/** Resets status and scalar outputs before any parallel label validation or edge accumulation. */
+function addStatusInitializationPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: ImportedModularity
+): void {
+  const bindings: Record<string, ModularityBinding> = {
+    status: {view: state.status, usage: 'storage-write', atomic: true},
+    output: {view: state.output, usage: 'storage-write'},
+    ...(state.valid ? {validity: {view: state.valid, usage: 'storage-write'}} : {})
+  };
+  const validityInitialization = state.valid
+    ? `validity[${getViewElementOffset(state.valid)}u] = 0u;`
+    : '';
+  const source = /* wgsl */ `
+${getBindingDeclarations(bindings)}
+
+@compute @workgroup_size(1)
+fn main() {
+  atomicStore(&status[${getViewElementOffset(state.status)}u], 0u);
+  output[${getViewElementOffset(state.output)}u] = 0.0;
+  ${validityInitialization}
+}`;
+  addModularityPass(commandGraph, {
+    id: `${state.id}-initialize-status`,
+    source,
+    bindings,
+    dispatchLayout: {x: 1, y: 1, z: 1}
+  });
+}
+
+/** Clears dense community volumes and rejects every out-of-domain label, including isolates. */
+function addCommunityInitializationPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: ImportedModularity
+): void {
+  const bindings: Record<string, ModularityBinding> = {
+    communities: {view: state.communities, usage: 'storage-read'},
+    outgoingVolumes: {view: state.outgoingVolumes, usage: 'storage-write', atomic: true},
+    ...(state.incomingVolumes
+      ? {incomingVolumes: {view: state.incomingVolumes, usage: 'storage-write', atomic: true}}
+      : {}),
+    internalWeights: {view: state.internalWeights, usage: 'storage-write', atomic: true},
+    contributions: {view: state.contributions, usage: 'storage-write'},
+    status: {view: state.status, usage: 'storage-read-write', atomic: true}
+  };
+  const initializeIncoming = state.incomingVolumes
+    ? `atomicStore(&incomingVolumes[${getViewElementOffset(state.incomingVolumes)}u + index], 0u);`
+    : '';
+  const dispatchLayout = getDispatchLayout(state, state.vertexCount);
+  const source = /* wgsl */ `
+const VERTEX_COUNT: u32 = ${state.vertexCount}u;
+${getBindingDeclarations(bindings)}
+
+@compute @workgroup_size(${MODULARITY_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getBoundedInvocationIndexSource(dispatchLayout, MODULARITY_WORKGROUP_SIZE)}
+  if (index >= VERTEX_COUNT) { return; }
+  atomicStore(&outgoingVolumes[${getViewElementOffset(state.outgoingVolumes)}u + index], 0u);
+  ${initializeIncoming}
+  atomicStore(&internalWeights[${getViewElementOffset(state.internalWeights)}u + index], 0u);
+  contributions[${getViewElementOffset(state.contributions)}u + index] = 0.0;
+  if (communities[${getViewElementOffset(state.communities)}u + index] >= VERTEX_COUNT) {
+    atomicStore(&status[${getViewElementOffset(state.status)}u], 1u);
+  }
+}`;
+  addModularityPass(commandGraph, {
+    id: `${state.id}-initialize-communities`,
+    source,
+    bindings,
+    dispatchLayout
+  });
+}
+
+/** Atomically aggregates one unchanged source chunk into dense directed or undirected volumes. */
+function addEdgeAccumulationPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  props: {
+    state: ImportedModularity;
+    chunkIndex: number;
+    sources: GraphDataView<'uint32'>;
+    targets: GraphDataView<'uint32'>;
+    weights?: GraphDataView<'float32'>;
+  }
+): void {
+  const {state} = props;
+  const bindings: Record<string, ModularityBinding> = {
+    sourceVertices: {view: props.sources, usage: 'storage-read'},
+    targetVertices: {view: props.targets, usage: 'storage-read'},
+    ...(props.weights ? {edgeWeights: {view: props.weights, usage: 'storage-read'}} : {}),
+    communities: {view: state.communities, usage: 'storage-read'},
+    outgoingVolumes: {view: state.outgoingVolumes, usage: 'storage-read-write', atomic: true},
+    ...(state.incomingVolumes
+      ? {incomingVolumes: {view: state.incomingVolumes, usage: 'storage-read-write', atomic: true}}
+      : {}),
+    internalWeights: {view: state.internalWeights, usage: 'storage-read-write', atomic: true},
+    status: {view: state.status, usage: 'storage-read-write', atomic: true}
+  };
+  const weightExpression = props.weights
+    ? `edgeWeights[${getViewElementOffset(props.weights)}u + index]`
+    : '1.0';
+  const accumulateSecondEndpoint = state.incomingVolumes
+    ? `atomicAddFloat(&incomingVolumes[${getViewElementOffset(state.incomingVolumes)}u + targetCommunity], edgeWeight);`
+    : `atomicAddFloat(&outgoingVolumes[${getViewElementOffset(state.outgoingVolumes)}u + targetCommunity], edgeWeight);`;
+  const dispatchLayout = getDispatchLayout(state, props.sources.length);
+  const source = /* wgsl */ `
+const EDGE_COUNT: u32 = ${props.sources.length}u;
+const VERTEX_COUNT: u32 = ${state.vertexCount}u;
+${getBindingDeclarations(bindings)}
+
+${getAtomicFloatAdditionSource()}
+
+@compute @workgroup_size(${MODULARITY_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getBoundedInvocationIndexSource(dispatchLayout, MODULARITY_WORKGROUP_SIZE)}
+  if (index >= EDGE_COUNT) { return; }
+  let sourceVertex = sourceVertices[${getViewElementOffset(props.sources)}u + index];
+  let targetVertex = targetVertices[${getViewElementOffset(props.targets)}u + index];
+  if (sourceVertex >= VERTEX_COUNT || targetVertex >= VERTEX_COUNT) { return; }
+
+  let edgeWeight = ${weightExpression};
+  let weightMagnitudeBits = bitcast<u32>(edgeWeight) & 0x7fffffffu;
+  if (weightMagnitudeBits >= 0x7f800000u || edgeWeight < 0.0) {
+    atomicStore(&status[${getViewElementOffset(state.status)}u], 1u);
+    return;
+  }
+
+  let sourceCommunity = communities[${getViewElementOffset(state.communities)}u + sourceVertex];
+  let targetCommunity = communities[${getViewElementOffset(state.communities)}u + targetVertex];
+  if (sourceCommunity >= VERTEX_COUNT || targetCommunity >= VERTEX_COUNT) {
+    atomicStore(&status[${getViewElementOffset(state.status)}u], 1u);
+    return;
+  }
+
+  atomicAddFloat(&outgoingVolumes[${getViewElementOffset(state.outgoingVolumes)}u + sourceCommunity], edgeWeight);
+  ${accumulateSecondEndpoint}
+  if (sourceCommunity == targetCommunity) {
+    atomicAddFloat(&internalWeights[${getViewElementOffset(state.internalWeights)}u + sourceCommunity], edgeWeight);
+  }
+}`;
+  addModularityPass(commandGraph, {
+    id: `${state.id}-accumulate-chunk-${props.chunkIndex}`,
+    source,
+    bindings,
+    dispatchLayout
+  });
+}
+
+/** Computes stable-label contributions after a synchronized exact total-volume reduction. */
+function addContributionPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: ImportedModularity
+): void {
+  const bindings: Record<string, ModularityBinding> = {
+    outgoingVolumes: {view: state.outgoingVolumes, usage: 'storage-read'},
+    ...(state.incomingVolumes
+      ? {incomingVolumes: {view: state.incomingVolumes, usage: 'storage-read'}}
+      : {}),
+    internalWeights: {view: state.internalWeights, usage: 'storage-read'},
+    totalVolume: {view: state.totalVolume, usage: 'storage-read'},
+    contributions: {view: state.contributions, usage: 'storage-write'},
+    status: {view: state.status, usage: 'storage-read-write', atomic: true}
+  };
+  const incomingVolume = state.incomingVolumes
+    ? `incomingVolumes[${getViewElementOffset(state.incomingVolumes)}u + index]`
+    : `outgoingVolumes[${getViewElementOffset(state.outgoingVolumes)}u + index]`;
+  const internalFactor = state.directed ? '1.0' : '2.0';
+  const dispatchLayout = getDispatchLayout(state, state.vertexCount);
+  const source = /* wgsl */ `
+const VERTEX_COUNT: u32 = ${state.vertexCount}u;
+const RESOLUTION: f32 = ${state.resolution.toExponential()};
+${getBindingDeclarations(bindings)}
+
+fn isFiniteValue(value: f32) -> bool {
+  return (bitcast<u32>(value) & 0x7fffffffu) < 0x7f800000u;
+}
+
+@compute @workgroup_size(${MODULARITY_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getBoundedInvocationIndexSource(dispatchLayout, MODULARITY_WORKGROUP_SIZE)}
+  if (index >= VERTEX_COUNT) { return; }
+
+  let volume = totalVolume[${getViewElementOffset(state.totalVolume)}u];
+  if (atomicLoad(&status[${getViewElementOffset(state.status)}u]) != 0u ||
+      !isFiniteValue(volume) || volume <= 0.0) {
+    contributions[${getViewElementOffset(state.contributions)}u + index] = 0.0;
+    return;
+  }
+
+  let internal = internalWeights[${getViewElementOffset(state.internalWeights)}u + index];
+  let outgoing = outgoingVolumes[${getViewElementOffset(state.outgoingVolumes)}u + index];
+  let incoming = ${incomingVolume};
+  let contribution =
+    (internal / volume) * ${internalFactor} - RESOLUTION * (outgoing / volume) * (incoming / volume);
+  if (!isFiniteValue(contribution)) {
+    atomicStore(&status[${getViewElementOffset(state.status)}u], 1u);
+    contributions[${getViewElementOffset(state.contributions)}u + index] = 0.0;
+    return;
+  }
+  contributions[${getViewElementOffset(state.contributions)}u + index] = contribution;
+}`;
+  addModularityPass(commandGraph, {
+    id: `${state.id}-community-contributions`,
+    source,
+    bindings,
+    dispatchLayout
+  });
+}
+
+/** Publishes final scalar validity and clears every contribution when any stage failed closed. */
+function addValidityFinalizationPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  state: ImportedModularity
+): void {
+  const bindings: Record<string, ModularityBinding> = {
+    status: {view: state.status, usage: 'storage-read'},
+    totalVolume: {view: state.totalVolume, usage: 'storage-read'},
+    output: {view: state.output, usage: 'storage-read-write'},
+    contributions: {view: state.contributions, usage: 'storage-read-write'},
+    ...(state.valid ? {validity: {view: state.valid, usage: 'storage-write'}} : {})
+  };
+  const publishValidity = state.valid
+    ? `validity[${getViewElementOffset(state.valid)}u] = select(0u, 1u, isValid);`
+    : '';
+  const dispatchLayout = getDispatchLayout(state, Math.max(state.vertexCount, 1));
+  const source = /* wgsl */ `
+const VERTEX_COUNT: u32 = ${state.vertexCount}u;
+${getBindingDeclarations(bindings)}
+
+fn isFiniteValue(value: f32) -> bool {
+  return (bitcast<u32>(value) & 0x7fffffffu) < 0x7f800000u;
+}
+
+@compute @workgroup_size(${MODULARITY_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getBoundedInvocationIndexSource(dispatchLayout, MODULARITY_WORKGROUP_SIZE)}
+  if (index >= max(VERTEX_COUNT, 1u)) { return; }
+  let volume = totalVolume[${getViewElementOffset(state.totalVolume)}u];
+  let score = output[${getViewElementOffset(state.output)}u];
+  let isValid = status[${getViewElementOffset(state.status)}u] == 0u &&
+    isFiniteValue(volume) && volume > 0.0 && isFiniteValue(score);
+  if (index == 0u) {
+    output[${getViewElementOffset(state.output)}u] = select(0.0, score, isValid);
+    ${publishValidity}
+  }
+  if (index < VERTEX_COUNT && !isValid) {
+    contributions[${getViewElementOffset(state.contributions)}u + index] = 0.0;
+  }
+}`;
+  addModularityPass(commandGraph, {
+    id: `${state.id}-finalize-validity`,
+    source,
+    bindings,
+    dispatchLayout
+  });
+}
+
+/** Implements portable float addition with the only universally available WGSL atomic type. */
+function getAtomicFloatAdditionSource(): string {
+  return /* wgsl */ `
+fn atomicAddFloat(destination: ptr<storage, atomic<u32>, read_write>, value: f32) {
+  var previousBits = atomicLoad(destination);
+  loop {
+    let nextBits = bitcast<u32>(bitcast<f32>(previousBits) + value);
+    let exchange = atomicCompareExchangeWeak(destination, previousBits, nextBits);
+    if (exchange.exchanged) { return; }
+    previousBits = exchange.old_value;
+  }
+}`;
+}
+
+/** Declares packed float, unsigned, and portable float-atomic storage bindings. */
+function getBindingDeclarations(bindings: Record<string, ModularityBinding>): string {
+  return Object.entries(bindings)
+    .map(([name, binding], location) => {
+      const access = binding.usage === 'storage-read' ? 'read' : 'read_write';
+      const element = binding.atomic
+        ? 'atomic<u32>'
+        : binding.view.format === 'float32'
+          ? 'f32'
+          : 'u32';
+      return `@group(0) @binding(${location}) var<storage, ${access}> ${name}: array<${element}>;`;
+    })
+    .join('\n');
+}
+
+/** Compiles one graph-owned bounded pass without hidden queue submission or result readback. */
+function addModularityPass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  props: ModularityPass
+): void {
+  commandGraph.addComputePass({
+    id: props.id,
+    resources: Object.values(props.bindings).map(({view, usage}) => ({buffer: view, usage})),
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id: props.id,
+        source: props.source,
+        shaderLayout: {
+          bindings: Object.keys(props.bindings).map((name, location) => ({
+            name,
+            type: 'storage' as const,
+            group: 0,
+            location
+          }))
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const shaderBindings: Record<string, Binding> = {};
+          for (const [name, binding] of Object.entries(props.bindings)) {
+            shaderBindings[name] = getViewBinding(binding.view, getBuffer);
+          }
+          computation.setBindings(shaderBindings);
+          computation.dispatch(
+            computePass,
+            props.dispatchLayout.x,
+            props.dispatchLayout.y,
+            props.dispatchLayout.z
+          );
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+function getDispatchLayout(
+  state: ImportedModularity,
+  elementCount: number
+): GPUBoundedDispatchLayout {
+  return getLuGraphModularityDispatchLayout(elementCount, state.maxComputeWorkgroupsPerDimension);
+}
+
+/** Plans bounded true three-dimensional edge-chunk, label, or finalization dispatch. @internal */
+export function getLuGraphModularityDispatchLayout(
+  elementCount: number,
+  maxComputeWorkgroupsPerDimension: number
+): GPUBoundedDispatchLayout {
+  return getBoundedDispatchLayout(
+    'LuGraphModularity',
+    elementCount,
+    MODULARITY_WORKGROUP_SIZE,
+    maxComputeWorkgroupsPerDimension
+  );
+}

--- a/modules/experimental/src/lugraph/lu-graph-modularity.ts
+++ b/modules/experimental/src/lugraph/lu-graph-modularity.ts
@@ -1,0 +1,181 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuGraph.
+
+import type {Buffer} from '@luma.gl/core';
+import {DynamicBuffer} from '@luma.gl/engine';
+import type {GPUData, GPUVector} from '@luma.gl/tables';
+import type {GPUCommandGraph} from '../gpu-primitives/gpu-command-graph';
+import type {LuGraph} from './lu-graph';
+import {addLuGraphModularityToGraphWithDispatchLimit} from './lu-graph-modularity-internals';
+
+const SCALAR_BYTE_LENGTH = 4;
+
+/** Existing GPU graph, vertex-aligned community labels, and caller-owned quality outputs. */
+export type LuGraphModularityProps = {
+  /** Prefix for generated command-graph nodes and imported-resource identifiers. */
+  id?: string;
+  /** Original directed or undirected edge columns, including their preserved source chunks. */
+  graph: LuGraph;
+  /** One existing unsigned community label below `vertexCount` for every graph vertex. */
+  communities: GPUVector<'uint32'>;
+  /** One caller-owned floating-point Newman modularity score. */
+  output: GPUVector<'float32'>;
+  /** Non-negative modularity resolution parameter. Defaults to one. */
+  resolution?: number;
+  /** Optional vertex-count-sized output indexed directly by stable community label. */
+  communityContributions?: GPUVector<'float32'>;
+  /** Optional scalar that is one only when labels, weights, and total edge weight are valid. */
+  valid?: GPUVector<'uint32'>;
+};
+
+/**
+ * Scores an existing graph partition without CPU synchronization or a CSR rebuild.
+ *
+ * Directed modularity is `sum(L / W - resolution * outgoing * incoming / W²)`. Undirected
+ * modularity is `sum(L / W - resolution * (degree / (2 * W))²)`. Each original edge contributes
+ * once to total and internal weight. Undirected edges contribute their weight to both endpoint
+ * volumes, including twice for a self-loop. Parallel and reciprocated source edges remain
+ * independent; missing edge weights are one, and invalid source endpoints are ignored.
+ *
+ * Invalid vertex-community labels, negative or nonfinite valid-endpoint edge weights, zero total
+ * accepted weight, and floating-point accumulation overflow publish zero score and contributions
+ * with zero optional validity. Contributions are indexed by community identifier rather than
+ * source vertex. Floating-point atomic accumulation can vary slightly with GPU execution order.
+ */
+export class LuGraphModularity {
+  /** Prefix for generated command-graph nodes and imported-resource identifiers. */
+  readonly id: string;
+  /** Existing caller-owned graph source columns. */
+  readonly graph: LuGraph;
+  /** Existing caller-owned vertex-aligned community assignments. */
+  readonly communities: GPUVector<'uint32'>;
+  /** Caller-owned scalar receiving the floating-point modularity score. */
+  readonly output: GPUVector<'float32'>;
+  /** Non-negative floating-point resolution parameter. */
+  readonly resolution: number;
+  /** Optional caller-owned contribution for every possible stable community label. */
+  readonly communityContributions?: GPUVector<'float32'>;
+  /** Optional caller-owned scalar publishing whether the score is mathematically valid. */
+  readonly valid?: GPUVector<'uint32'>;
+
+  /** Validates metadata without allocating, submitting, reading, or destroying GPU resources. */
+  constructor(props: LuGraphModularityProps) {
+    this.id = props.id ?? 'lu-graph-modularity';
+    this.graph = props.graph;
+    this.communities = props.communities;
+    this.output = props.output;
+    this.resolution = props.resolution ?? 1;
+    this.communityContributions = props.communityContributions;
+    this.valid = props.valid;
+
+    if (
+      !Number.isFinite(this.resolution) ||
+      this.resolution < 0 ||
+      !Number.isFinite(Math.fround(this.resolution))
+    ) {
+      throw new Error(`${this.id} resolution must be a non-negative finite float32`);
+    }
+
+    validateModularityVector(
+      this.communities,
+      'uint32',
+      this.graph.vertexCount,
+      `${this.id} communities`
+    );
+    validateModularityVector(this.output, 'float32', 1, `${this.id} output`);
+    if (this.communityContributions) {
+      validateModularityVector(
+        this.communityContributions,
+        'float32',
+        this.graph.vertexCount,
+        `${this.id} communityContributions`
+      );
+    }
+    if (this.valid) {
+      validateModularityVector(this.valid, 'uint32', 1, `${this.id} valid`);
+    }
+    validateDistinctModularityOutputs(this);
+  }
+
+  /** Declares chunk-preserving weighted scoring without submitting or reading commands. */
+  addToGraph<Parameters>(commandGraph: GPUCommandGraph<Parameters>): void {
+    addLuGraphModularityToGraphWithDispatchLimit(
+      this,
+      commandGraph,
+      commandGraph.device.limits.maxComputeWorkgroupsPerDimension
+    );
+  }
+}
+
+/** Requires one packed, aligned scalar vector chunk with its exact documented row count. */
+function validateModularityVector<Format extends 'uint32' | 'float32'>(
+  vector: GPUVector<Format>,
+  format: Format,
+  length: number,
+  name: string
+): void {
+  if (
+    vector.format !== format ||
+    vector.data.length !== 1 ||
+    vector.length !== length ||
+    vector.stride !== 1 ||
+    vector.byteStride !== SCALAR_BYTE_LENGTH ||
+    vector.rowByteLength !== SCALAR_BYTE_LENGTH ||
+    vector.valueLength !== vector.length ||
+    vector.bufferLayout
+  ) {
+    throw new Error(`${name} must contain exactly ${length} packed ${format} rows in one chunk`);
+  }
+
+  const chunk = vector.data[0];
+  if (
+    chunk.format !== format ||
+    chunk.length !== length ||
+    chunk.stride !== 1 ||
+    chunk.byteStride !== SCALAR_BYTE_LENGTH ||
+    chunk.rowByteLength !== SCALAR_BYTE_LENGTH ||
+    chunk.valueLength !== chunk.length ||
+    !Number.isSafeInteger(chunk.byteOffset) ||
+    chunk.byteOffset < 0 ||
+    chunk.byteOffset % SCALAR_BYTE_LENGTH !== 0
+  ) {
+    throw new Error(`${name} must contain one packed, uint32-aligned ${format} chunk`);
+  }
+}
+
+/** Keeps all caller-owned writable results physically disjoint from sources and community input. */
+function validateDistinctModularityOutputs(modularity: LuGraphModularity): void {
+  const inputs = [
+    modularity.graph.sourceVertices,
+    modularity.graph.targetVertices,
+    ...(modularity.graph.edgeWeights ? [modularity.graph.edgeWeights] : []),
+    ...(modularity.graph.edgeIds ? [modularity.graph.edgeIds] : []),
+    modularity.communities
+  ];
+  const allocations = new Set<Buffer>();
+  for (const vector of inputs) {
+    for (const chunk of vector.data) allocations.add(getPhysicalBuffer(chunk));
+  }
+
+  const outputs = [
+    {name: 'output', vector: modularity.output},
+    ...(modularity.communityContributions
+      ? [{name: 'communityContributions', vector: modularity.communityContributions}]
+      : []),
+    ...(modularity.valid ? [{name: 'valid', vector: modularity.valid}] : [])
+  ];
+  for (const {name, vector} of outputs) {
+    const buffer = getPhysicalBuffer(vector.data[0]);
+    if (allocations.has(buffer)) {
+      throw new Error(`${modularity.id} ${name} must use a distinct physical buffer allocation`);
+    }
+    allocations.add(buffer);
+  }
+}
+
+/** Resolves borrowed engine wrappers so sliced allocations cannot disguise writable aliases. */
+function getPhysicalBuffer(chunk: GPUData<'uint32'> | GPUData<'float32'>): Buffer {
+  return chunk.buffer instanceof DynamicBuffer ? chunk.buffer.buffer : chunk.buffer;
+}

--- a/modules/experimental/test/lugraph/lu-graph-benchmark.node.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-benchmark.node.spec.ts
@@ -458,6 +458,10 @@ describe('luGraph live documentation benchmark isolation', () => {
     expect(component).toContain('Weighted shortest paths');
     expect(component).toContain('Label-propagation communities');
     expect(component).toContain('Local clustering coefficient');
+    expect(component).toContain('https://ldbcouncil.org/');
+    expect(component).toContain('https://ldbcouncil.org/benchmarks/graphalytics/');
+    expect(component).toContain('Graph Data Council');
+    expect(component).toContain('not an official benchmark submission');
     expect(component.match(/await runLuGraphBenchmark\(/g)).toHaveLength(1);
     expect(documentation).toContain('<LuGraphBenchmark />');
     expect(documentation).toContain('explicit completion fence');

--- a/modules/experimental/test/lugraph/lu-graph-core-number.node.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-core-number.node.spec.ts
@@ -1,0 +1,389 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer} from '@luma.gl/core';
+import {DynamicBuffer} from '@luma.gl/engine';
+import * as experimentalModule from '@luma.gl/experimental';
+import {
+  LuGraph,
+  LuGraphCoreNumber,
+  LuGraphTopology,
+  type LuGraphAdjacency,
+  type LuGraphCoreNumberProps
+} from '@luma.gl/experimental/lugraph';
+import {GPUData, GPUVector} from '@luma.gl/tables';
+import {NullDevice} from '@luma.gl/test-utils';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {getLuGraphCoreNumberDispatchLayout} from '../../src/lugraph/lu-graph-core-number-internals';
+
+type ScalarFormat = 'uint32' | 'float32';
+type ScalarValues = Uint32Array | Float32Array;
+
+type CoreNumberFixture = {
+  device: NullDevice;
+  buffers: Buffer[];
+  dynamicBuffers: DynamicBuffer[];
+  vectors: GPUVector[];
+};
+
+type VectorOptions = {buffer?: Buffer | DynamicBuffer; byteOffset?: number; byteStride?: number};
+
+const coreNumberFixtures: CoreNumberFixture[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const fixture of coreNumberFixtures.splice(0)) {
+    for (const vector of fixture.vectors) vector.destroy();
+    for (const dynamicBuffer of fixture.dynamicBuffers) dynamicBuffer.destroy();
+    for (const buffer of fixture.buffers) buffer.destroy();
+    fixture.device.destroy();
+  }
+});
+
+describe('LuGraphCoreNumber optional graph-analysis API', () => {
+  test('exports GPU k-core decomposition only from the optional LuGraph subpath', () => {
+    expect(typeof LuGraphCoreNumber).toBe('function');
+    expect('LuGraphCoreNumber' in experimentalModule).toBe(false);
+  });
+
+  test('preserves topology, distinct destinations, and status without executing GPU work', () => {
+    const fixture = createCoreNumberFixture();
+    const props = createCoreNumberProps(fixture, {weighted: true, statuses: true});
+    const submit = vi.spyOn(fixture.device, 'submit');
+    const operation = new LuGraphCoreNumber(props);
+
+    expect(operation.id).toBe('lu-graph-core-number');
+    expect(operation.topology).toBe(props.topology);
+    expect(operation.output).toBe(props.output);
+    expect(operation.converged).toBe(props.converged);
+    expect(operation.degeneracy).toBe(props.degeneracy);
+    expect(operation.iterations).toBe(32);
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  test('does not require optional convergence or graph-degeneracy destinations', () => {
+    const fixture = createCoreNumberFixture();
+    const operation = new LuGraphCoreNumber(createCoreNumberProps(fixture));
+
+    expect(operation.converged).toBeUndefined();
+    expect(operation.degeneracy).toBeUndefined();
+  });
+
+  test.each([0, 1, 32, 1024])('accepts a bounded refinement budget: %s', iterations => {
+    const fixture = createCoreNumberFixture();
+    const props = createCoreNumberProps(fixture);
+
+    expect(new LuGraphCoreNumber({...props, iterations}).iterations).toBe(iterations);
+  });
+
+  test.each([
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    1025
+  ])('rejects invalid refinement budgets: %s', iterations => {
+    const fixture = createCoreNumberFixture();
+    const props = createCoreNumberProps(fixture);
+
+    expect(() => new LuGraphCoreNumber({...props, iterations})).toThrow(/iterations|1024/);
+  });
+
+  test('requires reverse CSR for the weak-simple projection of directed graphs', () => {
+    const fixture = createCoreNumberFixture();
+    const props = createCoreNumberProps(fixture, {reverse: false});
+
+    expect(() => new LuGraphCoreNumber(props)).toThrow(/directed|weak|reverse/);
+  });
+
+  test('reuses symmetric forward CSR for undirected graphs', () => {
+    const fixture = createCoreNumberFixture();
+    const props = createCoreNumberProps(fixture, {directed: false});
+
+    expect(new LuGraphCoreNumber(props).topology.reverse).toBeUndefined();
+  });
+
+  test('accepts empty output alongside independent optional scalar statuses', () => {
+    const fixture = createCoreNumberFixture();
+    const props = createCoreNumberProps(fixture, {vertexCount: 0, statuses: true});
+    const operation = new LuGraphCoreNumber(props);
+
+    expect(operation.output.length).toBe(0);
+    expect(operation.converged?.length).toBe(1);
+    expect(operation.degeneracy?.length).toBe(1);
+  });
+});
+
+describe('LuGraphCoreNumber packed vectors and physical caller ownership', () => {
+  test('rejects floating-point, truncated, and multichunk vertex destinations', () => {
+    const fixture = createCoreNumberFixture();
+    const props = createCoreNumberProps(fixture);
+    const floatOutput = createVector(fixture, 'float-output', 'float32', [
+      new Float32Array(4)
+    ]) as unknown as GPUVector<'uint32'>;
+    const shortOutput = createVector(fixture, 'short-output', 'uint32', [new Uint32Array(3)]);
+    const chunkedOutput = createVector(fixture, 'chunked-output', 'uint32', [
+      new Uint32Array(2),
+      new Uint32Array(2)
+    ]);
+
+    expect(() => new LuGraphCoreNumber({...props, output: floatOutput})).toThrow(/uint32|output/);
+    expect(() => new LuGraphCoreNumber({...props, output: shortOutput})).toThrow(/output|rows/);
+    expect(() => new LuGraphCoreNumber({...props, output: chunkedOutput})).toThrow(/chunk|output/);
+  });
+
+  test.each([
+    'converged',
+    'degeneracy'
+  ] as const)('requires exactly one packed uint32 %s row', statusName => {
+    const fixture = createCoreNumberFixture();
+    const props = createCoreNumberProps(fixture, {statuses: true});
+    const invalidStatus = createVector(fixture, `invalid-${statusName}`, 'uint32', [
+      new Uint32Array(2)
+    ]);
+
+    expect(() => new LuGraphCoreNumber({...props, [statusName]: invalidStatus})).toThrow(
+      new RegExp(`${statusName}|rows`)
+    );
+  });
+
+  test('preserves legal four-byte slices rather than requiring 256-byte logical offsets', () => {
+    const fixture = createCoreNumberFixture();
+    const props = createCoreNumberProps(fixture, {statuses: true, byteOffset: 4});
+    const operation = new LuGraphCoreNumber(props);
+
+    expect(operation.output.data[0].byteOffset).toBe(4);
+    expect(operation.converged?.data[0].byteOffset).toBe(4);
+    expect(operation.degeneracy?.data[0].byteOffset).toBe(4);
+  });
+
+  test.each([
+    'sourceVertices',
+    'targetVertices',
+    'edgeWeights',
+    'edgeIds',
+    'forward.offsets',
+    'forward.neighbors',
+    'forward.edgeIds',
+    'forward.edgeWeights',
+    'forward.count',
+    'forward.overflow',
+    'reverse.offsets',
+    'reverse.neighbors',
+    'reverse.edgeIds',
+    'reverse.edgeWeights',
+    'reverse.count',
+    'reverse.overflow',
+    'invalidEdgeCount'
+  ])('rejects writable outputs backed by existing graph allocations: %s', inputName => {
+    const fixture = createCoreNumberFixture();
+    const props = createCoreNumberProps(fixture, {vertexCount: 1, weighted: true});
+    const input = getCoreInputVector(props, inputName);
+    const output = createVector(fixture, 'aliased-output', 'uint32', [new Uint32Array(1)], {
+      buffer: input.data[0].buffer
+    });
+
+    expect(() => new LuGraphCoreNumber({...props, output})).toThrow(/distinct|physical|allocation/);
+  });
+
+  test.each([
+    ['converged', 'output'],
+    ['degeneracy', 'output'],
+    ['degeneracy', 'converged']
+  ] as const)('rejects aliases between %s and %s outputs', (outputName, sourceName) => {
+    const fixture = createCoreNumberFixture();
+    const props = createCoreNumberProps(fixture, {vertexCount: 1, statuses: true});
+    const sourceVector = props[sourceName]!;
+    const output = createVector(fixture, `aliased-${outputName}`, 'uint32', [new Uint32Array(1)], {
+      buffer: sourceVector.data[0].buffer
+    });
+
+    expect(() => new LuGraphCoreNumber({...props, [outputName]: output})).toThrow(
+      /distinct|physical|allocation/
+    );
+  });
+
+  test('unwraps borrowed DynamicBuffer aliases before validating physical independence', () => {
+    const fixture = createCoreNumberFixture();
+    const props = createCoreNumberProps(fixture);
+    const concreteBuffer = props.topology.forward.offsets.data[0].buffer as Buffer;
+    const wrapper = new DynamicBuffer(fixture.device, {
+      id: 'borrowed-core-offsets',
+      buffer: concreteBuffer,
+      ownsBuffer: false
+    });
+    fixture.dynamicBuffers.push(wrapper);
+    const output = createVector(fixture, 'wrapped-core-output', 'uint32', [new Uint32Array(4)], {
+      buffer: wrapper
+    });
+
+    expect(() => new LuGraphCoreNumber({...props, output})).toThrow(/distinct|physical|allocation/);
+    expect(concreteBuffer.destroyed).toBe(false);
+  });
+
+  test('plans bounded three-dimensional initialization and refinement dispatch', () => {
+    expect(getLuGraphCoreNumberDispatchLayout(0, 2)).toEqual({x: 1, y: 1, z: 1});
+    expect(getLuGraphCoreNumberDispatchLayout(512, 2)).toEqual({x: 2, y: 1, z: 1});
+    expect(getLuGraphCoreNumberDispatchLayout(513, 2)).toEqual({x: 2, y: 2, z: 1});
+    expect(getLuGraphCoreNumberDispatchLayout(1025, 2)).toEqual({x: 2, y: 2, z: 2});
+    expect(() => getLuGraphCoreNumberDispatchLayout(2049, 2)).toThrow(/3D dispatch limit/);
+  });
+});
+
+function createCoreNumberFixture(): CoreNumberFixture {
+  const fixture = {device: new NullDevice({}), buffers: [], dynamicBuffers: [], vectors: []};
+  coreNumberFixtures.push(fixture);
+  return fixture;
+}
+
+function createCoreNumberProps(
+  fixture: CoreNumberFixture,
+  options: {
+    vertexCount?: number;
+    directed?: boolean;
+    reverse?: boolean;
+    weighted?: boolean;
+    statuses?: boolean;
+    byteOffset?: number;
+  } = {}
+): LuGraphCoreNumberProps {
+  const vertexCount = options.vertexCount ?? 4;
+  const sourceVertices = createVector(fixture, 'sourceVertices', 'uint32', [
+    Uint32Array.from([0, 1]),
+    new Uint32Array(0),
+    Uint32Array.from([1, 2])
+  ]);
+  const targetVertices = createVector(fixture, 'targetVertices', 'uint32', [
+    Uint32Array.from([1, 2]),
+    new Uint32Array(0),
+    Uint32Array.from([2, 3])
+  ]);
+  const edgeWeights = options.weighted
+    ? createVector(fixture, 'edgeWeights', 'float32', [
+        Float32Array.from([1, 2]),
+        new Float32Array(0),
+        Float32Array.from([3, 4])
+      ])
+    : undefined;
+  const edgeIds = options.weighted
+    ? createVector(fixture, 'edgeIds', 'uint32', [
+        Uint32Array.from([10, 20]),
+        new Uint32Array(0),
+        Uint32Array.from([30, 40])
+      ])
+    : undefined;
+  const directed = options.directed ?? true;
+  const graph = new LuGraph({
+    vertexCount,
+    sourceVertices,
+    targetVertices,
+    edgeWeights,
+    edgeIds,
+    directed
+  });
+  const forward = createAdjacency(fixture, 'forward', vertexCount, 4, Boolean(edgeWeights));
+  const reverse =
+    directed && options.reverse !== false
+      ? createAdjacency(fixture, 'reverse', vertexCount, 4, Boolean(edgeWeights))
+      : undefined;
+  const invalidEdgeCount = createVector(fixture, 'invalidEdgeCount', 'uint32', [
+    new Uint32Array(1)
+  ]);
+  const topology = new LuGraphTopology({graph, forward, reverse, invalidEdgeCount});
+  const vectorOptions = {byteOffset: options.byteOffset};
+  return {
+    topology,
+    output: createVector(
+      fixture,
+      'coreNumbers',
+      'uint32',
+      [new Uint32Array(vertexCount)],
+      vectorOptions
+    ),
+    ...(options.statuses
+      ? {
+          converged: createVector(
+            fixture,
+            'converged',
+            'uint32',
+            [new Uint32Array(1)],
+            vectorOptions
+          ),
+          degeneracy: createVector(
+            fixture,
+            'degeneracy',
+            'uint32',
+            [new Uint32Array(1)],
+            vectorOptions
+          )
+        }
+      : {})
+  };
+}
+
+function createAdjacency(
+  fixture: CoreNumberFixture,
+  name: string,
+  vertexCount: number,
+  capacity: number,
+  weighted: boolean
+): LuGraphAdjacency {
+  return {
+    offsets: createVector(fixture, `${name}-offsets`, 'uint32', [new Uint32Array(vertexCount + 1)]),
+    neighbors: createVector(fixture, `${name}-neighbors`, 'uint32', [new Uint32Array(capacity)]),
+    edgeIds: createVector(fixture, `${name}-edge-ids`, 'uint32', [new Uint32Array(capacity)]),
+    ...(weighted
+      ? {
+          edgeWeights: createVector(fixture, `${name}-weights`, 'float32', [
+            new Float32Array(capacity)
+          ])
+        }
+      : {}),
+    count: createVector(fixture, `${name}-count`, 'uint32', [new Uint32Array(1)]),
+    overflow: createVector(fixture, `${name}-overflow`, 'uint32', [new Uint32Array(1)])
+  };
+}
+
+function getCoreInputVector(props: LuGraphCoreNumberProps, name: string): GPUVector {
+  if (name === 'sourceVertices') return props.topology.graph.sourceVertices;
+  if (name === 'targetVertices') return props.topology.graph.targetVertices;
+  if (name === 'edgeWeights') return props.topology.graph.edgeWeights!;
+  if (name === 'edgeIds') return props.topology.graph.edgeIds!;
+  if (name === 'invalidEdgeCount') return props.topology.invalidEdgeCount;
+  const [direction, vectorName] = name.split('.');
+  const adjacency = direction === 'forward' ? props.topology.forward : props.topology.reverse!;
+  return adjacency[vectorName as keyof LuGraphAdjacency]!;
+}
+
+function createVector<Format extends ScalarFormat>(
+  fixture: CoreNumberFixture,
+  name: string,
+  format: Format,
+  chunks: readonly ScalarValues[],
+  options: VectorOptions = {}
+): GPUVector<Format> {
+  const byteOffset = options.byteOffset ?? 0;
+  const byteStride = options.byteStride ?? Uint32Array.BYTES_PER_ELEMENT;
+  const data = chunks.map((values, chunkIndex) => {
+    const buffer =
+      options.buffer ??
+      fixture.device.createBuffer({
+        id: `${name}-${chunkIndex}-${fixture.buffers.length}`,
+        byteLength: byteOffset + Math.max(values.length, 1) * byteStride,
+        usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC
+      });
+    if (!options.buffer) fixture.buffers.push(buffer as Buffer);
+    return new GPUData<Format>({
+      buffer,
+      format,
+      length: values.length,
+      byteOffset,
+      byteStride,
+      ownsBuffer: false
+    });
+  });
+  const vector = new GPUVector<Format>({type: 'data', name, format, data, ownsData: false});
+  fixture.vectors.push(vector);
+  return vector;
+}

--- a/modules/experimental/test/lugraph/lu-graph-core-number.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-core-number.spec.ts
@@ -1,0 +1,759 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {GPUCommandGraph} from '@luma.gl/experimental';
+import {
+  LuGraph,
+  LuGraphCoreNumber,
+  LuGraphTopology,
+  type LuGraphAdjacency
+} from '@luma.gl/experimental/lugraph';
+import {GPUData, GPUVector} from '@luma.gl/tables';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import test, {type Test} from 'test/utils/vitest-tape';
+import {vi} from 'vitest';
+import {
+  addLuGraphCoreNumberToGraphWithDispatchLimit,
+  getLuGraphCoreNumberDispatchLayout
+} from '../../src/lugraph/lu-graph-core-number-internals';
+
+const INVALID_CORE_NUMBER = 0xffffffff;
+
+type ScalarFormat = 'uint32' | 'float32';
+
+type CoreNumberScenario = {
+  name: string;
+  vertexCount: number;
+  sourceChunks: number[][];
+  targetChunks: number[][];
+  weightChunks?: number[][];
+  directed?: boolean;
+  iterations?: number;
+  convergence?: boolean;
+  degeneracy?: boolean;
+  capacity?: number;
+  reverseCapacity?: number;
+  byteOffset?: number;
+  maximumWorkgroups?: number;
+  expectedCoreNumbers?: number[];
+};
+
+type ExpectedCoreNumbers = {
+  output: number[];
+  exactCoreNumbers: number[];
+  converged: boolean;
+  degeneracy: number;
+  invalidEdgeCount: number;
+  forwardCount: number;
+  reverseCount: number;
+  forwardOverflow: boolean;
+  reverseOverflow: boolean;
+};
+
+type CoreNumberExecutionFixture = {
+  device: Device;
+  buffers: Buffer[];
+  vectors: GPUVector[];
+  graph: LuGraph;
+  topology: LuGraphTopology;
+  operation: LuGraphCoreNumber;
+  commandGraph: GPUCommandGraph;
+  compiled?: ReturnType<GPUCommandGraph['compile']>;
+};
+
+const coreNumberScenarios: CoreNumberScenario[] = [
+  {
+    name: 'empty directed graph publishes an empty exact core and zero graph degeneracy',
+    vertexCount: 0,
+    sourceChunks: [[], []],
+    targetChunks: [[], []],
+    expectedCoreNumbers: []
+  },
+  {
+    name: 'empty graphs do not require optional convergence or degeneracy outputs',
+    vertexCount: 0,
+    sourceChunks: [[]],
+    targetChunks: [[]],
+    convergence: false,
+    degeneracy: false,
+    expectedCoreNumbers: []
+  },
+  {
+    name: 'isolated vertices have exact core number and degeneracy zero',
+    vertexCount: 5,
+    sourceChunks: [[], []],
+    targetChunks: [[], []],
+    expectedCoreNumbers: [0, 0, 0, 0, 0]
+  },
+  {
+    name: 'undirected edge endpoints both belong to the one-core',
+    vertexCount: 3,
+    sourceChunks: [[0]],
+    targetChunks: [[1]],
+    directed: false,
+    expectedCoreNumbers: [1, 1, 0]
+  },
+  {
+    name: 'high-degree star hubs collapse to the same one-core as their leaves',
+    vertexCount: 7,
+    sourceChunks: [[0, 0, 0], [], [0, 0, 0]],
+    targetChunks: [[1, 2, 3], [], [4, 5, 6]],
+    directed: false,
+    expectedCoreNumbers: [1, 1, 1, 1, 1, 1, 1]
+  },
+  {
+    name: 'cycles have exact core number two at every vertex',
+    vertexCount: 5,
+    sourceChunks: [[0, 1], [], [2, 3, 4]],
+    targetChunks: [[1, 2], [], [3, 4, 0]],
+    directed: false,
+    expectedCoreNumbers: [2, 2, 2, 2, 2]
+  },
+  {
+    name: 'a four-clique has core number and graph degeneracy three',
+    vertexCount: 4,
+    sourceChunks: [[0, 0, 0], [], [1, 1, 2]],
+    targetChunks: [[1, 2, 3], [], [2, 3, 3]],
+    directed: false,
+    expectedCoreNumbers: [3, 3, 3, 3]
+  },
+  {
+    name: 'pendant leaves peel away while a dense clique keeps its three-core',
+    vertexCount: 7,
+    sourceChunks: [[0, 0, 0, 1], [], [1, 2, 0, 1, 4]],
+    targetChunks: [[1, 2, 3, 2], [], [3, 3, 4, 5, 6]],
+    directed: false,
+    expectedCoreNumbers: [3, 3, 3, 3, 1, 1, 1]
+  },
+  {
+    name: 'disconnected cycles, paths, and isolated vertices publish distinct exact shells',
+    vertexCount: 8,
+    sourceChunks: [[0, 1, 2], [], [3, 4, 5]],
+    targetChunks: [[1, 2, 0], [], [4, 5, 6]],
+    directed: false,
+    expectedCoreNumbers: [2, 2, 2, 1, 1, 1, 1, 0]
+  },
+  {
+    name: 'directed inputs use distinct weak neighbors rather than directed in-plus-out degree',
+    vertexCount: 4,
+    sourceChunks: [[0, 1], [], [2]],
+    targetChunks: [[1, 2], [], [0]],
+    expectedCoreNumbers: [2, 2, 2, 0]
+  },
+  {
+    name: 'reciprocal edges, repeated source rows, and self-loops preserve simple-graph cores',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 0, 1], [], [0, 2, 2, 3, 3]],
+    targetChunks: [[1, 0, 1, 2], [], [2, 0, 2, 3, 3]],
+    expectedCoreNumbers: [2, 2, 2, 0]
+  },
+  {
+    name: 'weighted source and CSR columns are preserved but do not affect coreness',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 0]],
+    weightChunks: [[100, 0, 0.25]],
+    expectedCoreNumbers: [2, 2, 2, 0]
+  },
+  {
+    name: 'invalid endpoints remain excluded from exact weak-simple neighborhoods',
+    vertexCount: 4,
+    sourceChunks: [[0, 9], [], [1, 2]],
+    targetChunks: [[1, 2], [], [2, 0]],
+    expectedCoreNumbers: [2, 2, 2, 0]
+  },
+  {
+    name: 'zero refinement rounds publish distinct-degree upper bounds without false convergence',
+    vertexCount: 5,
+    sourceChunks: [[0, 0, 0, 0]],
+    targetChunks: [[1, 2, 3, 4]],
+    iterations: 0,
+    expectedCoreNumbers: [1, 1, 1, 1, 1]
+  },
+  {
+    name: 'one synchronized round can leave path-center core bounds above their final values',
+    vertexCount: 7,
+    sourceChunks: [[0, 1, 2], [], [3, 4, 5]],
+    targetChunks: [[1, 2, 3], [], [4, 5, 6]],
+    directed: false,
+    iterations: 1,
+    expectedCoreNumbers: [1, 1, 1, 1, 1, 1, 1]
+  },
+  {
+    name: 'self-loop-only zero-round graphs report conservative nonconvergence despite zero cores',
+    vertexCount: 2,
+    sourceChunks: [[0, 1]],
+    targetChunks: [[0, 1]],
+    iterations: 0,
+    expectedCoreNumbers: [0, 0]
+  },
+  {
+    name: 'optional caller-visible convergence status may be omitted',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 0]],
+    convergence: false,
+    expectedCoreNumbers: [2, 2, 2, 0]
+  },
+  {
+    name: 'optional caller-visible degeneracy output may be omitted',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 0]],
+    degeneracy: false,
+    expectedCoreNumbers: [2, 2, 2, 0]
+  },
+  {
+    name: 'forward directed overflow fails closed for every core and graph degeneracy',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 3]],
+    capacity: 1
+  },
+  {
+    name: 'reverse directed overflow fails closed instead of publishing partial weak neighborhoods',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 3]],
+    reverseCapacity: 1
+  },
+  {
+    name: 'undirected symmetrized CSR overflow publishes explicit invalid-core sentinels',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 3]],
+    directed: false,
+    capacity: 2
+  },
+  {
+    name: 'caller-owned four-byte CSR, output, status, and reduction slices remain aligned',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 0]],
+    byteOffset: 4,
+    expectedCoreNumbers: [2, 2, 2, 0]
+  },
+  {
+    name: 'bounded three-dimensional dispatch reaches the final source and isolated vertices',
+    vertexCount: 1025,
+    sourceChunks: [[1024]],
+    targetChunks: [[512]],
+    iterations: 1,
+    maximumWorkgroups: 2
+  }
+];
+
+test('LuGraphCoreNumber plans bounded three-dimensional graph dispatch', tapeTest => {
+  tapeTest.deepEqual(getLuGraphCoreNumberDispatchLayout(0, 2), {x: 1, y: 1, z: 1});
+  tapeTest.deepEqual(getLuGraphCoreNumberDispatchLayout(513, 2), {x: 2, y: 2, z: 1});
+  tapeTest.deepEqual(getLuGraphCoreNumberDispatchLayout(1025, 2), {x: 2, y: 2, z: 2});
+  tapeTest.throws(() => getLuGraphCoreNumberDispatchLayout(2049, 2), /3D dispatch limit/);
+  tapeTest.end();
+});
+
+for (const scenario of coreNumberScenarios) {
+  test(`LuGraphCoreNumber GPU decomposition: ${scenario.name}`, async tapeTest => {
+    const device = await getWebGPUTestDevice();
+    if (!device) {
+      tapeTest.comment('WebGPU is not available');
+      tapeTest.end();
+      return;
+    }
+
+    const expected = calculateExpectedCoreNumbers(scenario);
+    const fixture = createExecutionFixture(device, scenario, expected);
+    try {
+      compileCoreNumber(fixture, scenario.maximumWorkgroups);
+      executeCoreNumber(fixture);
+      await assertCoreNumbers(tapeTest, fixture, expected, scenario);
+    } finally {
+      destroyExecutionFixture(tapeTest, fixture);
+    }
+    tapeTest.end();
+  });
+}
+
+test('LuGraphCoreNumber rereads caller-owned edge columns on each graph encoding', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const initial: CoreNumberScenario = {
+    name: 'triangle',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 0]]
+  };
+  const expectedInitial = calculateExpectedCoreNumbers(initial);
+  const fixture = createExecutionFixture(device, initial, expectedInitial);
+  try {
+    compileCoreNumber(fixture);
+    executeCoreNumber(fixture);
+    await assertCoreNumbers(tapeTest, fixture, expectedInitial, initial);
+
+    const updated: CoreNumberScenario = {
+      ...initial,
+      name: 'path',
+      targetChunks: [[1, 2, 3]]
+    };
+    (fixture.graph.targetVertices.data[0].buffer as Buffer).write(Uint32Array.from([1, 2, 3]));
+    executeCoreNumber(fixture);
+    await assertCoreNumbers(tapeTest, fixture, calculateExpectedCoreNumbers(updated), updated);
+  } finally {
+    destroyExecutionFixture(tapeTest, fixture);
+  }
+  tapeTest.end();
+});
+
+test('LuGraphCoreNumber schedules GPU work without submission or source readback', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const scenario: CoreNumberScenario = {
+    name: 'command ownership',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 2]],
+    targetChunks: [[1, 2, 0]]
+  };
+  const expected = calculateExpectedCoreNumbers(scenario);
+  const fixture = createExecutionFixture(device, scenario, expected);
+  const submit = vi.spyOn(device, 'submit');
+  const sourceBuffers = [
+    ...fixture.graph.sourceVertices.data,
+    ...fixture.graph.targetVertices.data
+  ];
+  const readbacks = sourceBuffers.map(chunk => vi.spyOn(chunk.buffer as Buffer, 'readAsync'));
+  try {
+    compileCoreNumber(fixture);
+    tapeTest.equal(submit.mock.calls.length, 0, 'construction and compilation never submit work');
+    executeCoreNumber(fixture);
+    await assertCoreNumbers(tapeTest, fixture, expected, scenario);
+    tapeTest.ok(
+      readbacks.every(readback => readback.mock.calls.length === 0),
+      'source and adjacency data remain resident on the caller-owned device'
+    );
+  } finally {
+    submit.mockRestore();
+    for (const readback of readbacks) readback.mockRestore();
+    destroyExecutionFixture(tapeTest, fixture);
+  }
+  tapeTest.end();
+});
+
+/** Independently builds simple weak neighborhoods and compares bounded H-index to exact peeling. */
+function calculateExpectedCoreNumbers(scenario: CoreNumberScenario): ExpectedCoreNumbers {
+  const weakNeighbors = Array.from({length: scenario.vertexCount}, () => new Set<number>());
+  let invalidEdgeCount = 0;
+  let forwardCount = 0;
+  let reverseCount = 0;
+
+  for (const [chunkIndex, sources] of scenario.sourceChunks.entries()) {
+    for (const [edgeIndex, source] of sources.entries()) {
+      const target = scenario.targetChunks[chunkIndex][edgeIndex];
+      if (source >= scenario.vertexCount || target >= scenario.vertexCount) {
+        invalidEdgeCount++;
+        continue;
+      }
+      forwardCount++;
+      if (scenario.directed === false) {
+        if (source !== target) forwardCount++;
+      } else {
+        reverseCount++;
+      }
+      if (source !== target) {
+        weakNeighbors[source].add(target);
+        weakNeighbors[target].add(source);
+      }
+    }
+  }
+
+  const exactCoreNumbers = calculateExactPeeling(weakNeighbors);
+  const forwardOverflow = forwardCount > (scenario.capacity ?? forwardCount);
+  const reverseOverflow =
+    scenario.directed !== false && reverseCount > (scenario.reverseCapacity ?? reverseCount);
+  const invalid = forwardOverflow || reverseOverflow;
+  let output = invalid
+    ? new Array<number>(scenario.vertexCount).fill(INVALID_CORE_NUMBER)
+    : weakNeighbors.map(neighbors => neighbors.size);
+  const edgeCount = scenario.sourceChunks.reduce((total, chunk) => total + chunk.length, 0);
+  let converged = !invalid && (scenario.vertexCount === 0 || edgeCount === 0);
+  const iterations = scenario.iterations ?? 32;
+
+  for (let iteration = 0; iteration < iterations && scenario.vertexCount > 0; iteration++) {
+    if (invalid) {
+      converged = false;
+      continue;
+    }
+    if (converged) continue;
+
+    const next = output.map((previous, vertex) => {
+      for (let candidate = previous; candidate >= 1; candidate--) {
+        let support = 0;
+        for (const neighbor of weakNeighbors[vertex]) {
+          if (output[neighbor] >= candidate) support++;
+        }
+        if (support >= candidate) return candidate;
+      }
+      return 0;
+    });
+    converged = next.every((value, vertex) => value === output[vertex]);
+    output = next;
+  }
+
+  return {
+    output,
+    exactCoreNumbers,
+    converged,
+    degeneracy: output.length === 0 ? 0 : Math.max(...output),
+    invalidEdgeCount,
+    forwardCount,
+    reverseCount,
+    forwardOverflow,
+    reverseOverflow
+  };
+}
+
+/** Peels an independent mutable simple graph to obtain exact reference coreness. */
+function calculateExactPeeling(neighborhoods: readonly ReadonlySet<number>[]): number[] {
+  const remaining = new Set(neighborhoods.map((_, vertex) => vertex));
+  const degrees = neighborhoods.map(neighbors => neighbors.size);
+  const result = new Array<number>(neighborhoods.length).fill(0);
+  let threshold = 0;
+
+  while (remaining.size > 0) {
+    const vertex = [...remaining].find(candidate => degrees[candidate] <= threshold);
+    if (vertex === undefined) {
+      threshold++;
+      continue;
+    }
+    remaining.delete(vertex);
+    result[vertex] = threshold;
+    for (const neighbor of neighborhoods[vertex]) {
+      if (remaining.has(neighbor)) degrees[neighbor]--;
+    }
+  }
+  return result;
+}
+
+function createExecutionFixture(
+  device: Device,
+  scenario: CoreNumberScenario,
+  expected: ExpectedCoreNumbers
+): CoreNumberExecutionFixture {
+  const buffers: Buffer[] = [];
+  const vectors: GPUVector[] = [];
+  const sourceVertices = createInputVector(
+    device,
+    buffers,
+    vectors,
+    'source-vertices',
+    'uint32',
+    scenario.sourceChunks
+  );
+  const targetVertices = createInputVector(
+    device,
+    buffers,
+    vectors,
+    'target-vertices',
+    'uint32',
+    scenario.targetChunks
+  );
+  const edgeWeights = scenario.weightChunks
+    ? createInputVector(device, buffers, vectors, 'edge-weights', 'float32', scenario.weightChunks)
+    : undefined;
+  const directed = scenario.directed ?? true;
+  const graph = new LuGraph({
+    vertexCount: scenario.vertexCount,
+    sourceVertices,
+    targetVertices,
+    edgeWeights,
+    directed
+  });
+  const forward = createOutputAdjacency(
+    device,
+    buffers,
+    vectors,
+    'forward',
+    scenario.vertexCount,
+    scenario.capacity ?? expected.forwardCount,
+    Boolean(edgeWeights),
+    scenario.byteOffset
+  );
+  const reverse = directed
+    ? createOutputAdjacency(
+        device,
+        buffers,
+        vectors,
+        'reverse',
+        scenario.vertexCount,
+        scenario.reverseCapacity ?? expected.reverseCount,
+        Boolean(edgeWeights),
+        scenario.byteOffset
+      )
+    : undefined;
+  const invalidEdgeCount = createOutputVector(
+    device,
+    buffers,
+    vectors,
+    'invalid-edges',
+    'uint32',
+    1
+  );
+  const topology = new LuGraphTopology({graph, forward, reverse, invalidEdgeCount});
+  const output = createOutputVector(
+    device,
+    buffers,
+    vectors,
+    'core-numbers',
+    'uint32',
+    scenario.vertexCount,
+    scenario.byteOffset
+  );
+  const converged =
+    scenario.convergence === false
+      ? undefined
+      : createOutputVector(device, buffers, vectors, 'converged', 'uint32', 1, scenario.byteOffset);
+  const degeneracy =
+    scenario.degeneracy === false
+      ? undefined
+      : createOutputVector(
+          device,
+          buffers,
+          vectors,
+          'degeneracy',
+          'uint32',
+          1,
+          scenario.byteOffset
+        );
+  const operation = new LuGraphCoreNumber({
+    topology,
+    output,
+    iterations: scenario.iterations,
+    converged,
+    degeneracy
+  });
+  return {
+    device,
+    buffers,
+    vectors,
+    graph,
+    topology,
+    operation,
+    commandGraph: new GPUCommandGraph(device)
+  };
+}
+
+function createInputVector<Format extends ScalarFormat>(
+  device: Device,
+  buffers: Buffer[],
+  vectors: GPUVector[],
+  name: string,
+  format: Format,
+  chunks: readonly number[][]
+): GPUVector<Format> {
+  const data = chunks.map((chunk, chunkIndex) => {
+    const values = format === 'float32' ? Float32Array.from(chunk) : Uint32Array.from(chunk);
+    const buffer = device.createBuffer({
+      id: `${name}-${chunkIndex}`,
+      byteLength: Math.max(values.length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+    if (values.length > 0) buffer.write(values);
+    buffers.push(buffer);
+    return new GPUData<Format>({buffer, format, length: values.length, ownsBuffer: false});
+  });
+  const vector = new GPUVector<Format>({type: 'data', name, format, data, ownsData: false});
+  vectors.push(vector);
+  return vector;
+}
+
+function createOutputAdjacency(
+  device: Device,
+  buffers: Buffer[],
+  vectors: GPUVector[],
+  name: string,
+  vertexCount: number,
+  capacity: number,
+  weighted: boolean,
+  byteOffset = 0
+): LuGraphAdjacency {
+  return {
+    offsets: createOutputVector(
+      device,
+      buffers,
+      vectors,
+      `${name}-offsets`,
+      'uint32',
+      vertexCount + 1,
+      byteOffset
+    ),
+    neighbors: createOutputVector(
+      device,
+      buffers,
+      vectors,
+      `${name}-neighbors`,
+      'uint32',
+      capacity
+    ),
+    edgeIds: createOutputVector(device, buffers, vectors, `${name}-edge-ids`, 'uint32', capacity),
+    ...(weighted
+      ? {
+          edgeWeights: createOutputVector(
+            device,
+            buffers,
+            vectors,
+            `${name}-weights`,
+            'float32',
+            capacity
+          )
+        }
+      : {}),
+    count: createOutputVector(device, buffers, vectors, `${name}-count`, 'uint32', 1),
+    overflow: createOutputVector(device, buffers, vectors, `${name}-overflow`, 'uint32', 1)
+  };
+}
+
+function createOutputVector<Format extends ScalarFormat>(
+  device: Device,
+  buffers: Buffer[],
+  vectors: GPUVector[],
+  name: string,
+  format: Format,
+  length: number,
+  byteOffset = 0
+): GPUVector<Format> {
+  const buffer = device.createBuffer({
+    id: name,
+    byteLength: byteOffset + Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  buffers.push(buffer);
+  const vector = new GPUVector<Format>({
+    type: 'buffer',
+    name,
+    format,
+    buffer,
+    length,
+    byteOffset,
+    ownsBuffer: false
+  });
+  vectors.push(vector);
+  return vector;
+}
+
+function compileCoreNumber(fixture: CoreNumberExecutionFixture, maximumWorkgroups?: number): void {
+  fixture.topology.addToGraph(fixture.commandGraph);
+  if (maximumWorkgroups === undefined) {
+    fixture.operation.addToGraph(fixture.commandGraph);
+  } else {
+    addLuGraphCoreNumberToGraphWithDispatchLimit(
+      fixture.operation,
+      fixture.commandGraph,
+      maximumWorkgroups
+    );
+  }
+  fixture.compiled = fixture.commandGraph.compile();
+}
+
+function executeCoreNumber(fixture: CoreNumberExecutionFixture): void {
+  const encoder = fixture.device.createCommandEncoder({id: 'lu-graph-core-number-test'});
+  fixture.compiled!.encode(encoder, {parameters: undefined});
+  fixture.device.submit(encoder.finish());
+}
+
+async function assertCoreNumbers(
+  tapeTest: Test,
+  fixture: CoreNumberExecutionFixture,
+  expected: ExpectedCoreNumbers,
+  scenario: CoreNumberScenario
+): Promise<void> {
+  const [output, invalidEdges, forwardOverflow] = await Promise.all([
+    readUint32Vector(fixture.operation.output),
+    readUint32Vector(fixture.topology.invalidEdgeCount),
+    readUint32Vector(fixture.topology.forward.overflow)
+  ]);
+  tapeTest.deepEqual(
+    output,
+    expected.output,
+    'bounded GPU core numbers match synchronous H-indices'
+  );
+  tapeTest.equal(
+    invalidEdges[0],
+    expected.invalidEdgeCount,
+    'invalid source endpoints are excluded'
+  );
+  tapeTest.equal(
+    forwardOverflow[0],
+    Number(expected.forwardOverflow),
+    'forward overflow stays explicit'
+  );
+  if (scenario.expectedCoreNumbers) {
+    tapeTest.deepEqual(
+      expected.exactCoreNumbers,
+      scenario.expectedCoreNumbers,
+      'independent simple-graph peeling produces the documented exact shell numbers'
+    );
+  }
+  if (!expected.forwardOverflow && !expected.reverseOverflow) {
+    tapeTest.ok(
+      output.every((value, vertex) => value >= expected.exactCoreNumbers[vertex]),
+      'bounded, unconverged output remains a valid upper bound on exact core numbers'
+    );
+    if (expected.converged) {
+      tapeTest.deepEqual(
+        output,
+        expected.exactCoreNumbers,
+        'converged H-indices equal exact peeling'
+      );
+    }
+  }
+  if (fixture.operation.converged) {
+    const converged = await readUint32Vector(fixture.operation.converged);
+    tapeTest.equal(converged[0], Number(expected.converged), 'fixed-point convergence is truthful');
+  }
+  if (fixture.operation.degeneracy) {
+    const degeneracy = await readUint32Vector(fixture.operation.degeneracy);
+    tapeTest.equal(
+      degeneracy[0],
+      expected.degeneracy,
+      'GPU max reduction reports graph degeneracy'
+    );
+  }
+  if (fixture.topology.reverse) {
+    const reverseOverflow = await readUint32Vector(fixture.topology.reverse.overflow);
+    tapeTest.equal(
+      reverseOverflow[0],
+      Number(expected.reverseOverflow),
+      'reverse overflow stays explicit'
+    );
+  }
+}
+
+async function readUint32Vector(vector: GPUVector<'uint32'>): Promise<number[]> {
+  if (vector.length === 0) return [];
+  const data = vector.data[0];
+  const bytes = await (data.buffer as Buffer).readAsync(
+    data.byteOffset,
+    vector.length * Uint32Array.BYTES_PER_ELEMENT
+  );
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, vector.length));
+}
+
+function destroyExecutionFixture(tapeTest: Test, fixture: CoreNumberExecutionFixture): void {
+  fixture.compiled?.destroy();
+  for (const vector of fixture.vectors) vector.destroy();
+  tapeTest.ok(
+    fixture.buffers.every(buffer => !buffer.destroyed),
+    'destroying graph-owned scratch never destroys caller-owned source or output buffers'
+  );
+  for (const buffer of fixture.buffers) buffer.destroy();
+}

--- a/modules/experimental/test/lugraph/lu-graph-modularity.node.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-modularity.node.spec.ts
@@ -1,0 +1,482 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer} from '@luma.gl/core';
+import {DynamicBuffer} from '@luma.gl/engine';
+import * as experimentalModule from '@luma.gl/experimental';
+import {
+  LuGraph,
+  LuGraphModularity,
+  type LuGraphModularityProps
+} from '@luma.gl/experimental/lugraph';
+import {GPUData, GPUVector} from '@luma.gl/tables';
+import {NullDevice} from '@luma.gl/test-utils';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {getLuGraphModularityDispatchLayout} from '../../src/lugraph/lu-graph-modularity-internals';
+
+type ScalarFormat = 'uint32' | 'float32';
+type ScalarValues = Uint32Array | Float32Array;
+
+type ModularityFixture = {
+  device: NullDevice;
+  buffers: Buffer[];
+  dynamicBuffers: DynamicBuffer[];
+  vectors: GPUVector[];
+};
+
+type VectorOptions = {
+  buffer?: Buffer | DynamicBuffer;
+  byteOffset?: number;
+  byteStride?: number;
+  rowByteLength?: number;
+  stride?: number;
+};
+
+const modularityFixtures: ModularityFixture[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const fixture of modularityFixtures.splice(0)) {
+    for (const vector of fixture.vectors) vector.destroy();
+    for (const dynamicBuffer of fixture.dynamicBuffers) dynamicBuffer.destroy();
+    for (const buffer of fixture.buffers) buffer.destroy();
+    fixture.device.destroy();
+  }
+});
+
+describe('LuGraphModularity public contract and borrowed ownership', () => {
+  test('keeps weighted partition quality isolated in the optional luGraph entry point', () => {
+    expect(typeof LuGraphModularity).toBe('function');
+    expect('LuGraphModularity' in experimentalModule).toBe(false);
+  });
+
+  test('preserves original graph chunks and caller outputs without allocation or synchronization', () => {
+    const fixture = createModularityFixture();
+    const props = createModularityProps(fixture, {
+      weighted: true,
+      contributions: true,
+      valid: true
+    });
+    const createBufferSpy = vi.spyOn(fixture.device, 'createBuffer');
+    const createCommandEncoderSpy = vi.spyOn(fixture.device, 'createCommandEncoder');
+    const submitSpy = vi.spyOn(fixture.device, 'submit');
+    const readbackSpies = fixture.buffers.map(buffer => vi.spyOn(buffer, 'readAsync'));
+
+    const modularity = new LuGraphModularity({...props, id: 'borrowed-partition', resolution: 0.5});
+
+    expect(modularity.id).toBe('borrowed-partition');
+    expect(modularity.graph).toBe(props.graph);
+    expect(modularity.communities).toBe(props.communities);
+    expect(modularity.output).toBe(props.output);
+    expect(modularity.communityContributions).toBe(props.communityContributions);
+    expect(modularity.valid).toBe(props.valid);
+    expect(modularity.resolution).toBe(0.5);
+    expect(modularity.graph.sourceVertices.data.map(chunk => chunk.length)).toEqual([2, 0, 3]);
+    expect(createBufferSpy).not.toHaveBeenCalled();
+    expect(createCommandEncoderSpy).not.toHaveBeenCalled();
+    expect(submitSpy).not.toHaveBeenCalled();
+    for (const readbackSpy of readbackSpies) expect(readbackSpy).not.toHaveBeenCalled();
+    expect(Reflect.has(modularity, 'destroy')).toBe(false);
+
+    for (const vector of fixture.vectors) vector.destroy();
+    expect(fixture.buffers.every(buffer => !buffer.destroyed)).toBe(true);
+  });
+
+  test('defaults to directed, unweighted, resolution-one scoring with optional outputs omitted', () => {
+    const fixture = createModularityFixture();
+    const modularity = new LuGraphModularity(createModularityProps(fixture));
+
+    expect(modularity.id).toBe('lu-graph-modularity');
+    expect(modularity.graph.directed).toBe(true);
+    expect(modularity.graph.edgeWeights).toBeUndefined();
+    expect(modularity.resolution).toBe(1);
+    expect(modularity.communityContributions).toBeUndefined();
+    expect(modularity.valid).toBeUndefined();
+  });
+
+  test('accepts weighted undirected graphs without a CSR topology or reverse adjacency', () => {
+    const fixture = createModularityFixture();
+    const modularity = new LuGraphModularity(
+      createModularityProps(fixture, {directed: false, weighted: true})
+    );
+
+    expect(modularity.graph.directed).toBe(false);
+    expect(modularity.graph.edgeWeights?.data.map(chunk => chunk.length)).toEqual([2, 0, 3]);
+    expect(Reflect.has(modularity, 'topology')).toBe(false);
+  });
+
+  test('accepts empty vertex labels and contributions alongside scalar score and validity', () => {
+    const fixture = createModularityFixture();
+    const modularity = new LuGraphModularity(
+      createModularityProps(fixture, {vertexCount: 0, contributions: true, valid: true})
+    );
+
+    expect(modularity.communities.length).toBe(0);
+    expect(modularity.communityContributions?.length).toBe(0);
+    expect(modularity.output.length).toBe(1);
+    expect(modularity.valid?.length).toBe(1);
+  });
+
+  test.each([
+    0,
+    0.125,
+    1,
+    2,
+    Math.fround(3.4028234663852886e38)
+  ])('accepts a finite nonnegative resolution representable by float32: %s', resolution => {
+    const fixture = createModularityFixture();
+    const modularity = new LuGraphModularity({...createModularityProps(fixture), resolution});
+
+    expect(modularity.resolution).toBe(resolution);
+  });
+
+  test.each([
+    -1,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+    1e100
+  ])('rejects a negative, nonfinite, or float32-overflowing resolution: %s', resolution => {
+    const fixture = createModularityFixture();
+
+    expect(() => new LuGraphModularity({...createModularityProps(fixture), resolution})).toThrow(
+      /resolution|finite|float32|negative/
+    );
+  });
+
+  test('plans bounded three-dimensional vertex and edge dispatch without truncation', () => {
+    expect(getLuGraphModularityDispatchLayout(0, 2)).toEqual({x: 1, y: 1, z: 1});
+    expect(getLuGraphModularityDispatchLayout(512, 2)).toEqual({x: 2, y: 1, z: 1});
+    expect(getLuGraphModularityDispatchLayout(513, 2)).toEqual({x: 2, y: 2, z: 1});
+    expect(getLuGraphModularityDispatchLayout(1025, 2)).toEqual({x: 2, y: 2, z: 2});
+    expect(() => getLuGraphModularityDispatchLayout(2049, 2)).toThrow(/3D dispatch limit/);
+  });
+});
+
+describe('LuGraphModularity scalar/vector metadata and physical aliases', () => {
+  test.each([5, 7])('requires exactly one community label for each graph vertex: %i', length => {
+    const fixture = createModularityFixture();
+    const props = createModularityProps(fixture);
+    const communities = createVector(fixture, 'community-length', 'uint32', [
+      new Uint32Array(length)
+    ]);
+
+    expect(() => new LuGraphModularity({...props, communities})).toThrow(/communities|uint32|rows/);
+  });
+
+  test('requires one packed uint32 community chunk rather than floating-point labels', () => {
+    const fixture = createModularityFixture();
+    const props = createModularityProps(fixture);
+    const communities = createVector(fixture, 'floating-communities', 'float32', [
+      new Float32Array(props.graph.vertexCount)
+    ]) as unknown as GPUVector<'uint32'>;
+
+    expect(() => new LuGraphModularity({...props, communities})).toThrow(
+      /communities|uint32|packed/
+    );
+  });
+
+  test.each([0, 2])('requires exactly one community-label chunk: %i', chunkCount => {
+    const fixture = createModularityFixture();
+    const props = createModularityProps(fixture);
+    const chunks = chunkCount === 0 ? [] : [new Uint32Array(3), new Uint32Array(3)];
+    const communities = createVector(fixture, 'partitioned-communities', 'uint32', chunks);
+
+    expect(() => new LuGraphModularity({...props, communities})).toThrow(/communities|one|chunk/);
+  });
+
+  test.each([0, 2])('requires exactly one floating-point score scalar: %i', length => {
+    const fixture = createModularityFixture();
+    const props = createModularityProps(fixture);
+    const output = createVector(fixture, 'score-length', 'float32', [new Float32Array(length)]);
+
+    expect(() => new LuGraphModularity({...props, output})).toThrow(/output|float32|rows/);
+  });
+
+  test('rejects unsigned scores masquerading as modularity scalars', () => {
+    const fixture = createModularityFixture();
+    const props = createModularityProps(fixture);
+    const output = createVector(fixture, 'unsigned-score', 'uint32', [
+      new Uint32Array(1)
+    ]) as unknown as GPUVector<'float32'>;
+
+    expect(() => new LuGraphModularity({...props, output})).toThrow(/output|float32|packed/);
+  });
+
+  test.each([
+    5, 7
+  ])('requires one optional contribution per possible community label: %i', length => {
+    const fixture = createModularityFixture();
+    const props = createModularityProps(fixture);
+    const communityContributions = createVector(fixture, 'contribution-length', 'float32', [
+      new Float32Array(length)
+    ]);
+
+    expect(() => new LuGraphModularity({...props, communityContributions})).toThrow(
+      /communityContributions|float32|rows/
+    );
+  });
+
+  test('requires packed floating-point contributions instead of unsigned counts', () => {
+    const fixture = createModularityFixture();
+    const props = createModularityProps(fixture);
+    const communityContributions = createVector(fixture, 'unsigned-contributions', 'uint32', [
+      new Uint32Array(props.graph.vertexCount)
+    ]) as unknown as GPUVector<'float32'>;
+
+    expect(() => new LuGraphModularity({...props, communityContributions})).toThrow(
+      /communityContributions|float32|packed/
+    );
+  });
+
+  test.each([0, 2])('requires exactly one optional uint32 validity scalar: %i', length => {
+    const fixture = createModularityFixture();
+    const props = createModularityProps(fixture);
+    const valid = createVector(fixture, 'validity-length', 'uint32', [new Uint32Array(length)]);
+
+    expect(() => new LuGraphModularity({...props, valid})).toThrow(/valid|uint32|rows/);
+  });
+
+  test.each([
+    ['misaligned byte offset', {byteOffset: 2}],
+    ['padded byte stride', {byteStride: 8}],
+    ['oversized row payload', {rowByteLength: 8}],
+    ['multi-component scalar stride', {stride: 2}]
+  ] as [string, VectorOptions][])('rejects unpacked scalar score: %s', (_name, options) => {
+    const fixture = createModularityFixture();
+    const props = createModularityProps(fixture);
+    const output = createVector(
+      fixture,
+      'unpacked-score',
+      'float32',
+      [new Float32Array(1)],
+      options
+    );
+
+    expect(() => new LuGraphModularity({...props, output})).toThrow(
+      /output|float32|packed|aligned/
+    );
+  });
+
+  test('accepts uint32-aligned labels and all outputs at non-256-byte binding offsets', () => {
+    const fixture = createModularityFixture();
+    const props = createModularityProps(fixture);
+    const communities = createVector(
+      fixture,
+      'offset-communities',
+      'uint32',
+      [new Uint32Array(props.graph.vertexCount)],
+      {byteOffset: 4}
+    );
+    const output = createVector(fixture, 'offset-score', 'float32', [new Float32Array(1)], {
+      byteOffset: 4
+    });
+    const communityContributions = createVector(
+      fixture,
+      'offset-contributions',
+      'float32',
+      [new Float32Array(props.graph.vertexCount)],
+      {byteOffset: 4}
+    );
+    const valid = createVector(fixture, 'offset-validity', 'uint32', [new Uint32Array(1)], {
+      byteOffset: 4
+    });
+
+    const modularity = new LuGraphModularity({
+      ...props,
+      communities,
+      output,
+      communityContributions,
+      valid
+    });
+    expect(modularity.communities.data[0].byteOffset).toBe(4);
+    expect(modularity.output.data[0].byteOffset).toBe(4);
+    expect(modularity.communityContributions?.data[0].byteOffset).toBe(4);
+    expect(modularity.valid?.data[0].byteOffset).toBe(4);
+  });
+
+  test.each([
+    'sourceVertices',
+    'targetVertices',
+    'edgeWeights',
+    'edgeIds',
+    'communities'
+  ])('rejects writable scores aliasing existing physical input allocation: %s', inputName => {
+    const fixture = createModularityFixture();
+    const props = createModularityProps(fixture, {weighted: true, edgeIds: true});
+    const input =
+      inputName === 'communities'
+        ? props.communities
+        : props.graph[
+            inputName as 'sourceVertices' | 'targetVertices' | 'edgeWeights' | 'edgeIds'
+          ]!;
+    const output = createVector(fixture, 'aliased-score', 'float32', [new Float32Array(1)], {
+      buffer: input.data[0].buffer
+    });
+
+    expect(() => new LuGraphModularity({...props, output})).toThrow(
+      /output|distinct|physical|allocation/
+    );
+  });
+
+  test('rejects optional contributions and validity sharing any writable allocation', () => {
+    const fixture = createModularityFixture();
+    const props = createModularityProps(fixture, {
+      vertexCount: 1,
+      contributions: true,
+      valid: true
+    });
+    const contributionAlias = createVector(
+      fixture,
+      'score-alias',
+      'float32',
+      [new Float32Array(1)],
+      {
+        buffer: props.output.data[0].buffer
+      }
+    );
+    const validityAlias = createVector(
+      fixture,
+      'contribution-alias',
+      'uint32',
+      [new Uint32Array(1)],
+      {
+        buffer: props.communityContributions!.data[0].buffer
+      }
+    );
+
+    expect(
+      () => new LuGraphModularity({...props, communityContributions: contributionAlias})
+    ).toThrow(/communityContributions|distinct|physical|allocation/);
+    expect(() => new LuGraphModularity({...props, valid: validityAlias})).toThrow(
+      /valid|distinct|physical|allocation/
+    );
+  });
+
+  test('unwraps borrowed DynamicBuffer wrappers when checking physical output aliases', () => {
+    const fixture = createModularityFixture();
+    const props = createModularityProps(fixture);
+    const concreteBuffer = props.graph.sourceVertices.data[0].buffer as Buffer;
+    const dynamicBuffer = new DynamicBuffer(fixture.device, {
+      id: 'borrowed-source-wrapper',
+      buffer: concreteBuffer,
+      ownsBuffer: false
+    });
+    fixture.dynamicBuffers.push(dynamicBuffer);
+    const output = createVector(fixture, 'wrapped-score-alias', 'float32', [new Float32Array(1)], {
+      buffer: dynamicBuffer
+    });
+
+    expect(() => new LuGraphModularity({...props, output})).toThrow(/distinct|physical|allocation/);
+    expect(concreteBuffer.destroyed).toBe(false);
+  });
+});
+
+function createModularityFixture(): ModularityFixture {
+  const fixture = {device: new NullDevice({}), buffers: [], dynamicBuffers: [], vectors: []};
+  modularityFixtures.push(fixture);
+  return fixture;
+}
+
+function createModularityProps(
+  fixture: ModularityFixture,
+  options: {
+    vertexCount?: number;
+    directed?: boolean;
+    weighted?: boolean;
+    edgeIds?: boolean;
+    contributions?: boolean;
+    valid?: boolean;
+  } = {}
+): LuGraphModularityProps {
+  const vertexCount = options.vertexCount ?? 6;
+  const sourceVertices = createVector(fixture, 'sourceVertices', 'uint32', [
+    Uint32Array.from([0, 1]),
+    new Uint32Array(0),
+    Uint32Array.from([2, 3, 4])
+  ]);
+  const targetVertices = createVector(fixture, 'targetVertices', 'uint32', [
+    Uint32Array.from([1, 2]),
+    new Uint32Array(0),
+    Uint32Array.from([3, 4, 5])
+  ]);
+  const edgeWeights = options.weighted
+    ? createVector(fixture, 'edgeWeights', 'float32', [
+        Float32Array.from([0.5, 2]),
+        new Float32Array(0),
+        Float32Array.from([1, 4, 8])
+      ])
+    : undefined;
+  const edgeIds = options.edgeIds
+    ? createVector(fixture, 'edgeIds', 'uint32', [
+        Uint32Array.from([10, 20]),
+        new Uint32Array(0),
+        Uint32Array.from([30, 40, 50])
+      ])
+    : undefined;
+  const graph = new LuGraph({
+    vertexCount,
+    sourceVertices,
+    targetVertices,
+    edgeWeights,
+    edgeIds,
+    directed: options.directed
+  });
+  const communities = createVector(fixture, 'communities', 'uint32', [
+    new Uint32Array(vertexCount)
+  ]);
+  const output = createVector(fixture, 'modularity-score', 'float32', [new Float32Array(1)]);
+  const communityContributions = options.contributions
+    ? createVector(fixture, 'community-contributions', 'float32', [new Float32Array(vertexCount)])
+    : undefined;
+  const valid = options.valid
+    ? createVector(fixture, 'modularity-valid', 'uint32', [new Uint32Array(1)])
+    : undefined;
+  return {graph, communities, output, communityContributions, valid};
+}
+
+function createVector<Format extends ScalarFormat>(
+  fixture: ModularityFixture,
+  name: string,
+  format: Format,
+  chunks: readonly ScalarValues[],
+  options: VectorOptions = {}
+): GPUVector<Format> {
+  const byteOffset = options.byteOffset ?? 0;
+  const byteStride = options.byteStride ?? Uint32Array.BYTES_PER_ELEMENT;
+  const rowByteLength = options.rowByteLength ?? Uint32Array.BYTES_PER_ELEMENT;
+  const stride = options.stride ?? 1;
+  const data = chunks.map((values, chunkIndex) => {
+    const buffer =
+      options.buffer ??
+      fixture.device.createBuffer({
+        id: `${name}-chunk-${chunkIndex}-${fixture.buffers.length}`,
+        byteLength: byteOffset + Math.max(Math.max(values.length, 1) * byteStride, rowByteLength),
+        usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC
+      });
+    if (!options.buffer) fixture.buffers.push(buffer as Buffer);
+    return new GPUData<Format>({
+      buffer,
+      format,
+      length: values.length,
+      byteOffset,
+      byteStride,
+      rowByteLength,
+      stride,
+      ownsBuffer: false
+    });
+  });
+  const vector = new GPUVector<Format>({
+    type: 'data',
+    name,
+    format,
+    data,
+    byteStride,
+    rowByteLength,
+    stride,
+    ownsData: false
+  });
+  fixture.vectors.push(vector);
+  return vector;
+}

--- a/modules/experimental/test/lugraph/lu-graph-modularity.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-modularity.spec.ts
@@ -1,0 +1,810 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {GPUCommandGraph} from '@luma.gl/experimental';
+import {
+  LuGraph,
+  LuGraphLabelPropagation,
+  LuGraphModularity,
+  LuGraphTopology,
+  type LuGraphAdjacency
+} from '@luma.gl/experimental/lugraph';
+import {GPUData, GPUVector} from '@luma.gl/tables';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import test, {type Test} from 'test/utils/vitest-tape';
+import {vi} from 'vitest';
+import {addLuGraphModularityToGraphWithDispatchLimit} from '../../src/lugraph/lu-graph-modularity-internals';
+
+type ScalarFormat = 'uint32' | 'float32';
+
+type ModularityScenario = {
+  name: string;
+  vertexCount: number;
+  sourceChunks: number[][];
+  targetChunks: number[][];
+  weightChunks?: number[][];
+  communities: number[];
+  directed?: boolean;
+  resolution?: number;
+  contributions?: boolean;
+  validity?: boolean;
+  byteOffset?: number;
+  maximumWorkgroups?: number;
+  expectedScore?: number;
+  expectedContributions?: number[];
+  expectedValid?: boolean;
+};
+
+type ExpectedModularity = {
+  score: number;
+  contributions: number[];
+  valid: boolean;
+};
+
+type ModularityExecutionFixture = {
+  device: Device;
+  buffers: Buffer[];
+  vectors: GPUVector[];
+  graph: LuGraph;
+  modularity: LuGraphModularity;
+  commandGraph: GPUCommandGraph;
+  compiled?: ReturnType<GPUCommandGraph['compile']>;
+};
+
+const modularityScenarios: ModularityScenario[] = [
+  {
+    name: 'empty directed graph fails closed with zero score and empty contributions',
+    vertexCount: 0,
+    sourceChunks: [[], []],
+    targetChunks: [[], []],
+    communities: [],
+    expectedScore: 0,
+    expectedValid: false
+  },
+  {
+    name: 'nonempty edgeless graph has undefined modularity and publishes invalid zero',
+    vertexCount: 4,
+    sourceChunks: [[], [], []],
+    targetChunks: [[], [], []],
+    communities: [0, 0, 2, 2],
+    expectedScore: 0,
+    expectedValid: false
+  },
+  {
+    name: 'two disconnected directed communities have exact one-half modularity',
+    vertexCount: 4,
+    sourceChunks: [[0], [], [2]],
+    targetChunks: [[1], [], [3]],
+    communities: [0, 0, 2, 2],
+    expectedScore: 0.5,
+    expectedContributions: [0.25, 0, 0.25, 0]
+  },
+  {
+    name: 'two disconnected undirected communities have exact one-half modularity',
+    vertexCount: 4,
+    sourceChunks: [[0], [], [2]],
+    targetChunks: [[1], [], [3]],
+    communities: [0, 0, 2, 2],
+    directed: false,
+    expectedScore: 0.5,
+    expectedContributions: [0.25, 0, 0.25, 0]
+  },
+  {
+    name: 'placing every vertex in one directed community gives zero modularity',
+    vertexCount: 4,
+    sourceChunks: [[0, 1], [], [2]],
+    targetChunks: [[1, 2], [], [3]],
+    communities: [0, 0, 0, 0],
+    expectedScore: 0,
+    expectedContributions: [0, 0, 0, 0]
+  },
+  {
+    name: 'undirected singleton communities expose negative half modularity for one edge',
+    vertexCount: 2,
+    sourceChunks: [[0]],
+    targetChunks: [[1]],
+    communities: [0, 1],
+    directed: false,
+    expectedScore: -0.5,
+    expectedContributions: [-0.25, -0.25]
+  },
+  {
+    name: 'reciprocal cross-community directed edges remain two independent source rows',
+    vertexCount: 2,
+    sourceChunks: [[0], [], [1]],
+    targetChunks: [[1], [], [0]],
+    communities: [0, 1],
+    expectedScore: -0.5,
+    expectedContributions: [-0.25, -0.25]
+  },
+  {
+    name: 'weighted directed partitions use original positive float32 edge costs',
+    vertexCount: 4,
+    sourceChunks: [[0], [], [2]],
+    targetChunks: [[1], [], [3]],
+    weightChunks: [[3], [], [1]],
+    communities: [0, 0, 2, 2],
+    expectedScore: 0.375,
+    expectedContributions: [0.1875, 0, 0.1875, 0]
+  },
+  {
+    name: 'weighted undirected partitions normalize total endpoint volume by twice edge weight',
+    vertexCount: 4,
+    sourceChunks: [[0], [], [2]],
+    targetChunks: [[1], [], [3]],
+    weightChunks: [[3], [], [1]],
+    communities: [0, 0, 2, 2],
+    directed: false,
+    expectedScore: 0.375,
+    expectedContributions: [0.1875, 0, 0.1875, 0]
+  },
+  {
+    name: 'resolution zero preserves internal-edge fraction without a null-model penalty',
+    vertexCount: 4,
+    sourceChunks: [[0], [], [2]],
+    targetChunks: [[1], [], [3]],
+    communities: [0, 0, 2, 2],
+    resolution: 0,
+    expectedScore: 1,
+    expectedContributions: [0.5, 0, 0.5, 0]
+  },
+  {
+    name: 'resolution two doubles the null-model penalty deterministically',
+    vertexCount: 4,
+    sourceChunks: [[0], [], [2]],
+    targetChunks: [[1], [], [3]],
+    communities: [0, 0, 2, 2],
+    resolution: 2,
+    expectedScore: 0
+  },
+  {
+    name: 'undirected self-loops contribute twice to degree but only once to internal edge weight',
+    vertexCount: 4,
+    sourceChunks: [[0], [], [2]],
+    targetChunks: [[0], [], [3]],
+    weightChunks: [[2], [], [2]],
+    communities: [0, 1, 2, 2],
+    directed: false,
+    expectedScore: 0.5,
+    expectedContributions: [0.25, 0, 0.25, 0]
+  },
+  {
+    name: 'directed self-loops contribute once to outgoing, incoming, and internal weight',
+    vertexCount: 4,
+    sourceChunks: [[0], [], [2]],
+    targetChunks: [[0], [], [3]],
+    communities: [0, 1, 2, 2],
+    expectedScore: 0.5
+  },
+  {
+    name: 'parallel source edges preserve multigraph multiplicity instead of deduplicating',
+    vertexCount: 4,
+    sourceChunks: [[0, 0], [], [2]],
+    targetChunks: [[1, 1], [], [3]],
+    communities: [0, 0, 2, 2],
+    expectedScore: 4 / 9,
+    expectedContributions: [2 / 9, 0, 2 / 9, 0]
+  },
+  {
+    name: 'invalid endpoints are ignored even when their unused source weights are negative',
+    vertexCount: 4,
+    sourceChunks: [[0, 9], [], [2]],
+    targetChunks: [[1, 1], [], [3]],
+    weightChunks: [[1, -5], [], [1]],
+    communities: [0, 0, 2, 2],
+    expectedScore: 0.5,
+    expectedValid: true
+  },
+  {
+    name: 'negative valid-endpoint source weight invalidates every modularity output',
+    vertexCount: 4,
+    sourceChunks: [[0], [], [2]],
+    targetChunks: [[1], [], [3]],
+    weightChunks: [[1], [], [-1]],
+    communities: [0, 0, 2, 2],
+    expectedScore: 0,
+    expectedContributions: [0, 0, 0, 0],
+    expectedValid: false
+  },
+  {
+    name: 'NaN valid-endpoint source weight fails closed without poisoning group reductions',
+    vertexCount: 4,
+    sourceChunks: [[0], [], [2]],
+    targetChunks: [[1], [], [3]],
+    weightChunks: [[1], [], [Number.NaN]],
+    communities: [0, 0, 2, 2],
+    expectedValid: false
+  },
+  {
+    name: 'positive infinite edge weights fail closed with explicit invalid status',
+    vertexCount: 2,
+    sourceChunks: [[0]],
+    targetChunks: [[1]],
+    weightChunks: [[Number.POSITIVE_INFINITY]],
+    communities: [0, 0],
+    expectedValid: false
+  },
+  {
+    name: 'negative infinite edge weights fail closed with explicit invalid status',
+    vertexCount: 2,
+    sourceChunks: [[0]],
+    targetChunks: [[1]],
+    weightChunks: [[Number.NEGATIVE_INFINITY]],
+    communities: [0, 0],
+    expectedValid: false
+  },
+  {
+    name: 'all-zero accepted weights define no modularity even when each weight is finite',
+    vertexCount: 4,
+    sourceChunks: [[0], [], [2]],
+    targetChunks: [[1], [], [3]],
+    weightChunks: [[0], [], [0]],
+    communities: [0, 0, 2, 2],
+    expectedValid: false
+  },
+  {
+    name: 'an invalid isolated vertex community poisons the entire partition',
+    vertexCount: 4,
+    sourceChunks: [[0]],
+    targetChunks: [[1]],
+    communities: [0, 0, 2, 9],
+    expectedValid: false
+  },
+  {
+    name: 'the unsigned invalid-community sentinel fails closed',
+    vertexCount: 2,
+    sourceChunks: [[0]],
+    targetChunks: [[1]],
+    communities: [0, 0xffffffff],
+    expectedValid: false
+  },
+  {
+    name: 'float32 group-volume accumulation overflow fails closed',
+    vertexCount: 2,
+    sourceChunks: [[0], [], [0]],
+    targetChunks: [[1], [], [1]],
+    weightChunks: [[3.4028234663852886e38], [], [3.4028234663852886e38]],
+    communities: [0, 0],
+    expectedValid: false
+  },
+  {
+    name: 'optional contribution and validity buffers can be omitted independently',
+    vertexCount: 4,
+    sourceChunks: [[0], [], [2]],
+    targetChunks: [[1], [], [3]],
+    communities: [0, 0, 2, 2],
+    contributions: false,
+    validity: false,
+    expectedScore: 0.5
+  },
+  {
+    name: 'non-256-byte-aligned labels and scalar outputs preserve exact view offsets',
+    vertexCount: 4,
+    sourceChunks: [[0], [], [2]],
+    targetChunks: [[1], [], [3]],
+    communities: [0, 0, 2, 2],
+    byteOffset: 4,
+    expectedScore: 0.5
+  },
+  {
+    name: 'bounded three-dimensional dispatch validates and clears the final of 1025 communities',
+    vertexCount: 1025,
+    sourceChunks: [[0], [], [1024]],
+    targetChunks: [[1], [], [1023]],
+    communities: Array.from({length: 1025}, (_value, index) => (index < 2 ? 0 : 1023)),
+    maximumWorkgroups: 2,
+    expectedScore: 0.5
+  }
+];
+
+for (const scenario of modularityScenarios) {
+  test(`LuGraphModularity GPU: ${scenario.name}`, async tapeTest => {
+    const device = await getWebGPUTestDevice();
+    if (!device) {
+      tapeTest.comment('WebGPU is not available');
+      tapeTest.end();
+      return;
+    }
+
+    const expected = calculateExpectedModularity(scenario);
+    const fixture = createExecutionFixture(device, scenario);
+    try {
+      compileModularity(fixture, scenario.maximumWorkgroups);
+      executeModularity(fixture);
+      await assertModularity(tapeTest, fixture, expected);
+      tapeTest.deepEqual(
+        fixture.graph.sourceVertices.data.map(chunk => chunk.length),
+        scenario.sourceChunks.map(chunk => chunk.length),
+        'modularity consumes every original ordered source chunk without flattening'
+      );
+      if (scenario.expectedScore !== undefined) {
+        tapeTest.ok(
+          Math.abs(expected.score - scenario.expectedScore) < 1e-6,
+          'independent CPU modularity oracle agrees with the explicit exact partition score'
+        );
+      }
+      if (scenario.expectedContributions) {
+        assertApproximateValues(
+          tapeTest,
+          expected.contributions,
+          scenario.expectedContributions,
+          'independent CPU oracle confirms explicit stable-community contribution rows'
+        );
+      }
+      if (scenario.expectedValid !== undefined) {
+        tapeTest.equal(expected.valid, scenario.expectedValid);
+      }
+    } finally {
+      destroyExecutionFixture(tapeTest, fixture);
+    }
+
+    tapeTest.end();
+  });
+}
+
+test('LuGraphModularity scores existing GPU label propagation in the same command graph', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const scenario: ModularityScenario = {
+    name: 'GPU label propagation and modularity composition',
+    vertexCount: 6,
+    sourceChunks: [[0, 1, 2], [], [3, 4, 5]],
+    targetChunks: [[1, 2, 0], [], [4, 5, 3]],
+    communities: [0, 0, 0, 3, 3, 3],
+    directed: false,
+    expectedScore: 0.5
+  };
+  const fixture = createExecutionFixture(device, scenario);
+  const adjacency = createOutputAdjacency(
+    fixture.device,
+    fixture.buffers,
+    fixture.vectors,
+    'forward',
+    scenario.vertexCount,
+    fixture.graph.edgeCount * 2
+  );
+  const invalidEdgeCount = createOutputVector(
+    fixture.device,
+    fixture.buffers,
+    fixture.vectors,
+    'invalid-edges',
+    'uint32',
+    1
+  );
+  const topology = new LuGraphTopology({
+    graph: fixture.graph,
+    forward: adjacency,
+    invalidEdgeCount
+  });
+  const propagation = new LuGraphLabelPropagation({
+    topology,
+    output: fixture.modularity.communities,
+    iterations: 8
+  });
+  const communityBuffer = fixture.modularity.communities.data[0].buffer as Buffer;
+  const readbackSpy = vi.spyOn(communityBuffer, 'readAsync');
+  const submitSpy = vi.spyOn(device, 'submit');
+
+  try {
+    topology.addToGraph(fixture.commandGraph);
+    propagation.addToGraph(fixture.commandGraph);
+    fixture.modularity.addToGraph(fixture.commandGraph);
+    fixture.compiled = fixture.commandGraph.compile();
+    tapeTest.equal(
+      submitSpy.mock.calls.length,
+      0,
+      'composition declares and compiles without submission'
+    );
+    tapeTest.equal(
+      readbackSpy.mock.calls.length,
+      0,
+      'generated communities are never staged through CPU'
+    );
+    submitSpy.mockRestore();
+
+    executeModularity(fixture);
+    await assertModularity(tapeTest, fixture, calculateExpectedModularity(scenario));
+    tapeTest.equal(
+      readbackSpy.mock.calls.length,
+      0,
+      'the exact partition score consumes live label-propagation output entirely on the GPU'
+    );
+  } finally {
+    submitSpy.mockRestore();
+    readbackSpy.mockRestore();
+    destroyExecutionFixture(tapeTest, fixture);
+  }
+
+  tapeTest.end();
+});
+
+test('LuGraphModularity recomputes scores after caller-owned community and source updates', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const original: ModularityScenario = {
+    name: 'repeated exact partition scoring',
+    vertexCount: 4,
+    sourceChunks: [[0], [], [2]],
+    targetChunks: [[1], [], [3]],
+    communities: [0, 0, 2, 2]
+  };
+  const fixture = createExecutionFixture(device, original);
+  const submitSpy = vi.spyOn(device, 'submit');
+  const readbackSpies = [
+    ...fixture.graph.sourceVertices.data,
+    ...fixture.graph.targetVertices.data
+  ].map(chunk => vi.spyOn(chunk.buffer, 'readAsync'));
+
+  try {
+    compileModularity(fixture);
+    tapeTest.equal(submitSpy.mock.calls.length, 0);
+    tapeTest.ok(readbackSpies.every(spy => spy.mock.calls.length === 0));
+    submitSpy.mockRestore();
+    for (const readbackSpy of readbackSpies) readbackSpy.mockRestore();
+
+    executeModularity(fixture);
+    await assertModularity(tapeTest, fixture, calculateExpectedModularity(original));
+
+    const communityBuffer = fixture.modularity.communities.data[0].buffer as Buffer;
+    communityBuffer.write(Uint32Array.from([0, 0, 0, 0]));
+    const updated = {...original, communities: [0, 0, 0, 0]};
+    executeModularity(fixture);
+    await assertModularity(tapeTest, fixture, calculateExpectedModularity(updated));
+    tapeTest.equal(fixture.modularity.communities.data[0].buffer, communityBuffer);
+  } finally {
+    submitSpy.mockRestore();
+    for (const readbackSpy of readbackSpies) readbackSpy.mockRestore();
+    destroyExecutionFixture(tapeTest, fixture);
+  }
+
+  tapeTest.end();
+});
+
+/** Evaluates Newman community volumes independently over original graph source partitions. */
+function calculateExpectedModularity(scenario: ModularityScenario): ExpectedModularity {
+  const directed = scenario.directed !== false;
+  const resolution = Math.fround(scenario.resolution ?? 1);
+  const outgoingVolumes = new Float32Array(scenario.vertexCount);
+  const incomingVolumes = new Float32Array(scenario.vertexCount);
+  const internalWeights = new Float32Array(scenario.vertexCount);
+  let invalid = scenario.communities.some(community => community >= scenario.vertexCount);
+
+  for (const [chunkIndex, sources] of scenario.sourceChunks.entries()) {
+    for (const [rowIndex, sourceVertex] of sources.entries()) {
+      const targetVertex = scenario.targetChunks[chunkIndex][rowIndex];
+      if (sourceVertex >= scenario.vertexCount || targetVertex >= scenario.vertexCount) continue;
+
+      const weight = Math.fround(scenario.weightChunks?.[chunkIndex][rowIndex] ?? 1);
+      if (!Number.isFinite(weight) || weight < 0) {
+        invalid = true;
+        continue;
+      }
+
+      const sourceCommunity = scenario.communities[sourceVertex];
+      const targetCommunity = scenario.communities[targetVertex];
+      if (sourceCommunity >= scenario.vertexCount || targetCommunity >= scenario.vertexCount) {
+        invalid = true;
+        continue;
+      }
+
+      outgoingVolumes[sourceCommunity] = Math.fround(outgoingVolumes[sourceCommunity] + weight);
+      if (directed) {
+        incomingVolumes[targetCommunity] = Math.fround(incomingVolumes[targetCommunity] + weight);
+      } else {
+        outgoingVolumes[targetCommunity] = Math.fround(outgoingVolumes[targetCommunity] + weight);
+      }
+      if (sourceCommunity === targetCommunity) {
+        internalWeights[sourceCommunity] = Math.fround(internalWeights[sourceCommunity] + weight);
+      }
+    }
+  }
+
+  const totalVolume = Array.from(outgoingVolumes).reduce(
+    (total, volume) => Math.fround(total + volume),
+    0
+  );
+  if (!Number.isFinite(totalVolume) || totalVolume <= 0) invalid = true;
+
+  if (invalid) {
+    return {score: 0, contributions: Array(scenario.vertexCount).fill(0), valid: false};
+  }
+
+  const contributions = Array.from(outgoingVolumes, (outgoing, community) => {
+    const incoming = directed ? incomingVolumes[community] : outgoing;
+    const internalRatio = Math.fround(internalWeights[community] / totalVolume);
+    const internalTerm = Math.fround(internalRatio * (directed ? 1 : 2));
+    const expectedTerm = Math.fround(
+      Math.fround(resolution * Math.fround(outgoing / totalVolume)) *
+        Math.fround(incoming / totalVolume)
+    );
+    return Math.fround(internalTerm - expectedTerm);
+  });
+  const score = contributions.reduce((total, contribution) => Math.fround(total + contribution), 0);
+  if (
+    !Number.isFinite(score) ||
+    contributions.some(contribution => !Number.isFinite(contribution))
+  ) {
+    return {score: 0, contributions: Array(scenario.vertexCount).fill(0), valid: false};
+  }
+
+  return {score, contributions, valid: true};
+}
+
+function createExecutionFixture(
+  device: Device,
+  scenario: ModularityScenario
+): ModularityExecutionFixture {
+  const buffers: Buffer[] = [];
+  const vectors: GPUVector[] = [];
+  const sourceVertices = createInputVector(
+    device,
+    buffers,
+    vectors,
+    'source-vertices',
+    'uint32',
+    scenario.sourceChunks
+  );
+  const targetVertices = createInputVector(
+    device,
+    buffers,
+    vectors,
+    'target-vertices',
+    'uint32',
+    scenario.targetChunks
+  );
+  const edgeWeights = scenario.weightChunks
+    ? createInputVector(device, buffers, vectors, 'edge-weights', 'float32', scenario.weightChunks)
+    : undefined;
+  const graph = new LuGraph({
+    vertexCount: scenario.vertexCount,
+    sourceVertices,
+    targetVertices,
+    edgeWeights,
+    directed: scenario.directed
+  });
+  const communities = createOutputVector(
+    device,
+    buffers,
+    vectors,
+    'vertex-communities',
+    'uint32',
+    scenario.vertexCount,
+    scenario.byteOffset,
+    Uint32Array.from(scenario.communities)
+  );
+  const output = createOutputVector(
+    device,
+    buffers,
+    vectors,
+    'modularity-score',
+    'float32',
+    1,
+    scenario.byteOffset
+  );
+  const communityContributions =
+    scenario.contributions === false
+      ? undefined
+      : createOutputVector(
+          device,
+          buffers,
+          vectors,
+          'community-contributions',
+          'float32',
+          scenario.vertexCount,
+          scenario.byteOffset
+        );
+  const valid =
+    scenario.validity === false
+      ? undefined
+      : createOutputVector(
+          device,
+          buffers,
+          vectors,
+          'modularity-validity',
+          'uint32',
+          1,
+          scenario.byteOffset
+        );
+  const modularity = new LuGraphModularity({
+    graph,
+    communities,
+    output,
+    resolution: scenario.resolution,
+    communityContributions,
+    valid
+  });
+
+  return {device, buffers, vectors, graph, modularity, commandGraph: new GPUCommandGraph(device)};
+}
+
+function createInputVector<Format extends ScalarFormat>(
+  device: Device,
+  buffers: Buffer[],
+  vectors: GPUVector[],
+  name: string,
+  format: Format,
+  chunks: readonly number[][]
+): GPUVector<Format> {
+  const data = chunks.map((chunk, chunkIndex) => {
+    const values = format === 'float32' ? Float32Array.from(chunk) : Uint32Array.from(chunk);
+    const buffer = device.createBuffer({
+      id: `${name}-chunk-${chunkIndex}`,
+      data: values.length > 0 ? values : new Uint32Array(1),
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+    buffers.push(buffer);
+    return new GPUData<Format>({buffer, format, length: values.length, ownsBuffer: false});
+  });
+  const vector = new GPUVector<Format>({type: 'data', name, format, data, ownsData: false});
+  vectors.push(vector);
+  return vector;
+}
+
+function createOutputAdjacency(
+  device: Device,
+  buffers: Buffer[],
+  vectors: GPUVector[],
+  name: string,
+  vertexCount: number,
+  capacity: number
+): LuGraphAdjacency {
+  return {
+    offsets: createOutputVector(
+      device,
+      buffers,
+      vectors,
+      `${name}-offsets`,
+      'uint32',
+      vertexCount + 1
+    ),
+    neighbors: createOutputVector(
+      device,
+      buffers,
+      vectors,
+      `${name}-neighbors`,
+      'uint32',
+      capacity
+    ),
+    edgeIds: createOutputVector(device, buffers, vectors, `${name}-edge-ids`, 'uint32', capacity),
+    count: createOutputVector(device, buffers, vectors, `${name}-count`, 'uint32', 1),
+    overflow: createOutputVector(device, buffers, vectors, `${name}-overflow`, 'uint32', 1)
+  };
+}
+
+function createOutputVector<Format extends ScalarFormat>(
+  device: Device,
+  buffers: Buffer[],
+  vectors: GPUVector[],
+  name: string,
+  format: Format,
+  length: number,
+  byteOffset = 0,
+  initialValues?: Uint32Array | Float32Array
+): GPUVector<Format> {
+  const buffer = device.createBuffer({
+    id: name,
+    byteLength: byteOffset + Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+  if (initialValues && initialValues.length > 0) buffer.write(initialValues, byteOffset);
+  buffers.push(buffer);
+  const vector = new GPUVector<Format>({
+    type: 'buffer',
+    name,
+    format,
+    buffer,
+    length,
+    byteOffset,
+    ownsBuffer: false
+  });
+  vectors.push(vector);
+  return vector;
+}
+
+function compileModularity(fixture: ModularityExecutionFixture, maximumWorkgroups?: number): void {
+  if (maximumWorkgroups === undefined) {
+    fixture.modularity.addToGraph(fixture.commandGraph);
+  } else {
+    addLuGraphModularityToGraphWithDispatchLimit(
+      fixture.modularity,
+      fixture.commandGraph,
+      maximumWorkgroups
+    );
+  }
+  fixture.compiled = fixture.commandGraph.compile();
+}
+
+function executeModularity(fixture: ModularityExecutionFixture): void {
+  const encoder = fixture.device.createCommandEncoder({id: 'lu-graph-modularity-test'});
+  fixture.compiled!.encode(encoder, {parameters: undefined});
+  fixture.device.submit(encoder.finish());
+}
+
+async function assertModularity(
+  tapeTest: Test,
+  fixture: ModularityExecutionFixture,
+  expected: ExpectedModularity
+): Promise<void> {
+  const [score, contributions, valid] = await Promise.all([
+    readFloat32Vector(fixture.modularity.output),
+    fixture.modularity.communityContributions
+      ? readFloat32Vector(fixture.modularity.communityContributions)
+      : Promise.resolve(undefined),
+    fixture.modularity.valid
+      ? readUint32Vector(fixture.modularity.valid)
+      : Promise.resolve(undefined)
+  ]);
+
+  tapeTest.ok(
+    Math.abs(score[0] - expected.score) < 2e-5,
+    `GPU Newman modularity ${score[0]} matches independent weighted CPU score ${expected.score}`
+  );
+  if (contributions) {
+    assertApproximateValues(
+      tapeTest,
+      contributions,
+      expected.contributions,
+      'GPU contributions match stable community identifiers and independent group volumes'
+    );
+  }
+  if (valid)
+    tapeTest.equal(valid[0], Number(expected.valid), 'validity reports actual score status');
+  if (!expected.valid) {
+    tapeTest.equal(score[0], 0, 'invalid partitions never publish misleading partial scores');
+    if (contributions) tapeTest.ok(contributions.every(contribution => contribution === 0));
+  }
+}
+
+function assertApproximateValues(
+  tapeTest: Test,
+  actual: number[],
+  expected: number[],
+  message: string
+): void {
+  tapeTest.equal(actual.length, expected.length);
+  for (const [index, value] of actual.entries()) {
+    tapeTest.ok(Math.abs(value - expected[index]) < 2e-5, `${message}: row ${index}`);
+  }
+}
+
+async function readFloat32Vector(vector: GPUVector<'float32'>): Promise<number[]> {
+  if (vector.length === 0) return [];
+  const data = vector.data[0];
+  const bytes = await (data.buffer as Buffer).readAsync(
+    data.byteOffset,
+    vector.length * Float32Array.BYTES_PER_ELEMENT
+  );
+  return Array.from(new Float32Array(bytes.buffer, bytes.byteOffset, vector.length));
+}
+
+async function readUint32Vector(vector: GPUVector<'uint32'>): Promise<number[]> {
+  if (vector.length === 0) return [];
+  const data = vector.data[0];
+  const bytes = await (data.buffer as Buffer).readAsync(
+    data.byteOffset,
+    vector.length * Uint32Array.BYTES_PER_ELEMENT
+  );
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, vector.length));
+}
+
+function destroyExecutionFixture(tapeTest: Test, fixture: ModularityExecutionFixture): void {
+  fixture.compiled?.destroy();
+  for (const vector of fixture.vectors) vector.destroy();
+  tapeTest.ok(
+    fixture.buffers.every(buffer => !buffer.destroyed),
+    'borrowed source chunks, labels, and outputs retain caller-owned buffer lifetime'
+  );
+  for (const buffer of fixture.buffers) buffer.destroy();
+}

--- a/test/examples/lugraph-docs.node.spec.ts
+++ b/test/examples/lugraph-docs.node.spec.ts
@@ -17,6 +17,10 @@ const experimentalOverview = readFileSync(
   new URL('../../docs/api-reference/experimental/README.md', import.meta.url),
   'utf8'
 );
+const capabilitiesDocumentation = readFileSync(
+  new URL('../../docs/capabilities.mdx', import.meta.url),
+  'utf8'
+);
 const graphExplorerExample = readFileSync(
   new URL('../../website/content/examples/experimental/lugraph-explorer.mdx', import.meta.url),
   'utf8'
@@ -209,11 +213,13 @@ describe('luGraph GPU-resident graph analytics documentation', () => {
     expect(graphDocumentation).toContain('Knowledge and citation graphs');
     expect(graphDocumentation).toContain('A small, CPU-resident, one-off analysis');
     expect(graphDocumentation).toContain('**Question: How many direct relationships');
+    expect(graphDocumentation).toContain('**Question: Which vertices stay connected');
     expect(graphDocumentation).toContain("**Question: Do this vertex's neighbors actually connect");
     expect(graphDocumentation).toContain('**Question: Which entities can I reach');
     expect(graphDocumentation).toContain('**Question: Which route from my starting vertex costs');
     expect(graphDocumentation).toContain('**Question: Which vertices belong to the same connected');
     expect(graphDocumentation).toContain('**Question: Which vertices form closely connected');
+    expect(graphDocumentation).toContain('**Question: Does an existing community grouping');
     expect(graphDocumentation).toContain('**Question: Which vertices receive influence');
     expect(graphDocumentation).toContain('**Question: How can I position connected entities');
   });
@@ -223,11 +229,13 @@ describe('luGraph GPU-resident graph analytics documentation', () => {
       'LuGraph',
       'LuGraphTopology',
       'LuGraphDegree',
+      'LuGraphCoreNumber',
       'LuGraphLocalClusteringCoefficient',
       'LuGraphBreadthFirstSearch',
       'LuGraphSingleSourceShortestPath',
       'LuGraphConnectedComponents',
       'LuGraphLabelPropagation',
+      'LuGraphModularity',
       'LuGraphPageRank',
       'LuGraphForceLayout',
       'LuGraphSpatialForceLayout'
@@ -237,6 +245,7 @@ describe('luGraph GPU-resident graph analytics documentation', () => {
 
     expect(packageDocumentation).toContain('compressed adjacency');
     expect(packageDocumentation).toContain('vertex-degree queries');
+    expect(packageDocumentation).toContain('LuGraphCoreNumber');
     expect(packageDocumentation).toContain('breadth-first shortest paths');
     expect(packageDocumentation).toContain('nonnegative weighted single-source routes');
     expect(packageDocumentation).toContain('LuGraphSingleSourceShortestPath');
@@ -245,12 +254,15 @@ describe('luGraph GPU-resident graph analytics documentation', () => {
     expect(packageDocumentation).toContain('weakly connected components');
     expect(packageDocumentation).toContain('deterministic label-propagation communities');
     expect(packageDocumentation).toContain('LuGraphLabelPropagation');
+    expect(packageDocumentation).toContain('LuGraphModularity');
     expect(packageDocumentation).toContain('normalized PageRank');
     expect(packageDocumentation).toContain('progressive exact force-directed layout');
     expect(packageDocumentation).toContain('LuGraphSpatialForceLayout');
     expect(packageDocumentation).toContain('## Overview');
     expect(packageDocumentation).toContain('## When to use luGraph');
+    expect(packageDocumentation).toContain('## Graph Data Council and Graphalytics');
     expect(packageDocumentation).toContain('## Weighted routes and local neighborhoods');
+    expect(packageDocumentation).toContain('## Durable cores and community quality');
     expect(packageDocumentation).toContain('flat-grid approximation');
     expect(graphDocumentation).toContain("from '@luma.gl/experimental/lugraph';");
     expect(graphDocumentation).toContain('topology.addToGraph(workflow);');
@@ -276,6 +288,115 @@ describe('luGraph GPU-resident graph analytics documentation', () => {
     expect(packageDocumentation).toContain('Graphalytics workload');
     expect(packageDocumentation).toContain('does not');
     expect(packageDocumentation).toContain('official benchmark certification');
+  });
+
+  test('links official Graph Data Council definitions, datasets, rules, and benchmark boundaries', () => {
+    const councilHomepage = 'https://ldbcouncil.org/';
+    const graphalyticsOverview = 'https://ldbcouncil.org/benchmarks/graphalytics/';
+    const graphalyticsAlgorithms = `${graphalyticsOverview}algorithms/`;
+    const graphalyticsDatasets = `${graphalyticsOverview}datasets/`;
+    const graphalyticsRules = `${graphalyticsOverview}rules/`;
+
+    for (const documentation of [graphDocumentation, packageDocumentation]) {
+      expect(documentation).toContain(`[Graph Data Council (GDC)](${councilHomepage})`);
+      expect(documentation).toContain(graphalyticsOverview);
+      expect(documentation).toContain(graphalyticsAlgorithms);
+      expect(documentation).toContain(graphalyticsDatasets);
+      expect(documentation).toContain(graphalyticsRules);
+      expect(documentation).toContain('https://github.com/ldbc/ldbc_graphalytics');
+      expect(documentation).toContain('https://github.com/ldbc/ldbc_graphalytics_docs');
+      expect(documentation).toContain('Linked Data Benchmark Council (LDBC)');
+      expect(documentation).toContain('2025');
+      expect(documentation).toContain('Parquet');
+      expect(documentation).toContain('reference outputs');
+      expect(documentation).toContain('repeated runs');
+      expect(documentation).toContain('not');
+      expect(documentation).toContain('published Graphalytics score');
+    }
+
+    expect(graphDocumentation).toContain('organizer review and reproducibility');
+    expect(graphDocumentation).toContain('single-node, GPU-based, and partial implementations');
+    expect(graphDocumentation).toContain('core decomposition and modularity scoring');
+    expect(graphDocumentation).toContain('**beyond** those six standardized workload families');
+    expect(packageDocumentation).toContain('**beyond** the six Graphalytics workload families');
+    expect(experimentalOverview).toContain(councilHomepage);
+    expect(experimentalOverview).toContain(graphalyticsAlgorithms);
+    expect(experimentalOverview).toContain('formerly the Linked');
+    expect(experimentalOverview).toContain('official submission, certification, or published');
+    expect(capabilitiesDocumentation).toContain(councilHomepage);
+    expect(capabilitiesDocumentation).toContain(graphalyticsAlgorithms);
+    expect(capabilitiesDocumentation).toContain('beyond its');
+    expect(capabilitiesDocumentation).toContain('six standardized workload families');
+  });
+
+  test('explains bounded simple-weak core decomposition, useful backbones, and exactness limits', () => {
+    expect(graphDocumentation).toContain(
+      '## Find durable network backbones with LuGraphCoreNumber'
+    );
+    expect(graphDocumentation).toContain('many fragile spokes');
+    expect(graphDocumentation).toContain('100 followers');
+    expect(graphDocumentation).toContain('core number one');
+    expect(graphDocumentation).toContain('four-person clique');
+    expect(graphDocumentation).toContain('core number three');
+    expect(graphDocumentation).toContain('resilient social backbones');
+    expect(graphDocumentation).toContain('tightly sustained fraud rings');
+    expect(graphDocumentation).toContain('new LuGraphCoreNumber({');
+    expect(graphDocumentation).toContain('output: coreNumbers');
+    expect(graphDocumentation).toContain('converged: coresConverged');
+    expect(graphDocumentation).toContain('degeneracy: maximumCoreNumber');
+    expect(graphDocumentation).toContain('simple undirected weak graph');
+    expect(graphDocumentation).toContain('reciprocal directed edges and parallel edges');
+    expect(graphDocumentation).toContain('self-loops do not make a vertex support itself');
+    expect(graphDocumentation).toContain('in-degree-plus-out-degree convention');
+    expect(graphDocumentation).toContain(
+      'Directed\ngraphs require complete forward and reverse CSR'
+    );
+    expect(graphDocumentation).toContain('H-index of its neighbors');
+    expect(graphDocumentation).toContain('`iterations` may be any integer from `0` through `1024`');
+    expect(graphDocumentation).toContain('Zero rounds publish the');
+    expect(graphDocumentation).toContain(
+      'both the per-vertex values and the maximum are **upper bounds**'
+    );
+    expect(graphDocumentation).toContain('convergence one, and optional degeneracy zero');
+    expect(graphDocumentation).toContain('degeneracy become `0xffffffff`');
+    expect(graphDocumentation).toContain('`O(K × sum(d² × log(d + 1)))`');
+    expect(graphDocumentation).toContain('`O(V)` graph-owned scratch');
+    expect(packageDocumentation).toContain('simple undirected weak');
+    expect(packageDocumentation).toContain(
+      'otherwise both core numbers and degeneracy are upper bounds'
+    );
+    expect(capabilitiesDocumentation).toContain('| Structural graph core numbers | Experimental |');
+  });
+
+  test('explains weighted directed partition modularity without claiming community optimization', () => {
+    expect(graphDocumentation).toContain('## Evaluate community quality with LuGraphModularity');
+    expect(graphDocumentation).toContain('degree-matched random network');
+    expect(graphDocumentation).toContain('compare rival social-network groupings');
+    expect(graphDocumentation).toContain('fraud ring concentrates transaction weight');
+    expect(graphDocumentation).toContain('new LuGraphModularity({');
+    expect(graphDocumentation).toContain('communities: communityIds');
+    expect(graphDocumentation).toContain('output: modularityScore');
+    expect(graphDocumentation).toContain('resolution: 1');
+    expect(graphDocumentation).toContain('communityContributions');
+    expect(graphDocumentation).toContain('valid: modularityValid');
+    expect(graphDocumentation).toContain('`Q = Σc [Lc / W - γ × Kout,c × Kin,c / W²]`');
+    expect(graphDocumentation).toContain('`Q = Σc [Lc / W - γ × (Kc / (2W))²]`');
+    expect(graphDocumentation).toContain(
+      'self-loop contributes once to `W` and `Lc` but twice to `Kc`'
+    );
+    expect(graphDocumentation).toContain('Parallel source edges');
+    expect(graphDocumentation).toContain('retain their original multiplicity');
+    expect(graphDocumentation).toContain('must be a finite, nonnegative value');
+    expect(graphDocumentation).toContain('Edges with invalid endpoints are excluded');
+    expect(graphDocumentation).toContain('floating-point accumulation');
+    expect(graphDocumentation).toContain('constructing or requiring forward or reverse CSR');
+    expect(graphDocumentation).toContain('concurrent atomic accumulation');
+    expect(graphDocumentation).toContain('`O(V + E)`');
+    expect(graphDocumentation).toContain(
+      '**not** Louvain, Leiden, automatic community optimization'
+    );
+    expect(packageDocumentation).toContain('community-quality measurement, not Louvain, Leiden');
+    expect(capabilitiesDocumentation).toContain('| Weighted community modularity | Experimental |');
   });
 
   test('explains unique weak-neighborhood triangles and honest local clustering complexity', () => {

--- a/website/src/components/docs/lugraph-benchmark.tsx
+++ b/website/src/components/docs/lugraph-benchmark.tsx
@@ -36,6 +36,22 @@ export function LuGraphBenchmark(): ReactNode {
 
   return (
     <div>
+      <p style={{fontSize: 13, margin: '0 0 14px'}}>
+        This local demonstration includes the six graph-analysis workloads standardized by the{' '}
+        <a href="https://ldbcouncil.org/" rel="noreferrer" target="_blank">
+          Graph Data Council
+        </a>{' '}
+        in its{' '}
+        <a
+          href="https://ldbcouncil.org/benchmarks/graphalytics/"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Graphalytics benchmark
+        </a>
+        . Its small synthetic datasets and local CPU checks are not an official benchmark submission,
+        certification, or cross-platform performance claim.
+      </p>
       <div style={{display: 'flex', flexWrap: 'wrap', gap: 18, marginBottom: 12}}>
         <label
           htmlFor="lugraph-benchmark-dataset"


### PR DESCRIPTION
## Goals

- Extend the existing GPU-resident luGraph stack with reusable structural and community-quality analytics.
- Explain the Graph Data Council's role and why Graphalytics provides a meaningful, reproducible graph-analytics reference point without implying official benchmark certification.

## Changes

- Add `LuGraphCoreNumber`, a bounded GPU k-core decomposition over existing forward/reverse CSR with simple weak-neighbor deduplication, optional convergence and degeneracy outputs, overflow-safe failure, and caller-owned packed results.
- Add `LuGraphModularity`, a GPU-resident Newman modularity evaluator for directed/undirected and weighted/unweighted graphs, supporting adjustable resolution, per-community contributions, validity reporting, original edge chunks, and existing GPU-generated community labels.
- Keep both contributors under the optional `@luma.gl/experimental/lugraph` entry point; neither submits work, reads GPU buffers, adds deck.gl dependencies, nor claims Louvain/Leiden optimization.
- Expand the graph guide, package documentation, capability matrix, experimental overview, and live benchmark with official Graph Data Council, Graphalytics algorithm, dataset, specification, driver, and validation-rule links.
- Explicitly distinguish six-family Graphalytics feature coverage from official harness execution, certified results, comparable published scores, or extra Graphalytics workloads.
- Add real WebGPU, CPU-oracle, API ownership, dispatch/offset, overflow, documentation, and benchmark-link regression coverage.

## Verification

- `yarn lint fix`
- `yarn build`
- `CI=1 yarn test`
- `yarn website:build`
- Focused real Chromium/WebGPU suites: 26 k-core scenarios and 28 modularity scenarios, including GPU label propagation directly into modularity without intermediate readback.

## Risks and limitations

- Core refinement is bounded; unconverged values and degeneracy are explicitly upper bounds, and dense unsorted neighborhoods can require quadratic neighbor deduplication.
- Modularity uses portable float32 atomic compare-and-swap accumulation; low-order rounding can differ across GPUs or execution orders.
- Browser WebGPU remains single-device and memory-bound. These additions are not official Graphalytics submissions or performance claims.
