### PR TITLE
Preserve long spans in trace density LOD

### DIFF
--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -664,11 +664,30 @@ fn main(
   let densityVisible = sourceVisible && (isDensityModeActive() || !processExpanded);
   if (densityVisible && focusVisible) {
     let timeRange = max(viewUniforms.timeMax - viewUniforms.timeMin, 0.0001);
-    let fraction = clamp((span.start - viewUniforms.timeMin) / timeRange, 0.0, 0.999999);
-    let bin = min(u32(fraction * f32(${TRACE_DENSITY_BIN_COUNT}u)), ${TRACE_DENSITY_BIN_COUNT - 1}u);
-    let densityKey =
-      (u32(lane) * ${TRACE_DENSITY_BIN_COUNT}u + bin) * ${TRACE_GROUPS.length}u + span.group;
-    atomicAdd(&densityBins[densityKey], 1u);
+    let startFraction = clamp(
+      (span.start - viewUniforms.timeMin) / timeRange,
+      0.0,
+      0.999999
+    );
+    let endFraction = clamp(
+      (span.start + span.duration - viewUniforms.timeMin) / timeRange,
+      0.0,
+      0.999999
+    );
+    let firstBin = min(
+      u32(startFraction * f32(${TRACE_DENSITY_BIN_COUNT}u)),
+      ${TRACE_DENSITY_BIN_COUNT - 1}u
+    );
+    let lastBin = min(
+      u32(endFraction * f32(${TRACE_DENSITY_BIN_COUNT}u)),
+      ${TRACE_DENSITY_BIN_COUNT - 1}u
+    );
+    // Preserve temporal coverage: a long span contributes to every density bin it crosses.
+    for (var bin = firstBin; bin <= lastBin; bin++) {
+      let densityKey =
+        (u32(lane) * ${TRACE_DENSITY_BIN_COUNT}u + bin) * ${TRACE_GROUPS.length}u + span.group;
+      atomicAdd(&densityBins[densityKey], 1u);
+    }
   }
 }`;
 }

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -386,6 +386,11 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
     /sourceVisible \|\| destinationVisible/,
     'dependency visibility retains edges with either endpoint in view'
   );
+  t.match(
+    getCandidateDensityShader(spanChunk),
+    /for \(var bin = firstBin; bin <= lastBin; bin\+\+\)/,
+    'density aggregation preserves long-span coverage across bins'
+  );
   t.end();
 });
 


### PR DESCRIPTION
## Summary

- make every span contribute to each density bin covered by its full time range
- preserve the visible width of long spans when exact geometry transitions to the zoomed-out density LOD
- add a shader regression assertion for duration-aware density aggregation

## Root cause

The density pass recorded only each span's start time. When exact spans faded out, even a very long span was represented by a single narrow density bin.

## Performance

This reuses the existing fixed 512-bin aggregation buffer and graph passes. A visible span performs one atomic increment per crossed bin, bounded by 512; typical short spans still touch one or only a few bins.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-node test/examples/gpu-trace-viewer.node.spec.ts` (2,416 passed, 1 skipped)
- GPU trace viewer `tsc && vite build`
- visual verification in the local example
- repository commit hook additionally ran the full node suite: 2,413 passed; three unrelated tests timed out after 60 seconds