### PR TITLE
Cut 100M-span trace visibility scratch by 32x

### DIFF
--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -71,6 +71,7 @@ import {
 import {
   getBatchVisibilityShader,
   getCandidateDensityShader,
+  getCandidateDependencySpanVisibilityShader,
   getCandidateDependencyVisibilityShader,
   getCandidatePassDispatchShader,
   getCandidatePickShader,
@@ -698,7 +699,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
           uniforms,
           visibility: this.createStorageBuffer(
             `gpu-trace-span-visibility-${chunk.chunkIndex}`,
-            chunk.spanCount * UINT32_BYTE_LENGTH,
+            Math.ceil(chunk.spanCount / 32) * UINT32_BYTE_LENGTH,
             Buffer.COPY_SRC
           ),
           visibleIds: this.createStorageBuffer(
@@ -944,7 +945,10 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     const spanVisibility = makeTraceGraphVector(
       'trace-span-visibility',
       handles.spanChunks.map(chunk =>
-        graph.createDataView(chunk.visibility, {format: 'uint32', length: chunk.spanCount})
+        graph.createDataView(chunk.visibility, {
+          format: 'uint32',
+          length: Math.ceil(chunk.spanCount / 32)
+        })
       )
     );
     const visibleSpanIds = makeTraceGraphVector(
@@ -1204,22 +1208,17 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         dispatchBuffer: handles.exactCandidateDispatchCommands
       });
       if (resources.dependencyCount > 0) {
-        graph.addCopyPass({
-          id: `trace-copy-dependency-span-visibility-${chunk.chunkIndex}`,
-          resources: [
-            {buffer: chunk.visibility, usage: 'copy-source'},
-            {buffer: handles.dependencySpanVisibility, usage: 'copy-destination'}
+        addTraceIndirectComputePass(graph, {
+          id: `trace-publish-dependency-span-visibility-${chunk.chunkIndex}`,
+          source: getCandidateDependencySpanVisibilityShader(chunk),
+          bindings: [
+            storageRead('visibilityFlags', chunk.visibility),
+            storageRead('spanBatches', handles.spanBatchIndex),
+            storageRead('candidateBatchIds', handles.candidateBatchIds),
+            uniformBinding('viewUniforms', handles.uniforms),
+            storageWrite('dependencySpanVisibility', handles.dependencySpanVisibility)
           ],
-          compile: () => ({
-            encode: ({commandEncoder, getBuffer}) => {
-              commandEncoder.copyBufferToBuffer({
-                sourceBuffer: getBuffer(chunk.visibility),
-                destinationBuffer: getBuffer(handles.dependencySpanVisibility),
-                destinationOffset: chunk.firstSpanIndex * UINT32_BYTE_LENGTH,
-                size: chunk.spanCount * UINT32_BYTE_LENGTH
-              });
-            }
-          })
+          dispatchBuffer: handles.exactCandidateDispatchCommands
         });
       }
     }
@@ -1271,6 +1270,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     const rangeCompaction = new GPUPartitionedIndexedRangeCompaction({
       id: 'trace-visible-spans',
       flags: spanVisibility,
+      flagEncoding: 'bitset',
       ranges: graph.createDataView(handles.spanBatchIndex, {
         format: 'uint32',
         length: resources.spanBatchCount * 8

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -657,7 +657,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
 }`;
 }
 
-/** Publishes focused, generation-tagged exact visibility for candidate spans. */
+/** Publishes focused exact visibility as one atomic bit per candidate span. */
 export function getCandidateVisibilityShader(props: TraceSpanChunkShaderProps): string {
   return /* wgsl */ `
 ${TRACE_SHADER_DECLARATIONS}
@@ -681,7 +681,7 @@ ${TRACE_VISIBILITY_FILTER_DECLARATIONS}
 @group(0) @binding(5) var<storage, read> threadOffsets: array<u32>;
 @group(0) @binding(6) var<storage, read> threadStates: array<u32>;
 @group(0) @binding(7) var<storage, read> reachedSpans: array<u32>;
-@group(0) @binding(8) var<storage, read_write> visibilityFlags: array<u32>;
+@group(0) @binding(8) var<storage, read_write> visibilityFlags: array<atomic<u32>>;
 
 @compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
 fn main(
@@ -713,10 +713,64 @@ fn main(
     viewUniforms.focusMode != 0u && viewUniforms.selectedSpanIndex != 0xffffffffu;
   let focusVisible = !focusEnabled ||
     (reachedSpans[sourceIndex >> 5u] & (1u << (sourceIndex & 31u))) != 0u;
-  visibilityFlags[sourceIndex - CHUNK_FIRST_SPAN_INDEX] = select(
+  let chunkIndex = sourceIndex - CHUNK_FIRST_SPAN_INDEX;
+  let visibilityMask = 1u << (chunkIndex & 31u);
+  if (exactVisible && focusVisible) {
+    atomicOr(&visibilityFlags[chunkIndex >> 5u], visibilityMask);
+  } else {
+    atomicAnd(&visibilityFlags[chunkIndex >> 5u], ~visibilityMask);
+  }
+}`;
+}
+
+/** Expands candidate visibility bits for generation-tagged dependency endpoint resolution. */
+export function getCandidateDependencySpanVisibilityShader(
+  props: TraceSpanChunkShaderProps
+): string {
+  return /* wgsl */ `
+${TRACE_SHADER_DECLARATIONS}
+${getSpanChunkDeclarations(props)}
+struct TraceSpanBatch {
+  firstSpanIndex: u32,
+  spanCount: u32,
+  timeMin: f32,
+  timeMax: f32,
+  laneMin: u32,
+  laneMax: u32,
+  groupIndex: u32,
+  batchIndex: u32,
+};
+@group(0) @binding(0) var<storage, read> visibilityFlags: array<u32>;
+@group(0) @binding(1) var<storage, read> spanBatches: array<TraceSpanBatch>;
+@group(0) @binding(2) var<storage, read> candidateBatchIds: array<u32>;
+@group(0) @binding(3) var<uniform> viewUniforms: ViewUniforms;
+@group(0) @binding(4) var<storage, read_write> dependencySpanVisibility: array<u32>;
+
+@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
+fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  let batchIndex = candidateBatchIds[workgroupId.y];
+  if (
+    batchIndex < CHUNK_FIRST_BATCH_INDEX ||
+    batchIndex >= CHUNK_FIRST_BATCH_INDEX + CHUNK_BATCH_COUNT
+  ) {
+    return;
+  }
+  let batch = spanBatches[batchIndex];
+  let batchRowIndex = globalId.x;
+  if (batchRowIndex >= batch.spanCount) {
+    return;
+  }
+  let sourceIndex = batch.firstSpanIndex + batchRowIndex;
+  let chunkIndex = sourceIndex - CHUNK_FIRST_SPAN_INDEX;
+  let isVisible =
+    (visibilityFlags[chunkIndex >> 5u] & (1u << (chunkIndex & 31u))) != 0u;
+  dependencySpanVisibility[sourceIndex] = select(
     0u,
     viewUniforms.visibilityGeneration,
-    exactVisible && focusVisible
+    isVisible
   );
 }`;
 }

--- a/modules/experimental/src/gpu-primitives/gpu-indexed-range-compaction.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-indexed-range-compaction.ts
@@ -12,7 +12,6 @@ import {
 } from './gpu-command-graph';
 import {GPUScan} from './gpu-scan';
 import {
-  createTransientVectorView,
   createTransientView,
   getViewBinding,
   getViewElementOffset,
@@ -99,8 +98,6 @@ export type GPUPartitionedIndexedRangeCompactionProps = {
 
 /** GPU-generated partition metadata exposed to range-aware downstream consumers. */
 export type GPUPartitionedIndexedRangeCompactionResult = {
-  /** Source-aligned local offsets preserving the flags chunk topology. */
-  localOffsets: GraphVectorView<'uint32'>;
   /** Selected row count for every canonical range. */
   rangeCounts: GraphDataView<'uint32'>;
   /** Partition-local exclusive selected-row offset for every canonical range. */
@@ -220,10 +217,11 @@ export class GPUIndexedRangeCompaction {
 /**
  * Stably compacts active ranges into matching bounded output partitions.
  *
- * Range records remain one logical canonical index, while source flags, local scratch, and output
- * IDs preserve caller-provided chunk boundaries. Every range must be wholly contained by the flags
- * chunk selected by `partitionRangeEnds`. Each partition receives an independent compacted list;
- * emitted values remain global source indices.
+ * Range records remain one logical canonical index, while source flags and output IDs preserve
+ * caller-provided chunk boundaries. Every range must be wholly contained by the flags chunk
+ * selected by `partitionRangeEnds`. Each partition receives an independent compacted list; emitted
+ * values remain global source indices. Local offsets are recomputed during scatter instead of
+ * consuming source-sized scratch storage.
  */
 export class GPUPartitionedIndexedRangeCompaction {
   readonly id: string;
@@ -276,7 +274,7 @@ export class GPUPartitionedIndexedRangeCompaction {
     );
   }
 
-  /** Adds partitioned local scans, bounded range scans, scatter, and count publication. */
+  /** Adds partitioned range counts, bounded range scans, scratchless scatter, and count publication. */
   addToGraph<Parameters>(
     graph: GPUCommandGraph<Parameters>
   ): GPUPartitionedIndexedRangeCompactionResult {
@@ -295,7 +293,6 @@ export class GPUPartitionedIndexedRangeCompaction {
       throw new Error(`${this.id} activeRangeDispatch must belong to the target graph`);
     }
 
-    const localOffsets = createTransientVectorView(graph, `${this.id}-local-offsets`, this.output);
     const rangeCounts: GraphDataView<'uint32'> = createTransientView(
       graph,
       `${this.id}-range-counts`,
@@ -321,17 +318,15 @@ export class GPUPartitionedIndexedRangeCompaction {
     for (let partitionIndex = 0; partitionIndex < this.flags.data.length; partitionIndex++) {
       const flags = this.flags.data[partitionIndex];
       const output = this.output.data[partitionIndex];
-      const offsets = localOffsets.data[partitionIndex];
       const sourceEnd = sourceStart + output.length;
       const rangeEnd = this.partitionRangeEnds[partitionIndex];
-      addPartitionLocalScanPass(graph, this, {
+      addPartitionRangeCountPass(graph, this, {
         partitionIndex,
         sourceStart,
         sourceEnd,
         rangeStart,
         rangeEnd,
         flags,
-        localOffsets: offsets,
         rangeCounts
       });
       const partitionRangeCount = rangeEnd - rangeStart;
@@ -357,7 +352,6 @@ export class GPUPartitionedIndexedRangeCompaction {
         rangeStart,
         rangeEnd,
         flags,
-        localOffsets: offsets,
         rangeOffsets,
         output
       });
@@ -365,7 +359,7 @@ export class GPUPartitionedIndexedRangeCompaction {
       rangeStart = rangeEnd;
     }
     addPartitionCountPass(graph, this, rangeCounts, rangeOffsets, partitionCounts);
-    return {localOffsets, rangeCounts, rangeOffsets, partitionCounts};
+    return {rangeCounts, rangeOffsets, partitionCounts};
   }
 }
 
@@ -464,7 +458,7 @@ function validatePartitionRangeEnds(
   }
 }
 
-function addPartitionLocalScanPass<Parameters>(
+function addPartitionRangeCountPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   compaction: GPUPartitionedIndexedRangeCompaction,
   props: {
@@ -474,12 +468,10 @@ function addPartitionLocalScanPass<Parameters>(
     rangeStart: number;
     rangeEnd: number;
     flags: GraphDataView<'uint32'>;
-    localOffsets: GraphDataView<'uint32'>;
     rangeCounts: GraphDataView<'uint32'>;
   }
 ): void {
   const {rangeLayout} = compaction;
-  const selectedExpression = getFlagSelectionExpression(compaction.flagEncoding, 'chunkIndex');
   const source = /* wgsl */ `
 const RANGE_START: u32 = ${props.rangeStart}u;
 const RANGE_END: u32 = ${props.rangeEnd}u;
@@ -491,13 +483,11 @@ const RANGE_COUNT_WORD: u32 = ${rangeLayout.countWordOffset}u;
 const FLAGS_OFFSET: u32 = ${getViewElementOffset(props.flags)}u;
 const RANGES_OFFSET: u32 = ${getViewElementOffset(compaction.ranges)}u;
 const ACTIVE_RANGE_IDS_OFFSET: u32 = ${getViewElementOffset(compaction.activeRangeIds)}u;
-const LOCAL_OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.localOffsets)}u;
 const RANGE_COUNTS_OFFSET: u32 = ${getViewElementOffset(props.rangeCounts)}u;
 @group(0) @binding(0) var<storage, read> flags: array<u32>;
 @group(0) @binding(1) var<storage, read> ranges: array<u32>;
 @group(0) @binding(2) var<storage, read> activeRangeIds: array<u32>;
-@group(0) @binding(3) var<storage, read_write> localOffsets: array<u32>;
-@group(0) @binding(4) var<storage, read_write> rangeCounts: array<u32>;
+@group(0) @binding(3) var<storage, read_write> rangeCounts: array<u32>;
 var<workgroup> prefixes: array<u32, ${RANGE_COMPACTION_WORKGROUP_SIZE}>;
 
 @compute @workgroup_size(${RANGE_COMPACTION_WORKGROUP_SIZE})
@@ -515,6 +505,117 @@ fn main(
   if (firstIndex < SOURCE_START || firstIndex + elementCount > SOURCE_END) {
     return;
   }
+${getPartitionSelectionScanShader(compaction.flagEncoding)}
+
+  if (localIndex == 0u) {
+    var selectedCount = 0u;
+    if (elementCount != 0u) {
+      selectedCount = prefixes[elementCount - 1u];
+    }
+    rangeCounts[RANGE_COUNTS_OFFSET + rangeId] = selectedCount;
+  }
+}`;
+  addIndirectPass(graph, {
+    id: `${compaction.id}-partition-${props.partitionIndex}-range-count`,
+    source,
+    views: {
+      flags: props.flags,
+      ranges: compaction.ranges,
+      activeRangeIds: compaction.activeRangeIds,
+      rangeCounts: props.rangeCounts
+    },
+    resources: [
+      {buffer: props.flags, usage: 'storage-read'},
+      {buffer: compaction.ranges, usage: 'storage-read'},
+      {buffer: compaction.activeRangeIds, usage: 'storage-read'},
+      {buffer: props.rangeCounts, usage: 'storage-write'}
+    ],
+    dispatchBuffer: compaction.activeRangeDispatch
+  });
+}
+
+function addPartitionScatterPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  compaction: GPUPartitionedIndexedRangeCompaction,
+  props: {
+    partitionIndex: number;
+    sourceStart: number;
+    sourceEnd: number;
+    rangeStart: number;
+    rangeEnd: number;
+    flags: GraphDataView<'uint32'>;
+    rangeOffsets: GraphDataView<'uint32'>;
+    output: GraphDataView<'uint32'>;
+  }
+): void {
+  const {rangeLayout} = compaction;
+  const source = /* wgsl */ `
+const RANGE_START: u32 = ${props.rangeStart}u;
+const RANGE_END: u32 = ${props.rangeEnd}u;
+const SOURCE_START: u32 = ${props.sourceStart}u;
+const SOURCE_END: u32 = ${props.sourceEnd}u;
+const RANGE_WORD_STRIDE: u32 = ${rangeLayout.wordStride}u;
+const RANGE_FIRST_WORD: u32 = ${rangeLayout.firstIndexWordOffset}u;
+const RANGE_COUNT_WORD: u32 = ${rangeLayout.countWordOffset}u;
+const FLAGS_OFFSET: u32 = ${getViewElementOffset(props.flags)}u;
+const RANGES_OFFSET: u32 = ${getViewElementOffset(compaction.ranges)}u;
+const ACTIVE_RANGE_IDS_OFFSET: u32 = ${getViewElementOffset(compaction.activeRangeIds)}u;
+const RANGE_OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.rangeOffsets)}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
+@group(0) @binding(0) var<storage, read> flags: array<u32>;
+@group(0) @binding(1) var<storage, read> ranges: array<u32>;
+@group(0) @binding(2) var<storage, read> activeRangeIds: array<u32>;
+@group(0) @binding(3) var<storage, read> rangeOffsets: array<u32>;
+@group(0) @binding(4) var<storage, read_write> outputIds: array<u32>;
+var<workgroup> prefixes: array<u32, ${RANGE_COMPACTION_WORKGROUP_SIZE}>;
+
+@compute @workgroup_size(${RANGE_COMPACTION_WORKGROUP_SIZE})
+fn main(
+  @builtin(local_invocation_id) localId: vec3<u32>,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  let rangeId = activeRangeIds[ACTIVE_RANGE_IDS_OFFSET + workgroupId.y];
+  if (rangeId < RANGE_START || rangeId >= RANGE_END) {
+    return;
+  }
+  let recordOffset = RANGES_OFFSET + rangeId * RANGE_WORD_STRIDE;
+  let firstIndex = ranges[recordOffset + RANGE_FIRST_WORD];
+  let elementCount = ranges[recordOffset + RANGE_COUNT_WORD];
+  if (firstIndex < SOURCE_START || firstIndex + elementCount > SOURCE_END) {
+    return;
+  }
+${getPartitionSelectionScanShader(compaction.flagEncoding)}
+
+  if (selected != 0u) {
+    let outputIndex = rangeOffsets[RANGE_OFFSETS_OFFSET + rangeId] +
+      prefixes[localIndex] - selected;
+    outputIds[OUTPUT_OFFSET + outputIndex] = firstIndex + localIndex;
+  }
+}`;
+  addIndirectPass(graph, {
+    id: `${compaction.id}-partition-${props.partitionIndex}-scatter`,
+    source,
+    views: {
+      flags: props.flags,
+      ranges: compaction.ranges,
+      activeRangeIds: compaction.activeRangeIds,
+      rangeOffsets: props.rangeOffsets,
+      outputIds: props.output
+    },
+    resources: [
+      {buffer: props.flags, usage: 'storage-read'},
+      {buffer: compaction.ranges, usage: 'storage-read'},
+      {buffer: compaction.activeRangeIds, usage: 'storage-read'},
+      {buffer: props.rangeOffsets, usage: 'storage-read'},
+      {buffer: props.output, usage: 'storage-write'}
+    ],
+    dispatchBuffer: compaction.activeRangeDispatch
+  });
+}
+
+function getPartitionSelectionScanShader(encoding: GPUIndexedRangeFlagEncoding): string {
+  const selectedExpression = getFlagSelectionExpression(encoding, 'chunkIndex');
+  return /* wgsl */ `
   let localIndex = localId.x;
   let chunkIndex = firstIndex - SOURCE_START + localIndex;
   var selected = 0u;
@@ -537,122 +638,7 @@ fn main(
     prefixes[localIndex] += addend;
     workgroupBarrier();
     step *= 2u;
-  }
-
-  if (localIndex < elementCount) {
-    localOffsets[LOCAL_OFFSETS_OFFSET + chunkIndex] = prefixes[localIndex] - selected;
-  }
-  if (localIndex == 0u) {
-    var selectedCount = 0u;
-    if (elementCount != 0u) {
-      selectedCount = prefixes[elementCount - 1u];
-    }
-    rangeCounts[RANGE_COUNTS_OFFSET + rangeId] = selectedCount;
-  }
-}`;
-  addIndirectPass(graph, {
-    id: `${compaction.id}-partition-${props.partitionIndex}-local-scan`,
-    source,
-    views: {
-      flags: props.flags,
-      ranges: compaction.ranges,
-      activeRangeIds: compaction.activeRangeIds,
-      localOffsets: props.localOffsets,
-      rangeCounts: props.rangeCounts
-    },
-    resources: [
-      {buffer: props.flags, usage: 'storage-read'},
-      {buffer: compaction.ranges, usage: 'storage-read'},
-      {buffer: compaction.activeRangeIds, usage: 'storage-read'},
-      {buffer: props.localOffsets, usage: 'storage-write'},
-      {buffer: props.rangeCounts, usage: 'storage-write'}
-    ],
-    dispatchBuffer: compaction.activeRangeDispatch
-  });
-}
-
-function addPartitionScatterPass<Parameters>(
-  graph: GPUCommandGraph<Parameters>,
-  compaction: GPUPartitionedIndexedRangeCompaction,
-  props: {
-    partitionIndex: number;
-    sourceStart: number;
-    sourceEnd: number;
-    rangeStart: number;
-    rangeEnd: number;
-    flags: GraphDataView<'uint32'>;
-    localOffsets: GraphDataView<'uint32'>;
-    rangeOffsets: GraphDataView<'uint32'>;
-    output: GraphDataView<'uint32'>;
-  }
-): void {
-  const {rangeLayout} = compaction;
-  const selectedExpression = getFlagSelectionExpression(compaction.flagEncoding, 'chunkIndex');
-  const source = /* wgsl */ `
-const RANGE_START: u32 = ${props.rangeStart}u;
-const RANGE_END: u32 = ${props.rangeEnd}u;
-const SOURCE_START: u32 = ${props.sourceStart}u;
-const SOURCE_END: u32 = ${props.sourceEnd}u;
-const RANGE_WORD_STRIDE: u32 = ${rangeLayout.wordStride}u;
-const RANGE_FIRST_WORD: u32 = ${rangeLayout.firstIndexWordOffset}u;
-const RANGE_COUNT_WORD: u32 = ${rangeLayout.countWordOffset}u;
-const FLAGS_OFFSET: u32 = ${getViewElementOffset(props.flags)}u;
-const RANGES_OFFSET: u32 = ${getViewElementOffset(compaction.ranges)}u;
-const ACTIVE_RANGE_IDS_OFFSET: u32 = ${getViewElementOffset(compaction.activeRangeIds)}u;
-const LOCAL_OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.localOffsets)}u;
-const RANGE_OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.rangeOffsets)}u;
-const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
-@group(0) @binding(0) var<storage, read> flags: array<u32>;
-@group(0) @binding(1) var<storage, read> ranges: array<u32>;
-@group(0) @binding(2) var<storage, read> activeRangeIds: array<u32>;
-@group(0) @binding(3) var<storage, read> localOffsets: array<u32>;
-@group(0) @binding(4) var<storage, read> rangeOffsets: array<u32>;
-@group(0) @binding(5) var<storage, read_write> outputIds: array<u32>;
-
-@compute @workgroup_size(${RANGE_COMPACTION_WORKGROUP_SIZE})
-fn main(
-  @builtin(local_invocation_id) localId: vec3<u32>,
-  @builtin(workgroup_id) workgroupId: vec3<u32>
-) {
-  let rangeId = activeRangeIds[ACTIVE_RANGE_IDS_OFFSET + workgroupId.y];
-  if (rangeId < RANGE_START || rangeId >= RANGE_END) {
-    return;
-  }
-  let recordOffset = RANGES_OFFSET + rangeId * RANGE_WORD_STRIDE;
-  let firstIndex = ranges[recordOffset + RANGE_FIRST_WORD];
-  let elementCount = ranges[recordOffset + RANGE_COUNT_WORD];
-  if (firstIndex < SOURCE_START || firstIndex + elementCount > SOURCE_END ||
-      localId.x >= elementCount) {
-    return;
-  }
-  let chunkIndex = firstIndex - SOURCE_START + localId.x;
-  if (${selectedExpression}) {
-    let outputIndex = rangeOffsets[RANGE_OFFSETS_OFFSET + rangeId] +
-      localOffsets[LOCAL_OFFSETS_OFFSET + chunkIndex];
-    outputIds[OUTPUT_OFFSET + outputIndex] = firstIndex + localId.x;
-  }
-}`;
-  addIndirectPass(graph, {
-    id: `${compaction.id}-partition-${props.partitionIndex}-scatter`,
-    source,
-    views: {
-      flags: props.flags,
-      ranges: compaction.ranges,
-      activeRangeIds: compaction.activeRangeIds,
-      localOffsets: props.localOffsets,
-      rangeOffsets: props.rangeOffsets,
-      outputIds: props.output
-    },
-    resources: [
-      {buffer: props.flags, usage: 'storage-read'},
-      {buffer: compaction.ranges, usage: 'storage-read'},
-      {buffer: compaction.activeRangeIds, usage: 'storage-read'},
-      {buffer: props.localOffsets, usage: 'storage-read'},
-      {buffer: props.rangeOffsets, usage: 'storage-read'},
-      {buffer: props.output, usage: 'storage-write'}
-    ],
-    dispatchBuffer: compaction.activeRangeDispatch
-  });
+  }`;
 }
 
 function getFlagSelectionExpression(

--- a/modules/experimental/src/gpu-primitives/gpu-indexed-range-compaction.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-indexed-range-compaction.ts
@@ -32,6 +32,9 @@ export type GPUIndexedRangeLayout = {
   countWordOffset: number;
 };
 
+/** Physical representation of source-aligned selection flags. */
+export type GPUIndexedRangeFlagEncoding = 'uint32' | 'bitset';
+
 /** Properties for candidate-driven stable source-index compaction. */
 export type GPUIndexedRangeCompactionProps = {
   /** Prefix for generated resources and graph nodes. */
@@ -72,6 +75,8 @@ export type GPUPartitionedIndexedRangeCompactionProps = {
   id?: string;
   /** Source-aligned flags split at complete range boundaries. */
   flags: GraphVectorView<'uint32'>;
+  /** Flag representation. Defaults to one uint32 per source row. */
+  flagEncoding?: GPUIndexedRangeFlagEncoding;
   /** Packed source-range records shared by every partition. */
   ranges: GraphDataView<'uint32'>;
   /** Number of range records. */
@@ -223,6 +228,7 @@ export class GPUIndexedRangeCompaction {
 export class GPUPartitionedIndexedRangeCompaction {
   readonly id: string;
   readonly flags: GraphVectorView<'uint32'>;
+  readonly flagEncoding: GPUIndexedRangeFlagEncoding;
   readonly ranges: GraphDataView<'uint32'>;
   readonly rangeCount: number;
   readonly rangeLayout: GPUIndexedRangeLayout;
@@ -236,6 +242,7 @@ export class GPUPartitionedIndexedRangeCompaction {
   constructor(props: GPUPartitionedIndexedRangeCompactionProps) {
     this.id = props.id ?? 'gpu-partitioned-indexed-range-compaction';
     this.flags = props.flags;
+    this.flagEncoding = props.flagEncoding ?? 'uint32';
     this.ranges = props.ranges;
     this.rangeCount = props.rangeCount;
     this.rangeLayout = props.rangeLayout;
@@ -255,7 +262,11 @@ export class GPUPartitionedIndexedRangeCompaction {
     }
     validatePartitionedVector(this.id, 'flags', this.flags);
     validatePartitionedVector(this.id, 'output', this.output);
-    validateMatchingVectorTopology(this.flags, this.output, `${this.id} output`);
+    if (this.flagEncoding === 'bitset') {
+      validateBitsetVectorTopology(this.id, this.flags, this.output);
+    } else {
+      validateMatchingVectorTopology(this.flags, this.output, `${this.id} output`);
+    }
     validateRangeCompactionShape(this);
     validatePartitionRangeEnds(
       this.id,
@@ -284,7 +295,7 @@ export class GPUPartitionedIndexedRangeCompaction {
       throw new Error(`${this.id} activeRangeDispatch must belong to the target graph`);
     }
 
-    const localOffsets = createTransientVectorView(graph, `${this.id}-local-offsets`, this.flags);
+    const localOffsets = createTransientVectorView(graph, `${this.id}-local-offsets`, this.output);
     const rangeCounts: GraphDataView<'uint32'> = createTransientView(
       graph,
       `${this.id}-range-counts`,
@@ -311,7 +322,7 @@ export class GPUPartitionedIndexedRangeCompaction {
       const flags = this.flags.data[partitionIndex];
       const output = this.output.data[partitionIndex];
       const offsets = localOffsets.data[partitionIndex];
-      const sourceEnd = sourceStart + flags.length;
+      const sourceEnd = sourceStart + output.length;
       const rangeEnd = this.partitionRangeEnds[partitionIndex];
       addPartitionLocalScanPass(graph, this, {
         partitionIndex,
@@ -355,6 +366,23 @@ export class GPUPartitionedIndexedRangeCompaction {
     }
     addPartitionCountPass(graph, this, rangeCounts, rangeOffsets, partitionCounts);
     return {localOffsets, rangeCounts, rangeOffsets, partitionCounts};
+  }
+}
+
+function validateBitsetVectorTopology(
+  id: string,
+  flags: GraphVectorView<'uint32'>,
+  output: GraphVectorView<'uint32'>
+): void {
+  if (flags.data.length !== output.data.length) {
+    throw new Error(`${id} bitset flags must contain one chunk per output chunk`);
+  }
+  for (let chunkIndex = 0; chunkIndex < flags.data.length; chunkIndex++) {
+    const flagWordCount = flags.data[chunkIndex].length;
+    const sourceLength = output.data[chunkIndex].length;
+    if (flagWordCount !== Math.ceil(sourceLength / 32)) {
+      throw new Error(`${id} bitset flag chunks must contain one bit per output row`);
+    }
   }
 }
 
@@ -451,6 +479,7 @@ function addPartitionLocalScanPass<Parameters>(
   }
 ): void {
   const {rangeLayout} = compaction;
+  const selectedExpression = getFlagSelectionExpression(compaction.flagEncoding, 'chunkIndex');
   const source = /* wgsl */ `
 const RANGE_START: u32 = ${props.rangeStart}u;
 const RANGE_END: u32 = ${props.rangeEnd}u;
@@ -489,7 +518,7 @@ fn main(
   let localIndex = localId.x;
   let chunkIndex = firstIndex - SOURCE_START + localIndex;
   var selected = 0u;
-  if (localIndex < elementCount && flags[FLAGS_OFFSET + chunkIndex] != 0u) {
+  if (localIndex < elementCount && ${selectedExpression}) {
     selected = 1u;
   }
   prefixes[localIndex] = selected;
@@ -558,6 +587,7 @@ function addPartitionScatterPass<Parameters>(
   }
 ): void {
   const {rangeLayout} = compaction;
+  const selectedExpression = getFlagSelectionExpression(compaction.flagEncoding, 'chunkIndex');
   const source = /* wgsl */ `
 const RANGE_START: u32 = ${props.rangeStart}u;
 const RANGE_END: u32 = ${props.rangeEnd}u;
@@ -596,7 +626,7 @@ fn main(
     return;
   }
   let chunkIndex = firstIndex - SOURCE_START + localId.x;
-  if (flags[FLAGS_OFFSET + chunkIndex] != 0u) {
+  if (${selectedExpression}) {
     let outputIndex = rangeOffsets[RANGE_OFFSETS_OFFSET + rangeId] +
       localOffsets[LOCAL_OFFSETS_OFFSET + chunkIndex];
     outputIds[OUTPUT_OFFSET + outputIndex] = firstIndex + localId.x;
@@ -623,6 +653,15 @@ fn main(
     ],
     dispatchBuffer: compaction.activeRangeDispatch
   });
+}
+
+function getFlagSelectionExpression(
+  encoding: GPUIndexedRangeFlagEncoding,
+  sourceIndex: string
+): string {
+  return encoding === 'bitset'
+    ? `(flags[FLAGS_OFFSET + (${sourceIndex} >> 5u)] & (1u << (${sourceIndex} & 31u))) != 0u`
+    : `flags[FLAGS_OFFSET + ${sourceIndex}] != 0u`;
 }
 
 function addPartitionCountPass<Parameters>(

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -79,6 +79,7 @@ export {
 export type {
   GPUIndexedRangeCompactionProps,
   GPUIndexedRangeCompactionResult,
+  GPUIndexedRangeFlagEncoding,
   GPUIndexedRangeLayout,
   GPUPartitionedIndexedRangeCompactionProps,
   GPUPartitionedIndexedRangeCompactionResult

--- a/modules/experimental/test/gpu-primitives/gpu-partitioned-indexed-range-compaction.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-partitioned-indexed-range-compaction.node.spec.ts
@@ -38,6 +38,17 @@ describe('GPUPartitionedIndexedRangeCompaction graph construction', () => {
     }
   });
 
+  test('accepts one packed visibility bit per source row', () => {
+    const fixture = createCompactionFixture('bitset');
+    try {
+      const result = fixture.compaction.addToGraph(fixture.graph);
+      expect(fixture.compaction.flags.data.map(chunk => chunk.length)).toEqual([1, 1]);
+      expect(result.localOffsets.data.map(chunk => chunk.length)).toEqual([6, 5]);
+    } finally {
+      fixture.device.destroy();
+    }
+  });
+
   test('requires matching bounded chunks and complete range partitions', () => {
     const fixture = createCompactionFixture();
     const props = {
@@ -75,13 +86,22 @@ describe('GPUPartitionedIndexedRangeCompaction graph construction', () => {
             output: createVector(fixture.graph, 'mismatched-output', [5, 6])
           })
       ).toThrow(/same chunk topology/i);
+      expect(
+        () =>
+          new GPUPartitionedIndexedRangeCompaction({
+            ...props,
+            flagEncoding: 'bitset',
+            flags: createVector(fixture.graph, 'short-bitset-flags', [1, 1]),
+            output: createVector(fixture.graph, 'long-bitset-output', [33, 5])
+          })
+      ).toThrow(/one bit per output row/i);
     } finally {
       fixture.device.destroy();
     }
   });
 });
 
-function createCompactionFixture(): {
+function createCompactionFixture(flagEncoding: 'uint32' | 'bitset' = 'uint32'): {
   device: NullDevice;
   graph: GPUCommandGraph;
   compaction: GPUPartitionedIndexedRangeCompaction;
@@ -94,7 +114,8 @@ function createCompactionFixture(): {
   const graph = new GPUCommandGraph(device, {id: 'partitioned-range-compaction-node-graph'});
   const compaction = new GPUPartitionedIndexedRangeCompaction({
     id: 'visible',
-    flags: createVector(graph, 'flags', [6, 5]),
+    flags: createVector(graph, 'flags', flagEncoding === 'bitset' ? [1, 1] : [6, 5]),
+    flagEncoding,
     ranges: createView(graph, 'ranges', 8),
     rangeCount: 4,
     rangeLayout: {wordStride: 2, firstIndexWordOffset: 0, countWordOffset: 1},

--- a/modules/experimental/test/gpu-primitives/gpu-partitioned-indexed-range-compaction.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-partitioned-indexed-range-compaction.node.spec.ts
@@ -15,25 +15,31 @@ describe('GPUPartitionedIndexedRangeCompaction graph construction', () => {
   test('preserves source partitions through local range compaction', () => {
     const fixture = createCompactionFixture();
     const addComputePass = vi.spyOn(fixture.graph, 'addComputePass');
+    const createTransientBuffer = vi.spyOn(fixture.graph, 'createTransientBuffer');
 
     try {
       const result = fixture.compaction.addToGraph(fixture.graph);
       expect(addComputePass.mock.calls.map(([pass]) => pass.id)).toEqual([
         'visible-clear-range-counts',
-        'visible-partition-0-local-scan',
+        'visible-partition-0-range-count',
         'visible-partition-0-range-scan-level-0-scan',
         'visible-partition-0-scatter',
-        'visible-partition-1-local-scan',
+        'visible-partition-1-range-count',
         'visible-partition-1-range-scan-level-0-scan',
         'visible-partition-1-scatter',
         'visible-publish-counts'
       ]);
-      expect(result.localOffsets.data.map(chunk => chunk.length)).toEqual([6, 5]);
       expect(result.rangeCounts.length).toBe(4);
       expect(result.rangeOffsets.length).toBe(4);
       expect(result.partitionCounts.length).toBe(2);
+      expect(
+        createTransientBuffer.mock.calls.some(([descriptor]) =>
+          descriptor.id?.includes('local-offsets')
+        )
+      ).toBe(false);
     } finally {
       addComputePass.mockRestore();
+      createTransientBuffer.mockRestore();
       fixture.device.destroy();
     }
   });
@@ -43,7 +49,7 @@ describe('GPUPartitionedIndexedRangeCompaction graph construction', () => {
     try {
       const result = fixture.compaction.addToGraph(fixture.graph);
       expect(fixture.compaction.flags.data.map(chunk => chunk.length)).toEqual([1, 1]);
-      expect(result.localOffsets.data.map(chunk => chunk.length)).toEqual([6, 5]);
+      expect(result.partitionCounts.length).toBe(2);
     } finally {
       fixture.device.destroy();
     }

--- a/modules/experimental/test/gpu-primitives/gpu-partitioned-indexed-range-compaction.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-partitioned-indexed-range-compaction.spec.ts
@@ -22,10 +22,7 @@ test('GPUPartitionedIndexedRangeCompaction keeps visible IDs in bounded chunks',
 
   const resources: Buffer[] = [];
   const graph = new GPUCommandGraph(device, {id: 'partitioned-range-compaction-graph'});
-  const flags = createImportedVector(graph, device, resources, 'flags', [
-    [1, 0, 1, 0, 1, 1],
-    [0, 1, 1, 0, 1]
-  ]);
+  const flags = createImportedVector(graph, device, resources, 'flags', [[0b110101], [0b10110]]);
   const output = createOutputVector(graph, device, resources, 'output', [6, 5]);
   const ranges = createImportedView(graph, device, resources, 'ranges', [0, 3, 3, 3, 6, 2, 8, 3]);
   const activeRangeIdsResource = createImportedBuffer(
@@ -48,6 +45,7 @@ test('GPUPartitionedIndexedRangeCompaction keeps visible IDs in bounded chunks',
   const compaction = new GPUPartitionedIndexedRangeCompaction({
     id: 'visible',
     flags,
+    flagEncoding: 'bitset',
     ranges,
     rangeCount: 4,
     rangeLayout: {wordStride: 2, firstIndexWordOffset: 0, countWordOffset: 1},

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -42,6 +42,7 @@ import {
 import {
   getBatchVisibilityShader,
   getCandidateDensityShader,
+  getCandidateDependencySpanVisibilityShader,
   getCandidateDependencyVisibilityShader,
   getCandidatePassDispatchShader,
   getCandidatePickShader,
@@ -303,6 +304,7 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
     getBatchVisibilityShader(3),
     getPickClearShader(),
     getCandidateVisibilityShader(spanChunk),
+    getCandidateDependencySpanVisibilityShader(spanChunk),
     getCandidatePassDispatchShader(),
     getDensityClearShader(),
     getCandidateDensityShader(spanChunk),

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -51,7 +51,11 @@ describe('GPU hierarchical trace viewer', () => {
             buffer: {readAsync: () => Promise<Uint8Array>};
           };
           drawCommands: {buffer: {readAsync: () => Promise<Uint8Array>}};
-          spanChunks: Array<{visibleIds: {readAsync: () => Promise<Uint8Array>}}>;
+          spanChunks: Array<{
+            spanCount: number;
+            visibility: {byteLength: number};
+            visibleIds: {readAsync: () => Promise<Uint8Array>};
+          }>;
           visibleDependencyIds: {readAsync: () => Promise<Uint8Array>};
           dependencyResults: {readAsync: () => Promise<Uint8Array>};
           densityBins: {readAsync: () => Promise<Uint8Array>};
@@ -91,6 +95,13 @@ describe('GPU hierarchical trace viewer', () => {
       expect(state.resources.focusFrontierCapacity).toBe(
         getTraceFocusFrontierCapacity(state.resources.spanCount, state.resources.dependencyCount)
       );
+      expect(
+        state.resources.spanChunks.every(
+          chunk =>
+            chunk.visibility.byteLength ===
+            Math.ceil(chunk.spanCount / 32) * Uint32Array.BYTES_PER_ELEMENT
+        )
+      ).toBe(true);
       expect(state.resources.dependencyBatchCount).toBeGreaterThan(0);
       expect(host.querySelectorAll('[data-process]')).toHaveLength(TRACE_PROCESS_COUNT);
       expect(host.querySelectorAll('[data-thread]')).toHaveLength(TRACE_THREAD_COUNT);


### PR DESCRIPTION
## What changed

- Pack per-span exact visibility into one GPU bit per span.
- Add bitset flag support to partitioned indexed-range compaction.
- Expand packed visibility only for candidate spans needed by dependency endpoint resolution.
- Remove the source-sized local-offset scratch vector from stable partitioned compaction.
- Recompute bounded local prefixes during scatter while preserving stable source order.

## Why

At 100 million spans, one `uint32` visibility value and one `uint32` local-offset value per span consumed 800 MB before accounting for the span table or compacted output. Packed visibility reduces its column from 400 MB to 12.5 MB, and scratchless scatter removes the other 400 MB allocation.

The extra scatter scan is bounded to at most 256 rows per active range and keeps the result stable and partition-local.

## Validation

- Focused partitioned compaction suites: 4 tests passed.
- Exact repository Biome formatting comparison passed for all changed files.
- TypeScript syntax transpilation passed.
- WGSL reflection checks passed for the packed visibility shaders.
- Full local workspace install was attempted but the configured registry returned 403 for `@vis.gl/dev-tools@2.0.0-alpha.4` and `@vis.gl/ts-plugins@2.0.0-alpha.4`; GitHub CI remains the full build and test gate.
