### PR TITLE
feat(experimental): accelerate graph reductions with subgroups

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
@@ -83,26 +83,25 @@ compiler infer ordering and reuse physical scratch allocations when lifetimes do
 
 ## Performance notes
 
+<WorkgroupReductionBenchmark />
+
+### What the benchmark measures
+
+The benchmark isolates the 256-value workgroup reduction used at each hierarchy level. It reports
+absolute input throughput and compares the portable and subgroup paths on the same max-feature
+device.
+
 ### Subgroup acceleration
 
-On a max-feature WebGPU device that exposes both the `subgroups` device feature and the
-`subgroup_id` WGSL language feature, each reduction level uses subgroup `add`, `min`, and `max`
-collectives before merging the much smaller set of subgroup totals in workgroup memory. Other
-devices keep the portable shared-memory tree automatically; the `GPUReduction` API and results do
-not change.
+When a max-feature device exposes both `subgroups` and the `subgroup_id` WGSL feature,
+`GPUReduction` uses subgroup collectives before merging subgroup totals in workgroup memory. Other
+devices keep the portable tree automatically; the API does not change.
 
-This path also benefits graph features that compose `GPUReduction`, including automatic histogram
-domains, raster statistics, graph core-number and modularity summaries, and global data-frame
-aggregations. It is most useful when reduction synchronization is a meaningful part of the total
-work; end-to-end workloads dominated by reading the input buffer may show a smaller improvement.
+### Where it helps
 
-### Live benchmark
-
-The live benchmark isolates the 256-value workgroup reduction at the center of every hierarchy
-level. It reports absolute input-element throughput for the portable implementation and, when the
-reader's adapter supports it, the subgroup optimization requested on the same max-feature device.
-
-<WorkgroupReductionBenchmark />
+The fast path also benefits automatic histogram domains, raster statistics, graph summaries,
+PageRank, and global data-frame aggregations. Gains are largest when synchronization matters;
+bandwidth-bound graphs may improve less.
 
 ## `addToGraph(graph)`
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
@@ -53,8 +53,9 @@ graph-owned partial storage, followed by one global reduction. Chunk order and s
 unchanged; no input is packed or concatenated. An all-empty vector follows the same zero-result
 behavior as an empty data view.
 
-Integer sums wrap to 32 bits. Floating sums use a fixed 256-way tree. Floating minimum, maximum,
-and extent ignore NaN and infinity. Empty inputs and all-invalid floating inputs produce zero.
+Integer sums wrap to 32 bits. Floating sums use a 256-way hierarchical reduction. Floating
+minimum, maximum, and extent ignore NaN and infinity. Empty inputs and all-invalid floating inputs
+produce zero.
 
 ## Reduction hierarchy
 
@@ -80,7 +81,9 @@ Empty chunks add no passes and do not change the result.
 All intermediate views are graph-owned transients. Their declared node uses let the command-graph
 compiler infer ordering and reuse physical scratch allocations when lifetimes do not overlap.
 
-## Subgroup acceleration
+## Performance notes
+
+### Subgroup acceleration
 
 On a max-feature WebGPU device that exposes both the `subgroups` device feature and the
 `subgroup_id` WGSL language feature, each reduction level uses subgroup `add`, `min`, and `max`
@@ -93,7 +96,7 @@ domains, raster statistics, graph core-number and modularity summaries, and glob
 aggregations. It is most useful when reduction synchronization is a meaningful part of the total
 work; end-to-end workloads dominated by reading the input buffer may show a smaller improvement.
 
-### Performance expectations
+### Live benchmark
 
 The live benchmark isolates the 256-value workgroup reduction at the center of every hierarchy
 level. It reports absolute input-element throughput for the portable implementation and, when the

--- a/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
@@ -1,4 +1,5 @@
 import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+import {WorkgroupReductionBenchmark} from '@site/src/components/docs/workgroup-reduction-benchmark';
 
 # GPUReduction
 
@@ -6,15 +7,16 @@ import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-do
 
 ## Overview
 
-`GPUReduction` records a deterministic hierarchical reduction over a packed `uint32`, `sint32`,
-or `float32` graph data view or fixed-width graph vector.
+`GPUReduction` records a hierarchical reduction over a packed `uint32`, `sint32`, or `float32`
+graph data view or fixed-width graph vector.
 
 ## Concepts
 
 A reduction combines many scalar rows into one summary. `sum`, `min`, and `max` produce one value;
 `extent` produces the pair `[minimum, maximum]`. Workgroups first reduce independent blocks, then
-higher levels reduce those partial results until one row remains. This fixed tree avoids CPU
-readback and makes the floating-point order repeatable for a fixed input topology.
+higher levels reduce those partial results until one row remains. This hierarchy avoids CPU
+readback. The portable path uses a fixed floating-point tree; a subgroup-capable device may use its
+native subgroup reduction order and differ in the lowest-order floating-point bits.
 
 ### When to use it
 
@@ -37,6 +39,7 @@ new GPUReduction({input: values, output: extent, operation: 'extent'}).addToGrap
 type GPUReductionProps<T extends 'uint32' | 'sint32' | 'float32'> = {
   id?: string;
   input: GraphDataView<T> | GraphVectorView<T>;
+  mask?: GraphDataView<'uint32'> | GraphVectorView<'uint32'>;
   output: GraphDataView<T>;
   operation: 'sum' | 'min' | 'max' | 'extent';
 };
@@ -76,6 +79,27 @@ Empty chunks add no passes and do not change the result.
 
 All intermediate views are graph-owned transients. Their declared node uses let the command-graph
 compiler infer ordering and reuse physical scratch allocations when lifetimes do not overlap.
+
+## Subgroup acceleration
+
+On a max-feature WebGPU device that exposes both the `subgroups` device feature and the
+`subgroup_id` WGSL language feature, each reduction level uses subgroup `add`, `min`, and `max`
+collectives before merging the much smaller set of subgroup totals in workgroup memory. Other
+devices keep the portable shared-memory tree automatically; the `GPUReduction` API and results do
+not change.
+
+This path also benefits graph features that compose `GPUReduction`, including automatic histogram
+domains, raster statistics, graph core-number and modularity summaries, and global data-frame
+aggregations. It is most useful when reduction synchronization is a meaningful part of the total
+work; end-to-end workloads dominated by reading the input buffer may show a smaller improvement.
+
+### Performance expectations
+
+The live benchmark isolates the 256-value workgroup reduction at the center of every hierarchy
+level. It reports absolute input-element throughput for the portable implementation and, when the
+reader's adapter supports it, the subgroup optimization requested on the same max-feature device.
+
+<WorkgroupReductionBenchmark />
 
 ## `addToGraph(graph)`
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-scan.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-scan.md
@@ -87,7 +87,9 @@ are supported. A zero-length scan adds no nodes.
 All arithmetic wraps modulo 2^32. Signed, floating-point, minimum/maximum, and custom associative
 scans remain future work.
 
-## Subgroup acceleration
+## Performance notes
+
+### Subgroup acceleration
 
 Unsegmented scans automatically use WebGPU subgroup operations when the created device exposes the
 `subgroups` feature and the browser exposes the `subgroup_id` WGSL language extension. The portable
@@ -103,7 +105,7 @@ visibility compaction both scan large flag arrays on interactive updates. The GP
 `featureLevel: 'max'`, so recent Chrome releases opt into the fast path automatically when the
 adapter supports it and report the selected path in the inspector.
 
-### Performance expectations
+### Live benchmark
 
 The standalone subgroup scan reduces block-local synchronization, but its global reads, writes,
 summary hierarchy, and offset passes can make the full operation bandwidth-bound. On an Apple M4

--- a/docs/api-reference/experimental/gpu-primitives/gpu-texture-history.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-texture-history.md
@@ -1,4 +1,8 @@
+import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+
 # GPUTextureHistory
+
+<GPUPrimitivesDocsTabs active="texture-history" />
 
 ## Overview
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-trace-picking.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-trace-picking.md
@@ -89,7 +89,7 @@ All five bindings belong to bind group zero:
 | 0 | Read-only storage | Packed eight-word canonical span records from `GPUTraceScene` |
 | 1 | Read-only storage | Exclusive-scanned effective thread offsets from `GPUTraceInteraction` |
 | 2 | Read-only storage | Source-aligned final visibility mask from `GPUTraceInteraction` |
-| 3 | Read-only storage | Pick request: `time: f32`, `lane: f32`, `active: u32`, `padding: u32` |
+| 3 | Read-only storage | Pick request: `time: f32`, `lane: f32`, `enabled: u32`, `padding: u32` |
 | 4 | Read/write storage | One `atomic<u32>` result initialized to `0xffffffff` |
 
 `spanCount` must be a nonnegative safe integer, and `lanesPerThread` must be a positive safe

--- a/docs/api-reference/experimental/lugraph.md
+++ b/docs/api-reference/experimental/lugraph.md
@@ -911,8 +911,9 @@ The default bounded iteration count is `40`.
 The optional one-row `float32` `residual` reports the final iteration's L1 score change: the sum of
 absolute differences between the last two normalized score vectors. It is an observable error
 signal, not an automatic convergence threshold, early-termination mechanism, or promise that a
