### PR TITLE
feat(experimental): add outer, semi, and anti dataframe joins

### DIFF
--- a/docs/api-reference/experimental/ludf.md
+++ b/docs/api-reference/experimental/ludf.md
@@ -350,10 +350,10 @@ the CPU.
 
 ## Join or look up unique right-side keys
 
-luDF supports bounded, unique-right-key `uint32` inner joins and source-aligned left lookups. Left
-and right tables may have different batch topologies, empty chunks, nullable keys, and explicit
-original source-row offsets. The right-side hash index is built directly from its original batches;
-neither side is concatenated or repacked.
+luDF supports bounded, unique-right-key `uint32` inner, left outer, semi, and anti joins, together
+with source-aligned lookups. Left and right tables may have different batch topologies, empty
+chunks, nullable keys, and explicit original source-row offsets. The right-side hash index is built
+directly from its original batches; neither side is concatenated or repacked.
 
 ```ts
 const joined = customers
@@ -369,6 +369,8 @@ const joined = customers
 
 joined.rowIndices;
 joined.rightRowIndices;
+joined.rightValidity;
+joined.joinType;
 joined.requiredCounts;
 joined.selectedCounts;
 joined.overflows;
@@ -376,6 +378,18 @@ joined.indexStatistics;
 joined.lookupStatistics;
 joined.contractViolation;
 joined.rightTable;
+
+const leftOuter = customers
+  .leftJoin(accounts, {leftOn: 'customerId', rightOn: 'accountId'})
+  .compile(new GPUCommandGraph<LuDataFrameQueryParameters>(device));
+
+const matchedCustomers = customers
+  .semiJoin(accounts, {leftOn: 'customerId', rightOn: 'accountId'})
+  .compile(new GPUCommandGraph<LuDataFrameQueryParameters>(device));
+
+const unmatchedCustomers = customers
+  .antiJoin(accounts, {leftOn: 'customerId', rightOn: 'accountId'})
+  .compile(new GPUCommandGraph<LuDataFrameQueryParameters>(device));
 
 const lookups = customers
   .lookup(accounts, {leftOn: 'customerId', rightOn: 'accountId'})
@@ -389,21 +403,36 @@ lookups.indexStatistics;
 lookups.contractViolation;
 ```
 
-For an inner join, `rowIndices` and `rightRowIndices` contain paired stable source identifiers;
-`selectedCounts` gives the published prefix while `requiredCounts` reports all matches before
-capacity truncation. `overflows` flags insufficient output capacity per original left batch.
-Lookups instead preserve source-aligned right identifiers and expose a match flag and probe count
-for every left row.
+For every join, `rowIndices` and `rightRowIndices` contain paired stable source identifiers;
+`selectedCounts` gives the published prefix while `requiredCounts` reports all selected result rows
+before capacity truncation. `overflows` flags insufficient output capacity per original left batch.
+`rightValidity` is a compacted, GPU-resident `uint32` sidecar: `1` means a right partner exists;
+`0` means the published left row is unmatched and its right identifier is the reserved
+`0xffffffff` marker.
+
+- `innerJoin` publishes only matching left rows and their right partners.
+- `leftJoin` publishes every selected left row, including missing and nullable left keys, and
+  explicitly marks unmatched right partners through `rightValidity`.
+- `semiJoin` publishes only selected left rows with an existing right partner.
+- `antiJoin` publishes only selected unmatched left rows, including nullable left keys; every
+  published `rightValidity` entry is zero.
+- `lookup` preserves source-aligned right identifiers and exposes a match flag and probe count for
+  every left row without compacting the original batches.
+
+All four join modes support the same `capacity`, `indexCapacity`, and `maxProbeCount` options and
+compose with filtered, projected, or derived left plans. Publication remains stable within each
+original left batch; no implicit global row ordering or source-column materialization occurs.
 
 The six GPU-resident index statistic words are, in order, unique entries, duplicate keys, index
 overflow, invalid keys, total probe count, and maximum probe count. A valid key equal to
 `0xffffffff` is reserved and therefore invalid; nullable right rows are ignored. Duplicate right
 keys, reserved valid keys, or incomplete hash-index construction set `contractViolation` and
-suppress all published matches instead of returning ambiguous results. Dictionary-encoded keys
-must have identical labels and ordering on both sides.
+suppress all published rows in every join mode instead of returning ambiguous results or treating
+an incomplete index as missing matches. Dictionary-encoded keys must have identical labels and
+ordering on both sides.
 
-Many-to-many joins, outer joins, multi-key joins, string-key hashing, and CPU-side result
-materialization are intentionally unsupported.
+Many-to-many joins, right/full outer joins, multi-key joins, string-key hashing, and CPU-side result
+materialization remain intentionally unsupported.
 
 ## Share GPU outputs with rendering and LuxFilter
 

--- a/modules/experimental/src/ludf/index.ts
+++ b/modules/experimental/src/ludf/index.ts
@@ -43,7 +43,11 @@ export type {LuDataFrameHistogramOptions} from './lu-histogram-query';
 export {LuDataFrameGlobalSortQuery, LuDataFrameSortQuery} from './lu-sort-query';
 export type {LuDataFrameSortOptions} from './lu-sort-query';
 export {LuDataFrameJoinQuery, LuDataFrameLookupQuery} from './lu-join-query';
-export type {LuDataFrameJoinOptions, LuDataFrameLookupOptions} from './lu-join-query';
+export type {
+  LuDataFrameJoinOptions,
+  LuDataFrameJoinType,
+  LuDataFrameLookupOptions
+} from './lu-join-query';
 export {and, column, literal, LuExpression, not, or, parameter} from './lu-expression';
 export type {
   LuExpressionBinaryOperator,

--- a/modules/experimental/src/ludf/lu-data-frame-query.ts
+++ b/modules/experimental/src/ludf/lu-data-frame-query.ts
@@ -236,6 +236,42 @@ export class LuDataFrameQuery<
     return new LuDataFrameJoinQuery(this, right, options);
   }
 
