### PR TITLE
feat(experimental): add global dataframe sorting and top-k

### DIFF
--- a/docs/api-reference/experimental/ludf.md
+++ b/docs/api-reference/experimental/ludf.md
@@ -293,8 +293,41 @@ and negative zero compare equally and retain stable source order; infinities are
 values. Deselected rows never enter the published selected prefix.
 
 Sorting and top-K are performed independently within every original source batch. There is no
-implicit global cross-batch materialization or global top-K. Compiled results expose the original
-table, sorted `rowIndices`, updated `selectionMask`, and one selected count per preserved batch.
+implicit global cross-batch materialization. Compiled results expose the original table, sorted
+`rowIndices`, updated `selectionMask`, and one selected count per preserved batch.
+
+### Explicit global ordering and top-K
+
+Use `sortByGlobal` or `topKGlobal` when ordering must span every source batch. These operations
+explicitly stage numeric sort keys and source identities into GPU scratch; they never concatenate,
+copy, or reorder the original dataframe columns:
+
+```ts
+const globallySorted = dataframe.sortByGlobal('fare', {
+  direction: 'ascending',
+  nulls: 'last',
+  nans: 'last'
+});
+
+const highestOverall = dataframe.topKGlobal('fare', 10);
+const lowestOverall = dataframe.sortByGlobal('fare').topK(10);
+
+const compiled = highestOverall.compile(
+  new GPUCommandGraph<LuDataFrameQueryParameters>(device)
+);
+
+compiled.globalRowIndices;
+compiled.globalSelectedCount;
+compiled.selectionMask;
+compiled.selectedCounts;
+```
+
+`globalRowIndices` contains one globally stable source-row permutation, including discontinuous
+adapter-provided source offsets. `globalSelectedCount` is one GPU-owned scalar describing its
+valid prefix. Equal keys retain their original cross-batch source order; null placement, NaN
+placement, signed zeros, infinities, filtered rows, and derived values follow the same rules as
+per-batch sorting. A global top-K limit is applied once across all batches; the original
+batch-aligned selection masks and counts are updated to match that same global result.
 
 ### Scaling beyond one-dimensional workgroup limits
 
@@ -447,7 +480,7 @@ Always call `destroy()` on compiled queries and owned frames when they are no lo
 are idempotent. Applications without an available WebGPU adapter must offer their own CPU path or
 display an unsupported-device state. luDF does not transparently switch execution backends.
 
-Native GPU `float64` and `int64`, arbitrary GPU strings, distributed or multi-GPU execution, global
-cross-batch sorting, full SQL semantics, and complete cuDF compatibility are outside the supported
-scope. See [GPU Primitives and Command Graphs](/docs/api-reference/experimental/gpu-primitives) for
+Native GPU `float64` and `int64`, arbitrary GPU strings, distributed or multi-GPU execution, full SQL
+semantics, and complete cuDF compatibility are outside the supported scope. See
+[GPU Primitives and Command Graphs](/docs/api-reference/experimental/gpu-primitives) for
 the underlying WebGPU execution infrastructure.

--- a/modules/experimental/src/ludf/index.ts
+++ b/modules/experimental/src/ludf/index.ts
@@ -40,7 +40,7 @@ export type {
 } from './lu-global-aggregation-query';
 export {LuDataFrameHistogramQuery} from './lu-histogram-query';
 export type {LuDataFrameHistogramOptions} from './lu-histogram-query';
-export {LuDataFrameSortQuery} from './lu-sort-query';
+export {LuDataFrameGlobalSortQuery, LuDataFrameSortQuery} from './lu-sort-query';
 export type {LuDataFrameSortOptions} from './lu-sort-query';
 export {LuDataFrameJoinQuery, LuDataFrameLookupQuery} from './lu-join-query';
 export type {LuDataFrameJoinOptions, LuDataFrameLookupOptions} from './lu-join-query';
@@ -57,4 +57,5 @@ export {CompiledLuDataFrameGroupedAggregation} from './lu-group-aggregation-comp
 export {CompiledLuDataFrameAggregation} from './lu-global-aggregation-compiler';
 export {CompiledLuDataFrameHistogram} from './lu-histogram-compiler';
 export {CompiledLuDataFrameSort} from './lu-sort-compiler';
+export {CompiledLuDataFrameGlobalSort} from './lu-global-sort-compiler';
 export {CompiledLuDataFrameJoin, CompiledLuDataFrameLookup} from './lu-join-compiler';

--- a/modules/experimental/src/ludf/lu-data-frame-query.ts
+++ b/modules/experimental/src/ludf/lu-data-frame-query.ts
@@ -29,7 +29,11 @@ import {
   type CompiledLuDataFrameQuery,
   type LuDataFrameQueryParameters
 } from './lu-query-compiler';
-import {LuDataFrameSortQuery, type LuDataFrameSortOptions} from './lu-sort-query';
+import {
+  LuDataFrameGlobalSortQuery,
+  LuDataFrameSortQuery,
+  type LuDataFrameSortOptions
+} from './lu-sort-query';
 
 /** Portable scalar storage formats supported by computed dataframe columns. */
 export type LuDataFrameDerivedColumnFormat = 'float32' | 'sint32' | 'uint32';
@@ -201,6 +205,23 @@ export class LuDataFrameQuery<
     options: LuDataFrameSortOptions = {}
   ): LuDataFrameSortQuery<Logical, SelectedColumns, Column, Source> {
     return new LuDataFrameSortQuery(this, column, options, limit, 'descending');
+  }
+
+  /** Plans explicit stable ordering across every preserved source record batch. */
+  sortByGlobal<Column extends LuDataFrameScalarColumnNames<Logical, SelectedColumns>>(
+    column: Column,
+    options: LuDataFrameSortOptions = {}
+  ): LuDataFrameGlobalSortQuery<Logical, SelectedColumns, Column, Source> {
+    return new LuDataFrameGlobalSortQuery(this, column, options);
+  }
+
+  /** Plans one descending global top-K selection without copying source dataframe columns. */
+  topKGlobal<Column extends LuDataFrameScalarColumnNames<Logical, SelectedColumns>>(
+    column: Column,
+    limit: number,
+    options: LuDataFrameSortOptions = {}
+  ): LuDataFrameGlobalSortQuery<Logical, SelectedColumns, Column, Source> {
+    return new LuDataFrameGlobalSortQuery(this, column, options, limit, 'descending');
   }
 
   /** Plans a stable, unique-right inner join without allocating, repacking, or retaining rows. */

--- a/modules/experimental/src/ludf/lu-data-frame.ts
+++ b/modules/experimental/src/ludf/lu-data-frame.ts
@@ -40,7 +40,11 @@ import type {
   LuDataFrameLookupOptions,
   LuDataFrameLookupQuery
 } from './lu-join-query';
-import type {LuDataFrameSortOptions, LuDataFrameSortQuery} from './lu-sort-query';
+import type {
+  LuDataFrameGlobalSortQuery,
+  LuDataFrameSortOptions,
+  LuDataFrameSortQuery
+} from './lu-sort-query';
 
 /** Whether a dataframe borrows its source resources or releases them after its final view. */
 export type LuDataFrameOwnership = 'borrowed' | 'owned';
