### PR TITLE
Fix v10 GPU trace examples

### DIFF
--- a/examples/deck/deck-example-device.ts
+++ b/examples/deck/deck-example-device.ts
@@ -3,6 +3,11 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {Device} from '@luma.gl/core';
+import {
+  ShaderAssembler,
+  type GLSLShaderAssembler,
+  type WGSLShaderAssembler
+} from '@luma.gl/shadertools';
 import {webgl2Adapter} from '@luma.gl/webgl';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 
@@ -28,4 +33,42 @@ export function getDeckExampleDeviceProps(deviceType: DeckExampleDeviceType) {
 /** Resolves host device selection into Deck construction props. */
 export function getDeckExampleProps({device, deviceType = 'webgpu'}: DeckExampleDeviceOptions) {
   return device ? {device} : {deviceProps: getDeckExampleDeviceProps(deviceType)};
+}
+
+/** Bridges exactly one legacy Deck assembler call while preserving strict language separation. */
+export function installLegacyDeckShaderAssemblerCompatibility(device: Device): () => void {
+  const original = ShaderAssembler.getDefaultShaderAssembler;
+  let restored = false;
+
+  function restore(): void {
+    if (restored) return;
+    if (ShaderAssembler.getDefaultShaderAssembler === getLegacyDeckShaderAssembler) {
+      ShaderAssembler.getDefaultShaderAssembler = original;
+    }
+    restored = true;
+  }
+
+  function getLegacyDeckShaderAssembler(shaderLanguage: 'glsl'): GLSLShaderAssembler;
+  function getLegacyDeckShaderAssembler(shaderLanguage: 'wgsl'): WGSLShaderAssembler;
+  function getLegacyDeckShaderAssembler(
+    shaderLanguage: 'glsl' | 'wgsl'
+  ): GLSLShaderAssembler | WGSLShaderAssembler;
+  function getLegacyDeckShaderAssembler(
+    shaderLanguage?: 'glsl' | 'wgsl'
+  ): GLSLShaderAssembler | WGSLShaderAssembler {
+    if (shaderLanguage === undefined) {
+      // TODO: Remove after deck.gl forwards its known shading language to luma.gl.
+      // Restore before forwarding so later user calls retain strict explicit-language behavior.
+      restore();
+      return device.info.shadingLanguage === 'wgsl'
+        ? original.call(ShaderAssembler, 'wgsl')
+        : original.call(ShaderAssembler, 'glsl');
+    }
+    return shaderLanguage === 'wgsl'
+      ? original.call(ShaderAssembler, 'wgsl')
+      : original.call(ShaderAssembler, 'glsl');
+  }
+
+  ShaderAssembler.getDefaultShaderAssembler = getLegacyDeckShaderAssembler;
+  return restore;
 }

--- a/examples/deck/gpu-culled-trace/app.ts
+++ b/examples/deck/gpu-culled-trace/app.ts
@@ -7,7 +7,11 @@ import {buildSdfFontAtlas} from '@luma.gl/text';
 import {ArrowExamplePanelManager} from '../../arrow/arrow-example-panels';
 import {makeHtmlCustomPanel} from '../../example-panels';
 import {ArrowDeck} from '../arrow-deck';
-import {getDeckExampleProps, type DeckExampleDeviceOptions} from '../deck-example-device';
+import {
+  getDeckExampleProps,
+  installLegacyDeckShaderAssemblerCompatibility,
+  type DeckExampleDeviceOptions
+} from '../deck-example-device';
 import {GPUCulledArrowTextLayer} from './gpu-culled-arrow-text-layer';
 import {GPUCulledTraceLayer} from './gpu-culled-trace-layer';
 import {GPUTraceCullingEffect, type GPUTraceCullingStats} from './gpu-trace-culling-effect';
@@ -32,6 +36,7 @@ export function createGPUCulledTraceDeck(
   let animationFrame = 0;
   let lastAnimationTime = 0;
   let autoScroll = true;
+  let restoreShaderAssembler: (() => void) | null = null;
   let viewState: TraceViewState = {target: [150, TRACE_LANE_WINDOW / 2, 0], zoom: 0};
   let statsElement: HTMLElement | null = null;
   let cullingStats: GPUTraceCullingStats = {
@@ -84,6 +89,15 @@ export function createGPUCulledTraceDeck(
     },
     layers: [],
     effects: [],
+    onDeviceInitialized: initializedDevice => {
+      restoreShaderAssembler?.();
+      restoreShaderAssembler = installLegacyDeckShaderAssemblerCompatibility(initializedDevice);
+    },
+    onError: error => {
+      restoreShaderAssembler?.();
+      restoreShaderAssembler = null;
+      throw error;
+    },
     getTooltip: info => getTooltip(traceData, info),
     onViewStateChange: ({viewState: nextViewState}: ViewStateChangeParameters) => {
       viewState = nextViewState as TraceViewState;
@@ -141,6 +155,8 @@ export function createGPUCulledTraceDeck(
       });
     },
     onFinalize: () => {
+      restoreShaderAssembler?.();
+      restoreShaderAssembler = null;
       cancelAnimationFrame(animationFrame);
       panelManager.finalize();
     }

--- a/examples/deck/lugraph-explorer/app.ts
+++ b/examples/deck/lugraph-explorer/app.ts
@@ -10,14 +10,13 @@ import {
   type LuGraphDeckEffectStats,
   type PickingInfo
 } from '@deck.gl-community/arrow-layers';
-import {Buffer, type Device} from '@luma.gl/core';
-import {
-  ShaderAssembler,
-  type GLSLShaderAssembler,
-  type WGSLShaderAssembler
-} from '@luma.gl/shadertools';
+import {Buffer} from '@luma.gl/core';
 import {ArrowDeck} from '../arrow-deck';
-import {getDeckExampleProps, type DeckExampleDeviceOptions} from '../deck-example-device';
+import {
+  getDeckExampleProps,
+  installLegacyDeckShaderAssemblerCompatibility,
+  type DeckExampleDeviceOptions
+} from '../deck-example-device';
 import {
   GRAPH_EXPLORER_LINEAR_LAYOUT_VERTEX_COUNT,
   GRAPH_EXPLORER_MAXIMUM_EXACT_VERTEX_COUNT,
@@ -345,44 +344,6 @@ export function createLuGraphExplorerDeck(
     });
     return [...edgeLayers, nodeLayer];
   }
-}
-
-/** Bridges exactly one legacy Deck assembler call while preserving strict language separation. */
-function installLegacyDeckShaderAssemblerCompatibility(device: Device): () => void {
-  const original = ShaderAssembler.getDefaultShaderAssembler;
-  let restored = false;
-
-  function restore(): void {
-    if (restored) return;
-    if (ShaderAssembler.getDefaultShaderAssembler === getLegacyDeckShaderAssembler) {
-      ShaderAssembler.getDefaultShaderAssembler = original;
-    }
-    restored = true;
-  }
-
-  function getLegacyDeckShaderAssembler(shaderLanguage: 'glsl'): GLSLShaderAssembler;
-  function getLegacyDeckShaderAssembler(shaderLanguage: 'wgsl'): WGSLShaderAssembler;
-  function getLegacyDeckShaderAssembler(
-    shaderLanguage: 'glsl' | 'wgsl'
-  ): GLSLShaderAssembler | WGSLShaderAssembler;
-  function getLegacyDeckShaderAssembler(
-    shaderLanguage?: 'glsl' | 'wgsl'
-  ): GLSLShaderAssembler | WGSLShaderAssembler {
-    if (shaderLanguage === undefined) {
-      // TODO: Remove after deck.gl forwards its known shading language to luma.gl.
-      // Restore before forwarding so later user calls retain strict explicit-language behavior.
-      restore();
-      return device.info.shadingLanguage === 'wgsl'
-        ? original.call(ShaderAssembler, 'wgsl')
-        : original.call(ShaderAssembler, 'glsl');
-    }
-    return shaderLanguage === 'wgsl'
-      ? original.call(ShaderAssembler, 'wgsl')
-      : original.call(ShaderAssembler, 'glsl');
-  }
-
-  ShaderAssembler.getDefaultShaderAssembler = getLegacyDeckShaderAssembler;
-  return restore;
 }
 
 /** Updates the same float32x2 allocation bound directly by the node layer's instance attribute. */

