### PR TITLE
Add optional smooth trace LOD fading

### DIFF
--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -303,6 +303,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
   private processStates = new Uint32Array(TRACE_PROCESS_COUNT).fill(TRACE_EXPANDED_STATE);
   private threadStates = new Uint32Array(TRACE_THREAD_COUNT).fill(TRACE_EXPANDED_STATE);
   private autoScroll = true;
+  private lodFadeEnabled = false;
   private view: TraceViewParameters = {timeMin: 0, timeMax: 150, laneMin: 0, laneMax: 72};
   private dragging = false;
   private pointerMoved = false;
@@ -1547,6 +1548,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     floats[15] = pick?.lane ?? -1;
     unsigned[16] = visibilityGeneration;
     unsigned[17] = dependencyEndpointOffset;
+    unsigned[18] = this.lodFadeEnabled ? 1 : 0;
     this.viewUniformBuffer.write(data);
   }
 
@@ -1835,7 +1837,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       </section>
       <section class="trace-section">
         <div class="trace-section-header"><span class="trace-section-title">Timeline</span><span class="trace-section-note">drag to pan · wheel to zoom</span></div>
-        <div class="trace-check-row"><label><input type="checkbox" data-auto-scroll${this.autoScroll ? ' checked' : ''}> Auto-scroll</label></div>
+        <div class="trace-check-row"><label><input type="checkbox" data-auto-scroll${this.autoScroll ? ' checked' : ''}> Auto-scroll</label><label><input type="checkbox" data-lod-fade${this.lodFadeEnabled ? ' checked' : ''}> Smooth LOD fade</label></div>
         <div class="trace-actions" style="margin-top:6px"><button type="button" data-reset>Reset detail</button><button type="button" data-fit-trace>Fit trace</button></div>
       </section>
     </section>`;
@@ -1940,6 +1942,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         this.focusOnly = target.checked;
       } else if (target instanceof HTMLInputElement && target.matches('[data-auto-scroll]')) {
         this.autoScroll = target.checked;
+      } else if (target instanceof HTMLInputElement && target.matches('[data-lod-fade]')) {
+        this.lodFadeEnabled = target.checked;
       }
       this.updateInspector();
     };
@@ -2088,7 +2092,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         ${makeMetricCard('Span batches', `${formatCount(this.sampledCandidateBatchCount)}/${formatCount(resources.spanBatchCount)}`, 'candidate / total')}
         ${makeMetricCard('Edge batches', `${formatCount(this.sampledCandidateDependencyBatchCount)}/${formatCount(resources.dependencyBatchCount)}`, 'candidate / total')}
         ${makeMetricCard('CPU encode', `${this.encodeTimeMilliseconds.toFixed(2)} ms`, 'compiled graph')}
-        ${makeMetricCard('Trace LOD', densityMode ? 'Density' : 'Exact', densityMode ? 'adaptive bins' : 'individual spans')}
+        ${makeMetricCard('Trace LOD', densityMode ? 'Density' : 'Exact', `${densityMode ? 'adaptive bins' : 'individual spans'} · ${this.lodFadeEnabled ? 'smooth fade' : 'hard switch'}`)}
         ${makeMetricCard('Layout lanes', formatCount(this.getVisibleLaneCount()), `${formatCount(collapsedProcessCount)} collapsed processes`)}
         ${makeMetricCard('Transient reuse', `${stats.reusePercentage.toFixed(0)}%`, `${stats.physicalTransientBufferCount}/${stats.logicalTransientBufferCount} allocations`)}
       </div>

--- a/examples/experimental/gpu-trace-viewer/trace-data.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-data.ts
@@ -116,11 +116,12 @@ export function getTraceFocusFrontierCapacity(spanCount: number, dependencyCount
   return Math.max(Math.min(spanCount, dependencyCount + 1), 1);
 }
 
-/** Matches the GPU's smooth exact-span versus density-rendering blend. */
+/** Matches the GPU's exact-span versus density-rendering blend. */
 export function getTraceDensityBlend(
   timeMin: number,
   timeMax: number,
-  viewportWidth: number
+  viewportWidth: number,
+  smoothTransition = true
 ): number {
   const timePerPixel = (timeMax - timeMin) / Math.max(viewportWidth, 1);
   const blendRange =
@@ -129,7 +130,8 @@ export function getTraceDensityBlend(
     0,
     Math.min(1, (timePerPixel - TRACE_DENSITY_BLEND_START_TIME_PER_PIXEL) / blendRange)
   );
-  return linearBlend * linearBlend * (3 - 2 * linearBlend);
+  const smoothBlend = linearBlend * linearBlend * (3 - 2 * linearBlend);
+  return smoothTransition ? smoothBlend : Number(smoothBlend >= 0.5);
 }
 
 /** Reports the dominant LOD while both renderers overlap through the transition band. */

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -82,6 +82,7 @@ struct ViewUniforms {
   pickLane: f32,
   visibilityGeneration: u32,
   dependencyEndpointOffset: u32,
+  lodFadeEnabled: u32,
 };
 
 const LANES_PER_THREAD: u32 = ${TRACE_LANES_PER_THREAD}u;
@@ -89,7 +90,7 @@ const THREADS_PER_PROCESS: u32 = ${TRACE_THREADS_PER_PROCESS}u;
 const DENSITY_BLEND_START_TIME_PER_PIXEL: f32 = ${TRACE_DENSITY_BLEND_START_TIME_PER_PIXEL};
 const DENSITY_BLEND_END_TIME_PER_PIXEL: f32 = ${TRACE_DENSITY_BLEND_END_TIME_PER_PIXEL};
 
-fn getDensityBlend() -> f32 {
+fn getContinuousDensityBlend() -> f32 {
   let timeRange = max(viewUniforms.timeMax - viewUniforms.timeMin, 0.0001);
   let timePerPixel = timeRange / max(viewUniforms.viewportWidth, 1.0);
   let linearBlend = clamp(
@@ -99,6 +100,14 @@ fn getDensityBlend() -> f32 {
     1.0
   );
   return linearBlend * linearBlend * (3.0 - 2.0 * linearBlend);
+}
+
+fn getDensityBlend() -> f32 {
+  let continuousBlend = getContinuousDensityBlend();
+  if (viewUniforms.lodFadeEnabled != 0u) {
+    return continuousBlend;
+  }
+  return select(0.0, 1.0, continuousBlend >= 0.5);
 }
 
 fn isDensityMode() -> bool {
@@ -327,10 +336,11 @@ struct DensityVertexOutput {
     1.0
   );
   let groupColor = weightedColor / max(f32(count), 1.0);
-  let mutedColor = mix(vec3<f32>(0.16, 0.22, 0.3), groupColor, 0.72 + intensity * 0.18);
+  // Keep the density LOD at the same perceived brightness as exact span geometry.
+  let densityColor = groupColor * (0.92 + intensity * 0.08);
   output.color = vec4<f32>(
-    mutedColor,
-    select(0.0, (0.3 + 0.62 * intensity) * densityOpacity, visible)
+    densityColor,
+    select(0.0, (0.86 + 0.04 * intensity) * densityOpacity, visible)
   );
   return output;
 }

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -319,6 +319,11 @@ test('GPU trace LOD switches at a stable trace-time-per-pixel threshold', t => {
   t.equal(getTraceDensityBlend(0, 50, 2000), 0, 'exact rendering leads into the blend');
   t.equal(getTraceDensityBlend(0, 80, 2000), 0.5, 'both renderers share the midpoint');
   t.equal(getTraceDensityBlend(0, 110, 2000), 1, 'density rendering finishes the blend');
+  t.equal(getTraceDensityBlend(0, 50, 2000, false), 0, 'hard switch keeps the exact boundary');
+  t.equal(getTraceDensityBlend(0, 79, 2000, false), 0, 'hard switch stays exact below midpoint');
+  t.equal(getTraceDensityBlend(0, 80, 2000, false), 1, 'hard switch selects density at midpoint');
+  t.equal(getTraceDensityBlend(0, 81, 2000, false), 1, 'hard switch stays density above midpoint');
+  t.equal(getTraceDensityBlend(0, 110, 2000, false), 1, 'hard switch keeps density boundary');
   t.equal(isTraceDensityMode(0, 150, 2048), true, 'wide time range remains density-dominant');
   t.equal(isTraceDensityMode(0, 150, 1), true, 'zoomed-out viewport uses density bins');
   t.equal(isTraceDensityMode(10, 10.01, 0), false, 'zero-width viewport remains bounded');
@@ -390,6 +395,11 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
     getCandidateDensityShader(spanChunk),
     /for \(var bin = firstBin; bin <= lastBin; bin\+\+\)/,
     'density aggregation preserves long-span coverage across bins'
+  );
+  t.match(
+    TRACE_RENDER_SHADER,
+    /viewUniforms\.lodFadeEnabled/,
+    'rendering selects the smooth or hard LOD transition from the view uniform'
   );
   t.end();
 });

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -76,6 +76,7 @@ describe('GPU hierarchical trace viewer', () => {
         selectedSpanIndex: number;
         focusDepth: number;
         focusOnly: boolean;
+        lodFadeEnabled: boolean;
         activeFilterMask: number;
         spanCapacity: number;
         dependencyCapacity: number;
@@ -116,6 +117,10 @@ describe('GPU hierarchical trace viewer', () => {
       expect(durationFilter?.step).toBe('0.01');
       expect(state.spanCapacity).toBe(4096);
       expect(state.dependencyCapacity).toBe(250_000);
+      const lodFade = host.querySelector<HTMLInputElement>('[data-lod-fade]');
+      expect(lodFade).not.toBeNull();
+      expect(lodFade!.checked).toBe(false);
+      expect(state.lodFadeEnabled).toBe(false);
       const dependencyCapacity = host.querySelector<HTMLSelectElement>(
         '[data-dependency-capacity]'
       );
@@ -227,6 +232,75 @@ describe('GPU hierarchical trace viewer', () => {
       )[1];
       expect(dependencyCandidateCount).toBeGreaterThan(0);
       expect(dependencyCandidateCount).toBeLessThan(state.resources.dependencyBatchCount);
+
+      const autoScroll = host.querySelector<HTMLInputElement>('[data-auto-scroll]');
+      expect(autoScroll).not.toBeNull();
+      autoScroll!.checked = false;
+      autoScroll!.dispatchEvent(new Event('change', {bubbles: true}));
+      const initialView = {...state.view};
+      state.view = {timeMin: 0, timeMax: 82, laneMin: 0, laneMax: 72};
+      viewer.onRender({device, time: 6000, width: 2000, height: 1} as AnimationProps);
+      device.submit();
+      const hardExactCandidateBytes =
+        await state.resources.exactCandidateDispatchCommands.buffer.readAsync();
+      const hardDensityCandidateBytes =
+        await state.resources.densityCandidateDispatchCommands.buffer.readAsync();
+      const hardDependencyCandidateBytes =
+        await state.resources.candidateDependencyDispatchCommands.buffer.readAsync();
+      expect(
+        new Uint32Array(hardExactCandidateBytes.buffer, hardExactCandidateBytes.byteOffset, 3)[1]
+      ).toBe(0);
+      expect(
+        new Uint32Array(
+          hardDensityCandidateBytes.buffer,
+          hardDensityCandidateBytes.byteOffset,
+          3
+        )[1]
+      ).toBeGreaterThan(0);
+      expect(
+        new Uint32Array(
+          hardDependencyCandidateBytes.buffer,
+          hardDependencyCandidateBytes.byteOffset,
+          3
+        )[1]
+      ).toBe(0);
+
+      lodFade!.checked = true;
+      lodFade!.dispatchEvent(new Event('change', {bubbles: true}));
+      expect(state.lodFadeEnabled).toBe(true);
+      viewer.onRender({device, time: 6000, width: 2000, height: 1} as AnimationProps);
+      device.submit();
+      const smoothExactCandidateBytes =
+        await state.resources.exactCandidateDispatchCommands.buffer.readAsync();
+      const smoothDensityCandidateBytes =
+        await state.resources.densityCandidateDispatchCommands.buffer.readAsync();
+      const smoothDependencyCandidateBytes =
+        await state.resources.candidateDependencyDispatchCommands.buffer.readAsync();
+      expect(
+        new Uint32Array(
+          smoothExactCandidateBytes.buffer,
+          smoothExactCandidateBytes.byteOffset,
+          3
+        )[1]
+      ).toBeGreaterThan(0);
+      expect(
+        new Uint32Array(
+          smoothDensityCandidateBytes.buffer,
+          smoothDensityCandidateBytes.byteOffset,
+          3
+        )[1]
+      ).toBeGreaterThan(0);
+      expect(
+        new Uint32Array(
+          smoothDependencyCandidateBytes.buffer,
+          smoothDependencyCandidateBytes.byteOffset,
+          3
+        )[1]
+      ).toBeGreaterThan(0);
+      lodFade!.checked = false;
+      lodFade!.dispatchEvent(new Event('change', {bubbles: true}));
+      expect(state.lodFadeEnabled).toBe(false);
+      state.view = initialView;
 
       const firstGroup = host.querySelector<HTMLInputElement>('[data-group="0"]');
       expect(firstGroup).not.toBeNull();


### PR DESCRIPTION
Follow-up to #3073.

## Summary

- add a Smooth LOD fade Timeline toggle, disabled by default
- use the existing view-uniform padding word, with no buffer-size increase
- hard-switch exact spans, density bins, and dependencies at the transition midpoint when fading is disabled
- retain adaptive density for zoomed-out 10M-span traces
- normalize density colors and opacity to avoid the visible brightness dip
- show hard switch or smooth fade in the Trace LOD metric

## Tests

- `yarn lint fix`
- `yarn build`
- `yarn test-node test/examples/gpu-trace-viewer.node.spec.ts` (258 files passed, 2,417 tests passed, 1 skipped)
- GPU trace example `yarn build`
- live WebGPU visual verification across exact and density zoom levels
- `yarn test` completed the node phase with the same passing results; the browser phase could not launch because the local Playwright Chromium executable is not installed