### PR TITLE
fix(splats): address review feedback and embed the Coit roadmap

### DIFF
--- a/docs/api-reference/splats/README.md
+++ b/docs/api-reference/splats/README.md
@@ -1,3 +1,5 @@
+import {GaussianSplatViewerExample} from '@site/src/examples';
+
 # @luma.gl/splats
 
 `@luma.gl/splats` provides experimental GPU-native Gaussian splat rendering. It owns prepared
@@ -8,6 +10,47 @@ render models without depending on Apache Arrow, loaders.gl, glTF packages, or d
 The module is currently a private, unpublished luma.gl workspace. Install dependencies from the
 repository root and add `"@luma.gl/splats": "workspace:*"` to another workspace package when
 developing against it locally.
+
+## Interactive Coit Tower showcase
+
+Explore the 50,937,127-splat Coit Tower capture directly. WebGPU streams camera-selected RAD pages,
+decodes them in background workers, and keeps GPU residency bounded while the viewpoint changes.
+
+<GaussianSplatViewerExample embedded embeddedHeight={640} defaultScene="coit" showStats={false} />
+
+[Open the full Coit Tower viewer](/examples/showcase/gaussian-splat-viewer?scene=coit).
+
+## Gaussian splat implementation roadmap
+
+The completed tranches establish portable rendering, interaction, bounded out-of-core scenes, and
+a live 50,937,127-source-row Coit Tower viewer. Planned tranches describe remaining work; the
+current viewer does not retain all source rows simultaneously or claim measured Spark parity.
+
+### Current supremacy-track status
+
+| Track | Current status | Remaining work |
+| --- | --- | --- |
+| GPU graph feature parity | Implemented for the portable renderer and contiguous WebGPU command graph: directional harmonics, semantic filtering, stable GPU picking, and mixed mesh composition. | Extend picking and single-pass mixed composition to the segmented out-of-core renderer. |
+| Out-of-core RAD rendering | Implemented: authored row hierarchies, camera-selected pages, bounded module-worker decoding, foveated refinement, parent fallback, cancellation, and active-frontier residency. | Move hierarchy traversal and demand scheduling off the main thread; coordinate with the related [RAD renderer draft #3431](https://github.com/visgl/loaders.gl/pull/3431). |
+| 50-million-splat Spark parity | In progress: the 50,937,127-source-row Coit capture streams through a bounded one-million-row resident window with calibrated camera, covariance, antialiasing, and coarse-level opacity. | Establish reproducible Spark visual/performance benchmarks, larger active sort domains, and near-linear cross-segment routing. |
+| 3D Tiles integration | Partial: decoded Gaussian glTF primitives, feature identifiers, and caller-decoded SPZ v2 handoff work; loaders.gl already provides `Tileset3D` and `Tiles3DSource` traversal, transport, computed transforms, caching, and feature metadata. | Connect selected tiles to prepared splat batches or the existing `SplatLayer`, applying loader-computed transforms per tile/page in the renderer; add Gaussian glTF extension handlers and SPZ v2 decoding in loaders.gl, whose `SPZLoader` currently supports v4 only; see [tracking issue #1245](https://github.com/visgl/loaders.gl/issues/1245). |
+
+### Delivery tranches
+
+| Tranche | Scope | Status |
+| --- | --- | --- |
+| T0: portable rendering foundation | Caller-owned typed batches, anisotropic WebGPU/WebGL2 rendering, Arrow adapters, HDR source radiance, and the initial Gaussian showcase. | Implemented in [#2929](https://github.com/visgl/luma.gl/pull/2929). |
+| T0a: progressive GPU graphs | Captured-scene website viewer, reusable WebGPU command graphs, preserved-batch streaming, global GPU sorting, and indirect draws. | Implemented in [#2932](https://github.com/visgl/luma.gl/pull/2932), [#2938](https://github.com/visgl/luma.gl/pull/2938), and [#2966](https://github.com/visgl/luma.gl/pull/2966). |
+| T1: interaction and residency | Degree-one through degree-three harmonics, semantic filtering, GPU picking, dynamic source updates, mixed mesh composition, and bounded residency. | Implemented in [#3035](https://github.com/visgl/luma.gl/pull/3035). |
+| T2: graph and hierarchy parity | Graph-native harmonics, filtering, picking, and mixed rendering; parent-preserving hierarchical paging; decoded glTF splats, feature IDs, and external SPZ handoff. | Implemented in [#3041](https://github.com/visgl/luma.gl/pull/3041). |
+| T3: out-of-core RAD scenes | Authored row hierarchies, camera-prioritized cancellable page requests, bounded resident windows, and globally sorted segmented WebGPU rendering. | Implemented in [#3051](https://github.com/visgl/luma.gl/pull/3051). |
+| T4: Spark-calibrated Coit showcase | Analytic covariance, area-preserving antialiasing, nonlinear coarse opacity, angular refinement, a 75-degree camera, and bounded module-worker page decoding. | Implemented in [#3057](https://github.com/visgl/luma.gl/pull/3057). |
+| T5: documentation and correctness hardening | Embedded Coit documentation, asynchronous module-worker fallback, exact sorted WebGL compositing, unclamped WebGL harmonics, constructor-only graph allocation options, and validated Arrow source metadata. | Implemented in this follow-up. |
+| T6: incremental hierarchy scheduling | Move camera-driven hierarchy traversal, row selection, and page-demand scheduling into incremental worker/GPU workflows with bounded per-frame work. | Planned; authored row traversal currently runs on the CPU. |
+| T7: segmented picking and mixed composition | Resolve stable picking identities across paged GPU segments and composite paged splats with caller-owned meshes in one depth-aware render pass. | Planned; picking and mesh helpers currently target non-paged renderers. |
+| T8: partitioned global sorting | Sort beyond 33,554,432 active four-byte references on a 128 MiB storage-binding limit and replace segment-pair scatter with near-linear routing. | Planned; projected segments already exist, but global sorting still uses one binding. |
+| T9: streamed 3D Tiles and glTF transport | Reuse existing loaders.gl tileset traversal, fetching, computed transforms, caching, and feature metadata; add Gaussian glTF extension handlers and SPZ v2 decoding in loaders.gl; connect selected content to prepared splats or the existing `SplatLayer` with per-tile/page renderer transforms. | Planned; loaders.gl has SPZ v4 decoding, but not SPZ v2 or end-to-end transformed Gaussian tile integration. |
+| T10: reproducible Spark visual and performance evidence | Measure comparable scene imagery, frame times, startup, bandwidth, cancellation, and bounded residency against Spark's complete Coit source. | Planned; no measured visual or performance parity is claimed. |
 
 ## Rendering prepared splats
 
@@ -88,6 +131,9 @@ tone-mapping options from `SplatRenderer`, plus the following graph-specific pro
 | `cameraPosition` | `[number, number, number]` | World-space camera position used to evaluate directional source radiance directly on the GPU. |
 | `sphericalHarmonicsDegree` | `0 \| 1 \| 2 \| 3` | Highest fully prepared spherical-harmonic band evaluated by graph projection. |
 | `semanticFilter` | `SplatSemanticFilter` | GPU-resident include/exclude class selection and unlabeled-source visibility. |
+
+`clearColor`, `expectedSplatCount`, and `expectedBatchCount` are constructor-only options.
+`setProps(...)` accepts mutable camera, styling, semantic-filter, and borrowed-source updates.
 
 Provide both expected counts when source metadata is available. For example, a 741,883-row Train
 capture streamed in twelve Arrow record batches can reuse one compiled graph throughout its entire
@@ -326,8 +372,9 @@ colors. Changing `cameraPosition` refreshes directional colors independently fro
 
 Provide `semanticIds: Uint32Array` with one compact class identifier per source row. Configure
 `semanticFilter` with included or excluded IDs, an `includeUnlabeled` policy, or a predicate that
-receives the stable global row and source-batch identity. Arrow semantic columns must not contain
-null values; omit the column entirely for an unlabeled source batch.
+receives the stable global row and source-batch identity. Arrow semantic columns must contain
+finite unsigned 32-bit integer identifiers; nulls, string labels, fractions, and out-of-range
+values are rejected. Omit the column entirely for an unlabeled source batch.
 
 ```ts
 renderer.setProps({
@@ -591,6 +638,18 @@ DC radiance, and packs complete degree-one through degree-three RGB coefficient 
 `KHR_gaussian_splatting_compression_spz_2` payloads are handed to an explicitly caller-owned
 decoder; this renderer does not claim to parse SPZ or fetch 3D Tiles itself.
 
+loaders.gl already provides `Tileset3D` and `Tiles3DSource` for 3D Tiles traversal, content
+fetching, tile transforms, cache management, and request scheduling. Its glTF loader already
+decodes `EXT_mesh_features` and `EXT_structural_metadata`. The existing `SPZLoader` currently
+supports SPZ version 4, not SPZ version 2. End-to-end Gaussian 3D Tiles require loader-owned
+`KHR_gaussian_splatting` and `KHR_gaussian_splatting_compression_spz_2` runtime handlers, SPZ v2
+decoding, and an application bridge from selected tiles into prepared splat batches or the existing
+`SplatLayer`. loaders.gl already computes `Tile3D.computedTransform`, but the paged splat renderer
+currently exposes one global model-view-projection transform and no per-page model transform. The
+remaining renderer-side integration must therefore apply loader-computed transforms per tile/page.
+The tileset traversal and layer already exist; follow
+[tracking issue #1245](https://github.com/visgl/loaders.gl/issues/1245) for the missing integration.
+
 ## Apache Arrow conversion
 
 ```ts
@@ -670,6 +729,9 @@ during streaming, and idle redraw suppression keep large scenes easier to inspec
 ## Package boundaries
 
 - `@loaders.gl/splats` parses Gaussian splat file formats and produces application-level data.
+- `@loaders.gl/tiles` and `@loaders.gl/3d-tiles` own tileset traversal, content transport,
+  transforms, request scheduling, and caching.
+- `@loaders.gl/gltf` owns glTF parsing, extension decoding, and feature metadata.
 - `@luma.gl/arrow` maps Apache Arrow columns and metadata into GPU-ready splat data.
 - `@luma.gl/splats` owns rendering, Gaussian projection, sorting, and GPU resource lifetimes.
 - Applications or deck.gl layers own viewport integration, file selection, and interactive UI.

--- a/docs/capabilities.mdx
+++ b/docs/capabilities.mdx
@@ -611,7 +611,8 @@ Read the [ANARI ray-tracing renderer](/docs/api-reference/anari/anari-rendering)
 | --- | --- | --- | --- | --- |
 | Typed Gaussian splat columns | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Represent position, scale, orientation, opacity, supported colors, and row identity. |
 | Anisotropic covariance | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Project compatible anisotropic splats rather than reducing them to fixed point sprites. |
-| Portable splat rendering | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Select WebGPU storage or WebGL2 attribute-backed rendering paths. |
+| Portable splat rendering | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Select WebGPU storage or globally ordered WebGL2 attribute-backed rendering without mutating caller-owned source data. |
+| Globally sorted WebGL splat runs | Experimental | WebGL2 | `@luma.gl/splats` | Composite every visible row exactly once across interleaved source batches using independently owned reordered attributes. |
 | Progressive batch streaming | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Preserve independently owned streamed source batches. |
 | GPU projection and culling | Experimental | WebGPU | `@luma.gl/splats` | Project visible splats and apply supported frustum, opacity, and size thresholds. |
 | GPU depth sorting | Experimental | WebGPU | `@luma.gl/splats` | Execute supported command-graph-native global depth ordering. |
@@ -620,7 +621,8 @@ Read the [ANARI ray-tracing renderer](/docs/api-reference/anari/anari-rendering)
 | Spark-calibrated RAD reconstruction | Experimental | WebGPU | `@luma.gl/splats` | Project analytic Gaussian covariance with area-preserving antialiasing and authored nonlinear coarse-level opacity. |
 | HDR spherical-harmonic DC | Experimental | WebGPU | `@luma.gl/splats` | Preserve supported floating-point source radiance on compatible presentation targets. |
 | Standard-dynamic-range fallback | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Apply supported display mapping when extended HDR output is unavailable. |
-| View-dependent harmonics | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Evaluate degree-one through degree-three spherical harmonics in reusable WebGPU graphs or portable splat models. |
+| View-dependent harmonics | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Evaluate degree-one through degree-three spherical harmonics in reusable WebGPU graphs and unclamped Float32 WebGL2 attributes. |
+| Unclamped WebGL harmonic radiance | Experimental | WebGL2 | `@luma.gl/splats` | Preserve directional highlights and negative radiance from byte-backed source colors in stable Float32 vertex attributes. |
 | Dedicated splat picking | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Resolve stable batch, row, and semantic identities through graph-native integer picking or portable GPU passes. |
 | Semantic splat filtering | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Apply GPU-native graph class selection or portable class/predicate filtering without repacking batches. |
 | Dynamic splat updates | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Update prepared source rows in place while preserving GPU buffers and reusable command graphs. |
@@ -630,13 +632,15 @@ Read the [ANARI ray-tracing renderer](/docs/api-reference/anari/anari-rendering)
 | Row-accurate RAD hierarchy | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Prioritize authored child rows with best-first angular refinement, coarse-node coverage, parent fallback, and sparse source-row identity. |
 | Khronos glTF splat attributes | Experimental | WebGPU + WebGL2 | `@luma.gl/splats` | Render decoded `KHR_gaussian_splatting` attributes, feature IDs, and externally decoded SPZ v2 content. |
 | Camera-driven RAD page sources | Experimental | WebGPU + WebGL2 | `@luma.gl/arrow` and `@luma.gl/splats` | Demand, prioritize, cancel, and evict independently range-fetched source pages while preserving authored global row identities. |
-| Background RAD page decoding | Experimental | WebGPU | Gaussian Splat Viewer | Decode transferable RAD source ranges with a bounded module-worker pool and preserve Arrow page and hierarchy ownership. |
+| Background RAD page decoding | Experimental | WebGPU | Gaussian Splat Viewer | Decode transferable RAD ranges in bounded module workers; preserve Arrow ownership and automatically fall back when worker startup, CSP, or dynamic imports fail. |
 
 Higher-order harmonics, semantic filtering, dedicated picking, and mixed-scene composition are
 available through the portable `SplatRenderer` and the WebGPU-only `GPUSplatGraphRenderer`. The
 graph renderer preserves its high-throughput GPU depth sorting and indirect-drawing path.
 
-View captured scenes in the [Gaussian Splat Viewer](/examples/showcase/gaussian-splat-viewer).
+View captured scenes in the [Gaussian Splat Viewer](/examples/showcase/gaussian-splat-viewer) and
+review completed and planned work in the
+[Gaussian splat implementation roadmap](/docs/api-reference/splats#gaussian-splat-implementation-roadmap).
 
 ### Simulation and immersive presentation
 
@@ -680,7 +684,11 @@ commitments to release dates.
 | Massive geometry visualization | Opportunity | WebGPU | `@luma.gl/experimental` | Extend procedural virtual geometry toward imported mesh clusters and occlusion-aware residency. |
 | Motion-aware temporal reconstruction | Opportunity | WebGPU | `@luma.gl/effects` and `@luma.gl/anari` | Extend camera-reprojection antialiasing with animated-object motion vectors, compatible denoising, and temporal upscaling. |
 | GPU-resident crowd animation | Opportunity | WebGPU | `@luma.gl/gltf` | Extend existing instanced skeletal crowds toward GPU clip sampling, independent actor morph deformation, and material variation. |
-| Massive captured-scene parity | Opportunity | WebGPU | `@luma.gl/splats` | Extend worker-decoded RAD rendering with GPU hierarchy traversal, segmented GPU picking, larger global-sort domains, and measured 50-million-splat Spark visual/performance parity. |
+| Incremental GPU splat hierarchy scheduling | Opportunity | WebGPU | `@luma.gl/splats` | Move authored row traversal and camera-prioritized page scheduling into bounded incremental worker/GPU workflows. |
+| Segmented splat picking and mesh composition | Opportunity | WebGPU | `@luma.gl/splats` | Add stable GPU picking across paged segments and compose segmented splats with caller-owned meshes in one depth-aware pass. |
+| Partitioned splat sorting and scatter | Opportunity | WebGPU | `@luma.gl/splats` | Extend global ordering beyond 33,554,432 active rows on a 128 MiB binding limit and replace segment-pair scatter with near-linear routing. |
+| Streamed 3D Tiles and glTF splat transport | Opportunity | WebGPU + WebGL2 | `@luma.gl/splats` with existing loaders.gl packages | Reuse existing `Tileset3D` traversal, fetching, computed transforms, caching, and feature metadata; apply loader-computed transforms per tile/page in the renderer; connect selected tiles to prepared splats or the existing `SplatLayer` after loaders.gl adds Gaussian glTF extension handlers and SPZ v2 decoding ([#1245](https://github.com/visgl/loaders.gl/issues/1245)). |
+| Measured captured-scene visual and performance parity | Opportunity | WebGPU | `@luma.gl/splats` | Establish reproducible Coit imagery, frame-time, startup, bandwidth, and bounded-residency comparisons against Spark. |
 | Production-ready module boundaries | Opportunity | WebGPU + WebGL2 | `@luma.gl/engine`, `@luma.gl/tables`, and `@luma.gl/gpgpu` | Graduate reusable scheduling, data adapters, and algorithms into their natural published packages. |
 
 `@luma.gl/experimental`, `@luma.gl/anari`, `@luma.gl/splats`, `@luma.gl/arrow`,

--- a/examples/showcase/gaussian-splats/app.ts
+++ b/examples/showcase/gaussian-splats/app.ts
@@ -30,6 +30,7 @@ import {
   getLocalGaussianSplatLoadersConfiguration,
   loadLocalGaussianSplatArrowSources,
   openLocalGaussianSplatRADPageSource,
+  type GaussianSplatSourceCatalogEntry,
   type LocalGaussianSplatLoadProgress,
   type LocalGaussianSplatLoadersConfiguration
 } from './local-loaders';
@@ -208,7 +209,12 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
   private isLoading = false;
   private isFinalized = false;
 
-  constructor({device, width, height}: AnimationProps) {
+  constructor({
+    device,
+    width,
+    height,
+    defaultScene
+  }: AnimationProps & {defaultScene?: GaussianSplatSourceCatalogEntry['id']}) {
     super();
     this.device = device;
     this.executionMode = getGaussianSplatExecutionMode(
@@ -226,7 +232,7 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
             }
           })
         : undefined;
-    this.localLoadersConfiguration = getLocalGaussianSplatLoadersConfiguration();
+    this.localLoadersConfiguration = getLocalGaussianSplatLoadersConfiguration(defaultScene);
     const isRADScene = this.localLoadersConfiguration?.sourceFormat === 'RAD';
     this.clearColor =
       this.localLoadersConfiguration?.sceneId === 'coit' ? COIT_CLEAR_COLOR : CLEAR_COLOR;
@@ -1145,7 +1151,7 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
           ? 'Unable to load scene'
           : !this.isLoading
             ? this.radSceneController
-              ? this.radWorkerDecoder
+              ? this.radWorkerDecoder?.mode === 'worker'
                 ? 'Worker-decoded RAD paging'
                 : 'RAD paging · main-thread fallback'
               : this.loadedSplatCount < this.expectedSplatCount
@@ -1180,7 +1186,7 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
               : `${this.loadedSplatCount.toLocaleString()} splats ready`
           );
         }
-        if (this.radSceneController && this.radWorkerDecoder) {
+        if (this.radSceneController && this.radWorkerDecoder?.mode === 'worker') {
           const {workerCount, completedDecodeCount} = this.radWorkerDecoder;
           detailParts.push(
             `${workerCount} background worker${workerCount === 1 ? '' : 's'} · ${completedDecodeCount.toLocaleString()} decoded page${completedDecodeCount === 1 ? '' : 's'}`

--- a/examples/showcase/gaussian-splats/local-loaders.ts
+++ b/examples/showcase/gaussian-splats/local-loaders.ts
@@ -286,10 +286,10 @@ export const GAUSSIAN_SPLAT_SOURCE_CATALOG: readonly GaussianSplatSourceCatalogE
   }
 ];
 
-/** Keeps standalone synthetic by default while enabling real scenes in the published viewer. */
-export function getLocalGaussianSplatLoadersConfiguration():
-  | LocalGaussianSplatLoadersConfiguration
-  | undefined {
+/** Keeps scene defaults local to each viewer while preserving explicit URL selections. */
+export function getLocalGaussianSplatLoadersConfiguration(
+  defaultScene?: GaussianSplatSourceCatalogEntry['id']
+): LocalGaussianSplatLoadersConfiguration | undefined {
   if (typeof window === 'undefined') {
     return undefined;
   }
@@ -333,7 +333,7 @@ export function getLocalGaussianSplatLoadersConfiguration():
     };
   }
 
-  const sceneId = parameters.get('scene') || 'train';
+  const sceneId = parameters.get('scene') || defaultScene || 'train';
   const scene = GAUSSIAN_SPLAT_SOURCE_CATALOG.find(candidate => candidate.id === sceneId);
   if (!scene) {
     throw new Error(`Unknown Gaussian splat scene: ${sceneId}.`);

--- a/examples/showcase/gaussian-splats/rad-worker-decoder.ts
+++ b/examples/showcase/gaussian-splats/rad-worker-decoder.ts
@@ -30,12 +30,12 @@ type GaussianSplatRADWorkerResponse =
       shape?: string;
       loaderData: LocalGaussianSplatRADPage['loaderData'];
     }
-  | {id: number; status: 'error'; name?: string; message: string};
+  | {id: number; status: 'error'; name?: string; message: string; startup?: boolean};
 
 type GaussianSplatRADWorkerJob = {
   id: number;
   context: LocalGaussianSplatRADPageDecodeContext;
-  bytes: ArrayBuffer;
+  bytes?: ArrayBuffer;
   resolve: (page: LocalGaussianSplatRADPage) => void;
   reject: (error: unknown) => void;
   removeAbortListener: () => void;
@@ -60,9 +60,11 @@ let loaderBundlePromise;
 
 self.addEventListener('message', async event => {
   const request = event.data;
+  let loaderBundleReady = false;
   try {
     loaderBundlePromise ||= import(request.bundleUrl);
     const loaderBundle = await loaderBundlePromise;
+    loaderBundleReady = true;
     const page = loaderBundle.parseRADChunk(request.bytes, {
       radChunk: {
         splatEncoding: request.splatEncoding,
@@ -87,7 +89,8 @@ self.addEventListener('message', async event => {
       id: request.id,
       status: 'error',
       name: error instanceof Error ? error.name : 'Error',
-      message: error instanceof Error ? error.message : String(error)
+      message: error instanceof Error ? error.message : String(error),
+      startup: !loaderBundleReady
     });
   }
 });
@@ -95,16 +98,16 @@ self.addEventListener('message', async event => {
 
 /** Parses original RAD pages in real browser workers while preserving source-owned identities. */
 export class GaussianSplatRADWorkerDecoder {
-  readonly mode = 'worker';
-
   private readonly bundleUrl: string;
   private readonly maxWorkers: number;
   private readonly workerUrl: string;
   private readonly slots: GaussianSplatRADWorkerSlot[] = [];
   private readonly queue: GaussianSplatRADWorkerJob[] = [];
+  private readonly activeFallbackJobs = new Set<GaussianSplatRADWorkerJob>();
   private loaderBundlePromise?: Promise<GaussianSplatRADWorkerBundle>;
   private nextRequestId = 0;
   private completedDecodes = 0;
+  private workersAvailable = true;
   private destroyed = false;
 
   constructor(bundleUrl: string, options: GaussianSplatRADWorkerDecoderOptions = {}) {
@@ -122,6 +125,11 @@ export class GaussianSplatRADWorkerDecoder {
       URL.revokeObjectURL(this.workerUrl);
       throw error;
     }
+  }
+
+  /** Current decoder backend after accounting for asynchronous module-worker failures. */
+  get mode(): 'worker' | 'main-thread' {
+    return this.workersAvailable ? 'worker' : 'main-thread';
   }
 
   /** Number of currently live browser workers, including an idle reusable worker. */
@@ -142,7 +150,7 @@ export class GaussianSplatRADWorkerDecoder {
       throw makeGaussianSplatWorkerAbortError(context.signal);
     }
     context.signal.throwIfAborted();
-    const bytes = await context.fetchChunkBytes();
+    const bytes = this.workersAvailable ? await context.fetchChunkBytes() : undefined;
     context.signal.throwIfAborted();
     if (this.destroyed) {
       throw makeGaussianSplatWorkerAbortError(context.signal);
@@ -179,6 +187,9 @@ export class GaussianSplatRADWorkerDecoder {
     for (const job of [...this.queue]) {
       this.cancelWorkerJob(job);
     }
+    for (const job of [...this.activeFallbackJobs]) {
+      this.cancelWorkerJob(job);
+    }
     for (const slot of [...this.slots]) {
       if (slot.job) {
         this.cancelWorkerJob(slot.job);
@@ -206,39 +217,41 @@ export class GaussianSplatRADWorkerDecoder {
     );
     slot.worker.addEventListener('error', event => {
       event.preventDefault();
-      const error =
-        event.error || new Error(event.message || 'RAD worker could not decode a page.');
-      const job = slot.job;
-      this.removeWorkerSlot(slot);
-      if (job) {
-        this.finishWorkerJob(job, error);
-      } else {
-        this.dispatchQueuedJobs();
-      }
+      this.disableWorkerBackend();
     });
     slot.worker.addEventListener('messageerror', () => {
-      const job = slot.job;
-      this.removeWorkerSlot(slot);
-      if (job) {
-        this.finishWorkerJob(job, new Error('RAD worker returned an unreadable page.'));
-      }
+      this.disableWorkerBackend();
     });
     this.slots.push(slot);
     return slot;
   }
 
   private dispatchQueuedJobs(): void {
+    if (!this.workersAvailable) {
+      while (
+        !this.destroyed &&
+        this.queue.length > 0 &&
+        this.activeFallbackJobs.size < this.maxWorkers
+      ) {
+        const job = this.queue.shift()!;
+        if (job.context.signal.aborted) {
+          this.cancelWorkerJob(job);
+          continue;
+        }
+        this.activeFallbackJobs.add(job);
+        void this.decodeFallbackJob(job);
+      }
+      return;
+    }
+
     while (!this.destroyed && this.queue.length > 0) {
       let slot = this.slots.find(candidate => !candidate.job);
       if (!slot && this.slots.length < this.maxWorkers) {
         try {
           slot = this.createWorkerSlot();
-        } catch (error) {
-          const job = this.queue.shift();
-          if (job) {
-            this.finishWorkerJob(job, error);
-          }
-          continue;
+        } catch {
+          this.disableWorkerBackend();
+          return;
         }
       }
       if (!slot) {
@@ -255,16 +268,16 @@ export class GaussianSplatRADWorkerDecoder {
         id: job.id,
         chunkIndex: job.context.chunkIndex,
         bundleUrl: this.bundleUrl,
-        bytes: job.bytes,
+        bytes: job.bytes!,
         ...(job.context.metadata.splatEncoding === undefined
           ? {}
           : {splatEncoding: job.context.metadata.splatEncoding})
       };
       try {
-        slot.worker.postMessage(request, [job.bytes]);
-      } catch (error) {
-        this.removeWorkerSlot(slot);
-        this.finishWorkerJob(job, error);
+        slot.worker.postMessage(request, [request.bytes]);
+      } catch {
+        this.disableWorkerBackend();
+        return;
       }
     }
   }
@@ -278,6 +291,10 @@ export class GaussianSplatRADWorkerDecoder {
       return;
     }
     if (response.status === 'error') {
+      if (response.startup) {
+        this.disableWorkerBackend();
+        return;
+      }
       const error = new Error(response.message);
       error.name = response.name || 'Error';
       this.finishWorkerJob(job, error);
@@ -303,6 +320,43 @@ export class GaussianSplatRADWorkerDecoder {
       /* webpackIgnore: true */ /* @vite-ignore */ this.bundleUrl
     );
     return await this.loaderBundlePromise;
+  }
+
+  private disableWorkerBackend(): void {
+    if (!this.workersAvailable || this.destroyed) {
+      return;
+    }
+    this.workersAvailable = false;
+    const interruptedJobs: GaussianSplatRADWorkerJob[] = [];
+    for (const slot of [...this.slots]) {
+      const job = slot.job;
+      if (job && !job.settled) {
+        slot.job = undefined;
+        job.slot = undefined;
+        interruptedJobs.push(job);
+      }
+      this.removeWorkerSlot(slot);
+    }
+    this.queue.unshift(...interruptedJobs);
+    this.dispatchQueuedJobs();
+  }
+
+  private async decodeFallbackJob(job: GaussianSplatRADWorkerJob): Promise<void> {
+    try {
+      job.context.signal.throwIfAborted();
+      const page = (await job.context.decodeDefault()) as LocalGaussianSplatRADPage;
+      job.context.signal.throwIfAborted();
+      if (job.settled || this.destroyed) {
+        return;
+      }
+      this.completedDecodes++;
+      this.finishWorkerJob(job, undefined, page);
+    } catch (error) {
+      this.finishWorkerJob(job, error);
+    } finally {
+      this.activeFallbackJobs.delete(job);
+      this.dispatchQueuedJobs();
+    }
   }
 
   private cancelWorkerJob(job: GaussianSplatRADWorkerJob): void {

--- a/modules/arrow/src/arrow/renderers/splats/conversion/make-gpu-splat-data-from-arrow.ts
+++ b/modules/arrow/src/arrow/renderers/splats/conversion/make-gpu-splat-data-from-arrow.ts
@@ -299,7 +299,22 @@ function makeSplatSourceFromArrowRecordBatch(
       if (semanticId === null || semanticId === undefined) {
         throw new Error('Gaussian splat semantic identifiers cannot be null');
       }
-      semanticIds[rowIndex] = Number(semanticId);
+      const numericSemanticId =
+        typeof semanticId === 'number'
+          ? semanticId
+          : typeof semanticId === 'bigint'
+            ? Number(semanticId)
+            : Number.NaN;
+      if (
+        !Number.isInteger(numericSemanticId) ||
+        numericSemanticId < 0 ||
+        numericSemanticId > 0xffff_ffff
+      ) {
+        throw new RangeError(
+          'Gaussian splat semantic identifiers must be unsigned 32-bit integers'
+        );
+      }
+      semanticIds[rowIndex] = numericSemanticId;
     }
   }
 

--- a/modules/arrow/test/arrow/arrow-splats.node.spec.ts
+++ b/modules/arrow/test/arrow/arrow-splats.node.spec.ts
@@ -336,6 +336,88 @@ test('makeGPUSplatDataFromArrow rejects nullable semantic identifiers', t => {
   t.end();
 });
 
+test('makeGPUSplatDataFromArrow rejects invalid unsigned semantic identifiers', t => {
+  const device = new NullDevice({});
+  const source = makeSplatRecordBatch({positions: [0, 0, 0]});
+
+  for (const semanticId of [
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+    -1,
+    0.5,
+    0x1_0000_0000
+  ]) {
+    const semanticIds = arrow.vectorFromArray([semanticId], new arrow.Float64());
+    const recordBatch: GPUSplatArrowRecordBatchLike = {
+      numRows: source.numRows,
+      schema: source.schema,
+      getChild: columnName =>
+        columnName === 'custom_category' ? semanticIds : source.getChild(columnName)
+    };
+
+    t.throws(
+      () => makeGPUSplatDataFromArrow(device, recordBatch, {semanticColumn: 'custom_category'}),
+      /semantic identifiers must be unsigned 32-bit integers/,
+      `rejects invalid numeric semantic identifier ${String(semanticId)}`
+    );
+  }
+
+  for (const semanticId of ['building', '7']) {
+    const semanticIds = arrow.vectorFromArray([semanticId], new arrow.Utf8());
+    const recordBatch: GPUSplatArrowRecordBatchLike = {
+      numRows: source.numRows,
+      schema: source.schema,
+      getChild: columnName => (columnName === 'label' ? semanticIds : source.getChild(columnName))
+    };
+
+    t.throws(
+      () => makeGPUSplatDataFromArrow(device, recordBatch),
+      /semantic identifiers must be unsigned 32-bit integers/,
+      `never coerces automatically detected string label ${semanticId} into a class identifier`
+    );
+  }
+
+  for (const {semanticId, semanticIds} of [
+    {semanticId: -1n, semanticIds: arrow.vectorFromArray([-1n], new arrow.Int64())},
+    {
+      semanticId: 0x1_0000_0000n,
+      semanticIds: arrow.vectorFromArray([0x1_0000_0000n], new arrow.Uint64())
+    }
+  ]) {
+    const recordBatch: GPUSplatArrowRecordBatchLike = {
+      numRows: source.numRows,
+      schema: source.schema,
+      getChild: columnName =>
+        columnName === 'semantic_id' ? semanticIds : source.getChild(columnName)
+    };
+
+    t.throws(
+      () => makeGPUSplatDataFromArrow(device, recordBatch),
+      /semantic identifiers must be unsigned 32-bit integers/,
+      `rejects out-of-range 64-bit semantic identifier ${String(semanticId)}`
+    );
+  }
+
+  const validSource = makeSplatRecordBatch({positions: [0, 0, 0, 1, 1, 1]});
+  const validSemanticIds = arrow.vectorFromArray([0n, 0xffff_ffffn], new arrow.Uint64());
+  const validRecordBatch: GPUSplatArrowRecordBatchLike = {
+    numRows: validSource.numRows,
+    schema: validSource.schema,
+    getChild: columnName =>
+      columnName === 'semantic_id' ? validSemanticIds : validSource.getChild(columnName)
+  };
+  const prepared = makeGPUSplatDataFromArrow(device, validRecordBatch)[0]!;
+
+  t.deepEqual(
+    Array.from(prepared.source.semanticIds ?? []),
+    [0, 0xffff_ffff],
+    'preserves both unsigned 32-bit bounds from numeric Arrow columns'
+  );
+  prepared.destroy();
+  t.end();
+});
+
 test('makeGPUSplatDataFromArrow honors linear field metadata and independent scale encodings', t => {
   const device = new NullDevice({});
   const recordBatch = makeSplatRecordBatch({

--- a/modules/splats/src/gpu-splat-graph-renderer.ts
+++ b/modules/splats/src/gpu-splat-graph-renderer.ts
@@ -263,8 +263,12 @@ export class GPUSplatGraphRenderer {
     this.requiresEncoding = true;
   }
 
-  /** Updates camera or styling uniforms in O(batch count), never O(splat count). */
-  setProps(props: Partial<GPUSplatGraphRendererProps>): void {
+  /** Updates mutable camera, styling, or borrowed data; graph allocation options are immutable. */
+  setProps(
+    props: Partial<
+      Omit<GPUSplatGraphRendererProps, 'clearColor' | 'expectedSplatCount' | 'expectedBatchCount'>
+    >
+  ): void {
     if (props.data !== undefined) {
       const replacementBatches = normalizeSplatGraphBatches(props.data);
       const matchesRetainedBatches =

--- a/modules/splats/src/splat-hierarchy.ts
+++ b/modules/splats/src/splat-hierarchy.ts
@@ -375,12 +375,13 @@ export class SplatHierarchyManager {
       screenSpaceError
     );
     let residentChunk = this.residencyManager.getChunk(node.id);
-    if (!residentChunk && node.data && !node.data.destroyed) {
+    if (node.data && !node.data.destroyed) {
       residentChunk = this.residencyManager.add(node.data, {
         id: node.id,
         priority,
         levelOfDetail,
         bounds: node.bounds,
+        ...(residentChunk?.pinned ? {pinned: true} : {}),
         ...(node.ownsData !== undefined ? {ownsData: node.ownsData} : {})
       });
     }

--- a/modules/splats/src/splat-rad-hierarchy.ts
+++ b/modules/splats/src/splat-rad-hierarchy.ts
@@ -479,7 +479,7 @@ export class SplatRADHierarchyManager {
       selectedPages: new Map(),
       protectedPageIds: new Set(),
       requestedPages: new Map(),
-      allocatedRowCount: rootRows.length,
+      allocatedRowCount: 0,
       refinedRows: new Set()
     };
     const selectedRows = new Map<number, SplatRADFrontierCandidate>();
@@ -493,6 +493,7 @@ export class SplatRADHierarchyManager {
       }
       const candidate = this.makeFrontierCandidate(rootPage, rootRow);
       if (candidate) {
+        state.allocatedRowCount++;
         this.addFrontierCandidate(candidate, selectedRows, refinementQueue);
       }
     }
@@ -599,7 +600,6 @@ export class SplatRADHierarchyManager {
     if (
       childCount === 0 ||
       priority <= this.getRefinementThreshold(candidate) ||
-      state.allocatedRowCount + childCount - 1 > this.maximumActiveRows ||
       this.visibleRowCount + this.culledRowCount + childCount > this.maxTraversalRows ||
       !Number.isSafeInteger(childStart + childCount) ||
       childStart + childCount > 0x8000_0000
@@ -647,12 +647,15 @@ export class SplatRADHierarchyManager {
         childCandidates.push(child);
       }
     }
-    if (childCandidates.length === 0) {
+    if (
+      childCandidates.length === 0 ||
+      state.allocatedRowCount + childCandidates.length - 1 > this.maximumActiveRows
+    ) {
       return;
     }
 
     selectedRows.delete(globalRowIndex);
-    state.allocatedRowCount += childCount - 1;
+    state.allocatedRowCount += childCandidates.length - 1;
     state.refinedRows.add(globalRowIndex);
     for (const child of childCandidates) {
       this.addFrontierCandidate(child, selectedRows, refinementQueue);

--- a/modules/splats/src/splat-renderer.ts
+++ b/modules/splats/src/splat-renderer.ts
@@ -146,6 +146,8 @@ export type SplatDrawRun = {
   batchIndex: number;
   rowIndices: Uint32Array;
   indexBuffer?: Buffer;
+  /** Renderer-owned WebGL attributes reordered without modifying borrowed source data. */
+  attributeBuffers?: Record<string, Buffer>;
 };
 
 const IDENTITY_MATRIX: SplatUniforms['modelViewProjectionMatrix'] = [
@@ -221,6 +223,7 @@ export class SplatRenderer {
   private readonly cachedReferences: Array<Array<SplatSortReference | undefined>> = [];
   private readonly cachedBatchRevisions: number[] = [];
   private readonly evaluatedColorBuffers: Array<Buffer | undefined> = [];
+  private readonly evaluatedColorValues: Array<Float32Array | undefined> = [];
   private readonly opacityMaskBuffers: Array<Buffer | undefined> = [];
   private drawRuns: SplatDrawRun[] = [];
   private placeholderIndexBuffer?: Buffer;
@@ -228,6 +231,7 @@ export class SplatRenderer {
   private requiresUpdate = true;
   private requiresUniformUpdate = false;
   private requiresWebGLSourceUpdate = false;
+  private usesFloatWebGLColors = false;
   private hasExplicitToneMapping = false;
   private isDestroyed = false;
 
@@ -282,6 +286,7 @@ export class SplatRenderer {
     this.cachedReferences.push([]);
     this.cachedBatchRevisions.push(data.revision);
     this.evaluatedColorBuffers.push(undefined);
+    this.evaluatedColorValues.push(undefined);
     this.opacityMaskBuffers.push(undefined);
     if (
       !this.hasExplicitToneMapping &&
@@ -292,7 +297,11 @@ export class SplatRenderer {
     }
     if (this.table) {
       this.table.addBatch(borrowedBatch);
+      const previousVertexArray = this.model?.vertexArray;
       this.model?.setProps({table: this.table});
+      if (previousVertexArray && previousVertexArray !== this.model?.vertexArray) {
+        previousVertexArray.destroy();
+      }
     } else {
       this.table = new GPUTable({batches: [borrowedBatch]});
       this.model = this.createModel(this.table);
@@ -491,7 +500,16 @@ export class SplatRenderer {
       (this.model?.tableBindingByteLength ?? 0) +
       this.evaluatedColorBuffers.reduce((total, buffer) => total + (buffer?.byteLength ?? 0), 0) +
       this.opacityMaskBuffers.reduce((total, buffer) => total + (buffer?.byteLength ?? 0), 0) +
-      this.drawRuns.reduce((totalBytes, run) => totalBytes + (run.indexBuffer?.byteLength ?? 0), 0);
+      this.drawRuns.reduce(
+        (totalBytes, run) =>
+          totalBytes +
+          (run.indexBuffer?.byteLength ?? 0) +
+          Object.values(run.attributeBuffers ?? {}).reduce(
+            (attributeBytes, buffer) => attributeBytes + buffer.byteLength,
+            0
+          ),
+        0
+      );
     return {
       splatCount,
       rowCount: splatCount,
@@ -867,11 +885,23 @@ export class SplatRenderer {
           });
         }
       }
-      this.drawRuns.push({batchIndex: nextRun.batchIndex, rowIndices, indexBuffer});
+      const drawRun: SplatDrawRun = {
+        batchIndex: nextRun.batchIndex,
+        rowIndices,
+        indexBuffer,
+        ...(reusableRun?.attributeBuffers ? {attributeBuffers: reusableRun.attributeBuffers} : {})
+      };
+      if (this.device.type !== 'webgpu') {
+        this.updateWebGLDrawRunAttributes(drawRun);
+      }
+      this.drawRuns.push(drawRun);
     }
 
     for (const previousRun of previousRuns) {
       previousRun.indexBuffer?.destroy();
+      for (const buffer of Object.values(previousRun.attributeBuffers ?? {})) {
+        buffer.destroy();
+      }
     }
   }
 
@@ -908,31 +938,28 @@ export class SplatRenderer {
       return false;
     }
     let drawSuccess = true;
-    const drawnBatches = new Set<number>();
     for (const run of this.drawRuns) {
-      if (drawnBatches.has(run.batchIndex)) {
-        continue;
-      }
       const batch = this.table.batches[run.batchIndex];
       if (!batch) {
         continue;
       }
       const evaluatedColorBuffer = this.evaluatedColorBuffers[run.batchIndex];
+      const usesEvaluatedColors = this.usesFloatWebGLColors && Boolean(evaluatedColorBuffer);
       this.model.setAttributes(
         Object.fromEntries(
           Object.entries(batch.gpuData).map(([name, data]) => [
             name,
-            name === 'colors' && this.props.sphericalHarmonicsDegree > 0 && evaluatedColorBuffer
-              ? evaluatedColorBuffer
-              : name === 'opacities'
-                ? this.getBatchOpacityBuffer(run.batchIndex)
-                : data.buffer
+            run.attributeBuffers?.[name] ??
+              (name === 'colors' && usesEvaluatedColors && evaluatedColorBuffer
+                ? evaluatedColorBuffer
+                : name === 'opacities'
+                  ? this.getBatchOpacityBuffer(run.batchIndex)
+                  : data.buffer)
           ])
         )
       );
-      this.model.setInstanceCount(batch.numRows);
+      this.model.setInstanceCount(run.rowIndices.length);
       drawSuccess = this.model.draw(renderPass) && drawSuccess;
-      drawnBatches.add(run.batchIndex);
     }
     return drawSuccess;
   }
@@ -947,6 +974,9 @@ export class SplatRenderer {
     this.cachedReferences.length = 0;
     this.cachedBatchRevisions.length = 0;
     this.destroyWebGLSourceBuffers();
+    if (!this.hasExplicitToneMapping) {
+      this.setResolvedProp('toneMapping', 'none');
+    }
     for (const batch of batches) {
       this.appendData(batch);
     }
@@ -956,18 +986,118 @@ export class SplatRenderer {
   private destroyDrawRuns(): void {
     for (const run of this.drawRuns) {
       run.indexBuffer?.destroy();
+      for (const buffer of Object.values(run.attributeBuffers ?? {})) {
+        buffer.destroy();
+      }
     }
     this.drawRuns = [];
+  }
+
+  private updateWebGLDrawRunAttributes(run: SplatDrawRun): void {
+    const batch = this.batches[run.batchIndex];
+    if (!batch) {
+      return;
+    }
+    const needsSortedAttributes =
+      run.rowIndices.length !== batch.length ||
+      run.rowIndices.some((rowIndex, sortedRowIndex) => rowIndex !== sortedRowIndex);
+    if (!needsSortedAttributes) {
+      for (const buffer of Object.values(run.attributeBuffers ?? {})) {
+        buffer.destroy();
+      }
+      delete run.attributeBuffers;
+      return;
+    }
+
+    const evaluatedColors = this.usesFloatWebGLColors
+      ? this.evaluatedColorValues[run.batchIndex]
+      : undefined;
+    const sourceColors = evaluatedColors ?? batch.source.colors;
+    const sortedValues = {
+      positions: new Float32Array(run.rowIndices.length * 3),
+      scales: new Float32Array(run.rowIndices.length * 3),
+      rotations: new Float32Array(run.rowIndices.length * 4),
+      colors:
+        sourceColors instanceof Float32Array
+          ? new Float32Array(run.rowIndices.length * 4)
+          : new Uint8Array(run.rowIndices.length * 4),
+      opacities: new Float32Array(run.rowIndices.length),
+      rowIndices: new Uint32Array(run.rowIndices.length)
+    };
+
+    for (const [sortedRowIndex, sourceRowIndex] of run.rowIndices.entries()) {
+      sortedValues.positions.set(
+        batch.source.positions.subarray(sourceRowIndex * 3, sourceRowIndex * 3 + 3),
+        sortedRowIndex * 3
+      );
+      sortedValues.scales.set(
+        batch.source.scales.subarray(sourceRowIndex * 3, sourceRowIndex * 3 + 3),
+        sortedRowIndex * 3
+      );
+      sortedValues.rotations.set(
+        batch.source.rotations.subarray(sourceRowIndex * 4, sourceRowIndex * 4 + 4),
+        sortedRowIndex * 4
+      );
+      sortedValues.colors.set(
+        sourceColors.subarray(sourceRowIndex * 4, sourceRowIndex * 4 + 4),
+        sortedRowIndex * 4
+      );
+      sortedValues.opacities[sortedRowIndex] = batch.source.opacities[sourceRowIndex];
+      sortedValues.rowIndices[sortedRowIndex] = batch.rowIndexBase + sourceRowIndex;
+    }
+
+    const attributeBuffers = run.attributeBuffers ?? {};
+    for (const [name, values] of Object.entries(sortedValues)) {
+      const existingBuffer = attributeBuffers[name];
+      if (existingBuffer && existingBuffer.byteLength >= values.byteLength) {
+        existingBuffer.write(values);
+      } else {
+        existingBuffer?.destroy();
+        attributeBuffers[name] = this.device.createBuffer({
+          id: `splat-sorted-${name}-${batch.sourceBatchIndex}`,
+          data: values,
+          usage: Buffer.VERTEX | Buffer.COPY_DST
+        });
+      }
+    }
+    run.attributeBuffers = attributeBuffers;
   }
 
   private updateWebGLSourceBuffers(): void {
     if (this.device.type === 'webgpu') {
       return;
     }
+    this.usesFloatWebGLColors =
+      this.props.sphericalHarmonicsDegree > 0 &&
+      this.batches.some(batch => Boolean(batch.source.sphericalHarmonics));
+    const colorFormat = this.usesFloatWebGLColors ? 'float32x4' : this.batches[0]?.colors.format;
+    const currentColorFormat = this.model?.bufferLayout.find(
+      bufferLayout => bufferLayout.name === 'colors'
+    )?.format;
+    if (this.model && colorFormat && currentColorFormat !== colorFormat) {
+      const previousVertexArray = this.model.vertexArray;
+      this.model.setBufferLayout(
+        this.model.bufferLayout.map(bufferLayout =>
+          bufferLayout.name === 'colors'
+            ? {
+                ...bufferLayout,
+                format: colorFormat,
+                byteStride: colorFormat === 'float32x4' ? 16 : 4
+              }
+            : bufferLayout
+        )
+      );
+      if (this.model.vertexArray !== previousVertexArray) {
+        previousVertexArray.destroy();
+      }
+    }
     for (const [batchIndex, batch] of this.batches.entries()) {
       const coefficients = batch.source.sphericalHarmonics;
       if (coefficients && this.props.sphericalHarmonicsDegree > 0) {
         this.updateWebGLSphericalHarmonicColors(batchIndex, batch, coefficients);
+      } else if (this.usesFloatWebGLColors && batch.source.colors instanceof Uint8Array) {
+        const normalizedColors = Float32Array.from(batch.source.colors, color => color / 255);
+        this.setWebGLEvaluatedColors(batchIndex, batch, normalizedColors);
       }
       if (this.props.semanticFilter) {
         const opacities = new Float32Array(batch.source.opacities);
@@ -990,6 +1120,11 @@ export class SplatRenderer {
         }
       }
     }
+    if (!this.requiresUpdate) {
+      for (const run of this.drawRuns) {
+        this.updateWebGLDrawRunAttributes(run);
+      }
+    }
   }
 
   private updateWebGLSphericalHarmonicColors(
@@ -998,10 +1133,8 @@ export class SplatRenderer {
     coefficients: Float32Array
   ): void {
     const sourceColors = batch.source.colors;
-    const colors =
-      sourceColors instanceof Float32Array
-        ? new Float32Array(sourceColors)
-        : new Uint8Array(sourceColors);
+    const colors = new Float32Array(sourceColors.length);
+    const sourceColorScale = sourceColors instanceof Float32Array ? 1 : 1 / 255;
     const coefficientCount = batch.length > 0 ? coefficients.length / batch.length : 0;
     const degree =
       this.props.sphericalHarmonicsDegree < batch.sphericalHarmonicsDegree
@@ -1010,7 +1143,6 @@ export class SplatRenderer {
     for (let rowIndex = 0; rowIndex < batch.length; rowIndex++) {
       const colorOffset = rowIndex * 4;
       const positionOffset = rowIndex * 3;
-      const sourceColorScale = sourceColors instanceof Float32Array ? 1 : 1 / 255;
       const color = evaluateSplatSphericalHarmonics(
         [
           sourceColors[colorOffset] * sourceColorScale,
@@ -1026,12 +1158,19 @@ export class SplatRenderer {
         degree
       );
       for (let colorComponentIndex = 0; colorComponentIndex < 3; colorComponentIndex++) {
-        colors[colorOffset + colorComponentIndex] =
-          colors instanceof Float32Array
-            ? color[colorComponentIndex]
-            : Math.round(Math.min(Math.max(color[colorComponentIndex], 0), 1) * 255);
+        colors[colorOffset + colorComponentIndex] = color[colorComponentIndex];
       }
+      colors[colorOffset + 3] = sourceColors[colorOffset + 3] * sourceColorScale;
     }
+    this.setWebGLEvaluatedColors(batchIndex, batch, colors);
+  }
+
+  private setWebGLEvaluatedColors(
+    batchIndex: number,
+    batch: GPUSplatData,
+    colors: Float32Array
+  ): void {
+    this.evaluatedColorValues[batchIndex] = colors;
     const existingBuffer = this.evaluatedColorBuffers[batchIndex];
     if (existingBuffer) {
       existingBuffer.write(colors);
@@ -1052,7 +1191,9 @@ export class SplatRenderer {
       buffer?.destroy();
     }
     this.evaluatedColorBuffers.length = 0;
+    this.evaluatedColorValues.length = 0;
     this.opacityMaskBuffers.length = 0;
+    this.usesFloatWebGLColors = false;
   }
 }
 

--- a/modules/splats/test/splat-hierarchy.node.spec.ts
+++ b/modules/splats/test/splat-hierarchy.node.spec.ts
@@ -874,6 +874,127 @@ test('SplatHierarchyManager prunes large source hierarchies before loading invis
   t.end();
 });
 
+test('SplatHierarchyManager replaces same-identity roots without losing externally owned pins', t => {
+  const device = new NullDevice({});
+  const originalBatch = makeSplatHierarchyBatch(device, 17, 800);
+  const replacementBatch = makeSplatHierarchyBatch(device, 18, 900);
+  const originalNode = {
+    ...makeSplatHierarchyNode('shared-root', [0, 0, 0], 0),
+    data: originalBatch,
+    ownsData: false
+  };
+  const replacementNode = {
+    ...makeSplatHierarchyNode('shared-root', [0.4, 0, 0], 0, 0.2),
+    data: replacementBatch,
+    ownsData: true
+  };
+  const evictionEvents: Array<{data: GPUSplatData; reason: string}> = [];
+  const frontierEvents: number[][] = [];
+  const residencyManager = new SplatResidencyManager({
+    maxResidentChunks: 1,
+    onEvict: (chunk, reason) => evictionEvents.push({data: chunk.data, reason})
+  });
+  residencyManager.add(originalBatch, {
+    id: originalNode.id,
+    pinned: true,
+    ownsData: false,
+    bounds: originalNode.bounds
+  });
+  const manager = new SplatHierarchyManager({
+    roots: [originalNode],
+    residencyManager,
+    onFrontierChange: batches => {
+      frontierEvents.push(batches.map(batch => batch.sourceBatchIndex));
+    }
+  });
+
+  manager.update(makeSplatHierarchyView());
+  manager.setRoots([replacementNode]);
+
+  t.deepEqual(manager.frontierBatches, [replacementBatch], 'renders the replacement source batch');
+  t.equal(manager.frontier[0].node, replacementNode, 'publishes replacement source metadata');
+  t.equal(
+    manager.frontier[0].chunk.data.sourceInfo,
+    replacementBatch.sourceInfo,
+    'preserves the replacement source-batch and global-row identity'
+  );
+  t.deepEqual(
+    residencyManager.getChunk(originalNode.id)?.bounds,
+    replacementNode.bounds,
+    'updates the retained spatial metadata for the replacement source node'
+  );
+  t.equal(
+    residencyManager.getChunk(originalNode.id)?.ownsData,
+    true,
+    'honors explicitly transferred ownership for the replacement source batch'
+  );
+  t.ok(residencyManager.getChunk(originalNode.id)?.pinned, 'preserves the caller-owned source pin');
+  t.equal(residencyManager.stats.residentChunkCount, 1, 'reuses the existing bounded chunk slot');
+  t.deepEqual(
+    evictionEvents,
+    [{data: originalBatch, reason: 'replace'}],
+    'reports exact replacement ownership before updating the rendered frontier'
+  );
+  t.deepEqual(frontierEvents, [[17], [18]], 'notifies renderers when stable IDs gain new data');
+  t.notOk(originalBatch.destroyed, 'never destroys the original caller-owned source batch');
+
+  manager.destroy();
+  t.ok(
+    residencyManager.getChunk(originalNode.id)?.pinned,
+    'never releases externally owned pins after a same-identity replacement'
+  );
+  residencyManager.destroy();
+  t.ok(replacementBatch.destroyed, 'destroys the explicitly manager-owned replacement batch');
+  originalBatch.destroy();
+  t.end();
+});
+
+test('SplatHierarchyManager transfers hierarchy-owned pins and honors prior source ownership', t => {
+  const device = new NullDevice({});
+  const originalBatch = makeSplatHierarchyBatch(device, 19, 950);
+  const replacementBatch = makeSplatHierarchyBatch(device, 20, 1_000);
+  const residencyManager = new SplatResidencyManager({maxResidentChunks: 1});
+  const manager = new SplatHierarchyManager({
+    roots: [
+      {
+        ...makeSplatHierarchyNode('owned-root', [0, 0, 0], 0),
+        data: originalBatch,
+        ownsData: true
+      }
+    ],
+    residencyManager
+  });
+
+  manager.update(makeSplatHierarchyView());
+  t.ok(residencyManager.getChunk('owned-root')?.pinned, 'protects the original visible root');
+  manager.setRoots([
+    {
+      ...makeSplatHierarchyNode('owned-root', [0.2, 0, 0], 0),
+      data: replacementBatch,
+      ownsData: false
+    }
+  ]);
+
+  t.ok(originalBatch.destroyed, 'destroys the replaced source batch when its ownership was held');
+  t.deepEqual(manager.frontierBatches, [replacementBatch], 'publishes the intact borrowed source');
+  t.ok(residencyManager.getChunk('owned-root')?.pinned, 'transfers hierarchy-owned pin protection');
+  t.equal(
+    residencyManager.stats.pinnedChunkCount,
+    1,
+    'keeps pin accounting balanced across transactional replacement'
+  );
+
+  manager.destroy();
+  t.notOk(
+    residencyManager.getChunk('owned-root')?.pinned,
+    'releases transferred pins owned only by this hierarchy'
+  );
+  residencyManager.destroy();
+  t.notOk(replacementBatch.destroyed, 'preserves the explicitly borrowed replacement source');
+  replacementBatch.destroy();
+  t.end();
+});
+
 test('SplatHierarchyManager replaces source roots and rejects duplicate source identities', t => {
   const device = new NullDevice({});
   const firstBatch = makeSplatHierarchyBatch(device, 17, 800);

--- a/modules/splats/test/splat-mixed-renderer.node.spec.ts
+++ b/modules/splats/test/splat-mixed-renderer.node.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
+import {Buffer} from '@luma.gl/core';
 import {makeGPUSplatData, SplatRenderer, type SplatSource} from '@luma.gl/splats';
 import {NullDevice} from '@luma.gl/test-utils';
 
@@ -64,6 +65,7 @@ test('SplatRenderer composites opaque meshes, sorted splats, and transparent mes
 test('SplatRenderer enforces semantic filtering on WebGL without changing source opacity', async t => {
   const device = new NullDevice({});
   const source = makeMixedSplatSource();
+  source.opacities.set([0.25, 0.5, 0.75]);
   const prepared = makeGPUSplatData(device, source);
   const renderer = new SplatRenderer(device, {
     data: prepared,
@@ -80,16 +82,50 @@ test('SplatRenderer enforces semantic filtering on WebGL without changing source
   const bytes = await opacityBuffer.readAsync();
   t.deepEqual(
     Array.from(new Float32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4)),
-    [1, 0, 1],
+    [0.25, 0, 0.75],
     'masks rejected WebGL rows in a renderer-owned opacity allocation'
   );
-  t.deepEqual(Array.from(source.opacities), [1, 1, 1], 'preserves caller-owned source opacity');
+  t.deepEqual(
+    Array.from(source.opacities),
+    [0.25, 0.5, 0.75],
+    'preserves caller-owned source opacity'
+  );
 
   renderer.draw(device.getDefaultRenderPass());
-  t.equal(
-    renderer.model?.vertexArray.attributes[4],
+  const sortedOpacityBuffer = renderer.model?.vertexArray.attributes[4];
+  if (!(sortedOpacityBuffer instanceof Buffer)) {
+    t.fail('binds renderer-owned, semantically filtered opacity in sorted source-row order');
+    renderer.destroy();
+    prepared.destroy();
+    t.end();
+    return;
+  }
+  t.notEqual(
+    sortedOpacityBuffer,
     opacityBuffer,
-    'binds semantic masking to the fallback instanced shader'
+    'keeps batch-order semantic masks separate from sorted instanced attributes'
+  );
+  t.equal(
+    sortedOpacityBuffer,
+    renderer.getDrawRuns()[0]?.attributeBuffers?.opacities,
+    'binds the run-owned reordered opacity allocation'
+  );
+  const sortedOpacityBytes = await sortedOpacityBuffer.readAsync();
+  t.deepEqual(
+    Array.from(
+      new Float32Array(
+        sortedOpacityBytes.buffer,
+        sortedOpacityBytes.byteOffset,
+        sortedOpacityBytes.byteLength / Float32Array.BYTES_PER_ELEMENT
+      )
+    ),
+    [0.75, 0.25],
+    'preserves the accepted source opacities in exact back-to-front draw order'
+  );
+  t.deepEqual(
+    Array.from(source.opacities),
+    [0.25, 0.5, 0.75],
+    'does not reorder or mask caller-owned source opacity'
   );
   renderer.setProps({semanticFilter: undefined});
   t.equal(renderer.stats.visibleSplatCount, 3, 'restores every source row when the filter clears');
@@ -99,8 +135,17 @@ test('SplatRenderer enforces semantic filtering on WebGL without changing source
     'restores caller-owned opacity when semantic masking is disabled'
   );
 
+  renderer.setProps({sortMode: 'none', semanticFilter: {include: [7, 9]}});
+  renderer.draw(device.getDefaultRenderPass());
+  t.equal(
+    renderer.model?.vertexArray.attributes[4],
+    renderer.getBatchOpacityBuffer(0),
+    'binds the original semantic mask directly when all source rows retain their original order'
+  );
+
   renderer.destroy();
   t.ok(opacityBuffer.destroyed, 'releases only the renderer-owned semantic opacity mask');
+  t.ok(sortedOpacityBuffer.destroyed, 'releases the renderer-owned sorted opacity allocation');
   t.notOk(prepared.opacities.data[0].buffer.destroyed, 'preserves caller-owned opacity');
   prepared.destroy();
   t.end();

--- a/modules/splats/test/splat-rad-hierarchy.node.spec.ts
+++ b/modules/splats/test/splat-rad-hierarchy.node.spec.ts
@@ -348,6 +348,60 @@ test('SplatRADHierarchyManager respects active-row budgets and missing-page back
   t.end();
 });
 
+test('SplatRADHierarchyManager budgets only visible rows while retaining authored traversal limits', t => {
+  const device = new NullDevice({});
+  const parent = makeRADPage(device, {
+    id: 'parent',
+    rowIndexBase: 0,
+    positions: [0, 0, 0],
+    childCounts: [5],
+    childStarts: [1]
+  });
+  const children = makeRADPage(device, {
+    id: 'children',
+    rowIndexBase: 1,
+    positions: [0, 0, 0, 4, 0, 0, -4, 0, 0, 0, 4, 0, 0, -4, 0],
+    childCounts: [2, 0, 0, 0, 0],
+    childStarts: [6, 0, 0, 0, 0]
+  });
+  const grandchildren = makeRADPage(device, {
+    id: 'grandchildren',
+    rowIndexBase: 6,
+    positions: [-0.1, 0, 0, 0.1, 0, 0]
+  });
+  const manager = new SplatRADHierarchyManager({
+    pages: [parent, children, grandchildren],
+    maximumScreenSpaceError: 0,
+    maximumActiveRows: 2,
+    maxTraversalRows: 8,
+    refinementHysteresis: 0
+  });
+
+  manager.update(makeRADView());
+
+  t.deepEqual(
+    getFrontierSourceRows(manager.frontier),
+    [[6, 7]],
+    'refines the sole visible child through its next level instead of reserving culled siblings'
+  );
+  t.equal(manager.stats.activeRowCount, 2, 'accounts for only original visible frontier rows');
+  t.equal(manager.stats.culledRowCount, 4, 'still evaluates each authored invisible source child');
+  t.equal(
+    manager.stats.visibleRowCount + manager.stats.culledRowCount,
+    8,
+    'continues charging every authored child against the synchronous traversal budget'
+  );
+  t.equal(manager.stats.fallbackRowCount, 0, 'removes every fully replaced resident parent');
+  t.equal(manager.stats.requestedPageCount, 0, 'retains complete resident child-page readiness');
+  t.equal(manager.frontier[0].data, grandchildren.data, 'borrows the original finest source page');
+
+  manager.destroy();
+  parent.data.destroy();
+  children.data.destroy();
+  grandchildren.data.destroy();
+  t.end();
+});
+
 test('SplatRADHierarchyManager retains fallback when protected page budgets deny child admission', t => {
   const device = new NullDevice({});
   const residency = new SplatResidencyManager({maxResidentChunks: 2});

--- a/modules/splats/test/splat-renderer.node.spec.ts
+++ b/modules/splats/test/splat-renderer.node.spec.ts
@@ -115,6 +115,51 @@ test('SplatRenderer normalizes Float32 alpha and adapts HDR display mapping', t 
   t.end();
 });
 
+test('SplatRenderer recomputes automatic tone mapping when replacing source radiance', t => {
+  const device = new NullDevice({});
+  const highDynamicRangeSource = makeSplatSource([0.5]);
+  highDynamicRangeSource.colors = new Float32Array([4, 2, 0.5, 1]);
+  const highDynamicRangeBatch = makeGPUSplatData(device, highDynamicRangeSource);
+  const standardDynamicRangeBatch = makeGPUSplatData(device, makeSplatSource([0.5]));
+  const renderer = new SplatRenderer(device, {data: highDynamicRangeBatch});
+
+  t.equal(renderer.props.toneMapping, 'reinhard', 'automatically compresses HDR source colors');
+  renderer.setProps({data: standardDynamicRangeBatch});
+  t.equal(
+    renderer.props.toneMapping,
+    'none',
+    'removes automatic mapping for replacement SDR colors'
+  );
+  renderer.setProps({data: highDynamicRangeBatch});
+  t.equal(renderer.props.toneMapping, 'reinhard', 'restores automatic mapping for replacement HDR');
+  renderer.setProps({data: []});
+  t.equal(renderer.props.toneMapping, 'none', 'clears automatic mapping when all data is removed');
+  renderer.destroy();
+
+  const explicitlyMappedRenderer = new SplatRenderer(device, {
+    data: highDynamicRangeBatch,
+    toneMapping: 'none'
+  });
+  explicitlyMappedRenderer.setProps({data: standardDynamicRangeBatch});
+  explicitlyMappedRenderer.setProps({data: highDynamicRangeBatch});
+  t.equal(
+    explicitlyMappedRenderer.props.toneMapping,
+    'none',
+    'preserves an explicit unmapped override across both source formats'
+  );
+  explicitlyMappedRenderer.setProps({toneMapping: 'reinhard', data: []});
+  t.equal(
+    explicitlyMappedRenderer.props.toneMapping,
+    'reinhard',
+    'preserves an explicit mapping override when retained source data is cleared'
+  );
+
+  explicitlyMappedRenderer.destroy();
+  highDynamicRangeBatch.destroy();
+  standardDynamicRangeBatch.destroy();
+  t.end();
+});
+
 test('SplatRenderer preserves Float32 highlights on extended HDR presentation targets', t => {
   const device = new NullDevice({
     createCanvasContext: {colorFormat: 'rgba16float', toneMapping: 'extended'}
@@ -306,6 +351,83 @@ test('SplatRenderer preserves batches, stable cross-batch ordering, and source o
   secondBatch.destroy();
   t.ok(firstBuffer.destroyed, 'caller releases the first source batch');
   t.ok(secondBuffer.destroyed, 'caller releases the second source batch');
+  t.end();
+});
+
+test('SplatRenderer draws sorted WebGL rows and interleaved source batches exactly once', async t => {
+  const device = new NullDevice({});
+  const firstSource = makeSplatSource([0.2, 0.8], 0, 10);
+  const secondSource = makeSplatSource([0.5], 1, 20);
+  const firstBatch = makeGPUSplatData(device, firstSource);
+  const secondBatch = makeGPUSplatData(device, secondSource);
+  const firstSourceBuffer = firstBatch.positions.data[0].buffer;
+  const secondSourceBuffer = secondBatch.positions.data[0].buffer;
+  const renderer = new SplatRenderer(device, {
+    data: [firstBatch, secondBatch],
+    viewportSize: [32, 32],
+    sortMode: 'global'
+  });
+  const model = renderer.model;
+  if (!model) {
+    t.fail('creates an attribute-backed Gaussian splat model');
+    renderer.destroy();
+    firstBatch.destroy();
+    secondBatch.destroy();
+    t.end();
+    return;
+  }
+
+  const originalDraw = model.draw.bind(model);
+  const drawnRowBuffers: Array<{buffer: Buffer; rowCount: number}> = [];
+  model.draw = renderPass => {
+    const rowIndexBuffer = model.vertexArray.attributes[5];
+    if (rowIndexBuffer instanceof Buffer) {
+      drawnRowBuffers.push({buffer: rowIndexBuffer, rowCount: model.instanceCount});
+    }
+    return originalDraw(renderPass);
+  };
+  const renderPass = device.getDefaultRenderPass();
+  t.ok(renderer.draw(renderPass), 'draws every globally sorted source-batch run');
+
+  const drawnRows: number[] = [];
+  for (const {buffer, rowCount} of drawnRowBuffers) {
+    const rowBytes = await buffer.readAsync();
+    drawnRows.push(...new Uint32Array(rowBytes.buffer, rowBytes.byteOffset, rowCount).values());
+  }
+  t.deepEqual(drawnRows, [11, 20, 10], 'honors globally sorted cross-batch row identities');
+  t.deepEqual(
+    drawnRowBuffers.map(({rowCount}) => rowCount),
+    [1, 1, 1],
+    'draws each source row once without redrawing complete source batches'
+  );
+  const sortedPositionBuffer = renderer.getDrawRuns()[0]?.attributeBuffers?.positions;
+  if (!(sortedPositionBuffer instanceof Buffer)) {
+    t.fail('creates an independently owned, reordered WebGL position buffer');
+    renderer.destroy();
+    firstBatch.destroy();
+    secondBatch.destroy();
+    t.end();
+    return;
+  }
+  const sortedPositionBytes = await sortedPositionBuffer.readAsync();
+  const sortedPositions = new Float32Array(
+    sortedPositionBytes.buffer,
+    sortedPositionBytes.byteOffset,
+    sortedPositionBytes.byteLength / Float32Array.BYTES_PER_ELEMENT
+  );
+  t.ok(Math.abs(sortedPositions[2] - 0.8) < 1e-6, 'reorders the furthest source row first');
+  t.ok(
+    Math.abs(firstSource.positions[2] - 0.2) < 1e-6,
+    'preserves the caller-owned CPU source row order'
+  );
+  t.ok(renderer.stats.rendererGpuByteLength > 0, 'accounts for renderer-owned sorted attributes');
+
+  renderer.destroy();
+  t.ok(sortedPositionBuffer.destroyed, 'releases renderer-owned sorted WebGL attributes');
+  t.notOk(firstSourceBuffer.destroyed, 'preserves the first caller-owned source GPU buffer');
+  t.notOk(secondSourceBuffer.destroyed, 'preserves the second caller-owned source GPU buffer');
+  firstBatch.destroy();
+  secondBatch.destroy();
   t.end();
 });
 

--- a/modules/splats/test/splat-renderer.spec.ts
+++ b/modules/splats/test/splat-renderer.spec.ts
@@ -8,6 +8,10 @@ import {Model} from '@luma.gl/engine';
 import {makeGPUSplatData, SplatRenderer, type SplatSource} from '@luma.gl/splats';
 import {getTestDevices} from '@luma.gl/test-utils';
 
+// Keep renderer ownership, sorting, tone mapping, and SH fallback covered on software-only CI.
+import './splat-renderer.node.spec';
+import './splat-spherical-harmonics.node.spec';
+
 test('SplatRenderer renders Gaussian source batches on WebGPU and WebGL2', async t => {
   const devices = await getTestDevices(['webgpu', 'webgl']);
   t.ok(devices.length > 0, 'at least one browser graphics backend is available');
@@ -248,6 +252,162 @@ test('SplatRenderer evaluates higher-order directional radiance on WebGPU and We
     colorTexture.destroy();
   }
 
+  t.end();
+});
+
+test('SplatRenderer WebGL preserves HDR directional radiance from byte-backed source colors', async t => {
+  const [device] = await getTestDevices(['webgl']);
+  if (!device || isSoftwareBackedDevice(device)) {
+    t.comment('Skipping byte-backed spherical-harmonic WebGL readback without hardware support');
+    t.end();
+    return;
+  }
+
+  const textureSize = 16;
+  const colorTexture = device.createTexture({
+    width: textureSize,
+    height: textureSize,
+    format: 'rgba8unorm',
+    usage: Texture.RENDER_ATTACHMENT | Texture.COPY_SRC
+  });
+  const framebuffer = device.createFramebuffer({
+    width: textureSize,
+    height: textureSize,
+    colorAttachments: [colorTexture],
+    depthStencilAttachment: 'depth24plus'
+  });
+  const source = makeBrowserSplatSource(0.5, 0);
+  source.colors = new Uint8Array([128, 64, 32, 255]);
+  source.scales.set([0.8, 0.8, 0.05]);
+  source.sphericalHarmonics = new Float32Array(9);
+  source.sphericalHarmonics[2 * 3] = -4;
+  source.sphericalHarmonics[2 * 3 + 1] = 2;
+  source.sphericalHarmonicsDegree = 1;
+  const prepared = makeGPUSplatData(device, source);
+  const renderer = new SplatRenderer(device, {
+    data: prepared,
+    cameraPosition: [-1, 0, 0.5],
+    sphericalHarmonicsDegree: 1,
+    viewportSize: [textureSize, textureSize],
+    exposure: 0.25,
+    toneMapping: 'none',
+    alphaCutoff: 0
+  });
+  renderer.predraw(device.commandEncoder);
+  const renderPass = device.beginRenderPass({
+    framebuffer,
+    clearColor: [0, 0, 0, 0],
+    clearDepth: 1
+  });
+  t.ok(renderer.draw(renderPass), 'renders unclamped spherical-harmonic WebGL radiance');
+  renderPass.end();
+  device.submit();
+
+  const layout = colorTexture.computeMemoryLayout({width: textureSize, height: textureSize});
+  const readback = device.createBuffer({
+    byteLength: layout.byteLength,
+    usage: Buffer.COPY_DST | Buffer.MAP_READ
+  });
+  colorTexture.readBuffer({width: textureSize, height: textureSize}, readback);
+  const pixels = await readback.readAsync(0, layout.byteLength);
+  const centerPixelOffset = 8 * layout.bytesPerRow + 8 * 4;
+  t.ok(
+    pixels[centerPixelOffset] > 120,
+    'applies exposure after preserving a directional red highlight above one'
+  );
+  t.ok(
+    pixels[centerPixelOffset + 1] < 10,
+    'preserves negative directional green radiance until display output'
+  );
+  t.equal(
+    renderer.model?.bufferLayout.find(bufferLayout => bufferLayout.name === 'colors')?.format,
+    'float32x4',
+    'uses floating-point attributes for evaluated byte-backed spherical harmonics'
+  );
+  t.deepEqual(Array.from(source.colors), [128, 64, 32, 255], 'preserves original source bytes');
+
+  readback.destroy();
+  renderer.destroy();
+  prepared.destroy();
+  framebuffer.destroy();
+  colorTexture.destroy();
+  t.end();
+});
+
+test('SplatRenderer WebGL composites unsorted rows across interleaved source batches', async t => {
+  const [device] = await getTestDevices(['webgl']);
+  if (!device || isSoftwareBackedDevice(device)) {
+    t.comment('Skipping globally sorted Gaussian WebGL readback without hardware support');
+    t.end();
+    return;
+  }
+
+  const textureSize = 16;
+  const colorTexture = device.createTexture({
+    width: textureSize,
+    height: textureSize,
+    format: 'rgba8unorm',
+    usage: Texture.RENDER_ATTACHMENT | Texture.COPY_SRC
+  });
+  const framebuffer = device.createFramebuffer({
+    width: textureSize,
+    height: textureSize,
+    colorAttachments: [colorTexture],
+    depthStencilAttachment: 'depth24plus'
+  });
+  const firstSource: SplatSource = {
+    positions: new Float32Array([0, 0, 0.2, 0, 0, 0.8]),
+    scales: new Float32Array([0.8, 0.8, 0.05, 0.8, 0.8, 0.05]),
+    rotations: new Float32Array([1, 0, 0, 0, 1, 0, 0, 0]),
+    colors: new Uint8Array([255, 0, 0, 255, 0, 0, 255, 255]),
+    opacities: new Float32Array([0.6, 0.6]),
+    sourceBatchIndex: 0,
+    rowIndexBase: 0
+  };
+  const secondSource = makeBrowserSplatSource(0.5, 2);
+  secondSource.colors = new Uint8Array([0, 255, 0, 255]);
+  secondSource.scales.set([0.8, 0.8, 0.05]);
+  secondSource.opacities[0] = 0.6;
+  const firstBatch = makeGPUSplatData(device, firstSource);
+  const secondBatch = makeGPUSplatData(device, secondSource);
+  const renderer = new SplatRenderer(device, {
+    data: [firstBatch, secondBatch],
+    viewportSize: [textureSize, textureSize],
+    sortMode: 'global',
+    alphaCutoff: 0
+  });
+  renderer.predraw(device.commandEncoder);
+  const renderPass = device.beginRenderPass({
+    framebuffer,
+    clearColor: [0, 0, 0, 0],
+    clearDepth: 1
+  });
+  t.ok(renderer.draw(renderPass), 'draws all three globally ordered source rows');
+  renderPass.end();
+  device.submit();
+
+  const layout = colorTexture.computeMemoryLayout({width: textureSize, height: textureSize});
+  const readback = device.createBuffer({
+    byteLength: layout.byteLength,
+    usage: Buffer.COPY_DST | Buffer.MAP_READ
+  });
+  colorTexture.readBuffer({width: textureSize, height: textureSize}, readback);
+  const pixels = await readback.readAsync(0, layout.byteLength);
+  const centerPixelOffset = 8 * layout.bytesPerRow + 8 * 4;
+  const red = pixels[centerPixelOffset];
+  const green = pixels[centerPixelOffset + 1];
+  const blue = pixels[centerPixelOffset + 2];
+  t.deepEqual(Array.from(renderer.getSortedIndices()), [1, 2, 0], 'retains exact global row order');
+  t.ok(red > green + 25, 'blends the nearest red row after the middle green source batch');
+  t.ok(green > blue + 10, 'blends the middle green source batch after the furthest blue row');
+  t.deepEqual(Array.from(firstSource.colors), [255, 0, 0, 255, 0, 0, 255, 255], 'preserves source');
+
+  readback.destroy();
+  renderer.destroy();
+  firstBatch.destroy();
+  secondBatch.destroy();
+  framebuffer.destroy();
+  colorTexture.destroy();
   t.end();
 });
 

--- a/modules/splats/test/splat-spherical-harmonics.node.spec.ts
+++ b/modules/splats/test/splat-spherical-harmonics.node.spec.ts
@@ -118,6 +118,183 @@ test('SplatRenderer evaluates view-dependent spherical harmonics without mutatin
   t.end();
 });
 
+test('SplatRenderer preserves unclamped spherical-harmonic radiance for byte-backed WebGL colors', async t => {
+  const device = new NullDevice({});
+  const source = makeSphericalHarmonicSource();
+  source.colors = new Uint8Array([128, 64, 32, 255]);
+  source.sphericalHarmonics![2 * 3] = -4;
+  source.sphericalHarmonics![2 * 3 + 1] = 2;
+  const prepared = makeGPUSplatData(device, source);
+  const renderer = new SplatRenderer(device, {
+    data: prepared,
+    cameraPosition: [0, 0, 0],
+    sphericalHarmonicsDegree: 1,
+    viewportSize: [32, 32],
+    exposure: 0.25,
+    toneMapping: 'none'
+  });
+  const renderPass = device.getDefaultRenderPass();
+  renderer.draw(renderPass);
+  const evaluatedColorBuffer = renderer.model?.vertexArray.attributes[3];
+  if (!(evaluatedColorBuffer instanceof Buffer)) {
+    t.fail('creates independently owned Float32 evaluated WebGL colors');
+    renderer.destroy();
+    prepared.destroy();
+    t.end();
+    return;
+  }
+
+  const evaluatedColors = await readFloat32Buffer(evaluatedColorBuffer);
+  t.ok(evaluatedColors[0] > 2, 'retains HDR directional red radiance before exposure');
+  t.ok(
+    evaluatedColors[1] < 0,
+    'retains negative directional green radiance before display mapping'
+  );
+  t.equal(evaluatedColors[3], 1, 'normalizes the byte-backed source alpha exactly once');
+  t.equal(
+    renderer.model?.bufferLayout.find(layout => layout.name === 'colors')?.format,
+    'float32x4',
+    'binds evaluated HDR radiance through a Float32 WebGL vertex attribute'
+  );
+  t.deepEqual(
+    Array.from(source.colors),
+    [128, 64, 32, 255],
+    'does not clamp or mutate caller-owned byte source colors'
+  );
+
+  renderer.setProps({sphericalHarmonicsDegree: 0});
+  renderer.draw(renderPass);
+  t.equal(
+    renderer.model?.bufferLayout.find(layout => layout.name === 'colors')?.format,
+    'unorm8x4',
+    'restores the original normalized-byte vertex layout when higher bands are disabled'
+  );
+  t.equal(
+    renderer.model?.vertexArray.attributes[3],
+    prepared.colors.data[0].buffer,
+    'restores the caller-owned byte color buffer when higher bands are disabled'
+  );
+
+  renderer.destroy();
+  t.ok(evaluatedColorBuffer.destroyed, 'releases only renderer-owned Float32 evaluated colors');
+  t.notOk(prepared.colors.data[0].buffer.destroyed, 'preserves caller-owned byte source colors');
+  prepared.destroy();
+  t.end();
+});
+
+test('SplatRenderer uses one stable Float32 WebGL layout for mixed spherical-harmonic batches', async t => {
+  const device = new NullDevice({});
+  const directionalSource: SplatSource = {
+    positions: new Float32Array([1, 0, 0.2, 1, 0, 0.8]),
+    scales: new Float32Array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1]),
+    rotations: new Float32Array([1, 0, 0, 0, 1, 0, 0, 0]),
+    colors: new Uint8Array([128, 64, 32, 255, 128, 64, 32, 255]),
+    opacities: new Float32Array([1, 1]),
+    sphericalHarmonics: new Float32Array(18),
+    sphericalHarmonicsDegree: 1,
+    sourceBatchIndex: 0,
+    rowIndexBase: 0
+  };
+  directionalSource.sphericalHarmonics![2 * 3] = -4;
+  directionalSource.sphericalHarmonics![9 + 2 * 3] = -4;
+  const standardSource: SplatSource = {
+    positions: new Float32Array([1, 0, 0.5]),
+    scales: new Float32Array([0.1, 0.1, 0.1]),
+    rotations: new Float32Array([1, 0, 0, 0]),
+    colors: new Uint8Array([64, 128, 255, 255]),
+    opacities: new Float32Array([1]),
+    sourceBatchIndex: 1,
+    rowIndexBase: 2
+  };
+  const directionalBatch = makeGPUSplatData(device, directionalSource);
+  const standardBatch = makeGPUSplatData(device, standardSource);
+  const renderer = new SplatRenderer(device, {
+    data: [directionalBatch, standardBatch],
+    sphericalHarmonicsDegree: 1,
+    viewportSize: [32, 32]
+  });
+  const model = renderer.model;
+  if (!model) {
+    t.fail('creates a shared Gaussian splat WebGL model');
+    renderer.destroy();
+    directionalBatch.destroy();
+    standardBatch.destroy();
+    t.end();
+    return;
+  }
+
+  const originalDraw = model.draw.bind(model);
+  const firstVertexArray = model.vertexArray;
+  const firstPipeline = model.pipeline;
+  const drawnColorBuffers: Buffer[] = [];
+  model.draw = renderPass => {
+    t.equal(
+      model.vertexArray,
+      firstVertexArray,
+      'reuses one vertex array for every interleaved run'
+    );
+    t.equal(model.pipeline, firstPipeline, 'reuses one render pipeline for every interleaved run');
+    const colorBuffer = model.vertexArray.attributes[3];
+    if (colorBuffer instanceof Buffer) {
+      drawnColorBuffers.push(colorBuffer);
+    }
+    return originalDraw(renderPass);
+  };
+  const renderPass = device.getDefaultRenderPass();
+  renderer.draw(renderPass);
+  t.deepEqual(
+    Array.from(renderer.getSortedIndices()),
+    [1, 2, 0],
+    'interleaves both source batches'
+  );
+  t.equal(
+    model.bufferLayout.find(bufferLayout => bufferLayout.name === 'colors')?.format,
+    'float32x4',
+    'uses one Float32 color layout for directional and ordinary byte-backed batches'
+  );
+  const ordinaryColorBuffer = drawnColorBuffers[1];
+  if (!ordinaryColorBuffer) {
+    t.fail('binds renderer-owned normalized colors for the ordinary interleaved batch');
+    renderer.destroy();
+    directionalBatch.destroy();
+    standardBatch.destroy();
+    t.end();
+    return;
+  }
+  const normalizedOrdinaryColors = await readFloat32Buffer(ordinaryColorBuffer);
+  t.ok(
+    Math.abs(normalizedOrdinaryColors[0] - 64 / 255) < 1e-6 &&
+      Math.abs(normalizedOrdinaryColors[1] - 128 / 255) < 1e-6,
+    'normalizes ordinary source bytes into compatible renderer-owned Float32 colors'
+  );
+
+  drawnColorBuffers.length = 0;
+  renderer.setProps({cameraPosition: [2, 0, 0]});
+  renderer.draw(renderPass);
+  t.equal(model.vertexArray, firstVertexArray, 'retains the vertex array across animated frames');
+  t.equal(model.pipeline, firstPipeline, 'retains the pipeline across animated frames');
+  t.deepEqual(
+    Array.from(standardSource.colors),
+    [64, 128, 255, 255],
+    'preserves ordinary caller-owned byte colors'
+  );
+
+  model.draw = originalDraw;
+  renderer.setProps({sphericalHarmonicsDegree: 0});
+  renderer.draw(renderPass);
+  t.equal(
+    model.bufferLayout.find(bufferLayout => bufferLayout.name === 'colors')?.format,
+    'unorm8x4',
+    'switches once to the original byte layout when directional rendering is disabled'
+  );
+  t.ok(firstVertexArray.destroyed, 'releases the superseded Float32 vertex array');
+
+  renderer.destroy();
+  directionalBatch.destroy();
+  standardBatch.destroy();
+  t.end();
+});
+
 test('SplatRenderer binds batch-local spherical harmonics to the WebGPU storage pipeline', t => {
   const device = new NullDevice({});
   Object.defineProperties(device, {

--- a/test/examples/gaussian-splat-docs-embed.node.spec.ts
+++ b/test/examples/gaussian-splat-docs-embed.node.spec.ts
@@ -1,0 +1,155 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'node:fs';
+import path from 'node:path';
+import {describe, expect, test} from 'vitest';
+
+const SPLATS_DOCUMENTATION_PATH = path.join(process.cwd(), 'docs/api-reference/splats/README.md');
+const CAPABILITIES_PATH = path.join(process.cwd(), 'docs/capabilities.mdx');
+const WEBSITE_EXAMPLES_PATH = path.join(process.cwd(), 'website/src/examples.tsx');
+const WEBSITE_EXAMPLE_CATALOG_PATH = path.join(
+  process.cwd(),
+  'website/content/examples/table-of-contents.json'
+);
+const GAUSSIAN_SPLAT_VIEWER_PATH = path.join(
+  process.cwd(),
+  'website/content/examples/showcase/gaussian-splat-viewer.mdx'
+);
+const HOMEPAGE_PATH = path.join(process.cwd(), 'website/src/pages/index.jsx');
+const HOMEPAGE_GPU_SCENE_PATH = path.join(
+  process.cwd(),
+  'website/src/components/homepage-gpu-scene.tsx'
+);
+
+describe('Gaussian splat documentation showcase', () => {
+  test('embeds the live Coit Tower viewer directly in the splats API documentation', () => {
+    const documentation = readFileSync(SPLATS_DOCUMENTATION_PATH, 'utf8');
+
+    expect(documentation).toContain(
+      "import {GaussianSplatViewerExample} from '@site/src/examples';"
+    );
+    expect(documentation).toContain('## Interactive Coit Tower showcase');
+    expect(documentation).toContain('50,937,127-splat Coit Tower capture');
+    expect(documentation).toMatch(
+      /<GaussianSplatViewerExample\b(?=[^>]*\bembedded\b)(?=[^>]*\bembeddedHeight=\{640\})(?=[^>]*\bdefaultScene="coit")(?=[^>]*\bshowStats=\{false\})[^>]*\/>/
+    );
+    expect(documentation).toContain(
+      '[Open the full Coit Tower viewer](/examples/showcase/gaussian-splat-viewer?scene=coit)'
+    );
+  });
+
+  test('keeps the documentation scene scoped to its own viewer instance', () => {
+    const examples = readFileSync(WEBSITE_EXAMPLES_PATH, 'utf8');
+    const viewerStart = examples.indexOf('export const GaussianSplatViewerExample');
+    const viewerEnd = examples.indexOf('export const InstancingExample', viewerStart);
+    const viewer = examples.slice(viewerStart, viewerEnd);
+    const viewerDocumentation = readFileSync(GAUSSIAN_SPLAT_VIEWER_PATH, 'utf8');
+
+    expect(viewerStart).toBeGreaterThan(0);
+    expect(viewerEnd).toBeGreaterThan(viewerStart);
+    expect(viewer).toContain("defaultScene?: GaussianSplatSourceCatalogEntry['id']");
+    expect(viewer).toContain('const animationTemplate = useMemo(() => {');
+    expect(viewer).toContain('if (!defaultScene)');
+    expect(viewer).toContain('return GaussianSplatsApp;');
+    expect(viewer).toContain('extends GaussianSplatsApp');
+    expect(viewer).toContain('super({...animationProps, defaultScene});');
+    expect(viewer).toContain('template={animationTemplate}');
+    expect(viewer).not.toContain('__lumaGaussianSplatsDefaultScene');
+    expect(viewerDocumentation).toContain('<GaussianSplatViewerExample />');
+    expect(viewerDocumentation).toContain('741,883-splat Train');
+  });
+
+  test('distinguishes implemented Gaussian splat tranches from remaining opportunities', () => {
+    const documentation = readFileSync(SPLATS_DOCUMENTATION_PATH, 'utf8');
+    const capabilities = readFileSync(CAPABILITIES_PATH, 'utf8');
+    const roadmap = documentation.match(
+      /## Gaussian splat implementation roadmap\n([\s\S]*?)\n## Rendering prepared splats/
+    );
+
+    expect(roadmap).not.toBeNull();
+    expect(roadmap![1]).toContain('### Current supremacy-track status');
+    expect(roadmap![1]).toContain('| GPU graph feature parity | Implemented');
+    expect(roadmap![1]).toContain('| Out-of-core RAD rendering | Implemented');
+    expect(roadmap![1]).toContain('| 50-million-splat Spark parity | In progress');
+    expect(roadmap![1]).toContain('| 3D Tiles integration | Partial');
+    expect(roadmap![1]).toContain('https://github.com/visgl/loaders.gl/pull/3431');
+    expect(roadmap![1]).toContain('https://github.com/visgl/loaders.gl/issues/1245');
+    expect(roadmap![1]).toContain('`Tileset3D` and `Tiles3DSource` traversal');
+    expect(roadmap![1]).toContain('loaders.gl has SPZ v4 decoding, but not SPZ v2');
+    expect(roadmap![1]).toContain('existing `SplatLayer`');
+    expect(roadmap![1]).toContain('loader-computed transforms per tile/page in the renderer');
+    expect(roadmap![1]).toContain('per-tile/page renderer transforms');
+    expect(roadmap![1]).not.toContain('Add actual tileset traversal');
+    const trancheRows = roadmap![1].split('\n').filter(row => /^\| T\d/.test(row));
+    expect(trancheRows.map(row => row.match(/^\| (T\d+a?)/)?.[1])).toEqual([
+      'T0',
+      'T0a',
+      'T1',
+      'T2',
+      'T3',
+      'T4',
+      'T5',
+      'T6',
+      'T7',
+      'T8',
+      'T9',
+      'T10'
+    ]);
+    for (const tranche of trancheRows.slice(0, 7)) {
+      expect(tranche).toMatch(/\| Implemented/);
+    }
+    for (const tranche of trancheRows.slice(7)) {
+      expect(tranche).toMatch(/\| Planned/);
+    }
+    for (const pullRequest of [2929, 2932, 2938, 2966, 3035, 3041, 3051, 3057]) {
+      expect(roadmap![1]).toContain(`https://github.com/visgl/luma.gl/pull/${pullRequest}`);
+    }
+    expect(roadmap![1]).toContain('Implemented in this follow-up');
+    expect(roadmap![1]).toContain('33,554,432 active four-byte references');
+    expect(roadmap![1]).toContain('128 MiB storage-binding limit');
+    expect(roadmap![1]).toContain('near-linear routing');
+    expect(roadmap![1]).toContain('no measured visual or performance parity is claimed');
+
+    expect(capabilities).toContain('| Globally sorted WebGL splat runs | Experimental | WebGL2 |');
+    expect(capabilities).toContain('| Unclamped WebGL harmonic radiance | Experimental | WebGL2 |');
+    expect(capabilities).toMatch(/Background RAD page decoding[^\n]*automatically fall back/);
+    expect(capabilities).toContain('Reuse existing `Tileset3D` traversal');
+    expect(capabilities).toContain(
+      'apply loader-computed transforms per tile/page in the renderer'
+    );
+    expect(capabilities).toContain(
+      '[Gaussian splat implementation roadmap](/docs/api-reference/splats#gaussian-splat-implementation-roadmap)'
+    );
+    for (const opportunity of [
+      'Incremental GPU splat hierarchy scheduling',
+      'Segmented splat picking and mesh composition',
+      'Partitioned splat sorting and scatter',
+      'Streamed 3D Tiles and glTF splat transport',
+      'Measured captured-scene visual and performance parity'
+    ]) {
+      expect(capabilities).toContain(`| ${opportunity} | Opportunity |`);
+    }
+  });
+
+  test('preserves the public examples catalog and the instancing homepage hero', () => {
+    const exampleCatalog = JSON.parse(readFileSync(WEBSITE_EXAMPLE_CATALOG_PATH, 'utf8')) as Array<{
+      label?: string;
+      items?: unknown[];
+    }>;
+    const showcaseEntries = exampleCatalog.find(category => category.label === 'Showcase')?.items;
+    const homepage = readFileSync(HOMEPAGE_PATH, 'utf8');
+    const homepageScene = readFileSync(HOMEPAGE_GPU_SCENE_PATH, 'utf8');
+
+    expect(showcaseEntries).toContain('showcase/gaussian-splat-viewer');
+    expect(showcaseEntries).toContain('showcase/gaussian-splats');
+    expect(homepage).toContain("React.lazy(() => import('../components/homepage-gpu-scene'))");
+    expect(homepageScene).toContain(
+      "import InstancingApp from '../../../examples/showcase/instancing/app';"
+    );
+    expect(homepageScene).toContain('id="instancing"');
+    expect(homepageScene).toContain('template={InstancingApp}');
+    expect(homepageScene).not.toContain('GaussianSplatsApp');
+  });
+});

--- a/test/examples/gaussian-splat-rad-worker.spec.ts
+++ b/test/examples/gaussian-splat-rad-worker.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import {describe, expect, test} from 'vitest';
+import {describe, expect, test, vi} from 'vitest';
 import type {
   LocalGaussianSplatLoadersConfiguration,
   LocalGaussianSplatRADMetadata
@@ -85,6 +85,200 @@ describe('Gaussian splat RAD browser worker', () => {
     decoder.destroy();
     expect(decoder.workerCount).toBe(0);
     decoder.destroy();
+  });
+
+  test('retries the root page when an accepted module worker fails asynchronously', async () => {
+    const loaderBundleUrl = new URL(
+      '/website/static/standalone-examples/gaussian-splats/loaders-gl.mjs',
+      window.location.href
+    ).href;
+    const loaderBundle = await import(/* @vite-ignore */ loaderBundleUrl);
+    const originalCreateObjectURL = URL.createObjectURL.bind(URL);
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockImplementation(() =>
+      originalCreateObjectURL(
+        new Blob(['throw new Error("Module workers are blocked by the content security policy")'], {
+          type: 'text/javascript'
+        })
+      )
+    );
+    const configuration: LocalGaussianSplatLoadersConfiguration = {
+      loaderMode: 'bundled',
+      loadersRoot: '',
+      loaderBundleUrl,
+      sourceUrl: 'https://example.test/coit.rad',
+      sourceUrls: ['https://example.test/coit.rad'],
+      fallbackSourceUrls: [],
+      sourceFormat: 'RAD',
+      sceneId: 'coit',
+      sourceLabel: 'Worker startup fallback fixture',
+      upAxis: 'z',
+      up: [0, 0, 1]
+    };
+    const metadata: LocalGaussianSplatRADMetadata = {
+      count: 2,
+      chunks: [{chunkIndex: 0, base: 65_536, count: 2, bytes: 0}],
+      maxSh: 1,
+      lodTree: true,
+      splatEncoding: {lodOpacity: true}
+    };
+    const decoder = createGaussianSplatRADWorkerDecoder(configuration, {maxWorkers: 1});
+
+    try {
+      expect(decoder?.mode).toBe('worker');
+      expect(decoder?.workerCount).toBe(1);
+      if (!decoder) {
+        throw new Error('The browser did not accept the intentionally failing module worker.');
+      }
+
+      let fallbackCalls = 0;
+      const page = await decoder.decodePage({
+        chunkIndex: 0,
+        sourceUrl: configuration.sourceUrl,
+        metadata,
+        signal: new AbortController().signal,
+        fetchChunkBytes: async () => makeGaussianBrowserRADChunk(),
+        decodeDefault: async () => {
+          fallbackCalls++;
+          return loaderBundle.parseRADChunk(makeGaussianBrowserRADChunk(), {
+            radChunk: {
+              splatEncoding: metadata.splatEncoding,
+              includeLoDTree: true,
+              includeSphericalHarmonics: true
+            }
+          });
+        }
+      });
+
+      expect(decoder.mode).toBe('main-thread');
+      expect(decoder.workerCount).toBe(0);
+      expect(decoder.completedDecodeCount).toBe(1);
+      expect(fallbackCalls).toBe(1);
+      expect(page.data.numRows).toBe(2);
+      expect(page.loaderData).toMatchObject({
+        base: 65_536,
+        maxSh: 1,
+        lodTree: true,
+        splatEncoding: {lodOpacity: true}
+      });
+      expect(Array.from(page.loaderData.childCounts!)).toEqual([1, 0]);
+      expect(Array.from(page.loaderData.childStarts!)).toEqual([131_072, 0]);
+
+      let fallbackByteFetches = 0;
+      const nextPage = await decoder.decodePage({
+        chunkIndex: 0,
+        sourceUrl: configuration.sourceUrl,
+        metadata,
+        signal: new AbortController().signal,
+        fetchChunkBytes: async () => {
+          fallbackByteFetches++;
+          return makeGaussianBrowserRADChunk();
+        },
+        decodeDefault: async () => {
+          fallbackCalls++;
+          return loaderBundle.parseRADChunk(makeGaussianBrowserRADChunk(), {
+            radChunk: {splatEncoding: metadata.splatEncoding, includeLoDTree: true}
+          });
+        }
+      });
+
+      expect(nextPage.data.numRows).toBe(2);
+      expect(fallbackByteFetches).toBe(0);
+      expect(fallbackCalls).toBe(2);
+      expect(decoder.completedDecodeCount).toBe(2);
+      expect(decoder.workerCount).toBe(0);
+    } finally {
+      decoder?.destroy();
+      createObjectURL.mockRestore();
+    }
+  });
+
+  test('drains queued pages and preserves cancellation when the worker import fails', async () => {
+    const validBundleUrl = new URL(
+      '/website/static/standalone-examples/gaussian-splats/loaders-gl.mjs',
+      window.location.href
+    ).href;
+    const loaderBundle = await import(/* @vite-ignore */ validBundleUrl);
+    const failingBundleUrl = URL.createObjectURL(
+      new Blob(['throw new Error("Dynamic module imports are unavailable in workers")'], {
+        type: 'text/javascript'
+      })
+    );
+    const configuration: LocalGaussianSplatLoadersConfiguration = {
+      loaderMode: 'bundled',
+      loadersRoot: '',
+      loaderBundleUrl: failingBundleUrl,
+      sourceUrl: 'https://example.test/coit.rad',
+      sourceUrls: ['https://example.test/coit.rad'],
+      fallbackSourceUrls: [],
+      sourceFormat: 'RAD',
+      sceneId: 'coit',
+      sourceLabel: 'Worker import fallback fixture',
+      upAxis: 'z',
+      up: [0, 0, 1]
+    };
+    const metadata: LocalGaussianSplatRADMetadata = {
+      count: 6,
+      chunks: [
+        {chunkIndex: 0, base: 65_536, count: 2, bytes: 0},
+        {chunkIndex: 1, base: 65_538, count: 2, bytes: 0},
+        {chunkIndex: 2, base: 65_540, count: 2, bytes: 0}
+      ],
+      maxSh: 1,
+      lodTree: true,
+      splatEncoding: {lodOpacity: true}
+    };
+    const decoder = createGaussianSplatRADWorkerDecoder(configuration, {maxWorkers: 1});
+
+    try {
+      expect(decoder?.mode).toBe('worker');
+      if (!decoder) {
+        throw new Error('The browser did not create its failing-import module worker.');
+      }
+
+      const canceledController = new AbortController();
+      const fallbackChunkIndices: number[] = [];
+      let activeFallbacks = 0;
+      let maximumActiveFallbacks = 0;
+      const decodePage = (chunkIndex: number, signal = new AbortController().signal) =>
+        decoder.decodePage({
+          chunkIndex,
+          sourceUrl: configuration.sourceUrl,
+          metadata,
+          signal,
+          fetchChunkBytes: async () => makeGaussianBrowserRADChunk(),
+          decodeDefault: async () => {
+            fallbackChunkIndices.push(chunkIndex);
+            activeFallbacks++;
+            maximumActiveFallbacks = Math.max(maximumActiveFallbacks, activeFallbacks);
+            try {
+              await Promise.resolve();
+              signal.throwIfAborted();
+              return loaderBundle.parseRADChunk(makeGaussianBrowserRADChunk(), {
+                radChunk: {splatEncoding: metadata.splatEncoding, includeLoDTree: true}
+              });
+            } finally {
+              activeFallbacks--;
+            }
+          }
+        });
+      const rootPage = decodePage(0);
+      const queuedPage = decodePage(1);
+      const canceledPage = decodePage(2, canceledController.signal).catch(error => error);
+      await Promise.resolve();
+      canceledController.abort();
+
+      await expect(rootPage).resolves.toMatchObject({data: {numRows: 2}});
+      await expect(queuedPage).resolves.toMatchObject({data: {numRows: 2}});
+      await expect(canceledPage).resolves.toMatchObject({name: 'AbortError'});
+      expect(fallbackChunkIndices).toEqual([0, 1]);
+      expect(maximumActiveFallbacks).toBe(1);
+      expect(decoder.mode).toBe('main-thread');
+      expect(decoder.workerCount).toBe(0);
+      expect(decoder.completedDecodeCount).toBe(2);
+    } finally {
+      decoder?.destroy();
+      URL.revokeObjectURL(failingBundleUrl);
+    }
   });
 
   test('cancels an actual in-flight worker and recreates it for fresh camera demand', async () => {

--- a/test/examples/gaussian-splat-viewer.node.spec.ts
+++ b/test/examples/gaussian-splat-viewer.node.spec.ts
@@ -75,6 +75,24 @@ describe('published Gaussian splat viewer', () => {
     device.destroy();
   });
 
+  test('uses an isolated per-instance default scene to select the paged RAD renderer', () => {
+    installViewerWindow();
+    const device = makeViewerWebGPUDevice();
+    const animation = new GaussianSplatsAnimationLoopTemplate({
+      device,
+      width: 640,
+      height: 480,
+      defaultScene: 'coit'
+    } as AnimationProps & {defaultScene: 'coit'});
+
+    expect(animation.renderer).toBeInstanceOf(GPUPagedSplatRenderer);
+    expect(animation.renderer).not.toBeInstanceOf(GPUSplatGraphRenderer);
+    expect(getLocalGaussianSplatLoadersConfiguration()?.sceneId).toBe('train');
+
+    animation.renderer.destroy();
+    device.destroy();
+  });
+
   test('retains the explicit CPU comparison for captured WebGPU scenes', () => {
     installViewerWindow('?renderer=cpu');
     const device = makeViewerWebGPUDevice();
@@ -294,6 +312,27 @@ describe('published Gaussian splat viewer', () => {
       'https://raw.githubusercontent.com/visgl/deck.gl-data/master/formats/ply/gaussian-splat/train-iteration-7000-part-00.ply',
       'https://raw.githubusercontent.com/visgl/deck.gl-data/master/formats/ply/gaussian-splat/train-iteration-7000-part-01.ply'
     ]);
+  });
+
+  test('keeps embedded Coit defaults isolated and honors explicit scene and mode overrides', () => {
+    installViewerWindow();
+
+    expect(getLocalGaussianSplatLoadersConfiguration('coit')).toMatchObject({
+      sceneId: 'coit',
+      sourceFormat: 'RAD',
+      expectedSplatCount: 50_937_127,
+      maxResidentSplatCount: 1_000_000
+    });
+    expect(getLocalGaussianSplatLoadersConfiguration()?.sceneId).toBe('train');
+
+    installViewerWindow('?scene=truck');
+    expect(getLocalGaussianSplatLoadersConfiguration('coit')).toMatchObject({
+      sceneId: 'truck',
+      sourceFormat: 'PLY'
+    });
+
+    installViewerWindow('?mode=synthetic');
+    expect(getLocalGaussianSplatLoadersConfiguration('coit')).toBeUndefined();
   });
 
   test('retains catalog scenes, direct GitHub sources, and custom source URLs', () => {

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -14,6 +14,7 @@ import {
   useStore
 } from './react-luma';
 import type {Device} from '@luma.gl/core';
+import type {AnimationProps} from '@luma.gl/engine';
 
 import {makeHtmlCustomPanel} from '../../examples/example-panels';
 import {makeArrowExamplePanelHostHtml} from '../../examples/arrow/arrow-example-panels';
@@ -77,6 +78,7 @@ import ABufferApp from '../../examples/experimental/a-buffer/app';
 // import GeospatialApp from '../../examples/showcase/geospatial/app';
 import GLTFApp from '../../examples/showcase/gltf/app';
 import GaussianSplatsApp from '../../examples/showcase/gaussian-splats/app';
+import type {GaussianSplatSourceCatalogEntry} from '../../examples/showcase/gaussian-splats/local-loaders';
 import ArrowTemporalStarfieldApp from '../../examples/arrow/arrow-temporal-starfield/app';
 import ArrowTimeColumnsApp from '../../examples/arrow/arrow-time-columns/app';
 import ArrowText2DApp from '../../examples/arrow/arrow-text-2d/app';
@@ -801,8 +803,21 @@ export const GaussianSplatsExample: React.FC<WebsiteExampleProps> = props => {
   );
 };
 
-export const GaussianSplatViewerExample: React.FC<WebsiteExampleProps> = props => {
+export const GaussianSplatViewerExample: React.FC<
+  WebsiteExampleProps & {defaultScene?: GaussianSplatSourceCatalogEntry['id']}
+> = ({defaultScene, ...props}) => {
   const loaderBundleUrl = useBaseUrl('/standalone-examples/gaussian-splats/loaders-gl.mjs');
+  const animationTemplate = useMemo(() => {
+    if (!defaultScene) {
+      return GaussianSplatsApp;
+    }
+
+    return class GaussianSplatSceneAnimationTemplate extends GaussianSplatsApp {
+      constructor(animationProps: AnimationProps) {
+        super({...animationProps, defaultScene});
+      }
+    };
+  }, [defaultScene]);
 
   if (typeof window !== 'undefined') {
     window.__lumaGaussianSplatsLoaderBundleUrl = loaderBundleUrl;
@@ -816,7 +831,7 @@ export const GaussianSplatViewerExample: React.FC<WebsiteExampleProps> = props =
       directory="showcase"
       sourcePath="examples/showcase/gaussian-splats/app.ts"
       devices={['webgpu', 'webgl2']}
-      template={GaussianSplatsApp}
+      template={animationTemplate}
       config={exampleConfig}
       canvasContextProfile="high-dynamic-range"
       showStats


### PR DESCRIPTION
## Goals

- Make the 50.9-million-source-row Coit Tower scene visible in the Gaussian-splat documentation and examples without replacing the homepage's instancing hero.
- Address the eight outstanding review findings across merged Gaussian-splat PRs #2929, #3035, #3041, #3051, and #3057.
- Publish an accurate implementation roadmap and distinguish existing loaders.gl 3D Tiles infrastructure from genuinely missing interoperability work.

## Changes

- Embed an isolated, interactive Coit viewer directly in the splats API reference while preserving Train as the standalone viewer default and keeping the existing instancing homepage hero.
- Permanently fall back to bounded main-thread RAD decoding when module workers fail asynchronously, including CSP, import, startup, cancellation, and queued-page cases.
- Preserve exact globally sorted WebGL draw-run ordering, semantic masks, renderer-owned opacity/color buffers, unclamped Float32 spherical-harmonic radiance, and stable mixed-format vertex layouts.
- Reset automatic tone mapping when HDR sources are replaced by LDR sources, validate Arrow semantic IDs before uint32 conversion, and restrict command-graph updates to mutable properties.
- Replace same-ID hierarchy pages transactionally without losing ownership or pins, and count visible RAD children rather than culled descendants against the active-row budget.
- Add the four-track status matrix and detailed T0–T10 delivery roadmap.

## Gaussian-splat track status

| Track | Status | Remaining work |
| --- | --- | --- |
| GPU graph feature parity | Implemented | Paged GPU picking and mixed composition. |
| Out-of-core RAD rendering | Implemented | Incremental worker/GPU hierarchy traversal and scheduling. |
| 50-million-splat Spark parity | In progress | Reproducible visual/performance evidence and larger, more efficient global sort domains. |
| 3D Tiles integration | Partial | Reuse existing loaders.gl tile traversal, transport, caching, metadata, and transforms; add Gaussian glTF extension handlers, SPZ v2 decoding, selected-tile integration, and per-page renderer transforms. |

The existing loaders.gl SPZ codec supports v4 only; the Khronos compression extension specifically requires SPZ v2. Follow-up interoperability belongs primarily in loaders.gl and the renderer bridge; no duplicate 3D Tiles traversal engine is proposed. Tracking: visgl/loaders.gl#1245.

## Verification

- `yarn lint fix` — passed.
- Full pre-commit Node suite — **2,155 passed; one existing skipped**.
- `yarn build` — passed after rebasing onto the current upstream master.
- Focused actual Chromium/SwiftShader WebGL, WebGPU, worker-fallback, hierarchy, Arrow, and documentation regressions passed.
- Full website build, 47-example typecheck, complete serialized `yarn test`, GitHub Actions, and Coveralls are being verified on this draft.