### PR TITLE
feat(experimental): add graph-native ray tracing visual parity

### DIFF
--- a/docs/api-guide/engine/anari-rendering.md
+++ b/docs/api-guide/engine/anari-rendering.md
@@ -244,9 +244,11 @@ The instance-bounds pass reads each mesh BLAS root directly, producing a tight t
 AABB instead of expanding elongated meshes to their enclosing sphere. Small sorts and hierarchy
 builds execute inside one workgroup; larger sorts use stable four-bit radix passes, and consecutive
 compute nodes share a command-encoder compute pass when per-node GPU timestamps are not requested.
-The same `GPUCommandGraph` evaluates direct lights, progressively accumulates unchanged primary-ray
-samples, and presents HDR when the canvas is configured for it. Generated quads, cylinders, and
-cones use their existing triangle geometry.
+The same `GPUCommandGraph` evaluates direct lights with scalar metallic/roughness GGX shading,
+progressively accumulates unchanged primary-ray samples, and presents into either the canvas or a
+caller-owned offscreen framebuffer. The fullscreen presentation matches the actual target format,
+selected tone-mapping mode, and linear/sRGB output encoding, preserving HDR for floating-point
+targets. Generated quads, cylinders, and cones use their existing triangle geometry.
 
 Ray tracing starts at half the display width and height, reducing its initial pixel workload to one
 quarter of full resolution. Adaptive quality can lower that scale to `0.25`, interleave sampled
@@ -272,8 +274,9 @@ Morton-sorted per-mesh triangle BLASes. The ray-tracing pass uses exactly eight 
 while every TLAS or BLAS construction pass stays within the default WebGPU CORE limit of eight
 storage buffers without elevated device features. The hierarchy topology is not SAH-optimized or a
 Karras-style LBVH. This is software ray tracing, not hardware ray tracing or full path tracing.
-Skeletal skinning, morph-target deformation, material textures, alpha/transmission, advanced PBR
-shading, indirect bounces, denoising, and volume objects remain unsupported by this renderer.
+Skeletal skinning, morph-target deformation, material textures, alpha/transmission, more advanced
+PBR material extensions, indirect bounces, denoising, and volume objects remain unsupported by
+this renderer.
 `maxBounces` is reserved for future multi-bounce transport.
 
 ## Understand staging and commits
@@ -566,6 +569,21 @@ Debug renderers automatically skip bloom. Switch to `deferred` for the WebGPU G-
 `raytrace` for WebGPU software ray tracing, or `default` for the portable forward renderer with
 bloom.
 
+Renderer presentation controls are ordinary committed ANARI parameters and are also accepted in
+JSON renderer descriptions:
+
+```ts
+beauty
+  .setParameters({toneMapMode: 2, outputColorSpace: 'srgb'})
+  .commitParameters();
+```
+
+`toneMapMode` selects no tone mapping (`0`), Reinhard (`1`), Khronos PBR Neutral (`2`), or ACES
+(`3`). `outputColorSpace` selects `'linear'` or `'srgb'`. Omit either setting to retain automatic,
+target-aware defaults: floating-point targets default to no tone mapping and linear output,
+integer targets default to Khronos PBR Neutral, and hardware-sRGB attachments avoid an additional
+software sRGB transfer.
+
 ## Handle resizing
 
 If `frame.size` is omitted, the renderer derives its size from the graphics device's current drawing buffer:
@@ -714,6 +732,12 @@ Ray-traced frames additionally report their internal resolution and effective sc
 coverage, smoothed frame time, and accumulated sample count. Other renderer subtypes omit
 `statistics.rayTracing`.
 
+When present, `statistics.rayTracing.graph` exposes the actual logical node count, physical compute
+pass count, coalesced compute-node count, and synchronous CPU encoding time. Its `trace` stage is
+present on every ray-traced frame; `topology`, `acceleration`, and `refit` appear only when the
+corresponding work runs. `acceleration` and `refit` are mutually exclusive. These counters do not
+request GPU timestamp queries, read resources back, or submit an additional command buffer.
+
 The renderer also supports capability discovery:
 
 ```ts
@@ -773,12 +797,14 @@ for the runtime contract and ownership details.
 | T0: renderer and graph foundation | Lazy subtype registration, retained-scene adapters, the shared experimental `RayTracingSceneRenderer`, explicit WebGPU command-graph resources, and application-owned submission. | Implemented. |
 | T1: direct rays and shadows | Transformed analytic spheres, mesh triangles, tessellated analytic shapes, perspective/orthographic cameras, direct lights, hard shadow rays, progressive primary-ray sampling, and HDR presentation. | Implemented with WebGPU compute rather than hardware ray tracing. |
 | T2a: GPU object acceleration | World-space instance bounds, graph-owned complete-binary TLAS construction and refitting, nearest-hit object traversal, early-exit shadow rays, and default-CORE storage limits. | Implemented. |
-| T2b: interactive frame budgeting | Half-resolution defaults, bounded adaptive quality, interleaved pixel coverage, retained-identity temporal reprojection, rotating shadow samples, and dirty-only object acceleration. | Implemented; frame pacing uses CPU animation intervals. |
-| T2c: large-scene acceleration | GPU Morton-sorted object/instance TLAS leaves with retained-permutation transform refits, per-mesh triangle BLASes, and explicit traversal/build diagnostics. | Morton TLAS, transform refits, and Morton mesh BLASes implemented; SAH/Karras topology and diagnostics remain planned. |
-| T2d: dynamic scene extraction | Skeletal/morph geometry extraction, bounded deforming-mesh updates, and shared animated instance acceleration. | Planned. |
+| T2b: interactive frame budgeting | Half-resolution defaults, bounded adaptive quality, interleaved pixel coverage, retained-identity temporal reprojection, rotating shadow samples, and dirty-triggered object acceleration. | Implemented; frame pacing uses CPU animation intervals. |
+| T2c: large-scene acceleration | GPU Morton-sorted object/instance TLAS leaves, retained-permutation transform refits, tight transformed BLAS-root bounds, four-bit radix sorting, batched small-mesh sort/BVH construction, and CORE-compatible packed traversal. | Implemented; SAH/Karras topology, wide hierarchies, and traversal counters remain planned. |
+| T2d: retained scene updates | Categorized world/topology/transform/material/light revisions, cached scene descriptors, stable animated placement identities, sparse packed-transform uploads, and rotating copy-free texture history. | Implemented; camera- and light-only frames avoid acceleration rebuilds. |
+| T2e: presentation and direct-light parity | Caller-owned offscreen framebuffers, actual-target color/depth formats, exact SDR/HDR tone mapping and sRGB/linear presentation, incoming directional-light agreement, scalar metallic/roughness GGX shading, and per-stage graph encoding diagnostics. | Implemented for direct lighting; material textures, alpha/transmission, indirect transport, and GPU-stage timestamps remain separate work. |
+| T2f: deforming scene extraction | Skeletal/morph geometry extraction, bounded deforming-mesh updates, and shared animated instance acceleration. | Planned. |
 | T3: indirect transport and denoising | Advanced PBR texture, alpha, and transmission parity; multi-bounce material transport/path tracing, convergence controls, and denoising; primary-ray progressive accumulation already exists in T1. | Planned. |
 | T4: ray marching and volumes | Signed-distance-field ray marching, retained spatial fields, 3D textures, transfer functions, and ANARI volume objects. | Planned. |
-| T5: hybrid composition and diagnostics | Raster/ray composition, reusable graph timings, renderer capability reporting, and debug visualization channels. | Planned. |
+| T5: hybrid composition and advanced diagnostics | Raster/ray composition, GPU-stage timings, traversal counters, renderer capability reporting, and debug visualization channels. | Basic graph node/pass/CPU-encoding counters are implemented; hybrid composition, GPU timings, and advanced diagnostics remain planned. |
 
 ### Ray-tracing technique background and tradeoffs
 
@@ -885,6 +911,43 @@ coherent work. In WebGPU that also means more graph nodes, queue buffers, scans/
 indirect dispatch bookkeeping, so it should follow measured pressure from multi-bounce or complex
 materials rather than replace the direct-light megakernel preemptively.
 
+#### Target-aware presentation and physically based direct lighting
+
+**Implemented.** Radiance and progressive history remain in linear floating-point textures until a
+fullscreen graph render node presents the current frame. That node can render directly into the
+canvas or a compatible caller-owned offscreen framebuffer without taking ownership of command
+submission. Its pipeline follows the selected target's actual color and depth/stencil formats,
+including depthless targets, rather than assuming the canvas format.
+
+Presentation applies the same selected transfer policy as the forward renderer: no tone map,
+Reinhard, Khronos PBR Neutral, or ACES, followed by the exact piecewise IEC sRGB transfer function
+when software sRGB encoding is required. Floating-point and hardware-sRGB targets preserve linear
+shader output by default. Switching incompatible target formats or presentation policies refreshes
+the presentation pipeline; switching compatible caller-owned framebuffers does not require a new
+graph solely because their identities differ.
+
+Direct lighting evaluates scalar base color, metallic, and roughness with GGX distribution, Smith
+visibility, and Fresnel terms while retaining immediate ambient and emissive contributions. All
+renderer paths interpret the retained scene's directional-light vector as incoming light; the
+forward raster boundary adapts that vector to its shader module's outgoing convention without
+mutating shared scene lights. Multiple retained ambient lights are also combined consistently
+across forward, deferred, and ray-traced rendering. This closes direct-light and scalar-material
+gaps, but does not add material textures, alpha masking, transmission, image-based lighting, or
+indirect bounces to the ray tracer.
+
+#### Graph-stage diagnostics
+
+**Implemented without synchronization.** Ray-traced frame statistics expose logical node counts,
+physical compute passes, coalesced compute nodes, and synchronous CPU encoding time for the entire
+frame and for each graph stage actually encoded. The trace/presentation stage is always present;
+topology construction, Morton acceleration rebuild, and retained-order refit appear only when
+necessary. Stage counters make camera-only, light-only, topology-changing, and transform-changing
+frames distinguishable without GPU readback, timestamp-query requirements, or hidden submission.
+
+These values describe graph recording and scheduling, not GPU execution duration, ray throughput,
+hierarchy traversal quality, achieved frames per second, or image quality. Meaningful speed claims
+still require workload-controlled measurements against explicit hardware and image-quality targets.
+
 #### Frame budget, sparse sampling, and temporal reconstruction
 
 **Implemented.** The default internal target is half the display width and height, which traces
@@ -904,6 +967,12 @@ color checks reject disocclusions and incompatible samples, then valid history i
 effective sample count. This is temporal sample reuse, not a general frame-interpolation system and
 not a full denoiser.
 
+When `samplesPerPixel` is one and both `progressive` and `temporalReprojection` are explicitly
+disabled, the centered guide ray also supplies that pixel's radiance sample. This removes animated
+subpixel jitter and its otherwise redundant second nearest-hit traversal. Progressive or temporally
+reprojected rendering retains separate centered guide and jittered radiance samples, preserving
+the normal antialiasing and history-validation behavior.
+
 Color and metadata each use a reusable `GPUTextureHistory` pair. The command graph binds one texture
 as the previous frame and the other as the current output, then exchanges their logical roles only
 after encoding succeeds. This removes all full-frame history copies without increasing the four
@@ -922,11 +991,11 @@ current renderer.
 
 | Area | Implemented now | Planned or absent |
 | --- | --- | --- |
-| Acceleration | Morton-sorted TLAS, retained transform refits, topology-only Morton per-mesh BLASes | Karras/SAH topology, wide/compressed nodes, traversal-driven rebuild policy |
-| Execution | Direct-light megakernel with hard shadow rays | Wavefront queues, compaction, multi-bounce transport |
+| Acceleration | Morton-sorted TLAS/BLAS, retained transform refits, tight BLAS-root bounds, batched segmented sort/BVH construction | Karras/SAH topology, wide/compressed nodes, traversal-driven rebuild policy |
+| Execution | Direct-light megakernel, hard shadow rays, coalesced graph passes, per-stage node/pass/CPU counters | Wavefront queues, compaction, multi-bounce transport, GPU-stage timings |
 | Sampling | Half-resolution default, adaptive scales, interleaved phases, rotating shadow-light samples | Variance-driven adaptive sampling and reservoir-based many-light reuse |
 | Reconstruction | Motion-aware temporal reprojection, rejection, neighborhood clamp, manual HDR upscale | SVGF-class denoising, stronger edge-aware upscaling, reactive masks |
-| Shading | Analytic spheres, mesh triangles, direct lights | Full PBR texture parity, alpha/transmission, deformation, indirect bounces |
+| Shading and presentation | Analytic spheres, mesh triangles, scalar metallic/roughness GGX, directional-light parity, target-aware HDR/SDR tone mapping and offscreen output | Full PBR texture parity, alpha/transmission, deformation, indirect bounces |
 
 ### Cache invalidation
 
@@ -1097,7 +1166,7 @@ for each orb.
 | `version` | JSON schema version; currently `1`. |
 | `name`, `description` | Human-readable preview title and optional scene description. |
 | `camera` | Camera `@@type`, normal ANARI camera parameters, optional `target`, and optional orbit speed. |
-| `renderer` | Optional renderer preset parameters for exposure, bloom, background, and fog. The playground's renderer selector chooses the active renderer subtype independently of the scene. |
+| `renderer` | Optional renderer preset parameters for exposure, tone mapping, output color space, bloom, background, and fog. The playground's renderer selector chooses the active renderer subtype independently of the scene. |
 | `geometries` | Named geometry declarations; triangle meshes accept number arrays or compact `torus`, `crystal`, and beveled `prism` generators. |
 | `materials` | Named `matte` or `physicallyBased` material declarations. |
 | `surfaces` | Named surface declarations referencing geometry and material identifiers. |
@@ -1348,7 +1417,7 @@ The current package is a focused proof of concept, not a complete ANARI implemen
 - Automatically generated triangle normals assume non-indexed triangle-list positions.
 - Group-attached lights are not transformed by their owning instance.
 - The `deferred` renderer is WebGPU-only and does not yet include clustered lighting, screen-space effects, bloom, or temporal velocity history.
-- The WebGPU-only `raytrace` renderer builds Morton-sorted object/instance TLAS and per-mesh triangle BLAS hierarchies on the GPU; hardware ray tracing, SAH/Karras hierarchy topology, skeletal/morph deformation, material textures, alpha/transmission, advanced PBR parity, indirect bounces, and denoising are unsupported.
+- The WebGPU-only `raytrace` renderer builds Morton-sorted object/instance TLAS and per-mesh triangle BLAS hierarchies on the GPU and supports scalar metallic/roughness direct lighting; hardware ray tracing, SAH/Karras hierarchy topology, skeletal/morph deformation, material textures, alpha/transmission, advanced PBR extensions, indirect bounces, and denoising are unsupported.
 - Visibility, picking, volumes, clipping planes, raster shadow maps, and asynchronous frame mapping are not implemented; direct shadow rays are available only in the `raytrace` renderer.
 - Experimental OpenUSD import does not support binary USDC crates or complete USD composition semantics.
 - Imported glTF skin attributes require an application-supplied retained joint palette; automatic

--- a/docs/api-reference/anari/anari-rendering.md
+++ b/docs/api-reference/anari/anari-rendering.md
@@ -99,6 +99,8 @@ type ANARIRendererParameters = {
   background?: ANARIVector4;
   ambientRadiance?: number;
   exposure?: number;
+  toneMapMode?: 0 | 1 | 2 | 3;
+  outputColorSpace?: 'linear' | 'srgb';
   samplesPerPixel?: number;
   maxBounces?: number;
   progressive?: boolean;
@@ -122,6 +124,8 @@ type ANARIRendererParameters = {
 | `background` | `[0.015, 0.018, 0.038, 1]` | RGBA clear color. |
 | `ambientRadiance` | `0.12` | Base white ambient light added before explicit world/group lights. |
 | `exposure` | `1.35` | Final lighting exposure. |
+| `toneMapMode` | Target-dependent | `0` disables tone mapping, `1` selects Reinhard, `2` selects Khronos PBR Neutral, and `3` selects ACES. Floating-point targets default to `0`; normalized targets default to `2`. |
+| `outputColorSpace` | Target-dependent | Explicitly selects `'linear'` or `'srgb'` output. Floating-point and hardware-sRGB targets default to linear output; other normalized targets default to software sRGB encoding. |
 | `samplesPerPixel` | `1` | Primary-ray samples per frame in the `raytrace` renderer. |
 | `maxBounces` | Not applied | Reserved ray-tracing bounce limit; the current implementation evaluates direct lighting only. |
 | `progressive` | `true` | Accumulate ray-traced samples across unchanged frames. |
@@ -205,8 +209,11 @@ refreshes rebuild the Morton order. A topology-only graph Morton-sorts each mesh
 GPU-built BLASes, which transform-only updates reuse. It traces transformed analytic spheres and
 triangle meshes, including tessellated quads, cylinders, and cones; evaluates ambient, directional,
 point, and spot lights; and presents the result through a fullscreen pass. An `rgba16float` canvas
-preserves HDR radiance. The trace pass uses exactly eight storage buffers, and every TLAS or BLAS
-construction pass remains within the default WebGPU CORE limit of eight storage buffers.
+or caller-owned framebuffer preserves HDR radiance; ordinary targets use the same configurable
+tone-mapping and exact sRGB transfer as forward rendering. Scalar metallic-roughness materials use
+GGX distribution, Smith visibility, Schlick Fresnel, and energy-balanced diffuse lighting. The
+trace pass uses exactly eight storage buffers, and every TLAS or BLAS construction pass remains
+within the default WebGPU CORE limit of eight storage buffers.
 
 The default half-resolution internal target traces one quarter as many pixels as the output canvas.
 When adaptive quality is enabled, the renderer can reduce scale to `0.25`, spread interleaved pixel
@@ -225,9 +232,9 @@ build graph.
 The Morton-sorted TLAS accelerates object and instance selection, while intersected meshes traverse
 GPU-built Morton-sorted triangle BLASes. Hardware ray tracing and SAH/Karras hierarchy topology are
 not implemented. Skeletal skinning, morph-target displacement, material textures, alpha/
-transmission, and advanced PBR shading remain on the forward/deferred renderer paths. Indirect
-multi-bounce path tracing, denoising, and volumes are also unsupported. `maxBounces` is accepted
-for forward compatibility but does not enable indirect bounces.
+transmission, and advanced PBR material extensions remain on the forward/deferred renderer paths.
+Indirect multi-bounce path tracing, denoising, and volumes are also unsupported. `maxBounces` is
+accepted for forward compatibility but does not enable indirect bounces.
 
 For the rationale behind the TLAS/BLAS split, Morton ordering, refit policy, megakernel execution,
 and temporal reconstruction roadmap, see
@@ -326,6 +333,16 @@ type ANARIFrameStatistics = {
     sampledPixelCoverage: number;
     frameTimeMilliseconds: number;
     accumulatedSamples: number;
+    graph?: {
+      nodeCount: number;
+      computePassCount: number;
+      coalescedComputeNodeCount: number;
+      cpuEncodeTimeMilliseconds: number;
+      topology?: ANARIRayTracingGraphStageStatistics;
+      acceleration?: ANARIRayTracingGraphStageStatistics;
+      refit?: ANARIRayTracingGraphStageStatistics;
+      trace: ANARIRayTracingGraphStageStatistics;
+    };
   };
 };
 ```
