### PR TITLE
fix(shadertools): WebGPU derivative normal calculation

### DIFF
--- a/modules/shadertools/src/modules/lighting/pbr-material/pbr-material-wgsl.ts
+++ b/modules/shadertools/src/modules/lighting/pbr-material/pbr-material-wgsl.ts
@@ -481,7 +481,7 @@ fn getTBN(uv: vec2f) -> mat3x3f
   let tex_dy: vec3f = dpdy(vec3f(uv, 0.0));
   var t: vec3f = (tex_dy.y * pos_dx - tex_dx.y * pos_dy) / (tex_dx.x * tex_dy.y - tex_dy.x * tex_dx.y);
 
-  var ng: vec3f = cross(pos_dx, pos_dy);
+  var ng: vec3f = cross(pos_dy, pos_dx);
 #ifdef HAS_NORMALS
   ng = normalize(fragmentInputs.pbr_vNormal);
 #endif


### PR DESCRIPTION
#### Background

WebGL and WebGPU use opposite screen-space Y-axis orientations, which reverses the direction of the Y derivative. In GLSL, `cross(dFdx(position), dFdy(position))` reconstructs the expected outward-facing surface normal, but applying the same operand order to WGSL’s `dpdx` and `dpdy` produces its inverse. Reversing the operands to `cross(dpdy(position), dpdx(position))` compensates for that coordinate-system difference, restoring outward-facing normals and therefore the correct diffuse and specular lighting. Geometry with supplied normals is unaffected; this only corrects normals reconstructed from screen-space derivatives.

#### Change List
- PBR material
