### PR TITLE
feat(webxr): add immersive rendering foundation

### DIFF
--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -264,6 +264,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   Fly through a stereoscopic field of animated prism shards. WebGPU renders directly into
   native WebXR projection layers when supported. WebGL2 remains available on older XR
   browsers and can fold raw AR camera imagery into the portal when access is granted.
+  Desktop testing works with the
+  <a href="https://chromewebstore.google.com/detail/codex/hehggadaopoacecdllhhajmbjkdcmajg?pli=1" target="_blank" rel="noreferrer">Immersive Web Emulator Chrome extension</a>.
   </p>
   `;
 

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -7,6 +7,7 @@ import {UniformStore} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, Geometry, Model, OrbitControls} from '@luma.gl/engine';
 import {
+  OrbitControls,
   WebXRAnimationFrameProvider,
   WebXRCameraTexture,
   WebXRManager,

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -7,7 +7,6 @@ import {UniformStore} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, Geometry, Model, OrbitControls} from '@luma.gl/engine';
 import {
-  OrbitControls,
   WebXRAnimationFrameProvider,
   WebXRCameraTexture,
   WebXRManager,

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -178,6 +178,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
   });
 
   test('keeps standalone launch, sidebar, and backend metadata accurate', () => {
+    const applicationSource = readFileSync(APPLICATION_PATH, 'utf8');
     const standaloneSource = readFileSync(STANDALONE_PATH, 'utf8');
     const metadataSource = readFileSync(EXAMPLE_METADATA_PATH, 'utf8');
     const packageSource = JSON.parse(readFileSync(PACKAGE_PATH, 'utf8')) as {
@@ -194,6 +195,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(standaloneSource).toContain("toggleSession('immersive-vr')");
     expect(standaloneSource).toContain("toggleSession('immersive-ar')");
     expect(standaloneSource).toContain('switch-backend');
+    expect(applicationSource).toContain(
+      'https://chromewebstore.google.com/detail/codex/hehggadaopoacecdllhhajmbjkdcmajg?pli=1'
+    );
     expect(metadataSource).toContain('backends: [webgpu, webgl2]');
     expect(metadataSource).toContain('Immersive Prism Portal');
     expect(packageSource.dependencies).toHaveProperty('@luma.gl/webgpu');


### PR DESCRIPTION
## Summary

This is PR 1 of 3 in the consolidated WebXR stack.

It adds the base immersive rendering path: native WebGPU projection layer support with WebGL fallback, the experimental WebXR prism portal example, emulator-facing example affordances, and the initial cleanup needed before the broader helper stack.

## Why

The previous tranche branches were too granular for review. This branch isolates the foundation needed to verify that luma.gl content renders in immersive sessions before layering on additional WebXR managers and input controls.

## Validation

- Earlier tranche validation included focused WebXR/example checks, `yarn lint fix`, and `yarn build`.
- During consolidation, `yarn lint fix` passed.
- During the final helper commit, focused WebXR checks passed with `yarn test-node modules/experimental/test/webxr/webxr-hit-test.node.spec.ts test/examples/webxr-kaleidoscope.node.spec.ts`.

## Notes

Stack order: this PR should merge before the capabilities PR, which should merge before the interactions PR.