--- a/examples/experimental/gpu-trace-scene/app.ts
+++ b/examples/experimental/gpu-trace-scene/app.ts
@@ -211,6 +211,8 @@ export default class GPUTraceSceneAnimationLoopTemplate extends AnimationLoopTem
 
   private createResources(capacity: number): SceneTraceResources {
     const dataset = makeTraceDataset(capacity);
+    // GPUTraceScene owns dense span-indexed adjacency. The viewer dataset's adjacency is sparse
+    // and carries an explicit node table for much larger traces, so it is not interchangeable.
     const trace = new GPUTraceScene(this.device, {
       id: 'scene-trace',
       spans: dataset.spans,
@@ -223,9 +225,7 @@ export default class GPUTraceSceneAnimationLoopTemplate extends AnimationLoopTem
       })),
       processCount: dataset.processCount,
       threadCount: dataset.threadCount,
-      geometryId: 0,
-      outgoing: dataset.outgoing,
-      incoming: dataset.incoming
+      geometryId: 0
     });
     const graph = new GPUCommandGraph<void>(this.device, {id: 'scene-trace-command-graph'});
     const source = trace.importToGraph(graph);

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -389,7 +389,11 @@ fn main() {
     count = 1u;
   }
   frontierCount[0] = count;
-  dispatchCommand[0] = (count + WORKGROUP_SIZE - 1u) / WORKGROUP_SIZE;
+  dispatchCommand[0] = select(
+    0u,
+    (count + WORKGROUP_SIZE - 1u) / WORKGROUP_SIZE,
+    focusTraversalState[0] > 0u
+  );
   dispatchCommand[1] = 1u;
   dispatchCommand[2] = 1u;
 }`;

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -342,6 +342,24 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
   t.end();
 });
 
+test('GPU trace focus seed exposes only resources consumed by its compute entry point', t => {
+  const reflection = new WgslReflect(getFocusFrontierSeedShader(11));
+  t.deepEqual(
+    reflection.storage.map(resource => ({name: resource.name, location: resource.binding})),
+    [
+      {name: 'selectedSeeds', location: 0},
+      {name: 'activeSeedCount', location: 1},
+      {name: 'focusTraversalState', location: 2},
+      {name: 'reachedSpans', location: 3},
+      {name: 'frontier', location: 4},
+      {name: 'frontierCount', location: 5},
+      {name: 'dispatchCommand', location: 6}
+    ],
+    'seed bindings match the native WebGPU pipeline layout without an optimized-out slot'
+  );
+  t.end();
+});
+
 test('GPU trace data preserves deterministic canonical group and hierarchy identities', t => {
   const dataset = makeTraceDataset(257);
   const repeated = makeTraceDataset(257);


### PR DESCRIPTION
## What changed

- reuse the legacy Deck shader-assembler compatibility bridge for the GPU-culled trace example, while keeping the existing LuGraph example on the shared helper
- let `GPUTraceScene` build its own dense span-indexed adjacency instead of passing the viewer dataset's sparse adjacency representation
- make the focus seed shader consume `focusTraversalState` to preserve its native WebGPU bind-group slot and skip unnecessary traversal dispatches at depth zero
- add a shader-reflection regression test for the complete focus seed binding layout

## Why

Three large-trace examples on the published v10 preview failed at runtime:

- `deck/gpu-culled-trace`: legacy Deck code requested a default shader assembler without specifying the shader language
- `experimental/gpu-trace-scene`: sparse viewer adjacency was passed to an API that requires dense span-indexed CSR adjacency
- `experimental/gpu-trace-viewer`: Dawn optimized an unused shader resource out of the native bind-group layout while the application still supplied it

These changes repair the example/API boundaries without weakening core validation.

## Validation

- `nvm use`
- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn examples:typecheck` — 47 example workspaces
- node suite / commit hook — 258 files, 2,415 tests passed
- focused trace-viewer node suite — 16 tests passed
- focused trace-viewer headless WebGPU suite — 2 tests passed

The complete headless suite was also attempted with Chromium 151. The trace-viewer tests exposed and then verified the binding correction; one unrelated existing engine test (`Model#draw skips WebGPU render pipelines that failed init`) remained failing in that environment.