-fixed budget reached the stationary distribution. Reductions use portable WebGPU workgroups and
-ordinary `float32` arithmetic, not floating-point atomics or native GPU `float64`.
+fixed budget reached the stationary distribution. Reductions use subgroup additions when the
+max-feature device exposes both required WebGPU capabilities, with a portable workgroup fallback.
+Both paths use ordinary `float32` arithmetic, not floating-point atomics or native GPU `float64`.
 
 ## Reveal relationships with LuGraphForceLayout
 

--- a/modules/experimental/src/gpu-primitives/gpu-reduction.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-reduction.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import {type Binding} from '@luma.gl/core';
+import {type Binding, type Device} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {
   GPUCommandGraph,
@@ -27,6 +27,16 @@ import {
 
 const REDUCTION_WORKGROUP_SIZE = 256;
 const SCALAR_FORMATS = ['uint32', 'sint32', 'float32'] as const;
+
+/** Compute strategy selected for one reduction level. @internal */
+export type GPUReductionStrategy = 'portable' | 'subgroups';
+
+/** Selects subgroup collectives only when the device and WGSL language both expose them. */
+export function getGPUReductionStrategy(device: Device): GPUReductionStrategy {
+  return device.features?.has('subgroups') && device.wgslLanguageFeatures?.has('subgroup_id')
+    ? 'subgroups'
+    : 'portable';
+}
 
 /**
  * Operation performed by {@link GPUReduction}.
@@ -421,7 +431,17 @@ function addReductionLevelPass<Parameters, T extends GPUScalarFormat>(
         }
         validityScratch[lane] = 1u;
       }`;
+  const strategy = getGPUReductionStrategy(graph.device);
+  const reductionSource =
+    strategy === 'subgroups'
+      ? getSubgroupReductionSource({
+          format: props.format,
+          operation: props.operation,
+          combine
+        })
+      : getPortableReductionSource(combine);
   const source = /* wgsl */ `
+${strategy === 'subgroups' ? 'enable subgroups;\nrequires subgroup_id;' : ''}
 const ELEMENT_COUNT: u32 = ${props.inputLength}u;
 const VALUES_PER_ROW: u32 = ${props.valuesPerRow}u;
 const INPUT_OFFSET: u32 = ${getViewElementOffset(props.inputValues)}u;
@@ -438,6 +458,7 @@ var<workgroup> validityScratch: array<u32, ${REDUCTION_WORKGROUP_SIZE}>;
 
 @compute @workgroup_size(${REDUCTION_WORKGROUP_SIZE}) fn main(
   @builtin(local_invocation_index) localInvocationIndex: u32,
+  ${strategy === 'subgroups' ? '@builtin(subgroup_invocation_id) subgroupInvocationId: u32,\n  @builtin(subgroup_size) subgroupSize: u32,\n  @builtin(subgroup_id) subgroupId: u32,' : ''}
   @builtin(workgroup_id) workgroupId: vec3<u32>
 ) {
   ${getBoundedInvocationIndexSource(dispatchLayout, REDUCTION_WORKGROUP_SIZE)}
@@ -451,19 +472,7 @@ var<workgroup> validityScratch: array<u32, ${REDUCTION_WORKGROUP_SIZE}>;
   if (index < ELEMENT_COUNT) {
     ${readFirst}
   }
-  firstScratch[lane] = value;
-  secondScratch[lane] = secondValue;
-  validityScratch[lane] = valid;
-  workgroupBarrier();
-  var stride = ${REDUCTION_WORKGROUP_SIZE / 2}u;
-  loop {
-    if (lane < stride) {
-      ${combine}
-    }
-    workgroupBarrier();
-    if (stride == 1u) { break; }
-    stride = stride / 2u;
-  }
+  ${reductionSource}
   if (lane == 0u) {
     outputValues[OUTPUT_OFFSET + workgroupIndex * VALUES_PER_ROW] = firstScratch[0];
     ${isExtent ? 'outputValues[OUTPUT_OFFSET + workgroupIndex * VALUES_PER_ROW + 1u] = secondScratch[0];' : ''}
@@ -492,6 +501,93 @@ var<workgroup> validityScratch: array<u32, ${REDUCTION_WORKGROUP_SIZE}>;
     bindings,
     dispatchLayout
   });
+}
+
+/** Emits the portable 256-lane shared-memory reduction. */
+function getPortableReductionSource(combine: string): string {
+  return `firstScratch[lane] = value;
+  secondScratch[lane] = secondValue;
+  validityScratch[lane] = valid;
+  workgroupBarrier();
+  var stride = ${REDUCTION_WORKGROUP_SIZE / 2}u;
+  loop {
+    if (lane < stride) {
+      ${combine}
+    }
+    workgroupBarrier();
+    if (stride == 1u) { break; }
+    stride = stride / 2u;
+  }`;
+}
+
+/** Emits one collective per subgroup followed by a short shared-memory merge of subgroup totals. */
+function getSubgroupReductionSource(props: {
+  format: GPUScalarFormat;
+  operation: GPUReductionOperation;
+  combine: string;
+}): string {
+  const firstCollective = getSubgroupCollective(
+    props.format,
+    props.operation === 'extent' ? 'min' : props.operation,
+    'value',
+    'valid'
+  );
+  const secondCollective = getSubgroupCollective(
+    props.format,
+    props.operation === 'extent' ? 'max' : props.operation,
+    'secondValue',
+    'valid'
+  );
+  return `let subgroupValid = subgroupMax(valid);
+  let subgroupFirst = ${firstCollective};
+  let subgroupSecond = ${secondCollective};
+  if (subgroupInvocationId == 0u) {
+    firstScratch[subgroupId] = subgroupFirst;
+    secondScratch[subgroupId] = subgroupSecond;
+    validityScratch[subgroupId] = subgroupValid;
+  }
+  workgroupBarrier();
+  let subgroupCount = ${REDUCTION_WORKGROUP_SIZE}u / subgroupSize;
+  if (subgroupCount > 1u) {
+    var stride = subgroupCount / 2u;
+    loop {
+      if (lane < stride) {
+        ${props.combine}
+      }
+      workgroupBarrier();
+      if (stride == 1u) { break; }
+      stride = stride / 2u;
+    }
+  }`;
+}
+
+/** Returns a type-correct subgroup collective with neutral values for invalid lanes. */
+function getSubgroupCollective(
+  format: GPUScalarFormat,
+  operation: Exclude<GPUReductionOperation, 'extent'>,
+  value: string,
+  validity: string
+): string {
+  if (operation === 'sum') {
+    return `subgroupAdd(${value})`;
+  }
+  const identity = getReductionIdentity(format, operation);
+  const collective = operation === 'min' ? 'subgroupMin' : 'subgroupMax';
+  return `${collective}(select(${identity}, ${value}, ${validity} != 0u))`;
+}
+
+/** Returns the neutral value used to exclude an invalid lane from min/max collectives. */
+function getReductionIdentity(
+  format: GPUScalarFormat,
+  operation: Exclude<GPUReductionOperation, 'sum' | 'extent'>
+): string {
+  if (format === 'uint32') {
+    return operation === 'min' ? '4294967295u' : '0u';
+  }
+  if (format === 'sint32') {
+    return operation === 'min' ? '2147483647' : '(-2147483647 - 1)';
+  }
+  return operation === 'min' ? '3.402823466e+38' : '-3.402823466e+38';
 }
 
 /** Copies the single partial row to caller output and maps an invalid aggregate to zero. */

--- a/modules/experimental/src/gpu-primitives/gpu-workgroup-reduction-benchmark.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-workgroup-reduction-benchmark.ts
@@ -1,0 +1,361 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {type CompiledGPUCommandGraph, GPUCommandGraph} from './gpu-command-graph';
+import {
+  summarizeGPUWorkgroupScanBenchmarkSamples,
+  type GPUWorkgroupScanBenchmarkDistribution
+} from './gpu-workgroup-scan-benchmark';
+
+const WORKGROUP_SIZE = 256;
+const DEFAULT_WORKGROUP_COUNT = 4096;
+const DEFAULT_ROUND_COUNT = 32;
+const DEFAULT_DISPATCH_COUNT = 10;
+const DEFAULT_WARMUP_ITERATIONS = 5;
+const DEFAULT_MEASURED_ITERATIONS = 30;
+
+/** Workgroup-local reduction implementation measured by the benchmark. */
+export type GPUWorkgroupReductionBenchmarkStrategy = 'portable' | 'subgroups';
+
+/** Options for the command-graph workgroup reduction benchmark. */
+export type GPUWorkgroupReductionBenchmarkProps = {
+  id?: string;
+  workgroupCount?: number;
+  roundCount?: number;
+  dispatchCount?: number;
+  warmupIterations?: number;
+  measuredIterations?: number;
+};
+
+/** Correctness-gated timing report for one reduction strategy. */
+export type GPUWorkgroupReductionBenchmarkPathReport = {
+  strategy: GPUWorkgroupReductionBenchmarkStrategy;
+  barrierCountPerRound: number;
+  checksum: number;
+  cpuEncodeTimeMilliseconds: GPUWorkgroupScanBenchmarkDistribution;
+  gpuTimeMilliseconds?: GPUWorkgroupScanBenchmarkDistribution;
+};
+
+/** Reproducible metadata and results from one workgroup reduction benchmark. */
+export type GPUWorkgroupReductionBenchmarkReport = {
+  id: string;
+  workgroupSize: number;
+  workgroupCount: number;
+  roundCount: number;
+  dispatchCount: number;
+  warmupIterations: number;
+  measuredIterations: number;
+  timestampQueries: boolean;
+  subgroupAvailable: boolean;
+  subgroupMinSize?: number;
+  subgroupMaxSize?: number;
+  paths: GPUWorkgroupReductionBenchmarkPathReport[];
+};
+
+type BenchmarkPath = {
+  strategy: GPUWorkgroupReductionBenchmarkStrategy;
+  barrierCountPerRound: number;
+  outputBuffer: Buffer;
+  compiled: CompiledGPUCommandGraph<void>;
+};
+
+type BenchmarkSamples = {cpu: number[]; gpu: number[]};
+
+/** Measures the synchronization-sensitive 256-value sum used by hierarchical GPU reductions. */
+export async function runGPUWorkgroupReductionBenchmark(
+  device: Device,
+  props: GPUWorkgroupReductionBenchmarkProps = {}
+): Promise<GPUWorkgroupReductionBenchmarkReport> {
+  const id = props.id ?? 'gpu-workgroup-reduction-benchmark';
+  const workgroupCount = props.workgroupCount ?? DEFAULT_WORKGROUP_COUNT;
+  const roundCount = props.roundCount ?? DEFAULT_ROUND_COUNT;
+  const dispatchCount = props.dispatchCount ?? DEFAULT_DISPATCH_COUNT;
+  const warmupIterations = props.warmupIterations ?? DEFAULT_WARMUP_ITERATIONS;
+  const measuredIterations = props.measuredIterations ?? DEFAULT_MEASURED_ITERATIONS;
+  validateProps(
+    device,
+    workgroupCount,
+    roundCount,
+    dispatchCount,
+    warmupIterations,
+    measuredIterations
+  );
+
+  const subgroupAvailable =
+    device.features.has('subgroups') && device.wgslLanguageFeatures.has('subgroup_id');
+  const strategies: GPUWorkgroupReductionBenchmarkStrategy[] = subgroupAvailable
+    ? ['portable', 'subgroups']
+    : ['portable'];
+  const expectedChecksum = getExpectedChecksum(roundCount);
+  const timestampQueries = device.features.has('timestamp-query');
+  const paths = strategies.map(strategy =>
+    makeBenchmarkPath(device, id, strategy, workgroupCount, roundCount, dispatchCount)
+  );
+  const samples = new Map<GPUWorkgroupReductionBenchmarkStrategy, BenchmarkSamples>(
+    strategies.map(strategy => [strategy, {cpu: [], gpu: []}])
+  );
+
+  try {
+    for (const path of paths) {
+      for (let iteration = 0; iteration < warmupIterations; iteration++) {
+        encodeAndSubmit(device, path, `${id}-${path.strategy}-warmup-${iteration}`);
+      }
+      await validatePath(path, expectedChecksum, workgroupCount, id);
+    }
+
+    for (let iteration = 0; iteration < measuredIterations; iteration++) {
+      const orderedPaths = iteration % 2 === 0 ? paths : [...paths].reverse();
+      for (const path of orderedPaths) {
+        const querySet = timestampQueries
+          ? device.createQuerySet({
+              id: `${id}-${path.strategy}-timestamps-${iteration}`,
+              type: 'timestamp',
+              count: 2
+            })
+          : undefined;
+        const commandEncoder = device.createCommandEncoder({
+          id: `${id}-${path.strategy}-measured-${iteration}`,
+          timeProfilingQuerySet: querySet
+        });
+        try {
+          const encoding = path.compiled.encode(commandEncoder, {parameters: undefined});
+          device.submit(commandEncoder.finish());
+          const timing = await encoding.readTimings();
+          const pathSamples = samples.get(path.strategy)!;
+          pathSamples.cpu.push(timing.cpuEncodeTimeMilliseconds / dispatchCount);
+          if (timing.gpuTimeMilliseconds !== undefined) {
+            pathSamples.gpu.push(timing.gpuTimeMilliseconds / dispatchCount);
+          }
+        } catch (error) {
+          commandEncoder.destroy();
+          throw error;
+        } finally {
+          querySet?.destroy();
+        }
+      }
+    }
+
+    const pathReports: GPUWorkgroupReductionBenchmarkPathReport[] = paths.map(path => {
+      const pathSamples = samples.get(path.strategy)!;
+      return {
+        strategy: path.strategy,
+        barrierCountPerRound: path.barrierCountPerRound,
+        checksum: expectedChecksum,
+        cpuEncodeTimeMilliseconds: summarizeGPUWorkgroupScanBenchmarkSamples(pathSamples.cpu),
+        ...(pathSamples.gpu.length > 0
+          ? {gpuTimeMilliseconds: summarizeGPUWorkgroupScanBenchmarkSamples(pathSamples.gpu)}
+          : {})
+      };
+    });
+    for (const path of paths) {
+      await validatePath(path, expectedChecksum, workgroupCount, id);
+    }
+
+    return {
+      id,
+      workgroupSize: WORKGROUP_SIZE,
+      workgroupCount,
+      roundCount,
+      dispatchCount,
+      warmupIterations,
+      measuredIterations,
+      timestampQueries,
+      subgroupAvailable,
+      subgroupMinSize: device.info.subgroupMinSize,
+      subgroupMaxSize: device.info.subgroupMaxSize,
+      paths: pathReports
+    };
+  } finally {
+    for (const path of paths) {
+      path.compiled.destroy();
+      path.outputBuffer.destroy();
+    }
+  }
+}
+
+function makeBenchmarkPath(
+  device: Device,
+  benchmarkId: string,
+  strategy: GPUWorkgroupReductionBenchmarkStrategy,
+  workgroupCount: number,
+  roundCount: number,
+  dispatchCount: number
+): BenchmarkPath {
+  const outputBuffer = device.createBuffer({
+    id: `${benchmarkId}-${strategy}-output`,
+    byteLength: workgroupCount * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  const graph = new GPUCommandGraph(device, {id: `${benchmarkId}-${strategy}`});
+  const output = graph.importBuffer(
+    {id: 'output', byteLength: outputBuffer.byteLength, usage: outputBuffer.usage},
+    outputBuffer
+  );
+  graph.addComputePass({
+    id: `${benchmarkId}-${strategy}-local-reduction`,
+    resources: [{buffer: output, usage: 'storage-write'}],
+    compile: () => {
+      const computation = new Computation(device, {
+        id: `${benchmarkId}-${strategy}-local-reduction`,
+        source:
+          strategy === 'subgroups' ? getSubgroupShader(roundCount) : getPortableShader(roundCount),
+        shaderLayout: {
+          bindings: [{name: 'outputValues', type: 'storage', group: 0, location: 0}]
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          computation.setBindings({outputValues: getBuffer(output)});
+          for (let dispatchIndex = 0; dispatchIndex < dispatchCount; dispatchIndex++) {
+            computation.dispatch(computePass, workgroupCount);
+          }
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+  const subgroupSize = device.info.subgroupMinSize || 32;
+  return {
+    strategy,
+    barrierCountPerRound:
+      strategy === 'subgroups'
+        ? 2 + Math.log2(WORKGROUP_SIZE / subgroupSize)
+        : 2 + Math.log2(WORKGROUP_SIZE),
+    outputBuffer,
+    compiled: graph.compile()
+  };
+}
+
+function encodeAndSubmit(device: Device, path: BenchmarkPath, id: string): void {
+  const commandEncoder = device.createCommandEncoder({id});
+  try {
+    path.compiled.encode(commandEncoder, {parameters: undefined});
+    device.submit(commandEncoder.finish());
+  } catch (error) {
+    commandEncoder.destroy();
+    throw error;
+  }
+}
+
+async function validatePath(
+  path: BenchmarkPath,
+  expectedChecksum: number,
+  workgroupCount: number,
+  benchmarkId: string
+): Promise<void> {
+  const outputBytes = await path.outputBuffer.readAsync();
+  const values = new Uint32Array(outputBytes.buffer, outputBytes.byteOffset, workgroupCount);
+  if (values.some(value => value !== expectedChecksum)) {
+    throw new Error(`${benchmarkId} ${path.strategy} path does not match the reduction oracle`);
+  }
+}
+
+function getExpectedChecksum(roundCount: number): number {
+  let total = 0;
+  for (let round = 0; round < roundCount; round++) {
+    const inputValue = total;
+    total = 0;
+    for (let lane = 0; lane < WORKGROUP_SIZE; lane++) {
+      const laneValue = round === 0 ? lane + 1 : inputValue;
+      total = (total + ((laneValue ^ (round + lane)) >>> 0)) >>> 0;
+    }
+  }
+  return total;
+}
+
+function validateProps(
+  device: Device,
+  workgroupCount: number,
+  roundCount: number,
+  dispatchCount: number,
+  warmupIterations: number,
+  measuredIterations: number
+): void {
+  const counts = [workgroupCount, roundCount, dispatchCount, warmupIterations, measuredIterations];
+  if (counts.some(value => !Number.isSafeInteger(value) || value < 1)) {
+    throw new Error('GPU workgroup reduction benchmark counts must be positive safe integers');
+  }
+  if (device.limits.maxComputeInvocationsPerWorkgroup < WORKGROUP_SIZE) {
+    throw new Error(`GPU workgroup reduction benchmark requires ${WORKGROUP_SIZE} invocations`);
+  }
+  if (workgroupCount > device.limits.maxComputeWorkgroupsPerDimension) {
+    throw new Error('GPU workgroup reduction benchmark exceeds maxComputeWorkgroupsPerDimension');
+  }
+}
+
+function getPortableShader(roundCount: number): string {
+  return /* wgsl */ `
+@group(0) @binding(0) var<storage, read_write> outputValues: array<u32>;
+var<workgroup> scratch: array<u32, ${WORKGROUP_SIZE}>;
+
+fn reduceValue(inputValue: u32, lane: u32) -> u32 {
+  scratch[lane] = inputValue;
+  workgroupBarrier();
+  for (var stride = ${WORKGROUP_SIZE / 2}u; stride > 0u; stride /= 2u) {
+    if (lane < stride) { scratch[lane] += scratch[lane + stride]; }
+    workgroupBarrier();
+  }
+  let result = scratch[0];
+  workgroupBarrier();
+  return result;
+}
+
+@compute @workgroup_size(${WORKGROUP_SIZE}) fn main(
+  @builtin(local_invocation_index) lane: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  var value = lane + 1u;
+  for (var round = 0u; round < ${roundCount}u; round++) {
+    value = reduceValue(value ^ (round + lane), lane);
+  }
+  if (lane == 0u) { outputValues[workgroupId.x] = value; }
+}`;
+}
+
+function getSubgroupShader(roundCount: number): string {
+  return /* wgsl */ `
+enable subgroups;
+requires subgroup_id;
+
+@group(0) @binding(0) var<storage, read_write> outputValues: array<u32>;
+var<workgroup> subgroupTotals: array<u32, 64>;
+
+fn reduceValue(
+  inputValue: u32,
+  lane: u32,
+  subgroupInvocationId: u32,
+  subgroupSize: u32,
+  subgroupId: u32
+) -> u32 {
+  let subgroupTotal = subgroupAdd(inputValue);
+  if (subgroupInvocationId == 0u) { subgroupTotals[subgroupId] = subgroupTotal; }
+  workgroupBarrier();
+  let subgroupCount = ${WORKGROUP_SIZE}u / subgroupSize;
+  if (subgroupCount > 1u) {
+    for (var stride = subgroupCount / 2u; stride > 0u; stride /= 2u) {
+      if (lane < stride) { subgroupTotals[lane] += subgroupTotals[lane + stride]; }
+      workgroupBarrier();
+    }
+  }
+  let result = subgroupTotals[0];
+  workgroupBarrier();
+  return result;
+}
+
+@compute @workgroup_size(${WORKGROUP_SIZE}) fn main(
+  @builtin(subgroup_invocation_id) subgroupInvocationId: u32,
+  @builtin(subgroup_size) subgroupSize: u32,
+  @builtin(subgroup_id) subgroupId: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  let lane = subgroupId * subgroupSize + subgroupInvocationId;
+  var value = lane + 1u;
+  for (var round = 0u; round < ${roundCount}u; round++) {
+    value = reduceValue(value ^ (round + lane), lane, subgroupInvocationId, subgroupSize, subgroupId);
+  }
+  if (lane == 0u) { outputValues[workgroupId.x] = value; }
+}`;
+}

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -83,6 +83,13 @@ export type {
   GPUWorkgroupScanBenchmarkReport,
   GPUWorkgroupScanBenchmarkStrategy
 } from './gpu-workgroup-scan-benchmark';
+export {runGPUWorkgroupReductionBenchmark} from './gpu-workgroup-reduction-benchmark';
+export type {
+  GPUWorkgroupReductionBenchmarkPathReport,
+  GPUWorkgroupReductionBenchmarkProps,
+  GPUWorkgroupReductionBenchmarkReport,
+  GPUWorkgroupReductionBenchmarkStrategy
+} from './gpu-workgroup-reduction-benchmark';
 export {GPUSegmentedSort} from './gpu-segmented-sort';
 export type {GPUSegmentedSortProps, GPUSortSegment} from './gpu-segmented-sort';
 export {GPUCompaction} from './gpu-compaction';

--- a/modules/experimental/src/lugraph/lu-graph-page-rank-internals.ts
+++ b/modules/experimental/src/lugraph/lu-graph-page-rank-internals.ts
@@ -20,6 +20,7 @@ import {
   getViewBinding,
   getViewElementOffset
 } from '../gpu-primitives/graph-data-view-utils';
+import {getGPUReductionStrategy} from '../gpu-primitives/gpu-reduction';
 import type {LuGraphPageRank} from './lu-graph-page-rank';
 
 const PAGE_RANK_WORKGROUP_SIZE = 256;
@@ -502,7 +503,33 @@ function addReductionPass<Parameters>(
     props.input.length,
     props.maxComputeWorkgroupsPerDimension
   );
+  const useSubgroups = getGPUReductionStrategy(commandGraph.device) === 'subgroups';
+  const reductionSource = useSubgroups
+    ? `let subgroupTotal = subgroupAdd(value);
+  if (subgroupInvocationId == 0u) {
+    reductionValues[subgroupId] = subgroupTotal;
+  }
+  workgroupBarrier();
+  let subgroupCount = ${PAGE_RANK_WORKGROUP_SIZE}u / subgroupSize;
+  if (subgroupCount > 1u) {
+    for (var stride = subgroupCount / 2u; stride > 0u; stride /= 2u) {
+      if (localInvocationIndex < stride) {
+        reductionValues[localInvocationIndex] += reductionValues[localInvocationIndex + stride];
+      }
+      workgroupBarrier();
+    }
+  }`
+    : `reductionValues[localInvocationIndex] = value;
+  workgroupBarrier();
+
+  for (var stride = ${PAGE_RANK_WORKGROUP_SIZE / 2}u; stride > 0u; stride /= 2u) {
+    if (localInvocationIndex < stride) {
+      reductionValues[localInvocationIndex] += reductionValues[localInvocationIndex + stride];
+    }
+    workgroupBarrier();
+  }`;
   const source = /* wgsl */ `
+${useSubgroups ? 'enable subgroups;\nrequires subgroup_id;' : ''}
 const INPUT_COUNT: u32 = ${props.input.length}u;
 const OUTPUT_COUNT: u32 = ${props.output.length}u;
 const INPUT_OFFSET: u32 = ${getViewElementOffset(props.input)}u;
@@ -513,21 +540,14 @@ var<workgroup> reductionValues: array<f32, ${PAGE_RANK_WORKGROUP_SIZE}>;
 @compute @workgroup_size(${PAGE_RANK_WORKGROUP_SIZE})
 fn main(
   @builtin(workgroup_id) workgroupId: vec3<u32>,
+  ${useSubgroups ? '@builtin(subgroup_invocation_id) subgroupInvocationId: u32,\n  @builtin(subgroup_size) subgroupSize: u32,\n  @builtin(subgroup_id) subgroupId: u32,' : ''}
   @builtin(local_invocation_index) localInvocationIndex: u32
 ) {
   ${getBoundedInvocationIndexSource(dispatchLayout, PAGE_RANK_WORKGROUP_SIZE)}
   if (workgroupIndex >= OUTPUT_COUNT) { return; }
   var value = 0.0;
   if (index < INPUT_COUNT) { value = inputValues[INPUT_OFFSET + index]; }
-  reductionValues[localInvocationIndex] = value;
-  workgroupBarrier();
-
-  for (var stride = ${PAGE_RANK_WORKGROUP_SIZE / 2}u; stride > 0u; stride /= 2u) {
-    if (localInvocationIndex < stride) {
-      reductionValues[localInvocationIndex] += reductionValues[localInvocationIndex + stride];
-    }
-    workgroupBarrier();
-  }
+  ${reductionSource}
   if (localInvocationIndex == 0u) {
     outputValues[OUTPUT_OFFSET + workgroupIndex] = reductionValues[0];
   }

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
@@ -23,6 +23,7 @@ import {
   getBoundedDispatchLayout,
   getBoundedInvocationIndexSource
 } from '../../src/gpu-primitives/gpu-dispatch-utils';
+import {getGPUReductionStrategy} from '../../src/gpu-primitives/gpu-reduction';
 import {
   addGPUScanToGraphWithDispatchLimit,
   getGPUScanDispatchLayout,
@@ -750,6 +751,19 @@ test('GPUScan selects subgroups only when device and WGSL capabilities are both 
     'portable',
     'keeps segmented scans on the portable path'
   );
+  t.end();
+});
+
+test('GPUReduction selects subgroups only when device and WGSL capabilities are available', t => {
+  const makeDevice = (subgroups: boolean, subgroupId: boolean) =>
+    ({
+      features: {has: (feature: string) => feature === 'subgroups' && subgroups},
+      wgslLanguageFeatures: new Set(subgroupId ? ['subgroup_id'] : [])
+    }) as Device;
+
+  t.equal(getGPUReductionStrategy(makeDevice(true, true)), 'subgroups', 'selects subgroups');
+  t.equal(getGPUReductionStrategy(makeDevice(true, false)), 'portable', 'requires subgroup_id');
+  t.equal(getGPUReductionStrategy(makeDevice(false, true)), 'portable', 'requires device feature');
   t.end();
 });
 

--- a/modules/experimental/test/gpu-primitives/gpu-data-analysis.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-data-analysis.spec.ts
@@ -46,7 +46,7 @@ test('GPUReduction handles operations, formats, hierarchy, and invalid floats', 
 
   const invalidFloats = Float32Array.from([Number.NaN, 4, Number.POSITIVE_INFINITY, -2]);
   const floatSum = await runReduction(device, Float32Array.from([0.1, 0.2, 0.3]), 'float32', 'sum');
-  t.ok(Math.abs(floatSum[0] - 0.6) < 1e-6, 'float sum uses the fixed reduction tree');
+  t.ok(Math.abs(floatSum[0] - 0.6) < 1e-6, 'float sum remains numerically accurate');
   t.deepEqual(await runReduction(device, invalidFloats, 'float32', 'min'), [-2]);
   t.deepEqual(await runReduction(device, invalidFloats, 'float32', 'max'), [4]);
   t.deepEqual(await runReduction(device, invalidFloats, 'float32', 'extent'), [-2, 4]);

--- a/modules/experimental/test/gpu-primitives/gpu-workgroup-reduction-benchmark.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-workgroup-reduction-benchmark.spec.ts
@@ -1,0 +1,39 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {runGPUWorkgroupReductionBenchmark} from '@luma.gl/experimental';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+test('runGPUWorkgroupReductionBenchmark compares graph-owned reductions', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const report = await runGPUWorkgroupReductionBenchmark(device, {
+    workgroupCount: 2,
+    roundCount: 2,
+    dispatchCount: 2,
+    warmupIterations: 1,
+    measuredIterations: 2
+  });
+  t.equal(report.paths[0].strategy, 'portable', 'portable path is always measured');
+  t.equal(
+    report.paths.length,
+    report.subgroupAvailable ? 2 : 1,
+    'subgroup path is measured only when both capabilities are available'
+  );
+  t.ok(
+    report.paths.every(path => path.checksum === report.paths[0].checksum),
+    'every measured path passes the shared checksum oracle'
+  );
+  t.ok(
+    report.paths.every(path => path.cpuEncodeTimeMilliseconds.minimum >= 0),
+    'per-dispatch CPU encoding distributions are reported'
+  );
+  t.end();
+});

--- a/website/src/components/docs/gpu-primitives-docs-tabs.tsx
+++ b/website/src/components/docs/gpu-primitives-docs-tabs.tsx
@@ -4,6 +4,7 @@ import Link from '@docusaurus/Link';
 export type GPUPrimitivesDocsTabId =
   | 'overview'
   | 'command-graph'
+  | 'texture-history'
   | 'scan'
   | 'compaction'
   | 'mask'
@@ -50,6 +51,11 @@ const TABS: {id: GPUPrimitivesDocsTabId; label: string; href: string}[] = [
     id: 'command-graph',
     label: 'Command Graph',
     href: '/docs/api-reference/experimental/gpu-primitives/gpu-command-graph'
+  },
+  {
+    id: 'texture-history',
+    label: 'Texture History',
+    href: '/docs/api-reference/experimental/gpu-primitives/gpu-texture-history'
   },
   {
     id: 'scan',
@@ -238,11 +244,11 @@ const TAB_GROUPS: GPUPrimitivesDocsTabGroup[] = [
   {
     id: 'foundation',
     label: 'Foundation',
-    tabIds: ['overview', 'command-graph', 'readback-ring']
+    tabIds: ['overview', 'command-graph', 'texture-history', 'readback-ring']
   },
   {
     id: 'transforms',
-    label: 'Transforms',
+    label: 'Operations',
     tabIds: ['scan', 'compaction', 'mask', 'sort', 'fft2d', 'reduction', 'histogram']
   },
   {

--- a/website/src/components/docs/live-benchmark-panel.tsx
+++ b/website/src/components/docs/live-benchmark-panel.tsx
@@ -5,7 +5,7 @@ export type LiveBenchmarkPanelProps = {
   /** Accessible panel heading describing the benchmarked operation. */
   title: string;
   /** Short explanation of the workload and what its measurements include. */
-  description: string;
+  description?: string;
   /** Optional benchmark controls rendered beside the run action. */
   controls?: ReactNode;
   /** Places the benchmark in a single disclosure card instead of an always-open panel. */
@@ -16,6 +16,8 @@ export type LiveBenchmarkPanelProps = {
   onRun: () => Promise<ReactNode>;
   /** Optional stable placeholder rendered in the results area while work is in progress. */
   runningContent?: ReactNode;
+  /** Optional stable table or preview rendered before the first benchmark run. */
+  idleContent?: ReactNode;
   /** Explicit capability message that disables the benchmark without claiming synthetic results. */
   unsupportedReason?: string;
 };
@@ -34,6 +36,7 @@ export function LiveBenchmarkPanel({
   runLabel = 'Run live WebGPU benchmark',
   onRun,
   runningContent,
+  idleContent,
   unsupportedReason
 }: LiveBenchmarkPanelProps): ReactNode {
   const [isRunning, setIsRunning] = useState(false);
@@ -75,21 +78,7 @@ export function LiveBenchmarkPanel({
 
   const content = (
     <>
-      <p className="luma-live-benchmark__description">{description}</p>
-
-      <div className="luma-live-benchmark__actions">
-        {controls}
-        <button
-          className="button button--primary button--sm"
-          disabled={isRunning || Boolean(unsupportedReason)}
-          onClick={() => {
-            void handleRun();
-          }}
-          type="button"
-        >
-          {isRunning ? 'Running…' : runLabel}
-        </button>
-      </div>
+      {description ? <p className="luma-live-benchmark__description">{description}</p> : null}
 
       {unsupportedReason ? (
         <p aria-live="polite" style={{marginBottom: 0}}>
@@ -111,7 +100,23 @@ export function LiveBenchmarkPanel({
         <div aria-live="polite" style={{marginTop: '1rem', overflowX: 'auto'}}>
           {results}
         </div>
+      ) : idleContent ? (
+        <div style={{marginTop: '1rem', overflowX: 'auto'}}>{idleContent}</div>
       ) : null}
+
+      <div className="luma-live-benchmark__actions">
+        {controls}
+        <button
+          className="button button--primary button--sm"
+          disabled={isRunning || Boolean(unsupportedReason)}
+          onClick={() => {
+            void handleRun();
+          }}
+          type="button"
+        >
+          {isRunning ? 'Running…' : runLabel}
+        </button>
+      </div>
     </>
   );
 
@@ -119,10 +124,7 @@ export function LiveBenchmarkPanel({
     return (
       <details className="luma-live-benchmark" data-live-benchmark="true">
         <summary className="luma-live-benchmark__summary">
-          <span>
-            <strong>{title}</strong>
-            <small>Live · runs on this device</small>
-          </span>
+          <strong>{title}</strong>
         </summary>
         <div className="luma-live-benchmark__body">{content}</div>
       </details>

--- a/website/src/components/docs/workgroup-reduction-benchmark.tsx
+++ b/website/src/components/docs/workgroup-reduction-benchmark.tsx
@@ -28,8 +28,7 @@ export function WorkgroupReductionBenchmark(): ReactNode {
   return (
     <LiveBenchmarkPanel
       collapsible
-      title="GPUReduction compute benchmark"
-      description="Each round sums 256 generated uint32 input elements using the same workgroup-local operation as a GPUReduction level. Throughput is reported as input elements reduced per second."
+      title="GPUReduction - Benchmark"
       runLabel="Run benchmark"
       controls={
         <div className="luma-live-benchmark__controls">
@@ -63,6 +62,7 @@ export function WorkgroupReductionBenchmark(): ReactNode {
           </label>
         </div>
       }
+      idleContent={<IdleTable workgroupCount={workgroupCount} roundCount={roundCount} />}
       runningContent={<RunningTable workgroupCount={workgroupCount} roundCount={roundCount} />}
       unsupportedReason={
         webGPUUnavailable
@@ -89,6 +89,19 @@ export function WorkgroupReductionBenchmark(): ReactNode {
   );
 }
 
+function IdleTable(props: {workgroupCount: number; roundCount: number}): ReactNode {
+  return (
+    <div>
+      <WorkloadSummary {...props} />
+      <BenchmarkTable>
+        <IdleRow barriers={10} label="GPUReduction" relative="1.00×" supported />
+        <IdleRow label="Subgroup optimization" secondary />
+      </BenchmarkTable>
+      <BenchmarkNotes />
+    </div>
+  );
+}
+
 function RunningTable(props: {workgroupCount: number; roundCount: number}): ReactNode {
   return (
     <div>
@@ -107,6 +120,7 @@ function RunningTable(props: {workgroupCount: number; roundCount: number}): Reac
           </tr>
         ))}
       </BenchmarkTable>
+      <BenchmarkNotes />
     </div>
   );
 }
@@ -140,12 +154,30 @@ function ResultsTable({
           supported={report.subgroupAvailable}
         />
       </BenchmarkTable>
-      <p style={{fontSize: 12, margin: '10px 0 0'}}>
-        {report.subgroupAvailable ? `Subgroups expose ${formatSubgroupSize(report)} lanes. ` : ''}
-        Measured paths passed the same CPU checksum oracle. Results are local to this browser,
-        adapter, and current system load.
-      </p>
+      <ul className="luma-live-benchmark__notes">
+        <li>
+          Each round sums 256 generated uint32 inputs using the workgroup-local operation at the
+          center of a GPUReduction level.
+        </li>
+        {report.subgroupAvailable ? (
+          <li>Subgroups expose {formatSubgroupSize(report)} lanes on this adapter.</li>
+        ) : null}
+        <li>Both paths passed the same CPU checksum oracle.</li>
+        <li>Results reflect this browser, adapter, and current system load.</li>
+      </ul>
     </div>
+  );
+}
+
+function BenchmarkNotes(): ReactNode {
+  return (
+    <ul className="luma-live-benchmark__notes">
+      <li>
+        Each round sums 256 generated uint32 inputs using the workgroup-local operation at the
+        center of a GPUReduction level.
+      </li>
+      <li>Throughput is input elements reduced per second.</li>
+    </ul>
   );
 }
 
@@ -162,7 +194,7 @@ function WorkloadSummary({
     <p style={{margin: '14px 0 10px'}}>
       <strong>{formatElementCount(workgroupCount, roundCount)}</strong> uint32 elements/dispatch ·{' '}
       <strong>{(workgroupCount * roundCount).toLocaleString()}</strong> reduction blocks
-      {suffix ? ` · ${suffix}` : '…'}
+      {suffix ? ` · ${suffix}` : null}
     </p>
   );
 }
@@ -174,9 +206,9 @@ function BenchmarkTable({children}: {children: ReactNode}): ReactNode {
         <tr>
           <th>Implementation</th>
           <th>Supported</th>
-          <th>Barriers / reduction</th>
+          <th title="Workgroup barriers per reduction round">Barriers</th>
           <th>GPU median</th>
-          <th>GPU p95</th>
+          <th>Relative</th>
           <th>Element throughput</th>
         </tr>
       </thead>
@@ -212,8 +244,45 @@ function ResultRow({
       </td>
       <td>{path?.barrierCountPerRound ?? '—'}</td>
       <td>{path ? formatMilliseconds(path.gpuTimeMilliseconds?.median) : '—'}</td>
-      <td>{path ? formatMilliseconds(path.gpuTimeMilliseconds?.percentile95) : '—'}</td>
+      <td>{path ? formatRelativeSpeed(report, path) : '—'}</td>
       <td>{path ? formatThroughput(report, path) : '—'}</td>
+    </tr>
+  );
+}
+
+function IdleRow({
+  barriers,
+  label,
+  relative = '—',
+  secondary = false,
+  supported = false
+}: {
+  barriers?: number;
+  label: string;
+  relative?: string;
+  secondary?: boolean;
+  supported?: boolean;
+}): ReactNode {
+  return (
+    <tr>
+      <td className={secondary ? 'luma-live-benchmark__secondary-label' : undefined}>{label}</td>
+      <td>
+        {supported ? (
+          <span
+            aria-label="Supported"
+            className="luma-live-benchmark__support luma-live-benchmark__support--yes"
+            title="Supported"
+          >
+            ✓
+          </span>
+        ) : (
+          '—'
+        )}
+      </td>
+      <td>{barriers ?? '—'}</td>
+      <td>—</td>
+      <td>{relative}</td>
+      <td>—</td>
     </tr>
   );
 }
@@ -235,6 +304,20 @@ function formatThroughput(
   if (!milliseconds) return '—';
   const elements = report.workgroupCount * report.roundCount * report.workgroupSize;
   return `${(elements / (milliseconds / 1000) / 1e9).toFixed(2)} G elements/s`;
+}
+
+function formatRelativeSpeed(
+  report: GPUWorkgroupReductionBenchmarkReport,
+  path: GPUWorkgroupReductionBenchmarkPathReport
+): string {
+  if (path.strategy === 'portable') return '1.00×';
+  const portableMilliseconds = report.paths.find(
+    candidate => candidate.strategy === 'portable'
+  )?.gpuTimeMilliseconds?.median;
+  const pathMilliseconds = path.gpuTimeMilliseconds?.median;
+  return portableMilliseconds && pathMilliseconds
+    ? `${(portableMilliseconds / pathMilliseconds).toFixed(2)}×`
+    : '—';
 }
 
 function formatSubgroupSize(report: GPUWorkgroupReductionBenchmarkReport): string {

--- a/website/src/components/docs/workgroup-reduction-benchmark.tsx
+++ b/website/src/components/docs/workgroup-reduction-benchmark.tsx
@@ -1,0 +1,245 @@
+import React, {type ReactNode, useEffect, useId, useState} from 'react';
+
+import {
+  runGPUWorkgroupReductionBenchmark,
+  type GPUWorkgroupReductionBenchmarkPathReport,
+  type GPUWorkgroupReductionBenchmarkReport
+} from '@luma.gl/experimental';
+
+import {createDevice, useStore} from '../../react-luma/store/device-store';
+import {LiveBenchmarkPanel} from './live-benchmark-panel';
+
+const WORKGROUP_COUNTS = [256, 1024, 4096] as const;
+const ROUND_COUNTS = [1, 8, 32, 128] as const;
+
+/** Compares portable and subgroup workgroup reductions on the reader's WebGPU adapter. */
+export function WorkgroupReductionBenchmark(): ReactNode {
+  const selectedDevice = useStore(store => store.presentationDevice || store.device);
+  const [workgroupCount, setWorkgroupCount] = useState<number>(4096);
+  const [roundCount, setRoundCount] = useState<number>(32);
+  const [webGPUUnavailable, setWebGPUUnavailable] = useState(false);
+  const workgroupCountId = useId();
+  const roundCountId = useId();
+
+  useEffect(() => {
+    setWebGPUUnavailable(typeof navigator === 'undefined' || !('gpu' in navigator));
+  }, []);
+
+  return (
+    <LiveBenchmarkPanel
+      collapsible
+      title="GPUReduction compute benchmark"
+      description="Each round sums 256 generated uint32 input elements using the same workgroup-local operation as a GPUReduction level. Throughput is reported as input elements reduced per second."
+      runLabel="Run benchmark"
+      controls={
+        <div className="luma-live-benchmark__controls">
+          <label htmlFor={workgroupCountId}>
+            Workgroups
+            <select
+              id={workgroupCountId}
+              onChange={event => setWorkgroupCount(Number(event.target.value))}
+              value={workgroupCount}
+            >
+              {WORKGROUP_COUNTS.map(count => (
+                <option key={count} value={count}>
+                  {count.toLocaleString()}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label htmlFor={roundCountId}>
+            Rounds
+            <select
+              id={roundCountId}
+              onChange={event => setRoundCount(Number(event.target.value))}
+              value={roundCount}
+            >
+              {ROUND_COUNTS.map(count => (
+                <option key={count} value={count}>
+                  {count}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      }
+      runningContent={<RunningTable workgroupCount={workgroupCount} roundCount={roundCount} />}
+      unsupportedReason={
+        webGPUUnavailable
+          ? 'WebGPU is unavailable in this browser. Use a WebGPU-capable browser and a secure origin.'
+          : undefined
+      }
+      onRun={async () => {
+        const device =
+          selectedDevice?.type === 'webgpu' && selectedDevice.info.featureLevel === 'max'
+            ? selectedDevice
+            : await createDevice('webgpu-max');
+        const report = await runGPUWorkgroupReductionBenchmark(device, {
+          workgroupCount,
+          roundCount
+        });
+        return (
+          <ResultsTable
+            report={report}
+            deviceLabel={device.info.renderer || device.info.vendor || device.info.gpu}
+          />
+        );
+      }}
+    />
+  );
+}
+
+function RunningTable(props: {workgroupCount: number; roundCount: number}): ReactNode {
+  return (
+    <div>
+      <WorkloadSummary {...props} />
+      <BenchmarkTable>
+        {['GPUReduction', 'Subgroup optimization'].map((label, rowIndex) => (
+          <tr key={label}>
+            <td className={rowIndex === 1 ? 'luma-live-benchmark__secondary-label' : undefined}>
+              {label}
+            </td>
+            {[0, 1, 2, 3, 4].map(column => (
+              <td key={column}>
+                <span aria-label="Measuring" className="luma-live-benchmark-spinner" role="status" />
+              </td>
+            ))}
+          </tr>
+        ))}
+      </BenchmarkTable>
+    </div>
+  );
+}
+
+function ResultsTable({
+  report,
+  deviceLabel
+}: {
+  report: GPUWorkgroupReductionBenchmarkReport;
+  deviceLabel: string;
+}): ReactNode {
+  return (
+    <div>
+      <WorkloadSummary
+        workgroupCount={report.workgroupCount}
+        roundCount={report.roundCount}
+        suffix={`${report.dispatchCount} dispatches/sample · ${deviceLabel}`}
+      />
+      <BenchmarkTable>
+        <ResultRow
+          label="GPUReduction"
+          path={report.paths.find(path => path.strategy === 'portable')!}
+          report={report}
+          supported
+        />
+        <ResultRow
+          label="Subgroup optimization"
+          path={report.paths.find(path => path.strategy === 'subgroups')}
+          report={report}
+          secondary
+          supported={report.subgroupAvailable}
+        />
+      </BenchmarkTable>
+      <p style={{fontSize: 12, margin: '10px 0 0'}}>
+        {report.subgroupAvailable ? `Subgroups expose ${formatSubgroupSize(report)} lanes. ` : ''}
+        Measured paths passed the same CPU checksum oracle. Results are local to this browser,
+        adapter, and current system load.
+      </p>
+    </div>
+  );
+}
+
+function WorkloadSummary({
+  workgroupCount,
+  roundCount,
+  suffix
+}: {
+  workgroupCount: number;
+  roundCount: number;
+  suffix?: string;
+}): ReactNode {
+  return (
+    <p style={{margin: '14px 0 10px'}}>
+      <strong>{formatElementCount(workgroupCount, roundCount)}</strong> uint32 elements/dispatch ·{' '}
+      <strong>{(workgroupCount * roundCount).toLocaleString()}</strong> reduction blocks
+      {suffix ? ` · ${suffix}` : '…'}
+    </p>
+  );
+}
+
+function BenchmarkTable({children}: {children: ReactNode}): ReactNode {
+  return (
+    <table style={{fontSize: 13, minWidth: 620, width: '100%'}}>
+      <thead>
+        <tr>
+          <th>Implementation</th>
+          <th>Supported</th>
+          <th>Barriers / reduction</th>
+          <th>GPU median</th>
+          <th>GPU p95</th>
+          <th>Element throughput</th>
+        </tr>
+      </thead>
+      <tbody>{children}</tbody>
+    </table>
+  );
+}
+
+function ResultRow({
+  label,
+  path,
+  report,
+  secondary = false,
+  supported
+}: {
+  label: string;
+  path?: GPUWorkgroupReductionBenchmarkPathReport;
+  report: GPUWorkgroupReductionBenchmarkReport;
+  secondary?: boolean;
+  supported: boolean;
+}): ReactNode {
+  return (
+    <tr>
+      <td className={secondary ? 'luma-live-benchmark__secondary-label' : undefined}>{label}</td>
+      <td>
+        <span
+          aria-label={supported ? 'Supported' : 'Not supported'}
+          className={`luma-live-benchmark__support luma-live-benchmark__support--${supported ? 'yes' : 'no'}`}
+          title={supported ? 'Supported' : 'Not supported'}
+        >
+          {supported ? '✓' : '×'}
+        </span>
+      </td>
+      <td>{path?.barrierCountPerRound ?? '—'}</td>
+      <td>{path ? formatMilliseconds(path.gpuTimeMilliseconds?.median) : '—'}</td>
+      <td>{path ? formatMilliseconds(path.gpuTimeMilliseconds?.percentile95) : '—'}</td>
+      <td>{path ? formatThroughput(report, path) : '—'}</td>
+    </tr>
+  );
+}
+
+function formatElementCount(workgroupCount: number, roundCount: number): string {
+  const count = workgroupCount * roundCount * 256;
+  return count >= 1e6 ? `${(count / 1e6).toFixed(2)}M` : count.toLocaleString();
+}
+
+function formatMilliseconds(value?: number): string {
+  return value === undefined ? 'CPU timing only' : `${value.toFixed(3)} ms`;
+}
+
+function formatThroughput(
+  report: GPUWorkgroupReductionBenchmarkReport,
+  path: GPUWorkgroupReductionBenchmarkPathReport
+): string {
+  const milliseconds = path.gpuTimeMilliseconds?.median;
+  if (!milliseconds) return '—';
+  const elements = report.workgroupCount * report.roundCount * report.workgroupSize;
+  return `${(elements / (milliseconds / 1000) / 1e9).toFixed(2)} G elements/s`;
+}
+
+function formatSubgroupSize(report: GPUWorkgroupReductionBenchmarkReport): string {
+  if (report.subgroupMinSize === undefined || report.subgroupMaxSize === undefined) return 'unknown';
+  return report.subgroupMinSize === report.subgroupMaxSize
+    ? `${report.subgroupMinSize}`
+    : `${report.subgroupMinSize}–${report.subgroupMaxSize}`;
+}

--- a/website/src/components/docs/workgroup-scan-benchmark.tsx
+++ b/website/src/components/docs/workgroup-scan-benchmark.tsx
@@ -29,7 +29,6 @@ export function WorkgroupScanBenchmark(): ReactNode {
     <LiveBenchmarkPanel
       collapsible
       title="GPUScan compute benchmark"
-      description="Each round applies the same 256-element exclusive prefix operation used within GPUScan. Throughput is reported as uint32 input elements processed per second."
       runLabel="Run benchmark"
       controls={
         <div className="luma-live-benchmark__controls">
@@ -64,6 +63,9 @@ export function WorkgroupScanBenchmark(): ReactNode {
           </label>
         </div>
       }
+      idleContent={
+        <WorkgroupScanBenchmarkIdle workgroupCount={workgroupCount} roundCount={roundCount} />
+      }
       runningContent={
         <WorkgroupScanBenchmarkRunning
           workgroupCount={workgroupCount}
@@ -96,6 +98,28 @@ export function WorkgroupScanBenchmark(): ReactNode {
   );
 }
 
+function WorkgroupScanBenchmarkIdle({
+  workgroupCount,
+  roundCount
+}: {
+  workgroupCount: number;
+  roundCount: number;
+}): ReactNode {
+  return (
+    <div>
+      <p style={{margin: '14px 0 10px'}}>
+        <strong>{formatElementCount(workgroupCount, roundCount)}</strong> uint32 elements/dispatch ·{' '}
+        <strong>{formatWorkgroupScanCount(workgroupCount, roundCount)}</strong> local scan blocks
+      </p>
+      <ScanBenchmarkTable>
+        <IdleRow barriers={17} label="GPUScan" relative="1.00×" supported />
+        <IdleRow label="Subgroup optimization" secondary />
+      </ScanBenchmarkTable>
+      <ScanBenchmarkNotes />
+    </div>
+  );
+}
+
 function WorkgroupScanBenchmarkRunning({
   workgroupCount,
   roundCount
@@ -111,43 +135,28 @@ function WorkgroupScanBenchmarkRunning({
         <strong>{formatWorkgroupScanCount(workgroupCount, roundCount)}</strong> local scan blocks…
       </p>
 
-      <table style={{fontSize: 13, minWidth: 620, width: '100%'}}>
-        <thead>
-          <tr>
-            <th>Implementation</th>
-            <th>Supported</th>
-            <th>Barriers / scan</th>
-            <th>GPU median</th>
-            <th>GPU p95</th>
-            <th>Element throughput</th>
-          </tr>
-        </thead>
-        <tbody>
-          {['GPUScan', 'Subgroup optimization'].map((implementation, rowIndex) => (
-            <tr key={implementation}>
-              <td className={rowIndex === 1 ? 'luma-live-benchmark__secondary-label' : undefined}>
-                {implementation}
+      <ScanBenchmarkTable>
+        {['GPUScan', 'Subgroup optimization'].map((implementation, rowIndex) => (
+          <tr key={implementation}>
+            <td className={rowIndex === 1 ? 'luma-live-benchmark__secondary-label' : undefined}>
+              {implementation}
+            </td>
+            {[0, 1, 2, 3, 4].map(column => (
+              <td key={column}>
+                <BenchmarkSpinner />
               </td>
-              {[0, 1, 2, 3, 4].map(column => (
-                <td key={column}>
-                  <BenchmarkSpinner />
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+            ))}
+          </tr>
+        ))}
+      </ScanBenchmarkTable>
+      <ScanBenchmarkNotes />
     </div>
   );
 }
 
 function BenchmarkSpinner(): ReactNode {
   return (
-    <span
-      aria-label="Measuring"
-      className="luma-live-benchmark-spinner"
-      role="status"
-    />
+    <span aria-label="Measuring" className="luma-live-benchmark-spinner" role="status" />
   );
 }
 
@@ -168,40 +177,60 @@ function WorkgroupScanBenchmarkResults({
         <strong>{report.dispatchCount}</strong> dispatches/sample · {deviceLabel}
       </p>
 
-      <table style={{fontSize: 13, minWidth: 620, width: '100%'}}>
-        <thead>
-          <tr>
-            <th>Implementation</th>
-            <th>Supported</th>
-            <th>Barriers / scan</th>
-            <th>GPU median</th>
-            <th>GPU p95</th>
-            <th>Element throughput</th>
-          </tr>
-        </thead>
-        <tbody>
-          <BenchmarkResultRow
-            label="GPUScan"
-            path={report.paths.find(path => path.strategy === 'portable')!}
-            report={report}
-            supported
-          />
-          <BenchmarkResultRow
-            label="Subgroup optimization"
-            path={report.paths.find(path => path.strategy === 'subgroups')}
-            report={report}
-            secondary
-            supported={report.subgroupAvailable}
-          />
-        </tbody>
-      </table>
+      <ScanBenchmarkTable>
+        <BenchmarkResultRow
+          label="GPUScan"
+          path={report.paths.find(path => path.strategy === 'portable')!}
+          report={report}
+          supported
+        />
+        <BenchmarkResultRow
+          label="Subgroup optimization"
+          path={report.paths.find(path => path.strategy === 'subgroups')}
+          report={report}
+          secondary
+          supported={report.subgroupAvailable}
+        />
+      </ScanBenchmarkTable>
 
-      <p style={{fontSize: 12, margin: '10px 0 0'}}>
-        {report.subgroupAvailable ? `Subgroups use ${formatSubgroupSize(report)} lanes. ` : ''}
-        Measured paths passed the same CPU checksum oracle. Results are local to this browser,
-        adapter, and current system load.
-      </p>
+      <ul className="luma-live-benchmark__notes">
+        <li>
+          Each round applies the 256-element exclusive prefix operation used inside GPUScan.
+        </li>
+        {report.subgroupAvailable ? (
+          <li>Subgroups use {formatSubgroupSize(report)} lanes on this adapter.</li>
+        ) : null}
+        <li>Both paths passed the same CPU checksum oracle.</li>
+        <li>Results reflect this browser, adapter, and current system load.</li>
+      </ul>
     </div>
+  );
+}
+
+function ScanBenchmarkTable({children}: {children: ReactNode}): ReactNode {
+  return (
+    <table style={{fontSize: 13, minWidth: 620, width: '100%'}}>
+      <thead>
+        <tr>
+          <th>Implementation</th>
+          <th>Supported</th>
+          <th title="Workgroup barriers per scan round">Barriers</th>
+          <th>GPU median</th>
+          <th>Relative</th>
+          <th>Element throughput</th>
+        </tr>
+      </thead>
+      <tbody>{children}</tbody>
+    </table>
+  );
+}
+
+function ScanBenchmarkNotes(): ReactNode {
+  return (
+    <ul className="luma-live-benchmark__notes">
+      <li>Each round applies the 256-element exclusive prefix operation used inside GPUScan.</li>
+      <li>Throughput is uint32 input elements processed per second.</li>
+    </ul>
   );
 }
 
@@ -226,7 +255,7 @@ function BenchmarkResultRow({
       </td>
       <td>{path?.barrierCountPerRound ?? '—'}</td>
       <td>{path ? formatOptionalMilliseconds(path.gpuTimeMilliseconds?.median) : '—'}</td>
-      <td>{path ? formatOptionalMilliseconds(path.gpuTimeMilliseconds?.percentile95) : '—'}</td>
+      <td>{path ? formatRelativeSpeed(report, path) : '—'}</td>
       <td>{path ? formatScanThroughput(report, path) : '—'}</td>
     </tr>
   );
@@ -245,6 +274,31 @@ function SupportedIndicator({supported}: {supported: boolean}): ReactNode {
     >
       {supported ? '✓' : '×'}
     </span>
+  );
+}
+
+function IdleRow({
+  barriers,
+  label,
+  relative = '—',
+  secondary = false,
+  supported = false
+}: {
+  barriers?: number;
+  label: string;
+  relative?: string;
+  secondary?: boolean;
+  supported?: boolean;
+}): ReactNode {
+  return (
+    <tr>
+      <td className={secondary ? 'luma-live-benchmark__secondary-label' : undefined}>{label}</td>
+      <td>{supported ? <SupportedIndicator supported /> : '—'}</td>
+      <td>{barriers ?? '—'}</td>
+      <td>—</td>
+      <td>{relative}</td>
+      <td>—</td>
+    </tr>
   );
 }
 
@@ -279,6 +333,20 @@ function formatMilliseconds(milliseconds: number): string {
 
 function formatOptionalMilliseconds(milliseconds: number | undefined): string {
   return milliseconds === undefined ? 'Unavailable' : formatMilliseconds(milliseconds);
+}
+
+function formatRelativeSpeed(
+  report: GPUWorkgroupScanBenchmarkReport,
+  path: GPUWorkgroupScanBenchmarkPathReport
+): string {
+  if (path.strategy === 'portable') return '1.00×';
+  const portableMilliseconds = report.paths.find(
+    candidate => candidate.strategy === 'portable'
+  )?.gpuTimeMilliseconds?.median;
+  const pathMilliseconds = path.gpuTimeMilliseconds?.median;
+  return portableMilliseconds && pathMilliseconds
+    ? `${(portableMilliseconds / pathMilliseconds).toFixed(2)}×`
+    : '—';
 }
 
 function formatSubgroupSize(report: GPUWorkgroupScanBenchmarkReport): string {

--- a/website/src/custom.css
+++ b/website/src/custom.css
@@ -120,16 +120,8 @@ main .container {
   transform: translateY(-50%) rotate(90deg);
 }
 
-.markdown .luma-live-benchmark__summary strong,
-.markdown .luma-live-benchmark__summary small {
+.markdown .luma-live-benchmark__summary strong {
   display: block;
-}
-
-.markdown .luma-live-benchmark__summary small {
-  color: var(--ifm-color-emphasis-600);
-  font-size: 0.75rem;
-  font-weight: 500;
-  margin-top: 0.15rem;
 }
 
 .markdown .luma-live-benchmark__body {
@@ -160,6 +152,7 @@ main .container {
 
 .markdown .luma-live-benchmark__actions {
   gap: 0.75rem 1rem;
+  margin-top: 0.9rem;
 }
 
 .markdown .luma-live-benchmark__controls {
@@ -174,6 +167,18 @@ main .container {
 
 .markdown .luma-live-benchmark__controls select {
   font-size: 0.85rem;
+}
+
+.markdown .luma-live-benchmark__notes {
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.75rem;
+  line-height: 1.4;
+  margin: 0.6rem 0 0;
+  padding-left: 1.15rem;
+}
+
+.markdown .luma-live-benchmark__notes li + li {
+  margin-top: 0.15rem;
 }
 
 .markdown .luma-live-benchmark__secondary-label {

--- a/website/src/custom.css
+++ b/website/src/custom.css
@@ -1512,6 +1512,43 @@ body:has(.integration-example-page) .theme-layout-footer {
   display: none;
 }
 
+/* Keep the shared site links useful without making the footer a second full-height page. */
+.theme-layout-footer.footer {
+  padding-block: 1.5rem;
+}
+
+.theme-layout-footer .footer__links {
+  display: grid;
+  gap: 1rem 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-inline: 0;
+  margin-bottom: 1rem;
+}
+
+.theme-layout-footer .footer__col {
+  flex: none;
+  margin-bottom: 0;
+  max-width: none;
+  padding-inline: 0;
+}
+
+.theme-layout-footer .footer__title {
+  margin-bottom: 0.4rem;
+}
+
+.theme-layout-footer .footer__item,
+.theme-layout-footer .footer__link-item {
+  line-height: 1.35;
+}
+
+.theme-layout-footer .footer__item + .footer__item {
+  margin-top: 0.25rem;
+}
+
+.theme-layout-footer .footer__copyright {
+  margin-top: 0.75rem;
+}
+
 /* Getting Started is an invitation into the GPU laboratory, not an install screen. */
 .markdown .luma-onboarding {
   --luma-onboarding-surface: #fff;


### PR DESCRIPTION
## Summary

- accelerate `GPUReduction` sum, min, max, and extent levels with subgroup collectives when both the `subgroups` device feature and `subgroup_id` WGSL language feature are available
- apply the same capability-gated subgroup sum to PageRank's repeated dangling-mass, normalization, and residual reductions
- preserve the portable workgroup trees automatically on devices without both capabilities
- add a correctness-gated live `GPUReduction` benchmark with absolute element throughput, GPU median, portable-relative speed, support state, and stable idle/loading/result tables
- tighten GPU primitive documentation navigation, rename the broad category from “Transforms” to “Operations,” add the missing `GPUTextureHistory` navigation, and make the shared footer more compact

## Why

The scan optimization established that subgroups are useful when workgroup synchronization is a meaningful part of the workload, even when a bandwidth-bound whole-array operation sees a smaller end-to-end change. `GPUReduction` is another strong fit: each 256-value block previously used a full shared-memory tree. The new path performs one native collective per subgroup, then merges only the subgroup totals in workgroup memory.

This benefits direct reduction users and higher-level consumers including automatic histogram domains, raster statistics, global dataframe aggregations, graph core-number and modularity summaries, and PageRank.

## Observed performance

The live benchmark ran 4,096 workgroups × 32 rounds, or 33.55 million `uint32` input elements per dispatch, with 30 measured samples and 10 dispatches per sample on the local Apple WebGPU adapter:

| Path | GPU median | Relative | Throughput |
| --- | ---: | ---: | ---: |
| Portable `GPUReduction` operation | 1.258 ms | 1.00× | 26.67 G elements/s |
| Subgroup optimization | 0.734 ms | 1.71× | 45.71 G elements/s |

That is about 1.7× local-reduction throughput for this synchronization-sensitive workload. Results remain device- and workload-dependent; global-memory-bound end-to-end graphs may show a smaller improvement.

## Correctness and compatibility

- subgroup shaders are dual-gated on the device feature and WGSL language capability
- unsupported devices compile the existing portable path
- every benchmark path is checked against the same CPU checksum before and after timing
- the live GPU data-analysis example passed its 65,537-row CPU/GPU validation with the subgroup extent path
- the live luGraph explorer compiled and ran PageRank with no shader or GPU validation errors
- floating-point subgroup reduction order may differ from the portable fixed tree in the lowest-order bits; documentation now states that explicitly

## Verification

- `yarn lint fix` — passed
- `yarn build` — passed
- pre-commit node tests — 258 files passed, 2,417 tests passed, 1 skipped
- `yarn website:build` — passed; existing circular-chunk and bundle-size warnings only
- browser sweep — scan, reduction, visibility, virtual geometry, hierarchy, traversal, ancestor projection, texture history, GPU data analysis, and luGraph explorer opened without compilation overlays or GPU validation errors
- live reduction benchmark — passed its CPU oracle and produced both portable and subgroup timing distributions
- direct Vitest browser invocation could not start its bundled browser because the updated Playwright Chromium binary is not installed; the same WebGPU paths were exercised through the already-running Chrome site instead