+  /** Preserves every selected left row and explicitly marks missing right-side partners. */
+  leftJoin<
+    Right extends GPUTypeMap,
+    LeftKey extends LuDataFrameColumnNamesOfFormat<Logical, SelectedColumns, 'uint32'>,
+    RightKey extends LuDataFrameColumnNamesOfFormat<Right, keyof Right & string, 'uint32'>
+  >(
+    right: LuDataFrame<Right>,
+    options: LuDataFrameJoinOptions<LeftKey, RightKey>
+  ): LuDataFrameJoinQuery<Logical, SelectedColumns, Right, LeftKey, RightKey, Source> {
+    return new LuDataFrameJoinQuery(this, right, options, 'left');
+  }
+
+  /** Preserves only selected left rows whose key exists in the unique-right index. */
+  semiJoin<
+    Right extends GPUTypeMap,
+    LeftKey extends LuDataFrameColumnNamesOfFormat<Logical, SelectedColumns, 'uint32'>,
+    RightKey extends LuDataFrameColumnNamesOfFormat<Right, keyof Right & string, 'uint32'>
+  >(
+    right: LuDataFrame<Right>,
+    options: LuDataFrameJoinOptions<LeftKey, RightKey>
+  ): LuDataFrameJoinQuery<Logical, SelectedColumns, Right, LeftKey, RightKey, Source> {
+    return new LuDataFrameJoinQuery(this, right, options, 'semi');
+  }
+
+  /** Preserves selected unmatched left rows, including rows with nullable left keys. */
+  antiJoin<
+    Right extends GPUTypeMap,
+    LeftKey extends LuDataFrameColumnNamesOfFormat<Logical, SelectedColumns, 'uint32'>,
+    RightKey extends LuDataFrameColumnNamesOfFormat<Right, keyof Right & string, 'uint32'>
+  >(
+    right: LuDataFrame<Right>,
+    options: LuDataFrameJoinOptions<LeftKey, RightKey>
+  ): LuDataFrameJoinQuery<Logical, SelectedColumns, Right, LeftKey, RightKey, Source> {
+    return new LuDataFrameJoinQuery(this, right, options, 'anti');
+  }
+
   /** Plans a bounded, source-aligned unique-right lookup while preserving both batch topologies. */
   lookup<
     Right extends GPUTypeMap,

--- a/modules/experimental/src/ludf/lu-data-frame.ts
+++ b/modules/experimental/src/ludf/lu-data-frame.ts
@@ -316,6 +316,54 @@ export class LuDataFrame<T extends GPUTypeMap = GPUTypeMap> {
     );
   }
 
+  /** Preserves selected left rows and publishes explicit validity for unmatched right partners. */
+  leftJoin<
+    Right extends GPUTypeMap,
+    LeftKey extends LuDataFrameColumnNamesOfFormat<T, keyof T & string, 'uint32'>,
+    RightKey extends LuDataFrameColumnNamesOfFormat<Right, keyof Right & string, 'uint32'>
+  >(
+    right: LuDataFrame<Right>,
+    options: LuDataFrameJoinOptions<LeftKey, RightKey>
+  ): LuDataFrameJoinQuery<T, keyof T & string, Right, LeftKey, RightKey, T> {
+    this.assertAvailable();
+    return new LuDataFrameQuery<T, keyof T & string, T>(this, [], this.columnNames).leftJoin(
+      right,
+      options
+    );
+  }
+
+  /** Preserves selected left rows that match one unique right key. */
+  semiJoin<
+    Right extends GPUTypeMap,
+    LeftKey extends LuDataFrameColumnNamesOfFormat<T, keyof T & string, 'uint32'>,
+    RightKey extends LuDataFrameColumnNamesOfFormat<Right, keyof Right & string, 'uint32'>
+  >(
+    right: LuDataFrame<Right>,
+    options: LuDataFrameJoinOptions<LeftKey, RightKey>
+  ): LuDataFrameJoinQuery<T, keyof T & string, Right, LeftKey, RightKey, T> {
+    this.assertAvailable();
+    return new LuDataFrameQuery<T, keyof T & string, T>(this, [], this.columnNames).semiJoin(
+      right,
+      options
+    );
+  }
+
+  /** Preserves selected unmatched left rows, including nullable left keys. */
+  antiJoin<
+    Right extends GPUTypeMap,
+    LeftKey extends LuDataFrameColumnNamesOfFormat<T, keyof T & string, 'uint32'>,
+    RightKey extends LuDataFrameColumnNamesOfFormat<Right, keyof Right & string, 'uint32'>
+  >(
+    right: LuDataFrame<Right>,
+    options: LuDataFrameJoinOptions<LeftKey, RightKey>
+  ): LuDataFrameJoinQuery<T, keyof T & string, Right, LeftKey, RightKey, T> {
+    this.assertAvailable();
+    return new LuDataFrameQuery<T, keyof T & string, T>(this, [], this.columnNames).antiJoin(
+      right,
+      options
+    );
+  }
+
   /** Plans bounded, source-aligned unique-right lookups without flattening source batches. */
   lookup<
     Right extends GPUTypeMap,

--- a/modules/experimental/src/ludf/lu-join-compiler.ts
+++ b/modules/experimental/src/ludf/lu-join-compiler.ts
@@ -18,7 +18,6 @@ import {
   GPU_HASH_INDEX_STATISTICS_LENGTH,
   GPU_HASH_QUERY_STATISTICS_LENGTH
 } from '../gpu-primitives/gpu-hash-index';
-import {GPUHashJoin} from '../gpu-primitives/gpu-hash-join';
 import {GPUScan} from '../gpu-primitives/gpu-scan';
 import {
   createTransientVectorView,
@@ -35,7 +34,7 @@ import {
 import type {LuDataFrame} from './lu-data-frame';
 import type {LuDataFrameDerivedColumn} from './lu-data-frame-query';
 import type {LuExpression} from './lu-expression';
-import type {LuDataFrameNormalizedJoinOptions} from './lu-join-query';
+import type {LuDataFrameJoinType, LuDataFrameNormalizedJoinOptions} from './lu-join-query';
 import {
   CompiledLuDataFrameQuery,
   compileLuDataFrameQuery,
@@ -65,6 +64,8 @@ type LuJoinCommonResources<Right extends GPUTypeMap> = {
 };
 
 type LuJoinResources<Right extends GPUTypeMap> = LuJoinCommonResources<Right> & {
+  joinType: LuDataFrameJoinType;
+  rightValidity: GPUVector<'uint32'>;
   requiredCounts: GPUVector<'uint32'>;
   overflows: GPUVector<'uint32'>;
 };
@@ -110,11 +111,15 @@ abstract class CompiledLuDataFrameHashQuery<
   }
 }
 
-/** Stable, source-batch-preserving unique-right inner join with explicit bounded diagnostics. */
+/** Stable, source-batch-preserving unique-right join with explicit bounded diagnostics. */
 export class CompiledLuDataFrameJoin<
   Left extends GPUTypeMap = GPUTypeMap,
   Right extends GPUTypeMap = GPUTypeMap
 > extends CompiledLuDataFrameHashQuery<Left, Right> {
+  /** Matching semantics used to select the compacted left-row prefix. */
+  readonly joinType: LuDataFrameJoinType;
+  /** Compacted right-side validity; unmatched outer/anti rows contain zero. */
+  readonly rightValidity: GPUVector<'uint32'>;
   /** Exact required pair count for each source batch, independent of publication capacity. */
   readonly requiredCounts: GPUVector<'uint32'>;
   /** One source-index or per-batch publication overflow flag for each original left batch. */
@@ -123,6 +128,8 @@ export class CompiledLuDataFrameJoin<
   /** @internal */
   constructor(props: CompiledLuDataFrameQueryProps<Left>, resources: LuJoinResources<Right>) {
     super(props, resources);
+    this.joinType = resources.joinType;
+    this.rightValidity = resources.rightValidity;
     this.requiredCounts = resources.requiredCounts;
     this.overflows = resources.overflows;
   }
@@ -146,7 +153,7 @@ export class CompiledLuDataFrameLookup<
   }
 }
 