@@ -264,6 +268,32 @@ export class LuDataFrame<T extends GPUTypeMap = GPUTypeMap> {
   ): LuDataFrameSortQuery<T, keyof T & string, Column, T> {
     this.assertAvailable();
     return new LuDataFrameQuery<T, keyof T & string, T>(this, [], this.columnNames).topK(
+      column,
+      limit,
+      options
+    );
+  }
+
+  /** Plans explicit stable ordering across every source batch without copying source columns. */
+  sortByGlobal<Column extends LuDataFrameScalarColumnNames<T, keyof T & string>>(
+    column: Column,
+    options: LuDataFrameSortOptions = {}
+  ): LuDataFrameGlobalSortQuery<T, keyof T & string, Column, T> {
+    this.assertAvailable();
+    return new LuDataFrameQuery<T, keyof T & string, T>(this, [], this.columnNames).sortByGlobal(
+      column,
+      options
+    );
+  }
+
+  /** Plans one descending top-K result across all original source record batches. */
+  topKGlobal<Column extends LuDataFrameScalarColumnNames<T, keyof T & string>>(
+    column: Column,
+    limit: number,
+    options: LuDataFrameSortOptions = {}
+  ): LuDataFrameGlobalSortQuery<T, keyof T & string, Column, T> {
+    this.assertAvailable();
+    return new LuDataFrameQuery<T, keyof T & string, T>(this, [], this.columnNames).topKGlobal(
       column,
       limit,
       options

--- a/modules/experimental/src/ludf/lu-global-sort-compiler.ts
+++ b/modules/experimental/src/ludf/lu-global-sort-compiler.ts
@@ -1,0 +1,555 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuDF.
+
+import {type GPUTypeMap, type GPUVector} from '@luma.gl/tables';
+import {
+  type GPUCommandGraph,
+  type GraphBufferUse,
+  type GraphDataView
+} from '../gpu-primitives/gpu-command-graph';
+import {GPUReduction} from '../gpu-primitives/gpu-reduction';
+import {GPUSort} from '../gpu-primitives/gpu-sort';
+import {GPUVisibilityWorkflow} from '../gpu-primitives/gpu-visibility-workflow';
+import {createTransientView, getViewElementOffset} from '../gpu-primitives/graph-data-view-utils';
+import {
+  LU_ANALYTICS_WORKGROUP_SIZE,
+  addLuAnalyticsComputePass,
+  createLuAnalyticsOutputVector,
+  getLuAnalyticsInvocationIndexSource,
+  getLuAnalyticsShaderType,
+  getLuAnalyticsVector,
+  validateLuAnalyticsOutputLength,
+  validateLuAnalyticsSource,
+  type LuAnalyticsScalarFormat
+} from './lu-analytics-compiler-utils';
+import type {LuDataFrame} from './lu-data-frame';
+import type {LuDataFrameDerivedColumn} from './lu-data-frame-query';
+import type {LuExpression} from './lu-expression';
+import {
+  compileLuDataFrameQuery,
+  type CompiledLuDataFrameQueryProps,
+  type LuDataFrameQueryExtensionContext,
+  type LuDataFrameQueryExtensionResult,
+  type LuDataFrameQueryParameters
+} from './lu-query-compiler';
+import {CompiledLuDataFrameSort} from './lu-sort-compiler';
+import type {LuDataFrameNormalizedSortOptions} from './lu-sort-query';
+
+const MAXIMUM_UINT32 = 0xffffffff;
+const MAXIMUM_GLOBAL_SORT_ROWS = 0x80000000;
+
+type LuGlobalSortScratch = {
+  encodedKeys: GraphDataView<'uint32'>;
+  sourceOrdinals: GraphDataView<'uint32'>;
+  sortedKeys: GraphDataView<'uint32'>;
+  sortedOrdinals: GraphDataView<'uint32'>;
+  sourceClasses: GraphDataView<'uint32'>;
+  sourceRows: GraphDataView<'uint32'>;
+};
+
+/** Stable cross-batch ordering with explicit GPU-owned global row identities and selected count. */
+export class CompiledLuDataFrameGlobalSort<
+  T extends GPUTypeMap = GPUTypeMap
+> extends CompiledLuDataFrameSort<T> {
+  /** One dense globally ordered source-row permutation; only the selected prefix is meaningful. */
+  readonly globalRowIndices: GPUVector<'uint32'>;
+  /** One GPU-resident count of selected rows after applying the optional global top-K limit. */
+  readonly globalSelectedCount: GPUVector<'uint32'>;
+
+  /** @internal */
+  constructor(
+    props: CompiledLuDataFrameQueryProps<T>,
+    column: keyof T & string,
+    options: LuDataFrameNormalizedSortOptions,
+    globalRowIndices: GPUVector<'uint32'>,
+    globalSelectedCount: GPUVector<'uint32'>
+  ) {
+    super(props, column, options);
+    this.globalRowIndices = globalRowIndices;
+    this.globalSelectedCount = globalSelectedCount;
+  }
+}
+
+/** Adds explicit globally stable ordering while leaving source buffers and batches untouched. */
+export function compileLuDataFrameGlobalSort<
+  Source extends GPUTypeMap,
+  Selection extends GPUTypeMap
+>(
+  source: LuDataFrame<Source>,
+  predicates: readonly LuExpression<boolean, string>[],
+  selectedColumns: readonly (keyof Selection & string)[],
+  derivedColumns: readonly LuDataFrameDerivedColumn[],
+  column: keyof Selection & string,
+  options: LuDataFrameNormalizedSortOptions,
+  graph: GPUCommandGraph<LuDataFrameQueryParameters>
+): CompiledLuDataFrameGlobalSort<Selection> {
+  validateLuAnalyticsSource(source, [column]);
+  validateLuGlobalSortCapacity(source, graph);
+  return compileLuDataFrameQuery<
+    Source,
+    Selection,
+    Selection,
+    CompiledLuDataFrameGlobalSort<Selection>
+  >(source, predicates, selectedColumns, graph, derivedColumns, {
+    allowEmptyPredicates: true,
+    prepare: context => addLuGlobalSortToGraph(context, column, options)
+  });
+}
+
+/** Validates source identity, packed sort length, and storage capacity before GPU allocations. */
+function validateLuGlobalSortCapacity<Source extends GPUTypeMap>(
+  source: LuDataFrame<Source>,
+  graph: GPUCommandGraph<LuDataFrameQueryParameters>
+): void {
+  if (source.numRows > MAXIMUM_GLOBAL_SORT_ROWS) {
+    throw new Error('LuDataFrame global sorting supports at most 2147483648 source rows');
+  }
+  if (source.numRows > 0) {
+    validateLuAnalyticsOutputLength(graph, source.numRows);
+  }
+  let fallbackOffset = 0;
+  for (const batch of source.batches) {
+    const offset = batch.sourceInfo?.sourceRowIndexOffset ?? fallbackOffset;
+    if (
+      !Number.isSafeInteger(offset) ||
+      offset < 0 ||
+      offset > MAXIMUM_UINT32 ||
+      offset + Math.max(batch.numRows - 1, 0) > MAXIMUM_UINT32
+    ) {
+      throw new Error('LuDataFrame global sort source-row identities must fit uint32');
+    }
+    fallbackOffset += batch.numRows;
+  }
+}
+
+/** Stages keys and identities explicitly, then stably orders numeric values and null/NaN classes. */
+function addLuGlobalSortToGraph<Selection extends GPUTypeMap>(
+  context: LuDataFrameQueryExtensionContext<Selection>,
+  column: keyof Selection & string,
+  options: LuDataFrameNormalizedSortOptions
+): LuDataFrameQueryExtensionResult<Selection, CompiledLuDataFrameGlobalSort<Selection>> {
+  const graph = context.graph;
+  const prefix = `${context.queryId}-global-sort`;
+  const ownedVectors: GPUVector[] = [];
+
+  try {
+    const input = graph.importGPUVector(`${prefix}-input`, getLuAnalyticsVector(context, column));
+    const field = context.table.schema.fields.find(candidate => candidate.name === column);
+    const validityVector = field?.nullable ? context.validity[column] : undefined;
+    if (field?.nullable && !validityVector && input.length > 0) {
+      throw new Error(`LuDataFrame nullable global sort column "${column}" requires GPU validity`);
+    }
+    const validity = validityVector
+      ? graph.importGPUVector(`${prefix}-source-validity`, validityVector)
+      : undefined;
+
+    const globalRowIndices = createLuAnalyticsOutputVector(
+      graph.device,
+      `${prefix}-row-indices`,
+      'uint32',
+      input.length
+    );
+    ownedVectors.push(globalRowIndices);
+    const globalSelectedCount = createLuAnalyticsOutputVector(
+      graph.device,
+      `${prefix}-selected-count`,
+      'uint32',
+      1
+    );
+    ownedVectors.push(globalSelectedCount);
+    const globalRows = graph.importGPUVector(`${prefix}-row-vector`, globalRowIndices).data[0];
+    const selectedCount = graph.importGPUVector(`${prefix}-count-vector`, globalSelectedCount)
+      .data[0];
+
+    new GPUReduction({
+      id: `${prefix}-count-selected`,
+      input: context.selectedCounts,
+      output: selectedCount,
+      operation: 'sum'
+    }).addToGraph(graph);
+
+    if (input.length > 0) {
+      const scratch = createLuGlobalSortScratch(graph, prefix, input.length);
+      let globalOffset = 0;
+      let fallbackOffset = 0;
+      for (const [batchIndex, batch] of context.table.batches.entries()) {
+        if (batch.numRows > 0) {
+          addLuGlobalSortStagePass(graph, `${prefix}-stage-batch-${batchIndex}`, {
+            input: input.data[batchIndex],
+            selection: context.selectionMask.data[batchIndex],
+            validity: validity?.data[batchIndex],
+            scratch,
+            globalOffset,
+            sourceOffset: batch.sourceInfo?.sourceRowIndexOffset ?? fallbackOffset,
+            options
+          });
+        }
+        globalOffset += batch.numRows;
+        fallbackOffset += batch.numRows;
+      }
+
+      new GPUSort({
+        id: `${prefix}-numeric`,
+        keys: scratch.encodedKeys,
+        values: scratch.sourceOrdinals,
+        outputKeys: scratch.sortedKeys,
+        outputValues: scratch.sortedOrdinals,
+        direction: options.direction,
+        algorithm: options.algorithm
+      }).addToGraph(graph);
+
+      addLuGlobalSortGatherClassesPass(graph, `${prefix}-gather-classes`, scratch);
+      new GPUSort({
+        id: `${prefix}-classes`,
+        keys: scratch.sortedKeys,
+        values: scratch.sortedOrdinals,
+        outputKeys: scratch.encodedKeys,
+        outputValues: scratch.sourceOrdinals,
+        direction: 'ascending',
+        algorithm: options.algorithm
+      }).addToGraph(graph);
+
+      addLuGlobalSortPublishPass(graph, `${prefix}-publish`, {
+        scratch,
+        output: globalRows,
+        count: selectedCount,
+        limit: options.limit ?? MAXIMUM_UINT32
+      });
+
+      if (options.limit !== undefined) {
+        let globalOffset = 0;
+        let fallbackOffset = 0;
+        for (const [batchIndex, batch] of context.table.batches.entries()) {
+          if (batch.numRows > 0) {
+            const selection = context.selectionMask.data[batchIndex];
+            addLuGlobalTopKSelectionPass(graph, `${prefix}-select-batch-${batchIndex}`, {
+              ranks: scratch.sourceClasses,
+              selection,
+              globalOffset,
+              limit: options.limit
+            });
+            new GPUVisibilityWorkflow({
+              id: `${prefix}-visibility-batch-${batchIndex}`,
+              predicates: [{kind: 'selection', mask: selection}],
+              outputMask: selection,
+              output: context.rowIndices.data[batchIndex],
+              count: context.selectedCounts.data[batchIndex],
+              firstSourceIndex: batch.sourceInfo?.sourceRowIndexOffset ?? fallbackOffset
+            }).addToGraph(graph);
+          }
+          globalOffset += batch.numRows;
+          fallbackOffset += batch.numRows;
+        }
+      }
+    }
+
+    return {
+      table: context.table,
+      validity: context.validity,
+      dictionaries: context.dictionaries,
+      ownedVectors,
+      createCompiled: props =>
+        new CompiledLuDataFrameGlobalSort(
+          props,
+          column,
+          options,
+          globalRowIndices,
+          globalSelectedCount
+        )
+    };
+  } catch (error) {
+    for (const vector of ownedVectors) {
+      vector.destroy();
+    }
+    throw error;
+  }
+}
+
+/** Allocates only explicit global permutation scratch; original dataframe vectors remain intact. */
+function createLuGlobalSortScratch(
+  graph: GPUCommandGraph<LuDataFrameQueryParameters>,
+  prefix: string,
+  length: number
+): LuGlobalSortScratch {
+  return {
+    encodedKeys: createTransientView(graph, `${prefix}-encoded-keys`, 'uint32', length),
+    sourceOrdinals: createTransientView(graph, `${prefix}-source-ordinals`, 'uint32', length),
+    sortedKeys: createTransientView(graph, `${prefix}-sorted-keys`, 'uint32', length),
+    sortedOrdinals: createTransientView(graph, `${prefix}-sorted-ordinals`, 'uint32', length),
+    sourceClasses: createTransientView(graph, `${prefix}-source-classes`, 'uint32', length),
+    sourceRows: createTransientView(graph, `${prefix}-source-rows`, 'uint32', length)
+  };
+}
+
+/** Encodes one preserved source batch into explicit global numeric, identity, and class scratch. */
+function addLuGlobalSortStagePass(
+  graph: GPUCommandGraph<LuDataFrameQueryParameters>,
+  id: string,
+  props: {
+    input: GraphDataView<LuAnalyticsScalarFormat>;
+    selection: GraphDataView<'uint32'>;
+    validity?: GraphDataView<'uint32'>;
+    scratch: LuGlobalSortScratch;
+    globalOffset: number;
+    sourceOffset: number;
+    options: LuDataFrameNormalizedSortOptions;
+  }
+): void {
+  const format = props.input.format;
+  const nullable = Boolean(props.validity);
+  const validityBinding = nullable
+    ? '@group(0) @binding(2) var<storage, read> validityValues: array<u32>;'
+    : '';
+  const outputBinding = nullable ? 3 : 2;
+  const validityOffset = props.validity ? getViewElementOffset(props.validity) : 0;
+  const nullExpression = nullable ? 'validityValues[VALIDITY_OFFSET + index] == 0u' : 'false';
+  const nanExpression =
+    format === 'float32' ? '(bitcast<u32>(value) & 0x7fffffffu) > 0x7f800000u' : 'false';
+  const keyExpression = getLuGlobalSortNumericKeyExpression(format);
+  const nullRank = props.options.nulls === 'first' ? 0 : 2;
+  const nanRank =
+    props.options.nulls === 'first'
+      ? props.options.nans === 'first'
+        ? 1
+        : 2
+      : props.options.nans === 'first'
+        ? 0
+        : 1;
+  const numericRank =
+    props.options.nulls === 'first'
+      ? props.options.nans === 'first'
+        ? 2
+        : 1
+      : props.options.nans === 'first'
+        ? 1
+        : 0;
+  const source = /* wgsl */ `
+const ELEMENT_COUNT: u32 = ${props.input.length}u;
+const INPUT_OFFSET: u32 = ${getViewElementOffset(props.input)}u;
+const SELECTION_OFFSET: u32 = ${getViewElementOffset(props.selection)}u;
+const VALIDITY_OFFSET: u32 = ${validityOffset}u;
+const GLOBAL_OFFSET: u32 = ${props.globalOffset}u;
+const SOURCE_OFFSET: u32 = ${props.sourceOffset}u;
+const KEY_OFFSET: u32 = ${getViewElementOffset(props.scratch.encodedKeys)}u;
+const ORDINAL_OFFSET: u32 = ${getViewElementOffset(props.scratch.sourceOrdinals)}u;
+const CLASS_OFFSET: u32 = ${getViewElementOffset(props.scratch.sourceClasses)}u;
+const ROW_OFFSET: u32 = ${getViewElementOffset(props.scratch.sourceRows)}u;
+@group(0) @binding(0) var<storage, read> inputValues: array<${getLuAnalyticsShaderType(format)}>;
+@group(0) @binding(1) var<storage, read> selectionMask: array<u32>;
+${validityBinding}
+@group(0) @binding(${outputBinding}) var<storage, read_write> encodedKeys: array<u32>;
+@group(0) @binding(${outputBinding + 1}) var<storage, read_write> sourceOrdinals: array<u32>;
+@group(0) @binding(${outputBinding + 2}) var<storage, read_write> sourceClasses: array<u32>;
+@group(0) @binding(${outputBinding + 3}) var<storage, read_write> sourceRows: array<u32>;
+
+@compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, props.input.length)}
+  if (index >= ELEMENT_COUNT) { return; }
+  let value = inputValues[INPUT_OFFSET + index];
+  let isNull = ${nullExpression};
+  let isNaN = ${nanExpression};
+  let ordinal = GLOBAL_OFFSET + index;
+  var rank = ${numericRank}u;
+  if (isNaN) { rank = ${nanRank}u; }
+  if (isNull) { rank = ${nullRank}u; }
+  if (selectionMask[SELECTION_OFFSET + index] == 0u) { rank = 3u; }
+  encodedKeys[KEY_OFFSET + ordinal] = select(${keyExpression}, 0u, isNull || isNaN);
+  sourceOrdinals[ORDINAL_OFFSET + ordinal] = ordinal;
+  sourceClasses[CLASS_OFFSET + ordinal] = rank;
+  sourceRows[ROW_OFFSET + ordinal] = SOURCE_OFFSET + index;
+}`;
+  const resources: GraphBufferUse[] = [
+    {buffer: props.input, usage: 'storage-read'},
+    {buffer: props.selection, usage: 'storage-read'}
+  ];
+  const bindings: Record<string, GraphDataView> = {
+    inputValues: props.input,
+    selectionMask: props.selection
+  };
+  if (props.validity) {
+    resources.push({buffer: props.validity, usage: 'storage-read'});
+    bindings['validityValues'] = props.validity;
+  }
+  for (const [name, view] of [
+    ['encodedKeys', props.scratch.encodedKeys],
+    ['sourceOrdinals', props.scratch.sourceOrdinals],
+    ['sourceClasses', props.scratch.sourceClasses],
+    ['sourceRows', props.scratch.sourceRows]
+  ] as const) {
+    resources.push({buffer: view, usage: 'storage-write'});
+    bindings[name] = view;
+  }
+  addLuAnalyticsComputePass(graph, {id, source, resources, bindings, length: props.input.length});
+}
+
+/** Produces full-width monotonic unsigned keys without sacrificing signed zero or NaN semantics. */
+function getLuGlobalSortNumericKeyExpression(format: LuAnalyticsScalarFormat): string {
+  switch (format) {
+    case 'uint32':
+      return 'value';
+    case 'sint32':
+      return 'bitcast<u32>(value) ^ 0x80000000u';
+    case 'float32':
+      return 'select(bitcast<u32>(value), 0u, value == 0.0) ^ select(0x80000000u, 0xffffffffu, (bitcast<u32>(value) & 0x80000000u) != 0u && value != 0.0)';
+  }
+}
+
+/** Gathers source null/NaN/filter classes in stable numeric order before the second stable sort. */
+function addLuGlobalSortGatherClassesPass(
+  graph: GPUCommandGraph<LuDataFrameQueryParameters>,
+  id: string,
+  scratch: LuGlobalSortScratch
+): void {
+  const source = /* wgsl */ `
+const ELEMENT_COUNT: u32 = ${scratch.sortedOrdinals.length}u;
+const ORDINAL_OFFSET: u32 = ${getViewElementOffset(scratch.sortedOrdinals)}u;
+const CLASS_OFFSET: u32 = ${getViewElementOffset(scratch.sourceClasses)}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(scratch.sortedKeys)}u;
+@group(0) @binding(0) var<storage, read> sortedOrdinals: array<u32>;
+@group(0) @binding(1) var<storage, read> sourceClasses: array<u32>;
+@group(0) @binding(2) var<storage, read_write> sortedClasses: array<u32>;
+
+@compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, scratch.sortedOrdinals.length)}
+  if (index < ELEMENT_COUNT) {
+    sortedClasses[OUTPUT_OFFSET + index] =
+      sourceClasses[CLASS_OFFSET + sortedOrdinals[ORDINAL_OFFSET + index]];
+  }
+}`;
+  addLuAnalyticsComputePass(graph, {
+    id,
+    source,
+    resources: [
+      {buffer: scratch.sortedOrdinals, usage: 'storage-read'},
+      {buffer: scratch.sourceClasses, usage: 'storage-read'},
+      {buffer: scratch.sortedKeys, usage: 'storage-write'}
+    ],
+    bindings: {
+      sortedOrdinals: scratch.sortedOrdinals,
+      sourceClasses: scratch.sourceClasses,
+      sortedClasses: scratch.sortedKeys
+    },
+    length: scratch.sortedOrdinals.length
+  });
+}
+
+/** Publishes globally stable source rows and stores inverse source ranks for bounded selection. */
+function addLuGlobalSortPublishPass(
+  graph: GPUCommandGraph<LuDataFrameQueryParameters>,
+  id: string,
+  props: {
+    scratch: LuGlobalSortScratch;
+    output: GraphDataView<'uint32'>;
+    count: GraphDataView<'uint32'>;
+    limit: number;
+  }
+): void {
+  const source = /* wgsl */ `
+const ELEMENT_COUNT: u32 = ${props.output.length}u;
+const CLASS_OFFSET: u32 = ${getViewElementOffset(props.scratch.encodedKeys)}u;
+const ORDINAL_OFFSET: u32 = ${getViewElementOffset(props.scratch.sourceOrdinals)}u;
+const SOURCE_ROW_OFFSET: u32 = ${getViewElementOffset(props.scratch.sourceRows)}u;
+const RANK_OFFSET: u32 = ${getViewElementOffset(props.scratch.sourceClasses)}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
+const COUNT_OFFSET: u32 = ${getViewElementOffset(props.count)}u;
+const ROW_LIMIT: u32 = ${props.limit}u;
+@group(0) @binding(0) var<storage, read> sortedClasses: array<u32>;
+@group(0) @binding(1) var<storage, read> sortedOrdinals: array<u32>;
+@group(0) @binding(2) var<storage, read> sourceRows: array<u32>;
+@group(0) @binding(3) var<storage, read_write> sourceRanks: array<u32>;
+@group(0) @binding(4) var<storage, read_write> outputRows: array<u32>;
+@group(0) @binding(5) var<storage, read_write> selectedCounts: array<u32>;
+
+@compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, props.output.length)}
+  if (index >= ELEMENT_COUNT) { return; }
+  let ordinal = sortedOrdinals[ORDINAL_OFFSET + index];
+  let accepted = sortedClasses[CLASS_OFFSET + index] != 3u;
+  sourceRanks[RANK_OFFSET + ordinal] = select(0xffffffffu, index, accepted);
+  outputRows[OUTPUT_OFFSET + index] = select(
+    0u,
+    sourceRows[SOURCE_ROW_OFFSET + ordinal],
+    accepted && index < ROW_LIMIT
+  );
+  if (index == 0u) {
+    selectedCounts[COUNT_OFFSET] = min(selectedCounts[COUNT_OFFSET], ROW_LIMIT);
+  }
+}`;
+  addLuAnalyticsComputePass(graph, {
+    id,
+    source,
+    resources: [
+      {buffer: props.scratch.encodedKeys, usage: 'storage-read'},
+      {buffer: props.scratch.sourceOrdinals, usage: 'storage-read'},
+      {buffer: props.scratch.sourceRows, usage: 'storage-read'},
+      {buffer: props.scratch.sourceClasses, usage: 'storage-write'},
+      {buffer: props.output, usage: 'storage-write'},
+      {buffer: props.count, usage: 'storage-read-write'}
+    ],
+    bindings: {
+      sortedClasses: props.scratch.encodedKeys,
+      sortedOrdinals: props.scratch.sourceOrdinals,
+      sourceRows: props.scratch.sourceRows,
+      sourceRanks: props.scratch.sourceClasses,
+      outputRows: props.output,
+      selectedCounts: props.count
+    },
+    length: props.output.length
+  });
+}
+
+/** Applies a global rank limit back to one original source-aligned selection-mask chunk. */
+function addLuGlobalTopKSelectionPass(
+  graph: GPUCommandGraph<LuDataFrameQueryParameters>,
+  id: string,
+  props: {
+    ranks: GraphDataView<'uint32'>;
+    selection: GraphDataView<'uint32'>;
+    globalOffset: number;
+    limit: number;
+  }
+): void {
+  const source = /* wgsl */ `
+const ELEMENT_COUNT: u32 = ${props.selection.length}u;
+const RANK_OFFSET: u32 = ${getViewElementOffset(props.ranks) + props.globalOffset}u;
+const SELECTION_OFFSET: u32 = ${getViewElementOffset(props.selection)}u;
+const ROW_LIMIT: u32 = ${props.limit}u;
+@group(0) @binding(0) var<storage, read> sourceRanks: array<u32>;
+@group(0) @binding(1) var<storage, read_write> selectionMask: array<u32>;
+
+@compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, props.selection.length)}
+  if (index < ELEMENT_COUNT) {
+    selectionMask[SELECTION_OFFSET + index] =
+      select(0u, 1u, sourceRanks[RANK_OFFSET + index] < ROW_LIMIT);
+  }
+}`;
+  addLuAnalyticsComputePass(graph, {
+    id,
+    source,
+    resources: [
+      {buffer: props.ranks, usage: 'storage-read'},
+      {buffer: props.selection, usage: 'storage-write'}
+    ],
+    bindings: {sourceRanks: props.ranks, selectionMask: props.selection},
+    length: props.selection.length
+  });
+}

--- a/modules/experimental/src/ludf/lu-sort-query.ts
+++ b/modules/experimental/src/ludf/lu-sort-query.ts
@@ -7,6 +7,10 @@ import type {GPUTypeMap} from '@luma.gl/tables';
 import type {GPUCommandGraph} from '../gpu-primitives/gpu-command-graph';
 import type {LuDataFrameQuery} from './lu-data-frame-query';
 import {
+  compileLuDataFrameGlobalSort,
+  type CompiledLuDataFrameGlobalSort
+} from './lu-global-sort-compiler';
+import {
   getLuDataFrameAnalyticColumnFormat,
   type LuDataFrameScalarColumnNames
 } from './lu-global-aggregation-query';
@@ -90,6 +94,41 @@ export class LuDataFrameSortQuery<
     graph: GPUCommandGraph<LuDataFrameQueryParameters>
   ): CompiledLuDataFrameSort<Pick<Logical, SelectedColumns>> {
     return compileLuDataFrameSort<Source, Pick<Logical, SelectedColumns>>(
+      this.query.source,
+      this.query.predicates,
+      this.query.selectedColumns,
+      this.query.derivedColumns,
+      this.column,
+      this.options,
+      graph
+    );
+  }
+}
+
+/**
+ * Explicit global scalar ordering across all preserved source batches.
+ *
+ * Source columns and record batches remain untouched; compilation creates only the GPU-resident
+ * permutation, selected count, and explicitly required sort scratch.
+ */
+export class LuDataFrameGlobalSortQuery<
+  Logical extends GPUTypeMap,
+  SelectedColumns extends keyof Logical & string,
+  Column extends LuDataFrameScalarColumnNames<Logical, SelectedColumns>,
+  Source extends GPUTypeMap = Logical
+> extends LuDataFrameSortQuery<Logical, SelectedColumns, Column, Source> {
+  /** Applies one global top-K bound across all source batches while preserving sort controls. */
+  override topK(
+    limit: number
+  ): LuDataFrameGlobalSortQuery<Logical, SelectedColumns, Column, Source> {
+    return new LuDataFrameGlobalSortQuery(this.query, this.column, this.options, limit);
+  }
+
+  /** Adds one cross-batch GPU permutation and global selected count to a reusable command graph. */
+  override compile(
+    graph: GPUCommandGraph<LuDataFrameQueryParameters>
+  ): CompiledLuDataFrameGlobalSort<Pick<Logical, SelectedColumns>> {
+    return compileLuDataFrameGlobalSort<Source, Pick<Logical, SelectedColumns>>(
       this.query.source,
       this.query.predicates,
       this.query.selectedColumns,

--- a/modules/experimental/test/ludf/lu-sort.node.spec.ts
+++ b/modules/experimental/test/ludf/lu-sort.node.spec.ts
@@ -6,9 +6,11 @@ import {Buffer} from '@luma.gl/core';
 import {GPUCommandGraph} from '@luma.gl/experimental';
 import {
   column,
+  CompiledLuDataFrameGlobalSort,
   CompiledLuDataFrameSort,
   literal,
   LuDataFrame,
+  LuDataFrameGlobalSortQuery,
   LuDataFrameSortQuery,
   parameter,
   type LuDataFrameQueryParameters,
@@ -224,6 +226,7 @@ describe('LuDataFrame immutable stable scalar sorting', () => {
     expect(score.stride).toBe(1);
     expect(score.data.map(chunk => chunk.byteStride)).toEqual([8, 8, 8]);
     expect(() => source.sortBy('score').compile(graph)).toThrow(/packed|stride|aligned/i);
+    expect(() => source.sortByGlobal('score').compile(graph)).toThrow(/packed|stride|aligned/i);
     expect(createBuffer).not.toHaveBeenCalled();
     expect(addComputePass).not.toHaveBeenCalled();
 
@@ -269,6 +272,74 @@ describe('LuDataFrame immutable stable scalar sorting', () => {
 
     expect(() => source.sortBy('score')).toThrow(/destroyed/i);
     expect(() => source.topK('score', 2)).toThrow(/destroyed/i);
+    expect(() => source.sortByGlobal('score')).toThrow(/destroyed/i);
+    expect(() => source.topKGlobal('score', 2)).toThrow(/destroyed/i);
+    fixture.table.destroy();
+  });
+
+  test('plans immutable global ordering without flattening batches or allocating GPU resources', () => {
+    const fixture = createSortSourceFixture([2, 0, 3]);
+    const source = new LuDataFrame({table: fixture.table, ownership: 'owned'});
+    const createBuffer = vi.spyOn(fixture.device, 'createBuffer');
+    const submit = vi.spyOn(fixture.device, 'submit');
+
+    const sorted = source.sortByGlobal('score', {nulls: 'first', nans: 'first'});
+    const highest = source.topKGlobal('signed', 2);
+    const lowest = source.sortByGlobal('category').topK(3);
+
+    expect(sorted).toBeInstanceOf(LuDataFrameGlobalSortQuery);
+    expect(sorted).toBeInstanceOf(LuDataFrameSortQuery);
+    expect(sorted.options).toEqual({
+      direction: 'ascending',
+      nulls: 'first',
+      nans: 'first',
+      algorithm: 'auto'
+    });
+    expect(highest.options).toEqual({
+      direction: 'descending',
+      nulls: 'last',
+      nans: 'last',
+      algorithm: 'auto',
+      limit: 2
+    });
+    expect(lowest.options.direction).toBe('ascending');
+    expect(lowest.options.limit).toBe(3);
+    expect(Object.isFrozen(sorted)).toBe(true);
+    expect(Object.isFrozen(sorted.options)).toBe(true);
+    expect(source.batches.map(batch => batch.numRows)).toEqual([2, 0, 3]);
+    expect(createBuffer).not.toHaveBeenCalled();
+    expect(submit).not.toHaveBeenCalled();
+
+    createBuffer.mockRestore();
+    submit.mockRestore();
+    source.destroy();
+    expect(fixture.buffers.every(buffer => buffer.destroyed)).toBe(true);
+  });
+
+  test('preserves precise projected and derived global output types and validates global limits', () => {
+    const fixture = createSortSourceFixture([2, 0, 3]);
+    const source = new LuDataFrame({table: fixture.table});
+    const projected = source
+      .filter(column('score').greaterThan(literal(0)))
+      .select(['score', 'signed'])
+      .sortByGlobal('signed');
+    const derived = source
+      .withColumn('adjustedScore', column('score').add(literal(2)))
+      .select(['score', 'adjustedScore'])
+      .topKGlobal('adjustedScore', 1);
+
+    expectTypeOf(projected.compile).returns.toEqualTypeOf<
+      CompiledLuDataFrameGlobalSort<{score: 'float32'; signed: 'sint32'}>
+    >();
+    expectTypeOf(derived.compile).returns.toEqualTypeOf<
+      CompiledLuDataFrameGlobalSort<{score: 'float32'; adjustedScore: 'float32'}>
+    >();
+    for (const limit of [-1, 0.5, Number.NaN, 0x1_0000_0000]) {
+      expect(() => source.topKGlobal('score', limit)).toThrow(/limit|uint32/i);
+      expect(() => source.sortByGlobal('score').topK(limit)).toThrow(/limit|uint32/i);
+    }
+
+    source.destroy();
     fixture.table.destroy();
   });
 });

--- a/modules/experimental/test/ludf/lu-sort.spec.ts
+++ b/modules/experimental/test/ludf/lu-sort.spec.ts
@@ -3,12 +3,14 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Buffer, type Device} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
 import {GPUCommandGraph} from '@luma.gl/experimental';
 import {
   LuDataFrame,
   column,
   literal,
   parameter,
+  type CompiledLuDataFrameGlobalSort,
   type LuDataFrameQueryParameters
 } from '@luma.gl/experimental/ludf';
 import {GPUData, GPURecordBatch, GPUTable, GPUVector} from '@luma.gl/tables';
@@ -392,11 +394,17 @@ test('LuDataFrame sorts nullable derived columns and schema-only source tables',
     id: 'ludf-schema-only-sort'
   });
   const empty = emptyFrame.sortBy('score').compile(emptyGraph);
+  const emptyGlobal = emptyFrame
+    .sortByGlobal('score')
+    .compile(
+      new GPUCommandGraph<LuDataFrameQueryParameters>(device, {id: 'ludf-schema-only-global-sort'})
+    );
 
   try {
     const commandEncoder = device.createCommandEncoder({id: 'ludf-derived-and-empty-sort'});
     derived.encode(commandEncoder);
     empty.encode(commandEncoder);
+    emptyGlobal.encode(commandEncoder);
     device.submit(commandEncoder.finish());
 
     testContext.deepEqual(
@@ -419,9 +427,13 @@ test('LuDataFrame sorts nullable derived columns and schema-only source tables',
       'empty-sort',
       'schema-only sorted projections retain source metadata'
     );
+    testContext.deepEqual(await readLuSortChunks(emptyGlobal.globalSelectedCount), [[0]]);
+    testContext.equal(emptyGlobal.globalRowIndices.length, 0);
+    testContext.deepEqual(emptyGlobal.table.batches, []);
   } finally {
     derived.destroy();
     empty.destroy();
+    emptyGlobal.destroy();
     emptyFrame.destroy();
     fixture.frame.destroy();
   }
@@ -429,7 +441,271 @@ test('LuDataFrame sorts nullable derived columns and schema-only source tables',
   testContext.end();
 });
 
-function createLuSortFixture(device: Device): LuSortFixture {
+test('LuDataFrame globally sorts stable nullable floating-point keys across preserved batches', async testContext => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testContext.comment('WebGPU is not available');
+    testContext.end();
+    return;
+  }
+
+  const fixture = createLuSortFixture(device, {sourceOffsets: [100, 400, 900]});
+  const sorted = fixture.frame
+    .sortByGlobal('score')
+    .compile(
+      new GPUCommandGraph<LuDataFrameQueryParameters>(device, {id: 'ludf-global-float-sort'})
+    );
+  const nullsFirst = fixture.frame
+    .sortByGlobal('score', {nulls: 'first', nans: 'first'})
+    .compile(
+      new GPUCommandGraph<LuDataFrameQueryParameters>(device, {id: 'ludf-global-null-nan-sort'})
+    );
+
+  try {
+    const encoder = device.createCommandEncoder({id: 'ludf-global-float-sort-encode'});
+    sorted.encode(encoder);
+    nullsFirst.encode(encoder);
+    device.submit(encoder.finish());
+
+    testContext.deepEqual(
+      await readLuSortChunks(sorted.globalSelectedCount),
+      [[13]],
+      'global ordering exposes one selected-row count across every preserved batch'
+    );
+    testContext.deepEqual(
+      await readLuSortChunks(sorted.globalRowIndices),
+      [[103, 906, 901, 100, 101, 904, 905, 900, 902, 104, 102, 903, 105]],
+      'global numeric sorting merges batches stably and preserves discontinuous source identities'
+    );
+    testContext.deepEqual(
+      await readLuSortChunks(nullsFirst.globalRowIndices),
+      [[105, 102, 903, 103, 906, 901, 100, 101, 904, 905, 900, 902, 104]],
+      'global null placement is absolute while NaNs remain independently ordered and stable'
+    );
+    testContext.deepEqual(
+      sorted.table.batches.map(batch => batch.numRows),
+      [6, 0, 7],
+      'global permutation never concatenates or reorders original dataframe batches'
+    );
+    testContext.deepEqual(
+      await readLuSortChunks(sorted.selectedCounts),
+      [[6], [0], [7]],
+      'global full sorting preserves the existing batch-aligned selection counts'
+    );
+  } finally {
+    sorted.destroy();
+    nullsFirst.destroy();
+    fixture.frame.destroy();
+  }
+
+  testContext.end();
+});
+
+test('LuDataFrame applies one globally stable top-K and reconciles source-aligned batch masks', async testContext => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testContext.comment('WebGPU is not available');
+    testContext.end();
+    return;
+  }
+
+  const fixture = createLuSortFixture(device);
+  const highest = fixture.frame
+    .topKGlobal('score', 4)
+    .compile(new GPUCommandGraph<LuDataFrameQueryParameters>(device, {id: 'ludf-global-top-k'}));
+  const lowest = fixture.frame
+    .sortByGlobal('signed')
+    .topK(3)
+    .compile(new GPUCommandGraph<LuDataFrameQueryParameters>(device, {id: 'ludf-global-bottom-k'}));
+  const empty = fixture.frame
+    .topKGlobal('category', 0)
+    .compile(new GPUCommandGraph<LuDataFrameQueryParameters>(device, {id: 'ludf-global-zero-k'}));
+
+  try {
+    const encoder = device.createCommandEncoder({id: 'ludf-global-top-k-encode'});
+    highest.encode(encoder);
+    lowest.encode(encoder);
+    empty.encode(encoder);
+    device.submit(encoder.finish());
+
+    testContext.deepEqual(await readLuSortChunks(highest.globalSelectedCount), [[4]]);
+    testContext.deepEqual(
+      await readLuSortBuffer(getLuSortBuffer(highest.globalRowIndices.data[0]), 4),
+      [44, 46, 48, 40],
+      'one descending global bound selects the four largest rows across all batches'
+    );
+    testContext.deepEqual(
+      await readLuSortChunks(highest.selectionMask),
+      [[1, 0, 0, 0, 1, 0], [], [1, 0, 1, 0, 0, 0, 0]],
+      'global top-K updates every original source-aligned selection mask'
+    );
+    testContext.deepEqual(await readLuSortChunks(highest.selectedCounts), [[2], [0], [2]]);
+    testContext.deepEqual(
+      await readLuSortedSourceRows(highest.rowIndices, highest.selectedCounts),
+      [[40, 44], [], [46, 48]],
+      'inherited batch-local row outputs remain coherent with the global selection'
+    );
+
+    testContext.deepEqual(await readLuSortChunks(lowest.globalSelectedCount), [[3]]);
+    testContext.deepEqual(
+      await readLuSortBuffer(getLuSortBuffer(lowest.globalRowIndices.data[0]), 3),
+      [41, 48, 42],
+      'sorted-plan limiting preserves ascending full-width signed ordering across batches'
+    );
+    testContext.deepEqual(await readLuSortChunks(empty.globalSelectedCount), [[0]]);
+    testContext.deepEqual(await readLuSortChunks(empty.selectedCounts), [[0], [0], [0]]);
+  } finally {
+    highest.destroy();
+    lowest.destroy();
+    empty.destroy();
+    fixture.frame.destroy();
+  }
+
+  testContext.end();
+});
+
+test('LuDataFrame globally orders filtered derived keys and preserves reusable query parameters', async testContext => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testContext.comment('WebGPU is not available');
+    testContext.end();
+    return;
+  }
+
+  const fixture = createLuSortFixture(device);
+  const compiled = fixture.frame
+    .filter(column('signed').greaterThan(parameter('minimumSigned', -4)))
+    .withColumn('shiftedSigned', column('signed').add(literal(0)), {format: 'sint32'})
+    .topKGlobal('shiftedSigned', 2)
+    .compile(
+      new GPUCommandGraph<LuDataFrameQueryParameters>(device, {id: 'ludf-global-parameter'})
+    );
+
+  try {
+    let encoder = device.createCommandEncoder({id: 'ludf-global-parameter-first'});
+    compiled.encode(encoder, {minimumSigned: 6});
+    device.submit(encoder.finish());
+    testContext.deepEqual(await readLuSortChunks(compiled.globalSelectedCount), [[2]]);
+    testContext.deepEqual(
+      await readLuSortBuffer(getLuSortBuffer(compiled.globalRowIndices.data[0]), 2),
+      [40, 44],
+      'global derived top-K retains stable source order among maximum signed-key ties'
+    );
+
+    encoder = device.createCommandEncoder({id: 'ludf-global-parameter-second'});
+    compiled.encode(encoder, {minimumSigned: 0x7fffffff});
+    device.submit(encoder.finish());
+    testContext.deepEqual(await readLuSortChunks(compiled.globalSelectedCount), [[0]]);
+    testContext.deepEqual(await readLuSortChunks(compiled.selectedCounts), [[0], [0], [0]]);
+  } finally {
+    compiled.destroy();
+    fixture.frame.destroy();
+  }
+
+  testContext.end();
+});
+
+test('LuDataFrame globally orders preserved batches through bounded three-dimensional sorting', async testContext => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testContext.comment('WebGPU is not available');
+    testContext.end();
+    return;
+  }
+
+  const originalLimits = device.limits;
+  Object.defineProperty(device, 'limits', {
+    configurable: true,
+    value: new Proxy(originalLimits, {
+      get(target, property) {
+        return property === 'maxComputeWorkgroupsPerDimension'
+          ? 2
+          : Reflect.get(target, property, target);
+      }
+    })
+  });
+  const dispatch = vi.spyOn(Computation.prototype, 'dispatch');
+  const sourceBuffers: Buffer[] = [];
+  const expected: {score: number; sourceRow: number; ordinal: number}[] = [];
+  const lengths = [513, 0, 512];
+  const offsets = [1_000, 5_000, 9_000];
+  let ordinal = 0;
+  const batches = lengths.map((length, batchIndex) => {
+    const scores = Float32Array.from({length}, (_, index) => {
+      const score = ((ordinal + index) * 37) % 97;
+      expected.push({score, sourceRow: offsets[batchIndex] + index, ordinal: ordinal + index});
+      return score;
+    });
+    const batch = new GPURecordBatch<LuSortSourceSchema>({
+      gpuData: {
+        score: createLuSortData(device, sourceBuffers, scores, 'float32'),
+        signed: createLuSortData(device, sourceBuffers, Int32Array.from(scores), 'sint32'),
+        category: createLuSortData(device, sourceBuffers, Uint32Array.from(scores), 'uint32')
+      },
+      fields: [
+        {name: 'score', format: 'float32', nullable: false},
+        {name: 'signed', format: 'sint32', nullable: false},
+        {name: 'category', format: 'uint32', nullable: false}
+      ],
+      sourceInfo: {
+        sourceBatchIndex: batchIndex,
+        sourceRowIndexOffset: offsets[batchIndex],
+        sourceRowCount: length
+      }
+    });
+    ordinal += length;
+    return batch;
+  });
+  const frame = new LuDataFrame<LuSortSourceSchema>({
+    table: new GPUTable({batches}),
+    ownership: 'owned'
+  });
+  let compiled: CompiledLuDataFrameGlobalSort<LuSortSourceSchema> | undefined;
+
+  try {
+    compiled = frame
+      .topKGlobal('score', 25)
+      .compile(
+        new GPUCommandGraph<LuDataFrameQueryParameters>(device, {id: 'ludf-global-bounded-sort'})
+      );
+    const encoder = device.createCommandEncoder({id: 'ludf-global-bounded-sort-encode'});
+    compiled.encode(encoder);
+    device.submit(encoder.finish());
+
+    const expectedRows = expected
+      .sort((left, right) => right.score - left.score || left.ordinal - right.ordinal)
+      .slice(0, 25)
+      .map(row => row.sourceRow);
+    testContext.deepEqual(await readLuSortChunks(compiled.globalSelectedCount), [[25]]);
+    testContext.deepEqual(
+      await readLuSortBuffer(getLuSortBuffer(compiled.globalRowIndices.data[0]), 25),
+      expectedRows,
+      'stable global top-K merges 1,025 discontiguous source rows without collapsing batches'
+    );
+    testContext.deepEqual(
+      compiled.table.batches.map(batch => batch.numRows),
+      lengths
+    );
+    testContext.ok(
+      dispatch.mock.calls.some(
+        ([, horizontal, vertical, depth]) => horizontal === 2 && vertical === 2 && depth === 2
+      ),
+      'the explicit cross-batch permutation uses bounded 2×2×2 GPU sorting'
+    );
+  } finally {
+    compiled?.destroy();
+    frame.destroy();
+    dispatch.mockRestore();
+    Object.defineProperty(device, 'limits', {configurable: true, value: originalLimits});
+  }
+
+  testContext.end();
+});
+
+function createLuSortFixture(
+  device: Device,
+  options: {sourceOffsets?: readonly number[]} = {}
+): LuSortFixture {
   const sourceBuffers: Buffer[] = [];
   const scores = [
     Float32Array.from([-0, 0, Number.NaN, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY, 5]),
@@ -468,7 +744,7 @@ function createLuSortFixture(device: Device): LuSortFixture {
       ],
       sourceInfo: {
         sourceBatchIndex: batchIndex + 4,
-        sourceRowIndexOffset,
+        sourceRowIndexOffset: options.sourceOffsets?.[batchIndex] ?? sourceRowIndexOffset,
         sourceRowCount: values.length
       }
     });


