### PR TITLE
feat(webxr): add basic immersive input helpers

### DIFF
--- a/docs/api-reference/experimental/webxr/webxr-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-manager.md
@@ -60,6 +60,7 @@ const animationLoop = new AnimationLoop({
 - Resolves per-frame input-source target-ray and grip poses in the same reference space as rendering.
 - Tracks active `selectstart`/`selectend` state per input source so examples can build controller rays, pointer selection, and locomotion helpers without subscribing to raw session events.
 - Provides `getWebXRInputRay(inputState)` for normalized world-space target-ray origin and direction extraction.
+- Provides `getWebXRInputRayPlaneIntersection(ray, props)` for floor, wall, and placement plane hits used by teleport and pointer-selection examples.
 - Never destroys browser-owned WebGL framebuffers or WebGPU compositor textures.
 - Raw AR camera textures remain WebGL-only; WebGPU AR can use an application-provided procedural or video fallback.
 
@@ -144,6 +145,16 @@ export type WebXRInputRay = {
 };
 ```
 
+### `WebXRInputRayPlaneIntersection`
+
+```ts
+export type WebXRInputRayPlaneIntersection = {
+  ray: WebXRInputRay;
+  point: NumberArray3;
+  distance: number;
+};
+```
+
 ## Methods
 
 ### `constructor(device: Device, props?: WebXRManagerProps)`
@@ -165,6 +176,10 @@ Resolves input source state for an active XR frame. Returns `null` when no sessi
 ### `getWebXRInputRay(inputState: WebXRInputState): WebXRInputRay | null`
 
 Returns a normalized world-space target ray for an input state, or `null` when the input source has no target-ray pose for the frame.
+
+### `getWebXRInputRayPlaneIntersection(ray: WebXRInputRay, props?: WebXRInputRayPlaneIntersectionProps): WebXRInputRayPlaneIntersection | null`
+
+Returns the forward intersection between an input ray and a plane. The default plane is `y=0`, suitable for simple floor reticles and teleport candidates.
 
 ### `clearSession(): void`
 

--- a/docs/api-reference/experimental/webxr/webxr-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-manager.md
@@ -58,7 +58,7 @@ const animationLoop = new AnimationLoop({
 - Treats `XRViewerPose.views` as an arbitrary per-frame view list, not a fixed stereo pair.
 - Exposes `projectionMatrix` from `XRView.projectionMatrix` and `viewMatrix` from `XRView.transform.inverse.matrix`.
 - Resolves per-frame input-source target-ray and grip poses in the same reference space as rendering.
-- Tracks active `selectstart`/`selectend` state per input source so examples can build controller rays, pointer selection, and locomotion helpers without subscribing to raw session events.
+- Tracks active `selectstart`/`selectend` and `squeezestart`/`squeezeend` state per input source so examples can build controller rays, pointer selection, grab, and locomotion helpers without subscribing to raw session events.
 - Provides `getWebXRInputRay(inputState)` for normalized world-space target-ray origin and direction extraction.
 - Provides `getWebXRInputRayPlaneIntersection(ray, props)` for floor, wall, and placement plane hits used by teleport and pointer-selection examples.
 - Never destroys browser-owned WebGL framebuffers or WebGPU compositor textures.
@@ -131,6 +131,7 @@ export type WebXRInputState = {
   gripPose: XRPose | null;
   gripMatrix: Float32Array | null;
   selectActive: boolean;
+  squeezeActive: boolean;
 };
 ```
 

--- a/docs/api-reference/experimental/webxr/webxr-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-manager.md
@@ -57,6 +57,8 @@ const animationLoop = new AnimationLoop({
 - Uses `XRSession.requestReferenceSpace()` with `local` by default.
 - Treats `XRViewerPose.views` as an arbitrary per-frame view list, not a fixed stereo pair.
 - Exposes `projectionMatrix` from `XRView.projectionMatrix` and `viewMatrix` from `XRView.transform.inverse.matrix`.
+- Resolves per-frame input-source target-ray and grip poses in the same reference space as rendering.
+- Tracks active `selectstart`/`selectend` state per input source so examples can build controller rays, pointer selection, and locomotion helpers without subscribing to raw session events.
 - Never destroys browser-owned WebGL framebuffers or WebGPU compositor textures.
 - Raw AR camera textures remain WebGL-only; WebGPU AR can use an application-provided procedural or video fallback.
 
@@ -112,6 +114,24 @@ export type WebXRFrameState = {
 };
 ```
 
+### `WebXRInputState`
+
+```ts
+export type WebXRInputState = {
+  inputSource: XRInputSource;
+  index: number;
+  handedness: XRHandedness;
+  targetRayMode: XRTargetRayMode;
+  profiles: readonly string[];
+  gamepad: Gamepad | null;
+  targetRayPose: XRPose | null;
+  targetRayMatrix: Float32Array | null;
+  gripPose: XRPose | null;
+  gripMatrix: Float32Array | null;
+  selectActive: boolean;
+};
+```
+
 ## Methods
 
 ### `constructor(device: Device, props?: WebXRManagerProps)`
@@ -125,6 +145,10 @@ Attaches or clears the current XR session.
 ### `getFrameState(xrFrame: XRFrame): WebXRFrameState | null`
 
 Resolves frame state for an active XR frame. Returns `null` when no viewer pose is available.
+
+### `getInputState(xrFrame: XRFrame): readonly WebXRInputState[] | null`
+
+Resolves input source state for an active XR frame. Returns `null` when no session is attached.
 
 ### `clearSession(): void`
 

--- a/docs/api-reference/experimental/webxr/webxr-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-manager.md
@@ -59,6 +59,7 @@ const animationLoop = new AnimationLoop({
 - Exposes `projectionMatrix` from `XRView.projectionMatrix` and `viewMatrix` from `XRView.transform.inverse.matrix`.
 - Resolves per-frame input-source target-ray and grip poses in the same reference space as rendering.
 - Tracks active `selectstart`/`selectend` state per input source so examples can build controller rays, pointer selection, and locomotion helpers without subscribing to raw session events.
+- Provides `getWebXRInputRay(inputState)` for normalized world-space target-ray origin and direction extraction.
 - Never destroys browser-owned WebGL framebuffers or WebGPU compositor textures.
 - Raw AR camera textures remain WebGL-only; WebGPU AR can use an application-provided procedural or video fallback.
 
@@ -132,6 +133,17 @@ export type WebXRInputState = {
 };
 ```
 
+### `WebXRInputRay`
+
+```ts
+export type WebXRInputRay = {
+  inputState: WebXRInputState;
+  origin: NumberArray3;
+  direction: NumberArray3;
+  matrix: Float32Array;
+};
+```
+
 ## Methods
 
 ### `constructor(device: Device, props?: WebXRManagerProps)`
@@ -149,6 +161,10 @@ Resolves frame state for an active XR frame. Returns `null` when no viewer pose 
 ### `getInputState(xrFrame: XRFrame): readonly WebXRInputState[] | null`
 
 Resolves input source state for an active XR frame. Returns `null` when no session is attached.
+
+### `getWebXRInputRay(inputState: WebXRInputState): WebXRInputRay | null`
+
+Returns a normalized world-space target ray for an input state, or `null` when the input source has no target-ray pose for the frame.
 
 ### `clearSession(): void`
 

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -264,6 +264,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   Fly through a stereoscopic field of animated prism shards. WebGPU renders directly into
   native WebXR projection layers when supported. WebGL2 remains available on older XR
   browsers and can fold raw AR camera imagery into the portal when access is granted.
+  Desktop testing works with the
+  <a href="https://chromewebstore.google.com/detail/codex/hehggadaopoacecdllhhajmbjkdcmajg?pli=1" target="_blank" rel="noreferrer">Immersive Web Emulator Chrome extension</a>.
   </p>
   `;
 

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -11,6 +11,7 @@ import {
   WebXRCameraTexture,
   WebXRManager,
   getWebXRInputRay,
+  getWebXRInputRayPlaneIntersection,
   type WebXRFrameState,
   type WebXRInputState
 } from '@luma.gl/experimental';
@@ -353,10 +354,12 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly fallbackTexture: Texture;
   readonly model: Model;
   readonly controllerRayModel: Model;
+  readonly controllerReticleModel: Model;
   readonly webXRManager: WebXRManager;
   readonly modelMatrix = new Matrix4();
   readonly modelViewProjectionMatrix = new Matrix4();
   readonly controllerRayMatrix = new Matrix4();
+  readonly controllerReticleMatrix = new Matrix4();
   readonly viewMatrix = new Matrix4().lookAt({
     eye: [0.32, 0.24, 4.4],
     center: CAMERA_TARGET
@@ -434,6 +437,27 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         blendAlphaDstFactor: 'one-minus-src-alpha'
       }
     });
+    this.controllerReticleModel = new Model(device, {
+      id: 'immersive-prism-controller-reticles',
+      source: CONTROLLER_RAY_WGSL_SHADER,
+      vs: CONTROLLER_RAY_VS_GLSL,
+      fs: CONTROLLER_RAY_FS_GLSL,
+      geometry: makeControllerReticleGeometry(),
+      bindings: {
+        app: this.uniformStore.getManagedUniformBuffer('app')
+      },
+      parameters: {
+        depthWriteEnabled: false,
+        depthCompare: 'less-equal',
+        blend: true,
+        blendColorOperation: 'add',
+        blendAlphaOperation: 'add',
+        blendColorSrcFactor: 'src-alpha',
+        blendColorDstFactor: 'one',
+        blendAlphaSrcFactor: 'one',
+        blendAlphaDstFactor: 'one-minus-src-alpha'
+      }
+    });
     this.initializePreviewControls();
 
     if (typeof window !== 'undefined') {
@@ -452,6 +476,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       window.removeEventListener('keydown', this._keyDownListener);
     }
     this.orbitControls?.destroy();
+    this.controllerReticleModel.destroy();
     this.controllerRayModel.destroy();
     this.model.destroy();
     this.fallbackTexture.destroy();
@@ -592,7 +617,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       });
       renderPass.setParameters({viewport: view.viewport});
       this.drawPortal(renderPass);
-      this.drawControllerRays(renderPass, view, inputState, time);
+      this.drawControllerTargets(renderPass, view, inputState, time);
       renderPass.end();
     }
   }
@@ -620,7 +645,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.model.draw(renderPass);
   }
 
-  private drawControllerRays(
+  private drawControllerTargets(
     renderPass: ReturnType<Device['beginRenderPass']>,
     view: WebXRFrameState['views'][number],
     inputState: readonly WebXRInputState[],
@@ -632,11 +657,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         continue;
       }
 
-      this.controllerRayMatrix.copy(inputRay.matrix);
       this.modelViewProjectionMatrix
         .copy(view.projectionMatrix)
         .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))
-        .multiplyRight(this.controllerRayMatrix);
+        .multiplyRight(this.controllerRayMatrix.copy(inputRay.matrix));
       this.uniformStore.setUniforms(
         {
           app: {
@@ -649,6 +673,27 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       );
       this.controllerRayModel.predraw(this.device.commandEncoder);
       this.controllerRayModel.draw(renderPass);
+
+      const floorHit = getWebXRInputRayPlaneIntersection(inputRay, {maxDistance: 8});
+      if (floorHit) {
+        this.controllerReticleMatrix.identity().translate(floorHit.point);
+        this.modelViewProjectionMatrix
+          .copy(view.projectionMatrix)
+          .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))
+          .multiplyRight(this.controllerReticleMatrix);
+        this.uniformStore.setUniforms(
+          {
+            app: {
+              modelViewProjectionMatrix: this.modelViewProjectionMatrix,
+              time,
+              cameraMix: input.selectActive ? 1 : 0
+            }
+          },
+          this.device.commandEncoder
+        );
+        this.controllerReticleModel.predraw(this.device.commandEncoder);
+        this.controllerReticleModel.draw(renderPass);
+      }
     }
   }
 
@@ -756,6 +801,35 @@ function makeControllerRayGeometry(): Geometry {
       positions: {
         size: 3,
         value: new Float32Array([0, 0, 0, 0, 0, -3.2])
+      }
+    }
+  });
+}
+
+function makeControllerReticleGeometry(): Geometry {
+  const positions: number[] = [];
+  const segmentCount = 32;
+  const radius = 0.12;
+
+  for (let segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++) {
+    const startAngle = (segmentIndex / segmentCount) * Math.PI * 2;
+    const endAngle = ((segmentIndex + 1) / segmentCount) * Math.PI * 2;
+    positions.push(
+      Math.cos(startAngle) * radius,
+      0,
+      Math.sin(startAngle) * radius,
+      Math.cos(endAngle) * radius,
+      0,
+      Math.sin(endAngle) * radius
+    );
+  }
+
+  return new Geometry({
+    topology: 'line-list',
+    attributes: {
+      positions: {
+        size: 3,
+        value: new Float32Array(positions)
       }
     }
   });

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -10,6 +10,7 @@ import {
   WebXRAnimationFrameProvider,
   WebXRCameraTexture,
   WebXRManager,
+  getWebXRInputRay,
   type WebXRFrameState,
   type WebXRInputState
 } from '@luma.gl/experimental';
@@ -626,11 +627,12 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     time: number
   ): void {
     for (const input of inputState) {
-      if (input.targetRayMode !== 'tracked-pointer' || !input.targetRayMatrix) {
+      const inputRay = getWebXRInputRay(input);
+      if (input.targetRayMode !== 'tracked-pointer' || !inputRay) {
         continue;
       }
 
-      this.controllerRayMatrix.copy(input.targetRayMatrix);
+      this.controllerRayMatrix.copy(inputRay.matrix);
       this.modelViewProjectionMatrix
         .copy(view.projectionMatrix)
         .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -360,6 +360,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly modelViewProjectionMatrix = new Matrix4();
   readonly controllerRayMatrix = new Matrix4();
   readonly controllerReticleMatrix = new Matrix4();
+  readonly xrSceneOffset: [number, number, number] = [0, 0, 0];
   readonly viewMatrix = new Matrix4().lookAt({
     eye: [0.32, 0.24, 4.4],
     center: CAMERA_TARGET
@@ -371,8 +372,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   xrSession: XRSession | null = null;
   xrSessionMode: ImmersiveXRSessionMode | null = null;
   private _isFinalized = false;
+  private _floorHitByInputSource = new Map<XRInputSource, [number, number, number]>();
   private _xrSessionEndListener = () => this._clearXRSession();
-  private _xrSelectEndListener = () => void this.exitXR();
+  private _xrSelectEndListener = (event: Event) =>
+    this.teleportToInputSource((event as XRInputSourceEvent).inputSource);
+  private _xrSqueezeEndListener = () => void this.exitXR();
   private _keyDownListener = (event: KeyboardEvent) => {
     if (!this.xrSession) {
       return;
@@ -548,6 +552,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.xrSessionMode = sessionMode;
       session.addEventListener('end', this._xrSessionEndListener);
       session.addEventListener('selectend', this._xrSelectEndListener);
+      session.addEventListener('squeezeend', this._xrSqueezeEndListener);
       this.animationLoop.setProps({
         animationFrameProvider: new WebXRAnimationFrameProvider(session)
       });
@@ -593,6 +598,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     const clearColor: [number, number, number, number] =
       this.xrSessionMode === 'immersive-ar' ? [0, 0, 0, 0] : [0.006, 0.008, 0.028, 1];
     const renderedFramebuffers = new Set<Framebuffer>();
+    this._floorHitByInputSource.clear();
 
     for (const view of frameState.views) {
       this.modelViewProjectionMatrix
@@ -676,6 +682,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
       const floorHit = getWebXRInputRayPlaneIntersection(inputRay, {maxDistance: 8});
       if (floorHit) {
+        this._floorHitByInputSource.set(input.inputSource, floorHit.point);
         this.controllerReticleMatrix.identity().translate(floorHit.point);
         this.modelViewProjectionMatrix
           .copy(view.projectionMatrix)
@@ -701,6 +708,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.modelMatrix.identity();
     if (isXR) {
       this.modelMatrix
+        .translate(this.xrSceneOffset)
         .translate([0, 0.12, -2.15])
         .scale([0.88, 0.88, 0.88])
         .rotateZ(Math.sin(time * 0.2) * 0.055)
@@ -711,6 +719,17 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         .rotateX(Math.sin(time * 0.31) * 0.055)
         .rotateY(Math.cos(time * 0.26) * 0.075);
     }
+  }
+
+  private teleportToInputSource(inputSource: XRInputSource | undefined): void {
+    const floorHit = inputSource && this._floorHitByInputSource.get(inputSource);
+    if (!floorHit) {
+      return;
+    }
+
+    this.xrSceneOffset[0] -= floorHit[0];
+    this.xrSceneOffset[2] -= floorHit[2];
+    this._floorHitByInputSource.clear();
   }
 
   private createCameraTexture(session: XRSession): WebXRCameraTexture | null {
@@ -754,8 +773,13 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     const session = this.xrSession;
     session?.removeEventListener('end', this._xrSessionEndListener);
     session?.removeEventListener('selectend', this._xrSelectEndListener);
+    session?.removeEventListener('squeezeend', this._xrSqueezeEndListener);
     this.xrSession = null;
     this.xrSessionMode = null;
+    this.xrSceneOffset[0] = 0;
+    this.xrSceneOffset[1] = 0;
+    this.xrSceneOffset[2] = 0;
+    this._floorHitByInputSource.clear();
     this.cameraTexture?.destroy();
     this.cameraTexture = null;
     this.webXRManager.clearSession();

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -10,7 +10,8 @@ import {
   WebXRAnimationFrameProvider,
   WebXRCameraTexture,
   WebXRManager,
-  type WebXRFrameState
+  type WebXRFrameState,
+  type WebXRInputState
 } from '@luma.gl/experimental';
 import {Matrix4} from '@math.gl/core';
 
@@ -240,6 +241,83 @@ void main(void) {
 }
 `;
 
+const CONTROLLER_RAY_WGSL_SHADER = /* wgsl */ `\
+struct AppUniforms {
+  modelViewProjectionMatrix: mat4x4<f32>,
+  time: f32,
+  cameraMix: f32,
+};
+
+@group(0) @binding(auto) var<uniform> app: AppUniforms;
+
+struct VertexInputs {
+  @location(0) positions: vec3<f32>,
+};
+
+struct FragmentInputs {
+  @builtin(position) Position: vec4<f32>,
+  @location(0) rayDepth: f32,
+};
+
+@vertex
+fn vertexMain(inputs: VertexInputs) -> FragmentInputs {
+  var outputs: FragmentInputs;
+  outputs.Position = app.modelViewProjectionMatrix * vec4<f32>(inputs.positions, 1.0);
+  outputs.rayDepth = clamp(-inputs.positions.z / 3.2, 0.0, 1.0);
+  return outputs;
+}
+
+@fragment
+fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
+  let idleColor = vec3<f32>(0.05, 0.92, 1.0);
+  let activeColor = vec3<f32>(1.0, 0.36, 0.18);
+  let color = mix(idleColor, activeColor, app.cameraMix);
+  let alpha = mix(0.86, 0.28, inputs.rayDepth);
+  return vec4<f32>(color * (1.15 - inputs.rayDepth * 0.38), alpha);
+}
+`;
+
+const CONTROLLER_RAY_VS_GLSL = /* glsl */ `\
+#version 300 es
+
+in vec3 positions;
+
+uniform appUniforms {
+  mat4 modelViewProjectionMatrix;
+  float time;
+  float cameraMix;
+} app;
+
+out float vRayDepth;
+
+void main(void) {
+  gl_Position = app.modelViewProjectionMatrix * vec4(positions, 1.0);
+  vRayDepth = clamp(-positions.z / 3.2, 0.0, 1.0);
+}
+`;
+
+const CONTROLLER_RAY_FS_GLSL = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+uniform appUniforms {
+  mat4 modelViewProjectionMatrix;
+  float time;
+  float cameraMix;
+} app;
+
+in float vRayDepth;
+out vec4 fragColor;
+
+void main(void) {
+  vec3 idleColor = vec3(0.05, 0.92, 1.0);
+  vec3 activeColor = vec3(1.0, 0.36, 0.18);
+  vec3 color = mix(idleColor, activeColor, app.cameraMix);
+  float alpha = mix(0.86, 0.28, vRayDepth);
+  fragColor = vec4(color * (1.15 - vRayDepth * 0.38), alpha);
+}
+`;
+
 export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   static current: AppAnimationLoopTemplate | null = null;
   private static readonly currentListeners = new Set<() => void>();
@@ -273,9 +351,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly uniformStore: UniformStore<{app: AppUniforms}>;
   readonly fallbackTexture: Texture;
   readonly model: Model;
+  readonly controllerRayModel: Model;
   readonly webXRManager: WebXRManager;
   readonly modelMatrix = new Matrix4();
   readonly modelViewProjectionMatrix = new Matrix4();
+  readonly controllerRayMatrix = new Matrix4();
   readonly viewMatrix = new Matrix4().lookAt({
     eye: [0.32, 0.24, 4.4],
     center: CAMERA_TARGET
@@ -332,6 +412,27 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         blendAlphaDstFactor: 'one-minus-src-alpha'
       }
     });
+    this.controllerRayModel = new Model(device, {
+      id: 'immersive-prism-controller-rays',
+      source: CONTROLLER_RAY_WGSL_SHADER,
+      vs: CONTROLLER_RAY_VS_GLSL,
+      fs: CONTROLLER_RAY_FS_GLSL,
+      geometry: makeControllerRayGeometry(),
+      bindings: {
+        app: this.uniformStore.getManagedUniformBuffer('app')
+      },
+      parameters: {
+        depthWriteEnabled: false,
+        depthCompare: 'less-equal',
+        blend: true,
+        blendColorOperation: 'add',
+        blendAlphaOperation: 'add',
+        blendColorSrcFactor: 'src-alpha',
+        blendColorDstFactor: 'one',
+        blendAlphaSrcFactor: 'one',
+        blendAlphaDstFactor: 'one-minus-src-alpha'
+      }
+    });
     this.initializePreviewControls();
 
     if (typeof window !== 'undefined') {
@@ -350,6 +451,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       window.removeEventListener('keydown', this._keyDownListener);
     }
     this.orbitControls?.destroy();
+    this.controllerRayModel.destroy();
     this.model.destroy();
     this.fallbackTexture.destroy();
     this.uniformStore.destroy();
@@ -360,9 +462,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     const time = elapsedTimeMilliseconds * 0.001;
     const xrFrame = animationFrame as XRFrame | null;
     const frameState = xrFrame && this.xrSession ? this.webXRManager.getFrameState(xrFrame) : null;
+    const inputState = xrFrame && this.xrSession ? this.webXRManager.getInputState(xrFrame) : null;
 
     if (frameState) {
-      this.renderXRFrame(time, frameState);
+      this.renderXRFrame(time, frameState, inputState || []);
       return;
     }
 
@@ -447,10 +550,19 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       .multiplyRight(this.viewMatrix)
       .multiplyRight(this.modelMatrix);
     this.preparePortal({cameraMix: 0, texture: this.fallbackTexture, time});
-    this.drawPortal(device.beginRenderPass({clearColor: [0.006, 0.008, 0.028, 1], clearDepth: 1}));
+    const renderPass = device.beginRenderPass({
+      clearColor: [0.006, 0.008, 0.028, 1],
+      clearDepth: 1
+    });
+    this.drawPortal(renderPass);
+    renderPass.end();
   }
 
-  private renderXRFrame(time: number, frameState: WebXRFrameState): void {
+  private renderXRFrame(
+    time: number,
+    frameState: WebXRFrameState,
+    inputState: readonly WebXRInputState[]
+  ): void {
     this.updateModelMatrix(time, true);
     const clearColor: [number, number, number, number] =
       this.xrSessionMode === 'immersive-ar' ? [0, 0, 0, 0] : [0.006, 0.008, 0.028, 1];
@@ -479,6 +591,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       });
       renderPass.setParameters({viewport: view.viewport});
       this.drawPortal(renderPass);
+      this.drawControllerRays(renderPass, view, inputState, time);
+      renderPass.end();
     }
   }
 
@@ -503,7 +617,37 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
   private drawPortal(renderPass: ReturnType<Device['beginRenderPass']>): void {
     this.model.draw(renderPass);
-    renderPass.end();
+  }
+
+  private drawControllerRays(
+    renderPass: ReturnType<Device['beginRenderPass']>,
+    view: WebXRFrameState['views'][number],
+    inputState: readonly WebXRInputState[],
+    time: number
+  ): void {
+    for (const input of inputState) {
+      if (input.targetRayMode !== 'tracked-pointer' || !input.targetRayMatrix) {
+        continue;
+      }
+
+      this.controllerRayMatrix.copy(input.targetRayMatrix);
+      this.modelViewProjectionMatrix
+        .copy(view.projectionMatrix)
+        .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))
+        .multiplyRight(this.controllerRayMatrix);
+      this.uniformStore.setUniforms(
+        {
+          app: {
+            modelViewProjectionMatrix: this.modelViewProjectionMatrix,
+            time,
+            cameraMix: input.selectActive ? 1 : 0
+          }
+        },
+        this.device.commandEncoder
+      );
+      this.controllerRayModel.predraw(this.device.commandEncoder);
+      this.controllerRayModel.draw(renderPass);
+    }
   }
 
   private updateModelMatrix(time: number, isXR: boolean): void {
@@ -599,6 +743,18 @@ function makeSpatialPortalGeometry(): Geometry {
       positions: {size: 3, value: new Float32Array(positions)},
       texCoords: {size: 2, value: new Float32Array(texCoords)},
       shardData: {size: 4, value: new Float32Array(shardAttributes)}
+    }
+  });
+}
+
+function makeControllerRayGeometry(): Geometry {
+  return new Geometry({
+    topology: 'line-list',
+    attributes: {
+      positions: {
+        size: 3,
+        value: new Float32Array([0, 0, 0, 0, 0, -3.2])
+      }
     }
   });
 }

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -7,6 +7,7 @@ import {UniformStore} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, Geometry, Model, OrbitControls} from '@luma.gl/engine';
 import {
+  OrbitControls,
   WebXRAnimationFrameProvider,
   WebXRCameraTexture,
   WebXRManager,

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -7,7 +7,6 @@ import {UniformStore} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, Geometry, Model, OrbitControls} from '@luma.gl/engine';
 import {
-  OrbitControls,
   WebXRAnimationFrameProvider,
   WebXRCameraTexture,
   WebXRManager,

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -2,7 +2,14 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import type {Device, Framebuffer, NumberArray, Texture, VariableShaderType} from '@luma.gl/core';
+import type {
+  Buffer,
+  Device,
+  Framebuffer,
+  NumberArray,
+  Texture,
+  VariableShaderType
+} from '@luma.gl/core';
 import {UniformStore} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, Geometry, Model, OrbitControls} from '@luma.gl/engine';
@@ -13,7 +20,8 @@ import {
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
   type WebXRFrameState,
-  type WebXRInputState
+  type WebXRInputState,
+  type WebXRManagerProps
 } from '@luma.gl/experimental';
 import {Matrix4} from '@math.gl/core';
 
@@ -35,6 +43,16 @@ type AppUniforms = {
   modelViewProjectionMatrix: NumberArray;
   time: number;
   cameraMix: number;
+};
+
+type ControllerTargetUniforms = {
+  uniformStore: UniformStore<{app: AppUniforms}>;
+  uniformBuffer: Buffer;
+};
+
+type PreparedControllerTarget = {
+  rayUniformBuffer: Buffer;
+  reticleUniformBuffer: Buffer | null;
 };
 
 const app: {uniformTypes: Record<keyof AppUniforms, VariableShaderType>} = {
@@ -373,6 +391,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   xrSessionMode: ImmersiveXRSessionMode | null = null;
   private _isFinalized = false;
   private _floorHitByInputSource = new Map<XRInputSource, [number, number, number]>();
+  private _controllerRayUniforms: ControllerTargetUniforms[] = [];
+  private _controllerReticleUniforms: ControllerTargetUniforms[] = [];
   private _xrSessionEndListener = () => this._clearXRSession();
   private _xrSelectEndListener = (event: Event) =>
     this.teleportToInputSource((event as XRInputSourceEvent).inputSource);
@@ -482,6 +502,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.orbitControls?.destroy();
     this.controllerReticleModel.destroy();
     this.controllerRayModel.destroy();
+    this.destroyControllerUniforms(this._controllerReticleUniforms);
+    this.destroyControllerUniforms(this._controllerRayUniforms);
     this.model.destroy();
     this.fallbackTexture.destroy();
     this.uniformStore.destroy();
@@ -538,12 +560,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     );
 
     try {
-      await this.webXRManager.setSession(session, {
-        referenceSpaceType: 'local',
-        ...(this.device.type === 'webgl'
-          ? {layerInit: {alpha: sessionMode === 'immersive-ar'}}
-          : {})
-      });
+      await this.setXRSession(session, sessionMode);
       this.cameraTexture =
         sessionMode === 'immersive-ar' && this.device.type === 'webgl'
           ? this.createCameraTexture(session)
@@ -615,6 +632,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         texture: cameraTexture || this.fallbackTexture,
         time
       });
+      const controllerTargets = this.prepareControllerTargets(view, inputState, time);
       const renderPass = this.device.beginRenderPass({
         framebuffer,
         clearColor: clearView ? clearColor : false,
@@ -623,7 +641,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       });
       renderPass.setParameters({viewport: view.viewport});
       this.drawPortal(renderPass);
-      this.drawControllerTargets(renderPass, view, inputState, time);
+      this.drawControllerTargets(renderPass, controllerTargets);
       renderPass.end();
     }
   }
@@ -651,23 +669,26 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.model.draw(renderPass);
   }
 
-  private drawControllerTargets(
-    renderPass: ReturnType<Device['beginRenderPass']>,
+  private prepareControllerTargets(
     view: WebXRFrameState['views'][number],
     inputState: readonly WebXRInputState[],
     time: number
-  ): void {
+  ): PreparedControllerTarget[] {
+    const preparedControllerTargets: PreparedControllerTarget[] = [];
+
     for (const input of inputState) {
       const inputRay = getWebXRInputRay(input);
       if (input.targetRayMode !== 'tracked-pointer' || !inputRay) {
         continue;
       }
 
+      const targetIndex = preparedControllerTargets.length;
+      const rayUniforms = this.getControllerUniforms(this._controllerRayUniforms, targetIndex);
       this.modelViewProjectionMatrix
         .copy(view.projectionMatrix)
         .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))
         .multiplyRight(this.controllerRayMatrix.copy(inputRay.matrix));
-      this.uniformStore.setUniforms(
+      rayUniforms.uniformStore.setUniforms(
         {
           app: {
             modelViewProjectionMatrix: this.modelViewProjectionMatrix,
@@ -677,10 +698,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         },
         this.device.commandEncoder
       );
-      this.controllerRayModel.predraw(this.device.commandEncoder);
-      this.controllerRayModel.draw(renderPass);
 
       const floorHit = getWebXRInputRayPlaneIntersection(inputRay, {maxDistance: 8});
+      let reticleUniformBuffer: Buffer | null = null;
       if (floorHit) {
         this._floorHitByInputSource.set(input.inputSource, floorHit.point);
         this.controllerReticleMatrix.identity().translate(floorHit.point);
@@ -688,7 +708,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           .copy(view.projectionMatrix)
           .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))
           .multiplyRight(this.controllerReticleMatrix);
-        this.uniformStore.setUniforms(
+        const reticleUniforms = this.getControllerUniforms(
+          this._controllerReticleUniforms,
+          targetIndex
+        );
+        reticleUniforms.uniformStore.setUniforms(
           {
             app: {
               modelViewProjectionMatrix: this.modelViewProjectionMatrix,
@@ -698,7 +722,30 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           },
           this.device.commandEncoder
         );
-        this.controllerReticleModel.predraw(this.device.commandEncoder);
+        reticleUniformBuffer = reticleUniforms.uniformBuffer;
+      }
+
+      preparedControllerTargets.push({
+        rayUniformBuffer: rayUniforms.uniformBuffer,
+        reticleUniformBuffer
+      });
+    }
+
+    this.controllerRayModel.predraw(this.device.commandEncoder);
+    this.controllerReticleModel.predraw(this.device.commandEncoder);
+    return preparedControllerTargets;
+  }
+
+  private drawControllerTargets(
+    renderPass: ReturnType<Device['beginRenderPass']>,
+    controllerTargets: readonly PreparedControllerTarget[]
+  ): void {
+    for (const controllerTarget of controllerTargets) {
+      this.controllerRayModel.setBindings({app: controllerTarget.rayUniformBuffer});
+      this.controllerRayModel.draw(renderPass);
+
+      if (controllerTarget.reticleUniformBuffer) {
+        this.controllerReticleModel.setBindings({app: controllerTarget.reticleUniformBuffer});
         this.controllerReticleModel.draw(renderPass);
       }
     }
@@ -750,6 +797,57 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     }
   }
 
+  private async setXRSession(
+    session: XRSession,
+    sessionMode: ImmersiveXRSessionMode
+  ): Promise<void> {
+    try {
+      await this.webXRManager.setSession(
+        session,
+        this.getWebXRManagerProps(sessionMode, 'local-floor')
+      );
+    } catch (error) {
+      if (!isXRReferenceSpaceUnavailable(error)) {
+        throw error;
+      }
+      await this.webXRManager.setSession(session, this.getWebXRManagerProps(sessionMode, 'local'));
+    }
+  }
+
+  private getWebXRManagerProps(
+    sessionMode: ImmersiveXRSessionMode,
+    referenceSpaceType: XRReferenceSpaceType
+  ): WebXRManagerProps {
+    return {
+      referenceSpaceType,
+      ...(this.device.type === 'webgl' ? {layerInit: {alpha: sessionMode === 'immersive-ar'}} : {})
+    };
+  }
+
+  private getControllerUniforms(
+    controllerUniforms: ControllerTargetUniforms[],
+    index: number
+  ): ControllerTargetUniforms {
+    let targetUniforms = controllerUniforms[index];
+    if (!targetUniforms) {
+      const uniformStore = new UniformStore(this.device, {app});
+      targetUniforms = {
+        uniformStore,
+        uniformBuffer: uniformStore.getManagedUniformBuffer('app')
+      };
+      controllerUniforms[index] = targetUniforms;
+    }
+
+    return targetUniforms;
+  }
+
+  private destroyControllerUniforms(controllerUniforms: ControllerTargetUniforms[]): void {
+    for (const targetUniforms of controllerUniforms) {
+      targetUniforms.uniformStore.destroy();
+    }
+    controllerUniforms.length = 0;
+  }
+
   private initializePreviewControls(): void {
     const canvas = this.device.getDefaultCanvasContext().canvas;
     if (!(canvas instanceof HTMLCanvasElement)) {
@@ -787,6 +885,15 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.animationLoop.setProps({animationFrameProvider: undefined});
     }
   }
+}
+
+function isXRReferenceSpaceUnavailable(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    error.name === 'NotSupportedError'
+  );
 }
 
 function getXRSessionInit(sessionMode: ImmersiveXRSessionMode, deviceType: string): XRSessionInit {

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -6,8 +6,12 @@ export type {WebXRRawCameraBinding} from './webxr-types';
 export {WebXRAnimationFrameProvider} from './webxr-animation-frame-provider';
 export type {WebXRCameraTextureProps} from './webxr-camera-texture';
 export {WebXRCameraTexture} from './webxr-camera-texture';
-export type {WebXRInputRay} from './webxr-input';
-export {getWebXRInputRay} from './webxr-input';
+export type {
+  WebXRInputRay,
+  WebXRInputRayPlaneIntersection,
+  WebXRInputRayPlaneIntersectionProps
+} from './webxr-input';
+export {getWebXRInputRay, getWebXRInputRayPlaneIntersection} from './webxr-input';
 export type {
   WebXRFrameState,
   WebXRInputState,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -6,6 +6,8 @@ export type {WebXRRawCameraBinding} from './webxr-types';
 export {WebXRAnimationFrameProvider} from './webxr-animation-frame-provider';
 export type {WebXRCameraTextureProps} from './webxr-camera-texture';
 export {WebXRCameraTexture} from './webxr-camera-texture';
+export type {WebXRInputRay} from './webxr-input';
+export {getWebXRInputRay} from './webxr-input';
 export type {
   WebXRFrameState,
   WebXRInputState,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -6,5 +6,10 @@ export type {WebXRRawCameraBinding} from './webxr-types';
 export {WebXRAnimationFrameProvider} from './webxr-animation-frame-provider';
 export type {WebXRCameraTextureProps} from './webxr-camera-texture';
 export {WebXRCameraTexture} from './webxr-camera-texture';
-export type {WebXRFrameState, WebXRManagerProps, WebXRViewState} from './webxr-manager';
+export type {
+  WebXRFrameState,
+  WebXRInputState,
+  WebXRManagerProps,
+  WebXRViewState
+} from './webxr-manager';
 export {WebXRManager} from './webxr-manager';

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -13,6 +13,20 @@ export type WebXRInputRay = {
   matrix: Float32Array;
 };
 
+export type WebXRInputRayPlaneIntersectionProps = {
+  planePoint?: NumberArray3;
+  planeNormal?: NumberArray3;
+  minDistance?: number;
+  maxDistance?: number;
+};
+
+/** Experimental v10 world-space hit derived from one input ray and plane. */
+export type WebXRInputRayPlaneIntersection = {
+  ray: WebXRInputRay;
+  point: NumberArray3;
+  distance: number;
+};
+
 export function getWebXRInputRay(inputState: WebXRInputState): WebXRInputRay | null {
   const matrix = inputState.targetRayMatrix;
   if (!matrix) {
@@ -30,13 +44,67 @@ export function getWebXRInputRay(inputState: WebXRInputState): WebXRInputRay | n
   };
 }
 
-function normalizeVector3(vector: NumberArray3): void {
+export function getWebXRInputRayPlaneIntersection(
+  ray: WebXRInputRay,
+  props: WebXRInputRayPlaneIntersectionProps = {}
+): WebXRInputRayPlaneIntersection | null {
+  const planePoint = props.planePoint || [0, 0, 0];
+  const sourcePlaneNormal = props.planeNormal || [0, 1, 0];
+  const planeNormal: NumberArray3 = [
+    sourcePlaneNormal[0],
+    sourcePlaneNormal[1],
+    sourcePlaneNormal[2]
+  ];
+  if (!normalizeVector3(planeNormal, null)) {
+    return null;
+  }
+
+  const denominator = dotVector3(ray.direction, planeNormal);
+  if (Math.abs(denominator) < 1e-6) {
+    return null;
+  }
+
+  const distance =
+    dotVector3(
+      [planePoint[0] - ray.origin[0], planePoint[1] - ray.origin[1], planePoint[2] - ray.origin[2]],
+      planeNormal
+    ) / denominator;
+
+  if (
+    distance < (props.minDistance ?? 0) ||
+    (props.maxDistance !== undefined && distance > props.maxDistance)
+  ) {
+    return null;
+  }
+
+  return {
+    ray,
+    distance,
+    point: [
+      ray.origin[0] + ray.direction[0] * distance,
+      ray.origin[1] + ray.direction[1] * distance,
+      ray.origin[2] + ray.direction[2] * distance
+    ]
+  };
+}
+
+function dotVector3(left: NumberArray3, right: NumberArray3): number {
+  return left[0] * right[0] + left[1] * right[1] + left[2] * right[2];
+}
+
+function normalizeVector3(
+  vector: NumberArray3,
+  fallback: NumberArray3 | null = [0, 0, -1]
+): boolean {
   const length = Math.hypot(vector[0], vector[1], vector[2]);
   if (length === 0) {
-    vector[0] = 0;
-    vector[1] = 0;
-    vector[2] = -1;
-    return;
+    if (!fallback) {
+      return false;
+    }
+    vector[0] = fallback[0];
+    vector[1] = fallback[1];
+    vector[2] = fallback[2];
+    return true;
   }
 
   vector[0] /= length;
@@ -45,4 +113,5 @@ function normalizeVector3(vector: NumberArray3): void {
   vector[0] ||= 0;
   vector[1] ||= 0;
   vector[2] ||= 0;
+  return true;
 }

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -1,0 +1,48 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {NumberArray3} from '@math.gl/core';
+import type {WebXRInputState} from './webxr-manager';
+
+/** Experimental v10 world-space target ray derived from one WebXR input source. */
+export type WebXRInputRay = {
+  inputState: WebXRInputState;
+  origin: NumberArray3;
+  direction: NumberArray3;
+  matrix: Float32Array;
+};
+
+export function getWebXRInputRay(inputState: WebXRInputState): WebXRInputRay | null {
+  const matrix = inputState.targetRayMatrix;
+  if (!matrix) {
+    return null;
+  }
+
+  const direction: NumberArray3 = [-matrix[8], -matrix[9], -matrix[10]];
+  normalizeVector3(direction);
+
+  return {
+    inputState,
+    origin: [matrix[12], matrix[13], matrix[14]],
+    direction,
+    matrix
+  };
+}
+
+function normalizeVector3(vector: NumberArray3): void {
+  const length = Math.hypot(vector[0], vector[1], vector[2]);
+  if (length === 0) {
+    vector[0] = 0;
+    vector[1] = 0;
+    vector[2] = -1;
+    return;
+  }
+
+  vector[0] /= length;
+  vector[1] /= length;
+  vector[2] /= length;
+  vector[0] ||= 0;
+  vector[1] ||= 0;
+  vector[2] ||= 0;
+}

--- a/modules/experimental/src/webxr/webxr-manager.ts
+++ b/modules/experimental/src/webxr/webxr-manager.ts
@@ -51,6 +51,21 @@ export type WebXRFrameState = {
   views: readonly WebXRViewState[];
 };
 
+/** Experimental v10 input state for one active XR frame. */
+export type WebXRInputState = {
+  inputSource: XRInputSource;
+  index: number;
+  handedness: XRHandedness;
+  targetRayMode: XRTargetRayMode;
+  profiles: readonly string[];
+  gamepad: Gamepad | null;
+  targetRayPose: XRPose | null;
+  targetRayMatrix: Float32Array | null;
+  gripPose: XRPose | null;
+  gripMatrix: Float32Array | null;
+  selectActive: boolean;
+};
+
 /**
  * Experimental v10 WebXR session and per-view render-state helper.
  *
@@ -69,7 +84,11 @@ export class WebXRManager {
 
   private _framebuffer: Framebuffer | null = null;
   private _webGPUViewResources: WebXRWebGPUViewResources[] = [];
+  private _selectActiveInputSources = new Set<XRInputSource>();
   private _sessionEndListener = () => this.clearSession();
+  private _selectStartListener = (event: Event) => this._handleSelectActive(event, true);
+  private _selectEndListener = (event: Event) => this._handleSelectActive(event, false);
+  private _inputSourcesChangeListener = (event: Event) => this._handleInputSourcesChange(event);
 
   constructor(device: Device, props: WebXRManagerProps = {}) {
     if (!isWebXRWebGLDevice(device) && !isWebXRWebGPUDevice(device)) {
@@ -117,6 +136,9 @@ export class WebXRManager {
       this.referenceSpace = await session.requestReferenceSpace(this.props.referenceSpaceType);
       this.session = session;
       session.addEventListener('end', this._sessionEndListener);
+      session.addEventListener('selectstart', this._selectStartListener);
+      session.addEventListener('selectend', this._selectEndListener);
+      session.addEventListener('inputsourceschange', this._inputSourcesChangeListener);
       return this;
     } catch (error) {
       this.clearSession();
@@ -144,8 +166,44 @@ export class WebXRManager {
     return this._getWebGPUFrameState(xrFrame, viewerPose);
   }
 
+  getInputState(xrFrame: XRFrame): readonly WebXRInputState[] | null {
+    if (!this.session || !this.referenceSpace) {
+      return null;
+    }
+    if (xrFrame.session !== this.session) {
+      throw new Error('XRFrame belongs to a different XRSession');
+    }
+
+    const inputSources = Array.from(this.session.inputSources);
+    this._trimSelectActiveInputSources(inputSources);
+
+    return inputSources.map((inputSource, index) => {
+      const targetRayPose = xrFrame.getPose(inputSource.targetRaySpace, this.referenceSpace!);
+      const gripPose = inputSource.gripSpace
+        ? xrFrame.getPose(inputSource.gripSpace, this.referenceSpace!)
+        : undefined;
+
+      return {
+        inputSource,
+        index,
+        handedness: inputSource.handedness,
+        targetRayMode: inputSource.targetRayMode,
+        profiles: inputSource.profiles,
+        gamepad: inputSource.gamepad ?? null,
+        targetRayPose: targetRayPose ?? null,
+        targetRayMatrix: targetRayPose?.transform.matrix ?? null,
+        gripPose: gripPose ?? null,
+        gripMatrix: gripPose?.transform.matrix ?? null,
+        selectActive: this._selectActiveInputSources.has(inputSource)
+      };
+    });
+  }
+
   clearSession(): void {
     this.session?.removeEventListener('end', this._sessionEndListener);
+    this.session?.removeEventListener('selectstart', this._selectStartListener);
+    this.session?.removeEventListener('selectend', this._selectEndListener);
+    this.session?.removeEventListener('inputsourceschange', this._inputSourcesChangeListener);
     this._framebuffer?.destroy();
     this._framebuffer = null;
 
@@ -159,6 +217,7 @@ export class WebXRManager {
     this.webGPUBinding = null;
     this.referenceSpace = null;
     this.session = null;
+    this._selectActiveInputSources.clear();
   }
 
   destroy(): void {
@@ -337,6 +396,33 @@ export class WebXRManager {
     viewResources.framebuffer.destroy();
     viewResources.depthTexture?.destroy();
     viewResources.colorTexture.destroy();
+  }
+
+  private _handleSelectActive(event: Event, selectActive: boolean): void {
+    const inputSource = (event as XRInputSourceEvent).inputSource;
+    if (!inputSource) {
+      return;
+    }
+
+    if (selectActive) {
+      this._selectActiveInputSources.add(inputSource);
+    } else {
+      this._selectActiveInputSources.delete(inputSource);
+    }
+  }
+
+  private _handleInputSourcesChange(event: Event): void {
+    for (const inputSource of (event as XRInputSourcesChangeEvent).removed || []) {
+      this._selectActiveInputSources.delete(inputSource);
+    }
+  }
+
+  private _trimSelectActiveInputSources(inputSources: readonly XRInputSource[]): void {
+    for (const inputSource of this._selectActiveInputSources) {
+      if (!inputSources.includes(inputSource)) {
+        this._selectActiveInputSources.delete(inputSource);
+      }
+    }
   }
 
   static defaultProps: Required<WebXRManagerProps> = {

--- a/modules/experimental/src/webxr/webxr-manager.ts
+++ b/modules/experimental/src/webxr/webxr-manager.ts
@@ -64,6 +64,7 @@ export type WebXRInputState = {
   gripPose: XRPose | null;
   gripMatrix: Float32Array | null;
   selectActive: boolean;
+  squeezeActive: boolean;
 };
 
 /**
@@ -85,9 +86,16 @@ export class WebXRManager {
   private _framebuffer: Framebuffer | null = null;
   private _webGPUViewResources: WebXRWebGPUViewResources[] = [];
   private _selectActiveInputSources = new Set<XRInputSource>();
+  private _squeezeActiveInputSources = new Set<XRInputSource>();
   private _sessionEndListener = () => this.clearSession();
-  private _selectStartListener = (event: Event) => this._handleSelectActive(event, true);
-  private _selectEndListener = (event: Event) => this._handleSelectActive(event, false);
+  private _selectStartListener = (event: Event) =>
+    this._handleInputSourceActive(this._selectActiveInputSources, event, true);
+  private _selectEndListener = (event: Event) =>
+    this._handleInputSourceActive(this._selectActiveInputSources, event, false);
+  private _squeezeStartListener = (event: Event) =>
+    this._handleInputSourceActive(this._squeezeActiveInputSources, event, true);
+  private _squeezeEndListener = (event: Event) =>
+    this._handleInputSourceActive(this._squeezeActiveInputSources, event, false);
   private _inputSourcesChangeListener = (event: Event) => this._handleInputSourcesChange(event);
 
   constructor(device: Device, props: WebXRManagerProps = {}) {
@@ -138,6 +146,8 @@ export class WebXRManager {
       session.addEventListener('end', this._sessionEndListener);
       session.addEventListener('selectstart', this._selectStartListener);
       session.addEventListener('selectend', this._selectEndListener);
+      session.addEventListener('squeezestart', this._squeezeStartListener);
+      session.addEventListener('squeezeend', this._squeezeEndListener);
       session.addEventListener('inputsourceschange', this._inputSourcesChangeListener);
       return this;
     } catch (error) {
@@ -175,7 +185,8 @@ export class WebXRManager {
     }
 
     const inputSources = Array.from(this.session.inputSources);
-    this._trimSelectActiveInputSources(inputSources);
+    this._trimActiveInputSources(this._selectActiveInputSources, inputSources);
+    this._trimActiveInputSources(this._squeezeActiveInputSources, inputSources);
 
     return inputSources.map((inputSource, index) => {
       const targetRayPose = xrFrame.getPose(inputSource.targetRaySpace, this.referenceSpace!);
@@ -194,7 +205,8 @@ export class WebXRManager {
         targetRayMatrix: targetRayPose?.transform.matrix ?? null,
         gripPose: gripPose ?? null,
         gripMatrix: gripPose?.transform.matrix ?? null,
-        selectActive: this._selectActiveInputSources.has(inputSource)
+        selectActive: this._selectActiveInputSources.has(inputSource),
+        squeezeActive: this._squeezeActiveInputSources.has(inputSource)
       };
     });
   }
@@ -203,6 +215,8 @@ export class WebXRManager {
     this.session?.removeEventListener('end', this._sessionEndListener);
     this.session?.removeEventListener('selectstart', this._selectStartListener);
     this.session?.removeEventListener('selectend', this._selectEndListener);
+    this.session?.removeEventListener('squeezestart', this._squeezeStartListener);
+    this.session?.removeEventListener('squeezeend', this._squeezeEndListener);
     this.session?.removeEventListener('inputsourceschange', this._inputSourcesChangeListener);
     this._framebuffer?.destroy();
     this._framebuffer = null;
@@ -218,6 +232,7 @@ export class WebXRManager {
     this.referenceSpace = null;
     this.session = null;
     this._selectActiveInputSources.clear();
+    this._squeezeActiveInputSources.clear();
   }
 
   destroy(): void {
@@ -398,29 +413,37 @@ export class WebXRManager {
     viewResources.colorTexture.destroy();
   }
 
-  private _handleSelectActive(event: Event, selectActive: boolean): void {
+  private _handleInputSourceActive(
+    activeInputSources: Set<XRInputSource>,
+    event: Event,
+    active: boolean
+  ): void {
     const inputSource = (event as XRInputSourceEvent).inputSource;
     if (!inputSource) {
       return;
     }
 
-    if (selectActive) {
-      this._selectActiveInputSources.add(inputSource);
+    if (active) {
+      activeInputSources.add(inputSource);
     } else {
-      this._selectActiveInputSources.delete(inputSource);
+      activeInputSources.delete(inputSource);
     }
   }
 
   private _handleInputSourcesChange(event: Event): void {
     for (const inputSource of (event as XRInputSourcesChangeEvent).removed || []) {
       this._selectActiveInputSources.delete(inputSource);
+      this._squeezeActiveInputSources.delete(inputSource);
     }
   }
 
-  private _trimSelectActiveInputSources(inputSources: readonly XRInputSource[]): void {
-    for (const inputSource of this._selectActiveInputSources) {
+  private _trimActiveInputSources(
+    activeInputSources: Set<XRInputSource>,
+    inputSources: readonly XRInputSource[]
+  ): void {
+    for (const inputSource of activeInputSources) {
       if (!inputSources.includes(inputSource)) {
-        this._selectActiveInputSources.delete(inputSource);
+        activeInputSources.delete(inputSource);
       }
     }
   }

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -28,6 +28,8 @@ declare global {
   type XRSessionMode = 'inline' | 'immersive-vr' | 'immersive-ar';
   type XRReferenceSpaceType = 'viewer' | 'local' | 'local-floor' | 'bounded-floor' | 'unbounded';
   type XREye = 'none' | 'left' | 'right';
+  type XRHandedness = 'none' | 'left' | 'right';
+  type XRTargetRayMode = 'gaze' | 'tracked-pointer' | 'screen';
   type XRFrameRequestCallback = (time: DOMHighResTimeStamp, frame: XRFrame) => void;
 
   interface XRSystem extends EventTarget {
@@ -47,6 +49,7 @@ declare global {
 
   interface XRSession extends EventTarget {
     readonly enabledFeatures?: readonly string[];
+    readonly inputSources: XRInputSourceArray;
 
     cancelAnimationFrame(animationFrameId: number): void;
     end(): Promise<void>;
@@ -59,8 +62,44 @@ declare global {
 
   interface XRReferenceSpace extends XRSpace {}
 
+  interface XRInputSourceArray {
+    readonly length: number;
+    readonly [index: number]: XRInputSource;
+    [Symbol.iterator](): IterableIterator<XRInputSource>;
+  }
+
+  interface XRInputSource {
+    readonly handedness: XRHandedness;
+    readonly targetRayMode: XRTargetRayMode;
+    readonly targetRaySpace: XRSpace;
+    readonly gripSpace?: XRSpace;
+    readonly profiles: readonly string[];
+    readonly gamepad?: Gamepad;
+    readonly hand?: XRHand;
+  }
+
+  interface XRHand {
+    readonly size: number;
+  }
+
+  interface XRInputSourceEvent extends Event {
+    readonly frame: XRFrame;
+    readonly inputSource: XRInputSource;
+  }
+
+  interface XRInputSourcesChangeEvent extends Event {
+    readonly added: readonly XRInputSource[];
+    readonly removed: readonly XRInputSource[];
+    readonly session: XRSession;
+  }
+
+  interface XRPose {
+    readonly transform: XRRigidTransform;
+  }
+
   interface XRFrame {
     readonly session: XRSession;
+    getPose(space: XRSpace, baseSpace: XRSpace): XRPose | undefined;
     getViewerPose(referenceSpace: XRReferenceSpace): XRViewerPose | undefined;
   }
 

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
-import {getWebXRInputRay} from '../../src/webxr/webxr-input';
+import {getWebXRInputRay, getWebXRInputRayPlaneIntersection} from '../../src/webxr/webxr-input';
 import type {WebXRInputState} from '../../src/webxr/webxr-manager';
 
 test('webxr#getWebXRInputRay resolves origin and normalized target-ray direction', testCase => {
@@ -30,6 +30,71 @@ test('webxr#getWebXRInputRay handles missing and degenerate target rays', testCa
   );
   testCase.deepEqual(ray?.origin, [3, 4, 5], 'still resolves origin');
   testCase.deepEqual(ray?.direction, [0, 0, -1], 'falls back to forward direction');
+  testCase.end();
+});
+
+test('webxr#getWebXRInputRayPlaneIntersection resolves floor hits and custom planes', testCase => {
+  const floorRay = {
+    inputState: makeMockWebXRInputState(null),
+    origin: [0, 1.6, 0],
+    direction: [0, -0.8, -0.6],
+    matrix: new Float32Array(16)
+  };
+  const floorHit = getWebXRInputRayPlaneIntersection(floorRay);
+
+  testCase.equal(floorHit?.ray, floorRay, 'retains source ray');
+  testCase.equal(floorHit?.distance, 2, 'returns normalized ray distance');
+  testCase.deepEqual(floorHit?.point, [0, 0, -1.2], 'intersects default y=0 floor plane');
+
+  const wallRay = {
+    inputState: makeMockWebXRInputState(null),
+    origin: [1, 2, 3],
+    direction: [0, 0, -1],
+    matrix: new Float32Array(16)
+  };
+  const wallHit = getWebXRInputRayPlaneIntersection(wallRay, {
+    planePoint: [0, 0, 1],
+    planeNormal: [0, 0, 2]
+  });
+
+  testCase.equal(wallHit?.distance, 2, 'normalizes custom plane normals');
+  testCase.deepEqual(wallHit?.point, [1, 2, 1], 'intersects custom plane');
+  testCase.end();
+});
+
+test('webxr#getWebXRInputRayPlaneIntersection rejects unusable hits', testCase => {
+  const ray = {
+    inputState: makeMockWebXRInputState(null),
+    origin: [0, 1, 0],
+    direction: [0, -1, 0],
+    matrix: new Float32Array(16)
+  };
+
+  testCase.equal(
+    getWebXRInputRayPlaneIntersection(ray, {minDistance: 1.5}),
+    null,
+    'rejects hits before minDistance'
+  );
+  testCase.equal(
+    getWebXRInputRayPlaneIntersection(ray, {maxDistance: 0.5}),
+    null,
+    'rejects hits after maxDistance'
+  );
+  testCase.equal(
+    getWebXRInputRayPlaneIntersection({...ray, direction: [0, 1, 0]}),
+    null,
+    'rejects intersections behind the ray origin'
+  );
+  testCase.equal(
+    getWebXRInputRayPlaneIntersection({...ray, direction: [1, 0, 0]}),
+    null,
+    'rejects rays parallel to the plane'
+  );
+  testCase.equal(
+    getWebXRInputRayPlaneIntersection(ray, {planeNormal: [0, 0, 0]}),
+    null,
+    'rejects degenerate plane normals'
+  );
   testCase.end();
 });
 

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -110,6 +110,7 @@ function makeMockWebXRInputState(targetRayMatrix: Float32Array | null): WebXRInp
     targetRayMatrix,
     gripPose: null,
     gripMatrix: null,
-    selectActive: false
+    selectActive: false,
+    squeezeActive: false
   };
 }

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -1,0 +1,50 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {getWebXRInputRay} from '../../src/webxr/webxr-input';
+import type {WebXRInputState} from '../../src/webxr/webxr-manager';
+
+test('webxr#getWebXRInputRay resolves origin and normalized target-ray direction', testCase => {
+  const matrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, -3, 4, 0, 2, 5, 7, 1]);
+  const inputState = makeMockWebXRInputState(matrix);
+  const ray = getWebXRInputRay(inputState);
+
+  testCase.equal(ray?.inputState, inputState, 'retains source input state');
+  testCase.equal(ray?.matrix, matrix, 'retains source target-ray matrix');
+  testCase.deepEqual(ray?.origin, [2, 5, 7], 'uses matrix translation as origin');
+  testCase.deepEqual(ray?.direction, [0, 0.6, -0.8], 'normalizes negative local z');
+  testCase.end();
+});
+
+test('webxr#getWebXRInputRay handles missing and degenerate target rays', testCase => {
+  testCase.equal(
+    getWebXRInputRay(makeMockWebXRInputState(null)),
+    null,
+    'missing target ray matrices do not produce rays'
+  );
+
+  const ray = getWebXRInputRay(
+    makeMockWebXRInputState(new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 3, 4, 5, 1]))
+  );
+  testCase.deepEqual(ray?.origin, [3, 4, 5], 'still resolves origin');
+  testCase.deepEqual(ray?.direction, [0, 0, -1], 'falls back to forward direction');
+  testCase.end();
+});
+
+function makeMockWebXRInputState(targetRayMatrix: Float32Array | null): WebXRInputState {
+  return {
+    inputSource: {} as XRInputSource,
+    index: 0,
+    handedness: 'right',
+    targetRayMode: 'tracked-pointer',
+    profiles: [],
+    gamepad: null,
+    targetRayPose: null,
+    targetRayMatrix,
+    gripPose: null,
+    gripMatrix: null,
+    selectActive: false
+  };
+}

--- a/modules/experimental/test/webxr/webxr-manager.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-manager.node.spec.ts
@@ -512,18 +512,30 @@ test('webxr#WebXRManager resolves input source poses and select activity', async
     testCase.equal(inputState?.[0]?.gripPose, gripPose, 'keeps grip pose');
     testCase.equal(inputState?.[0]?.gripMatrix, gripPose.transform.matrix, 'keeps grip');
     testCase.equal(inputState?.[0]?.selectActive, false, 'select starts inactive');
+    testCase.equal(inputState?.[0]?.squeezeActive, false, 'squeeze starts inactive');
     testCase.equal(inputState?.[1]?.targetRayPose, null, 'missing poses become null');
     testCase.equal(inputState?.[1]?.gripPose, null, 'missing grip spaces become null');
 
     session.dispatchEvent(makeMockXRInputSourceEvent('selectstart', controllerInputSource, frame));
     inputState = manager.getInputState(frame);
     testCase.equal(inputState?.[0]?.selectActive, true, 'selectstart marks the source active');
+    testCase.equal(inputState?.[0]?.squeezeActive, false, 'select does not affect squeeze');
+
+    session.dispatchEvent(makeMockXRInputSourceEvent('squeezestart', controllerInputSource, frame));
+    inputState = manager.getInputState(frame);
+    testCase.equal(inputState?.[0]?.squeezeActive, true, 'squeezestart marks the source active');
+    testCase.equal(inputState?.[0]?.selectActive, true, 'squeeze does not affect select');
+
+    session.dispatchEvent(makeMockXRInputSourceEvent('squeezeend', controllerInputSource, frame));
+    inputState = manager.getInputState(frame);
+    testCase.equal(inputState?.[0]?.squeezeActive, false, 'squeezeend marks the source inactive');
 
     session.dispatchEvent(makeMockXRInputSourceEvent('selectend', controllerInputSource, frame));
     inputState = manager.getInputState(frame);
     testCase.equal(inputState?.[0]?.selectActive, false, 'selectend marks the source inactive');
 
     session.dispatchEvent(makeMockXRInputSourceEvent('selectstart', controllerInputSource, frame));
+    session.dispatchEvent(makeMockXRInputSourceEvent('squeezestart', controllerInputSource, frame));
     session.inputSources = [screenInputSource];
     session.dispatchEvent(
       Object.assign(new Event('inputsourceschange'), {
@@ -536,6 +548,7 @@ test('webxr#WebXRManager resolves input source poses and select activity', async
     testCase.equal(inputState?.length, 1, 'removed sources disappear from snapshots');
     testCase.equal(inputState?.[0]?.inputSource, screenInputSource, 'keeps remaining source');
     testCase.equal(inputState?.[0]?.selectActive, false, 'removed source cannot stay selected');
+    testCase.equal(inputState?.[0]?.squeezeActive, false, 'removed source cannot stay squeezed');
 
     const foreignFrame = {
       session: makeMockXRSession(referenceSpace, []),
@@ -736,7 +749,7 @@ function makeMockXRPose(matrix: number[]): XRPose {
 }
 
 function makeMockXRInputSourceEvent(
-  type: 'selectstart' | 'selectend',
+  type: 'selectstart' | 'selectend' | 'squeezestart' | 'squeezeend',
   inputSource: XRInputSource,
   frame: XRFrame
 ): XRInputSourceEvent {

--- a/modules/experimental/test/webxr/webxr-manager.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-manager.node.spec.ts
@@ -23,6 +23,7 @@ type MockWebGPUDevice = Device & {
   createdFramebuffers: MockFramebuffer[];
 };
 type MockXRSession = XRSession & {
+  inputSources: XRInputSource[];
   updatedBaseLayer: XRWebGLLayer | null;
   updatedLayers: XRProjectionLayer[] | null;
 };
@@ -437,6 +438,125 @@ test('webxr#WebXRManager rejects unsupported WebGPU sessions and foreign frames'
   testCase.end();
 });
 
+test('webxr#WebXRManager resolves input source poses and select activity', async testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const targetRaySpace = {} as XRSpace;
+  const gripSpace = {} as XRSpace;
+  const screenTargetRaySpace = {} as XRSpace;
+  const targetRayPose = makeMockXRPose([1, 2, 3, 4]);
+  const gripPose = makeMockXRPose([5, 6, 7, 8]);
+  const poseBySpace = new Map<XRSpace, XRPose>([
+    [targetRaySpace, targetRayPose],
+    [gripSpace, gripPose]
+  ]);
+  const controllerInputSource = makeMockXRInputSource({
+    handedness: 'left',
+    targetRayMode: 'tracked-pointer',
+    targetRaySpace,
+    gripSpace,
+    profiles: ['oculus-touch-v3', 'generic-trigger-squeeze-thumbstick'],
+    gamepad: {} as Gamepad
+  });
+  const screenInputSource = makeMockXRInputSource({
+    handedness: 'none',
+    targetRayMode: 'screen',
+    targetRaySpace: screenTargetRaySpace,
+    profiles: ['generic-screen']
+  });
+  const session = makeMockXRSession(referenceSpace, [], [controllerInputSource, screenInputSource]);
+  const gl = {
+    async makeXRCompatible() {}
+  } as WebGL2RenderingContext;
+  const device = {
+    type: 'webgl',
+    gl,
+    createFramebuffer: (props: FramebufferProps) => makeMockFramebuffer(props)
+  } as unknown as Device;
+  const originalXRWebGLLayer = globalThis.XRWebGLLayer;
+
+  globalThis.XRWebGLLayer = class {
+    readonly framebuffer = null;
+    readonly framebufferWidth = 1;
+    readonly framebufferHeight = 1;
+
+    getViewport(): XRViewport {
+      return {x: 0, y: 0, width: 1, height: 1};
+    }
+  } as typeof XRWebGLLayer;
+
+  try {
+    const manager = new WebXRManager(device);
+    await manager.setSession(session);
+    const frame = {
+      session,
+      getPose(space: XRSpace, baseSpace: XRReferenceSpace): XRPose | undefined {
+        testCase.equal(baseSpace, referenceSpace, 'queries poses in the manager reference space');
+        return poseBySpace.get(space);
+      },
+      getViewerPose: () => undefined
+    } as XRFrame;
+    let inputState = manager.getInputState(frame);
+
+    testCase.equal(inputState?.length, 2, 'reports every active input source');
+    testCase.equal(inputState?.[0]?.inputSource, controllerInputSource, 'retains input identity');
+    testCase.equal(inputState?.[0]?.handedness, 'left', 'keeps handedness');
+    testCase.equal(inputState?.[0]?.targetRayMode, 'tracked-pointer', 'keeps target ray mode');
+    testCase.deepEqual(
+      inputState?.[0]?.profiles,
+      ['oculus-touch-v3', 'generic-trigger-squeeze-thumbstick'],
+      'keeps profile order'
+    );
+    testCase.equal(inputState?.[0]?.gamepad, controllerInputSource.gamepad, 'keeps gamepad');
+    testCase.equal(inputState?.[0]?.targetRayPose, targetRayPose, 'keeps target ray pose');
+    testCase.equal(inputState?.[0]?.targetRayMatrix, targetRayPose.transform.matrix, 'keeps ray');
+    testCase.equal(inputState?.[0]?.gripPose, gripPose, 'keeps grip pose');
+    testCase.equal(inputState?.[0]?.gripMatrix, gripPose.transform.matrix, 'keeps grip');
+    testCase.equal(inputState?.[0]?.selectActive, false, 'select starts inactive');
+    testCase.equal(inputState?.[1]?.targetRayPose, null, 'missing poses become null');
+    testCase.equal(inputState?.[1]?.gripPose, null, 'missing grip spaces become null');
+
+    session.dispatchEvent(makeMockXRInputSourceEvent('selectstart', controllerInputSource, frame));
+    inputState = manager.getInputState(frame);
+    testCase.equal(inputState?.[0]?.selectActive, true, 'selectstart marks the source active');
+
+    session.dispatchEvent(makeMockXRInputSourceEvent('selectend', controllerInputSource, frame));
+    inputState = manager.getInputState(frame);
+    testCase.equal(inputState?.[0]?.selectActive, false, 'selectend marks the source inactive');
+
+    session.dispatchEvent(makeMockXRInputSourceEvent('selectstart', controllerInputSource, frame));
+    session.inputSources = [screenInputSource];
+    session.dispatchEvent(
+      Object.assign(new Event('inputsourceschange'), {
+        added: [],
+        removed: [controllerInputSource],
+        session
+      }) as XRInputSourcesChangeEvent
+    );
+    inputState = manager.getInputState(frame);
+    testCase.equal(inputState?.length, 1, 'removed sources disappear from snapshots');
+    testCase.equal(inputState?.[0]?.inputSource, screenInputSource, 'keeps remaining source');
+    testCase.equal(inputState?.[0]?.selectActive, false, 'removed source cannot stay selected');
+
+    const foreignFrame = {
+      session: makeMockXRSession(referenceSpace, []),
+      getPose: () => undefined,
+      getViewerPose: () => undefined
+    } as XRFrame;
+    testCase.throws(
+      () => manager.getInputState(foreignFrame),
+      /different XRSession/,
+      'rejects foreign frames for input snapshots'
+    );
+
+    manager.clearSession();
+    testCase.equal(manager.getInputState(frame), null, 'cleared sessions expose no inputs');
+  } finally {
+    globalThis.XRWebGLLayer = originalXRWebGLLayer;
+  }
+
+  testCase.end();
+});
+
 test('webxr#WebXRManager preserves shared WebGL framebuffers in a mocked Node session', async testCase => {
   const referenceSpace = {} as XRReferenceSpace;
   const session = makeMockXRSession(referenceSpace, []);
@@ -566,10 +686,12 @@ function makeMockTextureHandle(
 
 function makeMockXRSession(
   referenceSpace: XRReferenceSpace,
-  enabledFeatures: readonly string[]
+  enabledFeatures: readonly string[],
+  inputSources: XRInputSource[] = []
 ): MockXRSession {
   const session = Object.assign(new EventTarget(), {
     enabledFeatures,
+    inputSources,
     updatedBaseLayer: null as XRWebGLLayer | null,
     updatedLayers: null as XRProjectionLayer[] | null,
     async updateRenderState(renderStateInit: XRRenderStateInit = {}) {
@@ -591,4 +713,32 @@ function makeMockXRView(eye: XREye, index: number): XRView {
     projectionMatrix: new Float32Array([index + 1]),
     transform: {inverse: {matrix: new Float32Array([index + 10])}}
   } as XRView;
+}
+
+function makeMockXRInputSource(props: {
+  handedness: XRHandedness;
+  targetRayMode: XRTargetRayMode;
+  targetRaySpace: XRSpace;
+  gripSpace?: XRSpace;
+  profiles: readonly string[];
+  gamepad?: Gamepad;
+}): XRInputSource {
+  return props as XRInputSource;
+}
+
+function makeMockXRPose(matrix: number[]): XRPose {
+  return {
+    transform: {
+      matrix: new Float32Array(matrix),
+      inverse: {matrix: new Float32Array(matrix)}
+    }
+  } as XRPose;
+}
+
+function makeMockXRInputSourceEvent(
+  type: 'selectstart' | 'selectend',
+  inputSource: XRInputSource,
+  frame: XRFrame
+): XRInputSourceEvent {
+  return Object.assign(new Event(type), {inputSource, frame}) as XRInputSourceEvent;
 }

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -178,6 +178,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
   });
 
   test('keeps standalone launch, sidebar, and backend metadata accurate', () => {
+    const applicationSource = readFileSync(APPLICATION_PATH, 'utf8');
     const standaloneSource = readFileSync(STANDALONE_PATH, 'utf8');
     const metadataSource = readFileSync(EXAMPLE_METADATA_PATH, 'utf8');
     const packageSource = JSON.parse(readFileSync(PACKAGE_PATH, 'utf8')) as {
@@ -194,6 +195,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(standaloneSource).toContain("toggleSession('immersive-vr')");
     expect(standaloneSource).toContain("toggleSession('immersive-ar')");
     expect(standaloneSource).toContain('switch-backend');
+    expect(applicationSource).toContain(
+      'https://chromewebstore.google.com/detail/codex/hehggadaopoacecdllhhajmbjkdcmajg?pli=1'
+    );
     expect(metadataSource).toContain('backends: [webgpu, webgl2]');
     expect(metadataSource).toContain('Immersive Prism Portal');
     expect(packageSource.dependencies).toHaveProperty('@luma.gl/webgpu');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -117,11 +117,35 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       prepareMethodStart
     );
     const prepareMethod = applicationSource.slice(prepareMethodStart, prepareMethodEnd);
+    const prepareControllerMethodStart = applicationSource.indexOf(
+      'private prepareControllerTargets('
+    );
+    const prepareControllerMethodEnd = applicationSource.indexOf(
+      '\n  private drawControllerTargets(',
+      prepareControllerMethodStart
+    );
+    const prepareControllerMethod = applicationSource.slice(
+      prepareControllerMethodStart,
+      prepareControllerMethodEnd
+    );
+    const drawControllerMethodStart = applicationSource.indexOf('private drawControllerTargets(');
+    const drawControllerMethodEnd = applicationSource.indexOf(
+      '\n  private updateModelMatrix(',
+      drawControllerMethodStart
+    );
+    const drawControllerMethod = applicationSource.slice(
+      drawControllerMethodStart,
+      drawControllerMethodEnd
+    );
 
     expect(renderMethodStart).toBeGreaterThan(0);
     expect(renderMethodEnd).toBeGreaterThan(renderMethodStart);
     expect(previewMethodStart).toBeGreaterThan(0);
     expect(previewMethodEnd).toBeGreaterThan(previewMethodStart);
+    expect(prepareControllerMethodStart).toBeGreaterThan(0);
+    expect(prepareControllerMethodEnd).toBeGreaterThan(prepareControllerMethodStart);
+    expect(drawControllerMethodStart).toBeGreaterThan(0);
+    expect(drawControllerMethodEnd).toBeGreaterThan(drawControllerMethodStart);
     expect(previewMethod).toContain('const renderPass = device.beginRenderPass(');
     expect(previewMethod).toContain('this.drawPortal(renderPass)');
     expect(previewMethod).toContain('renderPass.end()');
@@ -130,10 +154,14 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain('!renderedFramebuffers.has(framebuffer)');
     expect(renderMethod).toContain('renderedFramebuffers.add(framebuffer)');
     expect(renderMethod).toContain(
-      'this.drawControllerTargets(renderPass, view, inputState, time)'
+      'const controllerTargets = this.prepareControllerTargets(view, inputState, time)'
     );
+    expect(renderMethod).toContain('this.drawControllerTargets(renderPass, controllerTargets)');
     expect(renderMethod).toMatch(
       /this\.xrSessionMode\s*===\s*'immersive-ar'\s*\?\s*\[0,\s*0,\s*0,\s*0\]/
+    );
+    expect(renderMethod.indexOf('this.prepareControllerTargets(')).toBeLessThan(
+      renderMethod.indexOf('this.device.beginRenderPass({')
     );
     expect(renderMethod.indexOf('this.preparePortal({')).toBeLessThan(
       renderMethod.indexOf('this.device.beginRenderPass({')
@@ -146,13 +174,30 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       renderMethod.indexOf('renderPass.setParameters({viewport: view.viewport})')
     ).toBeLessThan(renderMethod.indexOf('this.drawPortal(renderPass)'));
     expect(renderMethod.indexOf('this.drawPortal(renderPass)')).toBeLessThan(
-      renderMethod.indexOf('this.drawControllerTargets(renderPass, view, inputState, time)')
+      renderMethod.indexOf('this.drawControllerTargets(renderPass, controllerTargets)')
     );
     expect(prepareMethod).toContain('this.uniformStore.setUniforms(');
     expect(prepareMethod).toContain('this.device.commandEncoder');
     expect(prepareMethod).toContain('this.model.predraw(this.device.commandEncoder)');
     expect(prepareMethod.indexOf('this.uniformStore.setUniforms(')).toBeLessThan(
       prepareMethod.indexOf('this.model.predraw(this.device.commandEncoder)')
+    );
+    expect(prepareControllerMethod).toContain('rayUniforms.uniformStore.setUniforms(');
+    expect(prepareControllerMethod).toContain('reticleUniforms.uniformStore.setUniforms(');
+    expect(prepareControllerMethod).toContain('this.device.commandEncoder');
+    expect(prepareControllerMethod).toContain(
+      'this.controllerRayModel.predraw(this.device.commandEncoder)'
+    );
+    expect(prepareControllerMethod).toContain(
+      'this.controllerReticleModel.predraw(this.device.commandEncoder)'
+    );
+    expect(drawControllerMethod).not.toContain('setUniforms(');
+    expect(drawControllerMethod).not.toContain('this.device.commandEncoder');
+    expect(drawControllerMethod).toContain(
+      'this.controllerRayModel.setBindings({app: controllerTarget.rayUniformBuffer})'
+    );
+    expect(drawControllerMethod).toContain(
+      'this.controllerReticleModel.setBindings({app: controllerTarget.reticleUniformBuffer})'
     );
   });
 
@@ -164,12 +209,18 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       renderMethodStart
     );
     const renderMethod = applicationSource.slice(renderMethodStart, renderMethodEnd);
-    const rayMethodStart = applicationSource.indexOf('private drawControllerTargets(');
+    const rayMethodStart = applicationSource.indexOf('private prepareControllerTargets(');
     const rayMethodEnd = applicationSource.indexOf(
-      '\n  private updateModelMatrix(',
+      '\n  private drawControllerTargets(',
       rayMethodStart
     );
     const rayMethod = applicationSource.slice(rayMethodStart, rayMethodEnd);
+    const drawMethodStart = applicationSource.indexOf('private drawControllerTargets(');
+    const drawMethodEnd = applicationSource.indexOf(
+      '\n  private updateModelMatrix(',
+      drawMethodStart
+    );
+    const drawMethod = applicationSource.slice(drawMethodStart, drawMethodEnd);
 
     expect(applicationSource).toContain('type WebXRInputState');
     expect(applicationSource).toContain('getWebXRInputRay');
@@ -192,7 +243,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethod).toContain('multiplyRight(this.controllerRayMatrix.copy(inputRay.matrix))');
     expect(rayMethod).toContain('cameraMix: input.selectActive ? 1 : 0');
     expect(rayMethod).toContain('this.controllerRayModel.predraw(this.device.commandEncoder)');
-    expect(rayMethod).toContain('this.controllerRayModel.draw(renderPass)');
+    expect(drawMethod).toContain('this.controllerRayModel.draw(renderPass)');
     expect(rayMethod).toContain('getWebXRInputRayPlaneIntersection(inputRay, {maxDistance: 8})');
     expect(rayMethod).toContain(
       'this._floorHitByInputSource.set(input.inputSource, floorHit.point)'
@@ -202,7 +253,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     );
     expect(rayMethod).toContain('multiplyRight(this.controllerReticleMatrix)');
     expect(rayMethod).toContain('this.controllerReticleModel.predraw(this.device.commandEncoder)');
-    expect(rayMethod).toContain('this.controllerReticleModel.draw(renderPass)');
+    expect(drawMethod).toContain('this.controllerReticleModel.draw(renderPass)');
   });
 
   test('uses select for teleport candidates and squeeze or keyboard for exit', () => {
@@ -240,6 +291,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(enterMethod).toContain(
       "session.addEventListener('squeezeend', this._xrSqueezeEndListener)"
     );
+    expect(enterMethod).toContain('this.setXRSession(session, sessionMode)');
+    expect(applicationSource).toContain("this.getWebXRManagerProps(sessionMode, 'local-floor')");
+    expect(applicationSource).toContain("this.getWebXRManagerProps(sessionMode, 'local')");
     expect(updateModelMethod).toContain('translate(this.xrSceneOffset)');
     expect(teleportMethod).toContain('this._floorHitByInputSource.get(inputSource)');
     expect(teleportMethod).toContain('this.xrSceneOffset[0] -= floorHit[0]');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -57,6 +57,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('source: WGSL_SHADER');
     expect(applicationSource).toContain('vs: VS_GLSL');
     expect(applicationSource).toContain('fs: FS_GLSL');
+    expect(applicationSource).toContain('source: CONTROLLER_RAY_WGSL_SHADER');
+    expect(applicationSource).toContain('vs: CONTROLLER_RAY_VS_GLSL');
+    expect(applicationSource).toContain('fs: CONTROLLER_RAY_FS_GLSL');
     expect(applicationSource).not.toContain('WebXR Kaleidoscope requires WebGL2');
   });
 
@@ -102,6 +105,12 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       renderMethodStart
     );
     const renderMethod = applicationSource.slice(renderMethodStart, renderMethodEnd);
+    const previewMethodStart = applicationSource.indexOf('private renderPreviewFrame(');
+    const previewMethodEnd = applicationSource.indexOf(
+      '\n  private renderXRFrame(',
+      previewMethodStart
+    );
+    const previewMethod = applicationSource.slice(previewMethodStart, previewMethodEnd);
     const prepareMethodStart = applicationSource.indexOf('private preparePortal(');
     const prepareMethodEnd = applicationSource.indexOf(
       '\n  private drawPortal(',
@@ -111,10 +120,16 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
 
     expect(renderMethodStart).toBeGreaterThan(0);
     expect(renderMethodEnd).toBeGreaterThan(renderMethodStart);
+    expect(previewMethodStart).toBeGreaterThan(0);
+    expect(previewMethodEnd).toBeGreaterThan(previewMethodStart);
+    expect(previewMethod).toContain('const renderPass = device.beginRenderPass(');
+    expect(previewMethod).toContain('this.drawPortal(renderPass)');
+    expect(previewMethod).toContain('renderPass.end()');
     expect(renderMethod).toContain('view.framebuffer ?? frameState.framebuffer');
     expect(renderMethod).toContain('new Set<Framebuffer>()');
     expect(renderMethod).toContain('!renderedFramebuffers.has(framebuffer)');
     expect(renderMethod).toContain('renderedFramebuffers.add(framebuffer)');
+    expect(renderMethod).toContain('this.drawControllerRays(renderPass, view, inputState, time)');
     expect(renderMethod).toMatch(
       /this\.xrSessionMode\s*===\s*'immersive-ar'\s*\?\s*\[0,\s*0,\s*0,\s*0\]/
     );
@@ -128,12 +143,48 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(
       renderMethod.indexOf('renderPass.setParameters({viewport: view.viewport})')
     ).toBeLessThan(renderMethod.indexOf('this.drawPortal(renderPass)'));
+    expect(renderMethod.indexOf('this.drawPortal(renderPass)')).toBeLessThan(
+      renderMethod.indexOf('this.drawControllerRays(renderPass, view, inputState, time)')
+    );
     expect(prepareMethod).toContain('this.uniformStore.setUniforms(');
     expect(prepareMethod).toContain('this.device.commandEncoder');
     expect(prepareMethod).toContain('this.model.predraw(this.device.commandEncoder)');
     expect(prepareMethod.indexOf('this.uniformStore.setUniforms(')).toBeLessThan(
       prepareMethod.indexOf('this.model.predraw(this.device.commandEncoder)')
     );
+  });
+
+  test('renders tracked-pointer controller rays from WebXR input snapshots', () => {
+    const applicationSource = readFileSync(APPLICATION_PATH, 'utf8');
+    const renderMethodStart = applicationSource.indexOf('private renderXRFrame(');
+    const renderMethodEnd = applicationSource.indexOf(
+      '\n  private preparePortal(',
+      renderMethodStart
+    );
+    const renderMethod = applicationSource.slice(renderMethodStart, renderMethodEnd);
+    const rayMethodStart = applicationSource.indexOf('private drawControllerRays(');
+    const rayMethodEnd = applicationSource.indexOf(
+      '\n  private updateModelMatrix(',
+      rayMethodStart
+    );
+    const rayMethod = applicationSource.slice(rayMethodStart, rayMethodEnd);
+
+    expect(applicationSource).toContain('type WebXRInputState');
+    expect(applicationSource).toContain('this.webXRManager.getInputState(xrFrame)');
+    expect(applicationSource).toContain("id: 'immersive-prism-controller-rays'");
+    expect(applicationSource).toContain("topology: 'line-list'");
+    expect(applicationSource).toContain('new Float32Array([0, 0, 0, 0, 0, -3.2])');
+    expect(renderMethod).toContain('inputState: readonly WebXRInputState[]');
+    expect(renderMethod).toContain('renderPass.end()');
+    expect(rayMethodStart).toBeGreaterThan(0);
+    expect(rayMethodEnd).toBeGreaterThan(rayMethodStart);
+    expect(rayMethod).toContain("input.targetRayMode !== 'tracked-pointer'");
+    expect(rayMethod).toContain('!input.targetRayMatrix');
+    expect(rayMethod).toContain('this.controllerRayMatrix.copy(input.targetRayMatrix)');
+    expect(rayMethod).toContain('multiplyRight(this.controllerRayMatrix)');
+    expect(rayMethod).toContain('cameraMix: input.selectActive ? 1 : 0');
+    expect(rayMethod).toContain('this.controllerRayModel.predraw(this.device.commandEncoder)');
+    expect(rayMethod).toContain('this.controllerRayModel.draw(renderPass)');
   });
 
   test('requests isolated XR-compatible website devices while preserving preview fallback', () => {

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -170,6 +170,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     const rayMethod = applicationSource.slice(rayMethodStart, rayMethodEnd);
 
     expect(applicationSource).toContain('type WebXRInputState');
+    expect(applicationSource).toContain('getWebXRInputRay');
     expect(applicationSource).toContain('this.webXRManager.getInputState(xrFrame)');
     expect(applicationSource).toContain("id: 'immersive-prism-controller-rays'");
     expect(applicationSource).toContain("topology: 'line-list'");
@@ -178,9 +179,10 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain('renderPass.end()');
     expect(rayMethodStart).toBeGreaterThan(0);
     expect(rayMethodEnd).toBeGreaterThan(rayMethodStart);
+    expect(rayMethod).toContain('const inputRay = getWebXRInputRay(input)');
     expect(rayMethod).toContain("input.targetRayMode !== 'tracked-pointer'");
-    expect(rayMethod).toContain('!input.targetRayMatrix');
-    expect(rayMethod).toContain('this.controllerRayMatrix.copy(input.targetRayMatrix)');
+    expect(rayMethod).toContain('!inputRay');
+    expect(rayMethod).toContain('this.controllerRayMatrix.copy(inputRay.matrix)');
     expect(rayMethod).toContain('multiplyRight(this.controllerRayMatrix)');
     expect(rayMethod).toContain('cameraMix: input.selectActive ? 1 : 0');
     expect(rayMethod).toContain('this.controllerRayModel.predraw(this.device.commandEncoder)');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -129,7 +129,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain('new Set<Framebuffer>()');
     expect(renderMethod).toContain('!renderedFramebuffers.has(framebuffer)');
     expect(renderMethod).toContain('renderedFramebuffers.add(framebuffer)');
-    expect(renderMethod).toContain('this.drawControllerRays(renderPass, view, inputState, time)');
+    expect(renderMethod).toContain(
+      'this.drawControllerTargets(renderPass, view, inputState, time)'
+    );
     expect(renderMethod).toMatch(
       /this\.xrSessionMode\s*===\s*'immersive-ar'\s*\?\s*\[0,\s*0,\s*0,\s*0\]/
     );
@@ -144,7 +146,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       renderMethod.indexOf('renderPass.setParameters({viewport: view.viewport})')
     ).toBeLessThan(renderMethod.indexOf('this.drawPortal(renderPass)'));
     expect(renderMethod.indexOf('this.drawPortal(renderPass)')).toBeLessThan(
-      renderMethod.indexOf('this.drawControllerRays(renderPass, view, inputState, time)')
+      renderMethod.indexOf('this.drawControllerTargets(renderPass, view, inputState, time)')
     );
     expect(prepareMethod).toContain('this.uniformStore.setUniforms(');
     expect(prepareMethod).toContain('this.device.commandEncoder');
@@ -162,7 +164,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       renderMethodStart
     );
     const renderMethod = applicationSource.slice(renderMethodStart, renderMethodEnd);
-    const rayMethodStart = applicationSource.indexOf('private drawControllerRays(');
+    const rayMethodStart = applicationSource.indexOf('private drawControllerTargets(');
     const rayMethodEnd = applicationSource.indexOf(
       '\n  private updateModelMatrix(',
       rayMethodStart
@@ -171,10 +173,14 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
 
     expect(applicationSource).toContain('type WebXRInputState');
     expect(applicationSource).toContain('getWebXRInputRay');
+    expect(applicationSource).toContain('getWebXRInputRayPlaneIntersection');
     expect(applicationSource).toContain('this.webXRManager.getInputState(xrFrame)');
     expect(applicationSource).toContain("id: 'immersive-prism-controller-rays'");
+    expect(applicationSource).toContain("id: 'immersive-prism-controller-reticles'");
     expect(applicationSource).toContain("topology: 'line-list'");
     expect(applicationSource).toContain('new Float32Array([0, 0, 0, 0, 0, -3.2])');
+    expect(applicationSource).toContain('function makeControllerReticleGeometry()');
+    expect(applicationSource).toContain('const segmentCount = 32');
     expect(renderMethod).toContain('inputState: readonly WebXRInputState[]');
     expect(renderMethod).toContain('renderPass.end()');
     expect(rayMethodStart).toBeGreaterThan(0);
@@ -183,10 +189,17 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethod).toContain("input.targetRayMode !== 'tracked-pointer'");
     expect(rayMethod).toContain('!inputRay');
     expect(rayMethod).toContain('this.controllerRayMatrix.copy(inputRay.matrix)');
-    expect(rayMethod).toContain('multiplyRight(this.controllerRayMatrix)');
+    expect(rayMethod).toContain('multiplyRight(this.controllerRayMatrix.copy(inputRay.matrix))');
     expect(rayMethod).toContain('cameraMix: input.selectActive ? 1 : 0');
     expect(rayMethod).toContain('this.controllerRayModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerRayModel.draw(renderPass)');
+    expect(rayMethod).toContain('getWebXRInputRayPlaneIntersection(inputRay, {maxDistance: 8})');
+    expect(rayMethod).toContain(
+      'this.controllerReticleMatrix.identity().translate(floorHit.point)'
+    );
+    expect(rayMethod).toContain('multiplyRight(this.controllerReticleMatrix)');
+    expect(rayMethod).toContain('this.controllerReticleModel.predraw(this.device.commandEncoder)');
+    expect(rayMethod).toContain('this.controllerReticleModel.draw(renderPass)');
   });
 
   test('requests isolated XR-compatible website devices while preserving preview fallback', () => {

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -195,11 +195,67 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethod).toContain('this.controllerRayModel.draw(renderPass)');
     expect(rayMethod).toContain('getWebXRInputRayPlaneIntersection(inputRay, {maxDistance: 8})');
     expect(rayMethod).toContain(
+      'this._floorHitByInputSource.set(input.inputSource, floorHit.point)'
+    );
+    expect(rayMethod).toContain(
       'this.controllerReticleMatrix.identity().translate(floorHit.point)'
     );
     expect(rayMethod).toContain('multiplyRight(this.controllerReticleMatrix)');
     expect(rayMethod).toContain('this.controllerReticleModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerReticleModel.draw(renderPass)');
+  });
+
+  test('uses select for teleport candidates and squeeze or keyboard for exit', () => {
+    const applicationSource = readFileSync(APPLICATION_PATH, 'utf8');
+    const enterMethodStart = applicationSource.indexOf('async enterXR(');
+    const enterMethodEnd = applicationSource.indexOf('\n  async exitAR(', enterMethodStart);
+    const enterMethod = applicationSource.slice(enterMethodStart, enterMethodEnd);
+    const updateModelStart = applicationSource.indexOf('private updateModelMatrix(');
+    const updateModelEnd = applicationSource.indexOf(
+      '\n  private teleportToInputSource(',
+      updateModelStart
+    );
+    const updateModelMethod = applicationSource.slice(updateModelStart, updateModelEnd);
+    const teleportMethodStart = applicationSource.indexOf('private teleportToInputSource(');
+    const teleportMethodEnd = applicationSource.indexOf(
+      '\n  private createCameraTexture(',
+      teleportMethodStart
+    );
+    const teleportMethod = applicationSource.slice(teleportMethodStart, teleportMethodEnd);
+    const clearMethodStart = applicationSource.indexOf('private _clearXRSession(');
+    const clearMethod = applicationSource.slice(clearMethodStart);
+
+    expect(applicationSource).toContain('readonly xrSceneOffset: [number, number, number]');
+    expect(applicationSource).toContain('new Map<XRInputSource, [number, number, number]>()');
+    expect(applicationSource).not.toContain(
+      'private _xrSelectEndListener = () => void this.exitXR()'
+    );
+    expect(applicationSource).toContain('private _xrSqueezeEndListener = () => void this.exitXR()');
+    expect(applicationSource).toContain(
+      'this.teleportToInputSource((event as XRInputSourceEvent).inputSource)'
+    );
+    expect(enterMethod).toContain(
+      "session.addEventListener('selectend', this._xrSelectEndListener)"
+    );
+    expect(enterMethod).toContain(
+      "session.addEventListener('squeezeend', this._xrSqueezeEndListener)"
+    );
+    expect(updateModelMethod).toContain('translate(this.xrSceneOffset)');
+    expect(teleportMethod).toContain('this._floorHitByInputSource.get(inputSource)');
+    expect(teleportMethod).toContain('this.xrSceneOffset[0] -= floorHit[0]');
+    expect(teleportMethod).toContain('this.xrSceneOffset[2] -= floorHit[2]');
+    expect(teleportMethod).toContain('this._floorHitByInputSource.clear()');
+    expect(clearMethod).toContain(
+      "session?.removeEventListener('selectend', this._xrSelectEndListener)"
+    );
+    expect(clearMethod).toContain(
+      "session?.removeEventListener('squeezeend', this._xrSqueezeEndListener)"
+    );
+    expect(clearMethod).toContain('this.xrSceneOffset[0] = 0');
+    expect(clearMethod).toContain('this._floorHitByInputSource.clear()');
+    expect(applicationSource).toContain(
+      "event.key === 'Escape' || event.key.toLowerCase() === 'q'"
+    );
   });
 
   test('requests isolated XR-compatible website devices while preserving preview fallback', () => {


### PR DESCRIPTION
## Summary

This is the landable WebXR API basics PR. It keeps the scope to the minimal luma.gl-facing pieces needed by the immersive example and by application code that wants direct WebXR frame/input data:

- WebXR frame/view/input state on `WebXRManager`
- input ray and ray/plane intersection helpers
- controller rays, floor reticles, select targeting, and squeeze state in the example
- focused docs/tests for the basic manager/input surface

The optional capability-manager work has been moved out of this PR and left in the Advanced API RFC/PoC draft (#3092).

## Why

This keeps the first API surface small enough to review and land without committing luma.gl to scene-framework-level WebXR abstractions.

## Validation

- `yarn lint fix`
- `yarn workspace luma.gl-examples-experimental-webxr-kaleidoscope build`
- `yarn test-node modules/experimental/test/webxr/webxr-manager.node.spec.ts modules/experimental/test/webxr/webxr-input.node.spec.ts test/examples/webxr-kaleidoscope.node.spec.ts` was attempted locally but the shared runner stalled without output and was stopped; CI is the source of truth for the full node/browser matrix.

## Notes

Stack order: this PR should land before #3092. #3092 is intentionally draft/RFC until the advanced API shape is reviewed.