@@ -336,9 +353,15 @@ type ANARIFrameStatistics = {
 | `instanceCount` | Number of direct and instanced surface placements. |
 | `drawCount` | Number of successful model draws, normally one per distinct raster surface or one ray-tracing presentation draw. |
 | `triangleCount` | Sum of mesh triangles across all placements; analytic ray-traced spheres contribute zero. |
-| `rayTracing` | Optional internal resolution, effective scale, sampled-pixel coverage, smoothed frame time, and accumulated samples; present only for the `raytrace` renderer. |
+| `rayTracing` | Optional internal resolution, effective scale, sampled-pixel coverage, smoothed frame time, accumulated samples, and synchronous graph-stage diagnostics; present only for the `raytrace` renderer. |
+| `rayTracing.graph` | Logical node counts, physical compute-pass counts, coalesced compute-node counts, and CPU encoding time for the stages actually recorded during this frame. |
 
 `frame.statistics` is initialized with zeroes and updated by each `frame.render()` call.
+
+The `trace` graph stage is always present. `topology` appears only when mesh hierarchies are
+rebuilt, and `acceleration` and `refit` are mutually exclusive full-build and transform-only TLAS
+stages. These counters describe synchronous encoding only: collecting them does not submit the
+application's encoder, wait for the GPU, or read a buffer back to the CPU.
 
 ### Resizing
 

--- a/docs/api-reference/experimental/README.md
+++ b/docs/api-reference/experimental/README.md
@@ -61,16 +61,19 @@ default `0.5` resolution scale can decrease to
 required. Acceleration passes run only when geometry or instance transforms change. Shared scene
 adapters can provide categorized committed-scene revisions so camera-only frames avoid repeatedly
 serializing every instance transform, material, and light.
-Shared scene statistics optionally expose internal dimensions, effective scale, sampled-pixel coverage, frame
-timing, and accumulated samples. The ray pass uses exactly eight storage buffers, and every TLAS or
-BLAS construction pass fits the default WebGPU CORE limit of eight storage buffers. Applications
-retain command-submission ownership.
+The canvas or a caller-owned offscreen framebuffer determines the actual attachment formats and
+target dimensions; scalar metallic-roughness lighting follows GGX/Smith/Fresnel, and presentation
+uses the shared tone-mapping and exact linear/sRGB output conventions. Shared scene statistics expose
+internal dimensions, effective scale, sampled-pixel coverage, frame timing, accumulated samples,
+and per-stage command-graph node, physical-pass, coalescing, and CPU encoding costs. The ray pass
+uses exactly eight storage buffers, and every TLAS or BLAS construction pass fits the default WebGPU
+CORE limit of eight storage buffers. Applications retain command-submission ownership.
 
 The Morton-sorted TLAS accelerates objects and instances, while GPU-built Morton-sorted BLASes
 accelerate each mesh's triangles. Hardware ray tracing, SAH/Karras hierarchy topology, indirect path
 tracing, denoising, and volume rendering are not implemented. Skeletal/morph deformation, material
-textures, alpha/transmission, and advanced PBR shading remain on the forward/deferred renderer
-paths.
+textures, alpha/transmission, and advanced PBR material extensions remain on the forward/deferred
+renderer paths.
 
 `createPBRMaterialFactory`, `createPBRMaterial`, and `createPBRModel` are also available when an
 application needs lower-level composition with the same canonical material and shader contracts.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -440,6 +440,39 @@ ordered after the render pass.
 Multisample resolve is currently a WebGPU contract. Render-pass callbacks cannot also supply their
 own framebuffer or resolve targets when graph attachments are present.
 
+### Caller-owned per-encoding framebuffers
+
+A render node without graph-managed `attachments` can select an existing application framebuffer
+through its compiled executable's `getRenderPassProps()` callback:
+
+```ts
+const graph = new GPUCommandGraph<{framebuffer: Framebuffer}>(device);
+
+graph.addRenderPass({
+  id: 'present-offscreen',
+  resources: [{texture: tracedImage, usage: 'sampled'}],
+  compile: () => ({
+    getRenderPassProps: ({parameters}) => ({framebuffer: parameters.framebuffer}),
+    encode: ({renderPass}) => model.draw(renderPass)
+  })
+});
+
+const compiled = graph.compile();
+compiled.encode(commandEncoder, {parameters: {framebuffer: firstTarget}});
+compiled.encode(otherCommandEncoder, {parameters: {framebuffer: secondTarget}});
+```
+
+Changing the compatible framebuffer does not recompile the graph, and both framebuffers remain
+caller-owned. The graph still opens and closes the render pass; acquiring or destroying the
+framebuffer and submitting each command encoder remain the application's responsibilities. Render
+pipelines must match the selected target's color and depth/stencil formats, so callers should
+recreate incompatible pipelines when those formats change.
+
+Because an application-provided framebuffer is not a declared graph resource, the graph cannot
+infer hazards for its attachment textures or order later nodes that sample them. Import the target
+texture and declare graph-managed `attachments` when later work in the same graph depends on its
+output. A node cannot combine graph-managed attachments with a callback-provided framebuffer.
+
 ## Node APIs and graph commands
 
 A graph command is a reusable description of GPU work, not a second command queue or a hidden
@@ -451,7 +484,7 @@ readback share one dependency-ordered execution without taking ownership of the 
 | Feature | Why it exists | Typical use |
 | --- | --- | --- |
 | `addComputePass()` | Schedule shader dispatch alongside its declared buffer and texture hazards. | Filtering, scans, sorting, hash-index construction, aggregation, and indirect-command generation. |
-| `addRenderPass()` | Schedule drawing with graph-managed attachments, resolves, and sampled resources. | Scene rendering, picking, off-screen layers, and multisampled frame composition. |
+| `addRenderPass()` | Schedule drawing with graph-managed attachments or compatible caller-owned framebuffers. | Scene rendering, picking, off-screen layers, and multisampled frame composition. |
 | `addCopyPass()` | Express transfers or encoder-level operations in the same ordered graph. | Explicit compact-result readback, staging uploads, and copying finished render targets. |
 | `dependsOn` | Describe an ordering requirement that no shared graph resource can express. | External side effects, timestamp boundaries, and application-owned synchronization. |
 | Repeated `encode()` | Reuse compiled pipelines and scratch allocations with new parameters or imports. | Interactive filters, animation frames, changing selections, and reusable query plans. |
@@ -498,7 +531,9 @@ graph.addRenderPass({
 ```
 
 The graph owns the `RenderPass` lifecycle. The executable records drawing commands; it must not
-end the pass, submit the encoder, or replace a graph-managed framebuffer.
+end the pass, submit the encoder, or replace a graph-managed framebuffer. When no `attachments` are
+declared, `getRenderPassProps()` may choose a compatible caller-owned framebuffer for each
+encoding.
 
 ### `addCopyPass(node)`
 

--- a/docs/api-reference/experimental/scene-renderer.md
+++ b/docs/api-reference/experimental/scene-renderer.md
@@ -194,9 +194,9 @@ ordered back-to-front at the surface level.
 | `id` | Stable frame identifier used to retain compiled models between renders. |
 | `surfaces` | Retained surface batches. |
 | `camera` | `viewMatrix`, `projectionMatrix`, and world-space `position`. |
-| `lights` | Existing shadertools light descriptors using normalized color values. |
+| `lights` | Existing shadertools light descriptors using normalized color values; directional vectors describe incoming light propagation. |
 | `background` | Linear RGBA clear color; defaults to `[0, 0, 0, 1]`. |
-| `framebuffer` | Optional caller-owned forward-rendering target. |
+| `framebuffer` | Optional caller-owned forward-rendering or ray-tracing target; its attachment dimensions and formats determine presentation. |
 | `width`, `height` | Explicit target dimensions when a framebuffer is not supplied. |
 | `environment` | Optional complete `SceneEnvironment` image-based-lighting resource set. |
 | `transmission` | Enables automatic opaque-scene capture for transmissive materials; set `false` to disable it. |
@@ -228,7 +228,8 @@ An `rgba16float` framebuffer defaults to linear, untonemapped output, preserving
 one for subsequent HDR processing. A framebuffer with a hardware-sRGB attachment also receives
 linear shader output so the hardware performs the transfer exactly once. Explicit
 `outputColorSpace` overrides the automatic selection when the caller intentionally manages the
-target differently.
+target differently. `RayTracingSceneRenderer` follows the same framebuffer, tone-mapping, and
+output-encoding contract while keeping its retained radiance history in linear HDR storage.
 
 ## Image-based lighting
 
@@ -426,6 +427,12 @@ Creates a renderer for an existing WebGL or WebGPU device.
 
 Updates retained scene resources, draws opaque surfaces before back-to-front blended surfaces,
 and returns `surfaceCount`, `instanceCount`, `drawCount`, and `triangleCount`.
+
+The WebGPU `RayTracingSceneRenderer` consumes the same scene contract and additionally returns
+`rayTracing.graph`: logical node counts, physical compute-pass counts, coalesced compute nodes,
+and synchronous CPU encoding time for the stages recorded during that frame. Its `trace` stage is
+always present; `topology`, `acceleration`, and `refit` appear only when the corresponding work
+runs. Collecting these diagnostics never submits commands or waits for GPU results.
 
 ### `destroyFrame(frameIdentifier: string): void`
 

--- a/modules/anari/src/anari-scene-adapter.ts
+++ b/modules/anari/src/anari-scene-adapter.ts
@@ -308,6 +308,8 @@ export class ANARISceneAdapter {
 
     const [width, height] = getFrameSize(frame, frame.device.device);
     const ambientRadiance = renderer.getParameter('ambientRadiance') ?? 0.12;
+    const toneMapMode = renderer.getParameter('toneMapMode');
+    const outputColorSpace = renderer.getParameter('outputColorSpace');
     let cachedWorld = this.worlds.get(world);
     if (!cachedWorld) {
       cachedWorld = this.createCachedWorld(world, ambientRadiance);
@@ -326,6 +328,8 @@ export class ANARISceneAdapter {
       height,
       environment: renderer.getParameter('environment'),
       exposure: renderer.getParameter('exposure') ?? 1.35,
+      ...(toneMapMode !== undefined ? {toneMapMode} : {}),
+      ...(outputColorSpace !== undefined ? {outputColorSpace} : {}),
       fogColor: renderer.getParameter('fogColor') || [0.025, 0.035, 0.075],
       fogDensity: renderer.getParameter('fogDensity') ?? 0,
       renderMode:

--- a/modules/anari/src/anari-types.ts
+++ b/modules/anari/src/anari-types.ts
@@ -222,6 +222,10 @@ export type ANARIRendererParameters = {
     rotation?: number;
   };
   exposure?: number;
+  /** Tone mapping: 0 none, 1 Reinhard, 2 Khronos PBR Neutral, or 3 ACES. */
+  toneMapMode?: 0 | 1 | 2 | 3;
+  /** Explicit output transfer; omitted values follow the render-target format. */
+  outputColorSpace?: 'linear' | 'srgb';
   samplesPerPixel?: number;
   maxBounces?: number;
   progressive?: boolean;
@@ -250,6 +254,22 @@ export type ANARIFrameParameters = {
   size?: readonly [number, number];
 };
 
+/** Synchronous command-graph costs for one retained ray-tracing frame stage. */
+export type ANARIRayTracingGraphStageStatistics = {
+  nodeCount: number;
+  computePassCount: number;
+  coalescedComputeNodeCount: number;
+  cpuEncodeTimeMilliseconds: number;
+};
+
+/** Aggregate command-graph diagnostics plus the stages encoded for one frame. */
+export type ANARIRayTracingGraphStatistics = ANARIRayTracingGraphStageStatistics & {
+  topology?: ANARIRayTracingGraphStageStatistics;
+  acceleration?: ANARIRayTracingGraphStageStatistics;
+  refit?: ANARIRayTracingGraphStageStatistics;
+  trace: ANARIRayTracingGraphStageStatistics;
+};
+
 export type ANARIFrameStatistics = {
   surfaceCount: number;
   instanceCount: number;
@@ -262,6 +282,7 @@ export type ANARIFrameStatistics = {
     sampledPixelCoverage: number;
     frameTimeMilliseconds: number;
     accumulatedSamples: number;
+    graph?: ANARIRayTracingGraphStatistics;
   };
 };
 

--- a/modules/anari/src/index.ts
+++ b/modules/anari/src/index.ts
@@ -39,6 +39,8 @@ export type {
   ANARIObjectInfo,
   ANARIObjectReference,
   ANARIObjectType,
+  ANARIRayTracingGraphStageStatistics,
+  ANARIRayTracingGraphStatistics,
   ANARIRendererParameters,
   ANARIRendererSubtype,
   ANARISamplerParameters,

--- a/modules/anari/src/schemas.ts
+++ b/modules/anari/src/schemas.ts
@@ -287,6 +287,8 @@ const rendererProperties = {
   background: ANARIVector4Schema.optional(),
   ambientRadiance: nonnegativeNumberSchema.optional(),
   exposure: positiveNumberSchema.optional(),
+  toneMapMode: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)]).optional(),
+  outputColorSpace: z.enum(['linear', 'srgb']).optional(),
   bloomIntensity: nonnegativeNumberSchema.optional(),
   bloomThreshold: nonnegativeNumberSchema.optional(),
   bloomRadius: nonnegativeNumberSchema.optional(),

--- a/modules/anari/test/anari-renderer.spec.ts
+++ b/modules/anari/test/anari-renderer.spec.ts
@@ -462,6 +462,12 @@ test('ANARI ray tracing renderer accelerates analytic spheres and indexed meshes
       1,
       'analytic spheres do not generate mesh triangles'
     );
+    testContext.ok(
+      statistics.rayTracing?.graph?.topology &&
+        statistics.rayTracing.graph.acceleration &&
+        statistics.rayTracing.graph.trace,
+      'retained ANARI frames expose topology, acceleration, and tracing graph-stage diagnostics'
+    );
 
     if (supportsRawValidationErrorScopes) {
       graphicsDevice.handle.pushErrorScope('validation');
@@ -473,6 +479,29 @@ test('ANARI ray tracing renderer accelerates analytic spheres and indexed meshes
       accumulatedStatistics.instanceCount,
       3,
       'stable recommitted camera parameters preserve progressive rendering'
+    );
+    testContext.ok(
+      accumulatedStatistics.rayTracing?.graph?.trace &&
+        !accumulatedStatistics.rayTracing.graph.topology &&
+        !accumulatedStatistics.rayTracing.graph.acceleration &&
+        !accumulatedStatistics.rayTracing.graph.refit,
+      'stable ANARI frames expose only the tracing graph without rebuilding acceleration'
+    );
+
+    renderer.setParameters({toneMapMode: 1, outputColorSpace: 'linear'}).commitParameters();
+    const colorManagedStatistics = frame.render();
+    graphicsDevice.submit();
+    testContext.equal(
+      colorManagedStatistics.instanceCount,
+      3,
+      'committed ANARI tone-mapping and output-color settings preserve retained placements'
+    );
+    testContext.ok(
+      colorManagedStatistics.rayTracing?.graph?.trace &&
+        !colorManagedStatistics.rayTracing.graph.topology &&
+        !colorManagedStatistics.rayTracing.graph.acceleration &&
+        !colorManagedStatistics.rayTracing.graph.refit,
+      'presentation-policy updates recreate only the tracing graph, without rebuilding acceleration'
     );
 
     world.setParameter('instance', [firstInstance]).commitParameters();

--- a/modules/anari/test/anari-scene-adapter-cache.node.spec.ts
+++ b/modules/anari/test/anari-scene-adapter-cache.node.spec.ts
@@ -67,6 +67,60 @@ describe('ANARI retained scene adapter caching', () => {
     }
   });
 
+  test('forwards only committed presentation overrides without invalidating the retained scene', () => {
+    const fixture = createCachedSceneFixture();
+
+    try {
+      const initialOptions = fixture.adapter.makeRenderOptions(fixture.frame);
+      const initialPrimitives = fixture.adapter.getAnalyticPrimitives(fixture.world);
+      const initialSceneCommitRevision = fixture.device.getSceneCommitRevision();
+
+      expect(initialOptions).not.toHaveProperty('toneMapMode');
+      expect(initialOptions).not.toHaveProperty('outputColorSpace');
+
+      fixture.renderer.setParameters({toneMapMode: 0, outputColorSpace: 'linear'});
+      const stagedOptions = fixture.adapter.makeRenderOptions(fixture.frame);
+      expect(stagedOptions).not.toHaveProperty('toneMapMode');
+      expect(stagedOptions).not.toHaveProperty('outputColorSpace');
+
+      fixture.renderer.commitParameters();
+      const linearOptions = fixture.adapter.makeRenderOptions(fixture.frame);
+      expect(linearOptions?.toneMapMode).toBe(0);
+      expect(linearOptions?.outputColorSpace).toBe('linear');
+
+      fixture.renderer.setParameters({toneMapMode: 3, outputColorSpace: 'srgb'}).commitParameters();
+      const encodedOptions = fixture.adapter.makeRenderOptions(fixture.frame);
+      expect(encodedOptions?.toneMapMode).toBe(3);
+      expect(encodedOptions?.outputColorSpace).toBe('srgb');
+
+      fixture.renderer.unsetParameter('toneMapMode').unsetParameter('outputColorSpace');
+      const stagedRemoval = fixture.adapter.makeRenderOptions(fixture.frame);
+      expect(stagedRemoval?.toneMapMode).toBe(3);
+      expect(stagedRemoval?.outputColorSpace).toBe('srgb');
+
+      fixture.renderer.commitParameters();
+      const automaticOptions = fixture.adapter.makeRenderOptions(fixture.frame);
+      expect(automaticOptions).not.toHaveProperty('toneMapMode');
+      expect(automaticOptions).not.toHaveProperty('outputColorSpace');
+
+      for (const options of [
+        stagedOptions,
+        linearOptions,
+        encodedOptions,
+        stagedRemoval,
+        automaticOptions
+      ]) {
+        expect(options?.surfaces).toBe(initialOptions?.surfaces);
+        expect(options?.lights).toBe(initialOptions?.lights);
+        expect(options?.sceneRevisions).toEqual(initialOptions?.sceneRevisions);
+      }
+      expect(fixture.adapter.getAnalyticPrimitives(fixture.world)).toBe(initialPrimitives);
+      expect(fixture.device.getSceneCommitRevision()).toBe(initialSceneCommitRevision);
+    } finally {
+      destroyCachedSceneFixture(fixture);
+    }
+  });
+
   test('updates only committed instance placements and publishes exact stable dirty identifiers', () => {
     const fixture = createCachedSceneFixture();
 

--- a/modules/anari/test/anari-schemas.node.spec.ts
+++ b/modules/anari/test/anari-schemas.node.spec.ts
@@ -118,6 +118,56 @@ test('ANARI renderer schemas validate graph-based ray tracing settings', testCon
   testContext.end();
 });
 
+test('ANARI renderer schemas validate presentation controls across every renderer subtype', testContext => {
+  const rendererSubtypes = [
+    'default',
+    'deferred',
+    'raytrace',
+    'debugNormals',
+    'debugDepth'
+  ] as const;
+
+  for (const subtype of rendererSubtypes) {
+    for (const toneMapMode of [0, 1, 2, 3] as const) {
+      testContext.ok(
+        ANARIRendererSchema.safeParse({
+          '@@type': subtype,
+          toneMapMode,
+          outputColorSpace: toneMapMode % 2 === 0 ? 'linear' : 'srgb'
+        }).success,
+        `${subtype} accepts portable presentation mode ${toneMapMode}`
+      );
+    }
+
+    testContext.ok(
+      ANARIRendererSchema.safeParse({'@@type': subtype}).success,
+      `${subtype} retains automatic presentation defaults when controls are omitted`
+    );
+  }
+
+  for (const toneMapMode of [-1, 4, 0.5, Number.NaN, '1', null]) {
+    testContext.notOk(
+      ANARIRendererSchema.safeParse({'@@type': 'raytrace', toneMapMode}).success,
+      `unsupported tone-mapping selector ${String(toneMapMode)} is rejected`
+    );
+  }
+
+  for (const outputColorSpace of ['display-p3', 'LINEAR', 1, null]) {
+    testContext.notOk(
+      ANARIRendererSchema.safeParse({'@@type': 'default', outputColorSpace}).success,
+      `unsupported output color space ${String(outputColorSpace)} is rejected`
+    );
+  }
+
+  const generatedSchema = JSON.stringify(ANARI_SCENE_JSON_SCHEMA);
+  testContext.ok(generatedSchema.includes('toneMapMode'), 'JSON Schema advertises tone mapping');
+  testContext.ok(
+    generatedSchema.includes('outputColorSpace'),
+    'JSON Schema advertises output color-space selection'
+  );
+  testContext.end();
+});
+
 test('ANARI scene schemas identify invalid properties and retained references', testContext => {
   const scene = structuredClone(PLAYGROUND_PRESETS[0].scene);
   const materialIdentifier = Object.keys(scene.materials)[0];

--- a/modules/experimental/src/engine/ray-tracing-scene-renderer.ts
+++ b/modules/experimental/src/engine/ray-tracing-scene-renderer.ts
@@ -2,14 +2,23 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import {Buffer, type Device, Texture} from '@luma.gl/core';
+import {
+  Buffer,
+  type Device,
+  type Framebuffer,
+  Texture,
+  type TextureFormatColor,
+  type TextureFormatDepthStencil,
+  textureFormatDecoder
+} from '@luma.gl/core';
 import {Computation, type Geometry, Model} from '@luma.gl/engine';
-import type {Light} from '@luma.gl/shadertools';
+import {type Light, PBR_TONE_MAP_MODE} from '@luma.gl/shadertools';
 import {Matrix4, type NumericArray} from '@math.gl/core';
 import {GPUBVH} from '../gpu-primitives/gpu-bvh';
 import {
   type CompiledGPUCommandGraph,
   GPUCommandGraph,
+  type GPUCommandGraphEncodingStats,
   type GraphDataView
 } from '../gpu-primitives/gpu-command-graph';
 import {GPUSegmentedBVH, type GPUBVHSegment} from '../gpu-primitives/gpu-segmented-bvh';
@@ -27,7 +36,13 @@ import {
   RAY_TRACING_HISTORY_CARRY_SHADER,
   RAY_TRACING_SCENE_SHADER
 } from './ray-tracing-scene-shaders';
-import type {SceneRenderOptions, SceneRenderStatistics, SceneSurface} from './scene-renderer';
+import type {
+  RayTracingGraphStageStatistics,
+  RayTracingGraphStatistics,
+  SceneRenderOptions,
+  SceneRenderStatistics,
+  SceneSurface
+} from './scene-renderer';
 
 const PRIMITIVE_FLOAT_COUNT = 68;
 const TRIANGLE_FLOAT_COUNT = 24;
@@ -527,13 +542,22 @@ type RayTracingQualityOptions = {
 type RayTracingTraceGraphParameters = {
   dispatchWidth: number;
   carryWidth: number;
+  framebuffer?: Framebuffer;
 };
 
 type RayTracingAccelerationUpdateMode = 'rebuild' | 'refit' | 'none';
 
+type RayTracingPresentationOptions = {
+  colorFormat: TextureFormatColor;
+  depthStencilFormat?: TextureFormatDepthStencil;
+  toneMapMode: number;
+  outputEncoding: number;
+};
+
 type RayTracingFrameResources = {
   displayWidth: number;
   displayHeight: number;
+  presentation: RayTracingPresentationOptions;
   internalWidth: number;
   internalHeight: number;
   resolutionScale: number;
@@ -611,6 +635,7 @@ type RayTracingStatistics = {
   sampledPixelCoverage: number;
   frameTimeMilliseconds: number;
   accumulatedSamples: number;
+  graph: RayTracingGraphStatistics;
 };
 
 /** Shared WebGPU software ray tracer consuming the canonical retained-scene contract. */
@@ -627,11 +652,8 @@ export class RayTracingSceneRenderer {
   }
 
   render(options: RayTracingSceneRenderOptions): SceneRenderStatistics {
-    const [defaultWidth, defaultHeight] = this.device
-      .getDefaultCanvasContext()
-      .getDrawingBufferSize();
-    const displayWidth = options.width ?? defaultWidth;
-    const displayHeight = options.height ?? defaultHeight;
+    const [displayWidth, displayHeight] = getRayTracingDisplaySize(this.device, options);
+    const presentation = getRayTracingPresentationOptions(this.device, options);
     const lights = options.lights ?? [];
     const quality = getQualityOptions(options);
     const viewProjection = new Matrix4(options.camera.projectionMatrix).multiplyRight(
@@ -662,6 +684,7 @@ export class RayTracingSceneRenderer {
         frameIdentifier: options.id,
         displayWidth,
         displayHeight,
+        presentation,
         scene,
         topology,
         primitiveData,
@@ -759,6 +782,7 @@ export class RayTracingSceneRenderer {
           frameIdentifier: options.id,
           displayWidth,
           displayHeight,
+          presentation,
           scene,
           topology,
           primitiveData,
@@ -879,8 +903,11 @@ export class RayTracingSceneRenderer {
         displayWidth,
         displayHeight,
         internalDimensions.width,
-        internalDimensions.height
+        internalDimensions.height,
+        presentation
       );
+    } else if (!areRayTracingPresentationOptionsEqual(resources.presentation, presentation)) {
+      this.recreateTraceGraph(options.id, resources, presentation);
     }
 
     const progressive = options.progressive ?? true;
@@ -920,31 +947,41 @@ export class RayTracingSceneRenderer {
       })
     );
 
+    let topologyEncodingStats: GPUCommandGraphEncodingStats | undefined;
+    let accelerationEncodingStats: GPUCommandGraphEncodingStats | undefined;
+    let refitEncodingStats: GPUCommandGraphEncodingStats | undefined;
     if (resources.topologyNeedsUpdate) {
-      resources.topologyGraph.encode(this.device.commandEncoder, {parameters: undefined});
+      topologyEncodingStats = resources.topologyGraph.encode(this.device.commandEncoder, {
+        parameters: undefined
+      }).stats;
       resources.topologyNeedsUpdate = false;
     }
     if (resources.accelerationUpdateMode === 'rebuild') {
-      resources.accelerationGraph.encode(this.device.commandEncoder, {parameters: undefined});
+      accelerationEncodingStats = resources.accelerationGraph.encode(this.device.commandEncoder, {
+        parameters: undefined
+      }).stats;
       resources.refitsSinceMortonRebuild = 0;
     } else if (resources.accelerationUpdateMode === 'refit') {
-      resources.refitGraph.encode(this.device.commandEncoder, {parameters: undefined});
+      refitEncodingStats = resources.refitGraph.encode(this.device.commandEncoder, {
+        parameters: undefined
+      }).stats;
       resources.refitsSinceMortonRebuild++;
     }
     resources.accelerationUpdateMode = 'none';
-    resources.traceGraph.encode(this.device.commandEncoder, {
+    const traceEncodingStats = resources.traceGraph.encode(this.device.commandEncoder, {
       parameters: {
         dispatchWidth: Math.ceil(resources.internalWidth / activePhaseCount),
         carryWidth:
           activePhaseCount > 1
             ? Math.ceil((resources.internalWidth * (activePhaseCount - 1)) / activePhaseCount)
-            : 0
+            : 0,
+        ...(options.framebuffer ? {framebuffer: options.framebuffer} : {})
       },
       textures: {
         ...resources.colorHistory.getBindings('history', 'output'),
         ...resources.metadataHistory.getBindings('history-metadata', 'output-metadata')
       }
-    });
+    }).stats;
     resources.colorHistory.advance();
     resources.metadataHistory.advance();
     resources.previousViewProjection = new Matrix4(viewProjection);
@@ -969,7 +1006,13 @@ export class RayTracingSceneRenderer {
           resources.averageFrameTimeMilliseconds ?? resources.targetFrameTimeMilliseconds,
         accumulatedSamples: progressive
           ? Math.min(resources.accumulatedFrameCount * samplesPerPixel, MAXIMUM_HISTORY_SAMPLES)
-          : samplesPerPixel
+          : samplesPerPixel,
+        graph: makeRayTracingGraphStatistics({
+          topology: topologyEncodingStats,
+          acceleration: accelerationEncodingStats,
+          refit: refitEncodingStats,
+          trace: traceEncodingStats
+        })
       } satisfies RayTracingStatistics
     };
     return statistics as SceneRenderStatistics;
@@ -1012,6 +1055,7 @@ export class RayTracingSceneRenderer {
     frameIdentifier: string;
     displayWidth: number;
     displayHeight: number;
+    presentation: RayTracingPresentationOptions;
     scene: RayTracingScene;
     topology: RayTracingTopology;
     primitiveData: RayTracingPrimitiveData;
@@ -1157,6 +1201,7 @@ export class RayTracingSceneRenderer {
       frameIdentifier,
       internalWidth: internalDimensions.width,
       internalHeight: internalDimensions.height,
+      presentation: props.presentation,
       uniformBuffer,
       primitiveBuffer,
       triangleBuffer,
@@ -1173,6 +1218,7 @@ export class RayTracingSceneRenderer {
     return {
       displayWidth: props.displayWidth,
       displayHeight: props.displayHeight,
+      presentation: props.presentation,
       internalWidth: internalDimensions.width,
       internalHeight: internalDimensions.height,
       resolutionScale: props.quality.resolutionScale,
@@ -1237,7 +1283,8 @@ export class RayTracingSceneRenderer {
     displayWidth: number,
     displayHeight: number,
     internalWidth: number,
-    internalHeight: number
+    internalHeight: number,
+    presentation: RayTracingPresentationOptions
   ): void {
     resources.traceGraph.destroy();
     resources.colorHistory.destroy();
@@ -1258,6 +1305,7 @@ export class RayTracingSceneRenderer {
       frameIdentifier,
       internalWidth,
       internalHeight,
+      presentation,
       uniformBuffer: resources.uniformBuffer,
       primitiveBuffer: resources.primitiveBuffer,
       triangleBuffer: resources.triangleBuffer,
@@ -1272,10 +1320,38 @@ export class RayTracingSceneRenderer {
     });
     resources.displayWidth = displayWidth;
     resources.displayHeight = displayHeight;
+    resources.presentation = presentation;
     resources.internalWidth = internalWidth;
     resources.internalHeight = internalHeight;
     resources.phaseIndex = 0;
     resources.historyNeedsReset = true;
+  }
+
+  private recreateTraceGraph(
+    frameIdentifier: string,
+    resources: RayTracingFrameResources,
+    presentation: RayTracingPresentationOptions
+  ): void {
+    const traceGraph = this.createTraceGraph({
+      frameIdentifier,
+      internalWidth: resources.internalWidth,
+      internalHeight: resources.internalHeight,
+      presentation,
+      uniformBuffer: resources.uniformBuffer,
+      primitiveBuffer: resources.primitiveBuffer,
+      triangleBuffer: resources.triangleBuffer,
+      lightBuffer: resources.lightBuffer,
+      nodeMinimaBuffer: resources.nodeMinimaBuffer,
+      nodeMaximaBuffer: resources.nodeMaximaBuffer,
+      sortedPrimitiveIdsBuffer: resources.sortedPrimitiveIdsBuffer,
+      blasNodesBuffer: resources.blasNodesBuffer,
+      blasTriangleIdsBuffer: resources.blasTriangleIdsBuffer,
+      colorHistory: resources.colorHistory,
+      metadataHistory: resources.metadataHistory
+    });
+    resources.traceGraph.destroy();
+    resources.traceGraph = traceGraph;
+    resources.presentation = presentation;
   }
 
   private createTextureHistory(
@@ -2394,6 +2470,7 @@ export class RayTracingSceneRenderer {
     frameIdentifier: string;
     internalWidth: number;
     internalHeight: number;
+    presentation: RayTracingPresentationOptions;
     uniformBuffer: Buffer;
     primitiveBuffer: Buffer;
     triangleBuffer: Buffer;
@@ -2703,12 +2780,15 @@ export class RayTracingSceneRenderer {
       compile: ({device}) => {
         const model = new Model(device, {
           id: `${props.frameIdentifier}-ray-tracing-presentation`,
-          source: getRayTracingScenePresentationShader(
-            device.preferredColorFormat === 'rgba16float'
-          ),
+          source: getRayTracingScenePresentationShader({
+            toneMapMode: props.presentation.toneMapMode,
+            outputEncoding: props.presentation.outputEncoding
+          }),
           vertexCount: 3,
-          colorAttachmentFormats: [device.preferredColorFormat],
-          depthStencilAttachmentFormat: 'depth24plus',
+          colorAttachmentFormats: [props.presentation.colorFormat],
+          ...(props.presentation.depthStencilFormat
+            ? {depthStencilAttachmentFormat: props.presentation.depthStencilFormat}
+            : {}),
           shaderLayout: {
             attributes: [],
             bindings: [
@@ -2721,9 +2801,16 @@ export class RayTracingSceneRenderer {
               }
             ]
           },
-          parameters: {depthWriteEnabled: false, depthCompare: 'always'}
+          parameters: {
+            depthWriteEnabled: false,
+            ...(props.presentation.depthStencilFormat ? {depthCompare: 'always'} : {})
+          }
         });
         return {
+          getRenderPassProps: ({parameters}) => ({
+            id: `${props.frameIdentifier}-present-ray-tracing`,
+            ...(parameters.framebuffer ? {framebuffer: parameters.framebuffer} : {})
+          }),
           encode: ({renderPass, getTextureView}) => {
             model.setBindings({image: getTextureView(outputView)});
             model.draw(renderPass);
@@ -2735,6 +2822,104 @@ export class RayTracingSceneRenderer {
 
     return graph.compile();
   }
+}
+
+function getRayTracingDisplaySize(
+  device: Device,
+  options: RayTracingSceneRenderOptions
+): [number, number] {
+  if (options.framebuffer) {
+    return [options.framebuffer.width, options.framebuffer.height];
+  }
+  if (options.width !== undefined && options.height !== undefined) {
+    return [options.width, options.height];
+  }
+  const [defaultWidth, defaultHeight] = device.getDefaultCanvasContext().getDrawingBufferSize();
+  return [options.width ?? defaultWidth, options.height ?? defaultHeight];
+}
+
+function getRayTracingPresentationOptions(
+  device: Device,
+  options: RayTracingSceneRenderOptions
+): RayTracingPresentationOptions {
+  const colorFormat =
+    (options.framebuffer?.colorAttachments[0]?.texture.format as TextureFormatColor | undefined) ??
+    device.preferredColorFormat;
+  const formatInformation = textureFormatDecoder.getInfo(colorFormat);
+  const floatingPoint = Boolean(
+    formatInformation.dataType?.startsWith('float') || colorFormat.endsWith('ufloat')
+  );
+  const depthStencilFormat = options.framebuffer
+    ? (options.framebuffer.depthStencilAttachment?.texture.format as
+        | TextureFormatDepthStencil
+        | undefined)
+    : 'depth24plus';
+
+  return {
+    colorFormat,
+    ...(depthStencilFormat ? {depthStencilFormat} : {}),
+    toneMapMode:
+      options.toneMapMode ??
+      (floatingPoint ? PBR_TONE_MAP_MODE.NONE : PBR_TONE_MAP_MODE.KHRONOS_PBR_NEUTRAL),
+    outputEncoding: options.outputColorSpace
+      ? Number(options.outputColorSpace === 'srgb')
+      : Number(!floatingPoint && !colorFormat.endsWith('-srgb'))
+  };
+}
+
+function areRayTracingPresentationOptionsEqual(
+  first: RayTracingPresentationOptions,
+  second: RayTracingPresentationOptions
+): boolean {
+  return (
+    first.colorFormat === second.colorFormat &&
+    first.depthStencilFormat === second.depthStencilFormat &&
+    first.toneMapMode === second.toneMapMode &&
+    first.outputEncoding === second.outputEncoding
+  );
+}
+
+function makeRayTracingGraphStageStatistics(
+  statistics: GPUCommandGraphEncodingStats
+): RayTracingGraphStageStatistics {
+  return {
+    nodeCount: statistics.nodeCount,
+    computePassCount: statistics.computePassCount,
+    coalescedComputeNodeCount: statistics.coalescedComputeNodeCount,
+    cpuEncodeTimeMilliseconds: statistics.cpuEncodeTimeMilliseconds
+  };
+}
+
+function makeRayTracingGraphStatistics(props: {
+  topology?: GPUCommandGraphEncodingStats;
+  acceleration?: GPUCommandGraphEncodingStats;
+  refit?: GPUCommandGraphEncodingStats;
+  trace: GPUCommandGraphEncodingStats;
+}): RayTracingGraphStatistics {
+  const topology = props.topology && makeRayTracingGraphStageStatistics(props.topology);
+  const acceleration = props.acceleration && makeRayTracingGraphStageStatistics(props.acceleration);
+  const refit = props.refit && makeRayTracingGraphStageStatistics(props.refit);
+  const trace = makeRayTracingGraphStageStatistics(props.trace);
+  const stages = [topology, acceleration, refit, trace].filter(
+    (stage): stage is RayTracingGraphStageStatistics => Boolean(stage)
+  );
+
+  return {
+    nodeCount: stages.reduce((total, stage) => total + stage.nodeCount, 0),
+    computePassCount: stages.reduce((total, stage) => total + stage.computePassCount, 0),
+    coalescedComputeNodeCount: stages.reduce(
+      (total, stage) => total + stage.coalescedComputeNodeCount,
+      0
+    ),
+    cpuEncodeTimeMilliseconds: stages.reduce(
+      (total, stage) => total + stage.cpuEncodeTimeMilliseconds,
+      0
+    ),
+    ...(topology ? {topology} : {}),
+    ...(acceleration ? {acceleration} : {}),
+    ...(refit ? {refit} : {}),
+    trace
+  };
 }
 
 function getMaximumSparsePrimitiveUpdateCount(resources: RayTracingFrameResources): number {
@@ -3245,7 +3430,7 @@ function makeUniformData(props: {
   data[47] = (props.options.temporalReprojection ?? true) ? 1 : 0;
   data.set(props.previousViewProjection, 48);
   data.set(props.previousCameraPosition, 64);
-  data[67] = 1;
+  data[67] = (props.options.progressive ?? true) ? 1 : 0;
   return data;
 }
 

--- a/modules/experimental/src/engine/ray-tracing-scene-shaders.ts
+++ b/modules/experimental/src/engine/ray-tracing-scene-shaders.ts
@@ -695,9 +695,15 @@ fn evaluateDirectLighting(ray: Ray, hit: RayHit) -> vec3<f32> {
   let baseColor = primitive.baseColor.rgb;
   let metallic = clamp(primitive.emissive.w, 0.0, 1.0);
   let roughness = clamp(primitive.properties.x, 0.04, 1.0);
-  let reflectance = mix(vec3<f32>(0.04), baseColor, metallic);
-  let diffuse = baseColor * (1.0 - metallic) / PI;
-  let specularPower = mix(128.0, 4.0, roughness);
+  let dielectricReflectance = vec3<f32>(0.04);
+  let reflectance = mix(dielectricReflectance, baseColor, metallic);
+  let maximumReflectance = max(reflectance.r, max(reflectance.g, reflectance.b));
+  let grazingReflectance = vec3<f32>(clamp(maximumReflectance * 25.0, 0.0, 1.0));
+  let alphaRoughness = roughness * roughness;
+  let alphaRoughnessSquared = alphaRoughness * alphaRoughness;
+  let diffuse = baseColor * (vec3<f32>(1.0) - dielectricReflectance) *
+    (1.0 - metallic) / PI;
+  let normalView = clamp(abs(dot(normal, viewDirection)), 0.001, 1.0);
   var result = primitive.emissive.rgb;
   let directLightCount = u32(max(uniforms.temporal.y, 0.0));
   let boundedDirectLightCount = max(directLightCount, 1u);
@@ -762,9 +768,24 @@ fn evaluateDirectLighting(ray: Ray, hit: RayHit) -> vec3<f32> {
     let halfDirection = normalize(lightDirection + viewDirection);
     let normalHalf = max(dot(normal, halfDirection), 0.0);
     let viewHalf = max(dot(viewDirection, halfDirection), 0.0);
-    let fresnel = reflectance + (vec3<f32>(1.0) - reflectance) * pow(1.0 - viewHalf, 5.0);
-    let specular = fresnel * pow(normalHalf, specularPower) * (specularPower + 2.0) / (2.0 * PI);
-    result += (diffuse + specular) * lightColor * normalLight * attenuation * lightSampleWeight;
+    let fresnel = reflectance + (grazingReflectance - reflectance) *
+      pow(clamp(1.0 - viewHalf, 0.0, 1.0), 5.0);
+    let distributionDenominator =
+      (normalHalf * alphaRoughnessSquared - normalHalf) * normalHalf + 1.0;
+    let distribution = alphaRoughnessSquared /
+      (PI * distributionDenominator * distributionDenominator);
+    let lightVisibility = 2.0 * normalLight /
+      (normalLight + sqrt(alphaRoughnessSquared +
+        (1.0 - alphaRoughnessSquared) * normalLight * normalLight));
+    let viewVisibility = 2.0 * normalView /
+      (normalView + sqrt(alphaRoughnessSquared +
+        (1.0 - alphaRoughnessSquared) * normalView * normalView));
+    let geometricOcclusion = lightVisibility * viewVisibility;
+    let diffuseContribution = (vec3<f32>(1.0) - fresnel) * diffuse;
+    let specular = fresnel * geometricOcclusion * distribution /
+      (4.0 * normalLight * normalView);
+    result += (diffuseContribution + specular) * lightColor * normalLight *
+      attenuation * lightSampleWeight;
   }
 
   if (uniforms.fog.w > 0.0) {
@@ -1016,10 +1037,16 @@ fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
   let sampleCount = clamp(u32(uniforms.settings.z), 1u, 16u);
   let guideRay = makeGuideCameraRay(pixel);
   let guideHit = intersectScene(guideRay, RAY_INFINITY);
+  let useStableGuideSample = sampleCount == 1u &&
+    uniforms.previousCameraPosition.w < 0.5 && uniforms.temporal.w < 0.5;
   var accumulatedColor = vec3<f32>(0.0);
   for (var sampleIndex = 0u; sampleIndex < sampleCount; sampleIndex++) {
-    let ray = makeCameraRay(pixel, sampleIndex);
-    let hit = intersectScene(ray, RAY_INFINITY);
+    var ray = guideRay;
+    var hit = guideHit;
+    if (!useStableGuideSample) {
+      ray = makeCameraRay(pixel, sampleIndex);
+      hit = intersectScene(ray, RAY_INFINITY);
+    }
     var color = uniforms.background.rgb;
     if (hit.distance < RAY_INFINITY) {
       color = evaluateDirectLighting(ray, hit);
@@ -1054,8 +1081,21 @@ fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
 }
 `;
 
-/** Resolves accumulated ray colors while preserving linear HDR presentation. */
-export function getRayTracingScenePresentationShader(highDynamicRange: boolean): string {
+/** Compile-time presentation controls shared with the canonical forward PBR renderer. */
+export type RayTracingPresentationOptions = {
+  /** Zero disables tone mapping; one selects Reinhard, two Khronos Neutral, three ACES. */
+  toneMapMode: number;
+  /** Zero preserves linear color; one applies the exact sRGB transfer function. */
+  outputEncoding: number;
+};
+
+/** Resolves retained ray radiance with attachment-aware, canonical PBR color management. */
+export function getRayTracingScenePresentationShader(
+  options: RayTracingPresentationOptions | boolean
+): string {
+  const toneMapMode = typeof options === 'boolean' ? (options ? 0 : 2) : options.toneMapMode;
+  const outputEncoding = typeof options === 'boolean' ? (options ? 0 : 1) : options.outputEncoding;
+
   return /* wgsl */ `
 @group(0) @binding(0) var image: texture_2d<f32>;
 
@@ -1096,14 +1136,56 @@ fn sampleRayTracingImage(textureCoordinates: vec2<f32>) -> vec3<f32> {
   return mix(mix(topLeft, topRight, fraction.x), mix(bottomLeft, bottomRight, fraction.x), fraction.y);
 }
 
+fn encodeRayTracingLinearSRGB(linearColor: vec3<f32>) -> vec3<f32> {
+  let positiveColor = max(linearColor, vec3<f32>(0.0));
+  return select(
+    positiveColor * 12.92,
+    1.055 * pow(positiveColor, vec3<f32>(1.0 / 2.4)) - 0.055,
+    positiveColor > vec3<f32>(0.0031308)
+  );
+}
+
+fn toneMapRayTracingKhronosPBRNeutral(inputColor: vec3<f32>) -> vec3<f32> {
+  let startCompression = 0.76;
+  let darkestChannel = min(inputColor.r, min(inputColor.g, inputColor.b));
+  let offset = select(
+    0.04,
+    darkestChannel - 6.25 * darkestChannel * darkestChannel,
+    darkestChannel < 0.08
+  );
+  var color = inputColor - vec3<f32>(offset);
+  let peak = max(color.r, max(color.g, color.b));
+  if (peak < startCompression) {
+    return color;
+  }
+
+  let compressionRange = 1.0 - startCompression;
+  let compressedPeak = 1.0 - compressionRange * compressionRange /
+    (peak + compressionRange - startCompression);
+  color *= compressedPeak / max(peak, 0.0001);
+  let desaturation = 1.0 - 1.0 / (0.15 * (peak - compressedPeak) + 1.0);
+  return mix(color, vec3<f32>(compressedPeak), desaturation);
+}
+
 @fragment
 fn fragmentMain(@location(0) textureCoordinates: vec2<f32>) -> @location(0) vec4<f32> {
   let radiance = sampleRayTracingImage(textureCoordinates);
-  if (${highDynamicRange}) {
-    return vec4<f32>(radiance, 1.0);
+  var color = max(radiance, vec3<f32>(0.0));
+  if (${toneMapMode} == 1) {
+    color /= vec3<f32>(1.0) + color;
+  } else if (${toneMapMode} == 2) {
+    color = toneMapRayTracingKhronosPBRNeutral(color);
+  } else if (${toneMapMode} == 3) {
+    color = clamp(
+      (color * (2.51 * color + 0.03)) / (color * (2.43 * color + 0.59) + 0.14),
+      vec3<f32>(0.0),
+      vec3<f32>(1.0)
+    );
   }
-  let mappedColor = vec3<f32>(1.0) - exp(-radiance);
-  return vec4<f32>(pow(max(mappedColor, vec3<f32>(0.0)), vec3<f32>(1.0 / 2.2)), 1.0);
+  if (${outputEncoding} == 0) {
+    return vec4<f32>(color, 1.0);
+  }
+  return vec4<f32>(encodeRayTracingLinearSRGB(color), 1.0);
 }
 `;
 }

--- a/modules/experimental/src/engine/scene-renderer.ts
+++ b/modules/experimental/src/engine/scene-renderer.ts
@@ -157,6 +157,30 @@ export type SceneRenderOptions = {
   renderMode?: 'default' | 'debugNormals' | 'debugDepth';
 };
 
+/** Synchronous encoding costs for one graph-owned ray-tracing stage. */
+export type RayTracingGraphStageStatistics = {
+  /** Number of logical graph nodes encoded for this stage. */
+  nodeCount: number;
+  /** Number of physical compute passes opened by this stage. */
+  computePassCount: number;
+  /** Number of logical compute nodes merged into an existing physical pass. */
+  coalescedComputeNodeCount: number;
+  /** Synchronous CPU time spent recording this stage into the caller-owned encoder. */
+  cpuEncodeTimeMilliseconds: number;
+};
+
+/** Per-frame graph totals and the individual stages actually encoded for a ray-traced frame. */
+export type RayTracingGraphStatistics = RayTracingGraphStageStatistics & {
+  /** Mesh topology construction; present only when geometry changes. */
+  topology?: RayTracingGraphStageStatistics;
+  /** Morton TLAS construction; mutually exclusive with `refit`. */
+  acceleration?: RayTracingGraphStageStatistics;
+  /** Retained-order TLAS refit; mutually exclusive with `acceleration`. */
+  refit?: RayTracingGraphStageStatistics;
+  /** Ray tracing, optional sparse carry, and presentation for the current frame. */
+  trace: RayTracingGraphStageStatistics;
+};
+
 /** Draw statistics returned by the shared scene rendering contract. */
 export type SceneRenderStatistics = {
   surfaceCount: number;
@@ -171,6 +195,8 @@ export type SceneRenderStatistics = {
     sampledPixelCoverage: number;
     frameTimeMilliseconds: number;
     accumulatedSamples: number;
+    /** Optional synchronous graph-stage diagnostics; never submits, waits, or reads back. */
+    graph?: RayTracingGraphStatistics;
   };
 };
 
@@ -703,7 +729,7 @@ function setSceneShaderInputs(
       projectionMatrix,
       ...(transmissionTexture ? {pbr_transmissionFramebufferSampler: transmissionTexture} : {})
     },
-    lighting: {lights: Array.from(options.lights || []), useByteColors: false},
+    lighting: {lights: getScenePBRLights(options.lights), useByteColors: false},
     ...(hasCompleteEnvironment(options.environment)
       ? {
           ibl: {
@@ -714,6 +740,36 @@ function setSceneShaderInputs(
         }
       : {})
   });
+}
+
+/** Adapts incoming directional vectors and additive ambient radiance to forward PBR conventions. */
+function getScenePBRLights(lights: readonly Light[] = []): Light[] {
+  const adaptedLights = lights.map<Light>(light =>
+    light.type === 'directional'
+      ? {
+          ...light,
+          direction: [-light.direction[0], -light.direction[1], -light.direction[2]]
+        }
+      : light
+  );
+  const ambientLights = adaptedLights.filter(light => light.type === 'ambient');
+  if (ambientLights.length <= 1) {
+    return adaptedLights;
+  }
+
+  const ambientColor: [number, number, number] = [0, 0, 0];
+  for (const ambientLight of ambientLights) {
+    const color = ambientLight.color ?? [1, 1, 1];
+    const intensity = ambientLight.intensity ?? 1;
+    ambientColor[0] += color[0] * intensity;
+    ambientColor[1] += color[1] * intensity;
+    ambientColor[2] += color[2] * intensity;
+  }
+
+  return [
+    {type: 'ambient', color: ambientColor, intensity: 1},
+    ...adaptedLights.filter(light => light.type !== 'ambient')
+  ];
 }
 
 function hasCompleteEnvironment(environment?: SceneEnvironment): boolean {

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph-types.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph-types.ts
@@ -475,7 +475,12 @@ export type GPUCommandGraphComputeExecutable<Parameters> = {
 
 /** Compiled render-pass callback. */
 export type GPUCommandGraphRenderExecutable<Parameters> = {
-  /** Returns per-encoding render-pass options other than graph-declared attachments. */
+  /**
+   * Returns per-encoding render-pass options.
+   *
+   * A caller-owned framebuffer may be supplied only when the node does not declare graph-managed
+   * attachments. External framebuffer textures do not participate in graph hazard inference.
+   */
   getRenderPassProps?: (context: GPUCommandGraphEncodeContext<Parameters>) => RenderPassProps;
   /** Records commands into the render pass opened by the graph. */
   encode: (context: GPUCommandGraphEncodeContext<Parameters> & {renderPass: RenderPass}) => void;

--- a/modules/experimental/src/index.ts
+++ b/modules/experimental/src/index.ts
@@ -16,6 +16,8 @@ export type {CreatePBRModelOptions} from './engine/pbr-model';
 export {createPBRModel, getPBRGeometryDefines, getPBRTextureDefines} from './engine/pbr-model';
 export type {
   PreparedScene,
+  RayTracingGraphStageStatistics,
+  RayTracingGraphStatistics,
   SceneAlphaMode,
   SceneCamera,
   SceneEnvironment,

--- a/modules/experimental/test/engine/ray-tracing-scene-renderer.spec.ts
+++ b/modules/experimental/test/engine/ray-tracing-scene-renderer.spec.ts
@@ -432,6 +432,30 @@ test('RayTracingSceneRenderer builds and traverses Morton TLAS and mesh BLAS wit
       2,
       'ray-tracing telemetry reports samples per pixel rather than encoded frames'
     );
+    const initialGraphStatistics = initialStatistics.rayTracing?.graph;
+    testCase.ok(
+      initialGraphStatistics?.topology && initialGraphStatistics.acceleration,
+      'the initial frame reports its independently encoded topology and Morton acceleration stages'
+    );
+    testCase.notOk(
+      initialGraphStatistics?.refit,
+      'a full Morton acceleration build does not also report an unused refit stage'
+    );
+    testCase.equal(
+      initialGraphStatistics?.nodeCount,
+      (initialGraphStatistics?.topology?.nodeCount ?? 0) +
+        (initialGraphStatistics?.acceleration?.nodeCount ?? 0) +
+        (initialGraphStatistics?.trace.nodeCount ?? 0),
+      'aggregate graph telemetry counts only stages encoded during the current frame'
+    );
+    testCase.ok(
+      (initialGraphStatistics?.coalescedComputeNodeCount ?? 0) > 0,
+      'graph telemetry exposes logical compute nodes coalesced into physical passes'
+    );
+    testCase.ok(
+      (initialGraphStatistics?.cpuEncodeTimeMilliseconds ?? -1) >= 0,
+      'graph telemetry reports synchronous CPU encoding cost without GPU readback'
+    );
     const initialColorHistory = frameResources.colorHistory.previousTexture;
     const initialColorOutput = frameResources.colorHistory.currentTexture;
     const initialMetadataHistory = frameResources.metadataHistory.previousTexture;
@@ -451,6 +475,17 @@ test('RayTracingSceneRenderer builds and traverses Morton TLAS and mesh BLAS wit
       accumulatedStatistics.rayTracing?.accumulatedSamples,
       4,
       'progressive telemetry accumulates the requested samples per pixel'
+    );
+    testCase.notOk(
+      accumulatedStatistics.rayTracing?.graph?.topology ||
+        accumulatedStatistics.rayTracing?.graph?.acceleration ||
+        accumulatedStatistics.rayTracing?.graph?.refit,
+      'an unchanged frame reports only its trace/presentation graph stage'
+    );
+    testCase.equal(
+      accumulatedStatistics.rayTracing?.graph?.nodeCount,
+      accumulatedStatistics.rayTracing?.graph?.trace.nodeCount,
+      'unchanged-frame aggregate counts exactly match the trace graph'
     );
     testCase.equal(
       frameResources.colorHistory.previousTexture,
@@ -530,6 +565,11 @@ test('RayTracingSceneRenderer builds and traverses Morton TLAS and mesh BLAS wit
       getRayTracingFrameResources(renderer, options.id).refitsSinceMortonRebuild > 0,
       'same-count transform animation uses the retained-permutation refit path'
     );
+    testCase.ok(
+      refittedStatistics.rayTracing?.graph?.refit &&
+        !refittedStatistics.rayTracing.graph.acceleration,
+      'transform-only telemetry reports the retained TLAS refit without a full rebuild'
+    );
     testCase.notOk(
       getRayTracingFrameResources(renderer, options.id).topologyNeedsUpdate,
       'same-count transform animation reuses the topology-only BLAS graph'
@@ -557,6 +597,11 @@ test('RayTracingSceneRenderer builds and traverses Morton TLAS and mesh BLAS wit
       getRayTracingFrameResources(renderer, options.id).refitsSinceMortonRebuild,
       0,
       'topology-changing shrink rebuilds the Morton order before removing inactive leaves'
+    );
+    testCase.ok(
+      reducedStatistics.rayTracing?.graph?.acceleration &&
+        !reducedStatistics.rayTracing.graph.refit,
+      'topology-changing telemetry reports the rebuilt Morton acceleration stage'
     );
     testCase.ok(
       getRayTracingFrameResources(renderer, options.id).previousTransformsNeedCommit,

--- a/modules/experimental/test/engine/ray-tracing-scene-shaders.node.spec.ts
+++ b/modules/experimental/test/engine/ray-tracing-scene-shaders.node.spec.ts
@@ -480,8 +480,13 @@ describe('graph-accelerated ray tracing shaders', () => {
       )
     ).toHaveLength(1);
     for (const invariant of [
-      'let diffuse = baseColor * (1.0 - metallic) / PI',
-      'let specularPower = mix(128.0, 4.0, roughness)',
+      'let dielectricReflectance = vec3<f32>(0.04)',
+      'let reflectance = mix(dielectricReflectance, baseColor, metallic)',
+      'let grazingReflectance = vec3<f32>(clamp(maximumReflectance * 25.0, 0.0, 1.0))',
+      'let alphaRoughness = roughness * roughness',
+      'let alphaRoughnessSquared = alphaRoughness * alphaRoughness',
+      'let diffuse = baseColor * (vec3<f32>(1.0) - dielectricReflectance)',
+      'let normalView = clamp(abs(dot(normal, viewDirection)), 0.001, 1.0)',
       'let lightSampleWeight = f32(directLightCount) / f32(max(shadowSampleCount, 1u))'
     ]) {
       const invariantIndex = functionSource.indexOf(invariant);
@@ -497,6 +502,39 @@ describe('graph-accelerated ray tracing shaders', () => {
     expect(pointLightBranch).toBeGreaterThan(loopStart);
     expect(directionalNormalization).toBeGreaterThan(pointLightBranch);
     expect(functionSource.match(/normalize\(-light\.directionType\.xyz\)/g)).toHaveLength(1);
+  });
+
+  test('matches canonical energy-balanced GGX, Smith visibility, and Schlick Fresnel', () => {
+    const functionStart = RAY_TRACING_SCENE_SHADER.indexOf('fn evaluateDirectLighting(');
+    const functionEnd = RAY_TRACING_SCENE_SHADER.indexOf('\nfn ', functionStart + 1);
+    const functionSource = RAY_TRACING_SCENE_SHADER.slice(functionStart, functionEnd);
+
+    expect(functionSource).toContain('let roughness = clamp(primitive.properties.x, 0.04, 1.0)');
+    expect(functionSource).toContain('let metallic = clamp(primitive.emissive.w, 0.0, 1.0)');
+    expect(functionSource).toContain(
+      'let maximumReflectance = max(reflectance.r, max(reflectance.g, reflectance.b))'
+    );
+    expect(functionSource).toContain('grazingReflectance - reflectance');
+    expect(functionSource).toContain('pow(clamp(1.0 - viewHalf, 0.0, 1.0), 5.0)');
+    expect(functionSource).toContain(
+      '(normalHalf * alphaRoughnessSquared - normalHalf) * normalHalf + 1.0'
+    );
+    expect(functionSource).toContain(
+      'alphaRoughnessSquared /\n      (PI * distributionDenominator * distributionDenominator)'
+    );
+    expect(functionSource).toContain('let lightVisibility = 2.0 * normalLight');
+    expect(functionSource).toContain('let viewVisibility = 2.0 * normalView');
+    expect(functionSource).toContain('let geometricOcclusion = lightVisibility * viewVisibility');
+    expect(functionSource).toContain(
+      'let diffuseContribution = (vec3<f32>(1.0) - fresnel) * diffuse'
+    );
+    expect(functionSource).toContain(
+      'let specular = fresnel * geometricOcclusion * distribution /'
+    );
+    expect(functionSource).toContain('(4.0 * normalLight * normalView)');
+    expect(functionSource).toContain('result += baseColor * lightColor');
+    expect(functionSource).not.toContain('specularPower');
+    expect(functionSource).not.toContain('pow(normalHalf,');
   });
 
   test('uses a stable guide ray and low-discrepancy radiance samples', () => {
@@ -525,6 +563,46 @@ describe('graph-accelerated ray tracing shaders', () => {
     expect(orthographicBranch).toBeGreaterThan(farPoint);
     expect(nearPoint).toBeGreaterThan(orthographicBranch);
     expect(cameraRaySource).not.toContain('let nearPosition =');
+  });
+
+  test('reuses the centered guide hit only for explicitly non-temporal single samples', () => {
+    const mainStart = RAY_TRACING_SCENE_SHADER.indexOf('@compute @workgroup_size(8, 8, 1)');
+    const mainSource = RAY_TRACING_SCENE_SHADER.slice(mainStart);
+    const guideHitIndex = mainSource.indexOf(
+      'let guideHit = intersectScene(guideRay, RAY_INFINITY)'
+    );
+    const stableGuardIndex = mainSource.indexOf('let useStableGuideSample = sampleCount == 1u');
+    const loopIndex = mainSource.indexOf(
+      'for (var sampleIndex = 0u; sampleIndex < sampleCount; sampleIndex++)'
+    );
+    const reusedRayIndex = mainSource.indexOf('var ray = guideRay');
+    const reusedHitIndex = mainSource.indexOf('var hit = guideHit');
+    const jitterGuardIndex = mainSource.indexOf('if (!useStableGuideSample)');
+    const jitteredRayIndex = mainSource.indexOf('ray = makeCameraRay(pixel, sampleIndex)');
+    const tracedHitIndex = mainSource.indexOf('hit = intersectScene(ray, RAY_INFINITY)');
+
+    expect(guideHitIndex).toBeGreaterThan(0);
+    expect(stableGuardIndex).toBeGreaterThan(guideHitIndex);
+    expect(mainSource).toContain('uniforms.previousCameraPosition.w < 0.5');
+    expect(mainSource).toContain('uniforms.temporal.w < 0.5');
+    expect(loopIndex).toBeGreaterThan(stableGuardIndex);
+    expect(reusedRayIndex).toBeGreaterThan(loopIndex);
+    expect(reusedHitIndex).toBeGreaterThan(reusedRayIndex);
+    expect(jitterGuardIndex).toBeGreaterThan(reusedHitIndex);
+    expect(jitteredRayIndex).toBeGreaterThan(jitterGuardIndex);
+    expect(tracedHitIndex).toBeGreaterThan(jitteredRayIndex);
+    expect(mainSource.match(/intersectScene\(/g)).toHaveLength(2);
+
+    for (const [sampleCount, progressive, temporalReprojection, reusesGuide] of [
+      [1, false, false, true],
+      [1, true, false, false],
+      [1, false, true, false],
+      [1, true, true, false],
+      [2, false, false, false],
+      [16, false, false, false]
+    ] as const) {
+      expect(sampleCount === 1 && !progressive && !temporalReprojection).toBe(reusesGuide);
+    }
   });
 
   test('reprojects bilinear per-instance radiance and rejects invalid history', () => {
@@ -615,24 +693,67 @@ describe('graph-accelerated ray tracing shaders', () => {
     }
   });
 
-  test('manually reconstructs full-resolution HDR and SDR presentation without a sampler', () => {
-    for (const highDynamicRange of [false, true]) {
-      const presentationShader = getRayTracingScenePresentationShader(highDynamicRange);
-      const reflection = new WgslReflect(presentationShader);
+  test('manually reconstructs every canonical tone map and output encoding without new bindings', () => {
+    for (const toneMapMode of [0, 1, 2, 3]) {
+      for (const outputEncoding of [0, 1]) {
+        const presentationShader = getRayTracingScenePresentationShader({
+          toneMapMode,
+          outputEncoding
+        });
+        const reflection = new WgslReflect(presentationShader);
 
-      expect(reflection.entry.vertex.map(({name}) => name)).toEqual(['vertexMain']);
-      expect(reflection.entry.fragment.map(({name}) => name)).toEqual(['fragmentMain']);
-      expect(reflection.textures.map(({name, binding}) => ({name, binding}))).toEqual([
-        {name: 'image', binding: 0}
-      ]);
-      expect(reflection.uniforms).toHaveLength(0);
-      expect(presentationShader).toContain('textureDimensions(image)');
-      expect(presentationShader).toContain('let topLeft = textureLoad');
-      expect(presentationShader).toContain('let topRight = textureLoad');
-      expect(presentationShader).toContain('let bottomLeft = textureLoad');
-      expect(presentationShader).toContain('let bottomRight = textureLoad');
-      expect(presentationShader).toContain('vec4<f32>(radiance, 1.0)');
-      expect(presentationShader).not.toContain('@binding(1)');
+        expect(reflection.entry.vertex.map(({name}) => name)).toEqual(['vertexMain']);
+        expect(reflection.entry.fragment.map(({name}) => name)).toEqual(['fragmentMain']);
+        expect(reflection.textures.map(({name, binding}) => ({name, binding}))).toEqual([
+          {name: 'image', binding: 0}
+        ]);
+        expect(reflection.uniforms).toHaveLength(0);
+        expect(presentationShader).toContain('textureDimensions(image)');
+        expect(presentationShader).toContain('let topLeft = textureLoad');
+        expect(presentationShader).toContain('let topRight = textureLoad');
+        expect(presentationShader).toContain('let bottomLeft = textureLoad');
+        expect(presentationShader).toContain('let bottomRight = textureLoad');
+        expect(presentationShader).toContain(`if (${toneMapMode} == 1)`);
+        expect(presentationShader).toContain(`if (${outputEncoding} == 0)`);
+        expect(presentationShader).toContain('vec4<f32>(color, 1.0)');
+        expect(presentationShader).not.toContain('@binding(1)');
+      }
+    }
+  });
+
+  test('uses the exact canonical Khronos Neutral, ACES, and linear-to-sRGB equations', () => {
+    const presentationShader = getRayTracingScenePresentationShader({
+      toneMapMode: 2,
+      outputEncoding: 1
+    });
+
+    expect(presentationShader).toContain('fn toneMapRayTracingKhronosPBRNeutral(');
+    expect(presentationShader).toContain('let startCompression = 0.76');
+    expect(presentationShader).toContain('darkestChannel - 6.25 * darkestChannel * darkestChannel');
+    expect(presentationShader).toContain('let compressedPeak = 1.0 - compressionRange');
+    expect(presentationShader).toContain('0.15 * (peak - compressedPeak) + 1.0');
+    expect(presentationShader).toContain('color /= vec3<f32>(1.0) + color');
+    expect(presentationShader).toContain(
+      '(color * (2.51 * color + 0.03)) / (color * (2.43 * color + 0.59) + 0.14)'
+    );
+    expect(presentationShader).toContain('fn encodeRayTracingLinearSRGB(');
+    expect(presentationShader).toContain('positiveColor * 12.92');
+    expect(presentationShader).toContain(
+      '1.055 * pow(positiveColor, vec3<f32>(1.0 / 2.4)) - 0.055'
+    );
+    expect(presentationShader).toContain('positiveColor > vec3<f32>(0.0031308)');
+    expect(presentationShader).not.toContain('exp(-radiance)');
+    expect(presentationShader).not.toContain('1.0 / 2.2');
+  });
+
+  test('keeps the prior boolean presentation shortcut compatible during graph migration', () => {
+    for (const [highDynamicRange, toneMapMode, outputEncoding] of [
+      [true, 0, 0],
+      [false, 2, 1]
+    ] as const) {
+      expect(getRayTracingScenePresentationShader(highDynamicRange)).toEqual(
+        getRayTracingScenePresentationShader({toneMapMode, outputEncoding})
+      );
     }
   });
 });

--- a/modules/experimental/test/engine/scene-next-pbr-materials.spec.ts
+++ b/modules/experimental/test/engine/scene-next-pbr-materials.spec.ts
@@ -29,12 +29,7 @@ test('SceneRenderer exchanges diffuse reflection for backlit transmission and bo
     const renderer = new SceneRenderer(device);
     const target = makeExperimentalMaterialTarget(device);
     const surface = makeExperimentalMaterialSurface(device);
-    const options = makeExperimentalMaterialOptions(
-      device,
-      surface,
-      target.framebuffer,
-      [0, 0, -1]
-    );
+    const options = makeExperimentalMaterialOptions(device, surface, target.framebuffer, [0, 0, 1]);
 
     try {
       testCase.equal(renderer.render(options).drawCount, 1, `${device.type} renders backlit PBR`);
@@ -63,7 +58,7 @@ test('SceneRenderer exchanges diffuse reflection for backlit transmission and bo
         testCase.equal(transmittedBacklight[3], 255, `${device.type} preserves opaque alpha`);
 
         options.lights = [
-          {type: 'directional', color: [1, 1, 1], direction: [0, 0, 1], intensity: 3}
+          {type: 'directional', color: [1, 1, 1], direction: [0, 0, -1], intensity: 3}
         ];
         surface.material.uniforms = {
           ...surface.material.uniforms,
@@ -87,7 +82,7 @@ test('SceneRenderer exchanges diffuse reflection for backlit transmission and bo
         );
 
         options.lights = [
-          {type: 'directional', color: [1, 1, 1], direction: [0, 0, -1], intensity: 3}
+          {type: 'directional', color: [1, 1, 1], direction: [0, 0, 1], intensity: 3}
         ];
         surface.material.uniforms = {
           ...surface.material.uniforms,
@@ -154,7 +149,7 @@ test('SceneRenderer specializes bump, diffuse alpha/color, and draft scatter tex
       device,
       surface,
       target.framebuffer,
-      [0.8, 0, 0.6]
+      [-0.8, 0, -0.6]
     );
     surface.material.bindings = {
       pbr_normalSampler: normalTexture,
@@ -202,7 +197,7 @@ test('SceneRenderer specializes bump, diffuse alpha/color, and draft scatter tex
         scatterAnisotropy: 0.15
       };
       options.lights = [
-        {type: 'directional', color: [1, 1, 1], direction: [0, 0, -1], intensity: 3}
+        {type: 'directional', color: [1, 1, 1], direction: [0, 0, 1], intensity: 3}
       ];
 
       testCase.equal(

--- a/modules/experimental/test/engine/scene-renderer-lighting-parity.spec.ts
+++ b/modules/experimental/test/engine/scene-renderer-lighting-parity.spec.ts
@@ -1,0 +1,636 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer, type Device, type Framebuffer, Texture} from '@luma.gl/core';
+import {SphereGeometry} from '@luma.gl/engine';
+import {
+  DeferredSceneRenderer,
+  RayTracingSceneRenderer,
+  type RayTracingSceneRenderOptions,
+  SceneRenderer,
+  type SceneSurface
+} from '@luma.gl/experimental';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import {Matrix4} from '@math.gl/core';
+import test from 'test/utils/vitest-tape';
+
+type LightingParityTarget = {
+  color: Texture;
+  depth?: Texture;
+  framebuffer: Framebuffer;
+  destroy(): void;
+};
+
+type LightingParityRenderer = {
+  id: string;
+  renderer: SceneRenderer | DeferredSceneRenderer | RayTracingSceneRenderer;
+};
+
+test('forward, deferred, and ray tracing honor the same incoming directional-light hemisphere', async testCase => {
+  const device = await getWebGPUTestDevice('core');
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const width = 35;
+  const height = 29;
+  const target = makeLightingParityTarget(device, width, height, 'rgba8unorm', true);
+  const surface = makeLightingParitySurface();
+  const renderers: LightingParityRenderer[] = [
+    {id: 'forward', renderer: new SceneRenderer(device)},
+    {id: 'deferred', renderer: new DeferredSceneRenderer(device)},
+    {id: 'ray-tracing', renderer: new RayTracingSceneRenderer(device)}
+  ];
+
+  try {
+    for (const {id, renderer} of renderers) {
+      const options = makeLightingParityOptions(id, surface, target.framebuffer);
+      const frontStatistics = renderer.render(options);
+      device.submit();
+      const frontPixel = await readLightingParityPixel(target.color, 17, 14);
+
+      if (id === 'ray-tracing') {
+        testCase.equal(
+          frontStatistics.rayTracing?.internalWidth,
+          width,
+          'ray tracing derives its odd internal width from the supplied framebuffer'
+        );
+        testCase.equal(
+          frontStatistics.rayTracing?.internalHeight,
+          height,
+          'ray tracing derives its odd internal height from the supplied framebuffer'
+        );
+        testCase.ok(
+          frontStatistics.rayTracing?.graph?.topology,
+          'the first ray-traced frame exposes encoded mesh-topology work'
+        );
+        testCase.ok(
+          frontStatistics.rayTracing?.graph?.acceleration,
+          'the first ray-traced frame exposes encoded TLAS construction'
+        );
+        testCase.ok(
+          frontStatistics.rayTracing?.graph?.trace.nodeCount,
+          'the first ray-traced frame exposes encoded tracing and presentation work'
+        );
+      }
+
+      options.lights = [makeIncomingDirectionalLight([0, 0, 1])];
+      const backStatistics = renderer.render(options);
+      device.submit();
+      const backPixel = await readLightingParityPixel(target.color, 17, 14);
+
+      testCase.ok(
+        frontPixel[0] > backPixel[0] + 15,
+        `${id} illuminates the camera-facing hemisphere only for incoming negative-Z light ` +
+          `(${frontPixel[0]} versus ${backPixel[0]})`
+      );
+
+      if (id === 'ray-tracing') {
+        testCase.equal(
+          backStatistics.rayTracing?.graph?.topology,
+          undefined,
+          'light-only changes do not encode mesh-topology work'
+        );
+        testCase.equal(
+          backStatistics.rayTracing?.graph?.acceleration,
+          undefined,
+          'light-only changes do not rebuild the TLAS'
+        );
+        testCase.equal(
+          backStatistics.rayTracing?.graph?.refit,
+          undefined,
+          'light-only changes do not refit the TLAS'
+        );
+      }
+
+      options.lights = [makeIncomingDirectionalLight([-1, 0, -0.35])];
+      renderer.render(options);
+      device.submit();
+      const rightIlluminatedLeftPixel = await readLightingParityPixel(target.color, 13, 14);
+      const rightIlluminatedRightPixel = await readLightingParityPixel(target.color, 21, 14);
+
+      options.lights = [makeIncomingDirectionalLight([1, 0, -0.35])];
+      renderer.render(options);
+      device.submit();
+      const leftIlluminatedLeftPixel = await readLightingParityPixel(target.color, 13, 14);
+      const leftIlluminatedRightPixel = await readLightingParityPixel(target.color, 21, 14);
+
+      testCase.ok(
+        rightIlluminatedRightPixel[0] > rightIlluminatedLeftPixel[0] + 5,
+        `${id} places positive-X illumination on the visible right hemisphere`
+      );
+      testCase.ok(
+        leftIlluminatedLeftPixel[0] > leftIlluminatedRightPixel[0] + 5,
+        `${id} mirrors highlights when the incoming light direction is reversed`
+      );
+    }
+  } finally {
+    for (const {renderer} of renderers) {
+      renderer.destroy();
+    }
+    target.destroy();
+  }
+
+  testCase.end();
+});
+
+test('forward, deferred, and ray tracing add multiple independently colored ambient lights', async testCase => {
+  const device = await getWebGPUTestDevice('core');
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const target = makeLightingParityTarget(device, 35, 29, 'rgba8unorm', true);
+  const surface = makeLightingParitySurface();
+  const renderers: LightingParityRenderer[] = [
+    {id: 'forward', renderer: new SceneRenderer(device)},
+    {id: 'deferred', renderer: new DeferredSceneRenderer(device)},
+    {id: 'ray-tracing', renderer: new RayTracingSceneRenderer(device)}
+  ];
+  const redAmbientLight = {
+    type: 'ambient' as const,
+    color: [1, 0, 0] as [number, number, number],
+    intensity: 0.45
+  };
+  const greenAmbientLight = {
+    type: 'ambient' as const,
+    color: [0, 1, 0] as [number, number, number],
+    intensity: 0.65
+  };
+
+  try {
+    for (const {id, renderer} of renderers) {
+      const options = makeLightingParityOptions(
+        `${id}-multiple-ambient`,
+        surface,
+        target.framebuffer
+      );
+      options.lights = [redAmbientLight, greenAmbientLight];
+
+      renderer.render(options);
+      device.submit();
+      const pixel = await readLightingParityPixel(target.color, 17, 14);
+
+      testCase.ok(pixel[0] > 10, `${id} retains the first independently colored ambient light`);
+      testCase.ok(pixel[1] > 10, `${id} adds the second independently colored ambient light`);
+      testCase.ok(pixel[2] < 5, `${id} does not introduce unlit blue ambient radiance`);
+      testCase.equal(options.lights[0], redAmbientLight, `${id} preserves the first source light`);
+      testCase.equal(
+        options.lights[1],
+        greenAmbientLight,
+        `${id} preserves the second source light`
+      );
+    }
+  } finally {
+    for (const {renderer} of renderers) {
+      renderer.destroy();
+    }
+    target.destroy();
+  }
+
+  testCase.end();
+});
+
+test('ray tracing renders linear HDR into caller-owned depthless offscreen targets', async testCase => {
+  const device = await getWebGPUTestDevice('core');
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const renderer = new RayTracingSceneRenderer(device);
+  const surface = makeLightingParitySurface();
+  const highDynamicRangeTarget = makeLightingParityTarget(device, 19, 17, 'rgba16float', false);
+  const replacementHighDynamicRangeTarget = makeLightingParityTarget(
+    device,
+    19,
+    17,
+    'rgba16float',
+    false
+  );
+  const standardTarget = makeLightingParityTarget(device, 23, 15, 'rgba8unorm', false);
+  const supportsHardwareSRGB = device.getTextureFormatCapabilities('rgba8unorm-srgb').render;
+  const hardwareSRGBTarget = supportsHardwareSRGB
+    ? makeLightingParityTarget(device, 23, 15, 'rgba8unorm-srgb', false)
+    : undefined;
+
+  try {
+    const options = makeLightingParityOptions(
+      'ray-tracing-depthless-hdr',
+      surface,
+      highDynamicRangeTarget.framebuffer
+    );
+    options.lights = [makeIncomingDirectionalLight([0, 0, -1], 12)];
+    delete options.toneMapMode;
+    delete options.outputColorSpace;
+
+    const highDynamicRangeStatistics = renderer.render(options);
+    device.submit();
+    const highDynamicRangePixel = await readLightingParityFloat16Pixel(
+      highDynamicRangeTarget.color,
+      9,
+      8
+    );
+
+    testCase.equal(
+      highDynamicRangeStatistics.rayTracing?.internalWidth,
+      19,
+      'a depthless HDR framebuffer controls the odd internal width'
+    );
+    testCase.equal(
+      highDynamicRangeStatistics.rayTracing?.internalHeight,
+      17,
+      'a depthless HDR framebuffer controls the odd internal height'
+    );
+    testCase.ok(
+      highDynamicRangePixel[0] > 1,
+      `linear rgba16float presentation preserves unclamped radiance (${highDynamicRangePixel[0]})`
+    );
+    testCase.deepEqual(
+      getLightingParityPresentation(renderer, options.id),
+      {colorFormat: 'rgba16float', toneMapMode: 0, outputEncoding: 0},
+      'floating-point attachments default to untonemapped linear presentation'
+    );
+
+    const originalTraceGraph = getLightingParityTraceGraph(renderer, options.id);
+    options.framebuffer = replacementHighDynamicRangeTarget.framebuffer;
+    renderer.render(options);
+    device.submit();
+    const replacementPixel = await readLightingParityFloat16Pixel(
+      replacementHighDynamicRangeTarget.color,
+      9,
+      8
+    );
+
+    testCase.equal(
+      getLightingParityTraceGraph(renderer, options.id),
+      originalTraceGraph,
+      'a compatible caller-owned framebuffer swap reuses the compiled trace graph'
+    );
+    testCase.ok(
+      replacementPixel[0] > 1,
+      'a compatible retained graph binds the replacement HDR target without losing radiance'
+    );
+
+    options.toneMapMode = 1;
+    renderer.render(options);
+    device.submit();
+    const toneMappedGraph = getLightingParityTraceGraph(renderer, options.id);
+    const toneMappedPixel = await readLightingParityFloat16Pixel(
+      replacementHighDynamicRangeTarget.color,
+      9,
+      8
+    );
+
+    testCase.notEqual(
+      toneMappedGraph,
+      originalTraceGraph,
+      'an explicit tone-map override recompiles the presentation graph'
+    );
+    testCase.ok(
+      toneMappedPixel[0] > 0 && toneMappedPixel[0] < 1,
+      `Reinhard presentation maps HDR radiance into the unit interval (${toneMappedPixel[0]})`
+    );
+
+    options.outputColorSpace = 'srgb';
+    renderer.render(options);
+    device.submit();
+    const encodedGraph = getLightingParityTraceGraph(renderer, options.id);
+    const encodedPixel = await readLightingParityFloat16Pixel(
+      replacementHighDynamicRangeTarget.color,
+      9,
+      8
+    );
+
+    testCase.notEqual(
+      encodedGraph,
+      toneMappedGraph,
+      'an explicit output-color-space override recompiles the presentation graph'
+    );
+    testCase.ok(
+      encodedPixel[0] > toneMappedPixel[0],
+      'explicit sRGB presentation applies the canonical transfer function after tone mapping'
+    );
+
+    delete options.toneMapMode;
+    delete options.outputColorSpace;
+    options.framebuffer = standardTarget.framebuffer;
+    const standardStatistics = renderer.render(options);
+    device.submit();
+    const standardPixel = await readLightingParityPixel(standardTarget.color, 11, 7);
+
+    testCase.equal(
+      standardStatistics.rayTracing?.internalWidth,
+      23,
+      'changing the caller-owned framebuffer updates internal width'
+    );
+    testCase.equal(
+      standardStatistics.rayTracing?.internalHeight,
+      15,
+      'changing the caller-owned framebuffer updates internal height'
+    );
+    testCase.ok(
+      standardPixel[0] > 200,
+      'changing the target format rebuilds presentation for the bounded normalized attachment'
+    );
+    testCase.deepEqual(
+      getLightingParityPresentation(renderer, options.id),
+      {colorFormat: 'rgba8unorm', toneMapMode: 2, outputEncoding: 1},
+      'normalized linear attachments default to Khronos Neutral plus one exact sRGB transfer'
+    );
+
+    if (hardwareSRGBTarget) {
+      options.framebuffer = hardwareSRGBTarget.framebuffer;
+      renderer.render(options);
+      device.submit();
+      const hardwareSRGBPixel = await readLightingParityPixel(hardwareSRGBTarget.color, 11, 7);
+
+      testCase.deepEqual(
+        getLightingParityPresentation(renderer, options.id),
+        {colorFormat: 'rgba8unorm-srgb', toneMapMode: 2, outputEncoding: 0},
+        'hardware-sRGB attachments avoid a second shader-side transfer function'
+      );
+      testCase.ok(
+        Math.abs(hardwareSRGBPixel[0] - standardPixel[0]) <= 3,
+        'hardware-sRGB and explicitly encoded linear attachments produce matching physical pixels'
+      );
+    }
+  } finally {
+    renderer.destroy();
+    highDynamicRangeTarget.destroy();
+    replacementHighDynamicRangeTarget.destroy();
+    standardTarget.destroy();
+    hardwareSRGBTarget?.destroy();
+  }
+
+  testCase.end();
+});
+
+test('ray tracing without temporal accumulation renders deterministic one-sample pixels', async testCase => {
+  const device = await getWebGPUTestDevice('core');
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const renderer = new RayTracingSceneRenderer(device);
+  const target = makeLightingParityTarget(device, 35, 29, 'rgba8unorm', false);
+  const options = makeLightingParityOptions(
+    'ray-tracing-static-single-sample',
+    makeLightingParitySurface(),
+    target.framebuffer
+  );
+  options.temporalReprojection = false;
+  options.progressive = false;
+  options.samplesPerPixel = 1;
+  const sampleCoordinates: readonly [number, number][] = [
+    [11, 14],
+    [12, 14],
+    [17, 14],
+    [22, 14],
+    [23, 14],
+    [17, 8],
+    [17, 20]
+  ];
+
+  try {
+    const initialStatistics = renderer.render(options);
+    device.submit();
+    const referencePixels = await Promise.all(
+      sampleCoordinates.map(([horizontal, vertical]) =>
+        readLightingParityPixel(target.color, horizontal, vertical)
+      )
+    );
+
+    testCase.ok(
+      referencePixels.some(pixel => pixel[0] > 25),
+      'the deterministic reference includes a visibly lit center sample'
+    );
+    testCase.ok(
+      initialStatistics.rayTracing?.graph?.acceleration,
+      'the initial deterministic frame builds its scene acceleration'
+    );
+
+    for (let frameIndex = 1; frameIndex <= 4; frameIndex++) {
+      const frameStatistics = renderer.render(options);
+      device.submit();
+      const currentPixels = await Promise.all(
+        sampleCoordinates.map(([horizontal, vertical]) =>
+          readLightingParityPixel(target.color, horizontal, vertical)
+        )
+      );
+
+      testCase.deepEqual(
+        currentPixels.map(pixel => Array.from(pixel)),
+        referencePixels.map(pixel => Array.from(pixel)),
+        `frame ${frameIndex} preserves exact center and silhouette bytes with temporal AA disabled`
+      );
+      testCase.equal(
+        frameStatistics.rayTracing?.accumulatedSamples,
+        1,
+        `frame ${frameIndex} reports exactly one unaccumulated sample`
+      );
+      testCase.equal(
+        frameStatistics.rayTracing?.graph?.nodeCount,
+        frameStatistics.rayTracing?.graph?.trace.nodeCount,
+        `frame ${frameIndex} records only the steady-state tracing stage`
+      );
+      testCase.equal(
+        frameStatistics.rayTracing?.graph?.acceleration,
+        undefined,
+        `frame ${frameIndex} does not rebuild an unchanged scene`
+      );
+    }
+  } finally {
+    renderer.destroy();
+    target.destroy();
+  }
+
+  testCase.end();
+});
+
+function getLightingParityTraceGraph(
+  renderer: RayTracingSceneRenderer,
+  identifier: string
+): object {
+  const frames: Map<string, {traceGraph: object}> = Reflect.get(renderer, 'frames');
+  const frame = frames.get(identifier);
+  if (!frame) {
+    throw new Error('Expected the ray-tracing presentation graph to be retained.');
+  }
+  return frame.traceGraph;
+}
+
+function getLightingParityPresentation(
+  renderer: RayTracingSceneRenderer,
+  identifier: string
+): {colorFormat: string; toneMapMode: number; outputEncoding: number} {
+  const frames: Map<
+    string,
+    {presentation: {colorFormat: string; toneMapMode: number; outputEncoding: number}}
+  > = Reflect.get(renderer, 'frames');
+  const frame = frames.get(identifier);
+  if (!frame) {
+    throw new Error('Expected the ray-tracing presentation options to be retained.');
+  }
+  const {colorFormat, toneMapMode, outputEncoding} = frame.presentation;
+  return {colorFormat, toneMapMode, outputEncoding};
+}
+
+function makeLightingParitySurface(): SceneSurface {
+  return {
+    id: 'shared-lighting-parity-sphere',
+    geometry: new SphereGeometry({radius: 0.9, nlat: 6, nlong: 8}),
+    material: {
+      id: 'shared-lighting-parity-material',
+      uniforms: {
+        baseColorFactor: [0.9, 0.45, 0.2, 1],
+        metallicRoughnessValues: [0, 0.8]
+      }
+    },
+    transforms: [new Matrix4()]
+  };
+}
+
+function makeLightingParityOptions(
+  identifier: string,
+  surface: SceneSurface,
+  framebuffer: Framebuffer
+): RayTracingSceneRenderOptions {
+  return {
+    id: `lighting-parity-${identifier}`,
+    surfaces: [surface],
+    framebuffer,
+    camera: {
+      viewMatrix: new Matrix4().lookAt({eye: [0, 0, 4], center: [0, 0, 0], up: [0, 1, 0]}),
+      projectionMatrix: new Matrix4().perspective({
+        fovy: Math.PI / 3,
+        aspect: framebuffer.width / framebuffer.height,
+        near: 0.1,
+        far: 100
+      }),
+      position: [0, 0, 4]
+    },
+    lights: [makeIncomingDirectionalLight([0, 0, -1])],
+    background: [0, 0, 0, 1],
+    exposure: 1,
+    toneMapMode: 0,
+    outputColorSpace: 'linear',
+    resolutionScale: 1,
+    minimumResolutionScale: 1,
+    adaptiveResolution: false,
+    progressive: false,
+    shadows: false,
+    samplesPerPixel: 1,
+    width: 3,
+    height: 5
+  };
+}
+
+function makeIncomingDirectionalLight(direction: [number, number, number], intensity = 3) {
+  return {type: 'directional' as const, direction, color: [1, 1, 1] as const, intensity};
+}
+
+function makeLightingParityTarget(
+  device: Device,
+  width: number,
+  height: number,
+  format: 'rgba8unorm' | 'rgba8unorm-srgb' | 'rgba16float',
+  includeDepth: boolean
+): LightingParityTarget {
+  const color = device.createTexture({
+    id: `lighting-parity-${format}-${width}-${height}-color`,
+    width,
+    height,
+    format,
+    usage: Texture.RENDER | Texture.COPY_SRC
+  });
+  const depth = includeDepth
+    ? device.createTexture({
+        id: `lighting-parity-${format}-${width}-${height}-depth`,
+        width,
+        height,
+        format: 'depth24plus',
+        usage: Texture.RENDER
+      })
+    : undefined;
+  const framebuffer = device.createFramebuffer({
+    id: `lighting-parity-${format}-${width}-${height}-framebuffer`,
+    width,
+    height,
+    colorAttachments: [color],
+    ...(depth ? {depthStencilAttachment: depth} : {})
+  });
+
+  return {
+    color,
+    ...(depth ? {depth} : {}),
+    framebuffer,
+    destroy() {
+      framebuffer.destroy();
+      color.destroy();
+      depth?.destroy();
+    }
+  };
+}
+
+async function readLightingParityPixel(
+  texture: Texture,
+  horizontal: number,
+  vertical: number
+): Promise<Uint8Array> {
+  const bytes = await readLightingParityBytes(texture, horizontal, vertical);
+  return bytes.slice(0, 4);
+}
+
+async function readLightingParityFloat16Pixel(
+  texture: Texture,
+  horizontal: number,
+  vertical: number
+): Promise<number[]> {
+  const bytes = await readLightingParityBytes(texture, horizontal, vertical);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return [0, 1, 2, 3].map(channel =>
+    decodeLightingParityFloat16(view.getUint16(channel * 2, true))
+  );
+}
+
+async function readLightingParityBytes(
+  texture: Texture,
+  horizontal: number,
+  vertical: number
+): Promise<Uint8Array> {
+  const layout = texture.computeMemoryLayout({width: 1, height: 1});
+  const buffer = texture.device.createBuffer({
+    byteLength: layout.byteLength,
+    usage: Buffer.COPY_DST | Buffer.MAP_READ
+  });
+
+  try {
+    texture.readBuffer({x: horizontal, y: vertical, width: 1, height: 1}, buffer);
+    const bytes = await buffer.readAsync(0, layout.byteLength);
+    return new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength).slice();
+  } finally {
+    buffer.destroy();
+  }
+}
+
+function decodeLightingParityFloat16(value: number): number {
+  const sign = (value & 0x8000) === 0 ? 1 : -1;
+  const exponent = (value >> 10) & 0x1f;
+  const fraction = value & 0x03ff;
+  if (exponent === 0) {
+    return sign * 2 ** -14 * (fraction / 1024);
+  }
+  if (exponent === 31) {
+    return fraction ? Number.NaN : sign * Number.POSITIVE_INFINITY;
+  }
+  return sign * 2 ** (exponent - 15) * (1 + fraction / 1024);
+}

--- a/modules/experimental/test/engine/scene-renderer.node.spec.ts
+++ b/modules/experimental/test/engine/scene-renderer.node.spec.ts
@@ -317,6 +317,78 @@ describe('shared PBR material factories', () => {
 });
 
 describe('SceneRenderer', () => {
+  test('adapts incoming directional lights and additive ambient radiance at the forward PBR boundary', async () => {
+    const device = await getNullTestDevice();
+    const renderer = new InspectableSceneRenderer(device);
+    const surface: SceneSurface = {
+      id: 'directional-light-convention',
+      geometry: makeGeometry(),
+      material: {id: 'directional-light-convention-material'},
+      transforms: [new Matrix4()]
+    };
+    const pointLight = {
+      type: 'point' as const,
+      position: [2, 3, 4] as [number, number, number],
+      intensity: 1
+    };
+    const spotLight = {
+      type: 'spot' as const,
+      position: [1, 2, 3] as [number, number, number],
+      direction: [0, -1, 0] as [number, number, number],
+      intensity: 1
+    };
+    const directionalLight = {
+      type: 'directional' as const,
+      direction: [0.4, -0.6, -1] as [number, number, number],
+      intensity: 1
+    };
+    const redAmbientLight = {
+      type: 'ambient' as const,
+      color: [1, 0, 0] as [number, number, number],
+      intensity: 0.25
+    };
+    const greenAmbientLight = {
+      type: 'ambient' as const,
+      color: [0, 1, 0] as [number, number, number],
+      intensity: 0.4
+    };
+    const options: SceneRenderOptions = {
+      ...makeOptions([surface]),
+      lights: [redAmbientLight, pointLight, spotLight, directionalLight, greenAmbientLight]
+    };
+
+    try {
+      const model = renderer.inspect(options).surfaces[0].model;
+      const lighting = model.shaderInputs.getUniformValues().lighting;
+
+      expect(lighting).toMatchObject({
+        pointLightCount: 1,
+        spotLightCount: 1,
+        directionalLightCount: 1
+      });
+      expect(lighting.lights[0].position).toEqual([2, 3, 4]);
+      expect(lighting.lights[1].direction).toEqual([0, -1, 0]);
+      expect(lighting.lights[2].direction).toEqual([-0.4, 0.6, 1]);
+      expect(lighting.ambientColor).toEqual([0.25, 0.4, 0]);
+      expect(options.lights?.[0]).toBe(redAmbientLight);
+      expect(options.lights?.[4]).toBe(greenAmbientLight);
+      expect(options.lights?.[3]).toBe(directionalLight);
+      expect(directionalLight.direction).toEqual([0.4, -0.6, -1]);
+      expect(options.lights?.[2]).toBe(spotLight);
+      expect(redAmbientLight.color).toEqual([1, 0, 0]);
+      expect(greenAmbientLight.color).toEqual([0, 1, 0]);
+
+      options.lights = [redAmbientLight];
+      const singleAmbientModel = renderer.inspect(options).surfaces[0].model;
+      expect(singleAmbientModel.shaderInputs.getUniformValues().lighting.ambientColor).toEqual([
+        0.25, 0, 0
+      ]);
+      expect(options.lights[0]).toBe(redAmbientLight);
+    } finally {
+      renderer.destroy();
+    }
+  });
+
   test('rebuilds punctual-light shader specialization only when lighting becomes enabled or disabled', async () => {
     const device = await getNullTestDevice();
     const renderer = new InspectableSceneRenderer(device);

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
@@ -9,6 +9,7 @@ import {
   Sampler,
   Texture,
   type Device,
+  type Framebuffer,
   type SamplerProps
 } from '@luma.gl/core';
 import {Computation, Model} from '@luma.gl/engine';
@@ -256,6 +257,133 @@ test('GPUCommandGraph resolves multisampled color attachments', async t => {
     /match a multisampled source and be single-sampled/,
     'single-sample sources cannot declare resolve targets'
   );
+  t.end();
+});
+
+test('GPUCommandGraph redirects reusable render passes to caller-owned framebuffers', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const firstTexture = device.createTexture({
+    id: 'caller-owned-color-0',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    usage: Texture.RENDER | Texture.COPY_SRC
+  });
+  const secondTexture = device.createTexture({
+    id: 'caller-owned-color-1',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    usage: Texture.RENDER | Texture.COPY_SRC
+  });
+  const firstFramebuffer = device.createFramebuffer({
+    id: 'caller-owned-framebuffer-0',
+    width: 4,
+    height: 4,
+    colorAttachments: [firstTexture],
+    depthStencilAttachment: null
+  });
+  const secondFramebuffer = device.createFramebuffer({
+    id: 'caller-owned-framebuffer-1',
+    width: 4,
+    height: 4,
+    colorAttachments: [secondTexture],
+    depthStencilAttachment: null
+  });
+  const graph = new GPUCommandGraph<{
+    framebuffer: Framebuffer;
+    clearColor: [number, number, number, number];
+  }>(device, {id: 'caller-owned-framebuffers'});
+  let compilationCount = 0;
+  let encodingCount = 0;
+
+  graph.addRenderPass({
+    id: 'redirect-render-target',
+    compile: () => {
+      compilationCount++;
+      return {
+        getRenderPassProps: ({parameters}) => ({
+          framebuffer: parameters.framebuffer,
+          clearColor: parameters.clearColor
+        }),
+        encode: () => {
+          encodingCount++;
+        }
+      };
+    }
+  });
+
+  const compiled = graph.compile();
+  const firstEncoder = device.createCommandEncoder({id: 'caller-owned-encoding-0'});
+  compiled.encode(firstEncoder, {
+    parameters: {framebuffer: firstFramebuffer, clearColor: [1, 0, 0, 1]}
+  });
+  device.submit(firstEncoder.finish());
+
+  const secondEncoder = device.createCommandEncoder({id: 'caller-owned-encoding-1'});
+  compiled.encode(secondEncoder, {
+    parameters: {framebuffer: secondFramebuffer, clearColor: [0, 1, 0, 1]}
+  });
+  device.submit(secondEncoder.finish());
+
+  t.deepEqual(
+    Array.from((await readPixels(firstTexture, 4, 4)).subarray(0, 4)),
+    [255, 0, 0, 255],
+    'the first offscreen framebuffer receives only its own render pass'
+  );
+  t.deepEqual(
+    Array.from((await readPixels(secondTexture, 4, 4)).subarray(0, 4)),
+    [0, 255, 0, 255],
+    'the next encoding can target a different caller-owned framebuffer'
+  );
+  t.equal(compilationCount, 1, 'changing the target does not recompile the render executable');
+  t.equal(encodingCount, 2, 'the same compiled render executable records both frames');
+
+  const conflictingGraph = new GPUCommandGraph(device, {id: 'conflicting-framebuffer'});
+  const managedColor = conflictingGraph.importTexture(
+    {
+      id: 'managed-color',
+      format: 'rgba8unorm',
+      width: 4,
+      height: 4,
+      usage: Texture.RENDER
+    },
+    firstTexture
+  );
+  conflictingGraph.addRenderPass({
+    id: 'conflicting-render-target',
+    attachments: {colorAttachments: [conflictingGraph.createTextureView(managedColor)]},
+    compile: () => ({
+      getRenderPassProps: () => ({framebuffer: secondFramebuffer}),
+      encode: () => {}
+    })
+  });
+  const conflictingCompiled = conflictingGraph.compile();
+  t.throws(
+    () =>
+      conflictingCompiled.encode(device.createCommandEncoder({id: 'conflicting-encoding'}), {
+        parameters: undefined
+      }),
+    /cannot supply framebuffer with graph attachments/,
+    'graph-managed attachments cannot be replaced by a callback-supplied framebuffer'
+  );
+
+  conflictingCompiled.destroy();
+  compiled.destroy();
+  t.notOk(firstFramebuffer.destroyed, 'the first framebuffer remains caller-owned');
+  t.notOk(secondFramebuffer.destroyed, 'the replacement framebuffer remains caller-owned');
+  t.notOk(firstTexture.destroyed, 'the first framebuffer texture remains caller-owned');
+  t.notOk(secondTexture.destroyed, 'the replacement framebuffer texture remains caller-owned');
+  firstFramebuffer.destroy();
+  secondFramebuffer.destroy();
+  firstTexture.destroy();
+  secondTexture.destroy();
   t.end();
 });
 


### PR DESCRIPTION
## Goals

- Establish an objectively testable, framebuffer-correct WebGPU ray-tracing output path on top of the retained GPU-graph acceleration introduced in #3056.
- Make forward, deferred, and ray-traced rendering agree on directional and ambient lighting while preserving WebGPU CORE limits and application-owned submission.
- Expose truthful graph execution diagnostics without readbacks, timestamp dependencies, or fabricated GPU timings.

## Changes

- Route ray-tracing presentation to caller-owned offscreen framebuffers through the existing `GPUCommandGraphRenderExecutable.getRenderPassProps` contract. Honor actual framebuffer dimensions, color and optional depth formats, preserve compatible graph reuse, and rebuild only incompatible presentation pipelines.
- Implement canonical NONE/Reinhard/Khronos Neutral/ACES tone mapping and exact IEC sRGB transfer, with automatic linear HDR and hardware-sRGB behavior matching forward rendering. Expose explicit committed tone-mapping and output-color controls through the shared renderer, all ANARI renderer subtypes, and the strict ANARI JSON scene schema.
- Replace the simplified ray specular lobe with scalar metallic-roughness GGX distribution, Smith visibility, Schlick Fresnel, and energy-balanced diffuse lighting without increasing trace bindings or changing the existing uniform layout.
- Normalize canonical incoming directional lights at the forward-renderer boundary and combine multiple ambient lights consistently across forward, deferred, and ray paths without mutating caller-owned lights.
- Reuse the centered guide hit when one-sample rendering explicitly disables both progressive accumulation and temporal reprojection, eliminating animated jitter and the redundant primary traversal only in that safe mode.
- Expose additive graph stage statistics through both experimental and ANARI APIs: logical nodes, physical compute passes, coalesced compute nodes, and synchronous CPU encoding time for actual topology, acceleration, refit, and tracing stages.
- Add unconditional real-WebGPU pixel-readback oracles covering directional hemispheres, multiple ambient lights, no-AA temporal stability, odd/depthless HDR targets, automatic output encoding, compatible framebuffer swaps, and retained graph-stage behavior.
- Document the existing generic per-encoding framebuffer contract, shared color-management behavior, retained graph diagnostics, completed roadmap tranches, and still-unsupported textures, alpha, deformation, indirect transport, and denoising.

## Verification

- Full real Chromium WebGPU/WebGL regression: **113 browser suites and 635 tests passed**, including retained ANARI, forward/deferred/ray image parity, production skin, shadows, glTF, splats, effects, graph primitives, and all analytics domains.
- Final full repository node regression: **243 suites and 2,177 tests passed**, including every ANARI renderer subtype, strict JSON validation, staged-versus-committed color controls, exact literal types, and retained-scene invalidation.
- Final post-integration real Chromium regression: **10 browser suites and 38 tests passed**, including committed ANARI color settings with trace-only graph recreation and no acceleration rebuild.
- Latest-`master` compatibility after rebasing: **19 focused node suites and 293 tests passed**, including newly merged dataframe joins/sorting, graph core numbers/modularity, paged splats, ANARI, ray shaders, graph history, and segmented acceleration primitives.
- Final latest-`master` real-GPU gate: **11 Chromium WebGPU/WebGL suites and 114 tests passed**, including dataframe outer/semi/anti joins, global sorting, graph core numbers/modularity, animated glTF crowds, paged splats, ANARI color controls, ray image parity, and graph-managed presentation.
- All **19 workspace packages** compile successfully; all **640 documentation pages** pass MDX validation.
- Dedicated actual WebGPU pixel-readback oracle runs unconditionally on CORE software adapters and validates directional/ambient parity, offscreen HDR/sRGB policies, graph reuse, and deterministic no-AA frames.
- Strict source-mapped cross-package TypeScript, scoped Biome formatting, and `git diff --check` pass.

## Risks and follow-up

- The directional-light fix deliberately corrects a preexisting forward-renderer convention; existing PBR transmission/backlight fixtures are updated to preserve their intended physical lighting.
- Caller-owned framebuffer attachments are intentionally external to graph hazard inference; graph-managed attachments remain the appropriate choice when downstream graph nodes consume the rendered texture.
- The 1-spp guide reuse applies only when both progressive accumulation and temporal reprojection are disabled; normal temporal antialiasing retains its independent jittered primary sample.
- The renderer remains a direct-light software ray tracer. Material textures, alpha/transmission, environment sampling, mesh deformation, path tracing, denoising, and hardware ray tracing are not claimed or enabled.
- Builds directly on the retained graph-native acceleration from the now-merged #3056.
