### PR TITLE
fix(examples): compile trace endpoint shaders

### DIFF
--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -1469,7 +1469,6 @@ ${TRACE_SHADER_DECLARATIONS}
 ${getSpanChunkDeclarations(chunk)}
 const DEPENDENCY_COUNT: u32 = ${props.dependencyCount}u;
 const CHUNK_COUNT: u32 = ${props.spanChunks.length}u;
-const CHUNK_INDEX: u32 = ${chunkIndex}u;
 const OFFSET_BASE: u32 = ${props.spanChunks.length}u;
 @group(0) @binding(0) var<storage, read> spans: array<TraceSpan>;
 @group(0) @binding(1) var<storage, read> endpointJobs: array<u32>;

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -1466,7 +1466,7 @@ export function getDependencyEndpointResolveShader(
   const chunk = props.spanChunks[chunkIndex];
   return /* wgsl */ `
 ${TRACE_SHADER_DECLARATIONS}
-${getSpanChunkDeclarations(chunk)}
+${getSpanChunkDeclarations({...chunk, chunkIndex})}
 const DEPENDENCY_COUNT: u32 = ${props.dependencyCount}u;
 const CHUNK_COUNT: u32 = ${props.spanChunks.length}u;
 const OFFSET_BASE: u32 = ${props.spanChunks.length}u;

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -467,6 +467,14 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
       throw new Error(`shader ${shaderIndex} failed to parse`, {cause: error});
     }
   }
+  for (const chunkIndex of [0, 1]) {
+    const shader = getDependencyEndpointResolveShader(endpointRouting, chunkIndex);
+    t.equal(
+      shader.match(/const CHUNK_INDEX:/g)?.length,
+      1,
+      `dependency endpoint shader ${chunkIndex} declares its chunk index once`
+    );
+  }
   t.match(
     getCandidateDependencyVisibilityShader(endpointRouting),
     /sourceVisible \|\| destinationVisible/,

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -474,6 +474,11 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
       1,
       `dependency endpoint shader ${chunkIndex} declares its chunk index once`
     );
+    t.match(
+      shader,
+      new RegExp(`const CHUNK_INDEX: u32 = ${chunkIndex}u;`),
+      `dependency endpoint shader ${chunkIndex} declares the selected chunk index`
+    );
   }
   t.match(
     getCandidateDependencyVisibilityShader(endpointRouting),


### PR DESCRIPTION
## What changed

- remove the duplicate `CHUNK_INDEX` declaration from generated dependency endpoint resolver WGSL
- add regression coverage requiring each generated endpoint shader to declare its chunk index exactly once

## Why

The published GPU trace viewer failed immediately with a WebGPU shader compilation error. The shared span-chunk declarations began emitting `CHUNK_INDEX`, while the dependency endpoint resolver continued to emit its previous local declaration. Chrome rejects the duplicate global and the resulting invalid pipeline caused repeated failed command submissions.

## Impact

The GPU trace viewer can initialize and render again instead of opening shader error panels and repeatedly submitting invalid command buffers.

## Verification

- reproduced the failure on https://luma.gl/next/examples/experimental/gpu-trace-viewer
- verified the isolated local build in Chrome/WebGPU with zero shader compilation errors and no luma.gl/WebGPU console errors
- `yarn lint fix`
- `yarn build`
- example `yarn build`
- `yarn test-node` — 2,494 passed, 1 skipped