-/** Compiles a nullable, filtered, bounded inner join against an independently batched right side. */
+/** Compiles a nullable, filtered, bounded join against an independently batched right side. */
 export function compileLuDataFrameJoin<
   Source extends GPUTypeMap,
   Selection extends GPUTypeMap,
@@ -158,6 +165,7 @@ export function compileLuDataFrameJoin<
   derivedColumns: readonly LuDataFrameDerivedColumn[],
   right: LuDataFrame<Right>,
   options: LuDataFrameNormalizedJoinOptions,
+  joinType: LuDataFrameJoinType,
   graph: GPUCommandGraph<LuDataFrameQueryParameters>
 ): CompiledLuDataFrameJoin<Selection, Right> {
   validateLuJoinSources(source, right, options, graph);
@@ -170,7 +178,7 @@ export function compileLuDataFrameJoin<
       CompiledLuDataFrameJoin<Selection, Right>
     >(source, predicates, selectedColumns, graph, derivedColumns, {
       allowEmptyPredicates: true,
-      prepare: context => addLuInnerJoinToGraph(context, retainedRight, options)
+      prepare: context => addLuJoinToGraph(context, retainedRight, options, joinType)
     });
   } catch (error) {
     retainedRight.destroy();
@@ -247,18 +255,25 @@ function validateLuJoinSources<Source extends GPUTypeMap, Right extends GPUTypeM
 }
 
 /** Materializes owned pair diagnostics while sharing one chunk-preserving right index. */