### PR DESCRIPTION
## Goals

Add explicit, stable GPU sorting and top-K across all preserved dataframe batches while leaving the existing per-batch `sortBy` and `topK` contracts unchanged.

## Changes

- Introduce allocation-free immutable `LuDataFrame.sortByGlobal`, `LuDataFrame.topKGlobal`, and matching filtered/projected/derived query methods.
- Support `sortByGlobal(column, options).topK(limit)` while preserving explicit ascending/descending, null placement, NaN placement, and GPU sort-algorithm controls.
- Publish `LuDataFrameGlobalSortQuery` and `CompiledLuDataFrameGlobalSort` with dedicated GPU-owned `globalRowIndices` and single-row `globalSelectedCount` outputs.
- Stage only numeric keys, nullable/NaN/filter classes, stable original source identifiers, and row ordinals into explicit graph scratch; source columns, source buffers, record batches, dictionaries, and validity sidecars are never copied or reordered.
- Compose two existing stable, bounded-3D `GPUSort` operations so full-width uint32/sint32/float32 ordering, signed zero, infinities, stable ties, nulls, and NaNs remain correct across batch boundaries.
- Apply one global top-K bound back to original source-aligned masks, per-batch selected counts, and inherited compacted row identifiers without CPU readback.
- Preserve discontinuous Arrow/source offsets, zero-row batches, schema-only sources, filtered/derived expressions, repeated encoder parameters, graph ownership, and source resource leases.
- Document explicit global versus per-batch ordering, result vectors, stability semantics, and batching/storage limitations.
- Add immutable-planning/type regressions and real-WebGPU coverage for cross-batch ordering, null/NaN controls, global masks/counts, zero-K, derived/filter parameters, empty tables, and 1,025 rows through forced `2 × 2 × 2` dispatch.

## Verification

- `yarn lint fix` — passed; 1,853 files checked.
- `yarn build` — passed across the complete monorepo after final source changes.
- `CI=1 yarn test` — passed: **2,123 Node tests** and **2,058 actual Chromium/WebGPU tests**, with existing skips unchanged.
- Focused luDF Node suite — 77 tests passed.
- Dedicated real-WebGPU global/batch sorting and scalable-dispatch suites — 10 tests passed.
- `yarn website:build` — passed; 519 documentation pages validated.
- `(cd website && yarn build)` — passed; 519 documentation pages validated.
- `yarn examples:typecheck` — passed for all 47 example workspaces.
- Git pre-commit hooks independently reran formatting and all 2,123 Node tests.
- Dependencies were reused from an existing worktree; `yarn install` was unnecessary.

## Risks and follow-up

- Global ordering explicitly allocates GPU-resident permutation scratch proportional to total source rows; it does not silently repack source columns or transfer rows to the CPU.
- Existing sort APIs remain batch-local; global behavior requires the explicit new API.
- Stable ordering remains bounded by GPU storage capacity and the existing 2^31-row `GPUSort` implementation limit.
- Richer GPU join semantics are the next independent tranche.
