### PR TITLE
feat: Improve trace group coherence across zoom levels

### DIFF
--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -98,8 +98,8 @@ export const title = 'GPU Hierarchical Trace Viewer';
 export const description =
   'GPU-resident hierarchical traces with live filtering, adaptive density LOD, dependency traversal, picking, and indirect rendering.';
 
-const DEFAULT_CAPACITY = 250_000;
-const DEFAULT_DEPENDENCY_CAPACITY = 250_000;
+const DEFAULT_CAPACITY = 4_000_000;
+const DEFAULT_DEPENDENCY_CAPACITY = 4_000_000;
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 const TRACE_WORKGROUP_SIZE = 256;
 const TRACE_CANDIDATE_BATCH_WORKGROUP_COUNT = Math.ceil(

--- a/examples/experimental/gpu-trace-viewer/trace-data.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-data.ts
@@ -60,6 +60,9 @@ const TRACE_BASE_SLOT_COUNT = Math.ceil(TRACE_BASE_SPAN_CAPACITY / TRACE_LANE_CO
 const TRACE_SLOT_DURATION = TRACE_DURATION / TRACE_BASE_SLOT_COUNT;
 const TRACE_LANE_ROTATION = 73;
 const TRACE_DURATION_SCALE = 0.9;
+const TRACE_GROUP_PHASE_SLOT_COUNT = 24;
+const TRACE_GROUP_PHASE_CYCLE_LENGTH = 8;
+const TRACE_FOCUSED_GROUP_PHASE_COUNT = 6;
 const TRACE_MAXIMUM_DURATION_SLOT_COUNT = 30;
 /** Largest useful minimum-duration filter value for the generated span distribution. */
 export const TRACE_DURATION_FILTER_MAXIMUM =
@@ -525,17 +528,34 @@ function fillTraceSpans(
     return (randomState >>> 0) / 0x100000000;
   };
   const nextStartByLane = new Float64Array(TRACE_LANE_COUNT);
+  const groupRowCounts = new Uint32Array(groups.length);
   let maximumEnd = 0;
 
   for (let timelineIndex = 0; timelineIndex < spanCount; timelineIndex++) {
-    const groupIndex = timelineIndex % groups.length;
-    const groupRowIndex = Math.floor(timelineIndex / groups.length);
-    const spanIndex = groups[groupIndex].firstSpanIndex + groupRowIndex;
-    const wordOffset = spanIndex * TRACE_SPAN_RECORD_WORD_LENGTH;
     const slotIndex = Math.floor(timelineIndex / TRACE_LANE_COUNT);
     const laneIndex = (timelineIndex + slotIndex * TRACE_LANE_ROTATION) % TRACE_LANE_COUNT;
     const threadIndex = Math.floor(laneIndex / TRACE_LANES_PER_THREAD);
     const processIndex = Math.floor(threadIndex / TRACE_THREADS_PER_PROCESS);
+    const phaseIndex = Math.floor(slotIndex / TRACE_GROUP_PHASE_SLOT_COUNT);
+    const localLaneIndex = laneIndex % TRACE_LANES_PER_THREAD;
+    const focusedGroupIndex = (processIndex + localLaneIndex) % groups.length;
+    const phaseCycleIndex = phaseIndex % TRACE_GROUP_PHASE_CYCLE_LENGTH;
+    const preferredGroupIndex =
+      phaseCycleIndex < TRACE_FOCUSED_GROUP_PHASE_COUNT
+        ? focusedGroupIndex
+        : (focusedGroupIndex + phaseCycleIndex - TRACE_FOCUSED_GROUP_PHASE_COUNT + 1) %
+          groups.length;
+    let groupIndex = preferredGroupIndex;
+    for (let groupOffset = 0; groupOffset < groups.length; groupOffset++) {
+      const candidateGroupIndex = (preferredGroupIndex + groupOffset) % groups.length;
+      if (groupRowCounts[candidateGroupIndex] < groups[candidateGroupIndex].count) {
+        groupIndex = candidateGroupIndex;
+        break;
+      }
+    }
+    const groupRowIndex = groupRowCounts[groupIndex]++;
+    const spanIndex = groups[groupIndex].firstSpanIndex + groupRowIndex;
+    const wordOffset = spanIndex * TRACE_SPAN_RECORD_WORD_LENGTH;
     const gap = (0.02 + random() * 0.04) * TRACE_SLOT_DURATION;
     const durationClass = random();
     const durationVariation = random();

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -221,7 +221,12 @@ struct VertexOutput {
   // Long spans remain recognizable first; sub-pixel spans emerge only as they become readable.
   let spanPixelWidth = span.duration / timeRange * max(viewUniforms.viewportWidth, 1.0);
   let spanReadability = smoothstep(0.6, 1.4, spanPixelWidth);
-  let exactOpacity = (1.0 - getDensityBlend()) * spanReadability;
+  let readabilityOpacity = select(
+    1.0,
+    spanReadability,
+    viewUniforms.lodFadeEnabled != 0u
+  );
+  let exactOpacity = (1.0 - getDensityBlend()) * readabilityOpacity;
   let minimumClipWidth = 3.0 / max(viewUniforms.viewportWidth, 1.0);
   var output: VertexOutput;
   output.position = vec4<f32>(

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -401,6 +401,11 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
     /viewUniforms\.lodFadeEnabled/,
     'rendering selects the smooth or hard LOD transition from the view uniform'
   );
+  t.match(
+    TRACE_RENDER_SHADER,
+    /select\(\s*1\.0,\s*spanReadability,\s*viewUniforms\.lodFadeEnabled != 0u\s*\)/,
+    'hard-switch exact spans bypass sub-pixel readability fading'
+  );
   t.end();
 });
 
@@ -483,7 +488,10 @@ test('GPU trace duration grows with tightly packed non-overlapping lane slots', 
 
   const dataset = makeTraceDataset(65_536, 0);
   const spanFloats = new Float32Array(dataset.spans.buffer);
-  const laneSpans = Array.from({length: TRACE_LANE_COUNT}, () => [] as Array<[number, number]>);
+  const laneSpans = Array.from(
+    {length: TRACE_LANE_COUNT},
+    () => [] as Array<[start: number, end: number, group: number]>
+  );
   let occupiedDuration = 0;
   let minimumDuration = Number.POSITIVE_INFINITY;
   let maximumDuration = 0;
@@ -492,20 +500,38 @@ test('GPU trace duration grows with tightly packed non-overlapping lane slots', 
     const start = spanFloats[wordOffset];
     const duration = spanFloats[wordOffset + 1];
     const lane = dataset.spans[wordOffset + 2];
-    laneSpans[lane].push([start, start + duration]);
+    laneSpans[lane].push([start, start + duration, dataset.spans[wordOffset + 3]]);
     occupiedDuration += duration;
     minimumDuration = Math.min(minimumDuration, duration);
     maximumDuration = Math.max(maximumDuration, duration);
   }
+  let sameGroupNeighborCount = 0;
+  let neighborCount = 0;
+  let focusedLaneCount = 0;
   for (const spans of laneSpans) {
     spans.sort((left, right) => left[0] - right[0]);
+    const groupCounts = new Uint32Array(TRACE_GROUPS.length);
+    for (const span of spans) {
+      groupCounts[span[2]]++;
+    }
+    focusedLaneCount += Number(Math.max(...groupCounts) / spans.length > 0.65);
     for (let spanIndex = 1; spanIndex < spans.length; spanIndex++) {
       t.ok(
         spans[spanIndex][0] >= spans[spanIndex - 1][1],
         'successive spans in one lane do not overlap'
       );
+      sameGroupNeighborCount += Number(spans[spanIndex][2] === spans[spanIndex - 1][2]);
+      neighborCount++;
     }
   }
+  t.ok(
+    sameGroupNeighborCount / neighborCount > 0.9,
+    'span groups form coherent lane phases instead of alternating every span'
+  );
+  t.ok(
+    focusedLaneCount / laneSpans.length > 0.9,
+    'most lanes spend a clear majority of their time on one span group'
+  );
   const occupancy = occupiedDuration / (dataset.duration * TRACE_LANE_COUNT);
   t.ok(occupancy > 0.55 && occupancy < 0.8, 'lane packing stays dense without overlap');
   t.ok(minimumDuration < 0.05, 'the trace includes very short spans');


### PR DESCRIPTION
## What changed

- group generated spans into lane-focused category phases, with shorter alternate-category bursts
- keep exact spans at full opacity in hard-switch LOD mode when dependencies become visible
- default the example to 4M spans and 4M dependency capacity
- add coverage for lane category coherence and the hard-switch shader behavior

## Why

The generated source alternated span groups too uniformly. At density LOD, each bin therefore averaged nearly the same colors and the trace became muted. At the exact/density boundary, exact spans also retained a subpixel readability fade while dependencies switched on, making spans appear to disappear.

The updated data remains non-overlapping and tightly packed, but individual lanes now have a clear span-type affinity. Hard-switch mode presents either full-bright density or full-bright exact spans without a brightness dip.

## Verification

- `yarn lint fix`
- `yarn test-node test/examples/gpu-trace-viewer.node.spec.ts` (258 files passed, 1 skipped; 2417 tests passed, 1 skipped)
- `yarn build`
- `(cd examples/experimental/gpu-trace-viewer && yarn build)`
- visually checked full-trace density and exact-span zoom levels in the running WebGPU example