-function addLuInnerJoinToGraph<Left extends GPUTypeMap, Right extends GPUTypeMap>(
+function addLuJoinToGraph<Left extends GPUTypeMap, Right extends GPUTypeMap>(
   context: LuDataFrameQueryExtensionContext<Left>,
   right: LuDataFrame<Right>,
-  options: LuDataFrameNormalizedJoinOptions
+  options: LuDataFrameNormalizedJoinOptions,
+  joinType: LuDataFrameJoinType
 ): LuDataFrameQueryExtensionResult<Left, CompiledLuDataFrameJoin<Left, Right>> {
   const ownedVectors: GPUVector[] = [];
-  const id = `${context.queryId}-inner-join`;
+  const id = `${context.queryId}-${joinType}-join`;
   try {
     const indexState = buildLuJoinIndex(context, right, options, ownedVectors, id);
     const lengths = context.table.batches.map(batch => batch.numRows);
     const rightRowIndices = createLuJoinOutputVector(context.graph.device, `${id}-right`, lengths);
     ownedVectors.push(rightRowIndices);
+    const rightValidity = createLuJoinOutputVector(
+      context.graph.device,
+      `${id}-right-validity`,
+      lengths
+    );
+    ownedVectors.push(rightValidity);
     const requiredCounts = createLuJoinOutputVector(
       context.graph.device,
       `${id}-required`,
@@ -279,6 +294,7 @@ function addLuInnerJoinToGraph<Left extends GPUTypeMap, Right extends GPUTypeMap
     ownedVectors.push(lookupStatistics);
 
     const rightRows = context.graph.importGPUVector(`${id}-right-rows`, rightRowIndices);
+    const rightValid = context.graph.importGPUVector(`${id}-right-validity-rows`, rightValidity);
     const required = context.graph.importGPUVector(`${id}-required-counts`, requiredCounts);
     const overflow = context.graph.importGPUVector(`${id}-overflows`, overflows);
     const statistics = context.graph.importGPUVector(`${id}-statistics`, lookupStatistics);
@@ -287,36 +303,52 @@ function addLuInnerJoinToGraph<Left extends GPUTypeMap, Right extends GPUTypeMap
       `${id}-matches`,
       context.selectionMask
     );
+    const included = createTransientVectorView(
+      context.graph,
+      `${id}-included-rows`,
+      context.selectionMask
+    );
+    const matchedRightRows = createTransientVectorView(
+      context.graph,
+      `${id}-matched-right-rows`,
+      context.selectionMask
+    );
+    const probeCounts = createTransientVectorView(
+      context.graph,
+      `${id}-probe-counts`,
+      context.selectionMask
+    );
+    const violation = context.graph.importGPUVector(
+      `${id}-contract-flag`,
+      indexState.contractViolation
+    ).data[0];
+    const indexStatistics = context.graph.importGPUVector(
+      `${id}-index-statistics-view`,
+      indexState.indexStatistics
+    ).data[0];
 
     let firstLeftRow = 0;
     for (const [batchIndex, batch] of context.table.batches.entries()) {
       const batchId = `${id}-batch-${batchIndex}`;
       const capacity = Math.min(options.capacity ?? batch.numRows, batch.numRows);
-      const outputLeftRows = getLuJoinCapacityView(
-        context.graph,
-        context.rowIndices.data[batchIndex],
-        capacity
-      );
-      const outputRightRows = getLuJoinCapacityView(
-        context.graph,
-        rightRows.data[batchIndex],
-        capacity
-      );
-
-      new GPUHashJoin({
+      new GPUHashIndexQuery({
         id: batchId,
         index: indexState.index,
         keys: indexState.maskedLeftKeys.data[batchIndex],
-        firstLeftRow: batch.sourceInfo?.sourceRowIndexOffset ?? firstLeftRow,
-        outputLeftRows,
-        outputRightRows,
-        count: required.data[batchIndex],
-        overflow: overflow.data[batchIndex],
-        statistics: statistics.data[batchIndex],
+        values: matchedRightRows.data[batchIndex],
         found: matches.data[batchIndex],
+        probes: probeCounts.data[batchIndex],
+        statistics: statistics.data[batchIndex],
         maxProbeCount: options.maxProbeCount
       }).addToGraph(context.graph);
 
+      addLuJoinClassifyPass(context.graph, `${batchId}-classify`, {
+        matches: matches.data[batchIndex],
+        selection: context.selectionMask.data[batchIndex],
+        violation,
+        included: included.data[batchIndex],
+        joinType
+      });
       const offsets = createTransientView(
         context.graph,
         `${batchId}-match-offsets`,
@@ -325,17 +357,28 @@ function addLuInnerJoinToGraph<Left extends GPUTypeMap, Right extends GPUTypeMap
       );
       new GPUScan({
         id: `${batchId}-published-offsets`,
-        input: matches.data[batchIndex],
+        input: included.data[batchIndex],
         output: offsets
       }).addToGraph(context.graph);
-      addLuJoinPublishPass(context.graph, `${batchId}-publish`, {
-        matches: matches.data[batchIndex],
+      addLuJoinCountPass(context.graph, `${batchId}-count`, {
+        included: included.data[batchIndex],
         offsets,
         selection: context.selectionMask.data[batchIndex],
-        leftRows: context.rowIndices.data[batchIndex],
-        rightRows: rightRows.data[batchIndex],
         required: required.data[batchIndex],
         published: context.selectedCounts.data[batchIndex],
+        overflow: overflow.data[batchIndex],
+        indexStatistics,
+        capacity
+      });
+      addLuJoinScatterPass(context.graph, `${batchId}-publish`, {
+        included: included.data[batchIndex],
+        matches: matches.data[batchIndex],
+        offsets,
+        matchedRightRows: matchedRightRows.data[batchIndex],
+        leftRows: context.rowIndices.data[batchIndex],
+        rightRows: rightRows.data[batchIndex],
+        rightValidity: rightValid.data[batchIndex],
+        firstLeftRow: batch.sourceInfo?.sourceRowIndexOffset ?? firstLeftRow,
         capacity
       });
       firstLeftRow += batch.numRows;
@@ -343,7 +386,9 @@ function addLuInnerJoinToGraph<Left extends GPUTypeMap, Right extends GPUTypeMap
 
     const resources: LuJoinResources<Right> = {
       right,
+      joinType,
       rightRowIndices,
+      rightValidity,
       requiredCounts,
       overflows,
       lookupStatistics,
@@ -565,19 +610,6 @@ function createLuJoinOutputVector(
   }
 }
 
-/** Uses the canonical imported graph handle while exposing a bounded logical pair-output prefix. */
-function getLuJoinCapacityView(
-  graph: GPUCommandGraph<LuDataFrameQueryParameters>,
-  view: GraphDataView<'uint32'>,
-  capacity: number
-): GraphDataView<'uint32'> {
-  return graph.createDataView(view.buffer, {
-    format: 'uint32',
-    length: capacity,
-    byteOffset: view.byteOffset
-  });
-}
-
 /** Publishes one strict GPU contract flag for duplicates, bounded index overflow, or reserved keys. */
 function addLuJoinContractPass(
   graph: GPUCommandGraph<LuDataFrameQueryParameters>,
@@ -686,38 +718,34 @@ fn main(
   });
 }
 
-/** Keeps inherited masks/counts and stable left/right row prefixes coherent after bounded joins. */
-function addLuJoinPublishPass(
+/** Separates join semantics from nullable key lookup and suppresses invalid right indexes. */
+function addLuJoinClassifyPass(
   graph: GPUCommandGraph<LuDataFrameQueryParameters>,
   id: string,
   props: {
     matches: GraphDataView<'uint32'>;
-    offsets: GraphDataView<'uint32'>;
     selection: GraphDataView<'uint32'>;
-    leftRows: GraphDataView<'uint32'>;
-    rightRows: GraphDataView<'uint32'>;
-    required: GraphDataView<'uint32'>;
-    published: GraphDataView<'uint32'>;
-    capacity: number;
+    violation: GraphDataView<'uint32'>;
+    included: GraphDataView<'uint32'>;
+    joinType: LuDataFrameJoinType;
   }
 ): void {
+  const inclusion =
+    props.joinType === 'left'
+      ? 'selected'
+      : props.joinType === 'anti'
+        ? 'selected && !matched'
+        : 'selected && matched';
   const source = /* wgsl */ `
 const ELEMENT_COUNT: u32 = ${props.matches.length}u;
 const MATCH_OFFSET: u32 = ${getViewElementOffset(props.matches)}u;
-const OFFSET_OFFSET: u32 = ${getViewElementOffset(props.offsets)}u;
 const SELECTION_OFFSET: u32 = ${getViewElementOffset(props.selection)}u;
-const LEFT_OFFSET: u32 = ${getViewElementOffset(props.leftRows)}u;
-const RIGHT_OFFSET: u32 = ${getViewElementOffset(props.rightRows)}u;
-const REQUIRED_OFFSET: u32 = ${getViewElementOffset(props.required)}u;
-const PUBLISHED_OFFSET: u32 = ${getViewElementOffset(props.published)}u;
-const OUTPUT_CAPACITY: u32 = ${props.capacity}u;
+const CONTRACT_OFFSET: u32 = ${getViewElementOffset(props.violation)}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.included)}u;
 @group(0) @binding(0) var<storage, read> matchedRows: array<u32>;
-@group(0) @binding(1) var<storage, read> matchedOffsets: array<u32>;
-@group(0) @binding(2) var<storage, read_write> selectionMask: array<u32>;
-@group(0) @binding(3) var<storage, read_write> outputLeftRows: array<u32>;
-@group(0) @binding(4) var<storage, read_write> outputRightRows: array<u32>;
-@group(0) @binding(5) var<storage, read> requiredCounts: array<u32>;
-@group(0) @binding(6) var<storage, read_write> selectedCounts: array<u32>;
+@group(0) @binding(1) var<storage, read> selectionMask: array<u32>;
+@group(0) @binding(2) var<storage, read> contractViolation: array<u32>;
+@group(0) @binding(3) var<storage, read_write> includedRows: array<u32>;
 
 @compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
 fn main(
@@ -725,18 +753,11 @@ fn main(
   @builtin(workgroup_id) workgroupId: vec3<u32>
 ) {
   ${getLuAnalyticsInvocationIndexSource(graph, props.matches.length)}
-  let published = min(requiredCounts[REQUIRED_OFFSET], OUTPUT_CAPACITY);
-  if (index == 0u) {
-    selectedCounts[PUBLISHED_OFFSET] = published;
-  }
   if (index < ELEMENT_COUNT) {
-    let selected = matchedRows[MATCH_OFFSET + index] != 0u &&
-      matchedOffsets[OFFSET_OFFSET + index] < OUTPUT_CAPACITY;
-    selectionMask[SELECTION_OFFSET + index] = select(0u, 1u, selected);
-    if (index >= published) {
-      outputLeftRows[LEFT_OFFSET + index] = 0u;
-      outputRightRows[RIGHT_OFFSET + index] = 0u;
-    }
+    let selected = selectionMask[SELECTION_OFFSET + index] != 0u;
+    let matched = matchedRows[MATCH_OFFSET + index] != 0u;
+    let included = (${inclusion}) && contractViolation[CONTRACT_OFFSET] == 0u;
+    includedRows[OUTPUT_OFFSET + index] = select(0u, 1u, included);
   }
 }`;
   addLuAnalyticsComputePass(graph, {
@@ -744,22 +765,186 @@ fn main(
     source,
     resources: [
       {buffer: props.matches, usage: 'storage-read'},
-      {buffer: props.offsets, usage: 'storage-read'},
-      {buffer: props.selection, usage: 'storage-write'},
-      {buffer: props.leftRows, usage: 'storage-read-write'},
-      {buffer: props.rightRows, usage: 'storage-read-write'},
-      {buffer: props.required, usage: 'storage-read'},
-      {buffer: props.published, usage: 'storage-write'}
+      {buffer: props.selection, usage: 'storage-read'},
+      {buffer: props.violation, usage: 'storage-read'},
+      {buffer: props.included, usage: 'storage-write'}
     ],
     bindings: {
       matchedRows: props.matches,
-      matchedOffsets: props.offsets,
       selectionMask: props.selection,
-      outputLeftRows: props.leftRows,
-      outputRightRows: props.rightRows,
-      requiredCounts: props.required,
-      selectedCounts: props.published
+      contractViolation: props.violation,
+      includedRows: props.included
     },
     length: Math.max(props.matches.length, 1)
+  });
+}
+
+/** Publishes required/bounded counts and source-aligned selected masks for one left batch. */
+function addLuJoinCountPass(
+  graph: GPUCommandGraph<LuDataFrameQueryParameters>,
+  id: string,
+  props: {
+    included: GraphDataView<'uint32'>;
+    offsets: GraphDataView<'uint32'>;
+    selection: GraphDataView<'uint32'>;
+    required: GraphDataView<'uint32'>;
+    published: GraphDataView<'uint32'>;
+    overflow: GraphDataView<'uint32'>;
+    indexStatistics: GraphDataView<'uint32'>;
+    capacity: number;
+  }
+): void {
+  const source = /* wgsl */ `
+const ELEMENT_COUNT: u32 = ${props.included.length}u;
+const INCLUDED_OFFSET: u32 = ${getViewElementOffset(props.included)}u;
+const OFFSET_OFFSET: u32 = ${getViewElementOffset(props.offsets)}u;
+const SELECTION_OFFSET: u32 = ${getViewElementOffset(props.selection)}u;
+const REQUIRED_OFFSET: u32 = ${getViewElementOffset(props.required)}u;
+const PUBLISHED_OFFSET: u32 = ${getViewElementOffset(props.published)}u;
+const OVERFLOW_OFFSET: u32 = ${getViewElementOffset(props.overflow)}u;
+const STATISTICS_OFFSET: u32 = ${getViewElementOffset(props.indexStatistics)}u;
+const OUTPUT_CAPACITY: u32 = ${props.capacity}u;
+@group(0) @binding(0) var<storage, read> includedRows: array<u32>;
+@group(0) @binding(1) var<storage, read> includedOffsets: array<u32>;
+@group(0) @binding(2) var<storage, read_write> selectionMask: array<u32>;
+@group(0) @binding(3) var<storage, read_write> requiredCounts: array<u32>;
+@group(0) @binding(4) var<storage, read_write> selectedCounts: array<u32>;
+@group(0) @binding(5) var<storage, read_write> overflowFlags: array<u32>;
+@group(0) @binding(6) var<storage, read> indexStatistics: array<u32>;
+
+@compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, Math.max(props.included.length, 1))}
+  if (index == 0u) {
+    var required = 0u;
+    if (ELEMENT_COUNT > 0u) {
+      let last = ELEMENT_COUNT - 1u;
+      required = includedOffsets[OFFSET_OFFSET + last] + includedRows[INCLUDED_OFFSET + last];
+    }
+    requiredCounts[REQUIRED_OFFSET] = required;
+    selectedCounts[PUBLISHED_OFFSET] = min(required, OUTPUT_CAPACITY);
+    let overflow = required > OUTPUT_CAPACITY || indexStatistics[STATISTICS_OFFSET + 2u] != 0u;
+    overflowFlags[OVERFLOW_OFFSET] = select(0u, 1u, overflow);
+  }
+  if (index < ELEMENT_COUNT) {
+    let selected = includedRows[INCLUDED_OFFSET + index] != 0u &&
+      includedOffsets[OFFSET_OFFSET + index] < OUTPUT_CAPACITY;
+    selectionMask[SELECTION_OFFSET + index] = select(0u, 1u, selected);
+  }
+}`;
+  addLuAnalyticsComputePass(graph, {
+    id,
+    source,
+    resources: [
+      {buffer: props.included, usage: 'storage-read'},
+      {buffer: props.offsets, usage: 'storage-read'},
+      {buffer: props.selection, usage: 'storage-write'},
+      {buffer: props.required, usage: 'storage-write'},
+      {buffer: props.published, usage: 'storage-write'},
+      {buffer: props.overflow, usage: 'storage-write'},
+      {buffer: props.indexStatistics, usage: 'storage-read'}
+    ],
+    bindings: {
+      includedRows: props.included,
+      includedOffsets: props.offsets,
+      selectionMask: props.selection,
+      requiredCounts: props.required,
+      selectedCounts: props.published,
+      overflowFlags: props.overflow,
+      indexStatistics: props.indexStatistics
+    },
+    length: Math.max(props.included.length, 1)
+  });
+}
+
+/** Writes stable bounded source IDs and explicit compacted right validity without aliasing. */
+function addLuJoinScatterPass(
+  graph: GPUCommandGraph<LuDataFrameQueryParameters>,
+  id: string,
+  props: {
+    included: GraphDataView<'uint32'>;
+    matches: GraphDataView<'uint32'>;
+    offsets: GraphDataView<'uint32'>;
+    matchedRightRows: GraphDataView<'uint32'>;
+    leftRows: GraphDataView<'uint32'>;
+    rightRows: GraphDataView<'uint32'>;
+    rightValidity: GraphDataView<'uint32'>;
+    firstLeftRow: number;
+    capacity: number;
+  }
+): void {
+  const source = /* wgsl */ `
+const ELEMENT_COUNT: u32 = ${props.included.length}u;
+const INCLUDED_OFFSET: u32 = ${getViewElementOffset(props.included)}u;
+const MATCH_OFFSET: u32 = ${getViewElementOffset(props.matches)}u;
+const OFFSET_OFFSET: u32 = ${getViewElementOffset(props.offsets)}u;
+const MATCHED_RIGHT_OFFSET: u32 = ${getViewElementOffset(props.matchedRightRows)}u;
+const LEFT_OFFSET: u32 = ${getViewElementOffset(props.leftRows)}u;
+const RIGHT_OFFSET: u32 = ${getViewElementOffset(props.rightRows)}u;
+const VALIDITY_OFFSET: u32 = ${getViewElementOffset(props.rightValidity)}u;
+const FIRST_LEFT_ROW: u32 = ${props.firstLeftRow}u;
+const OUTPUT_CAPACITY: u32 = ${props.capacity}u;
+@group(0) @binding(0) var<storage, read> includedRows: array<u32>;
+@group(0) @binding(1) var<storage, read> matchedRows: array<u32>;
+@group(0) @binding(2) var<storage, read> includedOffsets: array<u32>;
+@group(0) @binding(3) var<storage, read> matchedRightRows: array<u32>;
+@group(0) @binding(4) var<storage, read_write> outputLeftRows: array<u32>;
+@group(0) @binding(5) var<storage, read_write> outputRightRows: array<u32>;
+@group(0) @binding(6) var<storage, read_write> rightValidity: array<u32>;
+
+@compute @workgroup_size(${LU_ANALYTICS_WORKGROUP_SIZE})
+fn main(
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  ${getLuAnalyticsInvocationIndexSource(graph, props.included.length)}
+  if (index < ELEMENT_COUNT) {
+    let outputIndex = includedOffsets[OFFSET_OFFSET + index];
+    let included = includedRows[INCLUDED_OFFSET + index] != 0u;
+    if (included && outputIndex < OUTPUT_CAPACITY) {
+      let matched = matchedRows[MATCH_OFFSET + index] != 0u;
+      outputLeftRows[LEFT_OFFSET + outputIndex] = FIRST_LEFT_ROW + index;
+      outputRightRows[RIGHT_OFFSET + outputIndex] = select(
+        ${GPU_HASH_INDEX_EMPTY_KEY}u,
+        matchedRightRows[MATCHED_RIGHT_OFFSET + index],
+        matched
+      );
+      rightValidity[VALIDITY_OFFSET + outputIndex] = select(0u, 1u, matched);
+    }
+    let required = includedOffsets[OFFSET_OFFSET + ELEMENT_COUNT - 1u] +
+      includedRows[INCLUDED_OFFSET + ELEMENT_COUNT - 1u];
+    let published = min(required, OUTPUT_CAPACITY);
+    if (index >= published) {
+      outputLeftRows[LEFT_OFFSET + index] = 0u;
+      outputRightRows[RIGHT_OFFSET + index] = 0u;
+      rightValidity[VALIDITY_OFFSET + index] = 0u;
+    }
+  }
+}`;
+  addLuAnalyticsComputePass(graph, {
+    id,
+    source,
+    resources: [
+      {buffer: props.included, usage: 'storage-read'},
+      {buffer: props.matches, usage: 'storage-read'},
+      {buffer: props.offsets, usage: 'storage-read'},
+      {buffer: props.matchedRightRows, usage: 'storage-read'},
+      {buffer: props.leftRows, usage: 'storage-write'},
+      {buffer: props.rightRows, usage: 'storage-write'},
+      {buffer: props.rightValidity, usage: 'storage-write'}
+    ],
+    bindings: {
+      includedRows: props.included,
+      matchedRows: props.matches,
+      includedOffsets: props.offsets,
+      matchedRightRows: props.matchedRightRows,
+      outputLeftRows: props.leftRows,
+      outputRightRows: props.rightRows,
+      rightValidity: props.rightValidity
+    },
+    length: Math.max(props.included.length, 1)
   });
 }

--- a/modules/experimental/src/ludf/lu-join-query.ts
+++ b/modules/experimental/src/ludf/lu-join-query.ts
@@ -20,7 +20,10 @@ import type {LuDataFrameQueryParameters} from './lu-query-compiler';
 const MAXIMUM_UINT32 = 0xffffffff;
 const MAXIMUM_HASH_CAPACITY = 0x80000000;
 
-/** Unique-right inner-join columns, per-batch output capacity, and bounded hash-index controls. */
+/** Stable, unique-right join semantics applied independently to every preserved left batch. */
+export type LuDataFrameJoinType = 'inner' | 'left' | 'semi' | 'anti';
+
+/** Unique-right join columns, per-batch output capacity, and bounded hash-index controls. */
 export type LuDataFrameJoinOptions<
   LeftKey extends string = string,
   RightKey extends string = string
@@ -64,7 +67,7 @@ export type LuDataFrameNormalizedJoinOptions<
   capacity?: number;
 }>;
 
-/** Immutable bounded, stable, unique-right unsigned inner join without source materialization. */
+/** Immutable bounded, stable, unique-right unsigned join without source materialization. */
 export class LuDataFrameJoinQuery<
   Logical extends GPUTypeMap,
   SelectedColumns extends keyof Logical & string,
@@ -79,16 +82,20 @@ export class LuDataFrameJoinQuery<
   readonly right: LuDataFrame<Right>;
   /** Immutable, fully validated key names and fixed GPU index/publication bounds. */
   readonly options: LuDataFrameNormalizedJoinOptions<LeftKey, RightKey>;
+  /** Explicit matching semantics; outer and anti joins preserve unmatched selected rows. */
+  readonly joinType: LuDataFrameJoinType;
 
   /** Validates both key schemas and bounded capacities without touching GPU resources. @internal */
   constructor(
     query: LuDataFrameQuery<Logical, SelectedColumns, Source>,
     right: LuDataFrame<Right>,
-    options: LuDataFrameJoinOptions<LeftKey, RightKey>
+    options: LuDataFrameJoinOptions<LeftKey, RightKey>,
+    joinType: LuDataFrameJoinType = 'inner'
   ) {
     this.query = query;
     this.right = right;
     this.options = normalizeLuDataFrameJoinOptions(query, right, options, true);
+    this.joinType = joinType;
     Object.freeze(this);
   }
 
@@ -103,6 +110,7 @@ export class LuDataFrameJoinQuery<
       this.query.derivedColumns,
       this.right,
       this.options,
+      this.joinType,
       graph
     );
   }

--- a/modules/experimental/test/ludf/lu-join.node.spec.ts
+++ b/modules/experimental/test/ludf/lu-join.node.spec.ts
@@ -143,6 +143,40 @@ describe('LuDataFrame immutable unique-right joins and bounded lookups', () => {
     rightFixture.table.destroy();
   });
 
+  test('plans frozen left outer, semi, and anti joins without touching either source', () => {
+    const leftFixture = createJoinSourceFixture('left', [3, 0, 5], LEFT_FIELDS);
+    const rightFixture = createJoinSourceFixture('right', [2, 0, 3], RIGHT_FIELDS);
+    const left = new LuDataFrame({table: leftFixture.table});
+    const right = new LuDataFrame({table: rightFixture.table});
+    const createBuffer = vi.spyOn(leftFixture.device, 'createBuffer');
+    const filtered = left.filter(column('amount').greaterThan(parameter('minimumAmount', 5)));
+
+    const plans = [
+      left.innerJoin(right, {leftOn: 'key', rightOn: 'lookupKey'}),
+      left.leftJoin(right, {leftOn: 'key', rightOn: 'lookupKey', capacity: 2}),
+      filtered.semiJoin(right, {leftOn: 'key', rightOn: 'lookupKey'}),
+      filtered.antiJoin(right, {leftOn: 'key', rightOn: 'lookupKey', capacity: 0})
+    ];
+
+    expect(plans.map(plan => plan.joinType)).toEqual(['inner', 'left', 'semi', 'anti']);
+    expect(plans.every(plan => plan instanceof LuDataFrameJoinQuery)).toBe(true);
+    expect(plans.every(plan => Object.isFrozen(plan) && Object.isFrozen(plan.options))).toBe(true);
+    expect(plans[1].options.capacity).toBe(2);
+    expect(plans[3].options.capacity).toBe(0);
+    expect(plans[2].query.predicates).toEqual(filtered.predicates);
+    expect(plans[3].query.predicates).toEqual(filtered.predicates);
+    expect(createBuffer).not.toHaveBeenCalled();
+    expectTypeOf(plans[1].compile).returns.toEqualTypeOf<
+      CompiledLuDataFrameJoin<LeftJoinColumns, RightJoinColumns>
+    >();
+
+    createBuffer.mockRestore();
+    left.destroy();
+    right.destroy();
+    leftFixture.table.destroy();
+    rightFixture.table.destroy();
+  });
+
   test('clones bounded options and safely clamps default cumulative hash probing', () => {
     const leftFixture = createJoinSourceFixture('left', [3], LEFT_FIELDS);
     const rightFixture = createJoinSourceFixture('right', [70_000], RIGHT_FIELDS);

--- a/modules/experimental/test/ludf/lu-join.spec.ts
+++ b/modules/experimental/test/ludf/lu-join.spec.ts
@@ -177,6 +177,174 @@ test('LuDataFrame bounded lookups keep source-aligned matches, nullable keys, an
   testContext.end();
 });
 
+test('LuDataFrame left outer joins retain nullable and unmatched left rows with explicit right validity', async testContext => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testContext.comment('WebGPU is not available');
+    testContext.end();
+    return;
+  }
+
+  const fixture = createLuJoinFixture(device);
+  const compiled = fixture.left
+    .leftJoin(fixture.right, {leftOn: 'key', rightOn: 'lookupKey'})
+    .compile(new GPUCommandGraph(device, {id: 'ludf-left-outer-join'}));
+
+  try {
+    const commandEncoder = device.createCommandEncoder({id: 'ludf-left-outer-encode'});
+    compiled.encode(commandEncoder);
+    device.submit(commandEncoder.finish());
+
+    testContext.equal(compiled.joinType, 'left');
+    testContext.deepEqual(await readLuJoinChunks(compiled.requiredCounts), [[3], [0], [5]]);
+    testContext.deepEqual(await readLuJoinChunks(compiled.selectedCounts), [[3], [0], [5]]);
+    testContext.deepEqual(
+      await readLuJoinPublishedRows(compiled.rowIndices, compiled.selectedCounts),
+      [[100, 101, 102], [], [800, 801, 802, 803, 804]],
+      'selected unmatched and nullable left keys retain their stable source identities'
+    );
+    testContext.deepEqual(
+      await readLuJoinPublishedRows(compiled.rightRowIndices, compiled.selectedCounts),
+      [[501, MISSING_JOIN_ROW, 500], [], [900, MISSING_JOIN_ROW, 901, 500, MISSING_JOIN_ROW]],
+      'outer joins publish an explicit missing marker without inventing a right row'
+    );
+    testContext.deepEqual(
+      await readLuJoinPublishedRows(compiled.rightValidity, compiled.selectedCounts),
+      [[1, 0, 1], [], [1, 0, 1, 1, 0]],
+      'right-side nullability remains explicit and aligned with compacted output pairs'
+    );
+  } finally {
+    compiled.destroy();
+    fixture.left.destroy();
+    fixture.right.destroy();
+  }
+
+  testContext.end();
+});
+
+test('LuDataFrame semi and anti joins stably partition selected matches and nullable nonmatches', async testContext => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testContext.comment('WebGPU is not available');
+    testContext.end();
+    return;
+  }
+
+  const fixture = createLuJoinFixture(device);
+  const semi = fixture.left
+    .semiJoin(fixture.right, {leftOn: 'key', rightOn: 'lookupKey'})
+    .compile(new GPUCommandGraph(device, {id: 'ludf-semi-join'}));
+  const anti = fixture.left
+    .antiJoin(fixture.right, {leftOn: 'key', rightOn: 'lookupKey'})
+    .compile(new GPUCommandGraph(device, {id: 'ludf-anti-join'}));
+
+  try {
+    const commandEncoder = device.createCommandEncoder({id: 'ludf-semi-and-anti'});
+    semi.encode(commandEncoder);
+    anti.encode(commandEncoder);
+    device.submit(commandEncoder.finish());
+
+    testContext.equal(semi.joinType, 'semi');
+    testContext.equal(anti.joinType, 'anti');
+    testContext.deepEqual(await readLuJoinChunks(semi.selectedCounts), [[2], [0], [3]]);
+    testContext.deepEqual(await readLuJoinPublishedRows(semi.rowIndices, semi.selectedCounts), [
+      [100, 102],
+      [],
+      [800, 802, 803]
+    ]);
+    testContext.deepEqual(await readLuJoinPublishedRows(semi.rightValidity, semi.selectedCounts), [
+      [1, 1],
+      [],
+      [1, 1, 1]
+    ]);
+    testContext.deepEqual(await readLuJoinChunks(anti.requiredCounts), [[1], [0], [2]]);
+    testContext.deepEqual(
+      await readLuJoinPublishedRows(anti.rowIndices, anti.selectedCounts),
+      [[101], [], [801, 804]],
+      'anti joins include selected nullable left keys as unmatched rows'
+    );
+    testContext.deepEqual(
+      await readLuJoinPublishedRows(anti.rightRowIndices, anti.selectedCounts),
+      [[MISSING_JOIN_ROW], [], [MISSING_JOIN_ROW, MISSING_JOIN_ROW]]
+    );
+    testContext.deepEqual(await readLuJoinPublishedRows(anti.rightValidity, anti.selectedCounts), [
+      [0],
+      [],
+      [0, 0]
+    ]);
+  } finally {
+    semi.destroy();
+    anti.destroy();
+    fixture.left.destroy();
+    fixture.right.destroy();
+  }
+
+  testContext.end();
+});
+
+test('LuDataFrame outer and anti joins respect filters, bounded capacity, and invalid-index suppression', async testContext => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testContext.comment('WebGPU is not available');
+    testContext.end();
+    return;
+  }
+
+  const fixture = createLuJoinFixture(device);
+  const duplicateFixture = createLuJoinFixture(device, {duplicateRight: true});
+  const bounded = fixture.left
+    .filter(column('fare').greaterThan(parameter('minimumFare', 10)))
+    .leftJoin(fixture.right, {leftOn: 'key', rightOn: 'lookupKey', capacity: 2})
+    .compile(new GPUCommandGraph(device, {id: 'ludf-filtered-bounded-left-join'}));
+  const invalidOuter = duplicateFixture.left
+    .leftJoin(duplicateFixture.right, {leftOn: 'key', rightOn: 'lookupKey'})
+    .compile(new GPUCommandGraph(device, {id: 'ludf-invalid-left-join'}));
+  const invalidAnti = duplicateFixture.left
+    .antiJoin(duplicateFixture.right, {leftOn: 'key', rightOn: 'lookupKey'})
+    .compile(new GPUCommandGraph(device, {id: 'ludf-invalid-anti-join'}));
+
+  try {
+    const commandEncoder = device.createCommandEncoder({id: 'ludf-richer-join-contracts'});
+    bounded.encode(commandEncoder, {minimumFare: 10});
+    invalidOuter.encode(commandEncoder);
+    invalidAnti.encode(commandEncoder);
+    device.submit(commandEncoder.finish());
+
+    testContext.deepEqual(await readLuJoinChunks(bounded.requiredCounts), [[2], [0], [4]]);
+    testContext.deepEqual(await readLuJoinChunks(bounded.selectedCounts), [[2], [0], [2]]);
+    testContext.deepEqual(await readLuJoinChunks(bounded.overflows), [[0], [0], [1]]);
+    testContext.deepEqual(
+      await readLuJoinPublishedRows(bounded.rowIndices, bounded.selectedCounts),
+      [[100, 102], [], [801, 802]],
+      'capacity truncates the stable filtered left prefix independently per source batch'
+    );
+    testContext.deepEqual(
+      await readLuJoinPublishedRows(bounded.rightValidity, bounded.selectedCounts),
+      [[1, 1], [], [0, 1]],
+      'nullable unmatched rows remain distinguishable after bounded publication'
+    );
+
+    for (const compiled of [invalidOuter, invalidAnti]) {
+      testContext.deepEqual(await readLuJoinChunks(compiled.contractViolation), [[1]]);
+      testContext.deepEqual(
+        await readLuJoinChunks(compiled.selectedCounts),
+        [[0], [0], [0]],
+        'invalid unique-right indexes never turn into fabricated outer or anti matches'
+      );
+    }
+  } finally {
+    bounded.destroy();
+    invalidOuter.destroy();
+    invalidAnti.destroy();
+    fixture.left.destroy();
+    fixture.right.destroy();
+    duplicateFixture.left.destroy();
+    duplicateFixture.right.destroy();
+  }
+
+  testContext.end();
+});
+
 test('LuDataFrame reuses filtered joins across two ordered encodings without reading source rows', async testContext => {
   const device = await getWebGPUTestDevice();
   if (!device) {


### PR DESCRIPTION
## Goals

Expand luDF beyond unique-right inner joins and source-aligned lookups with practical GPU-native left outer, semi, and anti joins while preserving existing batch topology, source ownership, stable identities, and explicit hash-index correctness diagnostics.

## Changes

- Add `leftJoin`, `semiJoin`, and `antiJoin` to both `LuDataFrame` and `LuDataFrameQuery`; export the precise `LuDataFrameJoinType` union.
- Preserve immutable, zero-GPU-work planning and all existing bounded `capacity`, `indexCapacity`, and `maxProbeCount` controls.
- Compile all four join modes through one reusable GPU hash lookup, mode classification, exclusive scan, bounded publication, and stable row scatter workflow.
- Expose `CompiledLuDataFrameJoin.joinType` and a compacted GPU-resident `rightValidity` vector so unmatched outer/anti rows cannot be confused with a real right row.
- Include nullable selected left keys in outer and anti results, preserve independently chunked left/right sources and discontinuous source-row offsets, and suppress every output mode on duplicate, reserved-key, or incomplete right indexes.
- Extend CPU planning and actual WebGPU tests for mode selection, immutable plans, nullable/unmatched rows, stable row identities, filtered capacity truncation, right validity, and invalid-index suppression.
- Document use cases, exact semantics, GPU output contracts, configurable bounds, and intentionally deferred many-to-many/right/full outer joins.

## Verification

- Node 22 via the existing repository toolchain and reused installed dependencies; no dependency or lockfile changes.
- `yarn lint fix`.
- Full post-format `yarn build`.
- Focused luDF Node suite: **9 files, 78 tests passed**.
- Focused real Chromium/WebGPU join suite: **8 tests passed**.
- Full `CI=1 yarn test`: **2,179 Node tests passed** and **2,080 real Chromium/WebGPU tests passed** (25 intentionally skipped).
- `yarn website:build` and `(cd website && yarn build)`.
- `yarn examples:typecheck`.

## Boundaries

- Right keys remain unique, packed `uint32`; duplicate expansion, many-to-many joins, right/full outer joins, multiple join keys, and string hashing are not claimed.
- Results remain bounded and stable independently within each original left record batch; no implicit source repacking, global ordering, CPU readback, or dataframe materialization is introduced.
