### PR TITLE
RFC(webxr): explore advanced capability managers

### DIFF
--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -24,6 +24,7 @@
 - [`WebXRHitTestManager`](/docs/api-reference/experimental/webxr/webxr-hit-test-manager) requests an AR hit-test source and resolves hit poses in the app reference space.
 - [`WebXRAnchorManager`](/docs/api-reference/experimental/webxr/webxr-anchor-manager) creates, tracks, resolves, and deletes AR anchors.
 - [`WebXRLightEstimationManager`](/docs/api-reference/experimental/webxr/webxr-light-estimation-manager) resolves AR light probes, direct-light estimates, spherical harmonics, and optional reflection cube maps.
+- [`getWebXRLocomotionState`](/docs/api-reference/experimental/webxr/webxr-locomotion) derives movement, turn, and snap-turn intent from WebXR gamepad axes.
 - [`WebXRMediaLayerManager`](/docs/api-reference/experimental/webxr/webxr-media-layer-manager) creates video-backed quad, cylinder, and equirect composition layers through the XR compositor.
 - [`WebXRMeshDetectionManager`](/docs/api-reference/experimental/webxr/webxr-mesh-detection-manager) resolves detected AR mesh poses, vertex/index buffers, labels, and added/updated/removed frame diffs.
 - [`WebXRPlaneDetectionManager`](/docs/api-reference/experimental/webxr/webxr-plane-detection-manager) resolves detected AR plane poses, polygons, labels, and added/updated/removed frame diffs.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -26,5 +26,6 @@
 - [`WebXRMediaLayerManager`](/docs/api-reference/experimental/webxr/webxr-media-layer-manager) creates video-backed quad, cylinder, and equirect composition layers through the XR compositor.
 - [`WebXRMeshDetectionManager`](/docs/api-reference/experimental/webxr/webxr-mesh-detection-manager) resolves detected AR mesh poses, vertex/index buffers, labels, and added/updated/removed frame diffs.
 - [`WebXRPlaneDetectionManager`](/docs/api-reference/experimental/webxr/webxr-plane-detection-manager) resolves detected AR plane poses, polygons, labels, and added/updated/removed frame diffs.
+- [`WebXRSessionStateManager`](/docs/api-reference/experimental/webxr/webxr-session-state-manager) tracks session visibility, frame rates, and optional target frame-rate requests.
 
 WebGPU raw camera textures are not part of this v10 work in progress.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -16,7 +16,7 @@
 - [`WebXRCompositionLayerManager`](/docs/api-reference/experimental/webxr/webxr-composition-layer-manager) creates WebGL quad, cylinder, equirect, and cube composition layers, manages common layer controls, and resolves borrowed subimage framebuffers for rendering.
 - [`WebXRDepthSensingManager`](/docs/api-reference/experimental/webxr/webxr-depth-sensing-manager) resolves WebXR depth sensing state from CPU buffers or borrowed WebGL depth textures.
 - [`WebXRDOMOverlayManager`](/docs/api-reference/experimental/webxr/webxr-dom-overlay-manager) tracks DOM overlay state and suppresses XR select events from overlay UI.
-- [`getWebXRGamepadState`](/docs/api-reference/experimental/webxr/webxr-gamepad) snapshots live XR gamepad buttons and axes into stable per-frame state.
+- [`getWebXRGamepadState`](/docs/api-reference/experimental/webxr/webxr-gamepad) snapshots live XR gamepad buttons and axes into stable per-frame state, with optional per-frame action transitions through `WebXRGamepadActionManager`.
 - [`getWebXRHandPinch`](/docs/api-reference/experimental/webxr/webxr-hand-gestures) derives simple thumb-to-finger pinch gestures from tracked hand joints.
 - [`WebXRHandTrackingManager`](/docs/api-reference/experimental/webxr/webxr-hand-tracking-manager) resolves articulated hand joint matrices and radii from WebXR hand input sources.
 - [`WebXRImageTrackingManager`](/docs/api-reference/experimental/webxr/webxr-image-tracking-manager) resolves AR tracked-image poses, tracking states, measured widths, and added/updated/removed frame diffs.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -22,6 +22,7 @@
 - [`WebXRAnchorManager`](/docs/api-reference/experimental/webxr/webxr-anchor-manager) creates, tracks, resolves, and deletes AR anchors.
 - [`WebXRLightEstimationManager`](/docs/api-reference/experimental/webxr/webxr-light-estimation-manager) resolves AR light probes, direct-light estimates, spherical harmonics, and optional reflection cube maps.
 - [`WebXRMediaLayerManager`](/docs/api-reference/experimental/webxr/webxr-media-layer-manager) creates video-backed quad, cylinder, and equirect composition layers through the XR compositor.
+- [`WebXRMeshDetectionManager`](/docs/api-reference/experimental/webxr/webxr-mesh-detection-manager) resolves detected AR mesh poses, vertex/index buffers, labels, and added/updated/removed frame diffs.
 - [`WebXRPlaneDetectionManager`](/docs/api-reference/experimental/webxr/webxr-plane-detection-manager) resolves detected AR plane poses, polygons, labels, and added/updated/removed frame diffs.
 
 WebGPU raw camera textures are not part of this v10 work in progress.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -27,7 +27,7 @@
 - [`WebXRMediaLayerManager`](/docs/api-reference/experimental/webxr/webxr-media-layer-manager) creates video-backed quad, cylinder, and equirect composition layers through the XR compositor.
 - [`WebXRMeshDetectionManager`](/docs/api-reference/experimental/webxr/webxr-mesh-detection-manager) resolves detected AR mesh poses, vertex/index buffers, labels, and added/updated/removed frame diffs.
 - [`WebXRPlaneDetectionManager`](/docs/api-reference/experimental/webxr/webxr-plane-detection-manager) resolves detected AR plane poses, polygons, labels, and added/updated/removed frame diffs.
-- [`WebXRReferenceSpaceManager`](/docs/api-reference/experimental/webxr/webxr-reference-space-manager) tracks reference-space reset events and forwards offset reference-space creation.
+- [`WebXRReferenceSpaceManager`](/docs/api-reference/experimental/webxr/webxr-reference-space-manager) tracks reference-space reset events, forwards offset reference-space creation, and builds bounded teleport offsets.
 - [`WebXRRenderStateManager`](/docs/api-reference/experimental/webxr/webxr-render-state-manager) updates and snapshots WebXR render-state clip planes and inline field of view.
 - [`mergeWebXRSessionInit`](/docs/api-reference/experimental/webxr/webxr-session-init) composes required and optional feature lists from multiple WebXR helper modules.
 - [`WebXRSessionStateManager`](/docs/api-reference/experimental/webxr/webxr-session-state-manager) tracks session visibility, frame rates, and optional target frame-rate requests.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -28,6 +28,7 @@
 - [`WebXRMeshDetectionManager`](/docs/api-reference/experimental/webxr/webxr-mesh-detection-manager) resolves detected AR mesh poses, vertex/index buffers, labels, and added/updated/removed frame diffs.
 - [`WebXRPlaneDetectionManager`](/docs/api-reference/experimental/webxr/webxr-plane-detection-manager) resolves detected AR plane poses, polygons, labels, and added/updated/removed frame diffs.
 - [`WebXRReferenceSpaceManager`](/docs/api-reference/experimental/webxr/webxr-reference-space-manager) tracks reference-space reset events and forwards offset reference-space creation.
+- [`WebXRRenderStateManager`](/docs/api-reference/experimental/webxr/webxr-render-state-manager) updates and snapshots WebXR render-state clip planes and inline field of view.
 - [`WebXRSessionStateManager`](/docs/api-reference/experimental/webxr/webxr-session-state-manager) tracks session visibility, frame rates, and optional target frame-rate requests.
 
 WebGPU raw camera textures are not part of this v10 work in progress.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -13,7 +13,7 @@
 - [`getWebXRBoundsState`](/docs/api-reference/experimental/webxr/webxr-bounds) reads room-scale `bounded-floor` geometry for teleport limits and floor overlays.
 - [`WebXRManager`](/docs/api-reference/experimental/webxr/webxr-manager) prepares WebGPU projection layers or an `XRWebGLLayer`, then resolves per-view framebuffer, viewport, projection, and view matrix state.
 - [`WebXRCameraTexture`](/docs/api-reference/experimental/webxr/webxr-camera-texture) binds WebXR Raw Camera Access as a borrowed read-only WebGL texture sampled through GLSL `sampler2D`.
-- [`WebXRCompositionLayerManager`](/docs/api-reference/experimental/webxr/webxr-composition-layer-manager) creates WebGL quad, cylinder, equirect, and cube composition layers and resolves borrowed subimage framebuffers for rendering.
+- [`WebXRCompositionLayerManager`](/docs/api-reference/experimental/webxr/webxr-composition-layer-manager) creates WebGL quad, cylinder, equirect, and cube composition layers, manages common layer controls, and resolves borrowed subimage framebuffers for rendering.
 - [`WebXRDepthSensingManager`](/docs/api-reference/experimental/webxr/webxr-depth-sensing-manager) resolves WebXR depth sensing state from CPU buffers or borrowed WebGL depth textures.
 - [`WebXRDOMOverlayManager`](/docs/api-reference/experimental/webxr/webxr-dom-overlay-manager) tracks DOM overlay state and suppresses XR select events from overlay UI.
 - [`getWebXRGamepadState`](/docs/api-reference/experimental/webxr/webxr-gamepad) snapshots live XR gamepad buttons and axes into stable per-frame state.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -16,6 +16,7 @@
 - [`WebXRCompositionLayerManager`](/docs/api-reference/experimental/webxr/webxr-composition-layer-manager) creates WebGL quad, cylinder, equirect, and cube composition layers and resolves borrowed subimage framebuffers for rendering.
 - [`WebXRDepthSensingManager`](/docs/api-reference/experimental/webxr/webxr-depth-sensing-manager) resolves WebXR depth sensing state from CPU buffers or borrowed WebGL depth textures.
 - [`WebXRDOMOverlayManager`](/docs/api-reference/experimental/webxr/webxr-dom-overlay-manager) tracks DOM overlay state and suppresses XR select events from overlay UI.
+- [`getWebXRGamepadState`](/docs/api-reference/experimental/webxr/webxr-gamepad) snapshots live XR gamepad buttons and axes into stable per-frame state.
 - [`getWebXRHandPinch`](/docs/api-reference/experimental/webxr/webxr-hand-gestures) derives simple thumb-to-finger pinch gestures from tracked hand joints.
 - [`WebXRHandTrackingManager`](/docs/api-reference/experimental/webxr/webxr-hand-tracking-manager) resolves articulated hand joint matrices and radii from WebXR hand input sources.
 - [`WebXRImageTrackingManager`](/docs/api-reference/experimental/webxr/webxr-image-tracking-manager) resolves AR tracked-image poses, tracking states, measured widths, and added/updated/removed frame diffs.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -22,5 +22,6 @@
 - [`WebXRAnchorManager`](/docs/api-reference/experimental/webxr/webxr-anchor-manager) creates, tracks, resolves, and deletes AR anchors.
 - [`WebXRLightEstimationManager`](/docs/api-reference/experimental/webxr/webxr-light-estimation-manager) resolves AR light probes, direct-light estimates, spherical harmonics, and optional reflection cube maps.
 - [`WebXRMediaLayerManager`](/docs/api-reference/experimental/webxr/webxr-media-layer-manager) creates video-backed quad, cylinder, and equirect composition layers through the XR compositor.
+- [`WebXRPlaneDetectionManager`](/docs/api-reference/experimental/webxr/webxr-plane-detection-manager) resolves detected AR plane poses, polygons, labels, and added/updated/removed frame diffs.
 
 WebGPU raw camera textures are not part of this v10 work in progress.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -13,6 +13,7 @@
 - [`WebXRManager`](/docs/api-reference/experimental/webxr/webxr-manager) prepares WebGPU projection layers or an `XRWebGLLayer`, then resolves per-view framebuffer, viewport, projection, and view matrix state.
 - [`WebXRCameraTexture`](/docs/api-reference/experimental/webxr/webxr-camera-texture) binds WebXR Raw Camera Access as a borrowed read-only WebGL texture sampled through GLSL `sampler2D`.
 - [`WebXRDepthSensingManager`](/docs/api-reference/experimental/webxr/webxr-depth-sensing-manager) resolves WebXR depth sensing state from CPU buffers or borrowed WebGL depth textures.
+- [`WebXRDOMOverlayManager`](/docs/api-reference/experimental/webxr/webxr-dom-overlay-manager) tracks DOM overlay state and suppresses XR select events from overlay UI.
 - [`WebXRHandTrackingManager`](/docs/api-reference/experimental/webxr/webxr-hand-tracking-manager) resolves articulated hand joint matrices and radii from WebXR hand input sources.
 - [`WebXRHitTestManager`](/docs/api-reference/experimental/webxr/webxr-hit-test-manager) requests an AR hit-test source and resolves hit poses in the app reference space.
 - [`WebXRAnchorManager`](/docs/api-reference/experimental/webxr/webxr-anchor-manager) creates, tracks, resolves, and deletes AR anchors.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -29,6 +29,7 @@
 - [`WebXRPlaneDetectionManager`](/docs/api-reference/experimental/webxr/webxr-plane-detection-manager) resolves detected AR plane poses, polygons, labels, and added/updated/removed frame diffs.
 - [`WebXRReferenceSpaceManager`](/docs/api-reference/experimental/webxr/webxr-reference-space-manager) tracks reference-space reset events and forwards offset reference-space creation.
 - [`WebXRRenderStateManager`](/docs/api-reference/experimental/webxr/webxr-render-state-manager) updates and snapshots WebXR render-state clip planes and inline field of view.
+- [`mergeWebXRSessionInit`](/docs/api-reference/experimental/webxr/webxr-session-init) composes required and optional feature lists from multiple WebXR helper modules.
 - [`WebXRSessionStateManager`](/docs/api-reference/experimental/webxr/webxr-session-state-manager) tracks session visibility, frame rates, and optional target frame-rate requests.
 
 WebGPU raw camera textures are not part of this v10 work in progress.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -17,6 +17,7 @@
 - [`WebXRDOMOverlayManager`](/docs/api-reference/experimental/webxr/webxr-dom-overlay-manager) tracks DOM overlay state and suppresses XR select events from overlay UI.
 - [`getWebXRHandPinch`](/docs/api-reference/experimental/webxr/webxr-hand-gestures) derives simple thumb-to-finger pinch gestures from tracked hand joints.
 - [`WebXRHandTrackingManager`](/docs/api-reference/experimental/webxr/webxr-hand-tracking-manager) resolves articulated hand joint matrices and radii from WebXR hand input sources.
+- [`pulseWebXRInputHaptics`](/docs/api-reference/experimental/webxr/webxr-haptics) pulses compatible controller haptic actuators exposed through WebXR input gamepads.
 - [`WebXRHitTestManager`](/docs/api-reference/experimental/webxr/webxr-hit-test-manager) requests an AR hit-test source and resolves hit poses in the app reference space.
 - [`WebXRAnchorManager`](/docs/api-reference/experimental/webxr/webxr-anchor-manager) creates, tracks, resolves, and deletes AR anchors.
 - [`WebXRMediaLayerManager`](/docs/api-reference/experimental/webxr/webxr-media-layer-manager) creates video-backed quad, cylinder, and equirect composition layers through the XR compositor.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -5,12 +5,13 @@
   <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
 </p>
 
-`@luma.gl/experimental` exposes experimental WebGPU and WebGL WebXR session helpers. They stay outside `@luma.gl/engine` because WebXR brings its own session lifecycle, frame scheduler, per-view rendering state, raw camera access, and future input/depth APIs.
+`@luma.gl/experimental` exposes experimental WebGPU and WebGL WebXR session helpers. They stay outside `@luma.gl/engine` because WebXR brings its own session lifecycle, frame scheduler, per-view rendering state, raw camera access, input, hit testing, and future depth APIs.
 
 ## Scope
 
 - [`WebXRAnimationFrameProvider`](/docs/api-reference/experimental/webxr/webxr-manager) drives an engine `AnimationLoop` from `XRSession.requestAnimationFrame()`.
 - [`WebXRManager`](/docs/api-reference/experimental/webxr/webxr-manager) prepares WebGPU projection layers or an `XRWebGLLayer`, then resolves per-view framebuffer, viewport, projection, and view matrix state.
 - [`WebXRCameraTexture`](/docs/api-reference/experimental/webxr/webxr-camera-texture) binds WebXR Raw Camera Access as a borrowed read-only WebGL texture sampled through GLSL `sampler2D`.
+- [`WebXRHitTestManager`](/docs/api-reference/experimental/webxr/webxr-hit-test-manager) requests an AR hit-test source and resolves hit poses in the app reference space.
 
-WebGPU raw camera textures, input sources, hit testing, anchors, depth sensing, and non-projection layers are not part of this v10 work in progress.
+WebGPU raw camera textures, anchors, depth sensing, and non-projection layers are not part of this v10 work in progress.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -12,7 +12,8 @@
 - [`WebXRAnimationFrameProvider`](/docs/api-reference/experimental/webxr/webxr-manager) drives an engine `AnimationLoop` from `XRSession.requestAnimationFrame()`.
 - [`WebXRManager`](/docs/api-reference/experimental/webxr/webxr-manager) prepares WebGPU projection layers or an `XRWebGLLayer`, then resolves per-view framebuffer, viewport, projection, and view matrix state.
 - [`WebXRCameraTexture`](/docs/api-reference/experimental/webxr/webxr-camera-texture) binds WebXR Raw Camera Access as a borrowed read-only WebGL texture sampled through GLSL `sampler2D`.
+- [`WebXRDepthSensingManager`](/docs/api-reference/experimental/webxr/webxr-depth-sensing-manager) resolves WebXR depth sensing state from CPU buffers or borrowed WebGL depth textures.
 - [`WebXRHitTestManager`](/docs/api-reference/experimental/webxr/webxr-hit-test-manager) requests an AR hit-test source and resolves hit poses in the app reference space.
 - [`WebXRAnchorManager`](/docs/api-reference/experimental/webxr/webxr-anchor-manager) creates, tracks, resolves, and deletes AR anchors.
 
-WebGPU raw camera textures, depth sensing, and non-projection layers are not part of this v10 work in progress.
+WebGPU raw camera textures and non-projection layers are not part of this v10 work in progress.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -16,7 +16,7 @@
 - [`WebXRCompositionLayerManager`](/docs/api-reference/experimental/webxr/webxr-composition-layer-manager) creates WebGL quad, cylinder, equirect, and cube composition layers, manages common layer controls, and resolves borrowed subimage framebuffers for rendering.
 - [`WebXRDepthSensingManager`](/docs/api-reference/experimental/webxr/webxr-depth-sensing-manager) resolves WebXR depth sensing state from CPU buffers or borrowed WebGL depth textures.
 - [`WebXRDOMOverlayManager`](/docs/api-reference/experimental/webxr/webxr-dom-overlay-manager) tracks DOM overlay state and suppresses XR select events from overlay UI.
-- [`getWebXRGamepadState`](/docs/api-reference/experimental/webxr/webxr-gamepad) snapshots live XR gamepad buttons and axes into stable per-frame state, with optional per-frame action transitions through `WebXRGamepadActionManager`.
+- [`getWebXRGamepadState`](/docs/api-reference/experimental/webxr/webxr-gamepad) snapshots live XR gamepad buttons and axes into stable per-frame state, with optional per-frame button and axis transitions through `WebXRGamepadActionManager` and `WebXRGamepadAxisManager`.
 - [`getWebXRHandPinch`](/docs/api-reference/experimental/webxr/webxr-hand-gestures) derives simple thumb-to-finger pinch gestures from tracked hand joints.
 - [`WebXRHandTrackingManager`](/docs/api-reference/experimental/webxr/webxr-hand-tracking-manager) resolves articulated hand joint matrices and radii from WebXR hand input sources.
 - [`WebXRImageTrackingManager`](/docs/api-reference/experimental/webxr/webxr-image-tracking-manager) resolves AR tracked-image poses, tracking states, measured widths, and added/updated/removed frame diffs.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -26,6 +26,7 @@
 - [`WebXRMediaLayerManager`](/docs/api-reference/experimental/webxr/webxr-media-layer-manager) creates video-backed quad, cylinder, and equirect composition layers through the XR compositor.
 - [`WebXRMeshDetectionManager`](/docs/api-reference/experimental/webxr/webxr-mesh-detection-manager) resolves detected AR mesh poses, vertex/index buffers, labels, and added/updated/removed frame diffs.
 - [`WebXRPlaneDetectionManager`](/docs/api-reference/experimental/webxr/webxr-plane-detection-manager) resolves detected AR plane poses, polygons, labels, and added/updated/removed frame diffs.
+- [`WebXRReferenceSpaceManager`](/docs/api-reference/experimental/webxr/webxr-reference-space-manager) tracks reference-space reset events and forwards offset reference-space creation.
 - [`WebXRSessionStateManager`](/docs/api-reference/experimental/webxr/webxr-session-state-manager) tracks session visibility, frame rates, and optional target frame-rate requests.
 
 WebGPU raw camera textures are not part of this v10 work in progress.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -12,7 +12,7 @@
 - [`WebXRAnimationFrameProvider`](/docs/api-reference/experimental/webxr/webxr-manager) drives an engine `AnimationLoop` from `XRSession.requestAnimationFrame()`.
 - [`WebXRManager`](/docs/api-reference/experimental/webxr/webxr-manager) prepares WebGPU projection layers or an `XRWebGLLayer`, then resolves per-view framebuffer, viewport, projection, and view matrix state.
 - [`WebXRCameraTexture`](/docs/api-reference/experimental/webxr/webxr-camera-texture) binds WebXR Raw Camera Access as a borrowed read-only WebGL texture sampled through GLSL `sampler2D`.
-- [`WebXRCompositionLayerManager`](/docs/api-reference/experimental/webxr/webxr-composition-layer-manager) creates WebGL quad and cylinder composition layers and resolves borrowed subimage framebuffers for rendering.
+- [`WebXRCompositionLayerManager`](/docs/api-reference/experimental/webxr/webxr-composition-layer-manager) creates WebGL quad, cylinder, equirect, and cube composition layers and resolves borrowed subimage framebuffers for rendering.
 - [`WebXRDepthSensingManager`](/docs/api-reference/experimental/webxr/webxr-depth-sensing-manager) resolves WebXR depth sensing state from CPU buffers or borrowed WebGL depth textures.
 - [`WebXRDOMOverlayManager`](/docs/api-reference/experimental/webxr/webxr-dom-overlay-manager) tracks DOM overlay state and suppresses XR select events from overlay UI.
 - [`WebXRHandTrackingManager`](/docs/api-reference/experimental/webxr/webxr-hand-tracking-manager) resolves articulated hand joint matrices and radii from WebXR hand input sources.
@@ -20,4 +20,4 @@
 - [`WebXRAnchorManager`](/docs/api-reference/experimental/webxr/webxr-anchor-manager) creates, tracks, resolves, and deletes AR anchors.
 - [`WebXRMediaLayerManager`](/docs/api-reference/experimental/webxr/webxr-media-layer-manager) creates video-backed quad, cylinder, and equirect composition layers through the XR compositor.
 
-WebGPU raw camera textures and cube composition layers are not part of this v10 work in progress.
+WebGPU raw camera textures are not part of this v10 work in progress.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -13,6 +13,7 @@
 - [`WebXRManager`](/docs/api-reference/experimental/webxr/webxr-manager) prepares WebGPU projection layers or an `XRWebGLLayer`, then resolves per-view framebuffer, viewport, projection, and view matrix state.
 - [`WebXRCameraTexture`](/docs/api-reference/experimental/webxr/webxr-camera-texture) binds WebXR Raw Camera Access as a borrowed read-only WebGL texture sampled through GLSL `sampler2D`.
 - [`WebXRDepthSensingManager`](/docs/api-reference/experimental/webxr/webxr-depth-sensing-manager) resolves WebXR depth sensing state from CPU buffers or borrowed WebGL depth textures.
+- [`WebXRHandTrackingManager`](/docs/api-reference/experimental/webxr/webxr-hand-tracking-manager) resolves articulated hand joint matrices and radii from WebXR hand input sources.
 - [`WebXRHitTestManager`](/docs/api-reference/experimental/webxr/webxr-hit-test-manager) requests an AR hit-test source and resolves hit poses in the app reference space.
 - [`WebXRAnchorManager`](/docs/api-reference/experimental/webxr/webxr-anchor-manager) creates, tracks, resolves, and deletes AR anchors.
 

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -10,6 +10,7 @@
 ## Scope
 
 - [`WebXRAnimationFrameProvider`](/docs/api-reference/experimental/webxr/webxr-manager) drives an engine `AnimationLoop` from `XRSession.requestAnimationFrame()`.
+- [`getWebXRBoundsState`](/docs/api-reference/experimental/webxr/webxr-bounds) reads room-scale `bounded-floor` geometry for teleport limits and floor overlays.
 - [`WebXRManager`](/docs/api-reference/experimental/webxr/webxr-manager) prepares WebGPU projection layers or an `XRWebGLLayer`, then resolves per-view framebuffer, viewport, projection, and view matrix state.
 - [`WebXRCameraTexture`](/docs/api-reference/experimental/webxr/webxr-camera-texture) binds WebXR Raw Camera Access as a borrowed read-only WebGL texture sampled through GLSL `sampler2D`.
 - [`WebXRCompositionLayerManager`](/docs/api-reference/experimental/webxr/webxr-composition-layer-manager) creates WebGL quad, cylinder, equirect, and cube composition layers and resolves borrowed subimage framebuffers for rendering.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -13,5 +13,6 @@
 - [`WebXRManager`](/docs/api-reference/experimental/webxr/webxr-manager) prepares WebGPU projection layers or an `XRWebGLLayer`, then resolves per-view framebuffer, viewport, projection, and view matrix state.
 - [`WebXRCameraTexture`](/docs/api-reference/experimental/webxr/webxr-camera-texture) binds WebXR Raw Camera Access as a borrowed read-only WebGL texture sampled through GLSL `sampler2D`.
 - [`WebXRHitTestManager`](/docs/api-reference/experimental/webxr/webxr-hit-test-manager) requests an AR hit-test source and resolves hit poses in the app reference space.
+- [`WebXRAnchorManager`](/docs/api-reference/experimental/webxr/webxr-anchor-manager) creates, tracks, resolves, and deletes AR anchors.
 
-WebGPU raw camera textures, anchors, depth sensing, and non-projection layers are not part of this v10 work in progress.
+WebGPU raw camera textures, depth sensing, and non-projection layers are not part of this v10 work in progress.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -12,10 +12,11 @@
 - [`WebXRAnimationFrameProvider`](/docs/api-reference/experimental/webxr/webxr-manager) drives an engine `AnimationLoop` from `XRSession.requestAnimationFrame()`.
 - [`WebXRManager`](/docs/api-reference/experimental/webxr/webxr-manager) prepares WebGPU projection layers or an `XRWebGLLayer`, then resolves per-view framebuffer, viewport, projection, and view matrix state.
 - [`WebXRCameraTexture`](/docs/api-reference/experimental/webxr/webxr-camera-texture) binds WebXR Raw Camera Access as a borrowed read-only WebGL texture sampled through GLSL `sampler2D`.
+- [`WebXRCompositionLayerManager`](/docs/api-reference/experimental/webxr/webxr-composition-layer-manager) creates WebGL quad and cylinder composition layers and resolves borrowed subimage framebuffers for rendering.
 - [`WebXRDepthSensingManager`](/docs/api-reference/experimental/webxr/webxr-depth-sensing-manager) resolves WebXR depth sensing state from CPU buffers or borrowed WebGL depth textures.
 - [`WebXRDOMOverlayManager`](/docs/api-reference/experimental/webxr/webxr-dom-overlay-manager) tracks DOM overlay state and suppresses XR select events from overlay UI.
 - [`WebXRHandTrackingManager`](/docs/api-reference/experimental/webxr/webxr-hand-tracking-manager) resolves articulated hand joint matrices and radii from WebXR hand input sources.
 - [`WebXRHitTestManager`](/docs/api-reference/experimental/webxr/webxr-hit-test-manager) requests an AR hit-test source and resolves hit poses in the app reference space.
 - [`WebXRAnchorManager`](/docs/api-reference/experimental/webxr/webxr-anchor-manager) creates, tracks, resolves, and deletes AR anchors.
 
-WebGPU raw camera textures and non-projection layers are not part of this v10 work in progress.
+WebGPU raw camera textures and media-backed composition layers are not part of this v10 work in progress.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -15,6 +15,7 @@
 - [`WebXRCompositionLayerManager`](/docs/api-reference/experimental/webxr/webxr-composition-layer-manager) creates WebGL quad, cylinder, equirect, and cube composition layers and resolves borrowed subimage framebuffers for rendering.
 - [`WebXRDepthSensingManager`](/docs/api-reference/experimental/webxr/webxr-depth-sensing-manager) resolves WebXR depth sensing state from CPU buffers or borrowed WebGL depth textures.
 - [`WebXRDOMOverlayManager`](/docs/api-reference/experimental/webxr/webxr-dom-overlay-manager) tracks DOM overlay state and suppresses XR select events from overlay UI.
+- [`getWebXRHandPinch`](/docs/api-reference/experimental/webxr/webxr-hand-gestures) derives simple thumb-to-finger pinch gestures from tracked hand joints.
 - [`WebXRHandTrackingManager`](/docs/api-reference/experimental/webxr/webxr-hand-tracking-manager) resolves articulated hand joint matrices and radii from WebXR hand input sources.
 - [`WebXRHitTestManager`](/docs/api-reference/experimental/webxr/webxr-hit-test-manager) requests an AR hit-test source and resolves hit poses in the app reference space.
 - [`WebXRAnchorManager`](/docs/api-reference/experimental/webxr/webxr-anchor-manager) creates, tracks, resolves, and deletes AR anchors.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -18,5 +18,6 @@
 - [`WebXRHandTrackingManager`](/docs/api-reference/experimental/webxr/webxr-hand-tracking-manager) resolves articulated hand joint matrices and radii from WebXR hand input sources.
 - [`WebXRHitTestManager`](/docs/api-reference/experimental/webxr/webxr-hit-test-manager) requests an AR hit-test source and resolves hit poses in the app reference space.
 - [`WebXRAnchorManager`](/docs/api-reference/experimental/webxr/webxr-anchor-manager) creates, tracks, resolves, and deletes AR anchors.
+- [`WebXRMediaLayerManager`](/docs/api-reference/experimental/webxr/webxr-media-layer-manager) creates video-backed quad, cylinder, and equirect composition layers through the XR compositor.
 
-WebGPU raw camera textures and media-backed composition layers are not part of this v10 work in progress.
+WebGPU raw camera textures and cube composition layers are not part of this v10 work in progress.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -17,6 +17,7 @@
 - [`WebXRDOMOverlayManager`](/docs/api-reference/experimental/webxr/webxr-dom-overlay-manager) tracks DOM overlay state and suppresses XR select events from overlay UI.
 - [`getWebXRHandPinch`](/docs/api-reference/experimental/webxr/webxr-hand-gestures) derives simple thumb-to-finger pinch gestures from tracked hand joints.
 - [`WebXRHandTrackingManager`](/docs/api-reference/experimental/webxr/webxr-hand-tracking-manager) resolves articulated hand joint matrices and radii from WebXR hand input sources.
+- [`WebXRImageTrackingManager`](/docs/api-reference/experimental/webxr/webxr-image-tracking-manager) resolves AR tracked-image poses, tracking states, measured widths, and added/updated/removed frame diffs.
 - [`pulseWebXRInputHaptics`](/docs/api-reference/experimental/webxr/webxr-haptics) pulses compatible controller haptic actuators exposed through WebXR input gamepads.
 - [`WebXRHitTestManager`](/docs/api-reference/experimental/webxr/webxr-hit-test-manager) requests an AR hit-test source and resolves hit poses in the app reference space.
 - [`WebXRAnchorManager`](/docs/api-reference/experimental/webxr/webxr-anchor-manager) creates, tracks, resolves, and deletes AR anchors.

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -20,6 +20,7 @@
 - [`pulseWebXRInputHaptics`](/docs/api-reference/experimental/webxr/webxr-haptics) pulses compatible controller haptic actuators exposed through WebXR input gamepads.
 - [`WebXRHitTestManager`](/docs/api-reference/experimental/webxr/webxr-hit-test-manager) requests an AR hit-test source and resolves hit poses in the app reference space.
 - [`WebXRAnchorManager`](/docs/api-reference/experimental/webxr/webxr-anchor-manager) creates, tracks, resolves, and deletes AR anchors.
+- [`WebXRLightEstimationManager`](/docs/api-reference/experimental/webxr/webxr-light-estimation-manager) resolves AR light probes, direct-light estimates, spherical harmonics, and optional reflection cube maps.
 - [`WebXRMediaLayerManager`](/docs/api-reference/experimental/webxr/webxr-media-layer-manager) creates video-backed quad, cylinder, and equirect composition layers through the XR compositor.
 
 WebGPU raw camera textures are not part of this v10 work in progress.

--- a/docs/api-reference/experimental/webxr/webxr-anchor-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-anchor-manager.md
@@ -1,0 +1,94 @@
+# WebXRAnchorManager
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRAnchorManager` is the experimental AR anchor lifecycle helper for luma.gl. It creates anchors from an active `XRFrame` or from AR hit-test results, tracks browser-owned anchors, resolves per-frame anchor poses in the app reference space, and deletes anchors when the session ends or is cleared.
+
+## Usage
+
+```typescript
+import {WebXRAnchorManager} from '@luma.gl/experimental';
+
+const anchorManager = new WebXRAnchorManager();
+anchorManager.setSession(session, webXRManager.referenceSpace);
+
+const anchor = await anchorManager.createAnchor(xrFrame, placementPose.transform);
+const anchorState = anchorManager.getAnchorState(xrFrame);
+const firstAnchorMatrix = anchorState?.anchors[0]?.matrix;
+
+anchorManager.deleteAnchor(anchor);
+```
+
+Request the WebXR `anchors` feature when starting an AR session:
+
+```typescript
+const session = await navigator.xr.requestSession('immersive-ar', {
+  optionalFeatures: ['anchors', 'hit-test', 'local-floor']
+});
+```
+
+Anchors can also be created directly from hit-test results when the browser supports `XRHitTestResult.createAnchor()`:
+
+```typescript
+const hitTestState = webXRHitTestManager.getHitTestState(xrFrame);
+const hit = hitTestState?.hits[0];
+const anchor = hit && (await anchorManager.createAnchorFromHitTestResult(hit.xrHitTestResult));
+```
+
+## Types
+
+### `WebXRAnchorPose`
+
+```ts
+export type WebXRAnchorPose = {
+  anchor: XRAnchor;
+  pose: XRPose;
+  matrix: Float32Array;
+};
+```
+
+### `WebXRAnchorState`
+
+```ts
+export type WebXRAnchorState = {
+  xrFrame: XRFrame;
+  anchors: readonly WebXRAnchorPose[];
+};
+```
+
+## Methods
+
+### `constructor()`
+
+Creates an experimental anchor manager.
+
+### `setSession(session: XRSession | null, referenceSpace: XRReferenceSpace | null): this`
+
+Attaches or clears the current XR session. A reference space is required for active sessions because anchor poses are resolved into that app space.
+
+### `createAnchor(xrFrame: XRFrame, pose: XRRigidTransform, space?: XRSpace): Promise<XRAnchor>`
+
+Creates and tracks an anchor through `XRFrame.createAnchor()`. The manager uses the app reference space when `space` is not provided.
+
+### `createAnchorFromHitTestResult(xrHitTestResult: XRHitTestResult): Promise<XRAnchor>`
+
+Creates and tracks an anchor through `XRHitTestResult.createAnchor()`.
+
+### `getAnchorState(xrFrame: XRFrame): WebXRAnchorState | null`
+
+Resolves tracked anchor poses for the current XR frame. When the frame exposes `trackedAnchors`, anchors that are no longer tracked by the browser are removed from the manager.
+
+### `deleteAnchor(anchor: XRAnchor): void`
+
+Deletes a tracked anchor and removes it from the manager.
+
+### `clearSession(): void`
+
+Deletes tracked anchors and releases session references without ending the browser XR session.
+
+### `destroy(): void`
+
+Clears the current session wrappers.

--- a/docs/api-reference/experimental/webxr/webxr-bounds.md
+++ b/docs/api-reference/experimental/webxr/webxr-bounds.md
@@ -1,0 +1,66 @@
+# WebXR Bounds
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`getWebXRBoundsState` is an experimental helper for reading room-scale bounds from a `bounded-floor` reference space. It converts `XRBoundedReferenceSpace.boundsGeometry` into numeric points and derives simple center, size, and radius metrics for teleport limits, floor overlays, and room-scale UI.
+
+## Usage
+
+```typescript
+import {getWebXRBoundsState, isPointInWebXRBounds} from '@luma.gl/experimental';
+
+await webXRManager.setSession(session, {
+  referenceSpaceTypes: ['bounded-floor', 'local-floor', 'local']
+});
+
+const boundsState = getWebXRBoundsState(webXRManager.referenceSpace);
+if (!boundsState || isPointInWebXRBounds(teleportTarget, boundsState.bounds)) {
+  // Move within the bounded room, or allow movement when no bounds are available.
+}
+```
+
+Request `bounded-floor` as an optional feature when starting an immersive session:
+
+```typescript
+const session = await navigator.xr.requestSession('immersive-vr', {
+  optionalFeatures: ['bounded-floor', 'local-floor']
+});
+```
+
+## Types
+
+### `WebXRBoundsPoint`
+
+```ts
+export type WebXRBoundsPoint = [x: number, y: number, z: number];
+```
+
+### `WebXRBoundsState`
+
+```ts
+export type WebXRBoundsState = {
+  referenceSpace: XRBoundedReferenceSpace;
+  boundsGeometry: readonly DOMPointReadOnly[];
+  bounds: readonly WebXRBoundsPoint[];
+  center: WebXRBoundsPoint;
+  size: WebXRBoundsPoint;
+  radius: number;
+};
+```
+
+## Functions
+
+### `getWebXRBoundsState(referenceSpace: XRReferenceSpace | null): WebXRBoundsState | null`
+
+Returns bounded reference-space geometry and derived metrics, or `null` when the current reference space is not bounded.
+
+### `isWebXRBoundedReferenceSpace(referenceSpace: XRReferenceSpace | null): referenceSpace is XRBoundedReferenceSpace`
+
+Returns whether a reference space exposes `boundsGeometry`.
+
+### `isPointInWebXRBounds(point: readonly [number, number, number], bounds: readonly WebXRBoundsPoint[]): boolean`
+
+Returns whether a point lies inside the horizontal X/Z polygon defined by `bounds`.

--- a/docs/api-reference/experimental/webxr/webxr-composition-layer-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-composition-layer-manager.md
@@ -1,0 +1,139 @@
+# WebXRCompositionLayerManager
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRCompositionLayerManager` is the experimental WebXR Layers API helper for WebGL composition layers. It creates quad and cylinder layers through `XRWebGLBinding`, resolves `XRWebGLSubImage` objects during an active XR animation frame, and exposes borrowed luma.gl texture and framebuffer wrappers for rendering into those browser-owned opaque textures.
+
+Use this manager for high-fidelity XR panels, HUDs, and curved UI surfaces that should be composited by the XR runtime instead of drawn into the main projection layer.
+
+## Usage
+
+Request the WebXR `layers` feature when starting the immersive session:
+
+```typescript
+import {
+  WebXRCompositionLayerManager,
+  getWebXRLayersSessionInit
+} from '@luma.gl/experimental';
+
+const session = await navigator.xr.requestSession('immersive-vr', {
+  ...getWebXRLayersSessionInit(),
+  optionalFeatures: ['layers', 'local-floor']
+});
+```
+
+Create a layer after the session and reference space are ready:
+
+```typescript
+const layerManager = new WebXRCompositionLayerManager(device);
+await layerManager.setSession(session);
+
+const quadLayer = layerManager.createQuadLayer({
+  space: referenceSpace,
+  viewPixelWidth: 1024,
+  viewPixelHeight: 512,
+  width: 1.2,
+  height: 0.6,
+  layout: 'mono'
+});
+
+await layerManager.updateRenderState([quadLayer]);
+```
+
+During an XR animation frame, resolve a framebuffer and draw into it:
+
+```typescript
+const layerState = layerManager.getLayerState(xrFrame, quadLayer);
+if (layerState && layerState.needsRedraw) {
+  device.submitPass({
+    framebuffer: layerState.framebuffer,
+    parameters: {
+      viewport: layerState.viewport
+    }
+  });
+}
+```
+
+The returned textures wrap opaque browser-owned `WebGLTexture` handles. They are only valid while the browser reports them through `XRWebGLBinding.getSubImage()` and should not be destroyed directly.
+
+## Types
+
+### `WebXRCompositionLayerManagerProps`
+
+```ts
+export type WebXRCompositionLayerManagerProps = {
+  colorTextureFormat?: TextureFormat;
+  depthStencilTextureFormat?: TextureFormat;
+  textureUsage?: number;
+};
+```
+
+### `WebXRLayersSessionInitProps`
+
+```ts
+export type WebXRLayersSessionInitProps = {
+  required?: boolean;
+};
+```
+
+### `WebXRCompositionLayerState`
+
+```ts
+export type WebXRCompositionLayerState = {
+  xrFrame: XRFrame;
+  session: XRSession;
+  layer: XRCompositionLayer;
+  subImage: XRWebGLSubImage;
+  framebuffer: Framebuffer;
+  colorTexture: Texture;
+  depthStencilTexture: Texture | null;
+  viewport: [x: number, y: number, width: number, height: number];
+  eye: XREye;
+  layout: XRLayerLayout;
+  needsRedraw: boolean;
+  imageIndex: number | null;
+};
+```
+
+## Methods
+
+### `constructor(device: Device, props?: WebXRCompositionLayerManagerProps)`
+
+Creates a WebGL composition-layer manager. WebXR composition layers are WebGL-only in this helper because the current WebXR Layers API exposes non-projection layer creation through `XRWebGLBinding` and `XRMediaBinding`.
+
+### `setSession(session: XRSession | null): Promise<this>`
+
+Attaches or clears the current XR session. The manager calls `makeXRCompatible()` before creating its `XRWebGLBinding`.
+
+### `createQuadLayer(init: XRQuadLayerInit): XRQuadLayer`
+
+Creates and tracks an `XRQuadLayer`.
+
+### `createCylinderLayer(init: XRCylinderLayerInit): XRCylinderLayer`
+
+Creates and tracks an `XRCylinderLayer`.
+
+### `updateRenderState(layers: readonly XRLayer[]): Promise<void>`
+
+Updates the session render state with the supplied WebXR layers.
+
+### `getLayerState(xrFrame: XRFrame, layer: XRCompositionLayer, eye?: XREye): WebXRCompositionLayerState | null`
+
+Resolves the current `XRWebGLSubImage`, borrowed luma texture wrappers, and framebuffer for a composition layer during an active XR animation frame.
+
+### `clearSession(): void`
+
+Releases borrowed luma wrappers, removes event listeners, and clears session references without ending the browser XR session.
+
+### `destroy(): void`
+
+Clears the current session wrappers.
+
+## Functions
+
+### `getWebXRLayersSessionInit(props?: WebXRLayersSessionInitProps): XRSessionInit`
+
+Builds a minimal `XRSessionInit` fragment for requesting the `layers` feature.

--- a/docs/api-reference/experimental/webxr/webxr-composition-layer-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-composition-layer-manager.md
@@ -5,7 +5,7 @@
   <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
 </p>
 
-`WebXRCompositionLayerManager` is the experimental WebXR Layers API helper for WebGL composition layers. It creates quad and cylinder layers through `XRWebGLBinding`, resolves `XRWebGLSubImage` objects during an active XR animation frame, and exposes borrowed luma.gl texture and framebuffer wrappers for rendering into those browser-owned opaque textures.
+`WebXRCompositionLayerManager` is the experimental WebXR Layers API helper for WebGL composition layers. It creates quad, cylinder, equirect, and cube layers through `XRWebGLBinding`, resolves `XRWebGLSubImage` objects during an active XR animation frame, and exposes borrowed luma.gl texture and framebuffer wrappers for rendering into those browser-owned opaque textures.
 
 Use this manager for high-fidelity XR panels, HUDs, and curved UI surfaces that should be composited by the XR runtime instead of drawn into the main projection layer.
 
@@ -115,6 +115,14 @@ Creates and tracks an `XRQuadLayer`.
 ### `createCylinderLayer(init: XRCylinderLayerInit): XRCylinderLayer`
 
 Creates and tracks an `XRCylinderLayer`.
+
+### `createEquirectLayer(init: XREquirectLayerInit): XREquirectLayer`
+
+Creates and tracks an `XREquirectLayer`.
+
+### `createCubeLayer(init: XRCubeLayerInit): XRCubeLayer`
+
+Creates and tracks an `XRCubeLayer`.
 
 ### `updateRenderState(layers: readonly XRLayer[]): Promise<void>`
 

--- a/docs/api-reference/experimental/webxr/webxr-composition-layer-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-composition-layer-manager.md
@@ -102,7 +102,7 @@ export type WebXRCompositionLayerState = {
 
 ### `constructor(device: Device, props?: WebXRCompositionLayerManagerProps)`
 
-Creates a WebGL composition-layer manager. WebXR composition layers are WebGL-only in this helper because the current WebXR Layers API exposes non-projection layer creation through `XRWebGLBinding` and `XRMediaBinding`.
+Creates a WebGL composition-layer manager. This helper is for renderable WebGL layers created through `XRWebGLBinding`. Use `WebXRMediaLayerManager` for video-backed layers created through `XRMediaBinding`.
 
 ### `setSession(session: XRSession | null): Promise<this>`
 

--- a/docs/api-reference/experimental/webxr/webxr-composition-layer-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-composition-layer-manager.md
@@ -86,6 +86,7 @@ export type WebXRCompositionLayerState = {
   xrFrame: XRFrame;
   session: XRSession;
   layer: XRCompositionLayer;
+  controls: WebXRCompositionLayerControlsState;
   subImage: XRWebGLSubImage;
   framebuffer: Framebuffer;
   colorTexture: Texture;
@@ -95,6 +96,31 @@ export type WebXRCompositionLayerState = {
   layout: XRLayerLayout;
   needsRedraw: boolean;
   imageIndex: number | null;
+};
+```
+
+### `WebXRCompositionLayerControlsProps`
+
+```ts
+export type WebXRCompositionLayerControlsProps = {
+  blendTextureSourceAlpha?: boolean;
+  forceMonoPresentation?: boolean;
+  opacity?: number;
+  quality?: XRLayerQuality;
+};
+```
+
+### `WebXRCompositionLayerControlsState`
+
+```ts
+export type WebXRCompositionLayerControlsState = {
+  layer: XRCompositionLayer;
+  blendTextureSourceAlpha: boolean;
+  forceMonoPresentation: boolean;
+  opacity: number;
+  mipLevels: number;
+  quality: XRLayerQuality;
+  needsRedraw: boolean;
 };
 ```
 
@@ -124,6 +150,18 @@ Creates and tracks an `XREquirectLayer`.
 
 Creates and tracks an `XRCubeLayer`.
 
+### `setLayerControls(layer: XRCompositionLayer, props: WebXRCompositionLayerControlsProps): WebXRCompositionLayerControlsState`
+
+Updates common composition-layer controls such as opacity, source alpha blending, mono presentation, and compositor quality.
+
+### `getLayerControls(layer: XRCompositionLayer): WebXRCompositionLayerControlsState`
+
+Returns common composition-layer controls without resolving a frame subimage.
+
+### `destroyLayer(layer: XRCompositionLayer): void`
+
+Removes event listeners, releases luma wrapper resources, and calls `XRCompositionLayer.destroy()` for a tracked layer.
+
 ### `updateRenderState(layers: readonly XRLayer[]): Promise<void>`
 
 Updates the session render state with the supplied WebXR layers.
@@ -145,3 +183,11 @@ Clears the current session wrappers.
 ### `getWebXRLayersSessionInit(props?: WebXRLayersSessionInitProps): XRSessionInit`
 
 Builds a minimal `XRSessionInit` fragment for requesting the `layers` feature.
+
+### `setWebXRCompositionLayerControls(layer, props): WebXRCompositionLayerControlsState`
+
+Updates common controls on any `XRCompositionLayer` and returns the resulting state.
+
+### `getWebXRCompositionLayerControls(layer, needsRedrawOverride?): WebXRCompositionLayerControlsState`
+
+Returns a snapshot of common composition-layer controls. `needsRedrawOverride` can include manager-observed redraw events that have not yet been consumed by `getLayerState()`.

--- a/docs/api-reference/experimental/webxr/webxr-depth-sensing-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-depth-sensing-manager.md
@@ -1,0 +1,129 @@
+# WebXRDepthSensingManager
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRDepthSensingManager` is the experimental AR depth-sensing helper for luma.gl. It resolves CPU depth data from `XRFrame.getDepthInformation(view)` and WebGL depth data from `XRWebGLBinding.getDepthInformation(view)`, wrapping browser-owned WebGL depth textures as borrowed luma [`Texture`](/docs/api-reference/core/resources/texture) objects.
+
+## Usage
+
+```typescript
+import {WebXRDepthSensingManager, getWebXRDepthSensingSessionInit} from '@luma.gl/experimental';
+
+const session = await navigator.xr.requestSession('immersive-ar', {
+  ...getWebXRDepthSensingSessionInit(),
+  optionalFeatures: ['depth-sensing', 'local-floor']
+});
+
+const depthManager = new WebXRDepthSensingManager();
+depthManager.setSession(session);
+depthManager.setWebGLBinding(device, xrWebGLBinding);
+
+const depthState = depthManager.getDepthState(
+  xrFrame,
+  frameState.views.map(view => view.xrView)
+);
+const firstDepthTexture = depthState?.views[0]?.texture;
+```
+
+When requesting `depth-sensing`, WebXR requires a `depthSensing` object with usage and data-format preferences:
+
+```typescript
+const sessionInit = {
+  optionalFeatures: ['depth-sensing'],
+  depthSensing: {
+    usagePreference: ['cpu-optimized', 'gpu-optimized'],
+    dataFormatPreference: ['luminance-alpha', 'float32', 'unsigned-short']
+  }
+};
+```
+
+## Types
+
+### `WebXRDepthSensingManagerProps`
+
+```ts
+export type WebXRDepthSensingManagerProps = {
+  textureFormat?: TextureFormat;
+  textureUsage?: number;
+};
+```
+
+### `WebXRDepthSensingSessionInitProps`
+
+```ts
+export type WebXRDepthSensingSessionInitProps = {
+  required?: boolean;
+  usagePreference?: XRDepthUsage[];
+  dataFormatPreference?: XRDepthDataFormat[];
+  depthTypeRequest?: XRDepthType[];
+  matchDepthView?: boolean;
+};
+```
+
+### `WebXRDepthViewState`
+
+```ts
+export type WebXRDepthViewState = {
+  xrView: XRView;
+  depthInformation: XRDepthInformation;
+  cpuDepthInformation: XRCPUDepthInformation | null;
+  webGLDepthInformation: XRWebGLDepthInformation | null;
+  texture: Texture | null;
+  width: number;
+  height: number;
+  rawValueToMeters: number;
+  normDepthBufferFromNormView: XRRigidTransform;
+  matrix: Float32Array;
+  textureType: XRTextureType | null;
+  imageIndex: number | null;
+};
+```
+
+### `WebXRDepthState`
+
+```ts
+export type WebXRDepthState = {
+  xrFrame: XRFrame;
+  session: XRSession;
+  views: readonly WebXRDepthViewState[];
+};
+```
+
+## Methods
+
+### `constructor(props?: WebXRDepthSensingManagerProps)`
+
+Creates an experimental depth-sensing manager.
+
+### `setSession(session: XRSession | null): this`
+
+Attaches or clears the current XR session. Session end clears borrowed texture wrappers.
+
+### `setWebGLBinding(device: Device | null, xrWebGLBinding: XRWebGLBinding | null): this`
+
+Attaches a WebGL device and `XRWebGLBinding` for GPU-optimized depth sensing. Omit this for CPU-only depth access.
+
+### `getDepthState(xrFrame: XRFrame, xrViews: readonly XRView[]): WebXRDepthState | null`
+
+Resolves depth information for the supplied XR views. Returns `null` when depth sensing is inactive, unsupported, unavailable for the current frame, or when all supplied views lack depth data.
+
+### `clearSession(): void`
+
+Releases session references and destroys borrowed luma texture wrappers without ending the browser XR session.
+
+### `destroy(): void`
+
+Clears the current session wrappers and WebGL binding references.
+
+## Functions
+
+### `getWebXRDepthSensingSessionInit(props?: WebXRDepthSensingSessionInitProps): XRSessionInit`
+
+Builds a minimal `XRSessionInit` fragment for requesting the WebXR `depth-sensing` feature with valid `depthSensing` preferences.
+
+### `getWebXRDepthTextureFormat(depthDataFormat?: XRDepthDataFormat | null): TextureFormat`
+
+Maps WebXR depth data formats to luma texture-format metadata: `luminance-alpha` to `rg8unorm`, `float32` to `r32float`, and `unsigned-short` to `r16uint`.

--- a/docs/api-reference/experimental/webxr/webxr-dom-overlay-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-dom-overlay-manager.md
@@ -1,0 +1,90 @@
+# WebXRDOMOverlayManager
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRDOMOverlayManager` is the experimental DOM overlay helper for luma.gl. It tracks `XRSession.domOverlayState`, keeps the overlay root associated with the active session, and suppresses `beforexrselect` on overlay UI so DOM controls do not also trigger XR world selection.
+
+## Usage
+
+```typescript
+import {WebXRDOMOverlayManager, getWebXRDOMOverlaySessionInit} from '@luma.gl/experimental';
+
+const overlayRoot = document.getElementById('xr-ui');
+const session = await navigator.xr.requestSession('immersive-ar', {
+  ...getWebXRDOMOverlaySessionInit(overlayRoot),
+  optionalFeatures: ['dom-overlay', 'local-floor']
+});
+
+const overlayManager = new WebXRDOMOverlayManager({root: overlayRoot});
+overlayManager.setSession(session);
+const overlayState = overlayManager.getOverlayState();
+```
+
+Request the WebXR `dom-overlay` feature with a root element:
+
+```typescript
+const sessionInit = {
+  optionalFeatures: ['dom-overlay'],
+  domOverlay: {root: overlayRoot}
+};
+```
+
+## Types
+
+### `WebXRDOMOverlayManagerProps`
+
+```ts
+export type WebXRDOMOverlayManagerProps = {
+  root?: Element | null;
+  suppressXRSelectEvents?: boolean;
+};
+```
+
+### `WebXRDOMOverlaySessionInitProps`
+
+```ts
+export type WebXRDOMOverlaySessionInitProps = {
+  required?: boolean;
+};
+```
+
+### `WebXRDOMOverlayState`
+
+```ts
+export type WebXRDOMOverlayState = {
+  session: XRSession;
+  root: Element | null;
+  type: XRDOMOverlayType;
+};
+```
+
+## Methods
+
+### `constructor(props?: WebXRDOMOverlayManagerProps)`
+
+Creates an experimental DOM overlay manager.
+
+### `setSession(session: XRSession | null, props?: WebXRDOMOverlayManagerProps): this`
+
+Attaches or clears the current XR session. When `suppressXRSelectEvents` is true, the manager calls `preventDefault()` for `beforexrselect` events on the overlay root.
+
+### `getOverlayState(): WebXRDOMOverlayState | null`
+
+Returns active DOM overlay state, or `null` when the browser did not enable the feature.
+
+### `clearSession(): void`
+
+Releases session references and removes overlay event listeners without ending the browser XR session.
+
+### `destroy(): void`
+
+Clears the current session wrappers.
+
+## Functions
+
+### `getWebXRDOMOverlaySessionInit(root: Element, props?: WebXRDOMOverlaySessionInitProps): XRSessionInit`
+
+Builds a minimal `XRSessionInit` fragment for requesting `dom-overlay` with a root element.

--- a/docs/api-reference/experimental/webxr/webxr-gamepad.md
+++ b/docs/api-reference/experimental/webxr/webxr-gamepad.md
@@ -9,14 +9,19 @@
 
 For `xr-standard` mappings, the helper names the reserved indices: trigger, squeeze, touchpad, thumbstick, touchpad axes, and thumbstick axes. Nonstandard mappings keep generic `button-N` and `axis-N` names because their layout is runtime specific.
 
-`WebXRGamepadActionManager` keeps the previous frame's button states and reports transitions such as `pressStarted`, `pressEnded`, `touchStarted`, and `valueDelta`.
+`WebXRGamepadActionManager` keeps the previous frame's button states and reports transitions such as `pressStarted`, `pressEnded`, `touchStarted`, and `valueDelta`. `WebXRGamepadAxisManager` does the same for axis values, with a configurable dead zone for `activeStarted` and `activeEnded`.
 
 ## Usage
 
 ```typescript
-import {WebXRGamepadActionManager, getWebXRGamepadState} from '@luma.gl/experimental';
+import {
+  WebXRGamepadActionManager,
+  WebXRGamepadAxisManager,
+  getWebXRGamepadState
+} from '@luma.gl/experimental';
 
 const gamepadActions = new WebXRGamepadActionManager();
+const gamepadAxes = new WebXRGamepadAxisManager();
 
 const inputStates = webXRManager.getInputState(xrFrame);
 for (const inputState of inputStates || []) {
@@ -30,6 +35,12 @@ for (const inputState of inputStates || []) {
 for (const action of gamepadActions.update(inputStates)) {
   if (action.name === 'trigger' && action.pressStarted) {
     // Trigger was pressed this frame.
+  }
+}
+
+for (const axis of gamepadAxes.update(inputStates, {deadzone: 0.2})) {
+  if (axis.name === 'thumbstick-y' && axis.active) {
+    // Use axis.value for locomotion or scrolling.
   }
 }
 ```
@@ -77,6 +88,44 @@ export type WebXRGamepadAxisState = {
   index: number;
   name: WebXRGamepadAxisName;
   value: number;
+};
+```
+
+### `WebXRGamepadAxisActionProps`
+
+```ts
+export type WebXRGamepadAxisActionProps = {
+  deadzone?: number;
+};
+```
+
+### `WebXRGamepadPreviousAxisState`
+
+```ts
+export type WebXRGamepadPreviousAxisState = {
+  value: number;
+  active: boolean;
+};
+```
+
+### `WebXRGamepadAxisActionState`
+
+```ts
+export type WebXRGamepadAxisActionState = {
+  inputState: WebXRInputState;
+  inputSource: XRInputSource;
+  gamepadState: WebXRGamepadState;
+  axis: WebXRGamepadAxisState;
+  index: number;
+  name: WebXRGamepadAxisName;
+  value: number;
+  previousValue: number;
+  valueDelta: number;
+  deadzone: number;
+  active: boolean;
+  wasActive: boolean;
+  activeStarted: boolean;
+  activeEnded: boolean;
 };
 ```
 
@@ -150,6 +199,10 @@ Returns snapshots for all input states with gamepads.
 
 Returns one button action state by comparing the current snapshot with an optional previous button state.
 
+### `getWebXRGamepadAxisActionState(gamepadState, axis, props?): WebXRGamepadAxisActionState`
+
+Returns one axis action state by comparing the current snapshot with an optional previous axis state. The `deadzone` option is clamped to the `[0, 1]` range and defaults to `0.15`.
+
 ### `WebXRGamepadActionManager`
 
 Tracks previous button state by `XRInputSource` identity.
@@ -161,3 +214,15 @@ Snapshots all current gamepads and returns one action state per button. Input so
 ### `reset(inputSource?: XRInputSource): void`
 
 Clears the previous-state cache for one input source, or for every tracked input source when omitted.
+
+### `WebXRGamepadAxisManager`
+
+Tracks previous axis state by `XRInputSource` identity.
+
+### `update(inputStates: readonly WebXRInputState[] | null, props?: WebXRGamepadAxisActionProps): readonly WebXRGamepadAxisActionState[]`
+
+Snapshots all current gamepad axes and returns one action state per axis. Input sources missing from the current frame are removed from the previous-state cache.
+
+### `reset(inputSource?: XRInputSource): void`
+
+Clears the previous-axis cache for one input source, or for every tracked input source when omitted.

--- a/docs/api-reference/experimental/webxr/webxr-gamepad.md
+++ b/docs/api-reference/experimental/webxr/webxr-gamepad.md
@@ -9,10 +9,14 @@
 
 For `xr-standard` mappings, the helper names the reserved indices: trigger, squeeze, touchpad, thumbstick, touchpad axes, and thumbstick axes. Nonstandard mappings keep generic `button-N` and `axis-N` names because their layout is runtime specific.
 
+`WebXRGamepadActionManager` keeps the previous frame's button states and reports transitions such as `pressStarted`, `pressEnded`, `touchStarted`, and `valueDelta`.
+
 ## Usage
 
 ```typescript
-import {getWebXRGamepadState} from '@luma.gl/experimental';
+import {WebXRGamepadActionManager, getWebXRGamepadState} from '@luma.gl/experimental';
+
+const gamepadActions = new WebXRGamepadActionManager();
 
 const inputStates = webXRManager.getInputState(xrFrame);
 for (const inputState of inputStates || []) {
@@ -20,6 +24,12 @@ for (const inputState of inputStates || []) {
   const trigger = gamepadState?.primaryTrigger?.value || 0;
   if (trigger > 0.25) {
     // Use analog trigger input for selection, locomotion, or UI.
+  }
+}
+
+for (const action of gamepadActions.update(inputStates)) {
+  if (action.name === 'trigger' && action.pressStarted) {
+    // Trigger was pressed this frame.
   }
 }
 ```
@@ -70,6 +80,40 @@ export type WebXRGamepadAxisState = {
 };
 ```
 
+### `WebXRGamepadPreviousButtonState`
+
+```ts
+export type WebXRGamepadPreviousButtonState = {
+  value: number;
+  pressed: boolean;
+  touched: boolean;
+};
+```
+
+### `WebXRGamepadButtonActionState`
+
+```ts
+export type WebXRGamepadButtonActionState = {
+  inputState: WebXRInputState;
+  inputSource: XRInputSource;
+  gamepadState: WebXRGamepadState;
+  button: WebXRGamepadButtonState;
+  index: number;
+  name: WebXRGamepadButtonName;
+  value: number;
+  previousValue: number;
+  valueDelta: number;
+  pressed: boolean;
+  wasPressed: boolean;
+  pressStarted: boolean;
+  pressEnded: boolean;
+  touched: boolean;
+  wasTouched: boolean;
+  touchStarted: boolean;
+  touchEnded: boolean;
+};
+```
+
 ### `WebXRGamepadState`
 
 ```ts
@@ -101,3 +145,19 @@ Returns a per-frame snapshot for the input state's gamepad, or `null` when the i
 ### `getWebXRGamepadStates(inputStates: readonly WebXRInputState[] | null): readonly WebXRGamepadState[]`
 
 Returns snapshots for all input states with gamepads.
+
+### `getWebXRGamepadButtonActionState(gamepadState, button, previousButton?): WebXRGamepadButtonActionState`
+
+Returns one button action state by comparing the current snapshot with an optional previous button state.
+
+### `WebXRGamepadActionManager`
+
+Tracks previous button state by `XRInputSource` identity.
+
+### `update(inputStates: readonly WebXRInputState[] | null): readonly WebXRGamepadButtonActionState[]`
+
+Snapshots all current gamepads and returns one action state per button. Input sources missing from the current frame are removed from the previous-state cache.
+
+### `reset(inputSource?: XRInputSource): void`
+
+Clears the previous-state cache for one input source, or for every tracked input source when omitted.

--- a/docs/api-reference/experimental/webxr/webxr-gamepad.md
+++ b/docs/api-reference/experimental/webxr/webxr-gamepad.md
@@ -1,0 +1,103 @@
+# WebXR Gamepad
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`getWebXRGamepadState` snapshots the live `Gamepad` attached to one `WebXRInputState`. XR gamepads are updated in place by the browser each frame, so callers that want change detection or stable render data should copy button and axis values for the frame they are handling.
+
+For `xr-standard` mappings, the helper names the reserved indices: trigger, squeeze, touchpad, thumbstick, touchpad axes, and thumbstick axes. Nonstandard mappings keep generic `button-N` and `axis-N` names because their layout is runtime specific.
+
+## Usage
+
+```typescript
+import {getWebXRGamepadState} from '@luma.gl/experimental';
+
+const inputStates = webXRManager.getInputState(xrFrame);
+for (const inputState of inputStates || []) {
+  const gamepadState = getWebXRGamepadState(inputState);
+  const trigger = gamepadState?.primaryTrigger?.value || 0;
+  if (trigger > 0.25) {
+    // Use analog trigger input for selection, locomotion, or UI.
+  }
+}
+```
+
+## Types
+
+### `WebXRGamepadButtonName`
+
+```ts
+export type WebXRGamepadButtonName =
+  | 'trigger'
+  | 'squeeze'
+  | 'touchpad'
+  | 'thumbstick'
+  | `button-${number}`;
+```
+
+### `WebXRGamepadAxisName`
+
+```ts
+export type WebXRGamepadAxisName =
+  | 'touchpad-x'
+  | 'touchpad-y'
+  | 'thumbstick-x'
+  | 'thumbstick-y'
+  | `axis-${number}`;
+```
+
+### `WebXRGamepadButtonState`
+
+```ts
+export type WebXRGamepadButtonState = {
+  index: number;
+  name: WebXRGamepadButtonName;
+  value: number;
+  pressed: boolean;
+  touched: boolean;
+};
+```
+
+### `WebXRGamepadAxisState`
+
+```ts
+export type WebXRGamepadAxisState = {
+  index: number;
+  name: WebXRGamepadAxisName;
+  value: number;
+};
+```
+
+### `WebXRGamepadState`
+
+```ts
+export type WebXRGamepadState = {
+  inputState: WebXRInputState;
+  inputSource: XRInputSource;
+  gamepad: Gamepad;
+  mapping: string;
+  isXRStandardMapping: boolean;
+  buttons: readonly WebXRGamepadButtonState[];
+  axes: readonly WebXRGamepadAxisState[];
+  primaryTrigger: WebXRGamepadButtonState | null;
+  primarySqueeze: WebXRGamepadButtonState | null;
+  primaryTouchpad: WebXRGamepadButtonState | null;
+  primaryThumbstick: WebXRGamepadButtonState | null;
+  touchpad: readonly [x: number, y: number] | null;
+  thumbstick: readonly [x: number, y: number] | null;
+  pressed: readonly WebXRGamepadButtonState[];
+  touched: readonly WebXRGamepadButtonState[];
+};
+```
+
+## Functions
+
+### `getWebXRGamepadState(inputState: WebXRInputState): WebXRGamepadState | null`
+
+Returns a per-frame snapshot for the input state's gamepad, or `null` when the input source does not expose gamepad data.
+
+### `getWebXRGamepadStates(inputStates: readonly WebXRInputState[] | null): readonly WebXRGamepadState[]`
+
+Returns snapshots for all input states with gamepads.

--- a/docs/api-reference/experimental/webxr/webxr-hand-gestures.md
+++ b/docs/api-reference/experimental/webxr/webxr-hand-gestures.md
@@ -1,0 +1,61 @@
+# WebXR Hand Gestures
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`getWebXRHandPinch` derives a simple thumb-to-finger pinch gesture from a `WebXRHandTrackingState`. It reads joint matrices resolved by `WebXRHandTrackingManager` and returns distance, midpoint, active state, and normalized strength.
+
+## Usage
+
+```typescript
+import {getWebXRHandPinch, WebXRHandTrackingManager} from '@luma.gl/experimental';
+
+const handManager = new WebXRHandTrackingManager();
+handManager.setSession(session, referenceSpace);
+
+const handStates = handManager.getHandsState(xrFrame);
+for (const handState of handStates || []) {
+  const pinch = getWebXRHandPinch(handState);
+  if (pinch?.pinchActive) {
+    // Use pinch.position or pinch.inputSource as app interaction input.
+  }
+}
+```
+
+## Types
+
+### `WebXRHandPinchProps`
+
+```ts
+export type WebXRHandPinchProps = {
+  thumbJointName?: XRHandJoint;
+  fingerJointName?: XRHandJoint;
+  activeDistance?: number;
+  strengthDistance?: number;
+};
+```
+
+### `WebXRHandPinchState`
+
+```ts
+export type WebXRHandPinchState = {
+  inputSource: XRInputSource;
+  handedness: XRHandedness;
+  thumbJoint: WebXRHandJointState;
+  fingerJoint: WebXRHandJointState;
+  distance: number;
+  pinchActive: boolean;
+  strength: number;
+  position: [number, number, number];
+};
+```
+
+## Functions
+
+### `getWebXRHandPinch(handState: WebXRHandTrackingState, props?: WebXRHandPinchProps): WebXRHandPinchState | null`
+
+Returns pinch state for one tracked hand, or `null` when either configured joint is missing or untracked.
+
+The default gesture compares `thumb-tip` and `index-finger-tip`, marks the pinch active at `0.025` meters or less, and computes strength across a `0.07` meter falloff distance.

--- a/docs/api-reference/experimental/webxr/webxr-hand-tracking-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-hand-tracking-manager.md
@@ -1,0 +1,93 @@
+# WebXRHandTrackingManager
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRHandTrackingManager` is the experimental articulated hand helper for luma.gl. It resolves WebXR `XRInputSource.hand` joint spaces into app-reference-space matrices and joint radii using `XRFrame.fillPoses()` and `XRFrame.fillJointRadii()`, with `XRFrame.getJointPose()` as a fallback.
+
+## Usage
+
+```typescript
+import {WebXRHandTrackingManager} from '@luma.gl/experimental';
+
+const session = await navigator.xr.requestSession('immersive-vr', {
+  optionalFeatures: ['hand-tracking', 'local-floor']
+});
+
+const handManager = new WebXRHandTrackingManager();
+handManager.setSession(session, webXRManager.referenceSpace);
+
+const handStates = handManager.getHandsState(xrFrame);
+const indexTip = handStates?.[0]?.joints.find(joint => joint.jointName === 'index-finger-tip');
+```
+
+Request the WebXR `hand-tracking` feature when starting an immersive session:
+
+```typescript
+const session = await navigator.xr.requestSession('immersive-vr', {
+  optionalFeatures: ['hand-tracking', 'local-floor']
+});
+```
+
+## Constants
+
+### `WEBXR_HAND_JOINTS`
+
+The ordered list of 25 standard WebXR hand joints, from `wrist` through each thumb, index, middle, ring, and pinky joint.
+
+## Types
+
+### `WebXRHandJointState`
+
+```ts
+export type WebXRHandJointState = {
+  jointName: XRHandJoint;
+  jointSpace: XRJointSpace;
+  pose: XRJointPose | null;
+  matrix: Float32Array | null;
+  radius: number | null;
+};
+```
+
+### `WebXRHandTrackingState`
+
+```ts
+export type WebXRHandTrackingState = {
+  xrFrame: XRFrame;
+  inputSource: XRInputSource;
+  handedness: XRHandedness;
+  hand: XRHand;
+  joints: readonly WebXRHandJointState[];
+  matrices: Float32Array;
+  radii: Float32Array;
+  allJointsTracked: boolean;
+};
+```
+
+## Methods
+
+### `constructor()`
+
+Creates an experimental hand-tracking manager.
+
+### `setSession(session: XRSession | null, referenceSpace: XRReferenceSpace | null): this`
+
+Attaches or clears the current XR session. A reference space is required for active sessions because joint matrices are resolved into that app space.
+
+### `getHandsState(xrFrame: XRFrame, inputSources?: readonly XRInputSource[]): readonly WebXRHandTrackingState[] | null`
+
+Resolves hand states for all current session input sources, or for a supplied input-source list.
+
+### `getHandState(xrFrame: XRFrame, inputSource: XRInputSource): WebXRHandTrackingState | null`
+
+Resolves one input source if it exposes `XRInputSource.hand`; returns `null` for controller, gaze, or screen input sources without hand tracking.
+
+### `clearSession(): void`
+
+Releases session references without ending the browser XR session.
+
+### `destroy(): void`
+
+Clears the current session wrappers.

--- a/docs/api-reference/experimental/webxr/webxr-haptics.md
+++ b/docs/api-reference/experimental/webxr/webxr-haptics.md
@@ -1,0 +1,62 @@
+# WebXR Haptics
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`pulseWebXRInputHaptics` sends a short pulse to the first haptic actuator exposed by a WebXR input source gamepad. It is a small compatibility helper around browser `Gamepad` haptics, including the older `vibrationActuator` fallback used by some XR runtimes.
+
+## Usage
+
+```typescript
+import {pulseWebXRInputHaptics} from '@luma.gl/experimental';
+
+const inputStates = webXRManager.getInputState(xrFrame);
+for (const inputState of inputStates || []) {
+  if (inputState.selectActive) {
+    await pulseWebXRInputHaptics(inputState, {intensity: 0.5, duration: 40});
+  }
+}
+```
+
+## Types
+
+### `WebXRHapticPulseProps`
+
+```ts
+export type WebXRHapticPulseProps = {
+  intensity?: number;
+  duration?: number;
+};
+```
+
+### `WebXRHapticPulseResult`
+
+```ts
+export type WebXRHapticPulseResult = {
+  inputState: WebXRInputState;
+  actuator: WebXRGamepadHapticActuator;
+  intensity: number;
+  duration: number;
+  value: unknown;
+};
+```
+
+### `WebXRGamepadHapticActuator`
+
+```ts
+export type WebXRGamepadHapticActuator = {
+  pulse?(intensity: number, duration: number): Promise<unknown> | unknown;
+};
+```
+
+## Functions
+
+### `pulseWebXRInputHaptics(inputState: WebXRInputState, props?: WebXRHapticPulseProps): Promise<WebXRHapticPulseResult | null>`
+
+Pulses the first available haptic actuator on `inputState.gamepad`. Returns `null` when the input has no haptic actuator.
+
+### `getWebXRInputHapticActuator(inputState: WebXRInputState): WebXRGamepadHapticActuator | null`
+
+Returns the first available gamepad haptic actuator, or `null` when no compatible actuator is exposed.

--- a/docs/api-reference/experimental/webxr/webxr-hit-test-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-hit-test-manager.md
@@ -5,7 +5,7 @@
   <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
 </p>
 
-`WebXRHitTestManager` is the experimental AR hit-test source helper for luma.gl. It requests a viewer-space `XRHitTestSource`, resolves per-frame hit poses in the app reference space, and cancels the source when the session ends or is cleared.
+`WebXRHitTestManager` is the experimental AR hit-test source helper for luma.gl. It requests a viewer-space `XRHitTestSource`, can also request a transient input hit-test source for touch/controller placement, resolves per-frame hit poses in the app reference space, and cancels sources when the session ends or is cleared.
 
 ## Usage
 
@@ -17,6 +17,21 @@ await hitTestManager.setSession(session, webXRManager.referenceSpace);
 
 const hitTestState = hitTestManager.getHitTestState(xrFrame);
 const firstHitMatrix = hitTestState?.hits[0]?.matrix;
+```
+
+Transient input hit tests are useful for placement from a tap or controller profile:
+
+```typescript
+const hitTestManager = new WebXRHitTestManager({
+  entityTypes: ['plane', 'point'],
+  transientInput: {
+    profile: 'generic-touchscreen',
+    entityTypes: ['plane', 'mesh']
+  }
+});
+
+const hitTestState = hitTestManager.getHitTestState(xrFrame);
+const firstTouchHitMatrix = hitTestState?.transientInput[0]?.results[0]?.matrix;
 ```
 
 Request the WebXR `hit-test` feature when starting an AR session:
@@ -34,6 +49,17 @@ const session = await navigator.xr.requestSession('immersive-ar', {
 
 ```ts
 export type WebXRHitTestManagerProps = {
+  entityTypes?: XRHitTestTrackableType[];
+  offsetRay?: XRRay;
+  transientInput?: WebXRTransientInputHitTestProps | false;
+};
+```
+
+### `WebXRTransientInputHitTestProps`
+
+```ts
+export type WebXRTransientInputHitTestProps = {
+  profile: string;
   entityTypes?: XRHitTestTrackableType[];
   offsetRay?: XRRay;
 };
@@ -55,6 +81,16 @@ export type WebXRHitTestResult = {
 export type WebXRHitTestState = {
   xrFrame: XRFrame;
   hits: readonly WebXRHitTestResult[];
+  transientInput: readonly WebXRTransientInputHitTestResult[];
+};
+```
+
+### `WebXRTransientInputHitTestResult`
+
+```ts
+export type WebXRTransientInputHitTestResult = {
+  inputSource: XRInputSource;
+  results: readonly WebXRHitTestResult[];
 };
 ```
 
@@ -66,15 +102,15 @@ Creates an experimental hit-test manager.
 
 ### `setSession(session: XRSession | null, referenceSpace: XRReferenceSpace | null, props?: WebXRHitTestManagerProps): Promise<this>`
 
-Attaches or clears the current XR session. When a session is attached, the manager requests `viewer` reference space and then calls `session.requestHitTestSource()`.
+Attaches or clears the current XR session. When a session is attached, the manager requests `viewer` reference space, calls `session.requestHitTestSource()`, and optionally calls `session.requestHitTestSourceForTransientInput()` when `transientInput` props are supplied.
 
 ### `getHitTestState(xrFrame: XRFrame): WebXRHitTestState | null`
 
-Resolves hit-test results for an active XR frame. Results without poses in the app reference space are filtered out. Returns `null` when no source is attached or when the browser does not expose `XRFrame.getHitTestResults()`.
+Resolves hit-test results for an active XR frame. Results without poses in the app reference space are filtered out. Transient input results are grouped by their `XRInputSource` and returned as an empty array when the browser does not expose `XRFrame.getHitTestResultsForTransientInput()` or no transient source was configured. Returns `null` when no source is attached or when the browser does not expose `XRFrame.getHitTestResults()`.
 
 ### `clearSession(): void`
 
-Cancels the current hit-test source and releases session references without ending the browser XR session.
+Cancels current hit-test sources and releases session references without ending the browser XR session.
 
 ### `destroy(): void`
 

--- a/docs/api-reference/experimental/webxr/webxr-hit-test-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-hit-test-manager.md
@@ -1,0 +1,81 @@
+# WebXRHitTestManager
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRHitTestManager` is the experimental AR hit-test source helper for luma.gl. It requests a viewer-space `XRHitTestSource`, resolves per-frame hit poses in the app reference space, and cancels the source when the session ends or is cleared.
+
+## Usage
+
+```typescript
+import {WebXRHitTestManager} from '@luma.gl/experimental';
+
+const hitTestManager = new WebXRHitTestManager({entityTypes: ['plane', 'point']});
+await hitTestManager.setSession(session, webXRManager.referenceSpace);
+
+const hitTestState = hitTestManager.getHitTestState(xrFrame);
+const firstHitMatrix = hitTestState?.hits[0]?.matrix;
+```
+
+Request the WebXR `hit-test` feature when starting an AR session:
+
+```typescript
+const session = await navigator.xr.requestSession('immersive-ar', {
+  requiredFeatures: ['hit-test'],
+  optionalFeatures: ['local-floor']
+});
+```
+
+## Types
+
+### `WebXRHitTestManagerProps`
+
+```ts
+export type WebXRHitTestManagerProps = {
+  entityTypes?: XRHitTestTrackableType[];
+  offsetRay?: XRRay;
+};
+```
+
+### `WebXRHitTestResult`
+
+```ts
+export type WebXRHitTestResult = {
+  xrHitTestResult: XRHitTestResult;
+  pose: XRPose;
+  matrix: Float32Array;
+};
+```
+
+### `WebXRHitTestState`
+
+```ts
+export type WebXRHitTestState = {
+  xrFrame: XRFrame;
+  hits: readonly WebXRHitTestResult[];
+};
+```
+
+## Methods
+
+### `constructor(props?: WebXRHitTestManagerProps)`
+
+Creates an experimental hit-test manager.
+
+### `setSession(session: XRSession | null, referenceSpace: XRReferenceSpace | null, props?: WebXRHitTestManagerProps): Promise<this>`
+
+Attaches or clears the current XR session. When a session is attached, the manager requests `viewer` reference space and then calls `session.requestHitTestSource()`.
+
+### `getHitTestState(xrFrame: XRFrame): WebXRHitTestState | null`
+
+Resolves hit-test results for an active XR frame. Results without poses in the app reference space are filtered out. Returns `null` when no source is attached or when the browser does not expose `XRFrame.getHitTestResults()`.
+
+### `clearSession(): void`
+
+Cancels the current hit-test source and releases session references without ending the browser XR session.
+
+### `destroy(): void`
+
+Clears the current session wrappers.

--- a/docs/api-reference/experimental/webxr/webxr-image-tracking-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-image-tracking-manager.md
@@ -1,0 +1,120 @@
+# WebXRImageTrackingManager
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRImageTrackingManager` is the experimental AR image-tracking helper for luma.gl. It resolves `XRFrame.getImageTrackingResults()` in the app reference space, exposes tracking state and measured image width, and reports added, updated, and removed tracked images between XR frames.
+
+Request the WebXR `image-tracking` feature with app-provided tracked images when starting the AR session:
+
+```ts
+import {
+  getWebXRImageTrackingSessionInit,
+  WebXRImageTrackingManager
+} from '@luma.gl/experimental';
+
+const trackedImages = [
+  {
+    image: await createImageBitmap(markerImage),
+    widthInMeters: 0.24
+  }
+];
+
+const session = await navigator.xr!.requestSession('immersive-ar', {
+  optionalFeatures: ['local-floor', ...getWebXRImageTrackingSessionInit({trackedImages}).optionalFeatures!],
+  trackedImages
+});
+
+const imageManager = new WebXRImageTrackingManager({trackedImages});
+imageManager.setSession(session, referenceSpace);
+```
+
+Then query tracked image poses from the active XR frame:
+
+```ts
+const imageState = imageManager.getImageTrackingState(xrFrame);
+
+if (imageState) {
+  for (const image of imageState.images) {
+    const matrix = image.matrix;
+    const index = image.index;
+    const trackingState = image.trackingState;
+  }
+}
+```
+
+## Types
+
+### `WebXRImageTrackingManagerProps`
+
+```ts
+export type WebXRImageTrackingManagerProps = {
+  trackedImages?: readonly XRTrackedImageInit[];
+};
+```
+
+`trackedImages` mirrors `XRSessionInit.trackedImages`. Each entry contains an `ImageBitmap` and its known physical width in meters.
+
+### `WebXRImageTrackingState`
+
+```ts
+export type WebXRImageTrackingState = {
+  xrFrame: XRFrame;
+  session: XRSession;
+  images: readonly WebXRTrackedImageState[];
+  added: readonly WebXRTrackedImageState[];
+  updated: readonly WebXRTrackedImageState[];
+  removed: readonly WebXRTrackedImageState[];
+};
+```
+
+`added`, `updated`, and `removed` are derived from tracked image `index`, `trackingState`, and `measuredWidthInMeters` compared with the previous successful call to `getImageTrackingState()`.
+
+### `WebXRTrackedImageState`
+
+```ts
+export type WebXRTrackedImageState = {
+  result: XRImageTrackingResult;
+  pose: XRPose;
+  matrix: Float32Array;
+  index: number;
+  trackingState: XRImageTrackingState;
+  measuredWidthInMeters: number;
+};
+```
+
+`matrix` places `XRImageTrackingResult.imageSpace` in the app reference space.
+
+## Methods
+
+### `constructor(props?: WebXRImageTrackingManagerProps)`
+
+Creates an inactive manager. Call `setSession()` after the XR session and app reference space are available.
+
+### `setSession(session: XRSession | null, referenceSpace: XRReferenceSpace | null, props?: WebXRImageTrackingManagerProps): this`
+
+Sets the active session and reference space. Passing `null` clears the active session.
+
+### `getImageTrackability(): Promise<readonly XRImageTrackability[] | null>`
+
+Forwards `XRSession.getImageTrackability()` when available. The returned array corresponds to the configured `trackedImages`.
+
+### `getImageTrackingState(xrFrame: XRFrame): WebXRImageTrackingState | null`
+
+Returns tracked image state for the active session, or `null` when the browser did not enable or expose `XRFrame.getImageTrackingResults()`.
+
+### `clearSession(): void`
+
+Removes listeners and clears cached tracked-image state.
+
+### `destroy(): void`
+
+Clears the active session.
+
+## Helpers
+
+### `getWebXRImageTrackingSessionInit(props?: WebXRImageTrackingSessionInitProps): XRSessionInit`
+
+Builds a minimal `XRSessionInit` fragment for requesting the `image-tracking` feature and passing `trackedImages`.

--- a/docs/api-reference/experimental/webxr/webxr-light-estimation-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-light-estimation-manager.md
@@ -1,0 +1,113 @@
+# WebXRLightEstimationManager
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRLightEstimationManager` is the experimental AR lighting helper for luma.gl. It requests an `XRLightProbe`, resolves `XRFrame.getLightEstimate()` values, exposes the probe pose in the app reference space, and can wrap a WebGL reflection cube-map handle as a borrowed luma [`Texture`](/docs/api-reference/core/resources/texture) when the application supplies the cube-map size.
+
+Request the WebXR `light-estimation` feature when starting the AR session:
+
+```ts
+import {
+  getWebXRLightEstimationSessionInit,
+  WebXRLightEstimationManager
+} from '@luma.gl/experimental';
+
+const session = await navigator.xr!.requestSession('immersive-ar', {
+  optionalFeatures: ['local-floor', ...getWebXRLightEstimationSessionInit().optionalFeatures!]
+});
+
+const lightManager = new WebXRLightEstimationManager({reflectionFormat: 'preferred'});
+await lightManager.setSession(session, referenceSpace);
+```
+
+Then query the light state from the active XR frame:
+
+```ts
+const lightState = lightManager.getLightEstimationState(xrFrame);
+
+if (lightState) {
+  const direction = lightState.primaryLightDirection;
+  const intensity = lightState.primaryLightIntensity;
+  const sphericalHarmonics = lightState.sphericalHarmonicsCoefficients;
+}
+```
+
+## Types
+
+### `WebXRLightEstimationManagerProps`
+
+```ts
+export type WebXRLightEstimationManagerProps = {
+  reflectionFormat?: XRReflectionFormat | 'preferred';
+  reflectionCubeMapSize?: number;
+  textureFormat?: TextureFormat;
+  textureUsage?: number;
+};
+```
+
+`reflectionFormat` defaults to `'srgba8'`. Use `'preferred'` to request `XRSession.preferredReflectionFormat` when the browser exposes it.
+
+`reflectionCubeMapSize` is intentionally explicit. The WebXR light-estimation API exposes a WebGL cube-map handle through `XRWebGLBinding.getReflectionCubeMap()`, but it does not expose the texture dimensions. Without a supplied size, luma.gl returns the raw `WebGLTexture` handle and leaves `reflectionCubeMapTexture` as `null`.
+
+### `WebXRLightEstimationState`
+
+```ts
+export type WebXRLightEstimationState = {
+  xrFrame: XRFrame;
+  session: XRSession;
+  lightProbe: XRLightProbe;
+  lightEstimate: XRLightEstimate;
+  probePose: XRPose | null;
+  matrix: Float32Array | null;
+  sphericalHarmonicsCoefficients: Float32Array;
+  primaryLightDirection: [number, number, number];
+  primaryLightIntensity: [number, number, number];
+  reflectionCubeMap: WebGLTexture | null;
+  reflectionCubeMapTexture: Texture | null;
+  reflectionRevision: number;
+};
+```
+
+`reflectionRevision` increments when the probe emits `reflectionchange`.
+
+## Methods
+
+### `constructor(props?: WebXRLightEstimationManagerProps)`
+
+Creates an inactive manager. Call `setSession()` after the XR session and app reference space are available.
+
+### `setSession(session: XRSession | null, referenceSpace: XRReferenceSpace | null, props?: WebXRLightEstimationManagerProps): Promise<this>`
+
+Requests an `XRLightProbe` from the session and listens for session end cleanup. Passing `null` clears the active session.
+
+### `setWebGLBinding(device: Device | null, xrWebGLBinding: WebXRLightEstimationBinding | null): this`
+
+Connects the manager to `XRWebGLBinding.getReflectionCubeMap()`. Reflection cube maps are browser-owned handles; any luma texture wrapper created for them is marked borrowed and destroyed when the session or binding is cleared.
+
+### `getLightEstimationState(xrFrame: XRFrame): WebXRLightEstimationState | null`
+
+Returns the current light estimate for the active probe, or `null` when the session, probe, or browser frame does not provide an estimate.
+
+### `clearSession(): void`
+
+Removes listeners and destroys borrowed reflection texture wrappers.
+
+### `destroy(): void`
+
+Clears the active session and binding.
+
+## Helpers
+
+### `getWebXRLightEstimationSessionInit(props?: WebXRLightEstimationSessionInitProps): XRSessionInit`
+
+Builds a minimal `XRSessionInit` fragment for requesting the `light-estimation` feature.
+
+### `getWebXRReflectionTextureFormat(reflectionFormat?: XRReflectionFormat | 'preferred' | null): TextureFormat`
+
+Maps WebXR reflection formats to luma texture formats:
+
+- `'srgba8'` and `'preferred'` map to `'rgba8unorm-srgb'`.
+- `'rgba16f'` maps to `'rgba16float'`.

--- a/docs/api-reference/experimental/webxr/webxr-locomotion.md
+++ b/docs/api-reference/experimental/webxr/webxr-locomotion.md
@@ -1,0 +1,96 @@
+# WebXR Locomotion
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`getWebXRLocomotionState` derives app-level movement and turn intent from WebXR gamepad axes. It is intentionally low-level: apps decide whether to use the returned values for smooth locomotion, snap turning, teleport targeting, scrolling, or UI navigation.
+
+The default convention uses the left thumbstick for movement and the right thumbstick for turning. Movement is returned as `[strafe, forward]`, with forward positive by default. Turning is a normalized horizontal value, and `snapTurn` is `-1`, `0`, or `1` once the turn axis reaches the configured threshold.
+
+## Usage
+
+```typescript
+import {getWebXRLocomotionState} from '@luma.gl/experimental';
+
+const inputStates = webXRManager.getInputState(xrFrame);
+const locomotion = getWebXRLocomotionState(inputStates, {
+  deadzone: 0.2,
+  snapTurnThreshold: 0.8
+});
+
+if (locomotion.moveActive) {
+  const [strafe, forward] = locomotion.move;
+  // Apply smooth locomotion or move a teleport reticle.
+}
+
+if (locomotion.snapTurn) {
+  // Rotate the viewer rig by one snap increment.
+}
+```
+
+## Types
+
+### `WebXRLocomotionAxis`
+
+```ts
+export type WebXRLocomotionAxis = 'thumbstick' | 'touchpad';
+```
+
+### `WebXRLocomotionHandedness`
+
+```ts
+export type WebXRLocomotionHandedness = XRHandedness | 'any';
+```
+
+### `WebXRLocomotionProps`
+
+```ts
+export type WebXRLocomotionProps = {
+  moveHandedness?: WebXRLocomotionHandedness;
+  turnHandedness?: WebXRLocomotionHandedness;
+  axis?: WebXRLocomotionAxis;
+  deadzone?: number;
+  snapTurnThreshold?: number;
+  invertMoveY?: boolean;
+  invertTurnX?: boolean;
+};
+```
+
+### `WebXRLocomotionState`
+
+```ts
+export type WebXRLocomotionState = {
+  inputStates: readonly WebXRInputState[];
+  gamepadStates: readonly WebXRGamepadState[];
+  moveInputState: WebXRInputState | null;
+  turnInputState: WebXRInputState | null;
+  move: NumberArray2;
+  turn: number;
+  snapTurn: -1 | 0 | 1;
+  moveActive: boolean;
+  turnActive: boolean;
+  axis: WebXRLocomotionAxis;
+  deadzone: number;
+  snapTurnThreshold: number;
+};
+```
+
+## Functions
+
+### `getWebXRLocomotionState(inputStates, props?): WebXRLocomotionState`
+
+Returns movement and turn intent from all current input states with gamepads.
+
+### `getWebXRLocomotionGamepadState(gamepadStates, handedness, axis?): WebXRGamepadState | null`
+
+Returns the first gamepad state that matches the handedness and exposes the requested axis pair.
+
+### `getWebXRLocomotionAxes(gamepadState, axis?): readonly [x: number, y: number] | null`
+
+Returns the requested `thumbstick` or `touchpad` axis pair.
+
+### `getWebXRLocomotionAxisValue(value, deadzone?): number`
+
+Applies a clamped dead zone and rescales the remaining axis range to `[-1, 1]`.

--- a/docs/api-reference/experimental/webxr/webxr-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-manager.md
@@ -132,6 +132,29 @@ export type WebXRFrameState = {
 };
 ```
 
+### `WebXRProjectionLayerControlsProps`
+
+```ts
+export type WebXRProjectionLayerControlsProps = {
+  fixedFoveation?: number | null;
+  deltaPose?: XRRigidTransform | null;
+};
+```
+
+### `WebXRProjectionLayerState`
+
+```ts
+export type WebXRProjectionLayerState = {
+  layer: XRProjectionLayer;
+  textureWidth: number;
+  textureHeight: number;
+  textureArrayLength: number;
+  ignoreDepthValues: boolean;
+  fixedFoveation: number | null;
+  deltaPose: XRRigidTransform | null;
+};
+```
+
 ### `WebXRInputState`
 
 ```ts
@@ -198,6 +221,22 @@ Resolves frame state for an active XR frame. Returns `null` when no viewer pose 
 ### `getInputState(xrFrame: XRFrame): readonly WebXRInputState[] | null`
 
 Resolves input source state for an active XR frame. Returns `null` when no session is attached.
+
+### `getProjectionLayerState(): WebXRProjectionLayerState | null`
+
+Returns WebGPU projection-layer metadata and current controls, or `null` when the active session is not using a native projection layer.
+
+### `setProjectionLayerControls(props: WebXRProjectionLayerControlsProps): WebXRProjectionLayerState | null`
+
+Updates native projection-layer controls such as fixed foveation and delta pose, then returns the updated state. Returns `null` when no projection layer is active.
+
+### `getWebXRProjectionLayerState(layer: XRProjectionLayer): WebXRProjectionLayerState`
+
+Returns projection-layer texture dimensions, array length, depth handling, fixed foveation, and delta pose.
+
+### `setWebXRProjectionLayerControls(layer, props): WebXRProjectionLayerState`
+
+Updates controls on any `XRProjectionLayer` and returns the updated state.
 
 ### `getWebXRInputRay(inputState: WebXRInputState): WebXRInputRay | null`
 

--- a/docs/api-reference/experimental/webxr/webxr-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-manager.md
@@ -60,6 +60,7 @@ const animationLoop = new AnimationLoop({
 - Resolves per-frame input-source target-ray and grip poses in the same reference space as rendering.
 - Tracks active `selectstart`/`selectend` state per input source so examples can build controller rays, pointer selection, and locomotion helpers without subscribing to raw session events.
 - Provides `getWebXRInputRay(inputState)` for normalized world-space target-ray origin and direction extraction.
+- Provides `getWebXRInputRayPlaneIntersection(ray, props)` for floor, wall, and placement plane hits used by teleport and pointer-selection examples.
 - Never destroys browser-owned WebGL framebuffers or WebGPU compositor textures.
 - Raw AR camera textures remain WebGL-only; WebGPU AR can use an application-provided procedural or video fallback.
 
@@ -144,6 +145,16 @@ export type WebXRInputRay = {
 };
 ```
 
+### `WebXRInputRayPlaneIntersection`
+
+```ts
+export type WebXRInputRayPlaneIntersection = {
+  ray: WebXRInputRay;
+  point: NumberArray3;
+  distance: number;
+};
+```
+
 ## Methods
 
 ### `constructor(device: Device, props?: WebXRManagerProps)`
@@ -165,6 +176,10 @@ Resolves input source state for an active XR frame. Returns `null` when no sessi
 ### `getWebXRInputRay(inputState: WebXRInputState): WebXRInputRay | null`
 
 Returns a normalized world-space target ray for an input state, or `null` when the input source has no target-ray pose for the frame.
+
+### `getWebXRInputRayPlaneIntersection(ray: WebXRInputRay, props?: WebXRInputRayPlaneIntersectionProps): WebXRInputRayPlaneIntersection | null`
+
+Returns the forward intersection between an input ray and a plane. The default plane is `y=0`, suitable for simple floor reticles and teleport candidates.
 
 ### `clearSession(): void`
 

--- a/docs/api-reference/experimental/webxr/webxr-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-manager.md
@@ -58,7 +58,7 @@ const animationLoop = new AnimationLoop({
 - Treats `XRViewerPose.views` as an arbitrary per-frame view list, not a fixed stereo pair.
 - Exposes `projectionMatrix` from `XRView.projectionMatrix` and `viewMatrix` from `XRView.transform.inverse.matrix`.
 - Resolves per-frame input-source target-ray and grip poses in the same reference space as rendering.
-- Tracks active `selectstart`/`selectend` state per input source so examples can build controller rays, pointer selection, and locomotion helpers without subscribing to raw session events.
+- Tracks active `selectstart`/`selectend` and `squeezestart`/`squeezeend` state per input source so examples can build controller rays, pointer selection, grab, and locomotion helpers without subscribing to raw session events.
 - Provides `getWebXRInputRay(inputState)` for normalized world-space target-ray origin and direction extraction.
 - Provides `getWebXRInputRayPlaneIntersection(ray, props)` for floor, wall, and placement plane hits used by teleport and pointer-selection examples.
 - Never destroys browser-owned WebGL framebuffers or WebGPU compositor textures.
@@ -131,6 +131,7 @@ export type WebXRInputState = {
   gripPose: XRPose | null;
   gripMatrix: Float32Array | null;
   selectActive: boolean;
+  squeezeActive: boolean;
 };
 ```
 

--- a/docs/api-reference/experimental/webxr/webxr-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-manager.md
@@ -57,6 +57,8 @@ const animationLoop = new AnimationLoop({
 - Uses `XRSession.requestReferenceSpace()` with `local` by default.
 - Treats `XRViewerPose.views` as an arbitrary per-frame view list, not a fixed stereo pair.
 - Exposes `projectionMatrix` from `XRView.projectionMatrix` and `viewMatrix` from `XRView.transform.inverse.matrix`.
+- Resolves per-frame input-source target-ray and grip poses in the same reference space as rendering.
+- Tracks active `selectstart`/`selectend` state per input source so examples can build controller rays, pointer selection, and locomotion helpers without subscribing to raw session events.
 - Never destroys browser-owned WebGL framebuffers or WebGPU compositor textures.
 - Raw AR camera textures remain WebGL-only; WebGPU AR can use an application-provided procedural or video fallback.
 
@@ -112,6 +114,24 @@ export type WebXRFrameState = {
 };
 ```
 
+### `WebXRInputState`
+
+```ts
+export type WebXRInputState = {
+  inputSource: XRInputSource;
+  index: number;
+  handedness: XRHandedness;
+  targetRayMode: XRTargetRayMode;
+  profiles: readonly string[];
+  gamepad: Gamepad | null;
+  targetRayPose: XRPose | null;
+  targetRayMatrix: Float32Array | null;
+  gripPose: XRPose | null;
+  gripMatrix: Float32Array | null;
+  selectActive: boolean;
+};
+```
+
 ## Methods
 
 ### `constructor(device: Device, props?: WebXRManagerProps)`
@@ -125,6 +145,10 @@ Attaches or clears the current XR session.
 ### `getFrameState(xrFrame: XRFrame): WebXRFrameState | null`
 
 Resolves frame state for an active XR frame. Returns `null` when no viewer pose is available.
+
+### `getInputState(xrFrame: XRFrame): readonly WebXRInputState[] | null`
+
+Resolves input source state for an active XR frame. Returns `null` when no session is attached.
 
 ### `clearSession(): void`
 

--- a/docs/api-reference/experimental/webxr/webxr-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-manager.md
@@ -59,6 +59,7 @@ const animationLoop = new AnimationLoop({
 - Exposes `projectionMatrix` from `XRView.projectionMatrix` and `viewMatrix` from `XRView.transform.inverse.matrix`.
 - Resolves per-frame input-source target-ray and grip poses in the same reference space as rendering.
 - Tracks active `selectstart`/`selectend` state per input source so examples can build controller rays, pointer selection, and locomotion helpers without subscribing to raw session events.
+- Provides `getWebXRInputRay(inputState)` for normalized world-space target-ray origin and direction extraction.
 - Never destroys browser-owned WebGL framebuffers or WebGPU compositor textures.
 - Raw AR camera textures remain WebGL-only; WebGPU AR can use an application-provided procedural or video fallback.
 
@@ -132,6 +133,17 @@ export type WebXRInputState = {
 };
 ```
 
+### `WebXRInputRay`
+
+```ts
+export type WebXRInputRay = {
+  inputState: WebXRInputState;
+  origin: NumberArray3;
+  direction: NumberArray3;
+  matrix: Float32Array;
+};
+```
+
 ## Methods
 
 ### `constructor(device: Device, props?: WebXRManagerProps)`
@@ -149,6 +161,10 @@ Resolves frame state for an active XR frame. Returns `null` when no viewer pose 
 ### `getInputState(xrFrame: XRFrame): readonly WebXRInputState[] | null`
 
 Resolves input source state for an active XR frame. Returns `null` when no session is attached.
+
+### `getWebXRInputRay(inputState: WebXRInputState): WebXRInputRay | null`
+
+Returns a normalized world-space target ray for an input state, or `null` when the input source has no target-ray pose for the frame.
 
 ### `clearSession(): void`
 

--- a/docs/api-reference/experimental/webxr/webxr-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-manager.md
@@ -5,7 +5,7 @@
   <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
 </p>
 
-`WebXRManager` is the experimental WebGPU and WebGL session and per-view render-state helper for luma.gl. It prepares a native WebGPU projection layer or an `XRWebGLLayer`, requests a reference space, and resolves framebuffers, viewports, projection matrices, and view matrices for one active `XRFrame`.
+`WebXRManager` is the experimental WebGPU and WebGL session and per-view render-state helper for luma.gl. It prepares a native WebGPU projection layer or an `XRWebGLLayer`, negotiates a reference space, and resolves framebuffers, viewports, projection matrices, and view matrices for one active `XRFrame`.
 
 ## Usage
 
@@ -15,7 +15,9 @@ import {AnimationLoop} from '@luma.gl/engine';
 import {WebXRAnimationFrameProvider, WebXRManager} from '@luma.gl/experimental';
 
 const webXRManager = new WebXRManager(device);
-await webXRManager.setSession(session);
+await webXRManager.setSession(session, {
+  referenceSpaceTypes: ['local-floor', 'local']
+});
 
 const animationLoop = new AnimationLoop({
   device,
@@ -55,6 +57,8 @@ const animationLoop = new AnimationLoop({
 - Wraps WebGPU compositor color and optional depth textures as borrowed per-view attachments, preserving browser-provided texture-array slices and viewports.
 - Shares a framebuffer when multiple eyes target the same texture slice; otherwise each eye receives an independently clearable framebuffer.
 - Uses `XRSession.requestReferenceSpace()` with `local` by default.
+- Accepts an ordered `referenceSpaceTypes` fallback list, useful for preferring `bounded-floor` or `local-floor` while retaining compatibility with devices and emulators that only expose `local`.
+- Exposes the resolved `referenceSpaceType` after `setSession()` succeeds.
 - Treats `XRViewerPose.views` as an arbitrary per-frame view list, not a fixed stereo pair.
 - Exposes `projectionMatrix` from `XRView.projectionMatrix` and `viewMatrix` from `XRView.transform.inverse.matrix`.
 - Resolves per-frame input-source target-ray and grip poses in the same reference space as rendering.
@@ -85,8 +89,20 @@ Browser support for native WebGPU WebXR is still emerging. Keep a WebGL2 fallbac
 ```ts
 export type WebXRManagerProps = {
   referenceSpaceType?: XRReferenceSpaceType;
+  referenceSpaceTypes?: readonly XRReferenceSpaceType[];
   layerInit?: XRWebGLLayerInit;
   projectionLayerInit?: XRProjectionLayerInit;
+};
+```
+
+When `referenceSpaceTypes` is supplied, the manager tries each type in order. When it is omitted, `referenceSpaceType` is used for backwards-compatible single-type setup.
+
+### `WebXRReferenceSpaceState`
+
+```ts
+export type WebXRReferenceSpaceState = {
+  referenceSpace: XRReferenceSpace;
+  referenceSpaceType: XRReferenceSpaceType;
 };
 ```
 
@@ -165,7 +181,15 @@ Creates an experimental WebGPU or WebGL WebXR manager.
 
 ### `setSession(session: XRSession | null, props?: WebXRManagerProps): Promise<this>`
 
-Attaches or clears the current XR session.
+Attaches or clears the current XR session. When attaching, the manager requests the first supported reference space from `referenceSpaceTypes` or falls back to `referenceSpaceType`.
+
+### `getWebXRReferenceSpaceTypes(props?: Pick<WebXRManagerProps, 'referenceSpaceType' | 'referenceSpaceTypes'>): readonly XRReferenceSpaceType[]`
+
+Normalizes reference-space props into a de-duplicated request order.
+
+### `requestWebXRReferenceSpace(session: XRSession, referenceSpaceTypes: readonly XRReferenceSpaceType[]): Promise<WebXRReferenceSpaceState>`
+
+Requests each reference-space type in order and resolves with the first successful reference space and its type.
 
 ### `getFrameState(xrFrame: XRFrame): WebXRFrameState | null`
 

--- a/docs/api-reference/experimental/webxr/webxr-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-manager.md
@@ -126,6 +126,7 @@ export type WebXRInputState = {
   targetRayMode: XRTargetRayMode;
   profiles: readonly string[];
   gamepad: Gamepad | null;
+  hand: XRHand | null;
   targetRayPose: XRPose | null;
   targetRayMatrix: Float32Array | null;
   gripPose: XRPose | null;

--- a/docs/api-reference/experimental/webxr/webxr-media-layer-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-media-layer-manager.md
@@ -1,0 +1,96 @@
+# WebXRMediaLayerManager
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRMediaLayerManager` is the experimental helper for WebXR video-backed composition layers. It creates quad, cylinder, and equirect layers through `XRMediaBinding` so the XR compositor can present video directly from an `HTMLVideoElement`.
+
+Use this manager for immersive video panels, curved video surfaces, and 360-degree video. Media layers do not expose a luma.gl framebuffer; the browser displays the current video frame through the XR compositor.
+
+## Usage
+
+Request the WebXR `layers` feature when starting the immersive session:
+
+```typescript
+import {WebXRMediaLayerManager, getWebXRLayersSessionInit} from '@luma.gl/experimental';
+
+const session = await navigator.xr.requestSession('immersive-vr', {
+  ...getWebXRLayersSessionInit(),
+  optionalFeatures: ['layers', 'local-floor']
+});
+```
+
+Create a media layer after the session and reference space are ready:
+
+```typescript
+const video = document.querySelector('video');
+const mediaLayerManager = new WebXRMediaLayerManager();
+mediaLayerManager.setSession(session);
+
+const videoLayer = mediaLayerManager.createEquirectLayer(video, {
+  space: referenceSpace,
+  layout: 'stereo-left-right',
+  centralHorizontalAngle: Math.PI * 2,
+  radius: 0
+});
+
+await mediaLayerManager.updateRenderState([videoLayer]);
+```
+
+## Types
+
+### `WebXRMediaLayerType`
+
+```ts
+export type WebXRMediaLayerType = 'quad' | 'cylinder' | 'equirect';
+```
+
+### `WebXRMediaLayerState`
+
+```ts
+export type WebXRMediaLayerState = {
+  session: XRSession;
+  layer: XRCompositionLayer;
+  video: HTMLVideoElement;
+  type: WebXRMediaLayerType;
+  layout: XRLayerLayout;
+  invertStereo: boolean;
+  needsRedraw: boolean;
+};
+```
+
+## Methods
+
+### `setSession(session: XRSession | null): this`
+
+Attaches or clears the current XR session. The manager creates an `XRMediaBinding` for the active session.
+
+### `createQuadLayer(video: HTMLVideoElement, init: XRMediaQuadLayerInit): XRQuadLayer`
+
+Creates and tracks a flat video layer.
+
+### `createCylinderLayer(video: HTMLVideoElement, init: XRMediaCylinderLayerInit): XRCylinderLayer`
+
+Creates and tracks a curved video layer.
+
+### `createEquirectLayer(video: HTMLVideoElement, init: XRMediaEquirectLayerInit): XREquirectLayer`
+
+Creates and tracks a 360-degree equirect video layer.
+
+### `updateRenderState(layers: readonly XRLayer[]): Promise<void>`
+
+Updates the session render state with the supplied WebXR layers.
+
+### `getLayerState(layer: XRCompositionLayer): WebXRMediaLayerState | null`
+
+Returns the tracked video, type, layout, stereo inversion, and redraw state for a media layer.
+
+### `clearSession(): void`
+
+Removes event listeners and clears session references without ending the browser XR session.
+
+### `destroy(): void`
+
+Clears the current session wrappers.

--- a/docs/api-reference/experimental/webxr/webxr-mesh-detection-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-mesh-detection-manager.md
@@ -1,0 +1,111 @@
+# WebXRMeshDetectionManager
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRMeshDetectionManager` is the experimental AR mesh-detection helper for luma.gl. It reads `XRFrame.detectedMeshes`, resolves each mesh pose in the app reference space, exposes browser-owned `vertices` and `indices`, and reports added, updated, and removed meshes between XR frames.
+
+Request the WebXR `mesh-detection` feature when starting the AR session:
+
+```ts
+import {
+  getWebXRMeshDetectionSessionInit,
+  WebXRMeshDetectionManager
+} from '@luma.gl/experimental';
+
+const session = await navigator.xr!.requestSession('immersive-ar', {
+  optionalFeatures: ['local-floor', ...getWebXRMeshDetectionSessionInit().optionalFeatures!]
+});
+
+const meshManager = new WebXRMeshDetectionManager();
+meshManager.setSession(session, referenceSpace);
+```
+
+Then query detected meshes from the active XR frame:
+
+```ts
+const meshState = meshManager.getMeshDetectionState(xrFrame);
+
+if (meshState) {
+  for (const mesh of meshState.meshes) {
+    const matrix = mesh.matrix;
+    const vertices = mesh.vertices;
+    const indices = mesh.indices;
+  }
+}
+```
+
+## Types
+
+### `WebXRMeshDetectionManagerProps`
+
+```ts
+export type WebXRMeshDetectionManagerProps = {
+  semanticLabels?: readonly string[];
+};
+```
+
+`semanticLabels` filters meshes by browser-provided labels, when available.
+
+### `WebXRMeshDetectionState`
+
+```ts
+export type WebXRMeshDetectionState = {
+  xrFrame: XRFrame;
+  session: XRSession;
+  meshes: readonly WebXRMeshState[];
+  added: readonly WebXRMeshState[];
+  updated: readonly WebXRMeshState[];
+  removed: readonly WebXRMeshState[];
+};
+```
+
+`added`, `updated`, and `removed` are derived from mesh object identity and `XRMesh.lastChangedTime` compared with the previous successful call to `getMeshDetectionState()`.
+
+### `WebXRMeshState`
+
+```ts
+export type WebXRMeshState = {
+  xrMesh: XRMesh;
+  pose: XRPose;
+  matrix: Float32Array;
+  vertices: Float32Array;
+  indices: Uint32Array;
+  vertexCount: number;
+  triangleCount: number;
+  semanticLabel: string | null;
+  lastChangedTime: DOMHighResTimeStamp;
+};
+```
+
+`vertices` are expressed in `XRMesh.meshSpace`. `matrix` places that mesh space in the app reference space.
+
+## Methods
+
+### `constructor(props?: WebXRMeshDetectionManagerProps)`
+
+Creates an inactive manager. Call `setSession()` after the XR session and app reference space are available.
+
+### `setSession(session: XRSession | null, referenceSpace: XRReferenceSpace | null, props?: WebXRMeshDetectionManagerProps): this`
+
+Sets the active session and reference space. Passing `null` clears the active session.
+
+### `getMeshDetectionState(xrFrame: XRFrame): WebXRMeshDetectionState | null`
+
+Returns detected mesh state for the active session, or `null` when the browser did not enable or expose `XRFrame.detectedMeshes`.
+
+### `clearSession(): void`
+
+Removes listeners and clears cached mesh state.
+
+### `destroy(): void`
+
+Clears the active session.
+
+## Helpers
+
+### `getWebXRMeshDetectionSessionInit(props?: WebXRMeshDetectionSessionInitProps): XRSessionInit`
+
+Builds a minimal `XRSessionInit` fragment for requesting the `mesh-detection` feature.

--- a/docs/api-reference/experimental/webxr/webxr-plane-detection-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-plane-detection-manager.md
@@ -1,0 +1,117 @@
+# WebXRPlaneDetectionManager
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRPlaneDetectionManager` is the experimental AR plane-detection helper for luma.gl. It reads `XRFrame.detectedPlanes`, resolves each plane pose in the app reference space, converts plane polygons to simple numeric coordinates, and reports added, updated, and removed planes between XR frames.
+
+Request the WebXR `plane-detection` feature when starting the AR session:
+
+```ts
+import {
+  getWebXRPlaneDetectionSessionInit,
+  WebXRPlaneDetectionManager
+} from '@luma.gl/experimental';
+
+const session = await navigator.xr!.requestSession('immersive-ar', {
+  optionalFeatures: ['local-floor', ...getWebXRPlaneDetectionSessionInit().optionalFeatures!]
+});
+
+const planeManager = new WebXRPlaneDetectionManager({
+  orientations: ['horizontal']
+});
+planeManager.setSession(session, referenceSpace);
+```
+
+Then query detected planes from the active XR frame:
+
+```ts
+const planeState = planeManager.getPlaneDetectionState(xrFrame);
+
+if (planeState) {
+  for (const plane of planeState.planes) {
+    const matrix = plane.matrix;
+    const polygon = plane.polygon;
+  }
+}
+```
+
+## Types
+
+### `WebXRPlaneDetectionManagerProps`
+
+```ts
+export type WebXRPlaneDetectionManagerProps = {
+  orientations?: readonly XRPlaneOrientation[];
+  semanticLabels?: readonly string[];
+};
+```
+
+`orientations` filters planes by `'horizontal'` or `'vertical'`.
+
+`semanticLabels` filters planes by browser-provided labels, when available.
+
+### `WebXRPlaneDetectionState`
+
+```ts
+export type WebXRPlaneDetectionState = {
+  xrFrame: XRFrame;
+  session: XRSession;
+  planes: readonly WebXRPlaneState[];
+  added: readonly WebXRPlaneState[];
+  updated: readonly WebXRPlaneState[];
+  removed: readonly WebXRPlaneState[];
+};
+```
+
+`added`, `updated`, and `removed` are derived from plane object identity and `XRPlane.lastChangedTime` compared with the previous successful call to `getPlaneDetectionState()`.
+
+### `WebXRPlaneState`
+
+```ts
+export type WebXRPlaneState = {
+  xrPlane: XRPlane;
+  pose: XRPose;
+  matrix: Float32Array;
+  polygon: readonly [number, number, number][];
+  orientation: XRPlaneOrientation | null;
+  semanticLabel: string | null;
+  lastChangedTime: DOMHighResTimeStamp;
+};
+```
+
+`polygon` coordinates are relative to the plane pose, matching the WebXR Plane Detection API.
+
+## Methods
+
+### `constructor(props?: WebXRPlaneDetectionManagerProps)`
+
+Creates an inactive manager. Call `setSession()` after the XR session and app reference space are available.
+
+### `setSession(session: XRSession | null, referenceSpace: XRReferenceSpace | null, props?: WebXRPlaneDetectionManagerProps): this`
+
+Sets the active session and reference space. Passing `null` clears the active session.
+
+### `getPlaneDetectionState(xrFrame: XRFrame): WebXRPlaneDetectionState | null`
+
+Returns detected plane state for the active session, or `null` when the browser did not enable or expose `XRFrame.detectedPlanes`.
+
+### `initiateRoomCapture(): Promise<boolean>`
+
+Calls `XRSession.initiateRoomCapture()` when the browser exposes it and returns `true`. Returns `false` when room capture is unavailable.
+
+### `clearSession(): void`
+
+Removes listeners and clears cached plane state.
+
+### `destroy(): void`
+
+Clears the active session.
+
+## Helpers
+
+### `getWebXRPlaneDetectionSessionInit(props?: WebXRPlaneDetectionSessionInitProps): XRSessionInit`
+
+Builds a minimal `XRSessionInit` fragment for requesting the `plane-detection` feature.

--- a/docs/api-reference/experimental/webxr/webxr-reference-space-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-reference-space-manager.md
@@ -7,6 +7,8 @@
 
 `WebXRReferenceSpaceManager` is an experimental helper for tracking `XRReferenceSpace` reset events. Resets can happen when the native origin or effective origin changes, so apps can use this state to rebuild cached anchors, floor overlays, teleport limits, or diagnostics after the browser reports a discontinuity.
 
+The teleport helpers turn a floor-space target into an `XRRigidTransform` origin offset and optional offset reference space. By default they invert the target X/Z coordinates and preserve viewer height, matching common room-scale teleport behavior.
+
 ## Usage
 
 ```typescript
@@ -19,6 +21,13 @@ referenceSpaceManager.setReferenceSpace(referenceSpace);
 const state = referenceSpaceManager.getReferenceSpaceState();
 if (state?.lastResetEvent) {
   // Rebuild cached scene state that depends on the old reference-space origin.
+}
+
+const teleportState = referenceSpaceManager.getTeleportReferenceSpace(floorHit, {
+  bounds: boundsState?.bounds
+});
+if (teleportState) {
+  referenceSpace = teleportState.offsetReferenceSpace;
 }
 ```
 
@@ -36,6 +45,29 @@ export type WebXRReferenceSpaceResetState = {
 };
 ```
 
+### `WebXRTeleportOffsetProps`
+
+```ts
+export type WebXRTeleportOffsetProps = {
+  bounds?: readonly WebXRBoundsPoint[] | null;
+  preserveY?: boolean;
+  invert?: boolean;
+  orientation?: DOMPointInit;
+};
+```
+
+### `WebXRTeleportState`
+
+```ts
+export type WebXRTeleportState = {
+  referenceSpace: XRReferenceSpace;
+  offsetReferenceSpace: XRReferenceSpace;
+  originOffset: XRRigidTransform;
+  target: NumberArray3;
+  translation: NumberArray3;
+};
+```
+
 ## Methods
 
 ### `setReferenceSpace(referenceSpace: XRReferenceSpace | null): this`
@@ -50,6 +82,10 @@ Returns the current reference-space state, including the reset count and last re
 
 Calls `XRReferenceSpace.getOffsetReferenceSpace()` on the active reference space when the browser exposes it. Returns `null` when no active reference space or offset API is available.
 
+### `getTeleportReferenceSpace(target, props?): WebXRTeleportState | null`
+
+Creates a teleport origin offset and applies it to the active reference space. Returns `null` when no active reference space is attached, the browser lacks offset-reference-space support, `XRRigidTransform` is unavailable, or the target is outside supplied bounds.
+
 ### `clearReferenceSpace(): void`
 
 Removes event listeners and clears the active reference-space state.
@@ -63,3 +99,19 @@ Clears the current reference-space wrapper.
 ### `makeWebXRReferenceSpaceState(referenceSpace, resetCount, lastResetEvent): WebXRReferenceSpaceResetState`
 
 Creates a reference-space state snapshot from a reference space and its last reset event.
+
+### `getWebXRTeleportState(referenceSpace, target, props?): WebXRTeleportState | null`
+
+Creates a teleport origin offset and returns the offset reference space state for a supplied reference space.
+
+### `makeWebXRTeleportOffset(target, props?): XRRigidTransform | null`
+
+Creates an `XRRigidTransform` offset for a teleport target. Returns `null` when `XRRigidTransform` is unavailable or supplied bounds reject the target.
+
+### `getWebXRTeleportTranslation(target, props?): NumberArray3`
+
+Returns the translation used for a teleport offset. Defaults to `[-target.x, 0, -target.z]`; set `preserveY: false` to include Y and `invert: false` to keep the target sign.
+
+### `isWebXRTeleportTargetAllowed(target, bounds?): boolean`
+
+Returns `true` when no bounds are supplied or the target is inside the supplied bounded-floor polygon.

--- a/docs/api-reference/experimental/webxr/webxr-reference-space-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-reference-space-manager.md
@@ -1,0 +1,65 @@
+# WebXRReferenceSpaceManager
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRReferenceSpaceManager` is an experimental helper for tracking `XRReferenceSpace` reset events. Resets can happen when the native origin or effective origin changes, so apps can use this state to rebuild cached anchors, floor overlays, teleport limits, or diagnostics after the browser reports a discontinuity.
+
+## Usage
+
+```typescript
+import {WebXRReferenceSpaceManager} from '@luma.gl/experimental';
+
+const referenceSpaceManager = new WebXRReferenceSpaceManager();
+
+referenceSpaceManager.setReferenceSpace(referenceSpace);
+
+const state = referenceSpaceManager.getReferenceSpaceState();
+if (state?.lastResetEvent) {
+  // Rebuild cached scene state that depends on the old reference-space origin.
+}
+```
+
+## Types
+
+### `WebXRReferenceSpaceResetState`
+
+```ts
+export type WebXRReferenceSpaceResetState = {
+  referenceSpace: XRReferenceSpace;
+  resetCount: number;
+  lastResetEvent: XRReferenceSpaceEvent | null;
+  transform: XRRigidTransform | null;
+  matrix: Float32Array | null;
+};
+```
+
+## Methods
+
+### `setReferenceSpace(referenceSpace: XRReferenceSpace | null): this`
+
+Attaches or clears the current reference space. When a reference space is attached, the manager listens for `reset` events.
+
+### `getReferenceSpaceState(): WebXRReferenceSpaceResetState | null`
+
+Returns the current reference-space state, including the reset count and last reset transform, or `null` when no reference space is attached.
+
+### `getOffsetReferenceSpace(originOffset: XRRigidTransform): XRReferenceSpace | null`
+
+Calls `XRReferenceSpace.getOffsetReferenceSpace()` on the active reference space when the browser exposes it. Returns `null` when no active reference space or offset API is available.
+
+### `clearReferenceSpace(): void`
+
+Removes event listeners and clears the active reference-space state.
+
+### `destroy(): void`
+
+Clears the current reference-space wrapper.
+
+## Functions
+
+### `makeWebXRReferenceSpaceState(referenceSpace, resetCount, lastResetEvent): WebXRReferenceSpaceResetState`
+
+Creates a reference-space state snapshot from a reference space and its last reset event.

--- a/docs/api-reference/experimental/webxr/webxr-render-state-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-render-state-manager.md
@@ -1,0 +1,84 @@
+# WebXRRenderStateManager
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRRenderStateManager` is an experimental helper for updating and reading WebXR render state. It focuses on clip planes and inline field of view, complementing `WebXRManager` which installs the base WebGL layer or WebGPU projection layer.
+
+## Usage
+
+```typescript
+import {WebXRRenderStateManager} from '@luma.gl/experimental';
+
+const renderStateManager = new WebXRRenderStateManager({
+  depthNear: 0.05,
+  depthFar: 100
+});
+
+await renderStateManager.setSession(session);
+
+const renderState = renderStateManager.getRenderState();
+```
+
+## Types
+
+### `WebXRRenderStateManagerProps`
+
+```ts
+export type WebXRRenderStateManagerProps = {
+  depthNear?: number | null;
+  depthFar?: number | null;
+  inlineVerticalFieldOfView?: number | null;
+};
+```
+
+### `WebXRRenderState`
+
+```ts
+export type WebXRRenderState = {
+  session: XRSession;
+  depthNear: number | null;
+  depthFar: number | null;
+  inlineVerticalFieldOfView: number | null;
+  baseLayer: XRWebGLLayer | null;
+  layers: readonly XRLayer[];
+};
+```
+
+## Methods
+
+### `constructor(props?: WebXRRenderStateManagerProps)`
+
+Creates an inactive render-state manager.
+
+### `setSession(session: XRSession | null, props?: WebXRRenderStateManagerProps): Promise<this>`
+
+Attaches or clears the current XR session. When a session is attached, the configured render-state values are queued with `XRSession.updateRenderState()`.
+
+### `getRenderState(): WebXRRenderState | null`
+
+Returns the current render-state snapshot, or `null` when no session is attached.
+
+### `updateRenderState(props?: WebXRRenderStateManagerProps): Promise<WebXRRenderState | null>`
+
+Queues a render-state update for defined clip-plane and inline-FOV values, then returns the latest snapshot. Returns `null` when no session is attached.
+
+### `clearSession(): void`
+
+Removes event listeners and releases the active session reference without ending the browser XR session.
+
+### `destroy(): void`
+
+Clears the current session wrapper.
+
+## Functions
+
+### `makeWebXRRenderState(session: XRSession): WebXRRenderState`
+
+Creates a render-state snapshot from `XRSession.renderState`.
+
+### `getWebXRRenderStateInit(props?: WebXRRenderStateManagerProps): XRRenderStateInit`
+
+Creates an `XRRenderStateInit` containing only defined clip-plane and inline-FOV values.

--- a/docs/api-reference/experimental/webxr/webxr-session-init.md
+++ b/docs/api-reference/experimental/webxr/webxr-session-init.md
@@ -1,0 +1,77 @@
+# WebXR Session Init
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`mergeWebXRSessionInit` composes `XRSessionInit` dictionaries from WebXR feature helpers. It de-duplicates feature descriptors, keeps required features out of the optional list, and preserves module-specific fields such as `depthSensing`, `domOverlay`, and `trackedImages`.
+
+## Usage
+
+```typescript
+import {
+  getWebXRDepthSensingSessionInit,
+  mergeWebXRSessionInit
+} from '@luma.gl/experimental';
+
+const sessionInit = mergeWebXRSessionInit(
+  {requiredFeatures: ['webgpu'], optionalFeatures: ['local-floor', 'depth-sensing']},
+  getWebXRDepthSensingSessionInit()
+);
+
+const session = await navigator.xr!.requestSession('immersive-ar', sessionInit);
+```
+
+## Constants
+
+### `WEBXR_DEFAULT_SESSION_SUPPORT_MODES`
+
+```ts
+export const WEBXR_DEFAULT_SESSION_SUPPORT_MODES: readonly XRSessionMode[] = [
+  'immersive-vr',
+  'immersive-ar',
+  'inline'
+];
+```
+
+## Types
+
+### `WebXRSessionFeatures`
+
+```ts
+export type WebXRSessionFeatures = {
+  requiredFeatures: readonly string[];
+  optionalFeatures: readonly string[];
+  requestedFeatures: readonly string[];
+};
+```
+
+### `WebXRSessionSupport`
+
+```ts
+export type WebXRSessionSupport = {
+  xr: XRSystem | null;
+  isSupported: boolean;
+  modes: Partial<Record<XRSessionMode, boolean>>;
+  supportedModes: readonly XRSessionMode[];
+};
+```
+
+## Functions
+
+### `mergeWebXRSessionInit(...sessionInits): XRSessionInit`
+
+Merges any number of `XRSessionInit` dictionaries. Required and optional features are de-duplicated in insertion order. If a feature is required by any input, it is removed from the merged optional feature list.
+
+### `getWebXRSessionFeatures(sessionInit): WebXRSessionFeatures`
+
+Returns normalized required, optional, and combined requested feature lists from one session init.
+
+### `isWebXRSessionFeatureEnabled(session, feature): boolean`
+
+Returns whether `XRSession.enabledFeatures` contains a feature descriptor.
+
+### `getWebXRSessionSupport(props?): Promise<WebXRSessionSupport>`
+
+Checks `XRSystem.isSessionSupported()` for the requested modes. Missing `navigator.xr` and rejected support probes are reported as unsupported.

--- a/docs/api-reference/experimental/webxr/webxr-session-state-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-session-state-manager.md
@@ -1,0 +1,95 @@
+# WebXRSessionStateManager
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRSessionStateManager` is an experimental helper for tracking XR session visibility and refresh-rate state. It snapshots `XRSession.visibilityState`, `frameRate`, `supportedFrameRates`, and system-keyboard availability, and can request a target frame rate when the browser exposes `XRSession.updateTargetFrameRate()`.
+
+## Usage
+
+```typescript
+import {WebXRSessionStateManager} from '@luma.gl/experimental';
+
+const sessionStateManager = new WebXRSessionStateManager({
+  targetFrameRate: 'highest'
+});
+
+await sessionStateManager.setSession(session);
+
+const sessionState = sessionStateManager.getSessionState();
+if (sessionState?.isVisible) {
+  // Keep rendering or running visibility-dependent app logic.
+}
+```
+
+## Types
+
+### `WebXRTargetFrameRate`
+
+```ts
+export type WebXRTargetFrameRate = number | 'highest' | 'lowest';
+```
+
+### `WebXRSessionStateManagerProps`
+
+```ts
+export type WebXRSessionStateManagerProps = {
+  targetFrameRate?: WebXRTargetFrameRate | null;
+};
+```
+
+### `WebXRSessionState`
+
+```ts
+export type WebXRSessionState = {
+  session: XRSession;
+  visibilityState: XRVisibilityState;
+  frameRate: number | null;
+  supportedFrameRates: readonly number[];
+  isVisible: boolean;
+  isFocused: boolean;
+  isSystemKeyboardSupported: boolean | null;
+};
+```
+
+## Methods
+
+### `constructor(props?: WebXRSessionStateManagerProps)`
+
+Creates an inactive session-state manager.
+
+### `setSession(session: XRSession | null, props?: WebXRSessionStateManagerProps): Promise<this>`
+
+Attaches or clears the current XR session. When a session is attached, the manager listens for `visibilitychange`, `frameratechange`, and `end` events, and optionally requests the configured target frame rate.
+
+### `getSessionState(): WebXRSessionState | null`
+
+Returns the current session-state snapshot, or `null` when no session is attached.
+
+### `updateTargetFrameRate(targetFrameRate: WebXRTargetFrameRate): Promise<number | null>`
+
+Requests an explicit, highest, or lowest supported target frame rate. Returns the requested numeric rate, or `null` when no session is active, no matching supported rate exists, or the browser does not expose `updateTargetFrameRate()`.
+
+### `clearSession(): void`
+
+Removes event listeners and releases the active session reference without ending the browser XR session.
+
+### `destroy(): void`
+
+Clears the current session wrapper.
+
+## Functions
+
+### `makeWebXRSessionState(session: XRSession): WebXRSessionState`
+
+Creates a session-state snapshot from an `XRSession`.
+
+### `getWebXRSupportedFrameRates(session: XRSession): readonly number[]`
+
+Returns `XRSession.supportedFrameRates` as a regular number array, or an empty array when unsupported.
+
+### `getWebXRTargetFrameRate(session: XRSession, targetFrameRate: WebXRTargetFrameRate): number | null`
+
+Resolves `'highest'`, `'lowest'`, or an explicit frame rate against `XRSession.supportedFrameRates`.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -420,6 +420,7 @@
               "api-reference/experimental/webxr/README",
               "api-reference/experimental/webxr/webxr-anchor-manager",
               "api-reference/experimental/webxr/webxr-camera-texture",
+              "api-reference/experimental/webxr/webxr-depth-sensing-manager",
               "api-reference/experimental/webxr/webxr-hit-test-manager",
               "api-reference/experimental/webxr/webxr-manager"
             ]

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -420,6 +420,7 @@
               "api-reference/experimental/webxr/README",
               "api-reference/experimental/webxr/webxr-anchor-manager",
               "api-reference/experimental/webxr/webxr-camera-texture",
+              "api-reference/experimental/webxr/webxr-composition-layer-manager",
               "api-reference/experimental/webxr/webxr-depth-sensing-manager",
               "api-reference/experimental/webxr/webxr-dom-overlay-manager",
               "api-reference/experimental/webxr/webxr-hand-tracking-manager",

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -429,6 +429,7 @@
               "api-reference/experimental/webxr/webxr-hit-test-manager",
               "api-reference/experimental/webxr/webxr-light-estimation-manager",
               "api-reference/experimental/webxr/webxr-media-layer-manager",
+              "api-reference/experimental/webxr/webxr-plane-detection-manager",
               "api-reference/experimental/webxr/webxr-manager"
             ]
           }

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -419,6 +419,7 @@
             "items": [
               "api-reference/experimental/webxr/README",
               "api-reference/experimental/webxr/webxr-camera-texture",
+              "api-reference/experimental/webxr/webxr-hit-test-manager",
               "api-reference/experimental/webxr/webxr-manager"
             ]
           }

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -426,6 +426,7 @@
               "api-reference/experimental/webxr/webxr-hand-gestures",
               "api-reference/experimental/webxr/webxr-hand-tracking-manager",
               "api-reference/experimental/webxr/webxr-haptics",
+              "api-reference/experimental/webxr/webxr-image-tracking-manager",
               "api-reference/experimental/webxr/webxr-hit-test-manager",
               "api-reference/experimental/webxr/webxr-light-estimation-manager",
               "api-reference/experimental/webxr/webxr-media-layer-manager",

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -425,6 +425,7 @@
               "api-reference/experimental/webxr/webxr-dom-overlay-manager",
               "api-reference/experimental/webxr/webxr-hand-gestures",
               "api-reference/experimental/webxr/webxr-hand-tracking-manager",
+              "api-reference/experimental/webxr/webxr-haptics",
               "api-reference/experimental/webxr/webxr-hit-test-manager",
               "api-reference/experimental/webxr/webxr-media-layer-manager",
               "api-reference/experimental/webxr/webxr-manager"

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -429,6 +429,7 @@
               "api-reference/experimental/webxr/webxr-hit-test-manager",
               "api-reference/experimental/webxr/webxr-light-estimation-manager",
               "api-reference/experimental/webxr/webxr-media-layer-manager",
+              "api-reference/experimental/webxr/webxr-mesh-detection-manager",
               "api-reference/experimental/webxr/webxr-plane-detection-manager",
               "api-reference/experimental/webxr/webxr-manager"
             ]

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -427,6 +427,7 @@
               "api-reference/experimental/webxr/webxr-hand-tracking-manager",
               "api-reference/experimental/webxr/webxr-haptics",
               "api-reference/experimental/webxr/webxr-hit-test-manager",
+              "api-reference/experimental/webxr/webxr-light-estimation-manager",
               "api-reference/experimental/webxr/webxr-media-layer-manager",
               "api-reference/experimental/webxr/webxr-manager"
             ]

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -421,6 +421,7 @@
               "api-reference/experimental/webxr/webxr-anchor-manager",
               "api-reference/experimental/webxr/webxr-camera-texture",
               "api-reference/experimental/webxr/webxr-depth-sensing-manager",
+              "api-reference/experimental/webxr/webxr-hand-tracking-manager",
               "api-reference/experimental/webxr/webxr-hit-test-manager",
               "api-reference/experimental/webxr/webxr-manager"
             ]

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -423,6 +423,7 @@
               "api-reference/experimental/webxr/webxr-composition-layer-manager",
               "api-reference/experimental/webxr/webxr-depth-sensing-manager",
               "api-reference/experimental/webxr/webxr-dom-overlay-manager",
+              "api-reference/experimental/webxr/webxr-hand-gestures",
               "api-reference/experimental/webxr/webxr-hand-tracking-manager",
               "api-reference/experimental/webxr/webxr-hit-test-manager",
               "api-reference/experimental/webxr/webxr-media-layer-manager",

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -421,6 +421,7 @@
               "api-reference/experimental/webxr/webxr-anchor-manager",
               "api-reference/experimental/webxr/webxr-camera-texture",
               "api-reference/experimental/webxr/webxr-depth-sensing-manager",
+              "api-reference/experimental/webxr/webxr-dom-overlay-manager",
               "api-reference/experimental/webxr/webxr-hand-tracking-manager",
               "api-reference/experimental/webxr/webxr-hit-test-manager",
               "api-reference/experimental/webxr/webxr-manager"

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -425,6 +425,7 @@
               "api-reference/experimental/webxr/webxr-dom-overlay-manager",
               "api-reference/experimental/webxr/webxr-hand-tracking-manager",
               "api-reference/experimental/webxr/webxr-hit-test-manager",
+              "api-reference/experimental/webxr/webxr-media-layer-manager",
               "api-reference/experimental/webxr/webxr-manager"
             ]
           }

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -418,6 +418,7 @@
             "label": "WebXR",
             "items": [
               "api-reference/experimental/webxr/README",
+              "api-reference/experimental/webxr/webxr-anchor-manager",
               "api-reference/experimental/webxr/webxr-camera-texture",
               "api-reference/experimental/webxr/webxr-hit-test-manager",
               "api-reference/experimental/webxr/webxr-manager"

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -25,7 +25,7 @@ import {
   getWebXRDOMOverlaySessionInit,
   getWebXRBoundsState,
   getWebXRHandPinch,
-  getWebXRControllerState,
+  getWebXRControllerStates,
   getWebXRInputRayPlaneIntersection,
   getWebXRLocomotionState,
   getWebXRSessionRenderState,
@@ -919,12 +919,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     time: number,
     boundsState: WebXRBoundsState | null
   ): void {
-    for (const input of inputState) {
-      const controllerState = getWebXRControllerState(input);
-      if (!controllerState) {
-        continue;
-      }
-
+    for (const controllerState of getWebXRControllerStates(inputState)) {
       if (controllerState.grip) {
         this.modelViewProjectionMatrix
           .copy(view.projectionMatrix)
@@ -976,7 +971,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       if (floorHit) {
         const teleportTarget = getXRTeleportTargetState(floorHit.point, boundsState);
         if (teleportTarget.allowed) {
-          this._floorHitByInputSource.set(input.inputSource, floorHit.point);
+          this._floorHitByInputSource.set(controllerState.inputSource, floorHit.point);
         }
         this.controllerReticleMatrix.identity().translate(teleportTarget.point);
         this.modelViewProjectionMatrix

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -17,6 +17,7 @@ import {
   WebXRManager,
   WebXRPlaneDetectionManager,
   WebXRReferenceSpaceManager,
+  WebXRRenderStateManager,
   WebXRSessionStateManager,
   getWebXRBoundsState,
   getWebXRGamepadState,
@@ -405,6 +406,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     orientations: ['horizontal']
   });
   readonly webXRReferenceSpaceManager = new WebXRReferenceSpaceManager();
+  readonly webXRRenderStateManager = new WebXRRenderStateManager({
+    depthNear: 0.05,
+    depthFar: 100
+  });
   readonly webXRSessionStateManager = new WebXRSessionStateManager({
     targetFrameRate: 'highest'
   });
@@ -568,6 +573,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.webXRMeshDetectionManager.destroy();
     this.webXRPlaneDetectionManager.destroy();
     this.webXRReferenceSpaceManager.destroy();
+    this.webXRRenderStateManager.destroy();
     this.webXRSessionStateManager.destroy();
     this.webXRManager.destroy();
   }
@@ -659,6 +665,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           : {})
       });
       this.webXRReferenceSpaceManager.setReferenceSpace(this.webXRManager.referenceSpace);
+      await this.webXRRenderStateManager
+        .setSession(session)
+        .catch(() => this.webXRRenderStateManager.clearSession());
       this.webXRHandTrackingManager.setSession(session, this.webXRManager.referenceSpace);
       if (sessionMode === 'immersive-ar') {
         await this.webXRHitTestManager
@@ -1017,6 +1026,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.webXRMeshDetectionManager.clearSession();
     this.webXRPlaneDetectionManager.clearSession();
     this.webXRReferenceSpaceManager.clearReferenceSpace();
+    this.webXRRenderStateManager.clearSession();
     this.webXRSessionStateManager.clearSession();
     this.webXRManager.clearSession();
     AppAnimationLoopTemplate.notifyCurrentListeners();

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -10,11 +10,13 @@ import {
   WebXRAnimationFrameProvider,
   WebXRCameraTexture,
   WebXRDOMOverlayManager,
+  WebXRHandTrackingManager,
   WebXRHitTestManager,
   WebXRManager,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
   type WebXRFrameState,
+  type WebXRHandTrackingState,
   type WebXRHitTestState,
   type WebXRInputState
 } from '@luma.gl/experimental';
@@ -363,13 +365,16 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly model: Model;
   readonly controllerRayModel: Model;
   readonly controllerReticleModel: Model;
+  readonly handJointModel: Model;
   readonly webXRManager: WebXRManager;
   readonly webXRDOMOverlayManager = new WebXRDOMOverlayManager();
+  readonly webXRHandTrackingManager = new WebXRHandTrackingManager();
   readonly webXRHitTestManager = new WebXRHitTestManager();
   readonly modelMatrix = new Matrix4();
   readonly modelViewProjectionMatrix = new Matrix4();
   readonly controllerRayMatrix = new Matrix4();
   readonly controllerReticleMatrix = new Matrix4();
+  readonly handJointMatrix = new Matrix4();
   readonly xrSceneOffset: [number, number, number] = [0, 0, 0];
   readonly viewMatrix = new Matrix4().lookAt({
     eye: [0.32, 0.24, 4.4],
@@ -472,6 +477,27 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         blendAlphaDstFactor: 'one-minus-src-alpha'
       }
     });
+    this.handJointModel = new Model(device, {
+      id: 'immersive-prism-hand-joints',
+      source: CONTROLLER_RAY_WGSL_SHADER,
+      vs: CONTROLLER_RAY_VS_GLSL,
+      fs: CONTROLLER_RAY_FS_GLSL,
+      geometry: makeHandJointGeometry(),
+      bindings: {
+        app: this.uniformStore.getManagedUniformBuffer('app')
+      },
+      parameters: {
+        depthWriteEnabled: false,
+        depthCompare: 'less-equal',
+        blend: true,
+        blendColorOperation: 'add',
+        blendAlphaOperation: 'add',
+        blendColorSrcFactor: 'src-alpha',
+        blendColorDstFactor: 'one',
+        blendAlphaSrcFactor: 'one',
+        blendAlphaDstFactor: 'one-minus-src-alpha'
+      }
+    });
     this.initializePreviewControls();
 
     if (typeof window !== 'undefined') {
@@ -491,11 +517,13 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     }
     this.orbitControls?.destroy();
     this.controllerReticleModel.destroy();
+    this.handJointModel.destroy();
     this.controllerRayModel.destroy();
     this.model.destroy();
     this.fallbackTexture.destroy();
     this.uniformStore.destroy();
     this.webXRDOMOverlayManager.destroy();
+    this.webXRHandTrackingManager.destroy();
     this.webXRHitTestManager.destroy();
     this.webXRManager.destroy();
   }
@@ -505,11 +533,18 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     const xrFrame = animationFrame as XRFrame | null;
     const frameState = xrFrame && this.xrSession ? this.webXRManager.getFrameState(xrFrame) : null;
     const inputState = xrFrame && this.xrSession ? this.webXRManager.getInputState(xrFrame) : null;
+    const handState =
+      xrFrame && this.xrSession
+        ? this.webXRHandTrackingManager.getHandsState(
+            xrFrame,
+            (inputState || []).map(input => input.inputSource)
+          )
+        : null;
     const hitTestState =
       xrFrame && this.xrSession ? this.webXRHitTestManager.getHitTestState(xrFrame) : null;
 
     if (frameState) {
-      this.renderXRFrame(time, frameState, inputState || [], hitTestState);
+      this.renderXRFrame(time, frameState, inputState || [], handState || [], hitTestState);
       return;
     }
 
@@ -558,6 +593,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           ? {layerInit: {alpha: sessionMode === 'immersive-ar'}}
           : {})
       });
+      this.webXRHandTrackingManager.setSession(session, this.webXRManager.referenceSpace);
       if (sessionMode === 'immersive-ar') {
         await this.webXRHitTestManager
           .setSession(session, this.webXRManager.referenceSpace, {entityTypes: ['plane', 'point']})
@@ -613,6 +649,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     time: number,
     frameState: WebXRFrameState,
     inputState: readonly WebXRInputState[],
+    handState: readonly WebXRHandTrackingState[],
     hitTestState: WebXRHitTestState | null
   ): void {
     this.updateModelMatrix(time, true, hitTestState);
@@ -645,6 +682,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       renderPass.setParameters({viewport: view.viewport});
       this.drawPortal(renderPass);
       this.drawControllerTargets(renderPass, view, inputState, time);
+      this.drawHandJoints(renderPass, view, handState, time);
       renderPass.end();
     }
   }
@@ -721,6 +759,42 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         );
         this.controllerReticleModel.predraw(this.device.commandEncoder);
         this.controllerReticleModel.draw(renderPass);
+      }
+    }
+  }
+
+  private drawHandJoints(
+    renderPass: ReturnType<Device['beginRenderPass']>,
+    view: WebXRFrameState['views'][number],
+    handState: readonly WebXRHandTrackingState[],
+    time: number
+  ): void {
+    for (const hand of handState) {
+      const handColorMix = hand.handedness === 'right' ? 1 : 0;
+
+      for (const joint of hand.joints) {
+        if (!joint.matrix) {
+          continue;
+        }
+
+        const jointScale = Math.max(joint.radius ?? 0.008, 0.006) * 1.8;
+        this.handJointMatrix.copy(joint.matrix).scale([jointScale, jointScale, jointScale]);
+        this.modelViewProjectionMatrix
+          .copy(view.projectionMatrix)
+          .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))
+          .multiplyRight(this.handJointMatrix);
+        this.uniformStore.setUniforms(
+          {
+            app: {
+              modelViewProjectionMatrix: this.modelViewProjectionMatrix,
+              time,
+              cameraMix: handColorMix
+            }
+          },
+          this.device.commandEncoder
+        );
+        this.handJointModel.predraw(this.device.commandEncoder);
+        this.handJointModel.draw(renderPass);
       }
     }
   }
@@ -813,6 +887,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.cameraTexture?.destroy();
     this.cameraTexture = null;
     this.webXRDOMOverlayManager.clearSession();
+    this.webXRHandTrackingManager.clearSession();
     this.webXRHitTestManager.clearSession();
     this.webXRManager.clearSession();
     if (!this._isFinalized) {
@@ -927,6 +1002,18 @@ function makeControllerReticleGeometry(): Geometry {
       positions: {
         size: 3,
         value: new Float32Array(positions)
+      }
+    }
+  });
+}
+
+function makeHandJointGeometry(): Geometry {
+  return new Geometry({
+    topology: 'line-list',
+    attributes: {
+      positions: {
+        size: 3,
+        value: new Float32Array([-1, 0, 0, 1, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, -1, 0, 0, 1])
       }
     }
   });

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -26,6 +26,8 @@ import {
   getWebXRHandPinch,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
+  getWebXRLocomotionState,
+  getWebXRTeleportTranslation,
   isPointInWebXRBounds,
   mergeWebXRSessionInit,
   pulseWebXRInputHaptics,
@@ -52,6 +54,7 @@ const RIBBON_SEGMENT_COUNT = 34;
 const PARTICLE_COUNT = 220;
 const PORTAL_DEPTH = 10.4;
 const CAMERA_TARGET: [number, number, number] = [0, 0, -2.6];
+const XR_LOCOMOTION_SPEED = 1.4;
 const AR_DEPTH_SENSING: XRDepthStateInit = {
   usagePreference: ['gpu-optimized', 'cpu-optimized'],
   dataFormatPreference: ['luminance-alpha', 'float32', 'unsigned-short'],
@@ -435,6 +438,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   private _isFinalized = false;
   private _floorHitByInputSource = new Map<XRInputSource, [number, number, number]>();
   private _inputStateByInputSource = new Map<XRInputSource, WebXRInputState>();
+  private _lastXRLocomotionTimeMilliseconds: number | null = null;
   private _xrSessionEndListener = () => this._clearXRSession();
   private _xrSelectEndListener = (event: Event) =>
     this.teleportToInputSource((event as XRInputSourceEvent).inputSource);
@@ -609,6 +613,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         : null;
 
     if (frameState) {
+      this.updateXRLocomotion(inputState || [], elapsedTimeMilliseconds);
       this.renderXRFrame(
         time,
         frameState,
@@ -791,6 +796,37 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     }
   }
 
+  private updateXRLocomotion(
+    inputState: readonly WebXRInputState[],
+    elapsedTimeMilliseconds: number
+  ): void {
+    if (this.xrSessionMode !== 'immersive-vr') {
+      this._lastXRLocomotionTimeMilliseconds = null;
+      return;
+    }
+
+    const lastTimeMilliseconds = this._lastXRLocomotionTimeMilliseconds;
+    this._lastXRLocomotionTimeMilliseconds = elapsedTimeMilliseconds;
+    const deltaSeconds =
+      lastTimeMilliseconds === null
+        ? 0
+        : Math.min(0.05, Math.max(0, (elapsedTimeMilliseconds - lastTimeMilliseconds) * 0.001));
+    const locomotionState = getWebXRLocomotionState(inputState, {
+      deadzone: 0.22,
+      snapTurnThreshold: 0.86
+    });
+    if (!locomotionState.moveActive) {
+      return;
+    }
+
+    const [strafe, forward] = locomotionState.move;
+    this.applyXRSceneOffset([
+      strafe * XR_LOCOMOTION_SPEED * deltaSeconds,
+      0,
+      -forward * XR_LOCOMOTION_SPEED * deltaSeconds
+    ]);
+  }
+
   private preparePortal(options: {
     cameraMix: number;
     lightIntensity: number;
@@ -962,13 +998,16 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       return;
     }
 
-    this.xrSceneOffset[0] -= floorHit[0];
-    this.xrSceneOffset[2] -= floorHit[2];
+    this.applyXRSceneOffset(getWebXRTeleportTranslation(floorHit));
     const inputState = this._inputStateByInputSource.get(inputSource);
     if (inputState) {
       void pulseWebXRInputHaptics(inputState, {intensity: 0.5, duration: 45});
     }
     this._floorHitByInputSource.clear();
+  }
+
+  private applyXRSceneOffset(offset: readonly [number, number, number]): void {
+    applyXRSceneOffset(this.xrSceneOffset, offset);
   }
 
   private createCameraTexture(session: XRSession): WebXRCameraTexture | null {
@@ -1018,6 +1057,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.xrSceneOffset[0] = 0;
     this.xrSceneOffset[1] = 0;
     this.xrSceneOffset[2] = 0;
+    this._lastXRLocomotionTimeMilliseconds = null;
     this._floorHitByInputSource.clear();
     this._inputStateByInputSource.clear();
     this.cameraTexture?.destroy();
@@ -1081,6 +1121,16 @@ function getXRLightIntensity(lightState: WebXRLightEstimationState | null): numb
 
   const [red, green, blue] = lightState.primaryLightIntensity;
   return Math.min(1.6, Math.max(0.55, (red + green + blue) / 3));
+}
+
+export function applyXRSceneOffset(
+  sceneOffset: [number, number, number],
+  offset: readonly [number, number, number]
+): [number, number, number] {
+  sceneOffset[0] += offset[0];
+  sceneOffset[1] += offset[1];
+  sceneOffset[2] += offset[2];
+  return sceneOffset;
 }
 
 function makeSpatialPortalGeometry(): Geometry {

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -264,6 +264,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   Fly through a stereoscopic field of animated prism shards. WebGPU renders directly into
   native WebXR projection layers when supported. WebGL2 remains available on older XR
   browsers and can fold raw AR camera imagery into the portal when access is granted.
+  Desktop testing works with the
+  <a href="https://chromewebstore.google.com/detail/codex/hehggadaopoacecdllhhajmbjkdcmajg?pli=1" target="_blank" rel="noreferrer">Immersive Web Emulator Chrome extension</a>.
   </p>
   `;
 

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -12,6 +12,7 @@ import {
   WebXRDOMOverlayManager,
   WebXRHandTrackingManager,
   WebXRHitTestManager,
+  WebXRLightEstimationManager,
   WebXRManager,
   getWebXRHandPinch,
   getWebXRInputRay,
@@ -20,7 +21,8 @@ import {
   type WebXRFrameState,
   type WebXRHandTrackingState,
   type WebXRHitTestState,
-  type WebXRInputState
+  type WebXRInputState,
+  type WebXRLightEstimationState
 } from '@luma.gl/experimental';
 import {Matrix4} from '@math.gl/core';
 
@@ -47,13 +49,15 @@ type AppUniforms = {
   modelViewProjectionMatrix: NumberArray;
   time: number;
   cameraMix: number;
+  lightIntensity: number;
 };
 
 const app: {uniformTypes: Record<keyof AppUniforms, VariableShaderType>} = {
   uniformTypes: {
     modelViewProjectionMatrix: 'mat4x4<f32>',
     time: 'f32',
-    cameraMix: 'f32'
+    cameraMix: 'f32',
+    lightIntensity: 'f32'
   }
 };
 
@@ -62,6 +66,7 @@ struct AppUniforms {
   modelViewProjectionMatrix: mat4x4<f32>,
   time: f32,
   cameraMix: f32,
+  lightIntensity: f32,
 };
 
 @group(0) @binding(auto) var<uniform> app: AppUniforms;
@@ -147,6 +152,7 @@ fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
   let cameraColor = textureSample(cameraTexture, cameraTextureSampler, cameraUv).rgb;
   color = mix(color, cameraColor * (0.72 + edgeGlow * 0.4) + spectralColor * edgeGlow * 0.55,
               app.cameraMix * (1.0 - inputs.depthFactor * 0.7));
+  color *= app.lightIntensity;
   let alpha = clamp((0.38 + edgeGlow * 0.5 + coreGlow * 0.45) *
                     (0.75 + inputs.shardKind * 0.12), 0.0, 0.98);
   return vec4<f32>(color, alpha);
@@ -164,6 +170,7 @@ uniform appUniforms {
   mat4 modelViewProjectionMatrix;
   float time;
   float cameraMix;
+  float lightIntensity;
 } app;
 
 out vec2 vUV;
@@ -208,6 +215,7 @@ uniform appUniforms {
   mat4 modelViewProjectionMatrix;
   float time;
   float cameraMix;
+  float lightIntensity;
 } app;
 
 in vec2 vUV;
@@ -249,6 +257,7 @@ void main(void) {
   color = mix(color,
     cameraColor * (0.72 + edgeGlow * 0.4) + spectralColor * edgeGlow * 0.55,
     app.cameraMix * (1.0 - vDepthFactor * 0.7));
+  color *= app.lightIntensity;
   float alpha = clamp((0.38 + edgeGlow * 0.5 + coreGlow * 0.45) *
     (0.75 + vShardKind * 0.12), 0.0, 0.98);
   fragColor = vec4(color, alpha);
@@ -260,6 +269,7 @@ struct AppUniforms {
   modelViewProjectionMatrix: mat4x4<f32>,
   time: f32,
   cameraMix: f32,
+  lightIntensity: f32,
 };
 
 @group(0) @binding(auto) var<uniform> app: AppUniforms;
@@ -300,6 +310,7 @@ uniform appUniforms {
   mat4 modelViewProjectionMatrix;
   float time;
   float cameraMix;
+  float lightIntensity;
 } app;
 
 out float vRayDepth;
@@ -318,6 +329,7 @@ uniform appUniforms {
   mat4 modelViewProjectionMatrix;
   float time;
   float cameraMix;
+  float lightIntensity;
 } app;
 
 in float vRayDepth;
@@ -376,6 +388,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly webXRDOMOverlayManager = new WebXRDOMOverlayManager();
   readonly webXRHandTrackingManager = new WebXRHandTrackingManager();
   readonly webXRHitTestManager = new WebXRHitTestManager();
+  readonly webXRLightEstimationManager = new WebXRLightEstimationManager({
+    reflectionFormat: 'preferred'
+  });
   readonly modelMatrix = new Matrix4();
   readonly modelViewProjectionMatrix = new Matrix4();
   readonly controllerRayMatrix = new Matrix4();
@@ -532,6 +547,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.webXRDOMOverlayManager.destroy();
     this.webXRHandTrackingManager.destroy();
     this.webXRHitTestManager.destroy();
+    this.webXRLightEstimationManager.destroy();
     this.webXRManager.destroy();
   }
 
@@ -549,9 +565,20 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         : null;
     const hitTestState =
       xrFrame && this.xrSession ? this.webXRHitTestManager.getHitTestState(xrFrame) : null;
+    const lightEstimationState =
+      xrFrame && this.xrSession
+        ? this.webXRLightEstimationManager.getLightEstimationState(xrFrame)
+        : null;
 
     if (frameState) {
-      this.renderXRFrame(time, frameState, inputState || [], handState || [], hitTestState);
+      this.renderXRFrame(
+        time,
+        frameState,
+        inputState || [],
+        handState || [],
+        hitTestState,
+        lightEstimationState
+      );
       return;
     }
 
@@ -605,6 +632,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         await this.webXRHitTestManager
           .setSession(session, this.webXRManager.referenceSpace, {entityTypes: ['plane', 'point']})
           .catch(() => this.webXRHitTestManager.clearSession());
+        await this.webXRLightEstimationManager
+          .setSession(session, this.webXRManager.referenceSpace)
+          .catch(() => this.webXRLightEstimationManager.clearSession());
       }
       this.cameraTexture =
         sessionMode === 'immersive-ar' && this.device.type === 'webgl'
@@ -644,7 +674,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       .perspective({fovy: Math.PI / 3.05, aspect, near: 0.08, far: 36})
       .multiplyRight(this.viewMatrix)
       .multiplyRight(this.modelMatrix);
-    this.preparePortal({cameraMix: 0, texture: this.fallbackTexture, time});
+    this.preparePortal({cameraMix: 0, lightIntensity: 1, texture: this.fallbackTexture, time});
     const renderPass = device.beginRenderPass({
       clearColor: [0.006, 0.008, 0.028, 1],
       clearDepth: 1
@@ -658,9 +688,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     frameState: WebXRFrameState,
     inputState: readonly WebXRInputState[],
     handState: readonly WebXRHandTrackingState[],
-    hitTestState: WebXRHitTestState | null
+    hitTestState: WebXRHitTestState | null,
+    lightEstimationState: WebXRLightEstimationState | null
   ): void {
     this.updateModelMatrix(time, true, hitTestState);
+    const lightIntensity = getXRLightIntensity(lightEstimationState);
     const clearColor: [number, number, number, number] =
       this.xrSessionMode === 'immersive-ar' ? [0, 0, 0, 0] : [0.006, 0.008, 0.028, 1];
     const renderedFramebuffers = new Set<Framebuffer>();
@@ -682,6 +714,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       renderedFramebuffers.add(framebuffer);
       this.preparePortal({
         cameraMix: cameraTexture ? 1 : 0,
+        lightIntensity,
         texture: cameraTexture || this.fallbackTexture,
         time
       });
@@ -701,6 +734,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
   private preparePortal(options: {
     cameraMix: number;
+    lightIntensity: number;
     texture: Texture | WebXRCameraTexture;
     time: number;
   }): void {
@@ -709,7 +743,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         app: {
           modelViewProjectionMatrix: this.modelViewProjectionMatrix,
           time: options.time,
-          cameraMix: options.cameraMix
+          cameraMix: options.cameraMix,
+          lightIntensity: options.lightIntensity
         }
       },
       this.device.commandEncoder
@@ -743,7 +778,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           app: {
             modelViewProjectionMatrix: this.modelViewProjectionMatrix,
             time,
-            cameraMix: input.selectActive ? 1 : 0
+            cameraMix: input.selectActive ? 1 : 0,
+            lightIntensity: 1
           }
         },
         this.device.commandEncoder
@@ -764,7 +800,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
             app: {
               modelViewProjectionMatrix: this.modelViewProjectionMatrix,
               time,
-              cameraMix: input.selectActive ? 1 : 0
+              cameraMix: input.selectActive ? 1 : 0,
+              lightIntensity: 1
             }
           },
           this.device.commandEncoder
@@ -801,7 +838,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
             app: {
               modelViewProjectionMatrix: this.modelViewProjectionMatrix,
               time,
-              cameraMix: handColorMix
+              cameraMix: handColorMix,
+              lightIntensity: 1
             }
           },
           this.device.commandEncoder
@@ -907,6 +945,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.webXRDOMOverlayManager.clearSession();
     this.webXRHandTrackingManager.clearSession();
     this.webXRHitTestManager.clearSession();
+    this.webXRLightEstimationManager.clearSession();
     this.webXRManager.clearSession();
     AppAnimationLoopTemplate.notifyCurrentListeners();
     if (!this._isFinalized) {
@@ -934,6 +973,7 @@ function getXRSessionInit(
               ...domOverlayFeatures,
               'hand-tracking',
               'hit-test',
+              'light-estimation',
               'local-floor'
             ]
           : [...domOverlayFeatures, 'hand-tracking', 'local-floor'],
@@ -951,6 +991,7 @@ function getXRSessionInit(
           ...domOverlayFeatures,
           'hand-tracking',
           'hit-test',
+          'light-estimation',
           'local-floor'
         ],
         depthSensing: AR_DEPTH_SENSING,
@@ -964,6 +1005,15 @@ function getXRSessionInit(
 
 function getDOMOverlayRoot(): Element | null {
   return typeof document !== 'undefined' ? document.getElementById('webxr-dom-overlay') : null;
+}
+
+function getXRLightIntensity(lightState: WebXRLightEstimationState | null): number {
+  if (!lightState) {
+    return 1;
+  }
+
+  const [red, green, blue] = lightState.primaryLightIntensity;
+  return Math.min(1.6, Math.max(0.55, (red + green + blue) / 3));
 }
 
 function makeSpatialPortalGeometry(): Geometry {

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -11,6 +11,7 @@ import {
   WebXRCameraTexture,
   WebXRManager,
   getWebXRInputRay,
+  getWebXRInputRayPlaneIntersection,
   type WebXRFrameState,
   type WebXRInputState
 } from '@luma.gl/experimental';
@@ -353,10 +354,12 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly fallbackTexture: Texture;
   readonly model: Model;
   readonly controllerRayModel: Model;
+  readonly controllerReticleModel: Model;
   readonly webXRManager: WebXRManager;
   readonly modelMatrix = new Matrix4();
   readonly modelViewProjectionMatrix = new Matrix4();
   readonly controllerRayMatrix = new Matrix4();
+  readonly controllerReticleMatrix = new Matrix4();
   readonly viewMatrix = new Matrix4().lookAt({
     eye: [0.32, 0.24, 4.4],
     center: CAMERA_TARGET
@@ -434,6 +437,27 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         blendAlphaDstFactor: 'one-minus-src-alpha'
       }
     });
+    this.controllerReticleModel = new Model(device, {
+      id: 'immersive-prism-controller-reticles',
+      source: CONTROLLER_RAY_WGSL_SHADER,
+      vs: CONTROLLER_RAY_VS_GLSL,
+      fs: CONTROLLER_RAY_FS_GLSL,
+      geometry: makeControllerReticleGeometry(),
+      bindings: {
+        app: this.uniformStore.getManagedUniformBuffer('app')
+      },
+      parameters: {
+        depthWriteEnabled: false,
+        depthCompare: 'less-equal',
+        blend: true,
+        blendColorOperation: 'add',
+        blendAlphaOperation: 'add',
+        blendColorSrcFactor: 'src-alpha',
+        blendColorDstFactor: 'one',
+        blendAlphaSrcFactor: 'one',
+        blendAlphaDstFactor: 'one-minus-src-alpha'
+      }
+    });
     this.initializePreviewControls();
 
     if (typeof window !== 'undefined') {
@@ -452,6 +476,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       window.removeEventListener('keydown', this._keyDownListener);
     }
     this.orbitControls?.destroy();
+    this.controllerReticleModel.destroy();
     this.controllerRayModel.destroy();
     this.model.destroy();
     this.fallbackTexture.destroy();
@@ -592,7 +617,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       });
       renderPass.setParameters({viewport: view.viewport});
       this.drawPortal(renderPass);
-      this.drawControllerRays(renderPass, view, inputState, time);
+      this.drawControllerTargets(renderPass, view, inputState, time);
       renderPass.end();
     }
   }
@@ -620,7 +645,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.model.draw(renderPass);
   }
 
-  private drawControllerRays(
+  private drawControllerTargets(
     renderPass: ReturnType<Device['beginRenderPass']>,
     view: WebXRFrameState['views'][number],
     inputState: readonly WebXRInputState[],
@@ -632,11 +657,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         continue;
       }
 
-      this.controllerRayMatrix.copy(inputRay.matrix);
       this.modelViewProjectionMatrix
         .copy(view.projectionMatrix)
         .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))
-        .multiplyRight(this.controllerRayMatrix);
+        .multiplyRight(this.controllerRayMatrix.copy(inputRay.matrix));
       this.uniformStore.setUniforms(
         {
           app: {
@@ -649,6 +673,27 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       );
       this.controllerRayModel.predraw(this.device.commandEncoder);
       this.controllerRayModel.draw(renderPass);
+
+      const floorHit = getWebXRInputRayPlaneIntersection(inputRay, {maxDistance: 8});
+      if (floorHit) {
+        this.controllerReticleMatrix.identity().translate(floorHit.point);
+        this.modelViewProjectionMatrix
+          .copy(view.projectionMatrix)
+          .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))
+          .multiplyRight(this.controllerReticleMatrix);
+        this.uniformStore.setUniforms(
+          {
+            app: {
+              modelViewProjectionMatrix: this.modelViewProjectionMatrix,
+              time,
+              cameraMix: input.selectActive ? 1 : 0
+            }
+          },
+          this.device.commandEncoder
+        );
+        this.controllerReticleModel.predraw(this.device.commandEncoder);
+        this.controllerReticleModel.draw(renderPass);
+      }
     }
   }
 
@@ -756,6 +801,35 @@ function makeControllerRayGeometry(): Geometry {
       positions: {
         size: 3,
         value: new Float32Array([0, 0, 0, 0, 0, -3.2])
+      }
+    }
+  });
+}
+
+function makeControllerReticleGeometry(): Geometry {
+  const positions: number[] = [];
+  const segmentCount = 32;
+  const radius = 0.12;
+
+  for (let segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++) {
+    const startAngle = (segmentIndex / segmentCount) * Math.PI * 2;
+    const endAngle = ((segmentIndex + 1) / segmentCount) * Math.PI * 2;
+    positions.push(
+      Math.cos(startAngle) * radius,
+      0,
+      Math.sin(startAngle) * radius,
+      Math.cos(endAngle) * radius,
+      0,
+      Math.sin(endAngle) * radius
+    );
+  }
+
+  return new Geometry({
+    topology: 'line-list',
+    attributes: {
+      positions: {
+        size: 3,
+        value: new Float32Array(positions)
       }
     }
   });

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -10,6 +10,7 @@ import {
   WebXRAnimationFrameProvider,
   WebXRCameraTexture,
   WebXRManager,
+  getWebXRInputRay,
   type WebXRFrameState,
   type WebXRInputState
 } from '@luma.gl/experimental';
@@ -626,11 +627,12 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     time: number
   ): void {
     for (const input of inputState) {
-      if (input.targetRayMode !== 'tracked-pointer' || !input.targetRayMatrix) {
+      const inputRay = getWebXRInputRay(input);
+      if (input.targetRayMode !== 'tracked-pointer' || !inputRay) {
         continue;
       }
 
-      this.controllerRayMatrix.copy(input.targetRayMatrix);
+      this.controllerRayMatrix.copy(inputRay.matrix);
       this.modelViewProjectionMatrix
         .copy(view.projectionMatrix)
         .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -6,7 +6,7 @@ import type {Device, Framebuffer, NumberArray, Texture, VariableShaderType} from
 import {UniformStore} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, Geometry, Model, OrbitControls} from '@luma.gl/engine';
-import type {NumberArray2} from '@math.gl/core';
+import type {NumberArray2, NumberArray3} from '@math.gl/core';
 import {
   WebXRAnimationFrameProvider,
   WebXRCameraTexture,
@@ -1260,12 +1260,12 @@ export function applyXRSnapTurn(
 }
 
 export type XRTeleportTargetState = {
-  point: readonly [number, number, number];
+  point: NumberArray3;
   allowed: boolean;
 };
 
 export function getXRTeleportTargetState(
-  point: readonly [number, number, number],
+  point: NumberArray3,
   boundsState: WebXRBoundsState | null
 ): XRTeleportTargetState {
   return {

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -360,6 +360,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly modelViewProjectionMatrix = new Matrix4();
   readonly controllerRayMatrix = new Matrix4();
   readonly controllerReticleMatrix = new Matrix4();
+  readonly xrSceneOffset: [number, number, number] = [0, 0, 0];
   readonly viewMatrix = new Matrix4().lookAt({
     eye: [0.32, 0.24, 4.4],
     center: CAMERA_TARGET
@@ -371,8 +372,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   xrSession: XRSession | null = null;
   xrSessionMode: ImmersiveXRSessionMode | null = null;
   private _isFinalized = false;
+  private _floorHitByInputSource = new Map<XRInputSource, [number, number, number]>();
   private _xrSessionEndListener = () => this._clearXRSession();
-  private _xrSelectEndListener = () => void this.exitXR();
+  private _xrSelectEndListener = (event: Event) =>
+    this.teleportToInputSource((event as XRInputSourceEvent).inputSource);
+  private _xrSqueezeEndListener = () => void this.exitXR();
   private _keyDownListener = (event: KeyboardEvent) => {
     if (!this.xrSession) {
       return;
@@ -548,6 +552,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.xrSessionMode = sessionMode;
       session.addEventListener('end', this._xrSessionEndListener);
       session.addEventListener('selectend', this._xrSelectEndListener);
+      session.addEventListener('squeezeend', this._xrSqueezeEndListener);
       this.animationLoop.setProps({
         animationFrameProvider: new WebXRAnimationFrameProvider(session)
       });
@@ -593,6 +598,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     const clearColor: [number, number, number, number] =
       this.xrSessionMode === 'immersive-ar' ? [0, 0, 0, 0] : [0.006, 0.008, 0.028, 1];
     const renderedFramebuffers = new Set<Framebuffer>();
+    this._floorHitByInputSource.clear();
 
     for (const view of frameState.views) {
       this.modelViewProjectionMatrix
@@ -676,6 +682,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
       const floorHit = getWebXRInputRayPlaneIntersection(inputRay, {maxDistance: 8});
       if (floorHit) {
+        this._floorHitByInputSource.set(input.inputSource, floorHit.point);
         this.controllerReticleMatrix.identity().translate(floorHit.point);
         this.modelViewProjectionMatrix
           .copy(view.projectionMatrix)
@@ -701,6 +708,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.modelMatrix.identity();
     if (isXR) {
       this.modelMatrix
+        .translate(this.xrSceneOffset)
         .translate([0, 0.12, -2.15])
         .scale([0.88, 0.88, 0.88])
         .rotateZ(Math.sin(time * 0.2) * 0.055)
@@ -711,6 +719,17 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         .rotateX(Math.sin(time * 0.31) * 0.055)
         .rotateY(Math.cos(time * 0.26) * 0.075);
     }
+  }
+
+  private teleportToInputSource(inputSource: XRInputSource | undefined): void {
+    const floorHit = inputSource && this._floorHitByInputSource.get(inputSource);
+    if (!floorHit) {
+      return;
+    }
+
+    this.xrSceneOffset[0] -= floorHit[0];
+    this.xrSceneOffset[2] -= floorHit[2];
+    this._floorHitByInputSource.clear();
   }
 
   private createCameraTexture(session: XRSession): WebXRCameraTexture | null {
@@ -754,8 +773,13 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     const session = this.xrSession;
     session?.removeEventListener('end', this._xrSessionEndListener);
     session?.removeEventListener('selectend', this._xrSelectEndListener);
+    session?.removeEventListener('squeezeend', this._xrSqueezeEndListener);
     this.xrSession = null;
     this.xrSessionMode = null;
+    this.xrSceneOffset[0] = 0;
+    this.xrSceneOffset[1] = 0;
+    this.xrSceneOffset[2] = 0;
+    this._floorHitByInputSource.clear();
     this.cameraTexture?.destroy();
     this.cameraTexture = null;
     this.webXRManager.clearSession();

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -642,7 +642,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
     try {
       await this.webXRManager.setSession(session, {
-        referenceSpaceType: 'local',
+        referenceSpaceTypes: ['local-floor', 'local'],
         ...(this.device.type === 'webgl'
           ? {layerInit: {alpha: sessionMode === 'immersive-ar'}}
           : {})

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -29,6 +29,8 @@ import {
   getWebXRControllerStateByHandedness,
   getWebXRControllerStates,
   getWebXRControllerRayPlaneTargetByInputSource,
+  getWebXRHitTestResult,
+  getWebXRTransientInputHitTestResult,
   getWebXRInputStateByInputSource,
   getWebXRLocomotionState,
   getWebXRSessionRenderState,
@@ -1055,7 +1057,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.modelMatrix.identity();
     if (isXR) {
       const hitTestMatrix =
-        hitTestState?.transientInput[0]?.results[0]?.matrix || hitTestState?.hits[0]?.matrix;
+        getWebXRTransientInputHitTestResult(hitTestState)?.matrix ||
+        getWebXRHitTestResult(hitTestState)?.matrix;
       if (this.xrSessionMode === 'immersive-ar' && hitTestMatrix) {
         this.modelMatrix.copy(hitTestMatrix).scale([0.54, 0.54, 0.54]);
         return;

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -14,6 +14,7 @@ import {
   WebXRHitTestManager,
   WebXRLightEstimationManager,
   WebXRManager,
+  WebXRPlaneDetectionManager,
   getWebXRHandPinch,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
@@ -22,7 +23,8 @@ import {
   type WebXRHandTrackingState,
   type WebXRHitTestState,
   type WebXRInputState,
-  type WebXRLightEstimationState
+  type WebXRLightEstimationState,
+  type WebXRPlaneDetectionState
 } from '@luma.gl/experimental';
 import {Matrix4} from '@math.gl/core';
 
@@ -391,6 +393,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly webXRLightEstimationManager = new WebXRLightEstimationManager({
     reflectionFormat: 'preferred'
   });
+  readonly webXRPlaneDetectionManager = new WebXRPlaneDetectionManager({
+    orientations: ['horizontal']
+  });
   readonly modelMatrix = new Matrix4();
   readonly modelViewProjectionMatrix = new Matrix4();
   readonly controllerRayMatrix = new Matrix4();
@@ -548,6 +553,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.webXRHandTrackingManager.destroy();
     this.webXRHitTestManager.destroy();
     this.webXRLightEstimationManager.destroy();
+    this.webXRPlaneDetectionManager.destroy();
     this.webXRManager.destroy();
   }
 
@@ -569,6 +575,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       xrFrame && this.xrSession
         ? this.webXRLightEstimationManager.getLightEstimationState(xrFrame)
         : null;
+    const planeDetectionState =
+      xrFrame && this.xrSession
+        ? this.webXRPlaneDetectionManager.getPlaneDetectionState(xrFrame)
+        : null;
 
     if (frameState) {
       this.renderXRFrame(
@@ -577,7 +587,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         inputState || [],
         handState || [],
         hitTestState,
-        lightEstimationState
+        lightEstimationState,
+        planeDetectionState
       );
       return;
     }
@@ -635,6 +646,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         await this.webXRLightEstimationManager
           .setSession(session, this.webXRManager.referenceSpace)
           .catch(() => this.webXRLightEstimationManager.clearSession());
+        this.webXRPlaneDetectionManager.setSession(session, this.webXRManager.referenceSpace, {
+          orientations: ['horizontal']
+        });
       }
       this.cameraTexture =
         sessionMode === 'immersive-ar' && this.device.type === 'webgl'
@@ -689,9 +703,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     inputState: readonly WebXRInputState[],
     handState: readonly WebXRHandTrackingState[],
     hitTestState: WebXRHitTestState | null,
-    lightEstimationState: WebXRLightEstimationState | null
+    lightEstimationState: WebXRLightEstimationState | null,
+    planeDetectionState: WebXRPlaneDetectionState | null
   ): void {
-    this.updateModelMatrix(time, true, hitTestState);
+    this.updateModelMatrix(time, true, hitTestState, planeDetectionState);
     const lightIntensity = getXRLightIntensity(lightEstimationState);
     const clearColor: [number, number, number, number] =
       this.xrSessionMode === 'immersive-ar' ? [0, 0, 0, 0] : [0.006, 0.008, 0.028, 1];
@@ -853,12 +868,17 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   private updateModelMatrix(
     time: number,
     isXR: boolean,
-    hitTestState: WebXRHitTestState | null = null
+    hitTestState: WebXRHitTestState | null = null,
+    planeDetectionState: WebXRPlaneDetectionState | null = null
   ): void {
     this.modelMatrix.identity();
     if (isXR) {
       if (this.xrSessionMode === 'immersive-ar' && hitTestState?.hits[0]) {
         this.modelMatrix.copy(hitTestState.hits[0].matrix).scale([0.54, 0.54, 0.54]);
+        return;
+      }
+      if (this.xrSessionMode === 'immersive-ar' && planeDetectionState?.planes[0]) {
+        this.modelMatrix.copy(planeDetectionState.planes[0].matrix).scale([0.54, 0.54, 0.54]);
         return;
       }
 
@@ -946,6 +966,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.webXRHandTrackingManager.clearSession();
     this.webXRHitTestManager.clearSession();
     this.webXRLightEstimationManager.clearSession();
+    this.webXRPlaneDetectionManager.clearSession();
     this.webXRManager.clearSession();
     AppAnimationLoopTemplate.notifyCurrentListeners();
     if (!this._isFinalized) {
@@ -974,6 +995,7 @@ function getXRSessionInit(
               'hand-tracking',
               'hit-test',
               'light-estimation',
+              'plane-detection',
               'local-floor'
             ]
           : [...domOverlayFeatures, 'hand-tracking', 'local-floor'],
@@ -992,6 +1014,7 @@ function getXRSessionInit(
           'hand-tracking',
           'hit-test',
           'light-estimation',
+          'plane-detection',
           'local-floor'
         ],
         depthSensing: AR_DEPTH_SENSING,

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -28,6 +28,7 @@ import {
   getWebXRControllerRayPlaneTargets,
   getWebXRControllerStateByHandedness,
   getWebXRControllerStates,
+  getWebXRControllerRayPlaneTargetByInputSource,
   getWebXRLocomotionState,
   getWebXRSessionRenderState,
   getWebXRTeleportTranslation,
@@ -926,12 +927,6 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       maxDistance: 8,
       bounds: boundsState
     });
-    const teleportTargetByInputSource = new Map(
-      teleportTargets.map(teleportTarget => [
-        teleportTarget.controllerState.inputSource,
-        teleportTarget
-      ])
-    );
 
     for (const controllerState of controllerStates) {
       if (controllerState.grip) {
@@ -981,7 +976,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.controllerRayModel.predraw(this.device.commandEncoder);
       this.controllerRayModel.draw(renderPass);
 
-      const teleportTarget = teleportTargetByInputSource.get(controllerState.inputSource);
+      const teleportTarget = getWebXRControllerRayPlaneTargetByInputSource(
+        teleportTargets,
+        controllerState.inputSource
+      );
       if (teleportTarget) {
         if (teleportTarget.allowed) {
           this._floorHitByInputSource.set(controllerState.inputSource, teleportTarget.point);

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -16,6 +16,7 @@ import {
   WebXRMeshDetectionManager,
   WebXRManager,
   WebXRPlaneDetectionManager,
+  WebXRSessionStateManager,
   getWebXRBoundsState,
   getWebXRHandPinch,
   getWebXRInputRay,
@@ -401,6 +402,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly webXRPlaneDetectionManager = new WebXRPlaneDetectionManager({
     orientations: ['horizontal']
   });
+  readonly webXRSessionStateManager = new WebXRSessionStateManager({
+    targetFrameRate: 'highest'
+  });
   readonly modelMatrix = new Matrix4();
   readonly modelViewProjectionMatrix = new Matrix4();
   readonly controllerRayMatrix = new Matrix4();
@@ -560,6 +564,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.webXRLightEstimationManager.destroy();
     this.webXRMeshDetectionManager.destroy();
     this.webXRPlaneDetectionManager.destroy();
+    this.webXRSessionStateManager.destroy();
     this.webXRManager.destroy();
   }
 
@@ -673,6 +678,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           ? this.createCameraTexture(session)
           : null;
       this.webXRDOMOverlayManager.setSession(session, {root: getDOMOverlayRoot()});
+      await this.webXRSessionStateManager
+        .setSession(session)
+        .catch(() => this.webXRSessionStateManager.clearSession());
       this.xrSession = session;
       this.xrSessionMode = sessionMode;
       AppAnimationLoopTemplate.notifyCurrentListeners();
@@ -998,6 +1006,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.webXRLightEstimationManager.clearSession();
     this.webXRMeshDetectionManager.clearSession();
     this.webXRPlaneDetectionManager.clearSession();
+    this.webXRSessionStateManager.clearSession();
     this.webXRManager.clearSession();
     AppAnimationLoopTemplate.notifyCurrentListeners();
     if (!this._isFinalized) {

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -6,6 +6,7 @@ import type {Device, Framebuffer, NumberArray, Texture, VariableShaderType} from
 import {UniformStore} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, Geometry, Model, OrbitControls} from '@luma.gl/engine';
+import type {NumberArray2} from '@math.gl/core';
 import {
   WebXRAnimationFrameProvider,
   WebXRCameraTexture,
@@ -834,11 +835,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     }
 
     const [strafe, forward] = locomotionState.move;
-    this.applyXRSceneOffset([
-      strafe * XR_LOCOMOTION_SPEED * deltaSeconds,
-      0,
-      -forward * XR_LOCOMOTION_SPEED * deltaSeconds
-    ]);
+    this.applyXRSceneOffset(
+      getXRLocomotionSceneOffset([strafe, forward], deltaSeconds, this.xrSceneYaw)
+    );
   }
 
   private preparePortal(options: {
@@ -1156,6 +1155,27 @@ export function applyXRSnapTurn(
   snapTurnRadians = XR_SNAP_TURN_RADIANS
 ): number {
   return sceneYaw + snapTurn * snapTurnRadians;
+}
+
+export function getXRLocomotionSceneOffset(
+  move: NumberArray2,
+  deltaSeconds: number,
+  sceneYaw = 0,
+  speed = XR_LOCOMOTION_SPEED
+): [number, number, number] {
+  const localX = move[0] * speed * deltaSeconds;
+  const localZ = -move[1] * speed * deltaSeconds;
+  const cosine = Math.cos(sceneYaw);
+  const sine = Math.sin(sceneYaw);
+  return [
+    normalizeXRSceneOffsetComponent(localX * cosine - localZ * sine),
+    0,
+    normalizeXRSceneOffsetComponent(localX * sine + localZ * cosine)
+  ];
+}
+
+function normalizeXRSceneOffsetComponent(value: number): number {
+  return Math.abs(value) < 1e-12 ? 0 : value;
 }
 
 function makeSpatialPortalGeometry(): Geometry {

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -32,6 +32,7 @@ import {
   isPointInWebXRBounds,
   mergeWebXRSessionInit,
   pulseWebXRInputHaptics,
+  type WebXRBoundsState,
   type WebXRFrameState,
   type WebXRHandTrackingState,
   type WebXRHitTestState,
@@ -313,7 +314,9 @@ fn vertexMain(inputs: VertexInputs) -> FragmentInputs {
 fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
   let idleColor = vec3<f32>(0.05, 0.92, 1.0);
   let activeColor = vec3<f32>(1.0, 0.36, 0.18);
-  let color = mix(idleColor, activeColor, app.cameraMix);
+  let blockedColor = vec3<f32>(1.0, 0.08, 0.10);
+  let targetColor = mix(idleColor, activeColor, clamp(app.cameraMix, 0.0, 1.0));
+  let color = select(blockedColor, targetColor, app.cameraMix >= 0.0);
   let alpha = mix(0.86, 0.28, inputs.rayDepth);
   return vec4<f32>(color * (1.15 - inputs.rayDepth * 0.38), alpha);
 }
@@ -356,7 +359,9 @@ out vec4 fragColor;
 void main(void) {
   vec3 idleColor = vec3(0.05, 0.92, 1.0);
   vec3 activeColor = vec3(1.0, 0.36, 0.18);
-  vec3 color = mix(idleColor, activeColor, app.cameraMix);
+  vec3 blockedColor = vec3(1.0, 0.08, 0.10);
+  vec3 targetColor = mix(idleColor, activeColor, clamp(app.cameraMix, 0.0, 1.0));
+  vec3 color = app.cameraMix < 0.0 ? blockedColor : targetColor;
   float alpha = mix(0.86, 0.28, vRayDepth);
   fragColor = vec4(color * (1.15 - vRayDepth * 0.38), alpha);
 }
@@ -766,6 +771,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     const renderedFramebuffers = new Set<Framebuffer>();
     this._floorHitByInputSource.clear();
     this._inputStateByInputSource.clear();
+    const boundsState = getWebXRBoundsState(this.webXRManager.referenceSpace);
     for (const input of inputState) {
       this._inputStateByInputSource.set(input.inputSource, input);
     }
@@ -794,7 +800,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       });
       renderPass.setParameters({viewport: view.viewport});
       this.drawPortal(renderPass);
-      this.drawControllerTargets(renderPass, view, inputState, time);
+      this.drawControllerTargets(renderPass, view, inputState, time, boundsState);
       this.drawHandJoints(renderPass, view, handState, time);
       renderPass.end();
     }
@@ -869,7 +875,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     renderPass: ReturnType<Device['beginRenderPass']>,
     view: WebXRFrameState['views'][number],
     inputState: readonly WebXRInputState[],
-    time: number
+    time: number,
+    boundsState: WebXRBoundsState | null
   ): void {
     for (const input of inputState) {
       const inputRay = getWebXRInputRay(input);
@@ -902,8 +909,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
       const floorHit = getWebXRInputRayPlaneIntersection(inputRay, {maxDistance: 8});
       if (floorHit) {
-        this._floorHitByInputSource.set(input.inputSource, floorHit.point);
-        this.controllerReticleMatrix.identity().translate(floorHit.point);
+        const teleportTarget = getXRTeleportTargetState(floorHit.point, boundsState);
+        if (teleportTarget.allowed) {
+          this._floorHitByInputSource.set(input.inputSource, floorHit.point);
+        }
+        this.controllerReticleMatrix.identity().translate(teleportTarget.point);
         this.modelViewProjectionMatrix
           .copy(view.projectionMatrix)
           .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))
@@ -913,7 +923,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
             app: {
               modelViewProjectionMatrix: this.modelViewProjectionMatrix,
               time,
-              cameraMix: controllerActivation,
+              cameraMix: teleportTarget.allowed ? controllerActivation : -1,
               lightIntensity: 1
             }
           },
@@ -1008,11 +1018,12 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       return;
     }
     const boundsState = getWebXRBoundsState(this.webXRManager.referenceSpace);
-    if (boundsState && !isPointInWebXRBounds(floorHit, boundsState.bounds)) {
+    const teleportTarget = getXRTeleportTargetState(floorHit, boundsState);
+    if (!teleportTarget.allowed) {
       return;
     }
 
-    this.applyXRSceneOffset(getWebXRTeleportTranslation(floorHit));
+    this.applyXRSceneOffset(getWebXRTeleportTranslation(teleportTarget.point));
     const inputState = this._inputStateByInputSource.get(inputSource);
     if (inputState) {
       void pulseWebXRInputHaptics(inputState, {intensity: 0.5, duration: 45});
@@ -1155,6 +1166,21 @@ export function applyXRSnapTurn(
   snapTurnRadians = XR_SNAP_TURN_RADIANS
 ): number {
   return sceneYaw + snapTurn * snapTurnRadians;
+}
+
+export type XRTeleportTargetState = {
+  point: readonly [number, number, number];
+  allowed: boolean;
+};
+
+export function getXRTeleportTargetState(
+  point: readonly [number, number, number],
+  boundsState: WebXRBoundsState | null
+): XRTeleportTargetState {
+  return {
+    point,
+    allowed: !boundsState || isPointInWebXRBounds(point, boundsState.bounds)
+  };
 }
 
 export function getXRLocomotionSceneOffset(

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -651,7 +651,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       if (sessionMode === 'immersive-ar') {
         await this.webXRHitTestManager
           .setSession(session, this.webXRManager.referenceSpace, {
-            entityTypes: ['plane', 'point', 'mesh']
+            entityTypes: ['plane', 'point', 'mesh'],
+            transientInput: {
+              profile: 'generic-touchscreen',
+              entityTypes: ['plane', 'point', 'mesh']
+            }
           })
           .catch(() => this.webXRHitTestManager.clearSession());
         await this.webXRLightEstimationManager
@@ -887,8 +891,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   ): void {
     this.modelMatrix.identity();
     if (isXR) {
-      if (this.xrSessionMode === 'immersive-ar' && hitTestState?.hits[0]) {
-        this.modelMatrix.copy(hitTestState.hits[0].matrix).scale([0.54, 0.54, 0.54]);
+      const hitTestMatrix =
+        hitTestState?.transientInput[0]?.results[0]?.matrix || hitTestState?.hits[0]?.matrix;
+      if (this.xrSessionMode === 'immersive-ar' && hitTestMatrix) {
+        this.modelMatrix.copy(hitTestMatrix).scale([0.54, 0.54, 0.54]);
         return;
       }
       if (this.xrSessionMode === 'immersive-ar' && planeDetectionState?.planes[0]) {

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -16,6 +16,7 @@ import {
   WebXRMeshDetectionManager,
   WebXRManager,
   WebXRPlaneDetectionManager,
+  WebXRReferenceSpaceManager,
   WebXRSessionStateManager,
   getWebXRBoundsState,
   getWebXRHandPinch,
@@ -402,6 +403,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly webXRPlaneDetectionManager = new WebXRPlaneDetectionManager({
     orientations: ['horizontal']
   });
+  readonly webXRReferenceSpaceManager = new WebXRReferenceSpaceManager();
   readonly webXRSessionStateManager = new WebXRSessionStateManager({
     targetFrameRate: 'highest'
   });
@@ -564,6 +566,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.webXRLightEstimationManager.destroy();
     this.webXRMeshDetectionManager.destroy();
     this.webXRPlaneDetectionManager.destroy();
+    this.webXRReferenceSpaceManager.destroy();
     this.webXRSessionStateManager.destroy();
     this.webXRManager.destroy();
   }
@@ -654,6 +657,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           ? {layerInit: {alpha: sessionMode === 'immersive-ar'}}
           : {})
       });
+      this.webXRReferenceSpaceManager.setReferenceSpace(this.webXRManager.referenceSpace);
       this.webXRHandTrackingManager.setSession(session, this.webXRManager.referenceSpace);
       if (sessionMode === 'immersive-ar') {
         await this.webXRHitTestManager
@@ -1006,6 +1010,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.webXRLightEstimationManager.clearSession();
     this.webXRMeshDetectionManager.clearSession();
     this.webXRPlaneDetectionManager.clearSession();
+    this.webXRReferenceSpaceManager.clearReferenceSpace();
     this.webXRSessionStateManager.clearSession();
     this.webXRManager.clearSession();
     AppAnimationLoopTemplate.notifyCurrentListeners();

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -25,11 +25,8 @@ import {
   getWebXRDOMOverlaySessionInit,
   getWebXRBoundsState,
   getWebXRHandPinch,
-  getWebXRInputActivationState,
-  getWebXRInputGrip,
-  getWebXRInputRay,
+  getWebXRControllerState,
   getWebXRInputRayPlaneIntersection,
-  getWebXRInputSourceState,
   getWebXRLocomotionState,
   getWebXRSessionRenderState,
   getWebXRTeleportTranslation,
@@ -923,22 +920,24 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     boundsState: WebXRBoundsState | null
   ): void {
     for (const input of inputState) {
-      const inputSourceState = getWebXRInputSourceState(input);
-      const inputActivationState = getWebXRInputActivationState(input);
-      const inputGrip = getWebXRInputGrip(input);
-      if (inputSourceState.isController && inputGrip) {
+      const controllerState = getWebXRControllerState(input);
+      if (!controllerState) {
+        continue;
+      }
+
+      if (controllerState.grip) {
         this.modelViewProjectionMatrix
           .copy(view.projectionMatrix)
           .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))
-          .multiplyRight(this.controllerGripMatrix.copy(inputGrip.matrix));
+          .multiplyRight(this.controllerGripMatrix.copy(controllerState.grip.matrix));
         this.uniformStore.setUniforms(
           {
             app: {
               modelViewProjectionMatrix: this.modelViewProjectionMatrix,
               time,
-              cameraMix: inputActivationState.isSqueezeActive
+              cameraMix: controllerState.isSqueezeActive
                 ? 1
-                : inputSourceState.handedness === 'right'
+                : controllerState.handedness === 'right'
                   ? 0.45
                   : 0,
               lightIntensity: 1
@@ -950,16 +949,15 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         this.controllerGripModel.draw(renderPass);
       }
 
-      const inputRay = getWebXRInputRay(input);
-      if (!inputSourceState.usesTrackedPointer || !inputRay) {
+      if (!controllerState.ray) {
         continue;
       }
-      const controllerActivation = inputActivationState.primaryAction;
+      const controllerActivation = controllerState.primaryAction;
 
       this.modelViewProjectionMatrix
         .copy(view.projectionMatrix)
         .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))
-        .multiplyRight(this.controllerRayMatrix.copy(inputRay.matrix));
+        .multiplyRight(this.controllerRayMatrix.copy(controllerState.ray.matrix));
       this.uniformStore.setUniforms(
         {
           app: {
@@ -974,7 +972,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.controllerRayModel.predraw(this.device.commandEncoder);
       this.controllerRayModel.draw(renderPass);
 
-      const floorHit = getWebXRInputRayPlaneIntersection(inputRay, {maxDistance: 8});
+      const floorHit = getWebXRInputRayPlaneIntersection(controllerState.ray, {maxDistance: 8});
       if (floorHit) {
         const teleportTarget = getXRTeleportTargetState(floorHit.point, boundsState);
         if (teleportTarget.allowed) {

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -19,6 +19,7 @@ import {
   WebXRReferenceSpaceManager,
   WebXRSessionStateManager,
   getWebXRBoundsState,
+  getWebXRGamepadState,
   getWebXRHandPinch,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
@@ -814,6 +815,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       if (input.targetRayMode !== 'tracked-pointer' || !inputRay) {
         continue;
       }
+      const gamepadState = getWebXRGamepadState(input);
+      const controllerActivation = Math.max(
+        input.selectActive ? 1 : 0,
+        gamepadState?.primaryTrigger?.value || 0
+      );
 
       this.modelViewProjectionMatrix
         .copy(view.projectionMatrix)
@@ -824,7 +830,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           app: {
             modelViewProjectionMatrix: this.modelViewProjectionMatrix,
             time,
-            cameraMix: input.selectActive ? 1 : 0,
+            cameraMix: controllerActivation,
             lightIntensity: 1
           }
         },
@@ -846,7 +852,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
             app: {
               modelViewProjectionMatrix: this.modelViewProjectionMatrix,
               time,
-              cameraMix: input.selectActive ? 1 : 0,
+              cameraMix: controllerActivation,
               lightIntensity: 1
             }
           },

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -19,12 +19,15 @@ import {
   WebXRReferenceSpaceManager,
   WebXRRenderStateManager,
   WebXRSessionStateManager,
+  getWebXRDepthSensingSessionInit,
+  getWebXRDOMOverlaySessionInit,
   getWebXRBoundsState,
   getWebXRGamepadState,
   getWebXRHandPinch,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
   isPointInWebXRBounds,
+  mergeWebXRSessionInit,
   pulseWebXRInputHaptics,
   type WebXRFrameState,
   type WebXRHandTrackingState,
@@ -1041,54 +1044,30 @@ function getXRSessionInit(
   deviceType: string,
   domOverlayRoot: Element | null = null
 ): XRSessionInit {
-  const domOverlayFeatures = domOverlayRoot ? ['dom-overlay'] : [];
-  const domOverlayInit = domOverlayRoot ? {domOverlay: {root: domOverlayRoot}} : {};
+  const baseOptionalFeatures = ['bounded-floor', 'hand-tracking', 'local-floor'];
+  const arOptionalFeatures = [
+    'anchors',
+    ...(deviceType === 'webgl' ? ['camera-access'] : []),
+    'hit-test',
+    'light-estimation',
+    'mesh-detection',
+    'plane-detection'
+  ];
+  const domOverlaySessionInit = domOverlayRoot
+    ? getWebXRDOMOverlaySessionInit(domOverlayRoot)
+    : undefined;
 
-  if (deviceType === 'webgpu') {
-    return {
-      requiredFeatures: ['webgpu'],
+  return mergeWebXRSessionInit(
+    deviceType === 'webgpu' ? {requiredFeatures: ['webgpu']} : undefined,
+    {
       optionalFeatures:
         sessionMode === 'immersive-ar'
-          ? [
-              'anchors',
-              'depth-sensing',
-              ...domOverlayFeatures,
-              'bounded-floor',
-              'hand-tracking',
-              'hit-test',
-              'light-estimation',
-              'mesh-detection',
-              'plane-detection',
-              'local-floor'
-            ]
-          : [...domOverlayFeatures, 'bounded-floor', 'hand-tracking', 'local-floor'],
-      ...(sessionMode === 'immersive-ar' ? {depthSensing: AR_DEPTH_SENSING} : {}),
-      ...domOverlayInit
-    };
-  }
-
-  return sessionMode === 'immersive-ar'
-    ? {
-        optionalFeatures: [
-          'anchors',
-          'camera-access',
-          'depth-sensing',
-          ...domOverlayFeatures,
-          'bounded-floor',
-          'hand-tracking',
-          'hit-test',
-          'light-estimation',
-          'mesh-detection',
-          'plane-detection',
-          'local-floor'
-        ],
-        depthSensing: AR_DEPTH_SENSING,
-        ...domOverlayInit
-      }
-    : {
-        optionalFeatures: [...domOverlayFeatures, 'bounded-floor', 'hand-tracking', 'local-floor'],
-        ...domOverlayInit
-      };
+          ? [...arOptionalFeatures, ...baseOptionalFeatures]
+          : baseOptionalFeatures
+    },
+    sessionMode === 'immersive-ar' ? getWebXRDepthSensingSessionInit(AR_DEPTH_SENSING) : undefined,
+    domOverlaySessionInit
+  );
 }
 
 function getDOMOverlayRoot(): Element | null {

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -822,18 +822,25 @@ function getXRSessionInit(sessionMode: ImmersiveXRSessionMode, deviceType: strin
       requiredFeatures: ['webgpu'],
       optionalFeatures:
         sessionMode === 'immersive-ar'
-          ? ['anchors', 'depth-sensing', 'hit-test', 'local-floor']
-          : ['local-floor'],
+          ? ['anchors', 'depth-sensing', 'hand-tracking', 'hit-test', 'local-floor']
+          : ['hand-tracking', 'local-floor'],
       ...(sessionMode === 'immersive-ar' ? {depthSensing: AR_DEPTH_SENSING} : {})
     };
   }
 
   return sessionMode === 'immersive-ar'
     ? {
-        optionalFeatures: ['anchors', 'camera-access', 'depth-sensing', 'hit-test', 'local-floor'],
+        optionalFeatures: [
+          'anchors',
+          'camera-access',
+          'depth-sensing',
+          'hand-tracking',
+          'hit-test',
+          'local-floor'
+        ],
         depthSensing: AR_DEPTH_SENSING
       }
-    : {optionalFeatures: ['local-floor']};
+    : {optionalFeatures: ['hand-tracking', 'local-floor']};
 }
 
 function makeSpatialPortalGeometry(): Geometry {

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -29,6 +29,7 @@ import {
   getWebXRControllerStateByHandedness,
   getWebXRControllerStates,
   getWebXRControllerRayPlaneTargetByInputSource,
+  getWebXRInputStateByInputSource,
   getWebXRLocomotionState,
   getWebXRSessionRenderState,
   getWebXRTeleportTranslation,
@@ -451,12 +452,16 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   xrSessionMode: ImmersiveXRSessionMode | null = null;
   private _isFinalized = false;
   private _floorHitByInputSource = new Map<XRInputSource, [number, number, number]>();
-  private _inputStateByInputSource = new Map<XRInputSource, WebXRInputState>();
   private _lastXRLocomotionTimeMilliseconds: number | null = null;
   private _lastXRSnapTurn = 0;
   private _xrSessionEndListener = () => this._clearXRSession();
-  private _xrSelectEndListener = (event: Event) =>
-    this.teleportToInputSource((event as XRInputSourceEvent).inputSource);
+  private _xrSelectEndListener = (event: Event) => {
+    const xrEvent = event as XRInputSourceEvent;
+    this.teleportToInputSource(
+      xrEvent.inputSource,
+      this.webXRManager.getInputState(xrEvent.frame) || []
+    );
+  };
   private _xrSqueezeEndListener = () => void this.exitXR();
   private _keyDownListener = (event: KeyboardEvent) => {
     if (!this.xrSession) {
@@ -811,11 +816,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.xrSessionMode === 'immersive-ar' ? [0, 0, 0, 0] : [0.006, 0.008, 0.028, 1];
     const renderedFramebuffers = new Set<Framebuffer>();
     this._floorHitByInputSource.clear();
-    this._inputStateByInputSource.clear();
     const boundsState = getWebXRBoundsState(this.webXRManager.referenceSpace);
-    for (const input of inputState) {
-      this._inputStateByInputSource.set(input.inputSource, input);
-    }
 
     for (const view of frameState.views) {
       this.modelViewProjectionMatrix
@@ -1083,7 +1084,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     }
   }
 
-  private teleportToInputSource(inputSource: XRInputSource | undefined): void {
+  private teleportToInputSource(
+    inputSource: XRInputSource | undefined,
+    inputState: readonly WebXRInputState[]
+  ): void {
     const floorHit = inputSource && this._floorHitByInputSource.get(inputSource);
     if (!floorHit) {
       return;
@@ -1095,9 +1099,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     }
 
     this.applyXRSceneOffset(getWebXRTeleportTranslation(teleportTarget.point));
-    const inputState = this._inputStateByInputSource.get(inputSource);
-    if (inputState) {
-      void pulseWebXRInputHaptics(inputState, {intensity: 0.5, duration: 45});
+    const sourceInputState = getWebXRInputStateByInputSource(inputState, inputSource);
+    if (sourceInputState) {
+      void pulseWebXRInputHaptics(sourceInputState, {intensity: 0.5, duration: 45});
     }
     this._floorHitByInputSource.clear();
   }
@@ -1106,7 +1110,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     const actionStates = this.webXRInputActionManager.update(inputState);
     for (const actionState of actionStates) {
       if (actionState.primaryActionEnded) {
-        this.teleportToInputSource(actionState.inputSource);
+        this.teleportToInputSource(actionState.inputSource, inputState);
       }
       if (actionState.squeezeActionEnded) {
         void this.exitXR();
@@ -1120,7 +1124,6 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
   private clearXRInteractionState(): void {
     this._floorHitByInputSource.clear();
-    this._inputStateByInputSource.clear();
     this.webXRInputActionManager.reset();
     this._lastXRLocomotionTimeMilliseconds = null;
     this._lastXRSnapTurn = 0;

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -16,6 +16,7 @@ import {
   getWebXRHandPinch,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
+  pulseWebXRInputHaptics,
   type WebXRFrameState,
   type WebXRHandTrackingState,
   type WebXRHitTestState,
@@ -393,6 +394,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   xrSessionMode: ImmersiveXRSessionMode | null = null;
   private _isFinalized = false;
   private _floorHitByInputSource = new Map<XRInputSource, [number, number, number]>();
+  private _inputStateByInputSource = new Map<XRInputSource, WebXRInputState>();
   private _xrSessionEndListener = () => this._clearXRSession();
   private _xrSelectEndListener = (event: Event) =>
     this.teleportToInputSource((event as XRInputSourceEvent).inputSource);
@@ -663,6 +665,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.xrSessionMode === 'immersive-ar' ? [0, 0, 0, 0] : [0.006, 0.008, 0.028, 1];
     const renderedFramebuffers = new Set<Framebuffer>();
     this._floorHitByInputSource.clear();
+    this._inputStateByInputSource.clear();
+    for (const input of inputState) {
+      this._inputStateByInputSource.set(input.inputSource, input);
+    }
 
     for (const view of frameState.views) {
       this.modelViewProjectionMatrix
@@ -840,6 +846,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
     this.xrSceneOffset[0] -= floorHit[0];
     this.xrSceneOffset[2] -= floorHit[2];
+    const inputState = this._inputStateByInputSource.get(inputSource);
+    if (inputState) {
+      void pulseWebXRInputHaptics(inputState, {intensity: 0.5, duration: 45});
+    }
     this._floorHitByInputSource.clear();
   }
 
@@ -891,6 +901,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.xrSceneOffset[1] = 0;
     this.xrSceneOffset[2] = 0;
     this._floorHitByInputSource.clear();
+    this._inputStateByInputSource.clear();
     this.cameraTexture?.destroy();
     this.cameraTexture = null;
     this.webXRDOMOverlayManager.clearSession();

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -25,7 +25,7 @@ import {
   getWebXRDOMOverlaySessionInit,
   getWebXRBoundsState,
   getWebXRHandPinch,
-  getWebXRControllerRayPlaneTarget,
+  getWebXRControllerRayPlaneTargets,
   getWebXRControllerStateByHandedness,
   getWebXRControllerStates,
   getWebXRLocomotionState,
@@ -922,6 +922,17 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   ): void {
     const controllerStates = getWebXRControllerStates(inputState);
     const dominantControllerState = getWebXRControllerStateByHandedness(controllerStates, 'right');
+    const teleportTargets = getWebXRControllerRayPlaneTargets(controllerStates, {
+      maxDistance: 8,
+      bounds: boundsState
+    });
+    const teleportTargetByInputSource = new Map(
+      teleportTargets.map(teleportTarget => [
+        teleportTarget.controllerState.inputSource,
+        teleportTarget
+      ])
+    );
+
     for (const controllerState of controllerStates) {
       if (controllerState.grip) {
         this.modelViewProjectionMatrix
@@ -970,10 +981,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.controllerRayModel.predraw(this.device.commandEncoder);
       this.controllerRayModel.draw(renderPass);
 
-      const teleportTarget = getWebXRControllerRayPlaneTarget(controllerState, {
-        maxDistance: 8,
-        bounds: boundsState
-      });
+      const teleportTarget = teleportTargetByInputSource.get(controllerState.inputSource);
       if (teleportTarget) {
         if (teleportTarget.allowed) {
           this._floorHitByInputSource.set(controllerState.inputSource, teleportTarget.point);

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -344,6 +344,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
   private static setCurrent(current: AppAnimationLoopTemplate | null): void {
     AppAnimationLoopTemplate.current = current;
+    AppAnimationLoopTemplate.notifyCurrentListeners();
+  }
+
+  private static notifyCurrentListeners(): void {
     for (const listener of AppAnimationLoopTemplate.currentListeners) {
       listener();
     }
@@ -607,6 +611,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.webXRDOMOverlayManager.setSession(session, {root: getDOMOverlayRoot()});
       this.xrSession = session;
       this.xrSessionMode = sessionMode;
+      AppAnimationLoopTemplate.notifyCurrentListeners();
       session.addEventListener('end', this._xrSessionEndListener);
       session.addEventListener('selectend', this._xrSelectEndListener);
       session.addEventListener('squeezeend', this._xrSqueezeEndListener);
@@ -892,6 +897,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.webXRHandTrackingManager.clearSession();
     this.webXRHitTestManager.clearSession();
     this.webXRManager.clearSession();
+    AppAnimationLoopTemplate.notifyCurrentListeners();
     if (!this._isFinalized) {
       this.animationLoop.setProps({animationFrameProvider: undefined});
     }

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -13,6 +13,7 @@ import {
   WebXRHandTrackingManager,
   WebXRHitTestManager,
   WebXRLightEstimationManager,
+  WebXRMeshDetectionManager,
   WebXRManager,
   WebXRPlaneDetectionManager,
   getWebXRHandPinch,
@@ -24,6 +25,7 @@ import {
   type WebXRHitTestState,
   type WebXRInputState,
   type WebXRLightEstimationState,
+  type WebXRMeshDetectionState,
   type WebXRPlaneDetectionState
 } from '@luma.gl/experimental';
 import {Matrix4} from '@math.gl/core';
@@ -393,6 +395,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly webXRLightEstimationManager = new WebXRLightEstimationManager({
     reflectionFormat: 'preferred'
   });
+  readonly webXRMeshDetectionManager = new WebXRMeshDetectionManager();
   readonly webXRPlaneDetectionManager = new WebXRPlaneDetectionManager({
     orientations: ['horizontal']
   });
@@ -553,6 +556,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.webXRHandTrackingManager.destroy();
     this.webXRHitTestManager.destroy();
     this.webXRLightEstimationManager.destroy();
+    this.webXRMeshDetectionManager.destroy();
     this.webXRPlaneDetectionManager.destroy();
     this.webXRManager.destroy();
   }
@@ -579,6 +583,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       xrFrame && this.xrSession
         ? this.webXRPlaneDetectionManager.getPlaneDetectionState(xrFrame)
         : null;
+    const meshDetectionState =
+      xrFrame && this.xrSession
+        ? this.webXRMeshDetectionManager.getMeshDetectionState(xrFrame)
+        : null;
 
     if (frameState) {
       this.renderXRFrame(
@@ -588,7 +596,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         handState || [],
         hitTestState,
         lightEstimationState,
-        planeDetectionState
+        planeDetectionState,
+        meshDetectionState
       );
       return;
     }
@@ -641,11 +650,14 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.webXRHandTrackingManager.setSession(session, this.webXRManager.referenceSpace);
       if (sessionMode === 'immersive-ar') {
         await this.webXRHitTestManager
-          .setSession(session, this.webXRManager.referenceSpace, {entityTypes: ['plane', 'point']})
+          .setSession(session, this.webXRManager.referenceSpace, {
+            entityTypes: ['plane', 'point', 'mesh']
+          })
           .catch(() => this.webXRHitTestManager.clearSession());
         await this.webXRLightEstimationManager
           .setSession(session, this.webXRManager.referenceSpace)
           .catch(() => this.webXRLightEstimationManager.clearSession());
+        this.webXRMeshDetectionManager.setSession(session, this.webXRManager.referenceSpace);
         this.webXRPlaneDetectionManager.setSession(session, this.webXRManager.referenceSpace, {
           orientations: ['horizontal']
         });
@@ -704,9 +716,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     handState: readonly WebXRHandTrackingState[],
     hitTestState: WebXRHitTestState | null,
     lightEstimationState: WebXRLightEstimationState | null,
-    planeDetectionState: WebXRPlaneDetectionState | null
+    planeDetectionState: WebXRPlaneDetectionState | null,
+    meshDetectionState: WebXRMeshDetectionState | null
   ): void {
-    this.updateModelMatrix(time, true, hitTestState, planeDetectionState);
+    this.updateModelMatrix(time, true, hitTestState, planeDetectionState, meshDetectionState);
     const lightIntensity = getXRLightIntensity(lightEstimationState);
     const clearColor: [number, number, number, number] =
       this.xrSessionMode === 'immersive-ar' ? [0, 0, 0, 0] : [0.006, 0.008, 0.028, 1];
@@ -869,7 +882,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     time: number,
     isXR: boolean,
     hitTestState: WebXRHitTestState | null = null,
-    planeDetectionState: WebXRPlaneDetectionState | null = null
+    planeDetectionState: WebXRPlaneDetectionState | null = null,
+    meshDetectionState: WebXRMeshDetectionState | null = null
   ): void {
     this.modelMatrix.identity();
     if (isXR) {
@@ -879,6 +893,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       }
       if (this.xrSessionMode === 'immersive-ar' && planeDetectionState?.planes[0]) {
         this.modelMatrix.copy(planeDetectionState.planes[0].matrix).scale([0.54, 0.54, 0.54]);
+        return;
+      }
+      if (this.xrSessionMode === 'immersive-ar' && meshDetectionState?.meshes[0]) {
+        this.modelMatrix.copy(meshDetectionState.meshes[0].matrix).scale([0.54, 0.54, 0.54]);
         return;
       }
 
@@ -966,6 +984,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.webXRHandTrackingManager.clearSession();
     this.webXRHitTestManager.clearSession();
     this.webXRLightEstimationManager.clearSession();
+    this.webXRMeshDetectionManager.clearSession();
     this.webXRPlaneDetectionManager.clearSession();
     this.webXRManager.clearSession();
     AppAnimationLoopTemplate.notifyCurrentListeners();
@@ -995,6 +1014,7 @@ function getXRSessionInit(
               'hand-tracking',
               'hit-test',
               'light-estimation',
+              'mesh-detection',
               'plane-detection',
               'local-floor'
             ]
@@ -1014,6 +1034,7 @@ function getXRSessionInit(
           'hand-tracking',
           'hit-test',
           'light-estimation',
+          'mesh-detection',
           'plane-detection',
           'local-floor'
         ],

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -9,10 +9,12 @@ import {AnimationLoopTemplate, Geometry, Model, OrbitControls} from '@luma.gl/en
 import {
   WebXRAnimationFrameProvider,
   WebXRCameraTexture,
+  WebXRHitTestManager,
   WebXRManager,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
   type WebXRFrameState,
+  type WebXRHitTestState,
   type WebXRInputState
 } from '@luma.gl/experimental';
 import {Matrix4} from '@math.gl/core';
@@ -356,6 +358,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly controllerRayModel: Model;
   readonly controllerReticleModel: Model;
   readonly webXRManager: WebXRManager;
+  readonly webXRHitTestManager = new WebXRHitTestManager();
   readonly modelMatrix = new Matrix4();
   readonly modelViewProjectionMatrix = new Matrix4();
   readonly controllerRayMatrix = new Matrix4();
@@ -485,6 +488,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.model.destroy();
     this.fallbackTexture.destroy();
     this.uniformStore.destroy();
+    this.webXRHitTestManager.destroy();
     this.webXRManager.destroy();
   }
 
@@ -493,9 +497,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     const xrFrame = animationFrame as XRFrame | null;
     const frameState = xrFrame && this.xrSession ? this.webXRManager.getFrameState(xrFrame) : null;
     const inputState = xrFrame && this.xrSession ? this.webXRManager.getInputState(xrFrame) : null;
+    const hitTestState =
+      xrFrame && this.xrSession ? this.webXRHitTestManager.getHitTestState(xrFrame) : null;
 
     if (frameState) {
-      this.renderXRFrame(time, frameState, inputState || []);
+      this.renderXRFrame(time, frameState, inputState || [], hitTestState);
       return;
     }
 
@@ -544,6 +550,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           ? {layerInit: {alpha: sessionMode === 'immersive-ar'}}
           : {})
       });
+      if (sessionMode === 'immersive-ar') {
+        await this.webXRHitTestManager
+          .setSession(session, this.webXRManager.referenceSpace, {entityTypes: ['plane', 'point']})
+          .catch(() => this.webXRHitTestManager.clearSession());
+      }
       this.cameraTexture =
         sessionMode === 'immersive-ar' && this.device.type === 'webgl'
           ? this.createCameraTexture(session)
@@ -592,9 +603,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   private renderXRFrame(
     time: number,
     frameState: WebXRFrameState,
-    inputState: readonly WebXRInputState[]
+    inputState: readonly WebXRInputState[],
+    hitTestState: WebXRHitTestState | null
   ): void {
-    this.updateModelMatrix(time, true);
+    this.updateModelMatrix(time, true, hitTestState);
     const clearColor: [number, number, number, number] =
       this.xrSessionMode === 'immersive-ar' ? [0, 0, 0, 0] : [0.006, 0.008, 0.028, 1];
     const renderedFramebuffers = new Set<Framebuffer>();
@@ -704,9 +716,18 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     }
   }
 
-  private updateModelMatrix(time: number, isXR: boolean): void {
+  private updateModelMatrix(
+    time: number,
+    isXR: boolean,
+    hitTestState: WebXRHitTestState | null = null
+  ): void {
     this.modelMatrix.identity();
     if (isXR) {
+      if (this.xrSessionMode === 'immersive-ar' && hitTestState?.hits[0]) {
+        this.modelMatrix.copy(hitTestState.hits[0].matrix).scale([0.54, 0.54, 0.54]);
+        return;
+      }
+
       this.modelMatrix
         .translate(this.xrSceneOffset)
         .translate([0, 0.12, -2.15])
@@ -782,6 +803,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this._floorHitByInputSource.clear();
     this.cameraTexture?.destroy();
     this.cameraTexture = null;
+    this.webXRHitTestManager.clearSession();
     this.webXRManager.clearSession();
     if (!this._isFinalized) {
       this.animationLoop.setProps({animationFrameProvider: undefined});
@@ -791,11 +813,15 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
 function getXRSessionInit(sessionMode: ImmersiveXRSessionMode, deviceType: string): XRSessionInit {
   if (deviceType === 'webgpu') {
-    return {requiredFeatures: ['webgpu'], optionalFeatures: ['local-floor']};
+    return {
+      requiredFeatures: ['webgpu'],
+      optionalFeatures:
+        sessionMode === 'immersive-ar' ? ['hit-test', 'local-floor'] : ['local-floor']
+    };
   }
 
   return sessionMode === 'immersive-ar'
-    ? {optionalFeatures: ['camera-access', 'local-floor']}
+    ? {optionalFeatures: ['camera-access', 'hit-test', 'local-floor']}
     : {optionalFeatures: ['local-floor']};
 }
 

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -25,9 +25,9 @@ import {
   getWebXRDOMOverlaySessionInit,
   getWebXRBoundsState,
   getWebXRHandPinch,
+  getWebXRControllerRayPlaneIntersection,
   getWebXRControllerStateByHandedness,
   getWebXRControllerStates,
-  getWebXRInputRayPlaneIntersection,
   getWebXRLocomotionState,
   getWebXRSessionRenderState,
   getWebXRTeleportTranslation,
@@ -970,7 +970,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.controllerRayModel.predraw(this.device.commandEncoder);
       this.controllerRayModel.draw(renderPass);
 
-      const floorHit = getWebXRInputRayPlaneIntersection(controllerState.ray, {maxDistance: 8});
+      const floorHit = getWebXRControllerRayPlaneIntersection(controllerState, {maxDistance: 8});
       if (floorHit) {
         const teleportTarget = getXRTeleportTargetState(floorHit.point, boundsState);
         if (teleportTarget.allowed) {

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -29,6 +29,7 @@ import {
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
   getWebXRLocomotionState,
+  getWebXRSessionRenderState,
   getWebXRTeleportTranslation,
   isPointInWebXRBounds,
   mergeWebXRSessionInit,
@@ -623,6 +624,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     const time = elapsedTimeMilliseconds * 0.001;
     const xrFrame = animationFrame as XRFrame | null;
     const frameState = xrFrame && this.xrSession ? this.webXRManager.getFrameState(xrFrame) : null;
+    const sessionRenderState = getWebXRSessionRenderState(
+      this.xrSession ? this.webXRSessionStateManager.getSessionState() : null
+    );
     const inputState = xrFrame && this.xrSession ? this.webXRManager.getInputState(xrFrame) : null;
     const handState =
       xrFrame && this.xrSession
@@ -647,16 +651,22 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         : null;
 
     if (frameState) {
-      this.updateXRLocomotion(inputState || [], elapsedTimeMilliseconds);
+      if (!sessionRenderState.isRenderable) {
+        this.clearXRInteractionState();
+        return;
+      }
+      const activeInputState = sessionRenderState.acceptsInput ? inputState || [] : [];
+      this.updateXRLocomotion(activeInputState, elapsedTimeMilliseconds);
       this.renderXRFrame(
         time,
         frameState,
-        inputState || [],
-        handState || [],
+        activeInputState,
+        sessionRenderState.acceptsInput ? handState || [] : [],
         hitTestState,
         lightEstimationState,
         planeDetectionState,
-        meshDetectionState
+        meshDetectionState,
+        sessionRenderState.intensityScale
       );
       return;
     }
@@ -787,12 +797,14 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     hitTestState: WebXRHitTestState | null,
     lightEstimationState: WebXRLightEstimationState | null,
     planeDetectionState: WebXRPlaneDetectionState | null,
-    meshDetectionState: WebXRMeshDetectionState | null
+    meshDetectionState: WebXRMeshDetectionState | null,
+    sessionIntensityScale: number
   ): void {
     this.updateModelMatrix(time, true, hitTestState, planeDetectionState, meshDetectionState);
     const lightIntensity =
       getXRLightIntensity(lightEstimationState) *
-      getXRViewerHeightLightScale(frameState.viewer.position);
+      getXRViewerHeightLightScale(frameState.viewer.position) *
+      sessionIntensityScale;
     const clearColor: [number, number, number, number] =
       this.xrSessionMode === 'immersive-ar' ? [0, 0, 0, 0] : [0.006, 0.008, 0.028, 1];
     const renderedFramebuffers = new Set<Framebuffer>();
@@ -1083,6 +1095,13 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     applyXRSceneOffset(this.xrSceneOffset, offset);
   }
 
+  private clearXRInteractionState(): void {
+    this._floorHitByInputSource.clear();
+    this._inputStateByInputSource.clear();
+    this._lastXRLocomotionTimeMilliseconds = null;
+    this._lastXRSnapTurn = 0;
+  }
+
   private createCameraTexture(session: XRSession): WebXRCameraTexture | null {
     if (this.device.type !== 'webgl' || typeof XRWebGLBinding === 'undefined') {
       return null;
@@ -1131,10 +1150,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.xrSceneOffset[1] = 0;
     this.xrSceneOffset[2] = 0;
     this.xrSceneYaw = 0;
-    this._lastXRLocomotionTimeMilliseconds = null;
-    this._lastXRSnapTurn = 0;
-    this._floorHitByInputSource.clear();
-    this._inputStateByInputSource.clear();
+    this.clearXRInteractionState();
     this.cameraTexture?.destroy();
     this.cameraTexture = null;
     this.webXRDOMOverlayManager.clearSession();

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -10,7 +10,8 @@ import {
   WebXRAnimationFrameProvider,
   WebXRCameraTexture,
   WebXRManager,
-  type WebXRFrameState
+  type WebXRFrameState,
+  type WebXRInputState
 } from '@luma.gl/experimental';
 import {Matrix4} from '@math.gl/core';
 
@@ -240,6 +241,83 @@ void main(void) {
 }
 `;
 
+const CONTROLLER_RAY_WGSL_SHADER = /* wgsl */ `\
+struct AppUniforms {
+  modelViewProjectionMatrix: mat4x4<f32>,
+  time: f32,
+  cameraMix: f32,
+};
+
+@group(0) @binding(auto) var<uniform> app: AppUniforms;
+
+struct VertexInputs {
+  @location(0) positions: vec3<f32>,
+};
+
+struct FragmentInputs {
+  @builtin(position) Position: vec4<f32>,
+  @location(0) rayDepth: f32,
+};
+
+@vertex
+fn vertexMain(inputs: VertexInputs) -> FragmentInputs {
+  var outputs: FragmentInputs;
+  outputs.Position = app.modelViewProjectionMatrix * vec4<f32>(inputs.positions, 1.0);
+  outputs.rayDepth = clamp(-inputs.positions.z / 3.2, 0.0, 1.0);
+  return outputs;
+}
+
+@fragment
+fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
+  let idleColor = vec3<f32>(0.05, 0.92, 1.0);
+  let activeColor = vec3<f32>(1.0, 0.36, 0.18);
+  let color = mix(idleColor, activeColor, app.cameraMix);
+  let alpha = mix(0.86, 0.28, inputs.rayDepth);
+  return vec4<f32>(color * (1.15 - inputs.rayDepth * 0.38), alpha);
+}
+`;
+
+const CONTROLLER_RAY_VS_GLSL = /* glsl */ `\
+#version 300 es
+
+in vec3 positions;
+
+uniform appUniforms {
+  mat4 modelViewProjectionMatrix;
+  float time;
+  float cameraMix;
+} app;
+
+out float vRayDepth;
+
+void main(void) {
+  gl_Position = app.modelViewProjectionMatrix * vec4(positions, 1.0);
+  vRayDepth = clamp(-positions.z / 3.2, 0.0, 1.0);
+}
+`;
+
+const CONTROLLER_RAY_FS_GLSL = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+uniform appUniforms {
+  mat4 modelViewProjectionMatrix;
+  float time;
+  float cameraMix;
+} app;
+
+in float vRayDepth;
+out vec4 fragColor;
+
+void main(void) {
+  vec3 idleColor = vec3(0.05, 0.92, 1.0);
+  vec3 activeColor = vec3(1.0, 0.36, 0.18);
+  vec3 color = mix(idleColor, activeColor, app.cameraMix);
+  float alpha = mix(0.86, 0.28, vRayDepth);
+  fragColor = vec4(color * (1.15 - vRayDepth * 0.38), alpha);
+}
+`;
+
 export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   static current: AppAnimationLoopTemplate | null = null;
   private static readonly currentListeners = new Set<() => void>();
@@ -273,9 +351,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly uniformStore: UniformStore<{app: AppUniforms}>;
   readonly fallbackTexture: Texture;
   readonly model: Model;
+  readonly controllerRayModel: Model;
   readonly webXRManager: WebXRManager;
   readonly modelMatrix = new Matrix4();
   readonly modelViewProjectionMatrix = new Matrix4();
+  readonly controllerRayMatrix = new Matrix4();
   readonly viewMatrix = new Matrix4().lookAt({
     eye: [0.32, 0.24, 4.4],
     center: CAMERA_TARGET
@@ -332,6 +412,27 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         blendAlphaDstFactor: 'one-minus-src-alpha'
       }
     });
+    this.controllerRayModel = new Model(device, {
+      id: 'immersive-prism-controller-rays',
+      source: CONTROLLER_RAY_WGSL_SHADER,
+      vs: CONTROLLER_RAY_VS_GLSL,
+      fs: CONTROLLER_RAY_FS_GLSL,
+      geometry: makeControllerRayGeometry(),
+      bindings: {
+        app: this.uniformStore.getManagedUniformBuffer('app')
+      },
+      parameters: {
+        depthWriteEnabled: false,
+        depthCompare: 'less-equal',
+        blend: true,
+        blendColorOperation: 'add',
+        blendAlphaOperation: 'add',
+        blendColorSrcFactor: 'src-alpha',
+        blendColorDstFactor: 'one',
+        blendAlphaSrcFactor: 'one',
+        blendAlphaDstFactor: 'one-minus-src-alpha'
+      }
+    });
     this.initializePreviewControls();
 
     if (typeof window !== 'undefined') {
@@ -350,6 +451,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       window.removeEventListener('keydown', this._keyDownListener);
     }
     this.orbitControls?.destroy();
+    this.controllerRayModel.destroy();
     this.model.destroy();
     this.fallbackTexture.destroy();
     this.uniformStore.destroy();
@@ -360,9 +462,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     const time = elapsedTimeMilliseconds * 0.001;
     const xrFrame = animationFrame as XRFrame | null;
     const frameState = xrFrame && this.xrSession ? this.webXRManager.getFrameState(xrFrame) : null;
+    const inputState = xrFrame && this.xrSession ? this.webXRManager.getInputState(xrFrame) : null;
 
     if (frameState) {
-      this.renderXRFrame(time, frameState);
+      this.renderXRFrame(time, frameState, inputState || []);
       return;
     }
 
@@ -447,10 +550,19 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       .multiplyRight(this.viewMatrix)
       .multiplyRight(this.modelMatrix);
     this.preparePortal({cameraMix: 0, texture: this.fallbackTexture, time});
-    this.drawPortal(device.beginRenderPass({clearColor: [0.006, 0.008, 0.028, 1], clearDepth: 1}));
+    const renderPass = device.beginRenderPass({
+      clearColor: [0.006, 0.008, 0.028, 1],
+      clearDepth: 1
+    });
+    this.drawPortal(renderPass);
+    renderPass.end();
   }
 
-  private renderXRFrame(time: number, frameState: WebXRFrameState): void {
+  private renderXRFrame(
+    time: number,
+    frameState: WebXRFrameState,
+    inputState: readonly WebXRInputState[]
+  ): void {
     this.updateModelMatrix(time, true);
     const clearColor: [number, number, number, number] =
       this.xrSessionMode === 'immersive-ar' ? [0, 0, 0, 0] : [0.006, 0.008, 0.028, 1];
@@ -479,6 +591,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       });
       renderPass.setParameters({viewport: view.viewport});
       this.drawPortal(renderPass);
+      this.drawControllerRays(renderPass, view, inputState, time);
+      renderPass.end();
     }
   }
 
@@ -503,7 +617,37 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
   private drawPortal(renderPass: ReturnType<Device['beginRenderPass']>): void {
     this.model.draw(renderPass);
-    renderPass.end();
+  }
+
+  private drawControllerRays(
+    renderPass: ReturnType<Device['beginRenderPass']>,
+    view: WebXRFrameState['views'][number],
+    inputState: readonly WebXRInputState[],
+    time: number
+  ): void {
+    for (const input of inputState) {
+      if (input.targetRayMode !== 'tracked-pointer' || !input.targetRayMatrix) {
+        continue;
+      }
+
+      this.controllerRayMatrix.copy(input.targetRayMatrix);
+      this.modelViewProjectionMatrix
+        .copy(view.projectionMatrix)
+        .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))
+        .multiplyRight(this.controllerRayMatrix);
+      this.uniformStore.setUniforms(
+        {
+          app: {
+            modelViewProjectionMatrix: this.modelViewProjectionMatrix,
+            time,
+            cameraMix: input.selectActive ? 1 : 0
+          }
+        },
+        this.device.commandEncoder
+      );
+      this.controllerRayModel.predraw(this.device.commandEncoder);
+      this.controllerRayModel.draw(renderPass);
+    }
   }
 
   private updateModelMatrix(time: number, isXR: boolean): void {
@@ -599,6 +743,18 @@ function makeSpatialPortalGeometry(): Geometry {
       positions: {size: 3, value: new Float32Array(positions)},
       texCoords: {size: 2, value: new Float32Array(texCoords)},
       shardData: {size: 4, value: new Float32Array(shardAttributes)}
+    }
+  });
+}
+
+function makeControllerRayGeometry(): Geometry {
+  return new Geometry({
+    topology: 'line-list',
+    attributes: {
+      positions: {
+        size: 3,
+        value: new Float32Array([0, 0, 0, 0, 0, -3.2])
+      }
     }
   });
 }

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -25,6 +25,7 @@ import {
   getWebXRDOMOverlaySessionInit,
   getWebXRBoundsState,
   getWebXRHandPinch,
+  getWebXRControllerStateByHandedness,
   getWebXRControllerStates,
   getWebXRInputRayPlaneIntersection,
   getWebXRLocomotionState,
@@ -919,7 +920,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     time: number,
     boundsState: WebXRBoundsState | null
   ): void {
-    for (const controllerState of getWebXRControllerStates(inputState)) {
+    const controllerStates = getWebXRControllerStates(inputState);
+    const dominantControllerState = getWebXRControllerStateByHandedness(controllerStates, 'right');
+    for (const controllerState of controllerStates) {
       if (controllerState.grip) {
         this.modelViewProjectionMatrix
           .copy(view.projectionMatrix)
@@ -932,7 +935,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
               time,
               cameraMix: controllerState.isSqueezeActive
                 ? 1
-                : controllerState.handedness === 'right'
+                : controllerState === dominantControllerState
                   ? 0.45
                   : 0,
               lightIntensity: 1

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -7,6 +7,7 @@ import {UniformStore} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, Geometry, Model, OrbitControls} from '@luma.gl/engine';
 import {
+  OrbitControls,
   WebXRAnimationFrameProvider,
   WebXRCameraTexture,
   WebXRManager,

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -816,12 +816,12 @@ function getXRSessionInit(sessionMode: ImmersiveXRSessionMode, deviceType: strin
     return {
       requiredFeatures: ['webgpu'],
       optionalFeatures:
-        sessionMode === 'immersive-ar' ? ['hit-test', 'local-floor'] : ['local-floor']
+        sessionMode === 'immersive-ar' ? ['anchors', 'hit-test', 'local-floor'] : ['local-floor']
     };
   }
 
   return sessionMode === 'immersive-ar'
-    ? {optionalFeatures: ['camera-access', 'hit-test', 'local-floor']}
+    ? {optionalFeatures: ['anchors', 'camera-access', 'hit-test', 'local-floor']}
     : {optionalFeatures: ['local-floor']};
 }
 

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -7,7 +7,6 @@ import {UniformStore} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, Geometry, Model, OrbitControls} from '@luma.gl/engine';
 import {
-  OrbitControls,
   WebXRAnimationFrameProvider,
   WebXRCameraTexture,
   WebXRManager,

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -790,7 +790,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     meshDetectionState: WebXRMeshDetectionState | null
   ): void {
     this.updateModelMatrix(time, true, hitTestState, planeDetectionState, meshDetectionState);
-    const lightIntensity = getXRLightIntensity(lightEstimationState);
+    const lightIntensity =
+      getXRLightIntensity(lightEstimationState) *
+      getXRViewerHeightLightScale(frameState.viewer.position);
     const clearColor: [number, number, number, number] =
       this.xrSessionMode === 'immersive-ar' ? [0, 0, 0, 0] : [0.006, 0.008, 0.028, 1];
     const renderedFramebuffers = new Set<Framebuffer>();
@@ -1227,6 +1229,10 @@ export function getXRTeleportTargetState(
     point,
     allowed: !boundsState || isPointInWebXRBounds(point, boundsState.bounds)
   };
+}
+
+export function getXRViewerHeightLightScale(position: readonly [number, number, number]): number {
+  return Math.min(1.15, Math.max(0.85, 0.85 + position[1] * 0.12));
 }
 
 export function getXRLocomotionSceneOffset(

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -25,6 +25,7 @@ import {
   getWebXRBoundsState,
   getWebXRGamepadState,
   getWebXRHandPinch,
+  getWebXRInputGrip,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
   getWebXRLocomotionState,
@@ -404,6 +405,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly uniformStore: UniformStore<{app: AppUniforms}>;
   readonly fallbackTexture: Texture;
   readonly model: Model;
+  readonly controllerGripModel: Model;
   readonly controllerRayModel: Model;
   readonly controllerReticleModel: Model;
   readonly handJointModel: Model;
@@ -428,6 +430,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   });
   readonly modelMatrix = new Matrix4();
   readonly modelViewProjectionMatrix = new Matrix4();
+  readonly controllerGripMatrix = new Matrix4();
   readonly controllerRayMatrix = new Matrix4();
   readonly controllerReticleMatrix = new Matrix4();
   readonly handJointMatrix = new Matrix4();
@@ -491,6 +494,27 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         blendAlphaOperation: 'add',
         blendColorSrcFactor: 'src-alpha',
         blendColorDstFactor: 'one-minus-src-alpha',
+        blendAlphaSrcFactor: 'one',
+        blendAlphaDstFactor: 'one-minus-src-alpha'
+      }
+    });
+    this.controllerGripModel = new Model(device, {
+      id: 'immersive-prism-controller-grips',
+      source: CONTROLLER_RAY_WGSL_SHADER,
+      vs: CONTROLLER_RAY_VS_GLSL,
+      fs: CONTROLLER_RAY_FS_GLSL,
+      geometry: makeControllerGripGeometry(),
+      bindings: {
+        app: this.uniformStore.getManagedUniformBuffer('app')
+      },
+      parameters: {
+        depthWriteEnabled: false,
+        depthCompare: 'less-equal',
+        blend: true,
+        blendColorOperation: 'add',
+        blendAlphaOperation: 'add',
+        blendColorSrcFactor: 'src-alpha',
+        blendColorDstFactor: 'one',
         blendAlphaSrcFactor: 'one',
         blendAlphaDstFactor: 'one-minus-src-alpha'
       }
@@ -577,6 +601,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     }
     this.orbitControls?.destroy();
     this.controllerReticleModel.destroy();
+    this.controllerGripModel.destroy();
     this.handJointModel.destroy();
     this.controllerRayModel.destroy();
     this.model.destroy();
@@ -879,6 +904,27 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     boundsState: WebXRBoundsState | null
   ): void {
     for (const input of inputState) {
+      const inputGrip = getWebXRInputGrip(input);
+      if (inputGrip) {
+        this.modelViewProjectionMatrix
+          .copy(view.projectionMatrix)
+          .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))
+          .multiplyRight(this.controllerGripMatrix.copy(inputGrip.matrix));
+        this.uniformStore.setUniforms(
+          {
+            app: {
+              modelViewProjectionMatrix: this.modelViewProjectionMatrix,
+              time,
+              cameraMix: input.squeezeActive ? 1 : input.handedness === 'right' ? 0.45 : 0,
+              lightIntensity: 1
+            }
+          },
+          this.device.commandEncoder
+        );
+        this.controllerGripModel.predraw(this.device.commandEncoder);
+        this.controllerGripModel.draw(renderPass);
+      }
+
       const inputRay = getWebXRInputRay(input);
       if (input.targetRayMode !== 'tracked-pointer' || !inputRay) {
         continue;
@@ -1230,6 +1276,24 @@ function makeControllerRayGeometry(): Geometry {
       positions: {
         size: 3,
         value: new Float32Array([0, 0, 0, 0, 0, -3.2])
+      }
+    }
+  });
+}
+
+function makeControllerGripGeometry(): Geometry {
+  return new Geometry({
+    topology: 'line-list',
+    attributes: {
+      positions: {
+        size: 3,
+        value: new Float32Array([
+          -0.045, 0, 0, 0.045, 0, 0, 0, -0.035, 0, 0, 0.035, 0, 0, 0, 0.045, 0, 0, -0.13, -0.032,
+          -0.032, -0.07, 0.032, -0.032, -0.07, 0.032, -0.032, -0.07, 0.032, 0.032, -0.07, 0.032,
+          0.032, -0.07, -0.032, 0.032, -0.07, -0.032, 0.032, -0.07, -0.032, -0.032, -0.07, -0.024,
+          -0.024, -0.15, 0.024, -0.024, -0.15, 0.024, -0.024, -0.15, 0.024, 0.024, -0.15, 0.024,
+          0.024, -0.15, -0.024, 0.024, -0.15, -0.024, 0.024, -0.15, -0.024, -0.024, -0.15
+        ])
       }
     }
   });

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -29,8 +29,7 @@ import {
   getWebXRControllerStateByHandedness,
   getWebXRControllerStates,
   getWebXRControllerRayPlaneTargetByInputSource,
-  getWebXRHitTestResult,
-  getWebXRTransientInputHitTestResult,
+  getWebXRHitTestPlacementResult,
   getWebXRInputStateByInputSource,
   getWebXRLocomotionState,
   getWebXRSessionRenderState,
@@ -1056,9 +1055,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   ): void {
     this.modelMatrix.identity();
     if (isXR) {
-      const hitTestMatrix =
-        getWebXRTransientInputHitTestResult(hitTestState)?.matrix ||
-        getWebXRHitTestResult(hitTestState)?.matrix;
+      const hitTestMatrix = getWebXRHitTestPlacementResult(hitTestState)?.matrix;
       if (this.xrSessionMode === 'immersive-ar' && hitTestMatrix) {
         this.modelMatrix.copy(hitTestMatrix).scale([0.54, 0.54, 0.54]);
         return;

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -55,6 +55,7 @@ const PARTICLE_COUNT = 220;
 const PORTAL_DEPTH = 10.4;
 const CAMERA_TARGET: [number, number, number] = [0, 0, -2.6];
 const XR_LOCOMOTION_SPEED = 1.4;
+const XR_SNAP_TURN_RADIANS = Math.PI / 8;
 const AR_DEPTH_SENSING: XRDepthStateInit = {
   usagePreference: ['gpu-optimized', 'cpu-optimized'],
   dataFormatPreference: ['luminance-alpha', 'float32', 'unsigned-short'],
@@ -425,6 +426,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly controllerReticleMatrix = new Matrix4();
   readonly handJointMatrix = new Matrix4();
   readonly xrSceneOffset: [number, number, number] = [0, 0, 0];
+  xrSceneYaw = 0;
   readonly viewMatrix = new Matrix4().lookAt({
     eye: [0.32, 0.24, 4.4],
     center: CAMERA_TARGET
@@ -439,6 +441,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   private _floorHitByInputSource = new Map<XRInputSource, [number, number, number]>();
   private _inputStateByInputSource = new Map<XRInputSource, WebXRInputState>();
   private _lastXRLocomotionTimeMilliseconds: number | null = null;
+  private _lastXRSnapTurn = 0;
   private _xrSessionEndListener = () => this._clearXRSession();
   private _xrSelectEndListener = (event: Event) =>
     this.teleportToInputSource((event as XRInputSourceEvent).inputSource);
@@ -815,6 +818,17 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       deadzone: 0.22,
       snapTurnThreshold: 0.86
     });
+    if (locomotionState.snapTurn && this._lastXRSnapTurn === 0) {
+      this.xrSceneYaw = applyXRSnapTurn(this.xrSceneYaw, locomotionState.snapTurn);
+      if (locomotionState.turnInputState) {
+        void pulseWebXRInputHaptics(locomotionState.turnInputState, {
+          intensity: 0.35,
+          duration: 30
+        });
+      }
+    }
+    this._lastXRSnapTurn = locomotionState.snapTurn;
+
     if (!locomotionState.moveActive) {
       return;
     }
@@ -976,6 +990,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
       this.modelMatrix
         .translate(this.xrSceneOffset)
+        .rotateY(this.xrSceneYaw)
         .translate([0, 0.12, -2.15])
         .scale([0.88, 0.88, 0.88])
         .rotateZ(Math.sin(time * 0.2) * 0.055)
@@ -1057,7 +1072,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.xrSceneOffset[0] = 0;
     this.xrSceneOffset[1] = 0;
     this.xrSceneOffset[2] = 0;
+    this.xrSceneYaw = 0;
     this._lastXRLocomotionTimeMilliseconds = null;
+    this._lastXRSnapTurn = 0;
     this._floorHitByInputSource.clear();
     this._inputStateByInputSource.clear();
     this.cameraTexture?.destroy();
@@ -1131,6 +1148,14 @@ export function applyXRSceneOffset(
   sceneOffset[1] += offset[1];
   sceneOffset[2] += offset[2];
   return sceneOffset;
+}
+
+export function applyXRSnapTurn(
+  sceneYaw: number,
+  snapTurn: -1 | 0 | 1,
+  snapTurnRadians = XR_SNAP_TURN_RADIANS
+): number {
+  return sceneYaw + snapTurn * snapTurnRadians;
 }
 
 function makeSpatialPortalGeometry(): Geometry {

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -16,9 +16,11 @@ import {
   WebXRMeshDetectionManager,
   WebXRManager,
   WebXRPlaneDetectionManager,
+  getWebXRBoundsState,
   getWebXRHandPinch,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
+  isPointInWebXRBounds,
   pulseWebXRInputHaptics,
   type WebXRFrameState,
   type WebXRHandTrackingState,
@@ -642,7 +644,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
     try {
       await this.webXRManager.setSession(session, {
-        referenceSpaceTypes: ['local-floor', 'local'],
+        referenceSpaceTypes: ['bounded-floor', 'local-floor', 'local'],
         ...(this.device.type === 'webgl'
           ? {layerInit: {alpha: sessionMode === 'immersive-ar'}}
           : {})
@@ -925,6 +927,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     if (!floorHit) {
       return;
     }
+    const boundsState = getWebXRBoundsState(this.webXRManager.referenceSpace);
+    if (boundsState && !isPointInWebXRBounds(floorHit, boundsState.bounds)) {
+      return;
+    }
 
     this.xrSceneOffset[0] -= floorHit[0];
     this.xrSceneOffset[2] -= floorHit[2];
@@ -1017,6 +1023,7 @@ function getXRSessionInit(
               'anchors',
               'depth-sensing',
               ...domOverlayFeatures,
+              'bounded-floor',
               'hand-tracking',
               'hit-test',
               'light-estimation',
@@ -1024,7 +1031,7 @@ function getXRSessionInit(
               'plane-detection',
               'local-floor'
             ]
-          : [...domOverlayFeatures, 'hand-tracking', 'local-floor'],
+          : [...domOverlayFeatures, 'bounded-floor', 'hand-tracking', 'local-floor'],
       ...(sessionMode === 'immersive-ar' ? {depthSensing: AR_DEPTH_SENSING} : {}),
       ...domOverlayInit
     };
@@ -1037,6 +1044,7 @@ function getXRSessionInit(
           'camera-access',
           'depth-sensing',
           ...domOverlayFeatures,
+          'bounded-floor',
           'hand-tracking',
           'hit-test',
           'light-estimation',
@@ -1048,7 +1056,7 @@ function getXRSessionInit(
         ...domOverlayInit
       }
     : {
-        optionalFeatures: [...domOverlayFeatures, 'hand-tracking', 'local-floor'],
+        optionalFeatures: [...domOverlayFeatures, 'bounded-floor', 'hand-tracking', 'local-floor'],
         ...domOverlayInit
       };
 }

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -13,6 +13,7 @@ import {
   WebXRHandTrackingManager,
   WebXRHitTestManager,
   WebXRManager,
+  getWebXRHandPinch,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
   type WebXRFrameState,
@@ -770,7 +771,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     time: number
   ): void {
     for (const hand of handState) {
-      const handColorMix = hand.handedness === 'right' ? 1 : 0;
+      const pinchState = getWebXRHandPinch(hand);
+      const handColorMix = pinchState?.pinchActive ? 1 : hand.handedness === 'right' ? 0.45 : 0;
 
       for (const joint of hand.joints) {
         if (!joint.matrix) {

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -13,6 +13,7 @@ import {
   WebXRDOMOverlayManager,
   WebXRHandTrackingManager,
   WebXRHitTestManager,
+  WebXRInputActionManager,
   WebXRLightEstimationManager,
   WebXRMeshDetectionManager,
   WebXRManager,
@@ -430,6 +431,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly webXRSessionStateManager = new WebXRSessionStateManager({
     targetFrameRate: 'highest'
   });
+  readonly webXRInputActionManager = new WebXRInputActionManager();
   readonly modelMatrix = new Matrix4();
   readonly modelViewProjectionMatrix = new Matrix4();
   readonly controllerGripMatrix = new Matrix4();
@@ -844,6 +846,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.drawHandJoints(renderPass, view, handState, time);
       renderPass.end();
     }
+
+    this.updateXRInputActions(inputState);
   }
 
   private updateXRLocomotion(
@@ -1094,6 +1098,18 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this._floorHitByInputSource.clear();
   }
 
+  private updateXRInputActions(inputState: readonly WebXRInputState[]): void {
+    const actionStates = this.webXRInputActionManager.update(inputState);
+    for (const actionState of actionStates) {
+      if (actionState.primaryActionEnded) {
+        this.teleportToInputSource(actionState.inputSource);
+      }
+      if (actionState.squeezeActionEnded) {
+        void this.exitXR();
+      }
+    }
+  }
+
   private applyXRSceneOffset(offset: readonly [number, number, number]): void {
     applyXRSceneOffset(this.xrSceneOffset, offset);
   }
@@ -1101,6 +1117,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   private clearXRInteractionState(): void {
     this._floorHitByInputSource.clear();
     this._inputStateByInputSource.clear();
+    this.webXRInputActionManager.reset();
     this._lastXRLocomotionTimeMilliseconds = null;
     this._lastXRSnapTurn = 0;
   }

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -28,6 +28,7 @@ import {
   getWebXRInputGrip,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
+  getWebXRInputSourceState,
   getWebXRLocomotionState,
   getWebXRSessionRenderState,
   getWebXRTeleportTranslation,
@@ -918,8 +919,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     boundsState: WebXRBoundsState | null
   ): void {
     for (const input of inputState) {
+      const inputSourceState = getWebXRInputSourceState(input);
       const inputGrip = getWebXRInputGrip(input);
-      if (inputGrip) {
+      if (inputSourceState.isController && inputGrip) {
         this.modelViewProjectionMatrix
           .copy(view.projectionMatrix)
           .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))
@@ -929,7 +931,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
             app: {
               modelViewProjectionMatrix: this.modelViewProjectionMatrix,
               time,
-              cameraMix: input.squeezeActive ? 1 : input.handedness === 'right' ? 0.45 : 0,
+              cameraMix: input.squeezeActive
+                ? 1
+                : inputSourceState.handedness === 'right'
+                  ? 0.45
+                  : 0,
               lightIntensity: 1
             }
           },
@@ -940,7 +946,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       }
 
       const inputRay = getWebXRInputRay(input);
-      if (input.targetRayMode !== 'tracked-pointer' || !inputRay) {
+      if (!inputSourceState.usesTrackedPointer || !inputRay) {
         continue;
       }
       const gamepadState = getWebXRGamepadState(input);

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -25,7 +25,7 @@ import {
   getWebXRDOMOverlaySessionInit,
   getWebXRBoundsState,
   getWebXRHandPinch,
-  getWebXRControllerRayPlaneIntersection,
+  getWebXRControllerRayPlaneTarget,
   getWebXRControllerStateByHandedness,
   getWebXRControllerStates,
   getWebXRLocomotionState,
@@ -970,11 +970,13 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.controllerRayModel.predraw(this.device.commandEncoder);
       this.controllerRayModel.draw(renderPass);
 
-      const floorHit = getWebXRControllerRayPlaneIntersection(controllerState, {maxDistance: 8});
-      if (floorHit) {
-        const teleportTarget = getXRTeleportTargetState(floorHit.point, boundsState);
+      const teleportTarget = getWebXRControllerRayPlaneTarget(controllerState, {
+        maxDistance: 8,
+        bounds: boundsState
+      });
+      if (teleportTarget) {
         if (teleportTarget.allowed) {
-          this._floorHitByInputSource.set(controllerState.inputSource, floorHit.point);
+          this._floorHitByInputSource.set(controllerState.inputSource, teleportTarget.point);
         }
         this.controllerReticleMatrix.identity().translate(teleportTarget.point);
         this.modelViewProjectionMatrix

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -23,8 +23,8 @@ import {
   getWebXRDepthSensingSessionInit,
   getWebXRDOMOverlaySessionInit,
   getWebXRBoundsState,
-  getWebXRGamepadState,
   getWebXRHandPinch,
+  getWebXRInputActivationState,
   getWebXRInputGrip,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
@@ -920,6 +920,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   ): void {
     for (const input of inputState) {
       const inputSourceState = getWebXRInputSourceState(input);
+      const inputActivationState = getWebXRInputActivationState(input);
       const inputGrip = getWebXRInputGrip(input);
       if (inputSourceState.isController && inputGrip) {
         this.modelViewProjectionMatrix
@@ -931,7 +932,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
             app: {
               modelViewProjectionMatrix: this.modelViewProjectionMatrix,
               time,
-              cameraMix: input.squeezeActive
+              cameraMix: inputActivationState.isSqueezeActive
                 ? 1
                 : inputSourceState.handedness === 'right'
                   ? 0.45
@@ -949,11 +950,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       if (!inputSourceState.usesTrackedPointer || !inputRay) {
         continue;
       }
-      const gamepadState = getWebXRGamepadState(input);
-      const controllerActivation = Math.max(
-        input.selectActive ? 1 : 0,
-        gamepadState?.primaryTrigger?.value || 0
-      );
+      const controllerActivation = inputActivationState.primaryAction;
 
       this.modelViewProjectionMatrix
         .copy(view.projectionMatrix)

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -32,6 +32,11 @@ const RIBBON_SEGMENT_COUNT = 34;
 const PARTICLE_COUNT = 220;
 const PORTAL_DEPTH = 10.4;
 const CAMERA_TARGET: [number, number, number] = [0, 0, -2.6];
+const AR_DEPTH_SENSING: XRDepthStateInit = {
+  usagePreference: ['gpu-optimized', 'cpu-optimized'],
+  dataFormatPreference: ['luminance-alpha', 'float32', 'unsigned-short'],
+  depthTypeRequest: ['smooth', 'raw']
+};
 
 type AppUniforms = {
   modelViewProjectionMatrix: NumberArray;
@@ -816,12 +821,18 @@ function getXRSessionInit(sessionMode: ImmersiveXRSessionMode, deviceType: strin
     return {
       requiredFeatures: ['webgpu'],
       optionalFeatures:
-        sessionMode === 'immersive-ar' ? ['anchors', 'hit-test', 'local-floor'] : ['local-floor']
+        sessionMode === 'immersive-ar'
+          ? ['anchors', 'depth-sensing', 'hit-test', 'local-floor']
+          : ['local-floor'],
+      ...(sessionMode === 'immersive-ar' ? {depthSensing: AR_DEPTH_SENSING} : {})
     };
   }
 
   return sessionMode === 'immersive-ar'
-    ? {optionalFeatures: ['anchors', 'camera-access', 'hit-test', 'local-floor']}
+    ? {
+        optionalFeatures: ['anchors', 'camera-access', 'depth-sensing', 'hit-test', 'local-floor'],
+        depthSensing: AR_DEPTH_SENSING
+      }
     : {optionalFeatures: ['local-floor']};
 }
 

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -9,6 +9,7 @@ import {AnimationLoopTemplate, Geometry, Model, OrbitControls} from '@luma.gl/en
 import {
   WebXRAnimationFrameProvider,
   WebXRCameraTexture,
+  WebXRDOMOverlayManager,
   WebXRHitTestManager,
   WebXRManager,
   getWebXRInputRay,
@@ -363,6 +364,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly controllerRayModel: Model;
   readonly controllerReticleModel: Model;
   readonly webXRManager: WebXRManager;
+  readonly webXRDOMOverlayManager = new WebXRDOMOverlayManager();
   readonly webXRHitTestManager = new WebXRHitTestManager();
   readonly modelMatrix = new Matrix4();
   readonly modelViewProjectionMatrix = new Matrix4();
@@ -493,6 +495,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.model.destroy();
     this.fallbackTexture.destroy();
     this.uniformStore.destroy();
+    this.webXRDOMOverlayManager.destroy();
     this.webXRHitTestManager.destroy();
     this.webXRManager.destroy();
   }
@@ -545,7 +548,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
     const session = await navigator.xr.requestSession(
       sessionMode,
-      getXRSessionInit(sessionMode, this.device.type)
+      getXRSessionInit(sessionMode, this.device.type, getDOMOverlayRoot())
     );
 
     try {
@@ -564,6 +567,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         sessionMode === 'immersive-ar' && this.device.type === 'webgl'
           ? this.createCameraTexture(session)
           : null;
+      this.webXRDOMOverlayManager.setSession(session, {root: getDOMOverlayRoot()});
       this.xrSession = session;
       this.xrSessionMode = sessionMode;
       session.addEventListener('end', this._xrSessionEndListener);
@@ -808,6 +812,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this._floorHitByInputSource.clear();
     this.cameraTexture?.destroy();
     this.cameraTexture = null;
+    this.webXRDOMOverlayManager.clearSession();
     this.webXRHitTestManager.clearSession();
     this.webXRManager.clearSession();
     if (!this._isFinalized) {
@@ -816,15 +821,30 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   }
 }
 
-function getXRSessionInit(sessionMode: ImmersiveXRSessionMode, deviceType: string): XRSessionInit {
+function getXRSessionInit(
+  sessionMode: ImmersiveXRSessionMode,
+  deviceType: string,
+  domOverlayRoot: Element | null = null
+): XRSessionInit {
+  const domOverlayFeatures = domOverlayRoot ? ['dom-overlay'] : [];
+  const domOverlayInit = domOverlayRoot ? {domOverlay: {root: domOverlayRoot}} : {};
+
   if (deviceType === 'webgpu') {
     return {
       requiredFeatures: ['webgpu'],
       optionalFeatures:
         sessionMode === 'immersive-ar'
-          ? ['anchors', 'depth-sensing', 'hand-tracking', 'hit-test', 'local-floor']
-          : ['hand-tracking', 'local-floor'],
-      ...(sessionMode === 'immersive-ar' ? {depthSensing: AR_DEPTH_SENSING} : {})
+          ? [
+              'anchors',
+              'depth-sensing',
+              ...domOverlayFeatures,
+              'hand-tracking',
+              'hit-test',
+              'local-floor'
+            ]
+          : [...domOverlayFeatures, 'hand-tracking', 'local-floor'],
+      ...(sessionMode === 'immersive-ar' ? {depthSensing: AR_DEPTH_SENSING} : {}),
+      ...domOverlayInit
     };
   }
 
@@ -834,13 +854,22 @@ function getXRSessionInit(sessionMode: ImmersiveXRSessionMode, deviceType: strin
           'anchors',
           'camera-access',
           'depth-sensing',
+          ...domOverlayFeatures,
           'hand-tracking',
           'hit-test',
           'local-floor'
         ],
-        depthSensing: AR_DEPTH_SENSING
+        depthSensing: AR_DEPTH_SENSING,
+        ...domOverlayInit
       }
-    : {optionalFeatures: ['hand-tracking', 'local-floor']};
+    : {
+        optionalFeatures: [...domOverlayFeatures, 'hand-tracking', 'local-floor'],
+        ...domOverlayInit
+      };
+}
+
+function getDOMOverlayRoot(): Element | null {
+  return typeof document !== 'undefined' ? document.getElementById('webxr-dom-overlay') : null;
 }
 
 function makeSpatialPortalGeometry(): Geometry {

--- a/examples/experimental/webxr-kaleidoscope/index.html
+++ b/examples/experimental/webxr-kaleidoscope/index.html
@@ -115,6 +115,10 @@
         color: #fda4af;
       }
 
+      #exit-xr[hidden] {
+        display: none;
+      }
+
       .preview-hint {
         position: fixed;
         right: 24px;
@@ -149,6 +153,7 @@
       <div class="portal-panel__actions">
         <button id="enter-vr" type="button">Enter VR</button>
         <button id="enter-ar" type="button">Enter AR</button>
+        <button id="exit-xr" type="button" hidden>Exit XR</button>
         <button id="switch-backend" type="button">Use WebGL2</button>
       </div>
       <span id="backend-status" role="status">Preparing GPU renderer…</span>
@@ -166,9 +171,32 @@
       const sceneElement = document.getElementById('scene');
       const backendStatus = document.getElementById('backend-status');
       const sessionStatus = document.getElementById('session-status');
+      const enterVRButton = document.getElementById('enter-vr');
+      const enterARButton = document.getElementById('enter-ar');
+      const exitXRButton = document.getElementById('exit-xr');
       const switchBackendButton = document.getElementById('switch-backend');
       let animationLoop = null;
       let currentDevice = null;
+
+      function updateSessionControls(message = '') {
+        const application = AnimationLoopTemplate.current;
+        const sessionMode = application?.xrSessionMode || null;
+        const isLive = Boolean(application?.xrSession);
+        enterVRButton.textContent =
+          isLive && sessionMode === 'immersive-vr' ? 'VR active' : 'Enter VR';
+        enterARButton.textContent =
+          isLive && sessionMode === 'immersive-ar' ? 'AR active' : 'Enter AR';
+        enterVRButton.disabled = isLive;
+        enterARButton.disabled = isLive;
+        switchBackendButton.disabled = isLive;
+        exitXRButton.hidden = !isLive;
+        sessionStatus.dataset.error = 'false';
+        sessionStatus.textContent =
+          message ||
+          (isLive
+            ? `${sessionMode === 'immersive-ar' ? 'AR' : 'VR'} session active`
+            : 'Desktop preview active');
+      }
 
       function makeDeviceProps(type, xrCompatible = false) {
         return {
@@ -205,6 +233,7 @@
         currentDevice = await createPreferredDevice(type);
         animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device: currentDevice});
         await animationLoop.start();
+        updateSessionControls();
 
         if (currentDevice.type === 'webgpu') {
           const supportsNativeXR = currentDevice.props.xrCompatible && 'XRGPUBinding' in window;
@@ -228,13 +257,13 @@
           sessionStatus.dataset.error = 'false';
           if (application.xrSessionMode === mode) {
             await application.exitXR();
-            sessionStatus.textContent = 'Returned to the live desktop preview';
+            updateSessionControls('Returned to the live desktop preview');
           } else {
             if (application.xrSession) {
               await application.exitXR();
             }
             await application.enterXR(mode);
-            sessionStatus.textContent = `${mode === 'immersive-ar' ? 'AR' : 'VR'} session active`;
+            updateSessionControls();
           }
         } catch (error) {
           sessionStatus.dataset.error = 'true';
@@ -242,11 +271,21 @@
         }
       }
 
-      document.getElementById('enter-vr').addEventListener('click', () => {
+      enterVRButton.addEventListener('click', () => {
         void toggleSession('immersive-vr');
       });
-      document.getElementById('enter-ar').addEventListener('click', () => {
+      enterARButton.addEventListener('click', () => {
         void toggleSession('immersive-ar');
+      });
+      exitXRButton.addEventListener('click', () => {
+        const application = AnimationLoopTemplate.current;
+        void application
+          ?.exitXR()
+          .then(() => updateSessionControls('Returned to the live desktop preview'))
+          .catch(error => {
+            sessionStatus.dataset.error = 'true';
+            sessionStatus.textContent = error instanceof Error ? error.message : String(error);
+          });
       });
       switchBackendButton.addEventListener('click', () => {
         void startRenderer(currentDevice?.type === 'webgpu' ? 'webgl' : 'webgpu').catch(error => {
@@ -259,6 +298,7 @@
         sessionStatus.dataset.error = 'true';
         sessionStatus.textContent = error instanceof Error ? error.message : String(error);
       });
+      AnimationLoopTemplate.subscribeToCurrent(() => updateSessionControls());
     </script>
   </body>
 </html>

--- a/examples/experimental/webxr-kaleidoscope/index.html
+++ b/examples/experimental/webxr-kaleidoscope/index.html
@@ -45,6 +45,13 @@
         backdrop-filter: blur(18px);
       }
 
+      .portal-panel:xr-overlay {
+        top: 18px;
+        left: 18px;
+        width: min(360px, calc(100vw - 36px));
+        background: rgba(6, 12, 28, 0.72);
+      }
+
       .portal-panel__eyebrow {
         margin: 0 0 9px;
         color: #67e8f9;
@@ -132,7 +139,7 @@
   </head>
   <body>
     <main id="scene" aria-label="Animated stereoscopic prism portal preview"></main>
-    <aside class="portal-panel">
+    <aside id="webxr-dom-overlay" class="portal-panel">
       <div class="portal-panel__eyebrow">luma.gl · spatial rendering</div>
       <h1>Immersive Prism Portal</h1>
       <p>

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -151,11 +151,15 @@ export type {
   WebXRFrameState,
   WebXRInputState,
   WebXRManagerProps,
+  WebXRProjectionLayerControlsProps,
+  WebXRProjectionLayerState,
   WebXRReferenceSpaceState,
   WebXRViewState
 } from './webxr-manager';
 export {
+  getWebXRProjectionLayerState,
   getWebXRReferenceSpaceTypes,
   requestWebXRReferenceSpace,
+  setWebXRProjectionLayerControls,
   WebXRManager
 } from './webxr-manager';

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -180,7 +180,10 @@ export {
   getWebXRInputActivationState,
   getWebXRInputGrip,
   getWebXRInputRay,
+  getWebXRInputRayByInputSource,
   getWebXRInputRayPlaneIntersection,
+  getWebXRInputRayPlaneIntersections,
+  getWebXRInputRays,
   getWebXRInputStateByInputSource,
   getWebXRInputSourceState,
   WebXRInputActionManager

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -164,6 +164,7 @@ export type {
 } from './webxr-input';
 export {
   getWebXRControllerState,
+  getWebXRControllerStates,
   getWebXRInputActionState,
   getWebXRInputActivationState,
   getWebXRInputGrip,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -194,6 +194,7 @@ export type {
   WebXRProjectionLayerControlsProps,
   WebXRProjectionLayerState,
   WebXRReferenceSpaceState,
+  WebXRViewerState,
   WebXRViewState
 } from './webxr-manager';
 export {

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -150,6 +150,7 @@ export type {
 } from './webxr-hit-test';
 export {WebXRHitTestManager} from './webxr-hit-test';
 export type {
+  WebXRControllerHandedness,
   WebXRControllerState,
   WebXRInputActionState,
   WebXRInputActivationState,
@@ -164,6 +165,7 @@ export type {
 } from './webxr-input';
 export {
   getWebXRControllerState,
+  getWebXRControllerStateByHandedness,
   getWebXRControllerStates,
   getWebXRInputActionState,
   getWebXRInputActivationState,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -25,6 +25,8 @@ export type {
   WebXRDOMOverlayState
 } from './webxr-dom-overlay';
 export {getWebXRDOMOverlaySessionInit, WebXRDOMOverlayManager} from './webxr-dom-overlay';
+export type {WebXRHandPinchProps, WebXRHandPinchState} from './webxr-hand-gestures';
+export {getWebXRHandPinch} from './webxr-hand-gestures';
 export type {WebXRHandJointState, WebXRHandTrackingState} from './webxr-hand-tracking';
 export {WEBXR_HAND_JOINTS, WebXRHandTrackingManager} from './webxr-hand-tracking';
 export type {

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -171,6 +171,7 @@ export {
   getWebXRControllerRayPlaneIntersections,
   getWebXRControllerRayPlaneTarget,
   getWebXRControllerRayPlaneTargetByHandedness,
+  getWebXRControllerRayPlaneTargetByInputSource,
   getWebXRControllerRayPlaneTargets,
   getWebXRControllerState,
   getWebXRControllerStateByHandedness,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -7,6 +7,12 @@ export {WebXRAnimationFrameProvider} from './webxr-animation-frame-provider';
 export type {WebXRCameraTextureProps} from './webxr-camera-texture';
 export {WebXRCameraTexture} from './webxr-camera-texture';
 export type {
+  WebXRHitTestManagerProps,
+  WebXRHitTestResult,
+  WebXRHitTestState
+} from './webxr-hit-test';
+export {WebXRHitTestManager} from './webxr-hit-test';
+export type {
   WebXRInputRay,
   WebXRInputRayPlaneIntersection,
   WebXRInputRayPlaneIntersectionProps

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -98,6 +98,11 @@ export type {
   WebXRFrameState,
   WebXRInputState,
   WebXRManagerProps,
+  WebXRReferenceSpaceState,
   WebXRViewState
 } from './webxr-manager';
-export {WebXRManager} from './webxr-manager';
+export {
+  getWebXRReferenceSpaceTypes,
+  requestWebXRReferenceSpace,
+  WebXRManager
+} from './webxr-manager';

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -148,11 +148,16 @@ export type {
 } from './webxr-hit-test';
 export {WebXRHitTestManager} from './webxr-hit-test';
 export type {
+  WebXRInputGrip,
   WebXRInputRay,
   WebXRInputRayPlaneIntersection,
   WebXRInputRayPlaneIntersectionProps
 } from './webxr-input';
-export {getWebXRInputRay, getWebXRInputRayPlaneIntersection} from './webxr-input';
+export {
+  getWebXRInputGrip,
+  getWebXRInputRay,
+  getWebXRInputRayPlaneIntersection
+} from './webxr-input';
 export type {
   WebXRReferenceSpaceResetState,
   WebXRTeleportOffsetProps,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -60,6 +60,17 @@ export {
 export type {WebXRMediaLayerState, WebXRMediaLayerType} from './webxr-media-layers';
 export {WebXRMediaLayerManager} from './webxr-media-layers';
 export type {
+  WebXRSessionState,
+  WebXRSessionStateManagerProps,
+  WebXRTargetFrameRate
+} from './webxr-session-state';
+export {
+  getWebXRSupportedFrameRates,
+  getWebXRTargetFrameRate,
+  makeWebXRSessionState,
+  WebXRSessionStateManager
+} from './webxr-session-state';
+export type {
   WebXRMeshDetectionManagerProps,
   WebXRMeshDetectionSessionInitProps,
   WebXRMeshDetectionState,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -6,8 +6,12 @@ export type {WebXRRawCameraBinding} from './webxr-types';
 export {WebXRAnimationFrameProvider} from './webxr-animation-frame-provider';
 export type {WebXRCameraTextureProps} from './webxr-camera-texture';
 export {WebXRCameraTexture} from './webxr-camera-texture';
-export type {WebXRInputRay} from './webxr-input';
-export {getWebXRInputRay} from './webxr-input';
+export type {
+  WebXRInputRay,
+  WebXRInputRayPlaneIntersection,
+  WebXRInputRayPlaneIntersectionProps
+} from './webxr-input';
+export {getWebXRInputRay, getWebXRInputRayPlaneIntersection} from './webxr-input';
 export type {
   WebXRFrameState,
   WebXRInputState,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -19,6 +19,8 @@ export {
   getWebXRDepthTextureFormat,
   WebXRDepthSensingManager
 } from './webxr-depth-sensing';
+export type {WebXRHandJointState, WebXRHandTrackingState} from './webxr-hand-tracking';
+export {WEBXR_HAND_JOINTS, WebXRHandTrackingManager} from './webxr-hand-tracking';
 export type {
   WebXRHitTestManagerProps,
   WebXRHitTestResult,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -163,6 +163,8 @@ export type {
   WebXRInputRay,
   WebXRInputRayPlaneIntersection,
   WebXRInputRayPlaneIntersectionProps,
+  WebXRInputRayPlaneTarget,
+  WebXRInputRayPlaneTargetProps,
   WebXRInputSourceKind,
   WebXRInputSourceState
 } from './webxr-input';
@@ -183,6 +185,9 @@ export {
   getWebXRInputRayByInputSource,
   getWebXRInputRayPlaneIntersection,
   getWebXRInputRayPlaneIntersections,
+  getWebXRInputRayPlaneTarget,
+  getWebXRInputRayPlaneTargetByInputSource,
+  getWebXRInputRayPlaneTargets,
   getWebXRInputRays,
   getWebXRInputStateByInputSource,
   getWebXRInputSourceState,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -101,6 +101,8 @@ export type {
   WebXRInputRayPlaneIntersectionProps
 } from './webxr-input';
 export {getWebXRInputRay, getWebXRInputRayPlaneIntersection} from './webxr-input';
+export type {WebXRReferenceSpaceResetState} from './webxr-reference-space';
+export {makeWebXRReferenceSpaceState, WebXRReferenceSpaceManager} from './webxr-reference-space';
 export type {
   WebXRImageTrackingManagerProps,
   WebXRImageTrackingSessionInitProps,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -3,6 +3,8 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 export type {WebXRRawCameraBinding} from './webxr-types';
+export type {WebXRAnchorPose, WebXRAnchorState} from './webxr-anchor';
+export {WebXRAnchorManager} from './webxr-anchor';
 export {WebXRAnimationFrameProvider} from './webxr-animation-frame-provider';
 export type {WebXRCameraTextureProps} from './webxr-camera-texture';
 export {WebXRCameraTexture} from './webxr-camera-texture';

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -83,6 +83,16 @@ export type {
 } from './webxr-input';
 export {getWebXRInputRay, getWebXRInputRayPlaneIntersection} from './webxr-input';
 export type {
+  WebXRImageTrackingManagerProps,
+  WebXRImageTrackingSessionInitProps,
+  WebXRImageTrackingState,
+  WebXRTrackedImageState
+} from './webxr-image-tracking';
+export {
+  getWebXRImageTrackingSessionInit,
+  WebXRImageTrackingManager
+} from './webxr-image-tracking';
+export type {
   WebXRFrameState,
   WebXRInputState,
   WebXRManagerProps,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -50,11 +50,18 @@ export type {
 } from './webxr-haptics';
 export {getWebXRInputHapticActuator, pulseWebXRInputHaptics} from './webxr-haptics';
 export type {
+  WebXRCompositionLayerControlsProps,
+  WebXRCompositionLayerControlsState,
   WebXRCompositionLayerManagerProps,
   WebXRCompositionLayerState,
   WebXRLayersSessionInitProps
 } from './webxr-layers';
-export {getWebXRLayersSessionInit, WebXRCompositionLayerManager} from './webxr-layers';
+export {
+  getWebXRCompositionLayerControls,
+  getWebXRLayersSessionInit,
+  setWebXRCompositionLayerControls,
+  WebXRCompositionLayerManager
+} from './webxr-layers';
 export type {
   WebXRLightEstimationManagerProps,
   WebXRLightEstimationSessionInitProps,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -141,8 +141,19 @@ export type {
   WebXRInputRayPlaneIntersectionProps
 } from './webxr-input';
 export {getWebXRInputRay, getWebXRInputRayPlaneIntersection} from './webxr-input';
-export type {WebXRReferenceSpaceResetState} from './webxr-reference-space';
-export {makeWebXRReferenceSpaceState, WebXRReferenceSpaceManager} from './webxr-reference-space';
+export type {
+  WebXRReferenceSpaceResetState,
+  WebXRTeleportOffsetProps,
+  WebXRTeleportState
+} from './webxr-reference-space';
+export {
+  getWebXRTeleportState,
+  getWebXRTeleportTranslation,
+  isWebXRTeleportTargetAllowed,
+  makeWebXRReferenceSpaceState,
+  makeWebXRTeleportOffset,
+  WebXRReferenceSpaceManager
+} from './webxr-reference-space';
 export type {WebXRRenderState, WebXRRenderStateManagerProps} from './webxr-render-state';
 export {
   getWebXRRenderStateInit,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -150,6 +150,7 @@ export type {
 } from './webxr-hit-test';
 export {WebXRHitTestManager} from './webxr-hit-test';
 export type {
+  WebXRInputActivationState,
   WebXRInputGrip,
   WebXRInputRay,
   WebXRInputRayPlaneIntersection,
@@ -158,6 +159,7 @@ export type {
   WebXRInputSourceState
 } from './webxr-input';
 export {
+  getWebXRInputActivationState,
   getWebXRInputGrip,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -73,7 +73,9 @@ export {
 export type {
   WebXRHitTestManagerProps,
   WebXRHitTestResult,
-  WebXRHitTestState
+  WebXRHitTestState,
+  WebXRTransientInputHitTestProps,
+  WebXRTransientInputHitTestResult
 } from './webxr-hit-test';
 export {WebXRHitTestManager} from './webxr-hit-test';
 export type {

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -36,19 +36,24 @@ export {getWebXRHandPinch} from './webxr-hand-gestures';
 export type {WebXRHandJointState, WebXRHandTrackingState} from './webxr-hand-tracking';
 export {WEBXR_HAND_JOINTS, WebXRHandTrackingManager} from './webxr-hand-tracking';
 export type {
+  WebXRGamepadAxisActionProps,
+  WebXRGamepadAxisActionState,
   WebXRGamepadAxisName,
   WebXRGamepadAxisState,
   WebXRGamepadButtonActionState,
   WebXRGamepadButtonName,
   WebXRGamepadButtonState,
+  WebXRGamepadPreviousAxisState,
   WebXRGamepadPreviousButtonState,
   WebXRGamepadState
 } from './webxr-gamepad';
 export {
+  getWebXRGamepadAxisActionState,
   getWebXRGamepadButtonActionState,
   getWebXRGamepadState,
   getWebXRGamepadStates,
-  WebXRGamepadActionManager
+  WebXRGamepadActionManager,
+  WebXRGamepadAxisManager
 } from './webxr-gamepad';
 export type {
   WebXRGamepadHapticActuator,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -150,6 +150,7 @@ export type {
 } from './webxr-hit-test';
 export {WebXRHitTestManager} from './webxr-hit-test';
 export type {
+  WebXRControllerState,
   WebXRInputActionState,
   WebXRInputActivationState,
   WebXRInputActivationProps,
@@ -162,6 +163,7 @@ export type {
   WebXRInputSourceState
 } from './webxr-input';
 export {
+  getWebXRControllerState,
   getWebXRInputActionState,
   getWebXRInputActivationState,
   getWebXRInputGrip,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -152,6 +152,8 @@ export {WebXRHitTestManager} from './webxr-hit-test';
 export type {
   WebXRControllerHandedness,
   WebXRControllerRayPlaneIntersection,
+  WebXRControllerRayPlaneTarget,
+  WebXRControllerRayPlaneTargetProps,
   WebXRControllerState,
   WebXRInputActionState,
   WebXRInputActivationState,
@@ -167,6 +169,8 @@ export type {
 export {
   getWebXRControllerRayPlaneIntersection,
   getWebXRControllerRayPlaneIntersections,
+  getWebXRControllerRayPlaneTarget,
+  getWebXRControllerRayPlaneTargets,
   getWebXRControllerState,
   getWebXRControllerStateByHandedness,
   getWebXRControllerStates,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -84,6 +84,18 @@ export {
   getWebXRReflectionTextureFormat,
   WebXRLightEstimationManager
 } from './webxr-light-estimation';
+export type {
+  WebXRLocomotionAxis,
+  WebXRLocomotionHandedness,
+  WebXRLocomotionProps,
+  WebXRLocomotionState
+} from './webxr-locomotion';
+export {
+  getWebXRLocomotionAxes,
+  getWebXRLocomotionAxisValue,
+  getWebXRLocomotionGamepadState,
+  getWebXRLocomotionState
+} from './webxr-locomotion';
 export type {WebXRMediaLayerState, WebXRMediaLayerType} from './webxr-media-layers';
 export {WebXRMediaLayerManager} from './webxr-media-layers';
 export type {

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -151,6 +151,7 @@ export type {
 export {WebXRHitTestManager} from './webxr-hit-test';
 export type {
   WebXRControllerHandedness,
+  WebXRControllerRayPlaneIntersection,
   WebXRControllerState,
   WebXRInputActionState,
   WebXRInputActivationState,
@@ -164,6 +165,8 @@ export type {
   WebXRInputSourceState
 } from './webxr-input';
 export {
+  getWebXRControllerRayPlaneIntersection,
+  getWebXRControllerRayPlaneIntersections,
   getWebXRControllerState,
   getWebXRControllerStateByHandedness,
   getWebXRControllerStates,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -6,6 +6,8 @@ export type {WebXRRawCameraBinding} from './webxr-types';
 export {WebXRAnimationFrameProvider} from './webxr-animation-frame-provider';
 export type {WebXRCameraTextureProps} from './webxr-camera-texture';
 export {WebXRCameraTexture} from './webxr-camera-texture';
+export type {WebXRInputRay} from './webxr-input';
+export {getWebXRInputRay} from './webxr-input';
 export type {
   WebXRFrameState,
   WebXRInputState,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -38,11 +38,18 @@ export {WEBXR_HAND_JOINTS, WebXRHandTrackingManager} from './webxr-hand-tracking
 export type {
   WebXRGamepadAxisName,
   WebXRGamepadAxisState,
+  WebXRGamepadButtonActionState,
   WebXRGamepadButtonName,
   WebXRGamepadButtonState,
+  WebXRGamepadPreviousButtonState,
   WebXRGamepadState
 } from './webxr-gamepad';
-export {getWebXRGamepadState, getWebXRGamepadStates} from './webxr-gamepad';
+export {
+  getWebXRGamepadButtonActionState,
+  getWebXRGamepadState,
+  getWebXRGamepadStates,
+  WebXRGamepadActionManager
+} from './webxr-gamepad';
 export type {
   WebXRGamepadHapticActuator,
   WebXRHapticPulseProps,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -54,6 +54,16 @@ export {
 export type {WebXRMediaLayerState, WebXRMediaLayerType} from './webxr-media-layers';
 export {WebXRMediaLayerManager} from './webxr-media-layers';
 export type {
+  WebXRPlaneDetectionManagerProps,
+  WebXRPlaneDetectionSessionInitProps,
+  WebXRPlaneDetectionState,
+  WebXRPlaneState
+} from './webxr-plane-detection';
+export {
+  getWebXRPlaneDetectionSessionInit,
+  WebXRPlaneDetectionManager
+} from './webxr-plane-detection';
+export type {
   WebXRHitTestManagerProps,
   WebXRHitTestResult,
   WebXRHitTestState

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -181,6 +181,7 @@ export {
   getWebXRInputGrip,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
+  getWebXRInputStateByInputSource,
   getWebXRInputSourceState,
   WebXRInputActionManager
 } from './webxr-input';

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -9,6 +9,17 @@ export {WebXRAnimationFrameProvider} from './webxr-animation-frame-provider';
 export type {WebXRCameraTextureProps} from './webxr-camera-texture';
 export {WebXRCameraTexture} from './webxr-camera-texture';
 export type {
+  WebXRDepthSensingManagerProps,
+  WebXRDepthSensingSessionInitProps,
+  WebXRDepthState,
+  WebXRDepthViewState
+} from './webxr-depth-sensing';
+export {
+  getWebXRDepthSensingSessionInit,
+  getWebXRDepthTextureFormat,
+  WebXRDepthSensingManager
+} from './webxr-depth-sensing';
+export type {
   WebXRHitTestManagerProps,
   WebXRHitTestResult,
   WebXRHitTestState

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -41,6 +41,16 @@ export type {
   WebXRLayersSessionInitProps
 } from './webxr-layers';
 export {getWebXRLayersSessionInit, WebXRCompositionLayerManager} from './webxr-layers';
+export type {
+  WebXRLightEstimationManagerProps,
+  WebXRLightEstimationSessionInitProps,
+  WebXRLightEstimationState
+} from './webxr-light-estimation';
+export {
+  getWebXRLightEstimationSessionInit,
+  getWebXRReflectionTextureFormat,
+  WebXRLightEstimationManager
+} from './webxr-light-estimation';
 export type {WebXRMediaLayerState, WebXRMediaLayerType} from './webxr-media-layers';
 export {WebXRMediaLayerManager} from './webxr-media-layers';
 export type {

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -33,6 +33,8 @@ export type {
   WebXRLayersSessionInitProps
 } from './webxr-layers';
 export {getWebXRLayersSessionInit, WebXRCompositionLayerManager} from './webxr-layers';
+export type {WebXRMediaLayerState, WebXRMediaLayerType} from './webxr-media-layers';
+export {WebXRMediaLayerManager} from './webxr-media-layers';
 export type {
   WebXRHitTestManagerProps,
   WebXRHitTestResult,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -54,6 +54,13 @@ export {
 export type {WebXRMediaLayerState, WebXRMediaLayerType} from './webxr-media-layers';
 export {WebXRMediaLayerManager} from './webxr-media-layers';
 export type {
+  WebXRMeshDetectionManagerProps,
+  WebXRMeshDetectionSessionInitProps,
+  WebXRMeshDetectionState,
+  WebXRMeshState
+} from './webxr-mesh-detection';
+export {getWebXRMeshDetectionSessionInit, WebXRMeshDetectionManager} from './webxr-mesh-detection';
+export type {
   WebXRPlaneDetectionManagerProps,
   WebXRPlaneDetectionSessionInitProps,
   WebXRPlaneDetectionState,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -99,11 +99,13 @@ export {
 export type {WebXRMediaLayerState, WebXRMediaLayerType} from './webxr-media-layers';
 export {WebXRMediaLayerManager} from './webxr-media-layers';
 export type {
+  WebXRSessionRenderState,
   WebXRSessionState,
   WebXRSessionStateManagerProps,
   WebXRTargetFrameRate
 } from './webxr-session-state';
 export {
+  getWebXRSessionRenderState,
   getWebXRSupportedFrameRates,
   getWebXRTargetFrameRate,
   makeWebXRSessionState,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -19,6 +19,12 @@ export {
   getWebXRDepthTextureFormat,
   WebXRDepthSensingManager
 } from './webxr-depth-sensing';
+export type {
+  WebXRDOMOverlayManagerProps,
+  WebXRDOMOverlaySessionInitProps,
+  WebXRDOMOverlayState
+} from './webxr-dom-overlay';
+export {getWebXRDOMOverlaySessionInit, WebXRDOMOverlayManager} from './webxr-dom-overlay';
 export type {WebXRHandJointState, WebXRHandTrackingState} from './webxr-hand-tracking';
 export {WEBXR_HAND_JOINTS, WebXRHandTrackingManager} from './webxr-hand-tracking';
 export type {

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -143,6 +143,7 @@ export {
 } from './webxr-plane-detection';
 export type {
   WebXRHitTestManagerProps,
+  WebXRHitTestPlacementResultProps,
   WebXRHitTestResult,
   WebXRHitTestResultSelectionProps,
   WebXRHitTestState,
@@ -151,6 +152,7 @@ export type {
   WebXRTransientInputHitTestResultSelectionProps
 } from './webxr-hit-test';
 export {
+  getWebXRHitTestPlacementResult,
   getWebXRHitTestResult,
   getWebXRTransientInputHitTestResult,
   WebXRHitTestManager

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -79,6 +79,19 @@ export {
   WebXRSessionStateManager
 } from './webxr-session-state';
 export type {
+  WebXRSessionFeature,
+  WebXRSessionFeatures,
+  WebXRSessionSupport,
+  WebXRSessionSupportProps
+} from './webxr-session-init';
+export {
+  getWebXRSessionFeatures,
+  getWebXRSessionSupport,
+  isWebXRSessionFeatureEnabled,
+  mergeWebXRSessionInit,
+  WEBXR_DEFAULT_SESSION_SUPPORT_MODES
+} from './webxr-session-init';
+export type {
   WebXRMeshDetectionManagerProps,
   WebXRMeshDetectionSessionInitProps,
   WebXRMeshDetectionState,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -6,5 +6,10 @@ export type {WebXRRawCameraBinding} from './webxr-types';
 export {WebXRAnimationFrameProvider} from './webxr-animation-frame-provider';
 export type {WebXRCameraTextureProps} from './webxr-camera-texture';
 export {WebXRCameraTexture} from './webxr-camera-texture';
-export type {WebXRFrameState, WebXRManagerProps, WebXRViewState} from './webxr-manager';
+export type {
+  WebXRFrameState,
+  WebXRInputState,
+  WebXRManagerProps,
+  WebXRViewState
+} from './webxr-manager';
 export {WebXRManager} from './webxr-manager';

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -36,6 +36,14 @@ export {getWebXRHandPinch} from './webxr-hand-gestures';
 export type {WebXRHandJointState, WebXRHandTrackingState} from './webxr-hand-tracking';
 export {WEBXR_HAND_JOINTS, WebXRHandTrackingManager} from './webxr-hand-tracking';
 export type {
+  WebXRGamepadAxisName,
+  WebXRGamepadAxisState,
+  WebXRGamepadButtonName,
+  WebXRGamepadButtonState,
+  WebXRGamepadState
+} from './webxr-gamepad';
+export {getWebXRGamepadState, getWebXRGamepadStates} from './webxr-gamepad';
+export type {
   WebXRGamepadHapticActuator,
   WebXRHapticPulseProps,
   WebXRHapticPulseResult

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -28,6 +28,12 @@ export {getWebXRDOMOverlaySessionInit, WebXRDOMOverlayManager} from './webxr-dom
 export type {WebXRHandJointState, WebXRHandTrackingState} from './webxr-hand-tracking';
 export {WEBXR_HAND_JOINTS, WebXRHandTrackingManager} from './webxr-hand-tracking';
 export type {
+  WebXRCompositionLayerManagerProps,
+  WebXRCompositionLayerState,
+  WebXRLayersSessionInitProps
+} from './webxr-layers';
+export {getWebXRLayersSessionInit, WebXRCompositionLayerManager} from './webxr-layers';
+export type {
   WebXRHitTestManagerProps,
   WebXRHitTestResult,
   WebXRHitTestState

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -153,12 +153,15 @@ export type {
   WebXRInputGrip,
   WebXRInputRay,
   WebXRInputRayPlaneIntersection,
-  WebXRInputRayPlaneIntersectionProps
+  WebXRInputRayPlaneIntersectionProps,
+  WebXRInputSourceKind,
+  WebXRInputSourceState
 } from './webxr-input';
 export {
   getWebXRInputGrip,
   getWebXRInputRay,
-  getWebXRInputRayPlaneIntersection
+  getWebXRInputRayPlaneIntersection,
+  getWebXRInputSourceState
 } from './webxr-input';
 export type {
   WebXRReferenceSpaceResetState,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -150,8 +150,11 @@ export type {
 } from './webxr-hit-test';
 export {WebXRHitTestManager} from './webxr-hit-test';
 export type {
+  WebXRInputActionState,
   WebXRInputActivationState,
+  WebXRInputActivationProps,
   WebXRInputGrip,
+  WebXRInputPreviousActionState,
   WebXRInputRay,
   WebXRInputRayPlaneIntersection,
   WebXRInputRayPlaneIntersectionProps,
@@ -159,11 +162,13 @@ export type {
   WebXRInputSourceState
 } from './webxr-input';
 export {
+  getWebXRInputActionState,
   getWebXRInputActivationState,
   getWebXRInputGrip,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
-  getWebXRInputSourceState
+  getWebXRInputSourceState,
+  WebXRInputActionManager
 } from './webxr-input';
 export type {
   WebXRReferenceSpaceResetState,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -170,6 +170,7 @@ export {
   getWebXRControllerRayPlaneIntersection,
   getWebXRControllerRayPlaneIntersections,
   getWebXRControllerRayPlaneTarget,
+  getWebXRControllerRayPlaneTargetByHandedness,
   getWebXRControllerRayPlaneTargets,
   getWebXRControllerState,
   getWebXRControllerStateByHandedness,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -111,6 +111,12 @@ export type {
 export {getWebXRInputRay, getWebXRInputRayPlaneIntersection} from './webxr-input';
 export type {WebXRReferenceSpaceResetState} from './webxr-reference-space';
 export {makeWebXRReferenceSpaceState, WebXRReferenceSpaceManager} from './webxr-reference-space';
+export type {WebXRRenderState, WebXRRenderStateManagerProps} from './webxr-render-state';
+export {
+  getWebXRRenderStateInit,
+  makeWebXRRenderState,
+  WebXRRenderStateManager
+} from './webxr-render-state';
 export type {
   WebXRImageTrackingManagerProps,
   WebXRImageTrackingSessionInitProps,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -144,11 +144,17 @@ export {
 export type {
   WebXRHitTestManagerProps,
   WebXRHitTestResult,
+  WebXRHitTestResultSelectionProps,
   WebXRHitTestState,
   WebXRTransientInputHitTestProps,
-  WebXRTransientInputHitTestResult
+  WebXRTransientInputHitTestResult,
+  WebXRTransientInputHitTestResultSelectionProps
 } from './webxr-hit-test';
-export {WebXRHitTestManager} from './webxr-hit-test';
+export {
+  getWebXRHitTestResult,
+  getWebXRTransientInputHitTestResult,
+  WebXRHitTestManager
+} from './webxr-hit-test';
 export type {
   WebXRControllerHandedness,
   WebXRControllerRayPlaneIntersection,

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -30,6 +30,12 @@ export {getWebXRHandPinch} from './webxr-hand-gestures';
 export type {WebXRHandJointState, WebXRHandTrackingState} from './webxr-hand-tracking';
 export {WEBXR_HAND_JOINTS, WebXRHandTrackingManager} from './webxr-hand-tracking';
 export type {
+  WebXRGamepadHapticActuator,
+  WebXRHapticPulseProps,
+  WebXRHapticPulseResult
+} from './webxr-haptics';
+export {getWebXRInputHapticActuator, pulseWebXRInputHaptics} from './webxr-haptics';
+export type {
   WebXRCompositionLayerManagerProps,
   WebXRCompositionLayerState,
   WebXRLayersSessionInitProps

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -6,6 +6,12 @@ export type {WebXRRawCameraBinding} from './webxr-types';
 export type {WebXRAnchorPose, WebXRAnchorState} from './webxr-anchor';
 export {WebXRAnchorManager} from './webxr-anchor';
 export {WebXRAnimationFrameProvider} from './webxr-animation-frame-provider';
+export type {WebXRBoundsPoint, WebXRBoundsState} from './webxr-bounds';
+export {
+  getWebXRBoundsState,
+  isPointInWebXRBounds,
+  isWebXRBoundedReferenceSpace
+} from './webxr-bounds';
 export type {WebXRCameraTextureProps} from './webxr-camera-texture';
 export {WebXRCameraTexture} from './webxr-camera-texture';
 export type {

--- a/modules/experimental/src/webxr/webxr-anchor.ts
+++ b/modules/experimental/src/webxr/webxr-anchor.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
+import type {WebXRHitTestResult} from './webxr-hit-test';
+
 export type WebXRAnchorState = {
   xrFrame: XRFrame;
   anchors: readonly WebXRAnchorPose[];
@@ -51,6 +53,12 @@ export class WebXRAnchorManager {
     const anchor = await xrFrame.createAnchor(pose, space || this.referenceSpace);
     this.anchors.add(anchor);
     return anchor;
+  }
+
+  async createAnchorFromHitTest(
+    hitTestResult: WebXRHitTestResult | null
+  ): Promise<XRAnchor | null> {
+    return hitTestResult ? this.createAnchorFromHitTestResult(hitTestResult.xrHitTestResult) : null;
   }
 
   async createAnchorFromHitTestResult(xrHitTestResult: XRHitTestResult): Promise<XRAnchor> {

--- a/modules/experimental/src/webxr/webxr-anchor.ts
+++ b/modules/experimental/src/webxr/webxr-anchor.ts
@@ -1,0 +1,133 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export type WebXRAnchorState = {
+  xrFrame: XRFrame;
+  anchors: readonly WebXRAnchorPose[];
+};
+
+export type WebXRAnchorPose = {
+  anchor: XRAnchor;
+  pose: XRPose;
+  matrix: Float32Array;
+};
+
+/** Experimental v10 WebXR anchor lifecycle and per-frame pose helper. */
+export class WebXRAnchorManager {
+  session: XRSession | null = null;
+  referenceSpace: XRReferenceSpace | null = null;
+  readonly anchors = new Set<XRAnchor>();
+
+  private _sessionEndListener = () => this.clearSession();
+
+  setSession(session: XRSession | null, referenceSpace: XRReferenceSpace | null): this {
+    this.clearSession();
+
+    if (!session) {
+      return this;
+    }
+    if (!referenceSpace) {
+      throw new Error('WebXRAnchorManager requires an app reference space');
+    }
+
+    this.session = session;
+    this.referenceSpace = referenceSpace;
+    session.addEventListener('end', this._sessionEndListener);
+    return this;
+  }
+
+  async createAnchor(xrFrame: XRFrame, pose: XRRigidTransform, space?: XRSpace): Promise<XRAnchor> {
+    if (!this.session || !this.referenceSpace) {
+      throw new Error('WebXRAnchorManager requires an active XRSession');
+    }
+    if (xrFrame.session !== this.session) {
+      throw new Error('XRFrame belongs to a different XRSession');
+    }
+    if (!xrFrame.createAnchor) {
+      throw new Error('WebXR anchors are not supported in this browser');
+    }
+
+    const anchor = await xrFrame.createAnchor(pose, space || this.referenceSpace);
+    this.anchors.add(anchor);
+    return anchor;
+  }
+
+  async createAnchorFromHitTestResult(xrHitTestResult: XRHitTestResult): Promise<XRAnchor> {
+    if (!this.session) {
+      throw new Error('WebXRAnchorManager requires an active XRSession');
+    }
+    if (!xrHitTestResult.createAnchor) {
+      throw new Error('WebXR hit-test anchors are not supported in this browser');
+    }
+
+    const anchor = await xrHitTestResult.createAnchor();
+    this.anchors.add(anchor);
+    return anchor;
+  }
+
+  getAnchorState(xrFrame: XRFrame): WebXRAnchorState | null {
+    if (!this.session || !this.referenceSpace) {
+      return null;
+    }
+    if (xrFrame.session !== this.session) {
+      throw new Error('XRFrame belongs to a different XRSession');
+    }
+
+    const trackedAnchors = xrFrame.trackedAnchors;
+    if (trackedAnchors) {
+      this._syncTrackedAnchors(trackedAnchors);
+    }
+
+    const anchors = Array.from(this.anchors)
+      .map(anchor => makeWebXRAnchorPose(anchor, xrFrame, this.referenceSpace!))
+      .filter((anchorPose): anchorPose is WebXRAnchorPose => Boolean(anchorPose));
+
+    return {xrFrame, anchors};
+  }
+
+  deleteAnchor(anchor: XRAnchor): void {
+    if (this.anchors.delete(anchor)) {
+      anchor.delete();
+    }
+  }
+
+  clearSession(): void {
+    this.session?.removeEventListener('end', this._sessionEndListener);
+    for (const anchor of this.anchors) {
+      anchor.delete();
+    }
+    this.anchors.clear();
+    this.session = null;
+    this.referenceSpace = null;
+  }
+
+  destroy(): void {
+    this.clearSession();
+  }
+
+  private _syncTrackedAnchors(trackedAnchors: ReadonlySet<XRAnchor>): void {
+    for (const anchor of this.anchors) {
+      if (!trackedAnchors.has(anchor)) {
+        this.anchors.delete(anchor);
+      }
+    }
+  }
+}
+
+function makeWebXRAnchorPose(
+  anchor: XRAnchor,
+  xrFrame: XRFrame,
+  referenceSpace: XRReferenceSpace
+): WebXRAnchorPose | null {
+  const pose = xrFrame.getPose(anchor.anchorSpace, referenceSpace);
+  if (!pose) {
+    return null;
+  }
+
+  return {
+    anchor,
+    pose,
+    matrix: pose.transform.matrix
+  };
+}

--- a/modules/experimental/src/webxr/webxr-bounds.ts
+++ b/modules/experimental/src/webxr/webxr-bounds.ts
@@ -1,0 +1,118 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export type WebXRBoundsPoint = [x: number, y: number, z: number];
+
+export type WebXRBoundsState = {
+  referenceSpace: XRBoundedReferenceSpace;
+  boundsGeometry: readonly DOMPointReadOnly[];
+  bounds: readonly WebXRBoundsPoint[];
+  center: WebXRBoundsPoint;
+  size: WebXRBoundsPoint;
+  radius: number;
+};
+
+/** Experimental v10 helper for room-scale bounded-floor reference spaces. */
+export function getWebXRBoundsState(
+  referenceSpace: XRReferenceSpace | null
+): WebXRBoundsState | null {
+  if (!isWebXRBoundedReferenceSpace(referenceSpace)) {
+    return null;
+  }
+
+  const boundsGeometry = Array.from(referenceSpace.boundsGeometry);
+  const bounds = boundsGeometry.map(getWebXRBoundsPoint);
+  const {center, size, radius} = getWebXRBoundsMetrics(bounds);
+
+  return {
+    referenceSpace,
+    boundsGeometry,
+    bounds,
+    center,
+    size,
+    radius
+  };
+}
+
+export function isWebXRBoundedReferenceSpace(
+  referenceSpace: XRReferenceSpace | null
+): referenceSpace is XRBoundedReferenceSpace {
+  return Boolean(referenceSpace && 'boundsGeometry' in referenceSpace);
+}
+
+export function isPointInWebXRBounds(
+  point: readonly [number, number, number],
+  bounds: readonly WebXRBoundsPoint[]
+): boolean {
+  if (bounds.length < 3) {
+    return false;
+  }
+
+  let inside = false;
+  for (
+    let index = 0, previousIndex = bounds.length - 1;
+    index < bounds.length;
+    previousIndex = index++
+  ) {
+    const current = bounds[index]!;
+    const previous = bounds[previousIndex]!;
+    const crossesZ =
+      current[2] > point[2] !== previous[2] > point[2] &&
+      point[0] <
+        ((previous[0] - current[0]) * (point[2] - current[2])) / (previous[2] - current[2]) +
+          current[0];
+
+    if (crossesZ) {
+      inside = !inside;
+    }
+  }
+
+  return inside;
+}
+
+function getWebXRBoundsPoint(point: DOMPointReadOnly): WebXRBoundsPoint {
+  return [point.x, point.y, point.z];
+}
+
+function getWebXRBoundsMetrics(bounds: readonly WebXRBoundsPoint[]): {
+  center: WebXRBoundsPoint;
+  size: WebXRBoundsPoint;
+  radius: number;
+} {
+  if (bounds.length === 0) {
+    return {
+      center: [0, 0, 0],
+      size: [0, 0, 0],
+      radius: 0
+    };
+  }
+
+  const minimum: WebXRBoundsPoint = [Infinity, Infinity, Infinity];
+  const maximum: WebXRBoundsPoint = [-Infinity, -Infinity, -Infinity];
+  for (const point of bounds) {
+    minimum[0] = Math.min(minimum[0], point[0]);
+    minimum[1] = Math.min(minimum[1], point[1]);
+    minimum[2] = Math.min(minimum[2], point[2]);
+    maximum[0] = Math.max(maximum[0], point[0]);
+    maximum[1] = Math.max(maximum[1], point[1]);
+    maximum[2] = Math.max(maximum[2], point[2]);
+  }
+
+  const center: WebXRBoundsPoint = [
+    (minimum[0] + maximum[0]) * 0.5,
+    (minimum[1] + maximum[1]) * 0.5,
+    (minimum[2] + maximum[2]) * 0.5
+  ];
+  const size: WebXRBoundsPoint = [
+    maximum[0] - minimum[0],
+    maximum[1] - minimum[1],
+    maximum[2] - minimum[2]
+  ];
+  let radius = 0;
+  for (const point of bounds) {
+    radius = Math.max(radius, Math.hypot(point[0] - center[0], point[2] - center[2]));
+  }
+
+  return {center, size, radius};
+}

--- a/modules/experimental/src/webxr/webxr-depth-sensing.ts
+++ b/modules/experimental/src/webxr/webxr-depth-sensing.ts
@@ -1,0 +1,247 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Device, Texture, TextureFormat, TextureProps} from '@luma.gl/core';
+import {Texture as TextureResource} from '@luma.gl/core';
+import type {WebXRDepthBinding} from './webxr-types';
+
+export type WebXRDepthSensingManagerProps = {
+  textureFormat?: TextureFormat;
+  textureUsage?: number;
+};
+
+export type WebXRDepthSensingSessionInitProps = {
+  required?: boolean;
+  usagePreference?: XRDepthUsage[];
+  dataFormatPreference?: XRDepthDataFormat[];
+  depthTypeRequest?: XRDepthType[];
+  matchDepthView?: boolean;
+};
+
+export type WebXRDepthState = {
+  xrFrame: XRFrame;
+  session: XRSession;
+  views: readonly WebXRDepthViewState[];
+};
+
+export type WebXRDepthViewState = {
+  xrView: XRView;
+  depthInformation: XRDepthInformation;
+  cpuDepthInformation: XRCPUDepthInformation | null;
+  webGLDepthInformation: XRWebGLDepthInformation | null;
+  texture: Texture | null;
+  width: number;
+  height: number;
+  rawValueToMeters: number;
+  normDepthBufferFromNormView: XRRigidTransform;
+  matrix: Float32Array;
+  textureType: XRTextureType | null;
+  imageIndex: number | null;
+};
+
+type ResolvedWebXRDepthSensingManagerProps = Required<WebXRDepthSensingManagerProps>;
+
+/** Experimental v10 WebXR depth-sensing CPU and WebGL texture helper. */
+export class WebXRDepthSensingManager {
+  props: ResolvedWebXRDepthSensingManagerProps;
+
+  session: XRSession | null = null;
+  device: Device | null = null;
+  xrWebGLBinding: WebXRDepthBinding | null = null;
+
+  private _textures = new Map<WebGLTexture, Texture>();
+  private _sessionEndListener = () => this.clearSession();
+
+  constructor(props: WebXRDepthSensingManagerProps = {}) {
+    this.props = {...WebXRDepthSensingManager.defaultProps, ...props};
+  }
+
+  setSession(session: XRSession | null): this {
+    this.clearSession();
+    if (!session) {
+      return this;
+    }
+
+    this.session = session;
+    session.addEventListener('end', this._sessionEndListener);
+    return this;
+  }
+
+  setWebGLBinding(device: Device | null, xrWebGLBinding: WebXRDepthBinding | null): this {
+    this._destroyTextures();
+    this.device = device;
+    this.xrWebGLBinding = xrWebGLBinding;
+    return this;
+  }
+
+  getDepthState(xrFrame: XRFrame, xrViews: readonly XRView[]): WebXRDepthState | null {
+    if (!this.session || xrViews.length === 0 || isDepthSensingPaused(this.session)) {
+      return null;
+    }
+    if (xrFrame.session !== this.session) {
+      throw new Error('XRFrame belongs to a different XRSession');
+    }
+    if (!xrFrame.getDepthInformation && !this.xrWebGLBinding?.getDepthInformation) {
+      return null;
+    }
+
+    const views = xrViews
+      .map(xrView => this._getDepthViewState(xrFrame, xrView))
+      .filter((viewState): viewState is WebXRDepthViewState => Boolean(viewState));
+
+    return views.length > 0 ? {xrFrame, session: this.session, views} : null;
+  }
+
+  clearSession(): void {
+    this.session?.removeEventListener('end', this._sessionEndListener);
+    this.session = null;
+    this._destroyTextures();
+  }
+
+  destroy(): void {
+    this.clearSession();
+    this.device = null;
+    this.xrWebGLBinding = null;
+  }
+
+  private _getDepthViewState(xrFrame: XRFrame, xrView: XRView): WebXRDepthViewState | null {
+    const cpuDepthInformation = getCPUDepthInformation(xrFrame, xrView);
+    const webGLDepthInformation = getWebGLDepthInformation(this.xrWebGLBinding, xrView);
+    const depthInformation = cpuDepthInformation || webGLDepthInformation;
+    if (!depthInformation) {
+      return null;
+    }
+
+    return {
+      xrView,
+      depthInformation,
+      cpuDepthInformation,
+      webGLDepthInformation,
+      texture: this._getDepthTexture(webGLDepthInformation),
+      width: depthInformation.width,
+      height: depthInformation.height,
+      rawValueToMeters: depthInformation.rawValueToMeters,
+      normDepthBufferFromNormView: depthInformation.normDepthBufferFromNormView,
+      matrix: depthInformation.normDepthBufferFromNormView.matrix,
+      textureType: webGLDepthInformation?.textureType ?? null,
+      imageIndex: webGLDepthInformation?.imageIndex ?? null
+    };
+  }
+
+  private _getDepthTexture(depthInformation: XRWebGLDepthInformation | null): Texture | null {
+    if (!depthInformation || !this.device || this.device.type !== 'webgl') {
+      return null;
+    }
+
+    const textureHandle = depthInformation.texture;
+    let texture = this._textures.get(textureHandle);
+    if (!texture) {
+      texture = this.device.createTexture({
+        id: `webxr-depth-texture-${this._textures.size + 1}`,
+        handle: textureHandle,
+        _isHandleBorrowed: true,
+        dimension: getDepthTextureDimension(depthInformation),
+        width: depthInformation.width,
+        height: depthInformation.height,
+        depth: getDepthTextureLayerCount(depthInformation),
+        format:
+          this.props.textureFormat || getWebXRDepthTextureFormat(this.session?.depthDataFormat),
+        usage: this.props.textureUsage
+      } as TextureProps);
+      this._textures.set(textureHandle, texture);
+    }
+
+    return texture;
+  }
+
+  private _destroyTextures(): void {
+    for (const texture of this._textures.values()) {
+      texture.destroy();
+    }
+    this._textures.clear();
+  }
+
+  static defaultProps: ResolvedWebXRDepthSensingManagerProps = {
+    textureFormat: undefined!,
+    textureUsage: TextureResource.SAMPLE
+  };
+}
+
+export function getWebXRDepthSensingSessionInit(
+  props: WebXRDepthSensingSessionInitProps = {}
+): XRSessionInit {
+  return {
+    [props.required ? 'requiredFeatures' : 'optionalFeatures']: ['depth-sensing'],
+    depthSensing: {
+      usagePreference: props.usagePreference || ['cpu-optimized', 'gpu-optimized'],
+      dataFormatPreference: props.dataFormatPreference || [
+        'luminance-alpha',
+        'float32',
+        'unsigned-short'
+      ],
+      depthTypeRequest: props.depthTypeRequest,
+      matchDepthView: props.matchDepthView
+    }
+  };
+}
+
+export function getWebXRDepthTextureFormat(
+  depthDataFormat: XRDepthDataFormat | null | undefined
+): TextureFormat {
+  switch (depthDataFormat) {
+    case 'float32':
+      return 'r32float';
+    case 'unsigned-short':
+      return 'r16uint';
+    case 'luminance-alpha':
+    default:
+      return 'rg8unorm';
+  }
+}
+
+function getCPUDepthInformation(xrFrame: XRFrame, xrView: XRView): XRCPUDepthInformation | null {
+  if (!xrFrame.getDepthInformation) {
+    return null;
+  }
+
+  try {
+    return xrFrame.getDepthInformation(xrView) || null;
+  } catch {
+    return null;
+  }
+}
+
+function getWebGLDepthInformation(
+  xrWebGLBinding: WebXRDepthBinding | null,
+  xrView: XRView
+): XRWebGLDepthInformation | null {
+  if (!xrWebGLBinding?.getDepthInformation) {
+    return null;
+  }
+
+  try {
+    return xrWebGLBinding.getDepthInformation(xrView) || null;
+  } catch {
+    return null;
+  }
+}
+
+function isDepthSensingPaused(session: XRSession): boolean {
+  return session.depthActive === false;
+}
+
+function getDepthTextureDimension(depthInformation: XRWebGLDepthInformation): '2d' | '2d-array' {
+  return depthInformation.textureType === WEBGL_TEXTURE_2D_ARRAY ||
+    depthInformation.imageIndex !== undefined
+    ? '2d-array'
+    : '2d';
+}
+
+function getDepthTextureLayerCount(depthInformation: XRWebGLDepthInformation): number {
+  return getDepthTextureDimension(depthInformation) === '2d-array'
+    ? Math.max(1, (depthInformation.imageIndex ?? 0) + 1)
+    : 1;
+}
+
+const WEBGL_TEXTURE_2D_ARRAY = 0x8c1a;

--- a/modules/experimental/src/webxr/webxr-dom-overlay.ts
+++ b/modules/experimental/src/webxr/webxr-dom-overlay.ts
@@ -1,0 +1,89 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export type WebXRDOMOverlayManagerProps = {
+  root?: Element | null;
+  suppressXRSelectEvents?: boolean;
+};
+
+export type WebXRDOMOverlaySessionInitProps = {
+  required?: boolean;
+};
+
+export type WebXRDOMOverlayState = {
+  session: XRSession;
+  root: Element | null;
+  type: XRDOMOverlayType;
+};
+
+/** Experimental v10 WebXR DOM overlay session-state helper. */
+export class WebXRDOMOverlayManager {
+  props: Required<WebXRDOMOverlayManagerProps>;
+
+  session: XRSession | null = null;
+  root: Element | null = null;
+
+  private _sessionEndListener = () => this.clearSession();
+  private _beforeXRSelectListener = (event: Event) => event.preventDefault();
+
+  constructor(props: WebXRDOMOverlayManagerProps = {}) {
+    this.props = {...WebXRDOMOverlayManager.defaultProps, ...props};
+  }
+
+  setSession(session: XRSession | null, props: WebXRDOMOverlayManagerProps = {}): this {
+    this.clearSession();
+    this.props = {...this.props, ...props};
+
+    if (!session) {
+      return this;
+    }
+
+    this.session = session;
+    this.root = this.props.root || null;
+    session.addEventListener('end', this._sessionEndListener);
+    if (this.root && this.props.suppressXRSelectEvents) {
+      this.root.addEventListener('beforexrselect', this._beforeXRSelectListener);
+    }
+    return this;
+  }
+
+  getOverlayState(): WebXRDOMOverlayState | null {
+    const domOverlayState = this.session?.domOverlayState;
+    if (!this.session || !domOverlayState) {
+      return null;
+    }
+
+    return {
+      session: this.session,
+      root: this.root,
+      type: domOverlayState.type
+    };
+  }
+
+  clearSession(): void {
+    this.session?.removeEventListener('end', this._sessionEndListener);
+    this.root?.removeEventListener('beforexrselect', this._beforeXRSelectListener);
+    this.session = null;
+    this.root = null;
+  }
+
+  destroy(): void {
+    this.clearSession();
+  }
+
+  static defaultProps: Required<WebXRDOMOverlayManagerProps> = {
+    root: null,
+    suppressXRSelectEvents: true
+  };
+}
+
+export function getWebXRDOMOverlaySessionInit(
+  root: Element,
+  props: WebXRDOMOverlaySessionInitProps = {}
+): XRSessionInit {
+  return {
+    [props.required ? 'requiredFeatures' : 'optionalFeatures']: ['dom-overlay'],
+    domOverlay: {root}
+  };
+}

--- a/modules/experimental/src/webxr/webxr-gamepad.ts
+++ b/modules/experimental/src/webxr/webxr-gamepad.ts
@@ -1,0 +1,144 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {WebXRInputState} from './webxr-manager';
+
+export type WebXRGamepadButtonName =
+  | 'trigger'
+  | 'squeeze'
+  | 'touchpad'
+  | 'thumbstick'
+  | `button-${number}`;
+
+export type WebXRGamepadAxisName =
+  | 'touchpad-x'
+  | 'touchpad-y'
+  | 'thumbstick-x'
+  | 'thumbstick-y'
+  | `axis-${number}`;
+
+export type WebXRGamepadButtonState = {
+  index: number;
+  name: WebXRGamepadButtonName;
+  value: number;
+  pressed: boolean;
+  touched: boolean;
+};
+
+export type WebXRGamepadAxisState = {
+  index: number;
+  name: WebXRGamepadAxisName;
+  value: number;
+};
+
+export type WebXRGamepadState = {
+  inputState: WebXRInputState;
+  inputSource: XRInputSource;
+  gamepad: Gamepad;
+  mapping: string;
+  isXRStandardMapping: boolean;
+  buttons: readonly WebXRGamepadButtonState[];
+  axes: readonly WebXRGamepadAxisState[];
+  primaryTrigger: WebXRGamepadButtonState | null;
+  primarySqueeze: WebXRGamepadButtonState | null;
+  primaryTouchpad: WebXRGamepadButtonState | null;
+  primaryThumbstick: WebXRGamepadButtonState | null;
+  touchpad: readonly [x: number, y: number] | null;
+  thumbstick: readonly [x: number, y: number] | null;
+  pressed: readonly WebXRGamepadButtonState[];
+  touched: readonly WebXRGamepadButtonState[];
+};
+
+const XR_STANDARD_BUTTON_NAMES: readonly WebXRGamepadButtonName[] = [
+  'trigger',
+  'squeeze',
+  'touchpad',
+  'thumbstick'
+];
+
+const XR_STANDARD_AXIS_NAMES: readonly WebXRGamepadAxisName[] = [
+  'touchpad-x',
+  'touchpad-y',
+  'thumbstick-x',
+  'thumbstick-y'
+];
+
+/** Snapshots the live XR gamepad attached to one WebXR input state. */
+export function getWebXRGamepadState(inputState: WebXRInputState): WebXRGamepadState | null {
+  const gamepad = inputState.gamepad;
+  if (!gamepad) {
+    return null;
+  }
+
+  const isXRStandardMapping = gamepad.mapping === 'xr-standard';
+  const buttons = Array.from(gamepad.buttons, (button, index) =>
+    getWebXRGamepadButtonState(button, index, isXRStandardMapping)
+  );
+  const axes = Array.from(gamepad.axes, (value, index) =>
+    getWebXRGamepadAxisState(value, index, isXRStandardMapping)
+  );
+
+  return {
+    inputState,
+    inputSource: inputState.inputSource,
+    gamepad,
+    mapping: gamepad.mapping,
+    isXRStandardMapping,
+    buttons,
+    axes,
+    primaryTrigger: isXRStandardMapping ? buttons[0] || null : null,
+    primarySqueeze: isXRStandardMapping ? buttons[1] || null : null,
+    primaryTouchpad: isXRStandardMapping ? buttons[2] || null : null,
+    primaryThumbstick: isXRStandardMapping ? buttons[3] || null : null,
+    touchpad: isXRStandardMapping ? getWebXRGamepadAxes(axes, 0) : null,
+    thumbstick: isXRStandardMapping ? getWebXRGamepadAxes(axes, 2) : null,
+    pressed: buttons.filter(button => button.pressed),
+    touched: buttons.filter(button => button.touched)
+  };
+}
+
+export function getWebXRGamepadStates(
+  inputStates: readonly WebXRInputState[] | null
+): readonly WebXRGamepadState[] {
+  return (inputStates || [])
+    .map(inputState => getWebXRGamepadState(inputState))
+    .filter((gamepadState): gamepadState is WebXRGamepadState => Boolean(gamepadState));
+}
+
+function getWebXRGamepadButtonState(
+  button: GamepadButton,
+  index: number,
+  isXRStandardMapping: boolean
+): WebXRGamepadButtonState {
+  return {
+    index,
+    name: isXRStandardMapping
+      ? XR_STANDARD_BUTTON_NAMES[index] || `button-${index}`
+      : `button-${index}`,
+    value: button.value,
+    pressed: button.pressed,
+    touched: button.touched
+  };
+}
+
+function getWebXRGamepadAxisState(
+  value: number,
+  index: number,
+  isXRStandardMapping: boolean
+): WebXRGamepadAxisState {
+  return {
+    index,
+    name: isXRStandardMapping ? XR_STANDARD_AXIS_NAMES[index] || `axis-${index}` : `axis-${index}`,
+    value
+  };
+}
+
+function getWebXRGamepadAxes(
+  axes: readonly WebXRGamepadAxisState[],
+  startIndex: number
+): readonly [x: number, y: number] | null {
+  const xAxis = axes[startIndex];
+  const yAxis = axes[startIndex + 1];
+  return xAxis && yAxis ? [xAxis.value, yAxis.value] : null;
+}

--- a/modules/experimental/src/webxr/webxr-gamepad.ts
+++ b/modules/experimental/src/webxr/webxr-gamepad.ts
@@ -70,10 +70,36 @@ export type WebXRGamepadButtonActionState = {
   touchEnded: boolean;
 };
 
+export type WebXRGamepadAxisActionProps = {
+  deadzone?: number;
+};
+
+export type WebXRGamepadAxisActionState = {
+  inputState: WebXRInputState;
+  inputSource: XRInputSource;
+  gamepadState: WebXRGamepadState;
+  axis: WebXRGamepadAxisState;
+  index: number;
+  name: WebXRGamepadAxisName;
+  value: number;
+  previousValue: number;
+  valueDelta: number;
+  deadzone: number;
+  active: boolean;
+  wasActive: boolean;
+  activeStarted: boolean;
+  activeEnded: boolean;
+};
+
 export type WebXRGamepadPreviousButtonState = {
   value: number;
   pressed: boolean;
   touched: boolean;
+};
+
+export type WebXRGamepadPreviousAxisState = {
+  value: number;
+  active: boolean;
 };
 
 const XR_STANDARD_BUTTON_NAMES: readonly WebXRGamepadButtonName[] = [
@@ -89,6 +115,8 @@ const XR_STANDARD_AXIS_NAMES: readonly WebXRGamepadAxisName[] = [
   'thumbstick-x',
   'thumbstick-y'
 ];
+
+const DEFAULT_AXIS_DEADZONE = 0.15;
 
 /** Tracks per-frame WebXR gamepad button action transitions. */
 export class WebXRGamepadActionManager {
@@ -135,6 +163,61 @@ export class WebXRGamepadActionManager {
       this._previousButtonsByInputSource.delete(inputSource);
     } else {
       this._previousButtonsByInputSource.clear();
+    }
+  }
+}
+
+/** Tracks per-frame WebXR gamepad axis value and dead-zone transitions. */
+export class WebXRGamepadAxisManager {
+  private _previousAxesByInputSource = new Map<
+    XRInputSource,
+    Map<number, WebXRGamepadPreviousAxisState>
+  >();
+
+  update(
+    inputStates: readonly WebXRInputState[] | null,
+    props: WebXRGamepadAxisActionProps = {}
+  ): readonly WebXRGamepadAxisActionState[] {
+    const gamepadStates = getWebXRGamepadStates(inputStates);
+    const activeInputSources = new Set<XRInputSource>();
+    const actionStates: WebXRGamepadAxisActionState[] = [];
+
+    for (const gamepadState of gamepadStates) {
+      activeInputSources.add(gamepadState.inputSource);
+      const previousAxes =
+        this._previousAxesByInputSource.get(gamepadState.inputSource) || new Map();
+      const nextAxes = new Map<number, WebXRGamepadPreviousAxisState>();
+
+      for (const axis of gamepadState.axes) {
+        const previousAxis = previousAxes.get(axis.index);
+        const actionState = getWebXRGamepadAxisActionState(gamepadState, axis, {
+          ...props,
+          previousAxis
+        });
+        actionStates.push(actionState);
+        nextAxes.set(axis.index, {
+          value: axis.value,
+          active: actionState.active
+        });
+      }
+
+      this._previousAxesByInputSource.set(gamepadState.inputSource, nextAxes);
+    }
+
+    for (const inputSource of this._previousAxesByInputSource.keys()) {
+      if (!activeInputSources.has(inputSource)) {
+        this._previousAxesByInputSource.delete(inputSource);
+      }
+    }
+
+    return actionStates;
+  }
+
+  reset(inputSource?: XRInputSource): void {
+    if (inputSource) {
+      this._previousAxesByInputSource.delete(inputSource);
+    } else {
+      this._previousAxesByInputSource.clear();
     }
   }
 }
@@ -211,6 +294,36 @@ export function getWebXRGamepadButtonActionState(
   };
 }
 
+export function getWebXRGamepadAxisActionState(
+  gamepadState: WebXRGamepadState,
+  axis: WebXRGamepadAxisState,
+  props: WebXRGamepadAxisActionProps & {
+    previousAxis?: WebXRGamepadPreviousAxisState | null;
+  } = {}
+): WebXRGamepadAxisActionState {
+  const deadzone = getNormalizedAxisDeadzone(props.deadzone);
+  const previousValue = props.previousAxis?.value ?? 0;
+  const wasActive = props.previousAxis?.active ?? false;
+  const active = Math.abs(axis.value) > deadzone;
+
+  return {
+    inputState: gamepadState.inputState,
+    inputSource: gamepadState.inputSource,
+    gamepadState,
+    axis,
+    index: axis.index,
+    name: axis.name,
+    value: axis.value,
+    previousValue,
+    valueDelta: axis.value - previousValue,
+    deadzone,
+    active,
+    wasActive,
+    activeStarted: active && !wasActive,
+    activeEnded: !active && wasActive
+  };
+}
+
 function getWebXRGamepadButtonState(
   button: GamepadButton,
   index: number,
@@ -246,4 +359,8 @@ function getWebXRGamepadAxes(
   const xAxis = axes[startIndex];
   const yAxis = axes[startIndex + 1];
   return xAxis && yAxis ? [xAxis.value, yAxis.value] : null;
+}
+
+function getNormalizedAxisDeadzone(deadzone: number = DEFAULT_AXIS_DEADZONE): number {
+  return Math.max(0, Math.min(1, deadzone));
 }

--- a/modules/experimental/src/webxr/webxr-gamepad.ts
+++ b/modules/experimental/src/webxr/webxr-gamepad.ts
@@ -50,6 +50,32 @@ export type WebXRGamepadState = {
   touched: readonly WebXRGamepadButtonState[];
 };
 
+export type WebXRGamepadButtonActionState = {
+  inputState: WebXRInputState;
+  inputSource: XRInputSource;
+  gamepadState: WebXRGamepadState;
+  button: WebXRGamepadButtonState;
+  index: number;
+  name: WebXRGamepadButtonName;
+  value: number;
+  previousValue: number;
+  valueDelta: number;
+  pressed: boolean;
+  wasPressed: boolean;
+  pressStarted: boolean;
+  pressEnded: boolean;
+  touched: boolean;
+  wasTouched: boolean;
+  touchStarted: boolean;
+  touchEnded: boolean;
+};
+
+export type WebXRGamepadPreviousButtonState = {
+  value: number;
+  pressed: boolean;
+  touched: boolean;
+};
+
 const XR_STANDARD_BUTTON_NAMES: readonly WebXRGamepadButtonName[] = [
   'trigger',
   'squeeze',
@@ -63,6 +89,55 @@ const XR_STANDARD_AXIS_NAMES: readonly WebXRGamepadAxisName[] = [
   'thumbstick-x',
   'thumbstick-y'
 ];
+
+/** Tracks per-frame WebXR gamepad button action transitions. */
+export class WebXRGamepadActionManager {
+  private _previousButtonsByInputSource = new Map<
+    XRInputSource,
+    Map<number, WebXRGamepadPreviousButtonState>
+  >();
+
+  update(inputStates: readonly WebXRInputState[] | null): readonly WebXRGamepadButtonActionState[] {
+    const gamepadStates = getWebXRGamepadStates(inputStates);
+    const activeInputSources = new Set<XRInputSource>();
+    const actionStates: WebXRGamepadButtonActionState[] = [];
+
+    for (const gamepadState of gamepadStates) {
+      activeInputSources.add(gamepadState.inputSource);
+      const previousButtons =
+        this._previousButtonsByInputSource.get(gamepadState.inputSource) || new Map();
+      const nextButtons = new Map<number, WebXRGamepadPreviousButtonState>();
+
+      for (const button of gamepadState.buttons) {
+        const previousButton = previousButtons.get(button.index);
+        actionStates.push(getWebXRGamepadButtonActionState(gamepadState, button, previousButton));
+        nextButtons.set(button.index, {
+          value: button.value,
+          pressed: button.pressed,
+          touched: button.touched
+        });
+      }
+
+      this._previousButtonsByInputSource.set(gamepadState.inputSource, nextButtons);
+    }
+
+    for (const inputSource of this._previousButtonsByInputSource.keys()) {
+      if (!activeInputSources.has(inputSource)) {
+        this._previousButtonsByInputSource.delete(inputSource);
+      }
+    }
+
+    return actionStates;
+  }
+
+  reset(inputSource?: XRInputSource): void {
+    if (inputSource) {
+      this._previousButtonsByInputSource.delete(inputSource);
+    } else {
+      this._previousButtonsByInputSource.clear();
+    }
+  }
+}
 
 /** Snapshots the live XR gamepad attached to one WebXR input state. */
 export function getWebXRGamepadState(inputState: WebXRInputState): WebXRGamepadState | null {
@@ -104,6 +179,36 @@ export function getWebXRGamepadStates(
   return (inputStates || [])
     .map(inputState => getWebXRGamepadState(inputState))
     .filter((gamepadState): gamepadState is WebXRGamepadState => Boolean(gamepadState));
+}
+
+export function getWebXRGamepadButtonActionState(
+  gamepadState: WebXRGamepadState,
+  button: WebXRGamepadButtonState,
+  previousButton: WebXRGamepadPreviousButtonState | null = null
+): WebXRGamepadButtonActionState {
+  const previousValue = previousButton?.value ?? 0;
+  const wasPressed = previousButton?.pressed ?? false;
+  const wasTouched = previousButton?.touched ?? false;
+
+  return {
+    inputState: gamepadState.inputState,
+    inputSource: gamepadState.inputSource,
+    gamepadState,
+    button,
+    index: button.index,
+    name: button.name,
+    value: button.value,
+    previousValue,
+    valueDelta: button.value - previousValue,
+    pressed: button.pressed,
+    wasPressed,
+    pressStarted: button.pressed && !wasPressed,
+    pressEnded: !button.pressed && wasPressed,
+    touched: button.touched,
+    wasTouched,
+    touchStarted: button.touched && !wasTouched,
+    touchEnded: !button.touched && wasTouched
+  };
 }
 
 function getWebXRGamepadButtonState(

--- a/modules/experimental/src/webxr/webxr-hand-gestures.ts
+++ b/modules/experimental/src/webxr/webxr-hand-gestures.ts
@@ -1,0 +1,82 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {WebXRHandJointState, WebXRHandTrackingState} from './webxr-hand-tracking';
+
+export type WebXRHandPinchProps = {
+  thumbJointName?: XRHandJoint;
+  fingerJointName?: XRHandJoint;
+  activeDistance?: number;
+  strengthDistance?: number;
+};
+
+export type WebXRHandPinchState = {
+  inputSource: XRInputSource;
+  handedness: XRHandedness;
+  thumbJoint: WebXRHandJointState;
+  fingerJoint: WebXRHandJointState;
+  distance: number;
+  pinchActive: boolean;
+  strength: number;
+  position: [number, number, number];
+};
+
+/** Returns a simple thumb-to-index pinch gesture state for one tracked hand. */
+export function getWebXRHandPinch(
+  handState: WebXRHandTrackingState,
+  props: WebXRHandPinchProps = {}
+): WebXRHandPinchState | null {
+  const thumbJoint = getHandJoint(handState, props.thumbJointName || 'thumb-tip');
+  const fingerJoint = getHandJoint(handState, props.fingerJointName || 'index-finger-tip');
+  if (!thumbJoint?.matrix || !fingerJoint?.matrix) {
+    return null;
+  }
+
+  const thumbPosition = getMatrixPosition(thumbJoint.matrix);
+  const fingerPosition = getMatrixPosition(fingerJoint.matrix);
+  const distance = getDistance(thumbPosition, fingerPosition);
+  const activeDistance = props.activeDistance ?? 0.025;
+  const strengthDistance = Math.max(props.strengthDistance ?? 0.07, activeDistance);
+  const strength =
+    strengthDistance === activeDistance
+      ? Number(distance <= activeDistance)
+      : clamp((strengthDistance - distance) / (strengthDistance - activeDistance), 0, 1);
+
+  return {
+    inputSource: handState.inputSource,
+    handedness: handState.handedness,
+    thumbJoint,
+    fingerJoint,
+    distance,
+    pinchActive: distance <= activeDistance,
+    strength,
+    position: [
+      (thumbPosition[0] + fingerPosition[0]) * 0.5,
+      (thumbPosition[1] + fingerPosition[1]) * 0.5,
+      (thumbPosition[2] + fingerPosition[2]) * 0.5
+    ]
+  };
+}
+
+function getHandJoint(
+  handState: WebXRHandTrackingState,
+  jointName: XRHandJoint
+): WebXRHandJointState | null {
+  return handState.joints.find(joint => joint.jointName === jointName) || null;
+}
+
+function getMatrixPosition(matrix: Float32Array): [number, number, number] {
+  return [matrix[12] || 0, matrix[13] || 0, matrix[14] || 0];
+}
+
+function getDistance(a: [number, number, number], b: [number, number, number]): number {
+  const deltaX = a[0] - b[0];
+  const deltaY = a[1] - b[1];
+  const deltaZ = a[2] - b[2];
+  return Math.hypot(deltaX, deltaY, deltaZ);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/modules/experimental/src/webxr/webxr-hand-tracking.ts
+++ b/modules/experimental/src/webxr/webxr-hand-tracking.ts
@@ -1,0 +1,233 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export const WEBXR_HAND_JOINTS: readonly XRHandJoint[] = [
+  'wrist',
+  'thumb-metacarpal',
+  'thumb-phalanx-proximal',
+  'thumb-phalanx-distal',
+  'thumb-tip',
+  'index-finger-metacarpal',
+  'index-finger-phalanx-proximal',
+  'index-finger-phalanx-intermediate',
+  'index-finger-phalanx-distal',
+  'index-finger-tip',
+  'middle-finger-metacarpal',
+  'middle-finger-phalanx-proximal',
+  'middle-finger-phalanx-intermediate',
+  'middle-finger-phalanx-distal',
+  'middle-finger-tip',
+  'ring-finger-metacarpal',
+  'ring-finger-phalanx-proximal',
+  'ring-finger-phalanx-intermediate',
+  'ring-finger-phalanx-distal',
+  'ring-finger-tip',
+  'pinky-finger-metacarpal',
+  'pinky-finger-phalanx-proximal',
+  'pinky-finger-phalanx-intermediate',
+  'pinky-finger-phalanx-distal',
+  'pinky-finger-tip'
+];
+
+export type WebXRHandTrackingState = {
+  xrFrame: XRFrame;
+  inputSource: XRInputSource;
+  handedness: XRHandedness;
+  hand: XRHand;
+  joints: readonly WebXRHandJointState[];
+  matrices: Float32Array;
+  radii: Float32Array;
+  allJointsTracked: boolean;
+};
+
+export type WebXRHandJointState = {
+  jointName: XRHandJoint;
+  jointSpace: XRJointSpace;
+  pose: XRJointPose | null;
+  matrix: Float32Array | null;
+  radius: number | null;
+};
+
+/** Experimental v10 WebXR articulated hand pose helper. */
+export class WebXRHandTrackingManager {
+  session: XRSession | null = null;
+  referenceSpace: XRReferenceSpace | null = null;
+
+  private _sessionEndListener = () => this.clearSession();
+
+  setSession(session: XRSession | null, referenceSpace: XRReferenceSpace | null): this {
+    this.clearSession();
+
+    if (!session) {
+      return this;
+    }
+    if (!referenceSpace) {
+      throw new Error('WebXRHandTrackingManager requires an app reference space');
+    }
+
+    this.session = session;
+    this.referenceSpace = referenceSpace;
+    session.addEventListener('end', this._sessionEndListener);
+    return this;
+  }
+
+  getHandsState(
+    xrFrame: XRFrame,
+    inputSources: readonly XRInputSource[] = Array.from(this.session?.inputSources || [])
+  ): readonly WebXRHandTrackingState[] | null {
+    if (!this.session || !this.referenceSpace) {
+      return null;
+    }
+    if (xrFrame.session !== this.session) {
+      throw new Error('XRFrame belongs to a different XRSession');
+    }
+
+    return inputSources
+      .map(inputSource => this.getHandState(xrFrame, inputSource))
+      .filter((handState): handState is WebXRHandTrackingState => Boolean(handState));
+  }
+
+  getHandState(xrFrame: XRFrame, inputSource: XRInputSource): WebXRHandTrackingState | null {
+    if (!this.session || !this.referenceSpace) {
+      return null;
+    }
+    if (xrFrame.session !== this.session) {
+      throw new Error('XRFrame belongs to a different XRSession');
+    }
+
+    const hand = inputSource.hand;
+    if (!hand) {
+      return null;
+    }
+
+    const jointEntries = WEBXR_HAND_JOINTS.map(jointName => ({
+      jointName,
+      jointSpace: hand.get(jointName)
+    })).filter((entry): entry is {jointName: XRHandJoint; jointSpace: XRJointSpace} =>
+      Boolean(entry.jointSpace)
+    );
+    if (jointEntries.length === 0) {
+      return null;
+    }
+
+    const jointSpaces = jointEntries.map(entry => entry.jointSpace);
+    const matrices = new Float32Array(jointEntries.length * 16);
+    const radii = new Float32Array(jointEntries.length);
+    const batchPoseResult = fillJointMatrices(xrFrame, jointSpaces, this.referenceSpace, matrices);
+    const batchRadiusResult = fillJointRadii(xrFrame, jointSpaces, radii);
+    const joints = jointEntries.map((entry, index) =>
+      makeWebXRHandJointState(
+        xrFrame,
+        this.referenceSpace!,
+        entry.jointName,
+        entry.jointSpace,
+        index,
+        matrices,
+        radii,
+        batchPoseResult,
+        batchRadiusResult
+      )
+    );
+
+    return {
+      xrFrame,
+      inputSource,
+      handedness: inputSource.handedness,
+      hand,
+      joints,
+      matrices,
+      radii,
+      allJointsTracked: joints.every(joint => joint.matrix && joint.radius !== null)
+    };
+  }
+
+  clearSession(): void {
+    this.session?.removeEventListener('end', this._sessionEndListener);
+    this.session = null;
+    this.referenceSpace = null;
+  }
+
+  destroy(): void {
+    this.clearSession();
+  }
+}
+
+function makeWebXRHandJointState(
+  xrFrame: XRFrame,
+  referenceSpace: XRReferenceSpace,
+  jointName: XRHandJoint,
+  jointSpace: XRJointSpace,
+  index: number,
+  matrices: Float32Array,
+  radii: Float32Array,
+  batchPoseResult: boolean | null,
+  batchRadiusResult: boolean | null
+): WebXRHandJointState {
+  const pose =
+    batchPoseResult === null ? xrFrame.getJointPose?.(jointSpace, referenceSpace) || null : null;
+  const matrixOffset = index * 16;
+  const matrix =
+    batchPoseResult === null
+      ? pose?.transform.matrix || null
+      : getMatrixSlice(matrices, matrixOffset, batchPoseResult);
+  const radius =
+    batchRadiusResult === null
+      ? (pose?.radius ?? null)
+      : Number.isFinite(radii[index]!) && !Number.isNaN(radii[index]!)
+        ? radii[index]!
+        : null;
+
+  return {
+    jointName,
+    jointSpace,
+    pose,
+    matrix,
+    radius
+  };
+}
+
+function fillJointMatrices(
+  xrFrame: XRFrame,
+  jointSpaces: readonly XRJointSpace[],
+  referenceSpace: XRReferenceSpace,
+  matrices: Float32Array
+): boolean | null {
+  if (!xrFrame.fillPoses) {
+    return null;
+  }
+
+  try {
+    return xrFrame.fillPoses(jointSpaces, referenceSpace, matrices);
+  } catch {
+    return null;
+  }
+}
+
+function fillJointRadii(
+  xrFrame: XRFrame,
+  jointSpaces: readonly XRJointSpace[],
+  radii: Float32Array
+): boolean | null {
+  if (!xrFrame.fillJointRadii) {
+    return null;
+  }
+
+  try {
+    return xrFrame.fillJointRadii(jointSpaces, radii);
+  } catch {
+    return null;
+  }
+}
+
+function getMatrixSlice(
+  matrices: Float32Array,
+  matrixOffset: number,
+  batchPoseResult: boolean
+): Float32Array | null {
+  if (!batchPoseResult) {
+    return null;
+  }
+
+  return matrices.subarray(matrixOffset, matrixOffset + 16);
+}

--- a/modules/experimental/src/webxr/webxr-haptics.ts
+++ b/modules/experimental/src/webxr/webxr-haptics.ts
@@ -1,0 +1,63 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {WebXRInputState} from './webxr-manager';
+
+export type WebXRHapticPulseProps = {
+  intensity?: number;
+  duration?: number;
+};
+
+export type WebXRHapticPulseResult = {
+  inputState: WebXRInputState;
+  actuator: WebXRGamepadHapticActuator;
+  intensity: number;
+  duration: number;
+  value: unknown;
+};
+
+export type WebXRGamepadHapticActuator = {
+  pulse?(intensity: number, duration: number): Promise<unknown> | unknown;
+};
+
+type WebXRHapticGamepad = Gamepad & {
+  hapticActuators?: readonly WebXRGamepadHapticActuator[];
+  vibrationActuator?: WebXRGamepadHapticActuator;
+};
+
+/** Pulses the first available gamepad haptic actuator for one WebXR input source. */
+export async function pulseWebXRInputHaptics(
+  inputState: WebXRInputState,
+  props: WebXRHapticPulseProps = {}
+): Promise<WebXRHapticPulseResult | null> {
+  const actuator = getWebXRInputHapticActuator(inputState);
+  if (!actuator?.pulse) {
+    return null;
+  }
+
+  const intensity = clamp(props.intensity ?? 0.45, 0, 1);
+  const duration = Math.max(0, props.duration ?? 35);
+  const value = await actuator.pulse(intensity, duration);
+
+  return {inputState, actuator, intensity, duration, value};
+}
+
+export function getWebXRInputHapticActuator(
+  inputState: WebXRInputState
+): WebXRGamepadHapticActuator | null {
+  const gamepad = inputState.gamepad as WebXRHapticGamepad | null;
+  if (!gamepad) {
+    return null;
+  }
+
+  return (
+    gamepad.hapticActuators?.find(actuator => Boolean(actuator.pulse)) ||
+    gamepad.vibrationActuator ||
+    null
+  );
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/modules/experimental/src/webxr/webxr-hit-test.ts
+++ b/modules/experimental/src/webxr/webxr-hit-test.ts
@@ -40,6 +40,10 @@ export type WebXRTransientInputHitTestResultSelectionProps = WebXRHitTestResultS
   inputSource?: XRInputSource | null;
 };
 
+export type WebXRHitTestPlacementResultProps = WebXRTransientInputHitTestResultSelectionProps & {
+  preferTransientInput?: boolean;
+};
+
 /**
  * Experimental v10 WebXR hit-test source and per-frame result helper.
  *
@@ -176,6 +180,23 @@ export function getWebXRTransientInputHitTestResult(
   );
 
   return transientInput?.results[props.index ?? 0] || null;
+}
+
+export function getWebXRHitTestPlacementResult(
+  hitTestState: WebXRHitTestState | null,
+  props: WebXRHitTestPlacementResultProps = {}
+): WebXRHitTestResult | null {
+  if (props.preferTransientInput !== false) {
+    return (
+      getWebXRTransientInputHitTestResult(hitTestState, props) ||
+      getWebXRHitTestResult(hitTestState, props)
+    );
+  }
+
+  return (
+    getWebXRHitTestResult(hitTestState, props) ||
+    getWebXRTransientInputHitTestResult(hitTestState, props)
+  );
 }
 
 async function requestTransientInputHitTestSource(

--- a/modules/experimental/src/webxr/webxr-hit-test.ts
+++ b/modules/experimental/src/webxr/webxr-hit-test.ts
@@ -6,17 +6,30 @@
 export type WebXRHitTestManagerProps = {
   entityTypes?: XRHitTestTrackableType[];
   offsetRay?: XRRay;
+  transientInput?: WebXRTransientInputHitTestProps | false;
+};
+
+export type WebXRTransientInputHitTestProps = {
+  profile: string;
+  entityTypes?: XRHitTestTrackableType[];
+  offsetRay?: XRRay;
 };
 
 export type WebXRHitTestState = {
   xrFrame: XRFrame;
   hits: readonly WebXRHitTestResult[];
+  transientInput: readonly WebXRTransientInputHitTestResult[];
 };
 
 export type WebXRHitTestResult = {
   xrHitTestResult: XRHitTestResult;
   pose: XRPose;
   matrix: Float32Array;
+};
+
+export type WebXRTransientInputHitTestResult = {
+  inputSource: XRInputSource;
+  results: readonly WebXRHitTestResult[];
 };
 
 /**
@@ -31,6 +44,7 @@ export class WebXRHitTestManager {
   referenceSpace: XRReferenceSpace | null = null;
   viewerSpace: XRReferenceSpace | null = null;
   hitTestSource: XRHitTestSource | null = null;
+  transientInputHitTestSource: XRTransientInputHitTestSource | null = null;
 
   private _sessionEndListener = () => this.clearSession();
 
@@ -70,6 +84,10 @@ export class WebXRHitTestManager {
     this.referenceSpace = referenceSpace;
     this.viewerSpace = viewerSpace;
     this.hitTestSource = hitTestSource;
+    this.transientInputHitTestSource = await requestTransientInputHitTestSource(
+      session,
+      this.props.transientInput
+    );
     session.addEventListener('end', this._sessionEndListener);
     return this;
   }
@@ -89,17 +107,20 @@ export class WebXRHitTestManager {
       .getHitTestResults(this.hitTestSource)
       .map(xrHitTestResult => makeWebXRHitTestResult(xrHitTestResult, this.referenceSpace!))
       .filter((hit): hit is WebXRHitTestResult => Boolean(hit));
+    const transientInput = this._getTransientInputHitTestResults(xrFrame);
 
-    return {xrFrame, hits};
+    return {xrFrame, hits, transientInput};
   }
 
   clearSession(): void {
     this.session?.removeEventListener('end', this._sessionEndListener);
     this.hitTestSource?.cancel();
+    this.transientInputHitTestSource?.cancel();
     this.session = null;
     this.referenceSpace = null;
     this.viewerSpace = null;
     this.hitTestSource = null;
+    this.transientInputHitTestSource = null;
   }
 
   destroy(): void {
@@ -108,8 +129,44 @@ export class WebXRHitTestManager {
 
   static defaultProps: Required<WebXRHitTestManagerProps> = {
     entityTypes: undefined!,
-    offsetRay: undefined!
+    offsetRay: undefined!,
+    transientInput: false
   };
+
+  private _getTransientInputHitTestResults(
+    xrFrame: XRFrame
+  ): readonly WebXRTransientInputHitTestResult[] {
+    if (!this.transientInputHitTestSource || !xrFrame.getHitTestResultsForTransientInput) {
+      return [];
+    }
+
+    return xrFrame
+      .getHitTestResultsForTransientInput(this.transientInputHitTestSource)
+      .map(transientResult => ({
+        inputSource: transientResult.inputSource,
+        results: transientResult.results
+          .map(xrHitTestResult => makeWebXRHitTestResult(xrHitTestResult, this.referenceSpace!))
+          .filter((hit): hit is WebXRHitTestResult => Boolean(hit))
+      }))
+      .filter(transientResult => transientResult.results.length > 0);
+  }
+}
+
+async function requestTransientInputHitTestSource(
+  session: XRSession,
+  props: WebXRTransientInputHitTestProps | false
+): Promise<XRTransientInputHitTestSource | null> {
+  if (!props || !session.requestHitTestSourceForTransientInput) {
+    return null;
+  }
+
+  const transientInputHitTestSource = await session.requestHitTestSourceForTransientInput({
+    profile: props.profile,
+    offsetRay: props.offsetRay,
+    entityTypes: props.entityTypes
+  });
+
+  return transientInputHitTestSource || null;
 }
 
 function makeWebXRHitTestResult(

--- a/modules/experimental/src/webxr/webxr-hit-test.ts
+++ b/modules/experimental/src/webxr/webxr-hit-test.ts
@@ -32,6 +32,14 @@ export type WebXRTransientInputHitTestResult = {
   results: readonly WebXRHitTestResult[];
 };
 
+export type WebXRHitTestResultSelectionProps = {
+  index?: number;
+};
+
+export type WebXRTransientInputHitTestResultSelectionProps = WebXRHitTestResultSelectionProps & {
+  inputSource?: XRInputSource | null;
+};
+
 /**
  * Experimental v10 WebXR hit-test source and per-frame result helper.
  *
@@ -150,6 +158,24 @@ export class WebXRHitTestManager {
       }))
       .filter(transientResult => transientResult.results.length > 0);
   }
+}
+
+export function getWebXRHitTestResult(
+  hitTestState: WebXRHitTestState | null,
+  props: WebXRHitTestResultSelectionProps = {}
+): WebXRHitTestResult | null {
+  return hitTestState?.hits[props.index ?? 0] || null;
+}
+
+export function getWebXRTransientInputHitTestResult(
+  hitTestState: WebXRHitTestState | null,
+  props: WebXRTransientInputHitTestResultSelectionProps = {}
+): WebXRHitTestResult | null {
+  const transientInput = (hitTestState?.transientInput || []).find(
+    transientResult => !props.inputSource || transientResult.inputSource === props.inputSource
+  );
+
+  return transientInput?.results[props.index ?? 0] || null;
 }
 
 async function requestTransientInputHitTestSource(

--- a/modules/experimental/src/webxr/webxr-hit-test.ts
+++ b/modules/experimental/src/webxr/webxr-hit-test.ts
@@ -1,0 +1,129 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+/** Experimental v10 WebXR hit-test source options. */
+export type WebXRHitTestManagerProps = {
+  entityTypes?: XRHitTestTrackableType[];
+  offsetRay?: XRRay;
+};
+
+export type WebXRHitTestState = {
+  xrFrame: XRFrame;
+  hits: readonly WebXRHitTestResult[];
+};
+
+export type WebXRHitTestResult = {
+  xrHitTestResult: XRHitTestResult;
+  pose: XRPose;
+  matrix: Float32Array;
+};
+
+/**
+ * Experimental v10 WebXR hit-test source and per-frame result helper.
+ *
+ * WebXR hit tests are primarily useful for immersive AR placement workflows.
+ */
+export class WebXRHitTestManager {
+  props: Required<WebXRHitTestManagerProps>;
+
+  session: XRSession | null = null;
+  referenceSpace: XRReferenceSpace | null = null;
+  viewerSpace: XRReferenceSpace | null = null;
+  hitTestSource: XRHitTestSource | null = null;
+
+  private _sessionEndListener = () => this.clearSession();
+
+  constructor(props: WebXRHitTestManagerProps = {}) {
+    this.props = {...WebXRHitTestManager.defaultProps, ...props};
+  }
+
+  async setSession(
+    session: XRSession | null,
+    referenceSpace: XRReferenceSpace | null,
+    props: WebXRHitTestManagerProps = {}
+  ): Promise<this> {
+    this.clearSession();
+    this.props = {...this.props, ...props};
+
+    if (!session) {
+      return this;
+    }
+    if (!referenceSpace) {
+      throw new Error('WebXRHitTestManager requires an app reference space');
+    }
+    if (!session.requestHitTestSource) {
+      throw new Error('WebXR hit-test source requests are not supported in this browser');
+    }
+
+    const viewerSpace = await session.requestReferenceSpace('viewer');
+    const hitTestSource = await session.requestHitTestSource({
+      space: viewerSpace,
+      offsetRay: this.props.offsetRay,
+      entityTypes: this.props.entityTypes
+    });
+    if (!hitTestSource) {
+      throw new Error('WebXR hit-test source request returned no source');
+    }
+
+    this.session = session;
+    this.referenceSpace = referenceSpace;
+    this.viewerSpace = viewerSpace;
+    this.hitTestSource = hitTestSource;
+    session.addEventListener('end', this._sessionEndListener);
+    return this;
+  }
+
+  getHitTestState(xrFrame: XRFrame): WebXRHitTestState | null {
+    if (!this.session || !this.referenceSpace || !this.hitTestSource) {
+      return null;
+    }
+    if (xrFrame.session !== this.session) {
+      throw new Error('XRFrame belongs to a different XRSession');
+    }
+    if (!xrFrame.getHitTestResults) {
+      return null;
+    }
+
+    const hits = xrFrame
+      .getHitTestResults(this.hitTestSource)
+      .map(xrHitTestResult => makeWebXRHitTestResult(xrHitTestResult, this.referenceSpace!))
+      .filter((hit): hit is WebXRHitTestResult => Boolean(hit));
+
+    return {xrFrame, hits};
+  }
+
+  clearSession(): void {
+    this.session?.removeEventListener('end', this._sessionEndListener);
+    this.hitTestSource?.cancel();
+    this.session = null;
+    this.referenceSpace = null;
+    this.viewerSpace = null;
+    this.hitTestSource = null;
+  }
+
+  destroy(): void {
+    this.clearSession();
+  }
+
+  static defaultProps: Required<WebXRHitTestManagerProps> = {
+    entityTypes: undefined!,
+    offsetRay: undefined!
+  };
+}
+
+function makeWebXRHitTestResult(
+  xrHitTestResult: XRHitTestResult,
+  referenceSpace: XRReferenceSpace
+): WebXRHitTestResult | null {
+  const pose = xrHitTestResult.getPose(referenceSpace);
+  if (!pose) {
+    return null;
+  }
+
+  return {
+    xrHitTestResult,
+    pose,
+    matrix: pose.transform.matrix
+  };
+}

--- a/modules/experimental/src/webxr/webxr-image-tracking.ts
+++ b/modules/experimental/src/webxr/webxr-image-tracking.ts
@@ -1,0 +1,169 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export type WebXRImageTrackingManagerProps = {
+  trackedImages?: readonly XRTrackedImageInit[];
+};
+
+export type WebXRImageTrackingSessionInitProps = WebXRImageTrackingManagerProps & {
+  required?: boolean;
+};
+
+export type WebXRImageTrackingState = {
+  xrFrame: XRFrame;
+  session: XRSession;
+  images: readonly WebXRTrackedImageState[];
+  added: readonly WebXRTrackedImageState[];
+  updated: readonly WebXRTrackedImageState[];
+  removed: readonly WebXRTrackedImageState[];
+};
+
+export type WebXRTrackedImageState = {
+  result: XRImageTrackingResult;
+  pose: XRPose;
+  matrix: Float32Array;
+  index: number;
+  trackingState: XRImageTrackingState;
+  measuredWidthInMeters: number;
+};
+
+/** Experimental v10 WebXR image-tracking result and per-frame diff helper. */
+export class WebXRImageTrackingManager {
+  props: Required<WebXRImageTrackingManagerProps>;
+
+  session: XRSession | null = null;
+  referenceSpace: XRReferenceSpace | null = null;
+
+  private _images = new Map<number, WebXRTrackedImageState>();
+  private _sessionEndListener = () => this.clearSession();
+
+  constructor(props: WebXRImageTrackingManagerProps = {}) {
+    this.props = {...WebXRImageTrackingManager.defaultProps, ...props};
+  }
+
+  setSession(
+    session: XRSession | null,
+    referenceSpace: XRReferenceSpace | null,
+    props: WebXRImageTrackingManagerProps = {}
+  ): this {
+    this.clearSession();
+    this.props = {...this.props, ...props};
+
+    if (!session) {
+      return this;
+    }
+    if (!referenceSpace) {
+      throw new Error('WebXRImageTrackingManager requires an app reference space');
+    }
+
+    this.session = session;
+    this.referenceSpace = referenceSpace;
+    session.addEventListener('end', this._sessionEndListener);
+    return this;
+  }
+
+  async getImageTrackability(): Promise<readonly XRImageTrackability[] | null> {
+    if (!this.session?.getImageTrackability) {
+      return null;
+    }
+
+    return this.session.getImageTrackability();
+  }
+
+  getImageTrackingState(xrFrame: XRFrame): WebXRImageTrackingState | null {
+    if (!this.session || !this.referenceSpace) {
+      return null;
+    }
+    if (xrFrame.session !== this.session) {
+      throw new Error('XRFrame belongs to a different XRSession');
+    }
+    if (!xrFrame.getImageTrackingResults) {
+      return null;
+    }
+
+    const previousImages = this._images;
+    const nextImages = new Map<number, WebXRTrackedImageState>();
+    const images: WebXRTrackedImageState[] = [];
+    const added: WebXRTrackedImageState[] = [];
+    const updated: WebXRTrackedImageState[] = [];
+
+    for (const result of xrFrame.getImageTrackingResults()) {
+      const image = this._getTrackedImageState(xrFrame, result);
+      if (!image) {
+        continue;
+      }
+
+      nextImages.set(image.index, image);
+      images.push(image);
+
+      const previousImage = previousImages.get(image.index);
+      if (!previousImage) {
+        added.push(image);
+      } else if (isTrackedImageUpdated(previousImage, image)) {
+        updated.push(image);
+      }
+    }
+
+    const removed = [...previousImages]
+      .filter(([index]) => !nextImages.has(index))
+      .map(([, image]) => image);
+
+    this._images = nextImages;
+
+    return {xrFrame, session: this.session, images, added, updated, removed};
+  }
+
+  clearSession(): void {
+    this.session?.removeEventListener('end', this._sessionEndListener);
+    this.session = null;
+    this.referenceSpace = null;
+    this._images.clear();
+  }
+
+  destroy(): void {
+    this.clearSession();
+  }
+
+  private _getTrackedImageState(
+    xrFrame: XRFrame,
+    result: XRImageTrackingResult
+  ): WebXRTrackedImageState | null {
+    const pose = xrFrame.getPose(result.imageSpace, this.referenceSpace!);
+    if (!pose) {
+      return null;
+    }
+
+    return {
+      result,
+      pose,
+      matrix: pose.transform.matrix,
+      index: result.index,
+      trackingState: result.trackingState,
+      measuredWidthInMeters: result.measuredWidthInMeters
+    };
+  }
+
+  static defaultProps: Required<WebXRImageTrackingManagerProps> = {
+    trackedImages: undefined!
+  };
+}
+
+export function getWebXRImageTrackingSessionInit(
+  props: WebXRImageTrackingSessionInitProps = {}
+): XRSessionInit {
+  return {
+    [props.required ? 'requiredFeatures' : 'optionalFeatures']: ['image-tracking'],
+    trackedImages: props.trackedImages ? [...props.trackedImages] : undefined
+  };
+}
+
+function isTrackedImageUpdated(
+  previousImage: WebXRTrackedImageState,
+  image: WebXRTrackedImageState
+): boolean {
+  return (
+    previousImage.trackingState !== image.trackingState ||
+    previousImage.measuredWidthInMeters !== image.measuredWidthInMeters
+  );
+}

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -13,6 +13,13 @@ export type WebXRInputRay = {
   matrix: Float32Array;
 };
 
+/** Experimental v10 world-space grip pose derived from one tracked WebXR input source. */
+export type WebXRInputGrip = {
+  inputState: WebXRInputState;
+  position: NumberArray3;
+  matrix: Float32Array;
+};
+
 export type WebXRInputRayPlaneIntersectionProps = {
   planePoint?: NumberArray3;
   planeNormal?: NumberArray3;
@@ -40,6 +47,19 @@ export function getWebXRInputRay(inputState: WebXRInputState): WebXRInputRay | n
     inputState,
     origin: [matrix[12], matrix[13], matrix[14]],
     direction,
+    matrix
+  };
+}
+
+export function getWebXRInputGrip(inputState: WebXRInputState): WebXRInputGrip | null {
+  const matrix = inputState.gripMatrix;
+  if (!matrix) {
+    return null;
+  }
+
+  return {
+    inputState,
+    position: [matrix[12], matrix[13], matrix[14]],
     matrix
   };
 }

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -20,6 +20,24 @@ export type WebXRInputGrip = {
   matrix: Float32Array;
 };
 
+export type WebXRInputSourceKind = 'controller' | 'hand' | 'screen' | 'gaze' | 'unknown';
+
+export type WebXRInputSourceState = {
+  inputState: WebXRInputState;
+  kind: WebXRInputSourceKind;
+  primaryProfile: string | null;
+  targetRayMode: XRTargetRayMode;
+  handedness: XRHandedness;
+  isController: boolean;
+  isHand: boolean;
+  isScreen: boolean;
+  isGaze: boolean;
+  usesTrackedPointer: boolean;
+  hasTargetRay: boolean;
+  hasGrip: boolean;
+  hasGamepad: boolean;
+};
+
 export type WebXRInputRayPlaneIntersectionProps = {
   planePoint?: NumberArray3;
   planeNormal?: NumberArray3;
@@ -61,6 +79,40 @@ export function getWebXRInputGrip(inputState: WebXRInputState): WebXRInputGrip |
     inputState,
     position: [matrix[12], matrix[13], matrix[14]],
     matrix
+  };
+}
+
+export function getWebXRInputSourceState(inputState: WebXRInputState): WebXRInputSourceState {
+  const primaryProfile = inputState.profiles[0] ?? null;
+  const isHand = Boolean(inputState.hand);
+  const isScreen = inputState.targetRayMode === 'screen';
+  const isGaze = inputState.targetRayMode === 'gaze';
+  const usesTrackedPointer = inputState.targetRayMode === 'tracked-pointer';
+  const isController = usesTrackedPointer && !isHand;
+  const kind: WebXRInputSourceKind = isHand
+    ? 'hand'
+    : isController
+      ? 'controller'
+      : isScreen
+        ? 'screen'
+        : isGaze
+          ? 'gaze'
+          : 'unknown';
+
+  return {
+    inputState,
+    kind,
+    primaryProfile,
+    targetRayMode: inputState.targetRayMode,
+    handedness: inputState.handedness,
+    isController,
+    isHand,
+    isScreen,
+    isGaze,
+    usesTrackedPointer,
+    hasTargetRay: Boolean(inputState.targetRayMatrix),
+    hasGrip: Boolean(inputState.gripMatrix),
+    hasGamepad: Boolean(inputState.gamepad)
   };
 }
 

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {NumberArray3} from '@math.gl/core';
+import {isPointInWebXRBounds, type WebXRBoundsPoint, type WebXRBoundsState} from './webxr-bounds';
 import {getWebXRGamepadState} from './webxr-gamepad';
 import type {WebXRInputState} from './webxr-manager';
 
@@ -117,6 +118,15 @@ export type WebXRControllerRayPlaneIntersection = {
   rayIntersection: WebXRInputRayPlaneIntersection;
   point: NumberArray3;
   distance: number;
+};
+
+export type WebXRControllerRayPlaneTargetProps = WebXRInputRayPlaneIntersectionProps & {
+  bounds?: readonly WebXRBoundsPoint[] | WebXRBoundsState | null;
+};
+
+/** Experimental v10 bounded target derived from one controller ray-plane hit. */
+export type WebXRControllerRayPlaneTarget = WebXRControllerRayPlaneIntersection & {
+  allowed: boolean;
 };
 
 const DEFAULT_INPUT_ACTION_THRESHOLD = 0.05;
@@ -363,6 +373,31 @@ export function getWebXRControllerRayPlaneIntersections(
     );
 }
 
+export function getWebXRControllerRayPlaneTarget(
+  controllerState: WebXRControllerState,
+  props: WebXRControllerRayPlaneTargetProps = {}
+): WebXRControllerRayPlaneTarget | null {
+  const intersection = getWebXRControllerRayPlaneIntersection(controllerState, props);
+  if (!intersection) {
+    return null;
+  }
+
+  const bounds = getWebXRTargetBounds(props.bounds);
+  return {
+    ...intersection,
+    allowed: !bounds || isPointInWebXRBounds(intersection.point, bounds)
+  };
+}
+
+export function getWebXRControllerRayPlaneTargets(
+  controllerStates: readonly WebXRControllerState[] | null,
+  props: WebXRControllerRayPlaneTargetProps = {}
+): readonly WebXRControllerRayPlaneTarget[] {
+  return (controllerStates || [])
+    .map(controllerState => getWebXRControllerRayPlaneTarget(controllerState, props))
+    .filter((target): target is WebXRControllerRayPlaneTarget => Boolean(target));
+}
+
 export function getWebXRInputRayPlaneIntersection(
   ray: WebXRInputRay,
   props: WebXRInputRayPlaneIntersectionProps = {}
@@ -405,6 +440,12 @@ export function getWebXRInputRayPlaneIntersection(
       ray.origin[2] + ray.direction[2] * distance
     ]
   };
+}
+
+function getWebXRTargetBounds(
+  bounds: readonly WebXRBoundsPoint[] | WebXRBoundsState | null | undefined
+): readonly WebXRBoundsPoint[] | null {
+  return bounds ? ('bounds' in bounds ? bounds.bounds : bounds) : null;
 }
 
 function clampActionValue(value: number): number {

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -95,6 +95,8 @@ export type WebXRControllerState = {
   isSqueezeActive: boolean;
 };
 
+export type WebXRControllerHandedness = XRHandedness | 'any';
+
 export type WebXRInputRayPlaneIntersectionProps = {
   planePoint?: NumberArray3;
   planeNormal?: NumberArray3;
@@ -307,6 +309,17 @@ export function getWebXRControllerStates(
   return (inputStates || [])
     .map(inputState => getWebXRControllerState(inputState, props))
     .filter((controllerState): controllerState is WebXRControllerState => Boolean(controllerState));
+}
+
+export function getWebXRControllerStateByHandedness(
+  controllerStates: readonly WebXRControllerState[] | null,
+  handedness: WebXRControllerHandedness = 'any'
+): WebXRControllerState | null {
+  return (
+    (controllerStates || []).find(
+      controllerState => handedness === 'any' || controllerState.handedness === handedness
+    ) || null
+  );
 }
 
 export function getWebXRInputRayPlaneIntersection(

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -79,6 +79,22 @@ export type WebXRInputActionState = WebXRInputActivationState & {
   squeezeActionEnded: boolean;
 };
 
+/** Experimental v10 consolidated state for one tracked-pointer WebXR controller. */
+export type WebXRControllerState = {
+  inputState: WebXRInputState;
+  inputSource: XRInputSource;
+  sourceState: WebXRInputSourceState;
+  activationState: WebXRInputActivationState;
+  primaryProfile: string | null;
+  handedness: XRHandedness;
+  ray: WebXRInputRay | null;
+  grip: WebXRInputGrip | null;
+  primaryAction: number;
+  squeezeAction: number;
+  isPrimaryActive: boolean;
+  isSqueezeActive: boolean;
+};
+
 export type WebXRInputRayPlaneIntersectionProps = {
   planePoint?: NumberArray3;
   planeNormal?: NumberArray3;
@@ -255,6 +271,32 @@ export function getWebXRInputActionState(
     primaryActionEnded: !activationState.isPrimaryActive && wasPrimaryActive,
     squeezeActionStarted: activationState.isSqueezeActive && !wasSqueezeActive,
     squeezeActionEnded: !activationState.isSqueezeActive && wasSqueezeActive
+  };
+}
+
+export function getWebXRControllerState(
+  inputState: WebXRInputState,
+  props: WebXRInputActivationProps = {}
+): WebXRControllerState | null {
+  const sourceState = getWebXRInputSourceState(inputState);
+  if (!sourceState.isController) {
+    return null;
+  }
+
+  const activationState = getWebXRInputActivationState(inputState, props);
+  return {
+    inputState,
+    inputSource: inputState.inputSource,
+    sourceState,
+    activationState,
+    primaryProfile: sourceState.primaryProfile,
+    handedness: sourceState.handedness,
+    ray: getWebXRInputRay(inputState),
+    grip: getWebXRInputGrip(inputState),
+    primaryAction: activationState.primaryAction,
+    squeezeAction: activationState.squeezeAction,
+    isPrimaryActive: activationState.isPrimaryActive,
+    isSqueezeActive: activationState.isSqueezeActive
   };
 }
 

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -329,6 +329,15 @@ export function getWebXRControllerStates(
     .filter((controllerState): controllerState is WebXRControllerState => Boolean(controllerState));
 }
 
+export function getWebXRInputStateByInputSource(
+  inputStates: readonly WebXRInputState[] | null,
+  inputSource: XRInputSource | null | undefined
+): WebXRInputState | null {
+  return (
+    (inputSource && (inputStates || []).find(input => input.inputSource === inputSource)) || null
+  );
+}
+
 export function getWebXRControllerStateByHandedness(
   controllerStates: readonly WebXRControllerState[] | null,
   handedness: WebXRControllerHandedness = 'any'

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -398,6 +398,17 @@ export function getWebXRControllerRayPlaneTargets(
     .filter((target): target is WebXRControllerRayPlaneTarget => Boolean(target));
 }
 
+export function getWebXRControllerRayPlaneTargetByHandedness(
+  targets: readonly WebXRControllerRayPlaneTarget[] | null,
+  handedness: WebXRControllerHandedness = 'any'
+): WebXRControllerRayPlaneTarget | null {
+  return (
+    (targets || []).find(
+      target => handedness === 'any' || target.controllerState.handedness === handedness
+    ) || null
+  );
+}
+
 export function getWebXRInputRayPlaneIntersection(
   ray: WebXRInputRay,
   props: WebXRInputRayPlaneIntersectionProps = {}

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -13,6 +13,20 @@ export type WebXRInputRay = {
   matrix: Float32Array;
 };
 
+export type WebXRInputRayPlaneIntersectionProps = {
+  planePoint?: NumberArray3;
+  planeNormal?: NumberArray3;
+  minDistance?: number;
+  maxDistance?: number;
+};
+
+/** Experimental v10 world-space hit derived from one input ray and plane. */
+export type WebXRInputRayPlaneIntersection = {
+  ray: WebXRInputRay;
+  point: NumberArray3;
+  distance: number;
+};
+
 export function getWebXRInputRay(inputState: WebXRInputState): WebXRInputRay | null {
   const matrix = inputState.targetRayMatrix;
   if (!matrix) {
@@ -30,13 +44,67 @@ export function getWebXRInputRay(inputState: WebXRInputState): WebXRInputRay | n
   };
 }
 
-function normalizeVector3(vector: NumberArray3): void {
+export function getWebXRInputRayPlaneIntersection(
+  ray: WebXRInputRay,
+  props: WebXRInputRayPlaneIntersectionProps = {}
+): WebXRInputRayPlaneIntersection | null {
+  const planePoint = props.planePoint || [0, 0, 0];
+  const sourcePlaneNormal = props.planeNormal || [0, 1, 0];
+  const planeNormal: NumberArray3 = [
+    sourcePlaneNormal[0],
+    sourcePlaneNormal[1],
+    sourcePlaneNormal[2]
+  ];
+  if (!normalizeVector3(planeNormal, null)) {
+    return null;
+  }
+
+  const denominator = dotVector3(ray.direction, planeNormal);
+  if (Math.abs(denominator) < 1e-6) {
+    return null;
+  }
+
+  const distance =
+    dotVector3(
+      [planePoint[0] - ray.origin[0], planePoint[1] - ray.origin[1], planePoint[2] - ray.origin[2]],
+      planeNormal
+    ) / denominator;
+
+  if (
+    distance < (props.minDistance ?? 0) ||
+    (props.maxDistance !== undefined && distance > props.maxDistance)
+  ) {
+    return null;
+  }
+
+  return {
+    ray,
+    distance,
+    point: [
+      ray.origin[0] + ray.direction[0] * distance,
+      ray.origin[1] + ray.direction[1] * distance,
+      ray.origin[2] + ray.direction[2] * distance
+    ]
+  };
+}
+
+function dotVector3(left: NumberArray3, right: NumberArray3): number {
+  return left[0] * right[0] + left[1] * right[1] + left[2] * right[2];
+}
+
+function normalizeVector3(
+  vector: NumberArray3,
+  fallback: NumberArray3 | null = [0, 0, -1]
+): boolean {
   const length = Math.hypot(vector[0], vector[1], vector[2]);
   if (length === 0) {
-    vector[0] = 0;
-    vector[1] = 0;
-    vector[2] = -1;
-    return;
+    if (!fallback) {
+      return false;
+    }
+    vector[0] = fallback[0];
+    vector[1] = fallback[1];
+    vector[2] = fallback[2];
+    return true;
   }
 
   vector[0] /= length;
@@ -45,4 +113,5 @@ function normalizeVector3(vector: NumberArray3): void {
   vector[0] ||= 0;
   vector[1] ||= 0;
   vector[2] ||= 0;
+  return true;
 }

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -112,6 +112,15 @@ export type WebXRInputRayPlaneIntersection = {
   distance: number;
 };
 
+export type WebXRInputRayPlaneTargetProps = WebXRInputRayPlaneIntersectionProps & {
+  bounds?: readonly WebXRBoundsPoint[] | WebXRBoundsState | null;
+};
+
+/** Experimental v10 bounded target derived from one input ray-plane hit. */
+export type WebXRInputRayPlaneTarget = WebXRInputRayPlaneIntersection & {
+  allowed: boolean;
+};
+
 /** Experimental v10 ray-plane hit derived from one WebXR controller state. */
 export type WebXRControllerRayPlaneIntersection = {
   controllerState: WebXRControllerState;
@@ -120,9 +129,7 @@ export type WebXRControllerRayPlaneIntersection = {
   distance: number;
 };
 
-export type WebXRControllerRayPlaneTargetProps = WebXRInputRayPlaneIntersectionProps & {
-  bounds?: readonly WebXRBoundsPoint[] | WebXRBoundsState | null;
-};
+export type WebXRControllerRayPlaneTargetProps = WebXRInputRayPlaneTargetProps;
 
 /** Experimental v10 bounded target derived from one controller ray-plane hit. */
 export type WebXRControllerRayPlaneTarget = WebXRControllerRayPlaneIntersection & {
@@ -408,10 +415,14 @@ export function getWebXRControllerRayPlaneTarget(
     return null;
   }
 
-  const bounds = getWebXRTargetBounds(props.bounds);
+  const target = getWebXRInputRayPlaneTarget(intersection.rayIntersection.ray, props);
+  if (!target) {
+    return null;
+  }
+
   return {
     ...intersection,
-    allowed: !bounds || isPointInWebXRBounds(intersection.point, bounds)
+    allowed: target.allowed
   };
 }
 
@@ -499,6 +510,42 @@ export function getWebXRInputRayPlaneIntersections(
     .filter((intersection): intersection is WebXRInputRayPlaneIntersection =>
       Boolean(intersection)
     );
+}
+
+export function getWebXRInputRayPlaneTarget(
+  ray: WebXRInputRay,
+  props: WebXRInputRayPlaneTargetProps = {}
+): WebXRInputRayPlaneTarget | null {
+  const intersection = getWebXRInputRayPlaneIntersection(ray, props);
+  if (!intersection) {
+    return null;
+  }
+
+  const bounds = getWebXRTargetBounds(props.bounds);
+  return {
+    ...intersection,
+    allowed: !bounds || isPointInWebXRBounds(intersection.point, bounds)
+  };
+}
+
+export function getWebXRInputRayPlaneTargets(
+  rays: readonly WebXRInputRay[] | null,
+  props: WebXRInputRayPlaneTargetProps = {}
+): readonly WebXRInputRayPlaneTarget[] {
+  return (rays || [])
+    .map(ray => getWebXRInputRayPlaneTarget(ray, props))
+    .filter((target): target is WebXRInputRayPlaneTarget => Boolean(target));
+}
+
+export function getWebXRInputRayPlaneTargetByInputSource(
+  targets: readonly WebXRInputRayPlaneTarget[] | null,
+  inputSource: XRInputSource | null | undefined
+): WebXRInputRayPlaneTarget | null {
+  return (
+    (inputSource &&
+      (targets || []).find(target => target.ray.inputState.inputSource === inputSource)) ||
+    null
+  );
 }
 
 function getWebXRTargetBounds(

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -409,6 +409,17 @@ export function getWebXRControllerRayPlaneTargetByHandedness(
   );
 }
 
+export function getWebXRControllerRayPlaneTargetByInputSource(
+  targets: readonly WebXRControllerRayPlaneTarget[] | null,
+  inputSource: XRInputSource | null | undefined
+): WebXRControllerRayPlaneTarget | null {
+  return (
+    (inputSource &&
+      (targets || []).find(target => target.controllerState.inputSource === inputSource)) ||
+    null
+  );
+}
+
 export function getWebXRInputRayPlaneIntersection(
   ray: WebXRInputRay,
   props: WebXRInputRayPlaneIntersectionProps = {}

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -192,6 +192,23 @@ export function getWebXRInputRay(inputState: WebXRInputState): WebXRInputRay | n
   };
 }
 
+export function getWebXRInputRays(
+  inputStates: readonly WebXRInputState[] | null
+): readonly WebXRInputRay[] {
+  return (inputStates || [])
+    .map(inputState => getWebXRInputRay(inputState))
+    .filter((ray): ray is WebXRInputRay => Boolean(ray));
+}
+
+export function getWebXRInputRayByInputSource(
+  rays: readonly WebXRInputRay[] | null,
+  inputSource: XRInputSource | null | undefined
+): WebXRInputRay | null {
+  return (
+    (inputSource && (rays || []).find(ray => ray.inputState.inputSource === inputSource)) || null
+  );
+}
+
 export function getWebXRInputGrip(inputState: WebXRInputState): WebXRInputGrip | null {
   const matrix = inputState.gripMatrix;
   if (!matrix) {
@@ -471,6 +488,17 @@ export function getWebXRInputRayPlaneIntersection(
       ray.origin[2] + ray.direction[2] * distance
     ]
   };
+}
+
+export function getWebXRInputRayPlaneIntersections(
+  rays: readonly WebXRInputRay[] | null,
+  props: WebXRInputRayPlaneIntersectionProps = {}
+): readonly WebXRInputRayPlaneIntersection[] {
+  return (rays || [])
+    .map(ray => getWebXRInputRayPlaneIntersection(ray, props))
+    .filter((intersection): intersection is WebXRInputRayPlaneIntersection =>
+      Boolean(intersection)
+    );
 }
 
 function getWebXRTargetBounds(

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {NumberArray3} from '@math.gl/core';
+import {getWebXRGamepadState} from './webxr-gamepad';
 import type {WebXRInputState} from './webxr-manager';
 
 /** Experimental v10 world-space target ray derived from one WebXR input source. */
@@ -36,6 +37,19 @@ export type WebXRInputSourceState = {
   hasTargetRay: boolean;
   hasGrip: boolean;
   hasGamepad: boolean;
+};
+
+/** Experimental v10 normalized select/squeeze activation for one WebXR input source. */
+export type WebXRInputActivationState = {
+  inputState: WebXRInputState;
+  selectActive: boolean;
+  squeezeActive: boolean;
+  triggerValue: number;
+  squeezeValue: number;
+  primaryAction: number;
+  squeezeAction: number;
+  isPrimaryActive: boolean;
+  isSqueezeActive: boolean;
 };
 
 export type WebXRInputRayPlaneIntersectionProps = {
@@ -116,6 +130,28 @@ export function getWebXRInputSourceState(inputState: WebXRInputState): WebXRInpu
   };
 }
 
+export function getWebXRInputActivationState(
+  inputState: WebXRInputState
+): WebXRInputActivationState {
+  const gamepadState = getWebXRGamepadState(inputState);
+  const triggerValue = clampActionValue(gamepadState?.primaryTrigger?.value ?? 0);
+  const squeezeValue = clampActionValue(gamepadState?.primarySqueeze?.value ?? 0);
+  const primaryAction = Math.max(inputState.selectActive ? 1 : 0, triggerValue);
+  const squeezeAction = Math.max(inputState.squeezeActive ? 1 : 0, squeezeValue);
+
+  return {
+    inputState,
+    selectActive: inputState.selectActive,
+    squeezeActive: inputState.squeezeActive,
+    triggerValue,
+    squeezeValue,
+    primaryAction,
+    squeezeAction,
+    isPrimaryActive: primaryAction > 0,
+    isSqueezeActive: squeezeAction > 0
+  };
+}
+
 export function getWebXRInputRayPlaneIntersection(
   ray: WebXRInputRay,
   props: WebXRInputRayPlaneIntersectionProps = {}
@@ -158,6 +194,10 @@ export function getWebXRInputRayPlaneIntersection(
       ray.origin[2] + ray.direction[2] * distance
     ]
   };
+}
+
+function clampActionValue(value: number): number {
+  return Math.max(0, Math.min(1, value));
 }
 
 function dotVector3(left: NumberArray3, right: NumberArray3): number {

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -300,6 +300,15 @@ export function getWebXRControllerState(
   };
 }
 
+export function getWebXRControllerStates(
+  inputStates: readonly WebXRInputState[] | null,
+  props: WebXRInputActivationProps = {}
+): readonly WebXRControllerState[] {
+  return (inputStates || [])
+    .map(inputState => getWebXRControllerState(inputState, props))
+    .filter((controllerState): controllerState is WebXRControllerState => Boolean(controllerState));
+}
+
 export function getWebXRInputRayPlaneIntersection(
   ray: WebXRInputRay,
   props: WebXRInputRayPlaneIntersectionProps = {}

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -40,16 +40,43 @@ export type WebXRInputSourceState = {
 };
 
 /** Experimental v10 normalized select/squeeze activation for one WebXR input source. */
+export type WebXRInputActivationProps = {
+  activationThreshold?: number;
+};
+
 export type WebXRInputActivationState = {
   inputState: WebXRInputState;
+  inputSource: XRInputSource;
   selectActive: boolean;
   squeezeActive: boolean;
   triggerValue: number;
   squeezeValue: number;
   primaryAction: number;
   squeezeAction: number;
+  activationThreshold: number;
   isPrimaryActive: boolean;
   isSqueezeActive: boolean;
+};
+
+export type WebXRInputPreviousActionState = {
+  primaryAction: number;
+  squeezeAction: number;
+  isPrimaryActive: boolean;
+  isSqueezeActive: boolean;
+};
+
+/** Experimental v10 per-frame action transition state for one WebXR input source. */
+export type WebXRInputActionState = WebXRInputActivationState & {
+  previousPrimaryAction: number;
+  previousSqueezeAction: number;
+  primaryActionDelta: number;
+  squeezeActionDelta: number;
+  wasPrimaryActive: boolean;
+  wasSqueezeActive: boolean;
+  primaryActionStarted: boolean;
+  primaryActionEnded: boolean;
+  squeezeActionStarted: boolean;
+  squeezeActionEnded: boolean;
 };
 
 export type WebXRInputRayPlaneIntersectionProps = {
@@ -65,6 +92,52 @@ export type WebXRInputRayPlaneIntersection = {
   point: NumberArray3;
   distance: number;
 };
+
+const DEFAULT_INPUT_ACTION_THRESHOLD = 0.05;
+
+/** Tracks per-frame select/squeeze transitions across WebXR input sources. */
+export class WebXRInputActionManager {
+  private _previousActionsByInputSource = new Map<XRInputSource, WebXRInputPreviousActionState>();
+
+  update(
+    inputStates: readonly WebXRInputState[] | null,
+    props: WebXRInputActivationProps = {}
+  ): readonly WebXRInputActionState[] {
+    const activeInputSources = new Set<XRInputSource>();
+    const actionStates: WebXRInputActionState[] = [];
+
+    for (const inputState of inputStates || []) {
+      activeInputSources.add(inputState.inputSource);
+      const actionState = getWebXRInputActionState(inputState, {
+        ...props,
+        previousAction: this._previousActionsByInputSource.get(inputState.inputSource)
+      });
+      actionStates.push(actionState);
+      this._previousActionsByInputSource.set(inputState.inputSource, {
+        primaryAction: actionState.primaryAction,
+        squeezeAction: actionState.squeezeAction,
+        isPrimaryActive: actionState.isPrimaryActive,
+        isSqueezeActive: actionState.isSqueezeActive
+      });
+    }
+
+    for (const inputSource of this._previousActionsByInputSource.keys()) {
+      if (!activeInputSources.has(inputSource)) {
+        this._previousActionsByInputSource.delete(inputSource);
+      }
+    }
+
+    return actionStates;
+  }
+
+  reset(inputSource?: XRInputSource): void {
+    if (inputSource) {
+      this._previousActionsByInputSource.delete(inputSource);
+    } else {
+      this._previousActionsByInputSource.clear();
+    }
+  }
+}
 
 export function getWebXRInputRay(inputState: WebXRInputState): WebXRInputRay | null {
   const matrix = inputState.targetRayMatrix;
@@ -131,8 +204,10 @@ export function getWebXRInputSourceState(inputState: WebXRInputState): WebXRInpu
 }
 
 export function getWebXRInputActivationState(
-  inputState: WebXRInputState
+  inputState: WebXRInputState,
+  props: WebXRInputActivationProps = {}
 ): WebXRInputActivationState {
+  const activationThreshold = clampActionValue(props.activationThreshold ?? 0);
   const gamepadState = getWebXRGamepadState(inputState);
   const triggerValue = clampActionValue(gamepadState?.primaryTrigger?.value ?? 0);
   const squeezeValue = clampActionValue(gamepadState?.primarySqueeze?.value ?? 0);
@@ -141,14 +216,45 @@ export function getWebXRInputActivationState(
 
   return {
     inputState,
+    inputSource: inputState.inputSource,
     selectActive: inputState.selectActive,
     squeezeActive: inputState.squeezeActive,
     triggerValue,
     squeezeValue,
     primaryAction,
     squeezeAction,
-    isPrimaryActive: primaryAction > 0,
-    isSqueezeActive: squeezeAction > 0
+    activationThreshold,
+    isPrimaryActive: primaryAction > activationThreshold,
+    isSqueezeActive: squeezeAction > activationThreshold
+  };
+}
+
+export function getWebXRInputActionState(
+  inputState: WebXRInputState,
+  props: WebXRInputActivationProps & {
+    previousAction?: WebXRInputPreviousActionState | null;
+  } = {}
+): WebXRInputActionState {
+  const activationState = getWebXRInputActivationState(inputState, {
+    activationThreshold: props.activationThreshold ?? DEFAULT_INPUT_ACTION_THRESHOLD
+  });
+  const previousPrimaryAction = props.previousAction?.primaryAction ?? 0;
+  const previousSqueezeAction = props.previousAction?.squeezeAction ?? 0;
+  const wasPrimaryActive = props.previousAction?.isPrimaryActive ?? false;
+  const wasSqueezeActive = props.previousAction?.isSqueezeActive ?? false;
+
+  return {
+    ...activationState,
+    previousPrimaryAction,
+    previousSqueezeAction,
+    primaryActionDelta: activationState.primaryAction - previousPrimaryAction,
+    squeezeActionDelta: activationState.squeezeAction - previousSqueezeAction,
+    wasPrimaryActive,
+    wasSqueezeActive,
+    primaryActionStarted: activationState.isPrimaryActive && !wasPrimaryActive,
+    primaryActionEnded: !activationState.isPrimaryActive && wasPrimaryActive,
+    squeezeActionStarted: activationState.isSqueezeActive && !wasSqueezeActive,
+    squeezeActionEnded: !activationState.isSqueezeActive && wasSqueezeActive
   };
 }
 

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -1,0 +1,48 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {NumberArray3} from '@math.gl/core';
+import type {WebXRInputState} from './webxr-manager';
+
+/** Experimental v10 world-space target ray derived from one WebXR input source. */
+export type WebXRInputRay = {
+  inputState: WebXRInputState;
+  origin: NumberArray3;
+  direction: NumberArray3;
+  matrix: Float32Array;
+};
+
+export function getWebXRInputRay(inputState: WebXRInputState): WebXRInputRay | null {
+  const matrix = inputState.targetRayMatrix;
+  if (!matrix) {
+    return null;
+  }
+
+  const direction: NumberArray3 = [-matrix[8], -matrix[9], -matrix[10]];
+  normalizeVector3(direction);
+
+  return {
+    inputState,
+    origin: [matrix[12], matrix[13], matrix[14]],
+    direction,
+    matrix
+  };
+}
+
+function normalizeVector3(vector: NumberArray3): void {
+  const length = Math.hypot(vector[0], vector[1], vector[2]);
+  if (length === 0) {
+    vector[0] = 0;
+    vector[1] = 0;
+    vector[2] = -1;
+    return;
+  }
+
+  vector[0] /= length;
+  vector[1] /= length;
+  vector[2] /= length;
+  vector[0] ||= 0;
+  vector[1] ||= 0;
+  vector[2] ||= 0;
+}

--- a/modules/experimental/src/webxr/webxr-input.ts
+++ b/modules/experimental/src/webxr/webxr-input.ts
@@ -111,6 +111,14 @@ export type WebXRInputRayPlaneIntersection = {
   distance: number;
 };
 
+/** Experimental v10 ray-plane hit derived from one WebXR controller state. */
+export type WebXRControllerRayPlaneIntersection = {
+  controllerState: WebXRControllerState;
+  rayIntersection: WebXRInputRayPlaneIntersection;
+  point: NumberArray3;
+  distance: number;
+};
+
 const DEFAULT_INPUT_ACTION_THRESHOLD = 0.05;
 
 /** Tracks per-frame select/squeeze transitions across WebXR input sources. */
@@ -320,6 +328,39 @@ export function getWebXRControllerStateByHandedness(
       controllerState => handedness === 'any' || controllerState.handedness === handedness
     ) || null
   );
+}
+
+export function getWebXRControllerRayPlaneIntersection(
+  controllerState: WebXRControllerState,
+  props: WebXRInputRayPlaneIntersectionProps = {}
+): WebXRControllerRayPlaneIntersection | null {
+  const ray = controllerState.ray;
+  if (!ray) {
+    return null;
+  }
+
+  const rayIntersection = getWebXRInputRayPlaneIntersection(ray, props);
+  if (!rayIntersection) {
+    return null;
+  }
+
+  return {
+    controllerState,
+    rayIntersection,
+    point: rayIntersection.point,
+    distance: rayIntersection.distance
+  };
+}
+
+export function getWebXRControllerRayPlaneIntersections(
+  controllerStates: readonly WebXRControllerState[] | null,
+  props: WebXRInputRayPlaneIntersectionProps = {}
+): readonly WebXRControllerRayPlaneIntersection[] {
+  return (controllerStates || [])
+    .map(controllerState => getWebXRControllerRayPlaneIntersection(controllerState, props))
+    .filter((intersection): intersection is WebXRControllerRayPlaneIntersection =>
+      Boolean(intersection)
+    );
 }
 
 export function getWebXRInputRayPlaneIntersection(

--- a/modules/experimental/src/webxr/webxr-layers.ts
+++ b/modules/experimental/src/webxr/webxr-layers.ts
@@ -24,6 +24,7 @@ export type WebXRCompositionLayerState = {
   xrFrame: XRFrame;
   session: XRSession;
   layer: XRCompositionLayer;
+  controls: WebXRCompositionLayerControlsState;
   subImage: XRWebGLSubImage;
   framebuffer: Framebuffer;
   colorTexture: Texture;
@@ -33,6 +34,23 @@ export type WebXRCompositionLayerState = {
   layout: XRLayerLayout;
   needsRedraw: boolean;
   imageIndex: number | null;
+};
+
+export type WebXRCompositionLayerControlsProps = {
+  blendTextureSourceAlpha?: boolean;
+  forceMonoPresentation?: boolean;
+  opacity?: number;
+  quality?: XRLayerQuality;
+};
+
+export type WebXRCompositionLayerControlsState = {
+  layer: XRCompositionLayer;
+  blendTextureSourceAlpha: boolean;
+  forceMonoPresentation: boolean;
+  opacity: number;
+  mipLevels: number;
+  quality: XRLayerQuality;
+  needsRedraw: boolean;
 };
 
 type ResolvedWebXRCompositionLayerManagerProps = Required<WebXRCompositionLayerManagerProps>;
@@ -89,6 +107,35 @@ export class WebXRCompositionLayerManager {
     const layer = this.xrWebGLBinding.createQuadLayer(init);
     this._trackLayer(layer);
     return layer;
+  }
+
+  setLayerControls(
+    layer: XRCompositionLayer,
+    props: WebXRCompositionLayerControlsProps
+  ): WebXRCompositionLayerControlsState {
+    if (!this._layers.has(layer)) {
+      throw new Error('XRCompositionLayer is not tracked by this manager');
+    }
+    return setWebXRCompositionLayerControls(layer, props);
+  }
+
+  getLayerControls(layer: XRCompositionLayer): WebXRCompositionLayerControlsState {
+    if (!this._layers.has(layer)) {
+      throw new Error('XRCompositionLayer is not tracked by this manager');
+    }
+    return getWebXRCompositionLayerControls(layer, this._redrawLayers.has(layer));
+  }
+
+  destroyLayer(layer: XRCompositionLayer): void {
+    if (!this._layers.has(layer)) {
+      return;
+    }
+
+    layer.removeEventListener('redraw', this._redrawListener);
+    this._redrawLayers.delete(layer);
+    this._layers.delete(layer);
+    this._destroyLayerResources(layer);
+    layer.destroy();
   }
 
   createCylinderLayer(init: XRCylinderLayerInit): XRCylinderLayer {
@@ -150,6 +197,7 @@ export class WebXRCompositionLayerManager {
       xrFrame,
       session: this.session,
       layer,
+      controls: getWebXRCompositionLayerControls(layer, needsRedraw),
       subImage,
       framebuffer: resources.framebuffer,
       colorTexture: resources.colorTexture,
@@ -251,17 +299,26 @@ export class WebXRCompositionLayerManager {
   }
 
   private _destroyResources(): void {
-    for (const resourceList of this._resources.values()) {
-      for (const resources of resourceList) {
-        if (!resources) {
-          continue;
-        }
-        resources.framebuffer.destroy();
-        resources.depthStencilTexture?.destroy();
-        resources.colorTexture.destroy();
-      }
+    for (const layer of this._resources.keys()) {
+      this._destroyLayerResources(layer);
     }
     this._resources.clear();
+  }
+
+  private _destroyLayerResources(layer: XRCompositionLayer): void {
+    const resourceList = this._resources.get(layer);
+    if (!resourceList) {
+      return;
+    }
+    for (const resources of resourceList) {
+      if (!resources) {
+        continue;
+      }
+      resources.framebuffer.destroy();
+      resources.depthStencilTexture?.destroy();
+      resources.colorTexture.destroy();
+    }
+    this._resources.delete(layer);
   }
 
   static defaultProps: ResolvedWebXRCompositionLayerManagerProps = {
@@ -274,6 +331,40 @@ export class WebXRCompositionLayerManager {
 export function getWebXRLayersSessionInit(props: WebXRLayersSessionInitProps = {}): XRSessionInit {
   return {
     [props.required ? 'requiredFeatures' : 'optionalFeatures']: ['layers']
+  };
+}
+
+export function setWebXRCompositionLayerControls(
+  layer: XRCompositionLayer,
+  props: WebXRCompositionLayerControlsProps
+): WebXRCompositionLayerControlsState {
+  if (props.blendTextureSourceAlpha !== undefined) {
+    layer.blendTextureSourceAlpha = props.blendTextureSourceAlpha;
+  }
+  if (props.forceMonoPresentation !== undefined) {
+    layer.forceMonoPresentation = props.forceMonoPresentation;
+  }
+  if (props.opacity !== undefined) {
+    layer.opacity = props.opacity;
+  }
+  if (props.quality !== undefined) {
+    layer.quality = props.quality;
+  }
+  return getWebXRCompositionLayerControls(layer);
+}
+
+export function getWebXRCompositionLayerControls(
+  layer: XRCompositionLayer,
+  needsRedrawOverride = false
+): WebXRCompositionLayerControlsState {
+  return {
+    layer,
+    blendTextureSourceAlpha: layer.blendTextureSourceAlpha,
+    forceMonoPresentation: layer.forceMonoPresentation,
+    opacity: layer.opacity,
+    mipLevels: layer.mipLevels,
+    quality: layer.quality,
+    needsRedraw: layer.needsRedraw || needsRedrawOverride
   };
 }
 

--- a/modules/experimental/src/webxr/webxr-layers.ts
+++ b/modules/experimental/src/webxr/webxr-layers.ts
@@ -1,0 +1,311 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Device, Framebuffer, Texture, TextureFormat, TextureProps} from '@luma.gl/core';
+import {Texture as TextureResource} from '@luma.gl/core';
+
+type WebXRWebGLDevice = Device & {
+  type: 'webgl';
+  gl: WebGLRenderingContext | WebGL2RenderingContext;
+};
+
+export type WebXRCompositionLayerManagerProps = {
+  colorTextureFormat?: TextureFormat;
+  depthStencilTextureFormat?: TextureFormat;
+  textureUsage?: number;
+};
+
+export type WebXRLayersSessionInitProps = {
+  required?: boolean;
+};
+
+export type WebXRCompositionLayerState = {
+  xrFrame: XRFrame;
+  session: XRSession;
+  layer: XRCompositionLayer;
+  subImage: XRWebGLSubImage;
+  framebuffer: Framebuffer;
+  colorTexture: Texture;
+  depthStencilTexture: Texture | null;
+  viewport: [x: number, y: number, width: number, height: number];
+  eye: XREye;
+  layout: XRLayerLayout;
+  needsRedraw: boolean;
+  imageIndex: number | null;
+};
+
+type ResolvedWebXRCompositionLayerManagerProps = Required<WebXRCompositionLayerManagerProps>;
+
+type WebXRCompositionLayerResources = {
+  subImage: XRWebGLSubImage;
+  framebuffer: Framebuffer;
+  colorTexture: Texture;
+  depthStencilTexture: Texture | null;
+};
+
+/** Experimental v10 WebXR Layers API helper for WebGL composition layers. */
+export class WebXRCompositionLayerManager {
+  readonly device: WebXRWebGLDevice;
+  props: ResolvedWebXRCompositionLayerManagerProps;
+
+  session: XRSession | null = null;
+  xrWebGLBinding: XRWebGLBinding | null = null;
+
+  private _layers = new Set<XRCompositionLayer>();
+  private _resources = new Map<XRCompositionLayer, WebXRCompositionLayerResources[]>();
+  private _sessionEndListener = () => this.clearSession();
+  private _redrawListener = (event: Event) => this._handleLayerRedraw(event);
+  private _redrawLayers = new Set<XRCompositionLayer>();
+
+  constructor(device: Device, props: WebXRCompositionLayerManagerProps = {}) {
+    if (!isWebXRWebGLDevice(device)) {
+      throw new Error('WebXRCompositionLayerManager requires a WebGL device');
+    }
+    this.device = device;
+    this.props = {...WebXRCompositionLayerManager.defaultProps, ...props};
+  }
+
+  async setSession(session: XRSession | null): Promise<this> {
+    this.clearSession();
+    if (!session) {
+      return this;
+    }
+    if (typeof XRWebGLBinding === 'undefined') {
+      throw new Error('WebXR Layers require XRWebGLBinding');
+    }
+
+    await this.device.gl.makeXRCompatible();
+    this.xrWebGLBinding = new XRWebGLBinding(session, this.device.gl);
+    this.session = session;
+    session.addEventListener('end', this._sessionEndListener);
+    return this;
+  }
+
+  createQuadLayer(init: XRQuadLayerInit): XRQuadLayer {
+    if (!this.xrWebGLBinding) {
+      throw new Error('WebXRCompositionLayerManager has no XRWebGLBinding');
+    }
+    const layer = this.xrWebGLBinding.createQuadLayer(init);
+    this._trackLayer(layer);
+    return layer;
+  }
+
+  createCylinderLayer(init: XRCylinderLayerInit): XRCylinderLayer {
+    if (!this.xrWebGLBinding) {
+      throw new Error('WebXRCompositionLayerManager has no XRWebGLBinding');
+    }
+    const layer = this.xrWebGLBinding.createCylinderLayer(init);
+    this._trackLayer(layer);
+    return layer;
+  }
+
+  async updateRenderState(layers: readonly XRLayer[]): Promise<void> {
+    if (!this.session) {
+      throw new Error('WebXRCompositionLayerManager has no XRSession');
+    }
+    await this.session.updateRenderState({layers});
+  }
+
+  getLayerState(
+    xrFrame: XRFrame,
+    layer: XRCompositionLayer,
+    eye: XREye = 'none'
+  ): WebXRCompositionLayerState | null {
+    if (!this.session || !this.xrWebGLBinding) {
+      return null;
+    }
+    if (xrFrame.session !== this.session) {
+      throw new Error('XRFrame belongs to a different XRSession');
+    }
+    if (!this._layers.has(layer)) {
+      throw new Error('XRCompositionLayer is not tracked by this manager');
+    }
+
+    const subImage = this.xrWebGLBinding.getSubImage(layer, xrFrame, eye);
+    const resources = this._getLayerResources(layer, subImage, eye);
+    const viewport = subImage.viewport;
+    const needsRedraw = layer.needsRedraw || this._redrawLayers.has(layer);
+    this._redrawLayers.delete(layer);
+
+    return {
+      xrFrame,
+      session: this.session,
+      layer,
+      subImage,
+      framebuffer: resources.framebuffer,
+      colorTexture: resources.colorTexture,
+      depthStencilTexture: resources.depthStencilTexture,
+      viewport: [viewport.x, viewport.y, viewport.width, viewport.height],
+      eye,
+      layout: layer.layout,
+      needsRedraw,
+      imageIndex: subImage.imageIndex ?? null
+    };
+  }
+
+  clearSession(): void {
+    this.session?.removeEventListener('end', this._sessionEndListener);
+    this._destroyResources();
+    for (const layer of this._layers) {
+      layer.removeEventListener('redraw', this._redrawListener);
+    }
+    this._layers.clear();
+    this._redrawLayers.clear();
+    this.xrWebGLBinding = null;
+    this.session = null;
+  }
+
+  destroy(): void {
+    this.clearSession();
+  }
+
+  private _trackLayer(layer: XRCompositionLayer): void {
+    this._layers.add(layer);
+    layer.addEventListener('redraw', this._redrawListener);
+  }
+
+  private _getLayerResources(
+    layer: XRCompositionLayer,
+    subImage: XRWebGLSubImage,
+    eye: XREye
+  ): WebXRCompositionLayerResources {
+    const resources = this._resources.get(layer) || [];
+    const index = getSubImageIndex(subImage, eye);
+    const previousResources = resources[index];
+
+    if (previousResources && hasMatchingSubImage(previousResources.subImage, subImage)) {
+      return previousResources;
+    }
+
+    const colorTexture = this._createBorrowedTexture(subImage, subImage.colorTexture, 'color');
+    let depthStencilTexture: Texture | null = null;
+    try {
+      depthStencilTexture = subImage.depthStencilTexture
+        ? this._createBorrowedTexture(subImage, subImage.depthStencilTexture, 'depth-stencil')
+        : null;
+      const framebuffer = this.device.createFramebuffer({
+        id: `webxr-composition-layer-framebuffer-${this._resources.size + 1}-${index}`,
+        width: subImage.colorTextureWidth,
+        height: subImage.colorTextureHeight,
+        colorAttachments: [colorTexture.view],
+        depthStencilAttachment: depthStencilTexture?.view || null
+      });
+      previousResources?.framebuffer.destroy();
+      previousResources?.depthStencilTexture?.destroy();
+      previousResources?.colorTexture.destroy();
+
+      const nextResources = {subImage, framebuffer, colorTexture, depthStencilTexture};
+      resources[index] = nextResources;
+      this._resources.set(layer, resources);
+      return nextResources;
+    } catch (error) {
+      depthStencilTexture?.destroy();
+      colorTexture.destroy();
+      throw error;
+    }
+  }
+
+  private _createBorrowedTexture(
+    subImage: XRWebGLSubImage,
+    textureHandle: WebGLTexture,
+    attachment: 'color' | 'depth-stencil'
+  ): Texture {
+    const imageIndex = subImage.imageIndex ?? null;
+    return this.device.createTexture({
+      id: `webxr-composition-layer-${attachment}-texture-${this._resources.size + 1}`,
+      handle: textureHandle,
+      _isHandleBorrowed: true,
+      dimension: imageIndex === null ? '2d' : '2d-array',
+      width: getSubImageTextureWidth(subImage, attachment),
+      height: getSubImageTextureHeight(subImage, attachment),
+      depth: imageIndex === null ? 1 : imageIndex + 1,
+      format:
+        attachment === 'color'
+          ? this.props.colorTextureFormat
+          : this.props.depthStencilTextureFormat,
+      usage: this.props.textureUsage
+    } as TextureProps);
+  }
+
+  private _handleLayerRedraw(event: Event): void {
+    this._redrawLayers.add(event.currentTarget as XRCompositionLayer);
+  }
+
+  private _destroyResources(): void {
+    for (const resourceList of this._resources.values()) {
+      for (const resources of resourceList) {
+        if (!resources) {
+          continue;
+        }
+        resources.framebuffer.destroy();
+        resources.depthStencilTexture?.destroy();
+        resources.colorTexture.destroy();
+      }
+    }
+    this._resources.clear();
+  }
+
+  static defaultProps: ResolvedWebXRCompositionLayerManagerProps = {
+    colorTextureFormat: 'rgba8unorm',
+    depthStencilTextureFormat: 'depth24plus',
+    textureUsage: TextureResource.RENDER_ATTACHMENT
+  };
+}
+
+export function getWebXRLayersSessionInit(props: WebXRLayersSessionInitProps = {}): XRSessionInit {
+  return {
+    [props.required ? 'requiredFeatures' : 'optionalFeatures']: ['layers']
+  };
+}
+
+function getSubImageIndex(subImage: XRWebGLSubImage, eye: XREye): number {
+  if (subImage.imageIndex !== undefined) {
+    return subImage.imageIndex;
+  }
+  switch (eye) {
+    case 'left':
+      return 1;
+    case 'right':
+      return 2;
+    default:
+      return 0;
+  }
+}
+
+function getSubImageTextureWidth(
+  subImage: XRWebGLSubImage,
+  attachment: 'color' | 'depth-stencil'
+): number {
+  return attachment === 'color'
+    ? subImage.colorTextureWidth
+    : subImage.depthStencilTextureWidth || subImage.colorTextureWidth;
+}
+
+function getSubImageTextureHeight(
+  subImage: XRWebGLSubImage,
+  attachment: 'color' | 'depth-stencil'
+): number {
+  return attachment === 'color'
+    ? subImage.colorTextureHeight
+    : subImage.depthStencilTextureHeight || subImage.colorTextureHeight;
+}
+
+function hasMatchingSubImage(
+  previousSubImage: XRWebGLSubImage,
+  nextSubImage: XRWebGLSubImage
+): boolean {
+  return (
+    previousSubImage.colorTexture === nextSubImage.colorTexture &&
+    previousSubImage.depthStencilTexture === nextSubImage.depthStencilTexture &&
+    previousSubImage.imageIndex === nextSubImage.imageIndex &&
+    previousSubImage.colorTextureWidth === nextSubImage.colorTextureWidth &&
+    previousSubImage.colorTextureHeight === nextSubImage.colorTextureHeight &&
+    previousSubImage.depthStencilTextureWidth === nextSubImage.depthStencilTextureWidth &&
+    previousSubImage.depthStencilTextureHeight === nextSubImage.depthStencilTextureHeight
+  );
+}
+
+function isWebXRWebGLDevice(device: Device): device is WebXRWebGLDevice {
+  return device.type === 'webgl' && 'gl' in device;
+}

--- a/modules/experimental/src/webxr/webxr-layers.ts
+++ b/modules/experimental/src/webxr/webxr-layers.ts
@@ -100,6 +100,24 @@ export class WebXRCompositionLayerManager {
     return layer;
   }
 
+  createEquirectLayer(init: XREquirectLayerInit): XREquirectLayer {
+    if (!this.xrWebGLBinding) {
+      throw new Error('WebXRCompositionLayerManager has no XRWebGLBinding');
+    }
+    const layer = this.xrWebGLBinding.createEquirectLayer(init);
+    this._trackLayer(layer);
+    return layer;
+  }
+
+  createCubeLayer(init: XRCubeLayerInit): XRCubeLayer {
+    if (!this.xrWebGLBinding) {
+      throw new Error('WebXRCompositionLayerManager has no XRWebGLBinding');
+    }
+    const layer = this.xrWebGLBinding.createCubeLayer(init);
+    this._trackLayer(layer);
+    return layer;
+  }
+
   async updateRenderState(layers: readonly XRLayer[]): Promise<void> {
     if (!this.session) {
       throw new Error('WebXRCompositionLayerManager has no XRSession');

--- a/modules/experimental/src/webxr/webxr-light-estimation.ts
+++ b/modules/experimental/src/webxr/webxr-light-estimation.ts
@@ -1,0 +1,226 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Device, Texture, TextureFormat, TextureProps} from '@luma.gl/core';
+import {Texture as TextureResource} from '@luma.gl/core';
+import type {WebXRLightEstimationBinding} from './webxr-types';
+
+export type WebXRLightEstimationManagerProps = {
+  reflectionFormat?: XRReflectionFormat | 'preferred';
+  reflectionCubeMapSize?: number;
+  textureFormat?: TextureFormat;
+  textureUsage?: number;
+};
+
+export type WebXRLightEstimationSessionInitProps = {
+  required?: boolean;
+};
+
+export type WebXRLightEstimationState = {
+  xrFrame: XRFrame;
+  session: XRSession;
+  lightProbe: XRLightProbe;
+  lightEstimate: XRLightEstimate;
+  probePose: XRPose | null;
+  matrix: Float32Array | null;
+  sphericalHarmonicsCoefficients: Float32Array;
+  primaryLightDirection: [number, number, number];
+  primaryLightIntensity: [number, number, number];
+  reflectionCubeMap: WebGLTexture | null;
+  reflectionCubeMapTexture: Texture | null;
+  reflectionRevision: number;
+};
+
+type ResolvedWebXRLightEstimationManagerProps = Required<WebXRLightEstimationManagerProps>;
+
+/** Experimental v10 WebXR lighting-estimation probe and reflection-cubemap helper. */
+export class WebXRLightEstimationManager {
+  props: ResolvedWebXRLightEstimationManagerProps;
+
+  session: XRSession | null = null;
+  referenceSpace: XRReferenceSpace | null = null;
+  lightProbe: XRLightProbe | null = null;
+  device: Device | null = null;
+  xrWebGLBinding: WebXRLightEstimationBinding | null = null;
+
+  private _reflectionCubeMapTextures = new Map<WebGLTexture, Texture>();
+  private _reflectionRevision = 0;
+  private _sessionEndListener = () => this.clearSession();
+  private _reflectionChangeListener = () => {
+    this._reflectionRevision++;
+  };
+
+  constructor(props: WebXRLightEstimationManagerProps = {}) {
+    this.props = {...WebXRLightEstimationManager.defaultProps, ...props};
+  }
+
+  async setSession(
+    session: XRSession | null,
+    referenceSpace: XRReferenceSpace | null,
+    props: WebXRLightEstimationManagerProps = {}
+  ): Promise<this> {
+    this.clearSession();
+    this.props = {...this.props, ...props};
+
+    if (!session) {
+      return this;
+    }
+    if (!referenceSpace) {
+      throw new Error('WebXRLightEstimationManager requires an app reference space');
+    }
+    if (!session.requestLightProbe) {
+      throw new Error('WebXR light-estimation probes are not supported in this browser');
+    }
+
+    const lightProbe = await session.requestLightProbe(getLightProbeInit(session, this.props));
+
+    this.session = session;
+    this.referenceSpace = referenceSpace;
+    this.lightProbe = lightProbe;
+    this._reflectionRevision = 0;
+    session.addEventListener('end', this._sessionEndListener);
+    lightProbe.addEventListener('reflectionchange', this._reflectionChangeListener);
+    return this;
+  }
+
+  setWebGLBinding(device: Device | null, xrWebGLBinding: WebXRLightEstimationBinding | null): this {
+    this._destroyReflectionCubeMapTextures();
+    this.device = device;
+    this.xrWebGLBinding = xrWebGLBinding;
+    return this;
+  }
+
+  getLightEstimationState(xrFrame: XRFrame): WebXRLightEstimationState | null {
+    if (!this.session || !this.referenceSpace || !this.lightProbe) {
+      return null;
+    }
+    if (xrFrame.session !== this.session) {
+      throw new Error('XRFrame belongs to a different XRSession');
+    }
+    if (!xrFrame.getLightEstimate) {
+      return null;
+    }
+
+    const lightEstimate = xrFrame.getLightEstimate(this.lightProbe);
+    if (!lightEstimate) {
+      return null;
+    }
+
+    const probePose = xrFrame.getPose(this.lightProbe.probeSpace, this.referenceSpace) || null;
+    const reflectionCubeMap = this._getReflectionCubeMap();
+
+    return {
+      xrFrame,
+      session: this.session,
+      lightProbe: this.lightProbe,
+      lightEstimate,
+      probePose,
+      matrix: probePose?.transform.matrix ?? null,
+      sphericalHarmonicsCoefficients: lightEstimate.sphericalHarmonicsCoefficients,
+      primaryLightDirection: getDOMPointVector3(lightEstimate.primaryLightDirection),
+      primaryLightIntensity: getDOMPointVector3(lightEstimate.primaryLightIntensity),
+      reflectionCubeMap,
+      reflectionCubeMapTexture: this._getReflectionCubeMapTexture(reflectionCubeMap),
+      reflectionRevision: this._reflectionRevision
+    };
+  }
+
+  clearSession(): void {
+    this.session?.removeEventListener('end', this._sessionEndListener);
+    this.lightProbe?.removeEventListener('reflectionchange', this._reflectionChangeListener);
+    this.session = null;
+    this.referenceSpace = null;
+    this.lightProbe = null;
+    this._reflectionRevision = 0;
+    this._destroyReflectionCubeMapTextures();
+  }
+
+  destroy(): void {
+    this.clearSession();
+    this.device = null;
+    this.xrWebGLBinding = null;
+  }
+
+  private _getReflectionCubeMap(): WebGLTexture | null {
+    if (!this.xrWebGLBinding?.getReflectionCubeMap || !this.lightProbe) {
+      return null;
+    }
+
+    try {
+      return this.xrWebGLBinding.getReflectionCubeMap(this.lightProbe) || null;
+    } catch {
+      return null;
+    }
+  }
+
+  private _getReflectionCubeMapTexture(reflectionCubeMap: WebGLTexture | null): Texture | null {
+    const size = this.props.reflectionCubeMapSize;
+    if (!reflectionCubeMap || !this.device || this.device.type !== 'webgl' || !size) {
+      return null;
+    }
+
+    let texture = this._reflectionCubeMapTextures.get(reflectionCubeMap);
+    if (!texture) {
+      texture = this.device.createTexture({
+        id: `webxr-light-reflection-cube-map-${this._reflectionCubeMapTextures.size + 1}`,
+        handle: reflectionCubeMap,
+        _isHandleBorrowed: true,
+        dimension: 'cube',
+        width: size,
+        height: size,
+        depth: 6,
+        format:
+          this.props.textureFormat || getWebXRReflectionTextureFormat(this.props.reflectionFormat),
+        usage: this.props.textureUsage
+      } as TextureProps);
+      this._reflectionCubeMapTextures.set(reflectionCubeMap, texture);
+    }
+
+    return texture;
+  }
+
+  private _destroyReflectionCubeMapTextures(): void {
+    for (const texture of this._reflectionCubeMapTextures.values()) {
+      texture.destroy();
+    }
+    this._reflectionCubeMapTextures.clear();
+  }
+
+  static defaultProps: ResolvedWebXRLightEstimationManagerProps = {
+    reflectionFormat: 'srgba8',
+    reflectionCubeMapSize: undefined!,
+    textureFormat: undefined!,
+    textureUsage: TextureResource.SAMPLE
+  };
+}
+
+export function getWebXRLightEstimationSessionInit(
+  props: WebXRLightEstimationSessionInitProps = {}
+): XRSessionInit {
+  return {
+    [props.required ? 'requiredFeatures' : 'optionalFeatures']: ['light-estimation']
+  };
+}
+
+export function getWebXRReflectionTextureFormat(
+  reflectionFormat: XRReflectionFormat | 'preferred' | null | undefined
+): TextureFormat {
+  return reflectionFormat === 'rgba16f' ? 'rgba16float' : 'rgba8unorm-srgb';
+}
+
+function getLightProbeInit(
+  session: XRSession,
+  props: ResolvedWebXRLightEstimationManagerProps
+): XRLightProbeInit {
+  const reflectionFormat =
+    props.reflectionFormat === 'preferred'
+      ? session.preferredReflectionFormat || 'srgba8'
+      : props.reflectionFormat;
+
+  return {reflectionFormat};
+}
+
+function getDOMPointVector3(point: DOMPointReadOnly): [number, number, number] {
+  return [point.x, point.y, point.z];
+}

--- a/modules/experimental/src/webxr/webxr-locomotion.ts
+++ b/modules/experimental/src/webxr/webxr-locomotion.ts
@@ -1,0 +1,124 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {NumberArray2} from '@math.gl/core';
+import {getWebXRGamepadStates, type WebXRGamepadState} from './webxr-gamepad';
+import type {WebXRInputState} from './webxr-manager';
+
+export type WebXRLocomotionAxis = 'thumbstick' | 'touchpad';
+export type WebXRLocomotionHandedness = XRHandedness | 'any';
+
+export type WebXRLocomotionProps = {
+  moveHandedness?: WebXRLocomotionHandedness;
+  turnHandedness?: WebXRLocomotionHandedness;
+  axis?: WebXRLocomotionAxis;
+  deadzone?: number;
+  snapTurnThreshold?: number;
+  invertMoveY?: boolean;
+  invertTurnX?: boolean;
+};
+
+export type WebXRLocomotionState = {
+  inputStates: readonly WebXRInputState[];
+  gamepadStates: readonly WebXRGamepadState[];
+  moveInputState: WebXRInputState | null;
+  turnInputState: WebXRInputState | null;
+  move: NumberArray2;
+  turn: number;
+  snapTurn: -1 | 0 | 1;
+  moveActive: boolean;
+  turnActive: boolean;
+  axis: WebXRLocomotionAxis;
+  deadzone: number;
+  snapTurnThreshold: number;
+};
+
+const DEFAULT_DEADZONE = 0.15;
+const DEFAULT_SNAP_TURN_THRESHOLD = 0.75;
+
+/** Derives app-level movement and turn intent from WebXR gamepad axes. */
+export function getWebXRLocomotionState(
+  inputStates: readonly WebXRInputState[] | null,
+  props: WebXRLocomotionProps = {}
+): WebXRLocomotionState {
+  const resolvedInputStates = inputStates || [];
+  const gamepadStates = getWebXRGamepadStates(resolvedInputStates);
+  const axis = props.axis || 'thumbstick';
+  const deadzone = getNormalizedThreshold(props.deadzone, DEFAULT_DEADZONE);
+  const snapTurnThreshold = getNormalizedThreshold(
+    props.snapTurnThreshold,
+    DEFAULT_SNAP_TURN_THRESHOLD
+  );
+  const moveGamepadState = getWebXRLocomotionGamepadState(
+    gamepadStates,
+    props.moveHandedness || 'left',
+    axis
+  );
+  const turnGamepadState = getWebXRLocomotionGamepadState(
+    gamepadStates,
+    props.turnHandedness || 'right',
+    axis
+  );
+  const moveAxis = moveGamepadState ? getWebXRLocomotionAxes(moveGamepadState, axis) : null;
+  const turnAxis = turnGamepadState ? getWebXRLocomotionAxes(turnGamepadState, axis) : null;
+  const moveX = getWebXRLocomotionAxisValue(moveAxis?.[0] || 0, deadzone);
+  const moveY = getWebXRLocomotionAxisValue(moveAxis?.[1] || 0, deadzone);
+  const turnX = getWebXRLocomotionAxisValue(turnAxis?.[0] || 0, deadzone);
+  const move: NumberArray2 = [moveX || 0, (props.invertMoveY === false ? moveY : -moveY) || 0];
+  const turn = (props.invertTurnX ? -turnX : turnX) || 0;
+  const snapTurn: -1 | 0 | 1 = Math.abs(turn) >= snapTurnThreshold ? (turn > 0 ? 1 : -1) : 0;
+
+  return {
+    inputStates: resolvedInputStates,
+    gamepadStates,
+    moveInputState: moveGamepadState?.inputState || null,
+    turnInputState: turnGamepadState?.inputState || null,
+    move,
+    turn,
+    snapTurn,
+    moveActive: moveX !== 0 || moveY !== 0,
+    turnActive: turn !== 0,
+    axis,
+    deadzone,
+    snapTurnThreshold
+  };
+}
+
+export function getWebXRLocomotionGamepadState(
+  gamepadStates: readonly WebXRGamepadState[],
+  handedness: WebXRLocomotionHandedness,
+  axis: WebXRLocomotionAxis = 'thumbstick'
+): WebXRGamepadState | null {
+  return (
+    gamepadStates.find(
+      gamepadState =>
+        (handedness === 'any' || gamepadState.inputState.handedness === handedness) &&
+        Boolean(getWebXRLocomotionAxes(gamepadState, axis))
+    ) || null
+  );
+}
+
+export function getWebXRLocomotionAxes(
+  gamepadState: WebXRGamepadState,
+  axis: WebXRLocomotionAxis = 'thumbstick'
+): readonly [x: number, y: number] | null {
+  return axis === 'thumbstick' ? gamepadState.thumbstick : gamepadState.touchpad;
+}
+
+export function getWebXRLocomotionAxisValue(value: number, deadzone = DEFAULT_DEADZONE): number {
+  const normalizedDeadzone = getNormalizedThreshold(deadzone, DEFAULT_DEADZONE);
+  const magnitude = Math.abs(value);
+  if (magnitude <= normalizedDeadzone) {
+    return 0;
+  }
+  if (normalizedDeadzone >= 1) {
+    return value > 0 ? 1 : -1;
+  }
+  const normalizedValue = (magnitude - normalizedDeadzone) / (1 - normalizedDeadzone);
+  return (value > 0 ? normalizedValue : -normalizedValue) || 0;
+}
+
+function getNormalizedThreshold(value: number | undefined, defaultValue: number): number {
+  return Math.max(0, Math.min(1, value ?? defaultValue));
+}

--- a/modules/experimental/src/webxr/webxr-manager.ts
+++ b/modules/experimental/src/webxr/webxr-manager.ts
@@ -59,6 +59,7 @@ export type WebXRInputState = {
   targetRayMode: XRTargetRayMode;
   profiles: readonly string[];
   gamepad: Gamepad | null;
+  hand: XRHand | null;
   targetRayPose: XRPose | null;
   targetRayMatrix: Float32Array | null;
   gripPose: XRPose | null;
@@ -201,6 +202,7 @@ export class WebXRManager {
         targetRayMode: inputSource.targetRayMode,
         profiles: inputSource.profiles,
         gamepad: inputSource.gamepad ?? null,
+        hand: inputSource.hand ?? null,
         targetRayPose: targetRayPose ?? null,
         targetRayMatrix: targetRayPose?.transform.matrix ?? null,
         gripPose: gripPose ?? null,

--- a/modules/experimental/src/webxr/webxr-manager.ts
+++ b/modules/experimental/src/webxr/webxr-manager.ts
@@ -49,9 +49,18 @@ export type WebXRViewState = {
   camera: XRCamera | null;
 };
 
+/** Experimental v10 viewer pose state resolved once for an active XR frame. */
+export type WebXRViewerState = {
+  pose: XRViewerPose;
+  matrix: Float32Array;
+  viewMatrix: Float32Array;
+  position: [x: number, y: number, z: number];
+};
+
 /** Experimental v10 render state resolved from one active XR frame. */
 export type WebXRFrameState = {
   xrFrame: XRFrame;
+  viewer: WebXRViewerState;
   /** The shared WebGL framebuffer or first WebGPU view framebuffer. */
   framebuffer: Framebuffer;
   views: readonly WebXRViewState[];
@@ -292,7 +301,7 @@ export class WebXRManager {
       return makeWebXRViewState(xrView, index, framebuffer, viewport);
     });
 
-    return {xrFrame, framebuffer, views};
+    return {xrFrame, viewer: makeWebXRViewerState(viewerPose), framebuffer, views};
   }
 
   private _getWebGPUFrameState(xrFrame: XRFrame, viewerPose: XRViewerPose): WebXRFrameState {
@@ -315,7 +324,12 @@ export class WebXRManager {
       }
     }
 
-    return {xrFrame, framebuffer: views[0]!.framebuffer, views};
+    return {
+      xrFrame,
+      viewer: makeWebXRViewerState(viewerPose),
+      framebuffer: views[0]!.framebuffer,
+      views
+    };
   }
 
   private _getWebGLFramebuffer(): Framebuffer {
@@ -571,6 +585,16 @@ function makeWebXRViewState(
     projectionMatrix: xrView.projectionMatrix,
     viewMatrix: xrView.transform.inverse.matrix,
     camera: xrView.camera ?? null
+  };
+}
+
+function makeWebXRViewerState(viewerPose: XRViewerPose): WebXRViewerState {
+  const {position} = viewerPose.transform;
+  return {
+    pose: viewerPose,
+    matrix: viewerPose.transform.matrix,
+    viewMatrix: viewerPose.transform.inverse.matrix,
+    position: [position.x, position.y, position.z]
   };
 }
 

--- a/modules/experimental/src/webxr/webxr-manager.ts
+++ b/modules/experimental/src/webxr/webxr-manager.ts
@@ -51,6 +51,21 @@ export type WebXRFrameState = {
   views: readonly WebXRViewState[];
 };
 
+/** Experimental v10 input state for one active XR frame. */
+export type WebXRInputState = {
+  inputSource: XRInputSource;
+  index: number;
+  handedness: XRHandedness;
+  targetRayMode: XRTargetRayMode;
+  profiles: readonly string[];
+  gamepad: Gamepad | null;
+  targetRayPose: XRPose | null;
+  targetRayMatrix: Float32Array | null;
+  gripPose: XRPose | null;
+  gripMatrix: Float32Array | null;
+  selectActive: boolean;
+};
+
 /**
  * Experimental v10 WebXR session and per-view render-state helper.
  *
@@ -69,7 +84,11 @@ export class WebXRManager {
 
   private _framebuffer: Framebuffer | null = null;
   private _webGPUViewResources: WebXRWebGPUViewResources[] = [];
+  private _selectActiveInputSources = new Set<XRInputSource>();
   private _sessionEndListener = () => this.clearSession();
+  private _selectStartListener = (event: Event) => this._handleSelectActive(event, true);
+  private _selectEndListener = (event: Event) => this._handleSelectActive(event, false);
+  private _inputSourcesChangeListener = (event: Event) => this._handleInputSourcesChange(event);
 
   constructor(device: Device, props: WebXRManagerProps = {}) {
     if (!isWebXRWebGLDevice(device) && !isWebXRWebGPUDevice(device)) {
@@ -117,6 +136,9 @@ export class WebXRManager {
       this.referenceSpace = await session.requestReferenceSpace(this.props.referenceSpaceType);
       this.session = session;
       session.addEventListener('end', this._sessionEndListener);
+      session.addEventListener('selectstart', this._selectStartListener);
+      session.addEventListener('selectend', this._selectEndListener);
+      session.addEventListener('inputsourceschange', this._inputSourcesChangeListener);
       return this;
     } catch (error) {
       this.clearSession();
@@ -144,8 +166,44 @@ export class WebXRManager {
     return this._getWebGPUFrameState(xrFrame, viewerPose);
   }
 
+  getInputState(xrFrame: XRFrame): readonly WebXRInputState[] | null {
+    if (!this.session || !this.referenceSpace) {
+      return null;
+    }
+    if (xrFrame.session !== this.session) {
+      throw new Error('XRFrame belongs to a different XRSession');
+    }
+
+    const inputSources = Array.from(this.session.inputSources);
+    this._trimSelectActiveInputSources(inputSources);
+
+    return inputSources.map((inputSource, index) => {
+      const targetRayPose = xrFrame.getPose(inputSource.targetRaySpace, this.referenceSpace!);
+      const gripPose = inputSource.gripSpace
+        ? xrFrame.getPose(inputSource.gripSpace, this.referenceSpace!)
+        : undefined;
+
+      return {
+        inputSource,
+        index,
+        handedness: inputSource.handedness,
+        targetRayMode: inputSource.targetRayMode,
+        profiles: inputSource.profiles,
+        gamepad: inputSource.gamepad ?? null,
+        targetRayPose: targetRayPose ?? null,
+        targetRayMatrix: targetRayPose?.transform.matrix ?? null,
+        gripPose: gripPose ?? null,
+        gripMatrix: gripPose?.transform.matrix ?? null,
+        selectActive: this._selectActiveInputSources.has(inputSource)
+      };
+    });
+  }
+
   clearSession(): void {
     this.session?.removeEventListener('end', this._sessionEndListener);
+    this.session?.removeEventListener('selectstart', this._selectStartListener);
+    this.session?.removeEventListener('selectend', this._selectEndListener);
+    this.session?.removeEventListener('inputsourceschange', this._inputSourcesChangeListener);
     this._framebuffer?.destroy();
     this._framebuffer = null;
 
@@ -159,6 +217,7 @@ export class WebXRManager {
     this.webGPUBinding = null;
     this.referenceSpace = null;
     this.session = null;
+    this._selectActiveInputSources.clear();
   }
 
   destroy(): void {
@@ -337,6 +396,33 @@ export class WebXRManager {
     viewResources.framebuffer.destroy();
     viewResources.depthTexture?.destroy();
     viewResources.colorTexture.destroy();
+  }
+
+  private _handleSelectActive(event: Event, selectActive: boolean): void {
+    const inputSource = (event as XRInputSourceEvent).inputSource;
+    if (!inputSource) {
+      return;
+    }
+
+    if (selectActive) {
+      this._selectActiveInputSources.add(inputSource);
+    } else {
+      this._selectActiveInputSources.delete(inputSource);
+    }
+  }
+
+  private _handleInputSourcesChange(event: Event): void {
+    for (const inputSource of (event as XRInputSourcesChangeEvent).removed || []) {
+      this._selectActiveInputSources.delete(inputSource);
+    }
+  }
+
+  private _trimSelectActiveInputSources(inputSources: readonly XRInputSource[]): void {
+    for (const inputSource of this._selectActiveInputSources) {
+      if (!inputSources.includes(inputSource)) {
+        this._selectActiveInputSources.delete(inputSource);
+      }
+    }
   }
 
   static defaultProps: Required<WebXRManagerProps> = {

--- a/modules/experimental/src/webxr/webxr-manager.ts
+++ b/modules/experimental/src/webxr/webxr-manager.ts
@@ -57,6 +57,21 @@ export type WebXRFrameState = {
   views: readonly WebXRViewState[];
 };
 
+export type WebXRProjectionLayerControlsProps = {
+  fixedFoveation?: number | null;
+  deltaPose?: XRRigidTransform | null;
+};
+
+export type WebXRProjectionLayerState = {
+  layer: XRProjectionLayer;
+  textureWidth: number;
+  textureHeight: number;
+  textureArrayLength: number;
+  ignoreDepthValues: boolean;
+  fixedFoveation: number | null;
+  deltaPose: XRRigidTransform | null;
+};
+
 /** Experimental v10 input state for one active XR frame. */
 export type WebXRInputState = {
   inputSource: XRInputSource;
@@ -223,6 +238,18 @@ export class WebXRManager {
         squeezeActive: this._squeezeActiveInputSources.has(inputSource)
       };
     });
+  }
+
+  getProjectionLayerState(): WebXRProjectionLayerState | null {
+    return this.projectionLayer ? getWebXRProjectionLayerState(this.projectionLayer) : null;
+  }
+
+  setProjectionLayerControls(
+    props: WebXRProjectionLayerControlsProps
+  ): WebXRProjectionLayerState | null {
+    return this.projectionLayer
+      ? setWebXRProjectionLayerControls(this.projectionLayer, props)
+      : null;
   }
 
   clearSession(): void {
@@ -502,6 +529,31 @@ export async function requestWebXRReferenceSpace(
     throw lastError;
   }
   throw new Error('WebXR reference space request failed');
+}
+
+export function setWebXRProjectionLayerControls(
+  layer: XRProjectionLayer,
+  props: WebXRProjectionLayerControlsProps
+): WebXRProjectionLayerState {
+  if (props.fixedFoveation !== undefined) {
+    layer.fixedFoveation = props.fixedFoveation;
+  }
+  if (props.deltaPose !== undefined) {
+    layer.deltaPose = props.deltaPose;
+  }
+  return getWebXRProjectionLayerState(layer);
+}
+
+export function getWebXRProjectionLayerState(layer: XRProjectionLayer): WebXRProjectionLayerState {
+  return {
+    layer,
+    textureWidth: layer.textureWidth,
+    textureHeight: layer.textureHeight,
+    textureArrayLength: layer.textureArrayLength,
+    ignoreDepthValues: layer.ignoreDepthValues,
+    fixedFoveation: layer.fixedFoveation,
+    deltaPose: layer.deltaPose
+  };
 }
 
 function makeWebXRViewState(

--- a/modules/experimental/src/webxr/webxr-manager.ts
+++ b/modules/experimental/src/webxr/webxr-manager.ts
@@ -27,8 +27,14 @@ type WebXRWebGPUViewResources = {
 /** Experimental v10 WebXR session setup options. */
 export type WebXRManagerProps = {
   referenceSpaceType?: XRReferenceSpaceType;
+  referenceSpaceTypes?: readonly XRReferenceSpaceType[];
   layerInit?: XRWebGLLayerInit;
   projectionLayerInit?: XRProjectionLayerInit;
+};
+
+export type WebXRReferenceSpaceState = {
+  referenceSpace: XRReferenceSpace;
+  referenceSpaceType: XRReferenceSpaceType;
 };
 
 /** Experimental v10 per-view render state for one active XR frame. */
@@ -80,6 +86,7 @@ export class WebXRManager {
 
   session: XRSession | null = null;
   referenceSpace: XRReferenceSpace | null = null;
+  referenceSpaceType: XRReferenceSpaceType | null = null;
   baseLayer: XRWebGLLayer | null = null;
   projectionLayer: XRProjectionLayer | null = null;
   webGPUBinding: XRGPUBinding | null = null;
@@ -142,7 +149,12 @@ export class WebXRManager {
     }
 
     try {
-      this.referenceSpace = await session.requestReferenceSpace(this.props.referenceSpaceType);
+      const referenceSpaceState = await requestWebXRReferenceSpace(
+        session,
+        getWebXRReferenceSpaceTypes(this.props)
+      );
+      this.referenceSpace = referenceSpaceState.referenceSpace;
+      this.referenceSpaceType = referenceSpaceState.referenceSpaceType;
       this.session = session;
       session.addEventListener('end', this._sessionEndListener);
       session.addEventListener('selectstart', this._selectStartListener);
@@ -232,6 +244,7 @@ export class WebXRManager {
     this.projectionLayer = null;
     this.webGPUBinding = null;
     this.referenceSpace = null;
+    this.referenceSpaceType = null;
     this.session = null;
     this._selectActiveInputSources.clear();
     this._squeezeActiveInputSources.clear();
@@ -452,9 +465,43 @@ export class WebXRManager {
 
   static defaultProps: Required<WebXRManagerProps> = {
     referenceSpaceType: 'local',
+    referenceSpaceTypes: undefined!,
     layerInit: undefined!,
     projectionLayerInit: undefined!
   };
+}
+
+export function getWebXRReferenceSpaceTypes(
+  props: Pick<WebXRManagerProps, 'referenceSpaceType' | 'referenceSpaceTypes'> = {}
+): readonly XRReferenceSpaceType[] {
+  const referenceSpaceTypes =
+    props.referenceSpaceTypes && props.referenceSpaceTypes.length > 0
+      ? props.referenceSpaceTypes
+      : [props.referenceSpaceType || WebXRManager.defaultProps.referenceSpaceType];
+
+  return Array.from(new Set(referenceSpaceTypes));
+}
+
+export async function requestWebXRReferenceSpace(
+  session: XRSession,
+  referenceSpaceTypes: readonly XRReferenceSpaceType[]
+): Promise<WebXRReferenceSpaceState> {
+  let lastError: unknown = null;
+  for (const referenceSpaceType of referenceSpaceTypes) {
+    try {
+      return {
+        referenceSpace: await session.requestReferenceSpace(referenceSpaceType),
+        referenceSpaceType
+      };
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+  throw new Error('WebXR reference space request failed');
 }
 
 function makeWebXRViewState(

--- a/modules/experimental/src/webxr/webxr-manager.ts
+++ b/modules/experimental/src/webxr/webxr-manager.ts
@@ -64,6 +64,7 @@ export type WebXRInputState = {
   gripPose: XRPose | null;
   gripMatrix: Float32Array | null;
   selectActive: boolean;
+  squeezeActive: boolean;
 };
 
 /**
@@ -85,9 +86,16 @@ export class WebXRManager {
   private _framebuffer: Framebuffer | null = null;
   private _webGPUViewResources: WebXRWebGPUViewResources[] = [];
   private _selectActiveInputSources = new Set<XRInputSource>();
+  private _squeezeActiveInputSources = new Set<XRInputSource>();
   private _sessionEndListener = () => this.clearSession();
-  private _selectStartListener = (event: Event) => this._handleSelectActive(event, true);
-  private _selectEndListener = (event: Event) => this._handleSelectActive(event, false);
+  private _selectStartListener = (event: Event) =>
+    this._handleInputSourceActive(this._selectActiveInputSources, event, true);
+  private _selectEndListener = (event: Event) =>
+    this._handleInputSourceActive(this._selectActiveInputSources, event, false);
+  private _squeezeStartListener = (event: Event) =>
+    this._handleInputSourceActive(this._squeezeActiveInputSources, event, true);
+  private _squeezeEndListener = (event: Event) =>
+    this._handleInputSourceActive(this._squeezeActiveInputSources, event, false);
   private _inputSourcesChangeListener = (event: Event) => this._handleInputSourcesChange(event);
 
   constructor(device: Device, props: WebXRManagerProps = {}) {
@@ -138,6 +146,8 @@ export class WebXRManager {
       session.addEventListener('end', this._sessionEndListener);
       session.addEventListener('selectstart', this._selectStartListener);
       session.addEventListener('selectend', this._selectEndListener);
+      session.addEventListener('squeezestart', this._squeezeStartListener);
+      session.addEventListener('squeezeend', this._squeezeEndListener);
       session.addEventListener('inputsourceschange', this._inputSourcesChangeListener);
       return this;
     } catch (error) {
@@ -175,7 +185,8 @@ export class WebXRManager {
     }
 
     const inputSources = Array.from(this.session.inputSources);
-    this._trimSelectActiveInputSources(inputSources);
+    this._trimActiveInputSources(this._selectActiveInputSources, inputSources);
+    this._trimActiveInputSources(this._squeezeActiveInputSources, inputSources);
 
     return inputSources.map((inputSource, index) => {
       const targetRayPose = xrFrame.getPose(inputSource.targetRaySpace, this.referenceSpace!);
@@ -194,7 +205,8 @@ export class WebXRManager {
         targetRayMatrix: targetRayPose?.transform.matrix ?? null,
         gripPose: gripPose ?? null,
         gripMatrix: gripPose?.transform.matrix ?? null,
-        selectActive: this._selectActiveInputSources.has(inputSource)
+        selectActive: this._selectActiveInputSources.has(inputSource),
+        squeezeActive: this._squeezeActiveInputSources.has(inputSource)
       };
     });
   }
@@ -203,6 +215,8 @@ export class WebXRManager {
     this.session?.removeEventListener('end', this._sessionEndListener);
     this.session?.removeEventListener('selectstart', this._selectStartListener);
     this.session?.removeEventListener('selectend', this._selectEndListener);
+    this.session?.removeEventListener('squeezestart', this._squeezeStartListener);
+    this.session?.removeEventListener('squeezeend', this._squeezeEndListener);
     this.session?.removeEventListener('inputsourceschange', this._inputSourcesChangeListener);
     this._framebuffer?.destroy();
     this._framebuffer = null;
@@ -218,6 +232,7 @@ export class WebXRManager {
     this.referenceSpace = null;
     this.session = null;
     this._selectActiveInputSources.clear();
+    this._squeezeActiveInputSources.clear();
   }
 
   destroy(): void {
@@ -398,29 +413,37 @@ export class WebXRManager {
     viewResources.colorTexture.destroy();
   }
 
-  private _handleSelectActive(event: Event, selectActive: boolean): void {
+  private _handleInputSourceActive(
+    activeInputSources: Set<XRInputSource>,
+    event: Event,
+    active: boolean
+  ): void {
     const inputSource = (event as XRInputSourceEvent).inputSource;
     if (!inputSource) {
       return;
     }
 
-    if (selectActive) {
-      this._selectActiveInputSources.add(inputSource);
+    if (active) {
+      activeInputSources.add(inputSource);
     } else {
-      this._selectActiveInputSources.delete(inputSource);
+      activeInputSources.delete(inputSource);
     }
   }
 
   private _handleInputSourcesChange(event: Event): void {
     for (const inputSource of (event as XRInputSourcesChangeEvent).removed || []) {
       this._selectActiveInputSources.delete(inputSource);
+      this._squeezeActiveInputSources.delete(inputSource);
     }
   }
 
-  private _trimSelectActiveInputSources(inputSources: readonly XRInputSource[]): void {
-    for (const inputSource of this._selectActiveInputSources) {
+  private _trimActiveInputSources(
+    activeInputSources: Set<XRInputSource>,
+    inputSources: readonly XRInputSource[]
+  ): void {
+    for (const inputSource of activeInputSources) {
       if (!inputSources.includes(inputSource)) {
-        this._selectActiveInputSources.delete(inputSource);
+        activeInputSources.delete(inputSource);
       }
     }
   }

--- a/modules/experimental/src/webxr/webxr-media-layers.ts
+++ b/modules/experimental/src/webxr/webxr-media-layers.ts
@@ -1,0 +1,138 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export type WebXRMediaLayerType = 'quad' | 'cylinder' | 'equirect';
+
+export type WebXRMediaLayerState = {
+  session: XRSession;
+  layer: XRCompositionLayer;
+  video: HTMLVideoElement;
+  type: WebXRMediaLayerType;
+  layout: XRLayerLayout;
+  invertStereo: boolean;
+  needsRedraw: boolean;
+};
+
+type WebXRMediaLayerRecord = {
+  video: HTMLVideoElement;
+  type: WebXRMediaLayerType;
+  invertStereo: boolean;
+};
+
+/** Experimental v10 WebXR Layers API helper for video-backed composition layers. */
+export class WebXRMediaLayerManager {
+  session: XRSession | null = null;
+  xrMediaBinding: XRMediaBinding | null = null;
+
+  private _layers = new Map<XRCompositionLayer, WebXRMediaLayerRecord>();
+  private _redrawLayers = new Set<XRCompositionLayer>();
+  private _sessionEndListener = () => this.clearSession();
+  private _redrawListener = (event: Event) => this._handleLayerRedraw(event);
+
+  setSession(session: XRSession | null): this {
+    this.clearSession();
+    if (!session) {
+      return this;
+    }
+    if (typeof XRMediaBinding === 'undefined') {
+      throw new Error('WebXR media layers require XRMediaBinding');
+    }
+
+    this.session = session;
+    this.xrMediaBinding = new XRMediaBinding(session);
+    session.addEventListener('end', this._sessionEndListener);
+    return this;
+  }
+
+  createQuadLayer(video: HTMLVideoElement, init: XRMediaQuadLayerInit): XRQuadLayer {
+    if (!this.xrMediaBinding) {
+      throw new Error('WebXRMediaLayerManager has no XRMediaBinding');
+    }
+    const layer = this.xrMediaBinding.createQuadLayer(video, init);
+    this._trackLayer(layer, video, 'quad', init);
+    return layer;
+  }
+
+  createCylinderLayer(video: HTMLVideoElement, init: XRMediaCylinderLayerInit): XRCylinderLayer {
+    if (!this.xrMediaBinding) {
+      throw new Error('WebXRMediaLayerManager has no XRMediaBinding');
+    }
+    const layer = this.xrMediaBinding.createCylinderLayer(video, init);
+    this._trackLayer(layer, video, 'cylinder', init);
+    return layer;
+  }
+
+  createEquirectLayer(video: HTMLVideoElement, init: XRMediaEquirectLayerInit): XREquirectLayer {
+    if (!this.xrMediaBinding) {
+      throw new Error('WebXRMediaLayerManager has no XRMediaBinding');
+    }
+    const layer = this.xrMediaBinding.createEquirectLayer(video, init);
+    this._trackLayer(layer, video, 'equirect', init);
+    return layer;
+  }
+
+  async updateRenderState(layers: readonly XRLayer[]): Promise<void> {
+    if (!this.session) {
+      throw new Error('WebXRMediaLayerManager has no XRSession');
+    }
+    await this.session.updateRenderState({layers});
+  }
+
+  getLayerState(layer: XRCompositionLayer): WebXRMediaLayerState | null {
+    if (!this.session) {
+      return null;
+    }
+
+    const record = this._layers.get(layer);
+    if (!record) {
+      throw new Error('XRCompositionLayer is not tracked by this manager');
+    }
+
+    const needsRedraw = layer.needsRedraw || this._redrawLayers.has(layer);
+    this._redrawLayers.delete(layer);
+
+    return {
+      session: this.session,
+      layer,
+      video: record.video,
+      type: record.type,
+      layout: layer.layout,
+      invertStereo: record.invertStereo,
+      needsRedraw
+    };
+  }
+
+  clearSession(): void {
+    this.session?.removeEventListener('end', this._sessionEndListener);
+    for (const layer of this._layers.keys()) {
+      layer.removeEventListener('redraw', this._redrawListener);
+    }
+    this._layers.clear();
+    this._redrawLayers.clear();
+    this.xrMediaBinding = null;
+    this.session = null;
+  }
+
+  destroy(): void {
+    this.clearSession();
+  }
+
+  private _trackLayer(
+    layer: XRCompositionLayer,
+    video: HTMLVideoElement,
+    type: WebXRMediaLayerType,
+    init: XRMediaLayerInit
+  ): void {
+    this._layers.set(layer, {
+      video,
+      type,
+      invertStereo: init.invertStereo || false
+    });
+    layer.addEventListener('redraw', this._redrawListener);
+  }
+
+  private _handleLayerRedraw(event: Event): void {
+    this._redrawLayers.add(event.currentTarget as XRCompositionLayer);
+  }
+}

--- a/modules/experimental/src/webxr/webxr-mesh-detection.ts
+++ b/modules/experimental/src/webxr/webxr-mesh-detection.ts
@@ -1,0 +1,165 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export type WebXRMeshDetectionManagerProps = {
+  semanticLabels?: readonly string[];
+};
+
+export type WebXRMeshDetectionSessionInitProps = {
+  required?: boolean;
+};
+
+export type WebXRMeshDetectionState = {
+  xrFrame: XRFrame;
+  session: XRSession;
+  meshes: readonly WebXRMeshState[];
+  added: readonly WebXRMeshState[];
+  updated: readonly WebXRMeshState[];
+  removed: readonly WebXRMeshState[];
+};
+
+export type WebXRMeshState = {
+  xrMesh: XRMesh;
+  pose: XRPose;
+  matrix: Float32Array;
+  vertices: Float32Array;
+  indices: Uint32Array;
+  vertexCount: number;
+  triangleCount: number;
+  semanticLabel: string | null;
+  lastChangedTime: DOMHighResTimeStamp;
+};
+
+/** Experimental v10 WebXR mesh-detection state and per-frame diff helper. */
+export class WebXRMeshDetectionManager {
+  props: Required<WebXRMeshDetectionManagerProps>;
+
+  session: XRSession | null = null;
+  referenceSpace: XRReferenceSpace | null = null;
+
+  private _meshes = new Map<XRMesh, WebXRMeshState>();
+  private _sessionEndListener = () => this.clearSession();
+
+  constructor(props: WebXRMeshDetectionManagerProps = {}) {
+    this.props = {...WebXRMeshDetectionManager.defaultProps, ...props};
+  }
+
+  setSession(
+    session: XRSession | null,
+    referenceSpace: XRReferenceSpace | null,
+    props: WebXRMeshDetectionManagerProps = {}
+  ): this {
+    this.clearSession();
+    this.props = {...this.props, ...props};
+
+    if (!session) {
+      return this;
+    }
+    if (!referenceSpace) {
+      throw new Error('WebXRMeshDetectionManager requires an app reference space');
+    }
+
+    this.session = session;
+    this.referenceSpace = referenceSpace;
+    session.addEventListener('end', this._sessionEndListener);
+    return this;
+  }
+
+  getMeshDetectionState(xrFrame: XRFrame): WebXRMeshDetectionState | null {
+    if (!this.session || !this.referenceSpace) {
+      return null;
+    }
+    if (xrFrame.session !== this.session) {
+      throw new Error('XRFrame belongs to a different XRSession');
+    }
+    if (!xrFrame.detectedMeshes) {
+      return null;
+    }
+
+    const previousMeshes = this._meshes;
+    const nextMeshes = new Map<XRMesh, WebXRMeshState>();
+    const meshes: WebXRMeshState[] = [];
+    const added: WebXRMeshState[] = [];
+    const updated: WebXRMeshState[] = [];
+
+    for (const xrMesh of xrFrame.detectedMeshes) {
+      const mesh = this._getMeshState(xrFrame, xrMesh);
+      if (!mesh) {
+        continue;
+      }
+
+      nextMeshes.set(xrMesh, mesh);
+      meshes.push(mesh);
+
+      const previousMesh = previousMeshes.get(xrMesh);
+      if (!previousMesh) {
+        added.push(mesh);
+      } else if (previousMesh.lastChangedTime !== mesh.lastChangedTime) {
+        updated.push(mesh);
+      }
+    }
+
+    const removed = [...previousMeshes]
+      .filter(([xrMesh]) => !nextMeshes.has(xrMesh))
+      .map(([, mesh]) => mesh);
+
+    this._meshes = nextMeshes;
+
+    return {xrFrame, session: this.session, meshes, added, updated, removed};
+  }
+
+  clearSession(): void {
+    this.session?.removeEventListener('end', this._sessionEndListener);
+    this.session = null;
+    this.referenceSpace = null;
+    this._meshes.clear();
+  }
+
+  destroy(): void {
+    this.clearSession();
+  }
+
+  private _getMeshState(xrFrame: XRFrame, xrMesh: XRMesh): WebXRMeshState | null {
+    if (!this._matchesMesh(xrMesh)) {
+      return null;
+    }
+
+    const pose = xrFrame.getPose(xrMesh.meshSpace, this.referenceSpace!);
+    if (!pose) {
+      return null;
+    }
+
+    return {
+      xrMesh,
+      pose,
+      matrix: pose.transform.matrix,
+      vertices: xrMesh.vertices,
+      indices: xrMesh.indices,
+      vertexCount: Math.floor(xrMesh.vertices.length / 3),
+      triangleCount: Math.floor(xrMesh.indices.length / 3),
+      semanticLabel: xrMesh.semanticLabel ?? null,
+      lastChangedTime: xrMesh.lastChangedTime
+    };
+  }
+
+  private _matchesMesh(xrMesh: XRMesh): boolean {
+    const {semanticLabels} = this.props;
+    return (
+      !semanticLabels?.length ||
+      Boolean(xrMesh.semanticLabel && semanticLabels.includes(xrMesh.semanticLabel))
+    );
+  }
+
+  static defaultProps: Required<WebXRMeshDetectionManagerProps> = {
+    semanticLabels: undefined!
+  };
+}
+
+export function getWebXRMeshDetectionSessionInit(
+  props: WebXRMeshDetectionSessionInitProps = {}
+): XRSessionInit {
+  return {
+    [props.required ? 'requiredFeatures' : 'optionalFeatures']: ['mesh-detection']
+  };
+}

--- a/modules/experimental/src/webxr/webxr-plane-detection.ts
+++ b/modules/experimental/src/webxr/webxr-plane-detection.ts
@@ -1,0 +1,186 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export type WebXRPlaneDetectionManagerProps = {
+  orientations?: readonly XRPlaneOrientation[];
+  semanticLabels?: readonly string[];
+};
+
+export type WebXRPlaneDetectionSessionInitProps = {
+  required?: boolean;
+};
+
+export type WebXRPlaneDetectionState = {
+  xrFrame: XRFrame;
+  session: XRSession;
+  planes: readonly WebXRPlaneState[];
+  added: readonly WebXRPlaneState[];
+  updated: readonly WebXRPlaneState[];
+  removed: readonly WebXRPlaneState[];
+};
+
+export type WebXRPlaneState = {
+  xrPlane: XRPlane;
+  pose: XRPose;
+  matrix: Float32Array;
+  polygon: readonly [number, number, number][];
+  orientation: XRPlaneOrientation | null;
+  semanticLabel: string | null;
+  lastChangedTime: DOMHighResTimeStamp;
+};
+
+/** Experimental v10 WebXR plane-detection state and per-frame diff helper. */
+export class WebXRPlaneDetectionManager {
+  props: Required<WebXRPlaneDetectionManagerProps>;
+
+  session: XRSession | null = null;
+  referenceSpace: XRReferenceSpace | null = null;
+
+  private _planes = new Map<XRPlane, WebXRPlaneState>();
+  private _sessionEndListener = () => this.clearSession();
+
+  constructor(props: WebXRPlaneDetectionManagerProps = {}) {
+    this.props = {...WebXRPlaneDetectionManager.defaultProps, ...props};
+  }
+
+  setSession(
+    session: XRSession | null,
+    referenceSpace: XRReferenceSpace | null,
+    props: WebXRPlaneDetectionManagerProps = {}
+  ): this {
+    this.clearSession();
+    this.props = {...this.props, ...props};
+
+    if (!session) {
+      return this;
+    }
+    if (!referenceSpace) {
+      throw new Error('WebXRPlaneDetectionManager requires an app reference space');
+    }
+
+    this.session = session;
+    this.referenceSpace = referenceSpace;
+    session.addEventListener('end', this._sessionEndListener);
+    return this;
+  }
+
+  getPlaneDetectionState(xrFrame: XRFrame): WebXRPlaneDetectionState | null {
+    if (!this.session || !this.referenceSpace) {
+      return null;
+    }
+    if (xrFrame.session !== this.session) {
+      throw new Error('XRFrame belongs to a different XRSession');
+    }
+    if (!xrFrame.detectedPlanes) {
+      return null;
+    }
+
+    const previousPlanes = this._planes;
+    const nextPlanes = new Map<XRPlane, WebXRPlaneState>();
+    const planes: WebXRPlaneState[] = [];
+    const added: WebXRPlaneState[] = [];
+    const updated: WebXRPlaneState[] = [];
+
+    for (const xrPlane of xrFrame.detectedPlanes) {
+      const plane = this._getPlaneState(xrFrame, xrPlane);
+      if (!plane) {
+        continue;
+      }
+
+      nextPlanes.set(xrPlane, plane);
+      planes.push(plane);
+
+      const previousPlane = previousPlanes.get(xrPlane);
+      if (!previousPlane) {
+        added.push(plane);
+      } else if (previousPlane.lastChangedTime !== plane.lastChangedTime) {
+        updated.push(plane);
+      }
+    }
+
+    const removed = [...previousPlanes]
+      .filter(([xrPlane]) => !nextPlanes.has(xrPlane))
+      .map(([, plane]) => plane);
+
+    this._planes = nextPlanes;
+
+    return {xrFrame, session: this.session, planes, added, updated, removed};
+  }
+
+  async initiateRoomCapture(): Promise<boolean> {
+    if (!this.session?.initiateRoomCapture) {
+      return false;
+    }
+
+    await this.session.initiateRoomCapture();
+    return true;
+  }
+
+  clearSession(): void {
+    this.session?.removeEventListener('end', this._sessionEndListener);
+    this.session = null;
+    this.referenceSpace = null;
+    this._planes.clear();
+  }
+
+  destroy(): void {
+    this.clearSession();
+  }
+
+  private _getPlaneState(xrFrame: XRFrame, xrPlane: XRPlane): WebXRPlaneState | null {
+    if (!this._matchesPlane(xrPlane)) {
+      return null;
+    }
+
+    const pose = xrFrame.getPose(xrPlane.planeSpace, this.referenceSpace!);
+    if (!pose) {
+      return null;
+    }
+
+    return {
+      xrPlane,
+      pose,
+      matrix: pose.transform.matrix,
+      polygon: xrPlane.polygon.map(getDOMPointVector3),
+      orientation: xrPlane.orientation,
+      semanticLabel: xrPlane.semanticLabel ?? null,
+      lastChangedTime: xrPlane.lastChangedTime
+    };
+  }
+
+  private _matchesPlane(xrPlane: XRPlane): boolean {
+    const {orientations, semanticLabels} = this.props;
+    if (
+      orientations?.length &&
+      (!xrPlane.orientation || !orientations.includes(xrPlane.orientation))
+    ) {
+      return false;
+    }
+    if (
+      semanticLabels?.length &&
+      (!xrPlane.semanticLabel || !semanticLabels.includes(xrPlane.semanticLabel))
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  static defaultProps: Required<WebXRPlaneDetectionManagerProps> = {
+    orientations: undefined!,
+    semanticLabels: undefined!
+  };
+}
+
+export function getWebXRPlaneDetectionSessionInit(
+  props: WebXRPlaneDetectionSessionInitProps = {}
+): XRSessionInit {
+  return {
+    [props.required ? 'requiredFeatures' : 'optionalFeatures']: ['plane-detection']
+  };
+}
+
+function getDOMPointVector3(point: DOMPointReadOnly): [number, number, number] {
+  return [point.x, point.y, point.z];
+}

--- a/modules/experimental/src/webxr/webxr-reference-space.ts
+++ b/modules/experimental/src/webxr/webxr-reference-space.ts
@@ -1,0 +1,75 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export type WebXRReferenceSpaceResetState = {
+  referenceSpace: XRReferenceSpace;
+  resetCount: number;
+  lastResetEvent: XRReferenceSpaceEvent | null;
+  transform: XRRigidTransform | null;
+  matrix: Float32Array | null;
+};
+
+/** Experimental v10 helper for tracking WebXR reference-space reset events. */
+export class WebXRReferenceSpaceManager {
+  referenceSpace: XRReferenceSpace | null = null;
+  resetCount = 0;
+  lastResetEvent: XRReferenceSpaceEvent | null = null;
+
+  private _resetListener = (event: Event) => {
+    const resetEvent = event as XRReferenceSpaceEvent;
+    if (resetEvent.referenceSpace && resetEvent.referenceSpace !== this.referenceSpace) {
+      return;
+    }
+    this.resetCount++;
+    this.lastResetEvent = resetEvent;
+  };
+
+  setReferenceSpace(referenceSpace: XRReferenceSpace | null): this {
+    this.clearReferenceSpace();
+
+    if (!referenceSpace) {
+      return this;
+    }
+
+    this.referenceSpace = referenceSpace;
+    referenceSpace.addEventListener('reset', this._resetListener);
+    return this;
+  }
+
+  getReferenceSpaceState(): WebXRReferenceSpaceResetState | null {
+    return this.referenceSpace
+      ? makeWebXRReferenceSpaceState(this.referenceSpace, this.resetCount, this.lastResetEvent)
+      : null;
+  }
+
+  getOffsetReferenceSpace(originOffset: XRRigidTransform): XRReferenceSpace | null {
+    return this.referenceSpace?.getOffsetReferenceSpace?.(originOffset) || null;
+  }
+
+  clearReferenceSpace(): void {
+    this.referenceSpace?.removeEventListener('reset', this._resetListener);
+    this.referenceSpace = null;
+    this.resetCount = 0;
+    this.lastResetEvent = null;
+  }
+
+  destroy(): void {
+    this.clearReferenceSpace();
+  }
+}
+
+export function makeWebXRReferenceSpaceState(
+  referenceSpace: XRReferenceSpace,
+  resetCount: number,
+  lastResetEvent: XRReferenceSpaceEvent | null
+): WebXRReferenceSpaceResetState {
+  const transform = lastResetEvent?.transform || null;
+  return {
+    referenceSpace,
+    resetCount,
+    lastResetEvent,
+    transform,
+    matrix: transform?.matrix || null
+  };
+}

--- a/modules/experimental/src/webxr/webxr-reference-space.ts
+++ b/modules/experimental/src/webxr/webxr-reference-space.ts
@@ -2,12 +2,30 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
+import type {NumberArray3} from '@math.gl/core';
+import {isPointInWebXRBounds, type WebXRBoundsPoint} from './webxr-bounds';
+
 export type WebXRReferenceSpaceResetState = {
   referenceSpace: XRReferenceSpace;
   resetCount: number;
   lastResetEvent: XRReferenceSpaceEvent | null;
   transform: XRRigidTransform | null;
   matrix: Float32Array | null;
+};
+
+export type WebXRTeleportOffsetProps = {
+  bounds?: readonly WebXRBoundsPoint[] | null;
+  preserveY?: boolean;
+  invert?: boolean;
+  orientation?: DOMPointInit;
+};
+
+export type WebXRTeleportState = {
+  referenceSpace: XRReferenceSpace;
+  offsetReferenceSpace: XRReferenceSpace;
+  originOffset: XRRigidTransform;
+  target: NumberArray3;
+  translation: NumberArray3;
 };
 
 /** Experimental v10 helper for tracking WebXR reference-space reset events. */
@@ -47,6 +65,13 @@ export class WebXRReferenceSpaceManager {
     return this.referenceSpace?.getOffsetReferenceSpace?.(originOffset) || null;
   }
 
+  getTeleportReferenceSpace(
+    target: NumberArray3,
+    props: WebXRTeleportOffsetProps = {}
+  ): WebXRTeleportState | null {
+    return this.referenceSpace ? getWebXRTeleportState(this.referenceSpace, target, props) : null;
+  }
+
   clearReferenceSpace(): void {
     this.referenceSpace?.removeEventListener('reset', this._resetListener);
     this.referenceSpace = null;
@@ -72,4 +97,66 @@ export function makeWebXRReferenceSpaceState(
     transform,
     matrix: transform?.matrix || null
   };
+}
+
+export function getWebXRTeleportState(
+  referenceSpace: XRReferenceSpace,
+  target: NumberArray3,
+  props: WebXRTeleportOffsetProps = {}
+): WebXRTeleportState | null {
+  const originOffset = makeWebXRTeleportOffset(target, props);
+  const offsetReferenceSpace = originOffset
+    ? referenceSpace.getOffsetReferenceSpace?.(originOffset) || null
+    : null;
+
+  return originOffset && offsetReferenceSpace
+    ? {
+        referenceSpace,
+        offsetReferenceSpace,
+        originOffset,
+        target: [target[0], target[1], target[2]],
+        translation: getWebXRTeleportTranslation(target, props)
+      }
+    : null;
+}
+
+export function makeWebXRTeleportOffset(
+  target: NumberArray3,
+  props: WebXRTeleportOffsetProps = {}
+): XRRigidTransform | null {
+  if (
+    !isWebXRTeleportTargetAllowed(target, props.bounds) ||
+    typeof XRRigidTransform === 'undefined'
+  ) {
+    return null;
+  }
+
+  const translation = getWebXRTeleportTranslation(target, props);
+  return new XRRigidTransform(
+    {
+      x: translation[0],
+      y: translation[1],
+      z: translation[2]
+    },
+    props.orientation
+  );
+}
+
+export function getWebXRTeleportTranslation(
+  target: NumberArray3,
+  props: Pick<WebXRTeleportOffsetProps, 'invert' | 'preserveY'> = {}
+): NumberArray3 {
+  const multiplier = props.invert === false ? 1 : -1;
+  return [
+    target[0] * multiplier,
+    props.preserveY === false ? target[1] * multiplier : 0,
+    target[2] * multiplier
+  ];
+}
+
+export function isWebXRTeleportTargetAllowed(
+  target: NumberArray3,
+  bounds?: readonly WebXRBoundsPoint[] | null
+): boolean {
+  return !bounds || isPointInWebXRBounds(target, bounds);
 }

--- a/modules/experimental/src/webxr/webxr-render-state.ts
+++ b/modules/experimental/src/webxr/webxr-render-state.ts
@@ -1,0 +1,110 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export type WebXRRenderStateManagerProps = {
+  depthNear?: number | null;
+  depthFar?: number | null;
+  inlineVerticalFieldOfView?: number | null;
+};
+
+export type WebXRRenderState = {
+  session: XRSession;
+  depthNear: number | null;
+  depthFar: number | null;
+  inlineVerticalFieldOfView: number | null;
+  baseLayer: XRWebGLLayer | null;
+  layers: readonly XRLayer[];
+};
+
+/** Experimental v10 helper for WebXR clip planes and inline FOV render state. */
+export class WebXRRenderStateManager {
+  props: Required<WebXRRenderStateManagerProps>;
+  session: XRSession | null = null;
+
+  private _sessionEndListener = () => this.clearSession();
+
+  constructor(props: WebXRRenderStateManagerProps = {}) {
+    this.props = {...WebXRRenderStateManager.defaultProps, ...props};
+  }
+
+  async setSession(
+    session: XRSession | null,
+    props: WebXRRenderStateManagerProps = {}
+  ): Promise<this> {
+    this.clearSession();
+    this.props = {...this.props, ...props};
+
+    if (!session) {
+      return this;
+    }
+
+    this.session = session;
+    session.addEventListener('end', this._sessionEndListener);
+    await this.updateRenderState(this.props);
+    return this;
+  }
+
+  getRenderState(): WebXRRenderState | null {
+    return this.session ? makeWebXRRenderState(this.session) : null;
+  }
+
+  async updateRenderState(
+    props: WebXRRenderStateManagerProps = {}
+  ): Promise<WebXRRenderState | null> {
+    if (!this.session) {
+      return null;
+    }
+
+    this.props = {...this.props, ...props};
+    const renderStateInit = getWebXRRenderStateInit(this.props);
+    if (Object.keys(renderStateInit).length > 0) {
+      await this.session.updateRenderState(renderStateInit);
+    }
+
+    return this.getRenderState();
+  }
+
+  clearSession(): void {
+    this.session?.removeEventListener('end', this._sessionEndListener);
+    this.session = null;
+  }
+
+  destroy(): void {
+    this.clearSession();
+  }
+
+  static defaultProps: Required<WebXRRenderStateManagerProps> = {
+    depthNear: null,
+    depthFar: null,
+    inlineVerticalFieldOfView: null
+  };
+}
+
+export function makeWebXRRenderState(session: XRSession): WebXRRenderState {
+  const renderState = session.renderState;
+  return {
+    session,
+    depthNear: renderState?.depthNear ?? null,
+    depthFar: renderState?.depthFar ?? null,
+    inlineVerticalFieldOfView: renderState?.inlineVerticalFieldOfView ?? null,
+    baseLayer: renderState?.baseLayer ?? null,
+    layers: renderState?.layers ? Array.from(renderState.layers) : []
+  };
+}
+
+export function getWebXRRenderStateInit(
+  props: WebXRRenderStateManagerProps = {}
+): XRRenderStateInit {
+  const renderStateInit: XRRenderStateInit = {};
+  if (props.depthNear !== null && props.depthNear !== undefined) {
+    renderStateInit.depthNear = props.depthNear;
+  }
+  if (props.depthFar !== null && props.depthFar !== undefined) {
+    renderStateInit.depthFar = props.depthFar;
+  }
+  if (props.inlineVerticalFieldOfView !== null && props.inlineVerticalFieldOfView !== undefined) {
+    renderStateInit.inlineVerticalFieldOfView = props.inlineVerticalFieldOfView;
+  }
+  return renderStateInit;
+}

--- a/modules/experimental/src/webxr/webxr-session-init.ts
+++ b/modules/experimental/src/webxr/webxr-session-init.ts
@@ -1,0 +1,129 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export type WebXRSessionFeature = string;
+
+export type WebXRSessionFeatures = {
+  requiredFeatures: readonly WebXRSessionFeature[];
+  optionalFeatures: readonly WebXRSessionFeature[];
+  requestedFeatures: readonly WebXRSessionFeature[];
+};
+
+export type WebXRSessionSupportProps = {
+  xr?: XRSystem | null;
+  modes?: readonly XRSessionMode[];
+};
+
+export type WebXRSessionSupport = {
+  xr: XRSystem | null;
+  isSupported: boolean;
+  modes: Partial<Record<XRSessionMode, boolean>>;
+  supportedModes: readonly XRSessionMode[];
+};
+
+export const WEBXR_DEFAULT_SESSION_SUPPORT_MODES: readonly XRSessionMode[] = [
+  'immersive-vr',
+  'immersive-ar',
+  'inline'
+];
+
+/** Merges WebXR session init dictionaries while de-duplicating feature descriptors. */
+export function mergeWebXRSessionInit(
+  ...sessionInits: (XRSessionInit | null | undefined)[]
+): XRSessionInit {
+  const mergedSessionInit = {} as XRSessionInit;
+  const requiredFeatureSet = new Set<WebXRSessionFeature>();
+  const optionalFeatureSet = new Set<WebXRSessionFeature>();
+
+  for (const sessionInit of sessionInits) {
+    if (!sessionInit) {
+      continue;
+    }
+    Object.assign(mergedSessionInit, sessionInit);
+    for (const feature of sessionInit.requiredFeatures || []) {
+      requiredFeatureSet.add(feature);
+    }
+    for (const feature of sessionInit.optionalFeatures || []) {
+      optionalFeatureSet.add(feature);
+    }
+  }
+
+  const requiredFeatures = Array.from(requiredFeatureSet);
+  const optionalFeatures = Array.from(optionalFeatureSet).filter(
+    feature => !requiredFeatureSet.has(feature)
+  );
+
+  delete mergedSessionInit.requiredFeatures;
+  delete mergedSessionInit.optionalFeatures;
+  if (requiredFeatures.length > 0) {
+    mergedSessionInit.requiredFeatures = requiredFeatures;
+  }
+  if (optionalFeatures.length > 0) {
+    mergedSessionInit.optionalFeatures = optionalFeatures;
+  }
+
+  return mergedSessionInit;
+}
+
+export function getWebXRSessionFeatures(
+  sessionInit: Pick<XRSessionInit, 'requiredFeatures' | 'optionalFeatures'> = {}
+): WebXRSessionFeatures {
+  const requiredFeatures = Array.from(new Set(sessionInit.requiredFeatures || []));
+  const optionalFeatures = Array.from(new Set(sessionInit.optionalFeatures || [])).filter(
+    feature => !requiredFeatures.includes(feature)
+  );
+  return {
+    requiredFeatures,
+    optionalFeatures,
+    requestedFeatures: [...requiredFeatures, ...optionalFeatures]
+  };
+}
+
+export function isWebXRSessionFeatureEnabled(
+  session: XRSession,
+  feature: WebXRSessionFeature
+): boolean {
+  return Boolean(session.enabledFeatures?.includes(feature));
+}
+
+export async function getWebXRSessionSupport(
+  props: WebXRSessionSupportProps = {}
+): Promise<WebXRSessionSupport> {
+  const xr = props.xr === undefined ? getNavigatorXR() : props.xr;
+  const modes = props.modes || WEBXR_DEFAULT_SESSION_SUPPORT_MODES;
+  const modeSupport: Partial<Record<XRSessionMode, boolean>> = {};
+
+  if (!xr) {
+    return {
+      xr: null,
+      isSupported: false,
+      modes: modeSupport,
+      supportedModes: []
+    };
+  }
+
+  for (const mode of modes) {
+    modeSupport[mode] = await isWebXRSessionModeSupported(xr, mode);
+  }
+
+  const supportedModes = modes.filter(mode => modeSupport[mode]);
+  return {
+    xr,
+    isSupported: supportedModes.length > 0,
+    modes: modeSupport,
+    supportedModes
+  };
+}
+
+async function isWebXRSessionModeSupported(xr: XRSystem, mode: XRSessionMode): Promise<boolean> {
+  try {
+    return await xr.isSessionSupported(mode);
+  } catch {
+    return false;
+  }
+}
+
+function getNavigatorXR(): XRSystem | null {
+  return typeof navigator !== 'undefined' ? navigator.xr || null : null;
+}

--- a/modules/experimental/src/webxr/webxr-session-state.ts
+++ b/modules/experimental/src/webxr/webxr-session-state.ts
@@ -1,0 +1,135 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export type WebXRTargetFrameRate = number | 'highest' | 'lowest';
+
+export type WebXRSessionStateManagerProps = {
+  targetFrameRate?: WebXRTargetFrameRate | null;
+};
+
+export type WebXRSessionState = {
+  session: XRSession;
+  visibilityState: XRVisibilityState;
+  frameRate: number | null;
+  supportedFrameRates: readonly number[];
+  isVisible: boolean;
+  isFocused: boolean;
+  isSystemKeyboardSupported: boolean | null;
+};
+
+/** Experimental v10 WebXR session visibility and frame-rate helper. */
+export class WebXRSessionStateManager {
+  props: Required<WebXRSessionStateManagerProps>;
+  session: XRSession | null = null;
+
+  private _sessionState: WebXRSessionState | null = null;
+  private _sessionEndListener = () => this.clearSession();
+  private _sessionStateChangeListener = () => {
+    this._sessionState = this.session ? makeWebXRSessionState(this.session) : null;
+  };
+
+  constructor(props: WebXRSessionStateManagerProps = {}) {
+    this.props = {...WebXRSessionStateManager.defaultProps, ...props};
+  }
+
+  async setSession(
+    session: XRSession | null,
+    props: WebXRSessionStateManagerProps = {}
+  ): Promise<this> {
+    this.clearSession();
+    this.props = {...this.props, ...props};
+
+    if (!session) {
+      return this;
+    }
+
+    this.session = session;
+    this._sessionState = makeWebXRSessionState(session);
+    session.addEventListener('end', this._sessionEndListener);
+    session.addEventListener('visibilitychange', this._sessionStateChangeListener);
+    session.addEventListener('frameratechange', this._sessionStateChangeListener);
+
+    if (this.props.targetFrameRate !== null) {
+      await this.updateTargetFrameRate(this.props.targetFrameRate);
+    }
+
+    return this;
+  }
+
+  getSessionState(): WebXRSessionState | null {
+    if (!this.session) {
+      return null;
+    }
+    this._sessionState = makeWebXRSessionState(this.session);
+    return this._sessionState;
+  }
+
+  async updateTargetFrameRate(targetFrameRate: WebXRTargetFrameRate): Promise<number | null> {
+    if (!this.session) {
+      return null;
+    }
+
+    const targetFrameRateValue = getWebXRTargetFrameRate(this.session, targetFrameRate);
+    if (targetFrameRateValue === null || !this.session.updateTargetFrameRate) {
+      return null;
+    }
+
+    await this.session.updateTargetFrameRate(targetFrameRateValue);
+    this._sessionState = makeWebXRSessionState(this.session);
+    return targetFrameRateValue;
+  }
+
+  clearSession(): void {
+    this.session?.removeEventListener('end', this._sessionEndListener);
+    this.session?.removeEventListener('visibilitychange', this._sessionStateChangeListener);
+    this.session?.removeEventListener('frameratechange', this._sessionStateChangeListener);
+    this.session = null;
+    this._sessionState = null;
+  }
+
+  destroy(): void {
+    this.clearSession();
+  }
+
+  static defaultProps: Required<WebXRSessionStateManagerProps> = {
+    targetFrameRate: null
+  };
+}
+
+export function makeWebXRSessionState(session: XRSession): WebXRSessionState {
+  const visibilityState = session.visibilityState || 'visible';
+
+  return {
+    session,
+    visibilityState,
+    frameRate: session.frameRate ?? null,
+    supportedFrameRates: getWebXRSupportedFrameRates(session),
+    isVisible: visibilityState !== 'hidden',
+    isFocused: visibilityState === 'visible',
+    isSystemKeyboardSupported: session.isSystemKeyboardSupported ?? null
+  };
+}
+
+export function getWebXRSupportedFrameRates(session: XRSession): readonly number[] {
+  return session.supportedFrameRates ? Array.from(session.supportedFrameRates) : [];
+}
+
+export function getWebXRTargetFrameRate(
+  session: XRSession,
+  targetFrameRate: WebXRTargetFrameRate
+): number | null {
+  const supportedFrameRates = getWebXRSupportedFrameRates(session);
+  if (supportedFrameRates.length === 0) {
+    return typeof targetFrameRate === 'number' ? targetFrameRate : null;
+  }
+
+  if (targetFrameRate === 'highest') {
+    return Math.max(...supportedFrameRates);
+  }
+  if (targetFrameRate === 'lowest') {
+    return Math.min(...supportedFrameRates);
+  }
+
+  return supportedFrameRates.includes(targetFrameRate) ? targetFrameRate : null;
+}

--- a/modules/experimental/src/webxr/webxr-session-state.ts
+++ b/modules/experimental/src/webxr/webxr-session-state.ts
@@ -18,6 +18,12 @@ export type WebXRSessionState = {
   isSystemKeyboardSupported: boolean | null;
 };
 
+export type WebXRSessionRenderState = {
+  isRenderable: boolean;
+  acceptsInput: boolean;
+  intensityScale: number;
+};
+
 /** Experimental v10 WebXR session visibility and frame-rate helper. */
 export class WebXRSessionStateManager {
   props: Required<WebXRSessionStateManagerProps>;
@@ -132,4 +138,30 @@ export function getWebXRTargetFrameRate(
   }
 
   return supportedFrameRates.includes(targetFrameRate) ? targetFrameRate : null;
+}
+
+export function getWebXRSessionRenderState(
+  sessionState: WebXRSessionState | null
+): WebXRSessionRenderState {
+  if (!sessionState) {
+    return {
+      isRenderable: true,
+      acceptsInput: true,
+      intensityScale: 1
+    };
+  }
+
+  if (!sessionState.isVisible) {
+    return {
+      isRenderable: false,
+      acceptsInput: false,
+      intensityScale: 0
+    };
+  }
+
+  return {
+    isRenderable: true,
+    acceptsInput: sessionState.isFocused,
+    intensityScale: sessionState.isFocused ? 1 : 0.62
+  };
 }

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -143,6 +143,10 @@ declare global {
 
   interface XRReferenceSpace extends XRSpace {}
 
+  interface XRBoundedReferenceSpace extends XRReferenceSpace {
+    readonly boundsGeometry: readonly DOMPointReadOnly[];
+  }
+
   interface XRInputSourceArray {
     readonly length: number;
     readonly [index: number]: XRInputSource;

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -515,7 +515,14 @@ declare global {
     textureUsage?: GPUTextureUsageFlags;
   }
 
-  interface XRProjectionLayer extends XRLayer {}
+  interface XRProjectionLayer extends XRCompositionLayer {
+    readonly textureWidth: number;
+    readonly textureHeight: number;
+    readonly textureArrayLength: number;
+    readonly ignoreDepthValues: boolean;
+    fixedFoveation: number | null;
+    deltaPose: XRRigidTransform | null;
+  }
 
   interface XRGPUSubImage {
     readonly colorTexture: GPUTexture;

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -35,6 +35,32 @@ declare global {
   type XRDepthType = 'raw' | 'smooth';
   type XRDepthUsage = 'cpu-optimized' | 'gpu-optimized';
   type XRTextureType = number;
+  type XRHandJoint =
+    | 'wrist'
+    | 'thumb-metacarpal'
+    | 'thumb-phalanx-proximal'
+    | 'thumb-phalanx-distal'
+    | 'thumb-tip'
+    | 'index-finger-metacarpal'
+    | 'index-finger-phalanx-proximal'
+    | 'index-finger-phalanx-intermediate'
+    | 'index-finger-phalanx-distal'
+    | 'index-finger-tip'
+    | 'middle-finger-metacarpal'
+    | 'middle-finger-phalanx-proximal'
+    | 'middle-finger-phalanx-intermediate'
+    | 'middle-finger-phalanx-distal'
+    | 'middle-finger-tip'
+    | 'ring-finger-metacarpal'
+    | 'ring-finger-phalanx-proximal'
+    | 'ring-finger-phalanx-intermediate'
+    | 'ring-finger-phalanx-distal'
+    | 'ring-finger-tip'
+    | 'pinky-finger-metacarpal'
+    | 'pinky-finger-phalanx-proximal'
+    | 'pinky-finger-phalanx-intermediate'
+    | 'pinky-finger-phalanx-distal'
+    | 'pinky-finger-tip';
   type XRFrameRequestCallback = (time: DOMHighResTimeStamp, frame: XRFrame) => void;
 
   interface XRSystem extends EventTarget {
@@ -100,6 +126,16 @@ declare global {
 
   interface XRHand {
     readonly size: number;
+    get(jointName: XRHandJoint): XRJointSpace | undefined;
+    [Symbol.iterator](): IterableIterator<[XRHandJoint, XRJointSpace]>;
+  }
+
+  interface XRJointSpace extends XRSpace {
+    readonly jointName: XRHandJoint;
+  }
+
+  interface XRJointPose extends XRPose {
+    readonly radius: number;
   }
 
   interface XRInputSourceEvent extends Event {
@@ -165,8 +201,11 @@ declare global {
     readonly session: XRSession;
     readonly trackedAnchors?: ReadonlySet<XRAnchor>;
     createAnchor?(pose: XRRigidTransform, space: XRSpace): Promise<XRAnchor>;
+    fillJointRadii?(jointSpaces: readonly XRJointSpace[], radii: Float32Array): boolean;
+    fillPoses?(spaces: readonly XRSpace[], baseSpace: XRSpace, transforms: Float32Array): boolean;
     getDepthInformation?(view: XRView): XRCPUDepthInformation | null;
     getHitTestResults?(hitTestSource: XRHitTestSource): XRHitTestResult[];
+    getJointPose?(joint: XRJointSpace, baseSpace: XRSpace): XRJointPose | null;
     getPose(space: XRSpace, baseSpace: XRSpace): XRPose | undefined;
     getViewerPose(referenceSpace: XRReferenceSpace): XRViewerPose | undefined;
   }

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -227,6 +227,16 @@ declare global {
 
   interface XRPlaneSet extends ReadonlySet<XRPlane> {}
 
+  interface XRMesh {
+    readonly meshSpace: XRSpace;
+    readonly vertices: Float32Array;
+    readonly indices: Uint32Array;
+    readonly lastChangedTime: DOMHighResTimeStamp;
+    readonly semanticLabel?: string | null;
+  }
+
+  interface XRMeshSet extends ReadonlySet<XRMesh> {}
+
   interface XRDepthInformation {
     readonly width: number;
     readonly height: number;
@@ -249,6 +259,7 @@ declare global {
     readonly session: XRSession;
     readonly trackedAnchors?: ReadonlySet<XRAnchor>;
     readonly detectedPlanes?: XRPlaneSet;
+    readonly detectedMeshes?: XRMeshSet;
     createAnchor?(pose: XRRigidTransform, space: XRSpace): Promise<XRAnchor>;
     fillJointRadii?(jointSpaces: readonly XRJointSpace[], radii: Float32Array): boolean;
     fillPoses?(spaces: readonly XRSpace[], baseSpace: XRSpace, transforms: Float32Array): boolean;

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -30,6 +30,7 @@ declare global {
   }
 
   type XRSessionMode = 'inline' | 'immersive-vr' | 'immersive-ar';
+  type XRVisibilityState = 'visible' | 'visible-blurred' | 'hidden';
   type XRReferenceSpaceType = 'viewer' | 'local' | 'local-floor' | 'bounded-floor' | 'unbounded';
   type XREye = 'none' | 'left' | 'right';
   type XRHandedness = 'none' | 'left' | 'right';
@@ -116,6 +117,10 @@ declare global {
   interface XRSession extends EventTarget {
     readonly enabledFeatures?: readonly string[];
     readonly inputSources: XRInputSourceArray;
+    readonly visibilityState?: XRVisibilityState;
+    readonly frameRate?: number;
+    readonly supportedFrameRates?: Float32Array | readonly number[];
+    readonly isSystemKeyboardSupported?: boolean;
     readonly depthUsage?: XRDepthUsage;
     readonly depthDataFormat?: XRDepthDataFormat;
     readonly depthType?: XRDepthType | null;
@@ -137,6 +142,7 @@ declare global {
     initiateRoomCapture?(): Promise<void>;
     resumeDepthSensing?(): void;
     updateRenderState(renderStateInit?: XRRenderStateInit): Promise<void>;
+    updateTargetFrameRate?(rate: number): Promise<void>;
   }
 
   interface XRSpace extends EventTarget {}

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -38,6 +38,7 @@ declare global {
   type XRDepthDataFormat = 'luminance-alpha' | 'float32' | 'unsigned-short';
   type XRDepthType = 'raw' | 'smooth';
   type XRDepthUsage = 'cpu-optimized' | 'gpu-optimized';
+  type XRReflectionFormat = 'srgba8' | 'rgba16f';
   type XRTextureType = number;
   type XRLayerTextureType = 'texture' | 'texture-array';
   type XRLayerLayout = 'default' | 'mono' | 'stereo' | 'stereo-left-right' | 'stereo-top-bottom';
@@ -111,12 +112,14 @@ declare global {
     readonly depthType?: XRDepthType | null;
     readonly depthActive?: boolean;
     readonly domOverlayState?: XRDOMOverlayState | null;
+    readonly preferredReflectionFormat?: XRReflectionFormat;
 
     cancelAnimationFrame(animationFrameId: number): void;
     end(): Promise<void>;
     pauseDepthSensing?(): void;
     requestAnimationFrame(callback: XRFrameRequestCallback): number;
     requestHitTestSource?(options: XRHitTestOptionsInit): Promise<XRHitTestSource | null>;
+    requestLightProbe?(options?: XRLightProbeInit): Promise<XRLightProbe>;
     requestReferenceSpace(type: XRReferenceSpaceType): Promise<XRReferenceSpace>;
     resumeDepthSensing?(): void;
     updateRenderState(renderStateInit?: XRRenderStateInit): Promise<void>;
@@ -197,6 +200,21 @@ declare global {
     delete(): void;
   }
 
+  interface XRLightProbe extends EventTarget {
+    readonly probeSpace: XRSpace;
+    onreflectionchange: ((this: XRLightProbe, event: Event) => unknown) | null;
+  }
+
+  interface XRLightProbeInit {
+    reflectionFormat?: XRReflectionFormat;
+  }
+
+  interface XRLightEstimate {
+    readonly sphericalHarmonicsCoefficients: Float32Array;
+    readonly primaryLightDirection: DOMPointReadOnly;
+    readonly primaryLightIntensity: DOMPointReadOnly;
+  }
+
   interface XRDepthInformation {
     readonly width: number;
     readonly height: number;
@@ -224,6 +242,7 @@ declare global {
     getDepthInformation?(view: XRView): XRCPUDepthInformation | null;
     getHitTestResults?(hitTestSource: XRHitTestSource): XRHitTestResult[];
     getJointPose?(joint: XRJointSpace, baseSpace: XRSpace): XRJointPose | null;
+    getLightEstimate?(lightProbe: XRLightProbe): XRLightEstimate | null;
     getPose(space: XRSpace, baseSpace: XRSpace): XRPose | undefined;
     getViewerPose(referenceSpace: XRReferenceSpace): XRViewerPose | undefined;
   }
@@ -435,6 +454,7 @@ declare global {
     createCubeLayer(layerInit: XRCubeLayerInit): XRCubeLayer;
     getCameraImage(camera: XRCamera): WebGLTexture | null;
     getDepthInformation?(view: XRView): XRWebGLDepthInformation | null;
+    getReflectionCubeMap?(lightProbe: XRLightProbe): WebGLTexture | null;
     getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye): XRWebGLSubImage;
     getViewSubImage(layer: XRProjectionLayer, view: XRView): XRWebGLSubImage;
   }
@@ -463,6 +483,9 @@ declare global {
 }
 
 export type WebXRDepthBinding = Pick<XRWebGLBinding, 'getDepthInformation'>;
+
+/** Experimental v10 WebXR lighting-estimation reflection cube-map subset. */
+export type WebXRLightEstimationBinding = Pick<XRWebGLBinding, 'getReflectionCubeMap'>;
 
 /** Experimental v10 raw-camera subset required by WebXRCameraTexture. */
 export type WebXRRawCameraBinding = Pick<XRWebGLBinding, 'getCameraImage'>;

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -147,7 +147,20 @@ declare global {
 
   interface XRSpace extends EventTarget {}
 
-  interface XRReferenceSpace extends XRSpace {}
+  interface XRReferenceSpace extends XRSpace {
+    getOffsetReferenceSpace?(originOffset: XRRigidTransform): XRReferenceSpace;
+    onreset?: ((this: XRReferenceSpace, event: XRReferenceSpaceEvent) => unknown) | null;
+  }
+
+  interface XRReferenceSpaceEvent extends Event {
+    readonly referenceSpace: XRReferenceSpace;
+    readonly transform: XRRigidTransform | null;
+  }
+
+  interface XRReferenceSpaceEventInit extends EventInit {
+    referenceSpace: XRReferenceSpace;
+    transform?: XRRigidTransform | null;
+  }
 
   interface XRBoundedReferenceSpace extends XRReferenceSpace {
     readonly boundsGeometry: readonly DOMPointReadOnly[];

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -344,11 +344,13 @@ declare global {
     getViewerPose(referenceSpace: XRReferenceSpace): XRViewerPose | undefined;
   }
 
-  interface XRViewerPose {
+  interface XRViewerPose extends XRPose {
     readonly views: readonly XRView[];
   }
 
   interface XRRigidTransform {
+    readonly position: DOMPointReadOnly;
+    readonly orientation: DOMPointReadOnly;
     readonly matrix: Float32Array;
     readonly inverse: XRRigidTransform;
   }

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -35,6 +35,7 @@ declare global {
   type XRHandedness = 'none' | 'left' | 'right';
   type XRTargetRayMode = 'gaze' | 'tracked-pointer' | 'screen';
   type XRHitTestTrackableType = 'point' | 'plane' | 'mesh';
+  type XRPlaneOrientation = 'horizontal' | 'vertical';
   type XRDepthDataFormat = 'luminance-alpha' | 'float32' | 'unsigned-short';
   type XRDepthType = 'raw' | 'smooth';
   type XRDepthUsage = 'cpu-optimized' | 'gpu-optimized';
@@ -121,6 +122,7 @@ declare global {
     requestHitTestSource?(options: XRHitTestOptionsInit): Promise<XRHitTestSource | null>;
     requestLightProbe?(options?: XRLightProbeInit): Promise<XRLightProbe>;
     requestReferenceSpace(type: XRReferenceSpaceType): Promise<XRReferenceSpace>;
+    initiateRoomCapture?(): Promise<void>;
     resumeDepthSensing?(): void;
     updateRenderState(renderStateInit?: XRRenderStateInit): Promise<void>;
   }
@@ -215,6 +217,16 @@ declare global {
     readonly primaryLightIntensity: DOMPointReadOnly;
   }
 
+  interface XRPlane {
+    readonly planeSpace: XRSpace;
+    readonly polygon: readonly DOMPointReadOnly[];
+    readonly orientation: XRPlaneOrientation | null;
+    readonly lastChangedTime: DOMHighResTimeStamp;
+    readonly semanticLabel?: string | null;
+  }
+
+  interface XRPlaneSet extends ReadonlySet<XRPlane> {}
+
   interface XRDepthInformation {
     readonly width: number;
     readonly height: number;
@@ -236,6 +248,7 @@ declare global {
   interface XRFrame {
     readonly session: XRSession;
     readonly trackedAnchors?: ReadonlySet<XRAnchor>;
+    readonly detectedPlanes?: XRPlaneSet;
     createAnchor?(pose: XRRigidTransform, space: XRSpace): Promise<XRAnchor>;
     fillJointRadii?(jointSpaces: readonly XRJointSpace[], radii: Float32Array): boolean;
     fillPoses?(spaces: readonly XRSpace[], baseSpace: XRSpace, transforms: Float32Array): boolean;

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -129,6 +129,9 @@ declare global {
     pauseDepthSensing?(): void;
     requestAnimationFrame(callback: XRFrameRequestCallback): number;
     requestHitTestSource?(options: XRHitTestOptionsInit): Promise<XRHitTestSource | null>;
+    requestHitTestSourceForTransientInput?(
+      options: XRTransientInputHitTestOptionsInit
+    ): Promise<XRTransientInputHitTestSource | null>;
     requestLightProbe?(options?: XRLightProbeInit): Promise<XRLightProbe>;
     requestReferenceSpace(type: XRReferenceSpaceType): Promise<XRReferenceSpace>;
     initiateRoomCapture?(): Promise<void>;
@@ -197,13 +200,28 @@ declare global {
     entityTypes?: XRHitTestTrackableType[];
   }
 
+  interface XRTransientInputHitTestOptionsInit {
+    profile: string;
+    offsetRay?: XRRay;
+    entityTypes?: XRHitTestTrackableType[];
+  }
+
   interface XRHitTestSource {
+    cancel(): void;
+  }
+
+  interface XRTransientInputHitTestSource {
     cancel(): void;
   }
 
   interface XRHitTestResult {
     createAnchor?(): Promise<XRAnchor>;
     getPose(baseSpace: XRSpace): XRPose | undefined;
+  }
+
+  interface XRTransientInputHitTestResult {
+    readonly inputSource: XRInputSource;
+    readonly results: readonly XRHitTestResult[];
   }
 
   interface XRAnchor {
@@ -281,6 +299,9 @@ declare global {
     fillPoses?(spaces: readonly XRSpace[], baseSpace: XRSpace, transforms: Float32Array): boolean;
     getDepthInformation?(view: XRView): XRCPUDepthInformation | null;
     getHitTestResults?(hitTestSource: XRHitTestSource): XRHitTestResult[];
+    getHitTestResultsForTransientInput?(
+      hitTestSource: XRTransientInputHitTestSource
+    ): XRTransientInputHitTestResult[];
     getImageTrackingResults?(): readonly XRImageTrackingResult[];
     getJointPose?(joint: XRJointSpace, baseSpace: XRSpace): XRJointPose | null;
     getLightEstimate?(lightProbe: XRLightProbe): XRLightEstimate | null;

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -35,6 +35,8 @@ declare global {
   type XRHandedness = 'none' | 'left' | 'right';
   type XRTargetRayMode = 'gaze' | 'tracked-pointer' | 'screen';
   type XRHitTestTrackableType = 'point' | 'plane' | 'mesh';
+  type XRImageTrackability = 'untrackable' | 'trackable';
+  type XRImageTrackingState = 'untracked' | 'tracked' | 'emulated';
   type XRPlaneOrientation = 'horizontal' | 'vertical';
   type XRDepthDataFormat = 'luminance-alpha' | 'float32' | 'unsigned-short';
   type XRDepthType = 'raw' | 'smooth';
@@ -83,6 +85,12 @@ declare global {
     requiredFeatures?: string[];
     depthSensing?: XRDepthStateInit;
     domOverlay?: XRDOMOverlayInit;
+    trackedImages?: XRTrackedImageInit[];
+  }
+
+  interface XRTrackedImageInit {
+    image: ImageBitmap;
+    widthInMeters: number;
   }
 
   interface XRDOMOverlayInit {
@@ -117,6 +125,7 @@ declare global {
 
     cancelAnimationFrame(animationFrameId: number): void;
     end(): Promise<void>;
+    getImageTrackability?(): Promise<readonly XRImageTrackability[]>;
     pauseDepthSensing?(): void;
     requestAnimationFrame(callback: XRFrameRequestCallback): number;
     requestHitTestSource?(options: XRHitTestOptionsInit): Promise<XRHitTestSource | null>;
@@ -237,6 +246,13 @@ declare global {
 
   interface XRMeshSet extends ReadonlySet<XRMesh> {}
 
+  interface XRImageTrackingResult {
+    readonly imageSpace: XRSpace;
+    readonly index: number;
+    readonly trackingState: XRImageTrackingState;
+    readonly measuredWidthInMeters: number;
+  }
+
   interface XRDepthInformation {
     readonly width: number;
     readonly height: number;
@@ -265,6 +281,7 @@ declare global {
     fillPoses?(spaces: readonly XRSpace[], baseSpace: XRSpace, transforms: Float32Array): boolean;
     getDepthInformation?(view: XRView): XRCPUDepthInformation | null;
     getHitTestResults?(hitTestSource: XRHitTestSource): XRHitTestResult[];
+    getImageTrackingResults?(): readonly XRImageTrackingResult[];
     getJointPose?(joint: XRJointSpace, baseSpace: XRSpace): XRJointPose | null;
     getLightEstimate?(lightProbe: XRLightProbe): XRLightEstimate | null;
     getPose(space: XRSpace, baseSpace: XRSpace): XRPose | undefined;

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -116,11 +116,19 @@ declare global {
   }
 
   interface XRHitTestResult {
+    createAnchor?(): Promise<XRAnchor>;
     getPose(baseSpace: XRSpace): XRPose | undefined;
+  }
+
+  interface XRAnchor {
+    readonly anchorSpace: XRSpace;
+    delete(): void;
   }
 
   interface XRFrame {
     readonly session: XRSession;
+    readonly trackedAnchors?: ReadonlySet<XRAnchor>;
+    createAnchor?(pose: XRRigidTransform, space: XRSpace): Promise<XRAnchor>;
     getHitTestResults?(hitTestSource: XRHitTestSource): XRHitTestResult[];
     getPose(space: XRSpace, baseSpace: XRSpace): XRPose | undefined;
     getViewerPose(referenceSpace: XRReferenceSpace): XRViewerPose | undefined;

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -110,13 +110,25 @@ declare global {
   }
 
   interface XRRenderStateInit {
+    depthNear?: number;
+    depthFar?: number;
+    inlineVerticalFieldOfView?: number;
     baseLayer?: XRWebGLLayer;
     layers?: readonly XRLayer[];
+  }
+
+  interface XRRenderState {
+    readonly depthNear: number;
+    readonly depthFar: number;
+    readonly inlineVerticalFieldOfView: number | null;
+    readonly baseLayer: XRWebGLLayer | null;
+    readonly layers?: readonly XRLayer[];
   }
 
   interface XRSession extends EventTarget {
     readonly enabledFeatures?: readonly string[];
     readonly inputSources: XRInputSourceArray;
+    readonly renderState?: XRRenderState;
     readonly visibilityState?: XRVisibilityState;
     readonly frameRate?: number;
     readonly supportedFrameRates?: Float32Array | readonly number[];

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -30,6 +30,7 @@ declare global {
   type XREye = 'none' | 'left' | 'right';
   type XRHandedness = 'none' | 'left' | 'right';
   type XRTargetRayMode = 'gaze' | 'tracked-pointer' | 'screen';
+  type XRHitTestTrackableType = 'point' | 'plane' | 'mesh';
   type XRFrameRequestCallback = (time: DOMHighResTimeStamp, frame: XRFrame) => void;
 
   interface XRSystem extends EventTarget {
@@ -54,6 +55,7 @@ declare global {
     cancelAnimationFrame(animationFrameId: number): void;
     end(): Promise<void>;
     requestAnimationFrame(callback: XRFrameRequestCallback): number;
+    requestHitTestSource?(options: XRHitTestOptionsInit): Promise<XRHitTestSource | null>;
     requestReferenceSpace(type: XRReferenceSpaceType): Promise<XRReferenceSpace>;
     updateRenderState(renderStateInit?: XRRenderStateInit): Promise<void>;
   }
@@ -97,8 +99,29 @@ declare global {
     readonly transform: XRRigidTransform;
   }
 
+  interface XRRay {
+    readonly origin: DOMPointReadOnly;
+    readonly direction: DOMPointReadOnly;
+    readonly matrix: Float32Array;
+  }
+
+  interface XRHitTestOptionsInit {
+    space: XRSpace;
+    offsetRay?: XRRay;
+    entityTypes?: XRHitTestTrackableType[];
+  }
+
+  interface XRHitTestSource {
+    cancel(): void;
+  }
+
+  interface XRHitTestResult {
+    getPose(baseSpace: XRSpace): XRPose | undefined;
+  }
+
   interface XRFrame {
     readonly session: XRSession;
+    getHitTestResults?(hitTestSource: XRHitTestSource): XRHitTestResult[];
     getPose(space: XRSpace, baseSpace: XRSpace): XRPose | undefined;
     getViewerPose(referenceSpace: XRReferenceSpace): XRViewerPose | undefined;
   }

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -353,6 +353,12 @@ declare global {
     readonly inverse: XRRigidTransform;
   }
 
+  interface XRRigidTransformConstructor {
+    new (position?: DOMPointInit, orientation?: DOMPointInit): XRRigidTransform;
+  }
+
+  var XRRigidTransform: XRRigidTransformConstructor | undefined;
+
   interface XRCamera {
     readonly width: number;
     readonly height: number;

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -297,6 +297,12 @@ declare global {
     onredraw: ((this: XREquirectLayer, event: Event) => unknown) | null;
   }
 
+  interface XRCubeLayer extends XRCompositionLayer {
+    space: XRReferenceSpace;
+    orientation: DOMPointReadOnly | null;
+    onredraw: ((this: XRCubeLayer, event: Event) => unknown) | null;
+  }
+
   interface XRSubImage {
     readonly viewport: XRViewport;
   }
@@ -336,6 +342,18 @@ declare global {
     radius?: number;
     centralAngle?: number;
     aspectRatio?: number;
+  }
+
+  interface XREquirectLayerInit extends XRLayerInit {
+    transform?: XRRigidTransform;
+    radius?: number;
+    centralHorizontalAngle?: number;
+    upperVerticalAngle?: number;
+    lowerVerticalAngle?: number;
+  }
+
+  interface XRCubeLayerInit extends XRLayerInit {
+    orientation?: DOMPointReadOnly | null;
   }
 
   interface XRMediaLayerInit {
@@ -413,6 +431,8 @@ declare global {
     createProjectionLayer(layerInit?: XRProjectionLayerInit): XRProjectionLayer;
     createQuadLayer(layerInit: XRQuadLayerInit): XRQuadLayer;
     createCylinderLayer(layerInit: XRCylinderLayerInit): XRCylinderLayer;
+    createEquirectLayer(layerInit: XREquirectLayerInit): XREquirectLayer;
+    createCubeLayer(layerInit: XRCubeLayerInit): XRCubeLayer;
     getCameraImage(camera: XRCamera): WebGLTexture | null;
     getDepthInformation?(view: XRView): XRWebGLDepthInformation | null;
     getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye): XRWebGLSubImage;

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -39,6 +39,9 @@ declare global {
   type XRDepthType = 'raw' | 'smooth';
   type XRDepthUsage = 'cpu-optimized' | 'gpu-optimized';
   type XRTextureType = number;
+  type XRLayerTextureType = 'texture' | 'texture-array';
+  type XRLayerLayout = 'default' | 'mono' | 'stereo' | 'stereo-left-right' | 'stereo-top-bottom';
+  type XRLayerQuality = 'default' | 'text-optimized' | 'graphics-optimized';
   type XRDOMOverlayType = 'screen' | 'floating' | 'head-locked';
   type XRHandJoint =
     | 'wrist'
@@ -97,7 +100,7 @@ declare global {
 
   interface XRRenderStateInit {
     baseLayer?: XRWebGLLayer;
-    layers?: XRProjectionLayer[];
+    layers?: readonly XRLayer[];
   }
 
   interface XRSession extends EventTarget {
@@ -253,6 +256,78 @@ declare global {
     readonly height: number;
   }
 
+  interface XRLayer extends EventTarget {}
+
+  interface XRCompositionLayer extends XRLayer {
+    readonly layout: XRLayerLayout;
+    blendTextureSourceAlpha: boolean;
+    forceMonoPresentation: boolean;
+    opacity: number;
+    readonly mipLevels: number;
+    quality: XRLayerQuality;
+    readonly needsRedraw: boolean;
+
+    destroy(): void;
+  }
+
+  interface XRQuadLayer extends XRCompositionLayer {
+    space: XRSpace;
+    transform: XRRigidTransform;
+    width: number;
+    height: number;
+    onredraw: ((this: XRQuadLayer, event: Event) => unknown) | null;
+  }
+
+  interface XRCylinderLayer extends XRCompositionLayer {
+    space: XRSpace;
+    transform: XRRigidTransform;
+    radius: number;
+    centralAngle: number;
+    aspectRatio: number;
+    onredraw: ((this: XRCylinderLayer, event: Event) => unknown) | null;
+  }
+
+  interface XRSubImage {
+    readonly viewport: XRViewport;
+  }
+
+  interface XRWebGLSubImage extends XRSubImage {
+    readonly colorTexture: WebGLTexture;
+    readonly depthStencilTexture: WebGLTexture | null;
+    readonly motionVectorTexture: WebGLTexture | null;
+    readonly imageIndex?: number;
+    readonly colorTextureWidth: number;
+    readonly colorTextureHeight: number;
+    readonly depthStencilTextureWidth?: number | null;
+    readonly depthStencilTextureHeight?: number | null;
+  }
+
+  interface XRLayerInit {
+    space: XRSpace;
+    textureType?: XRLayerTextureType;
+    colorFormat?: number;
+    depthFormat?: number | null;
+    mipLevels?: number;
+    viewPixelWidth: number;
+    viewPixelHeight: number;
+    layout?: XRLayerLayout;
+    isStatic?: boolean;
+    clearOnAccess?: boolean;
+  }
+
+  interface XRQuadLayerInit extends XRLayerInit {
+    transform?: XRRigidTransform;
+    width?: number;
+    height?: number;
+  }
+
+  interface XRCylinderLayerInit extends XRLayerInit {
+    transform?: XRRigidTransform;
+    radius?: number;
+    centralAngle?: number;
+    aspectRatio?: number;
+  }
+
   interface XRWebGLLayerInit {
     antialias?: boolean;
     depth?: boolean;
@@ -269,7 +344,7 @@ declare global {
     textureUsage?: GPUTextureUsageFlags;
   }
 
-  interface XRProjectionLayer {}
+  interface XRProjectionLayer extends XRLayer {}
 
   interface XRGPUSubImage {
     readonly colorTexture: GPUTexture;
@@ -298,8 +373,13 @@ declare global {
   class XRWebGLBinding {
     constructor(session: XRSession, context: WebGLRenderingContext | WebGL2RenderingContext);
 
+    createProjectionLayer(layerInit?: XRProjectionLayerInit): XRProjectionLayer;
+    createQuadLayer(layerInit: XRQuadLayerInit): XRQuadLayer;
+    createCylinderLayer(layerInit: XRCylinderLayerInit): XRCylinderLayer;
     getCameraImage(camera: XRCamera): WebGLTexture | null;
     getDepthInformation?(view: XRView): XRWebGLDepthInformation | null;
+    getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye): XRWebGLSubImage;
+    getViewSubImage(layer: XRProjectionLayer, view: XRView): XRWebGLSubImage;
   }
 
   class XRGPUBinding {

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -28,6 +28,8 @@ declare global {
   type XRSessionMode = 'inline' | 'immersive-vr' | 'immersive-ar';
   type XRReferenceSpaceType = 'viewer' | 'local' | 'local-floor' | 'bounded-floor' | 'unbounded';
   type XREye = 'none' | 'left' | 'right';
+  type XRHandedness = 'none' | 'left' | 'right';
+  type XRTargetRayMode = 'gaze' | 'tracked-pointer' | 'screen';
   type XRFrameRequestCallback = (time: DOMHighResTimeStamp, frame: XRFrame) => void;
 
   interface XRSystem extends EventTarget {
@@ -47,6 +49,7 @@ declare global {
 
   interface XRSession extends EventTarget {
     readonly enabledFeatures?: readonly string[];
+    readonly inputSources: XRInputSourceArray;
 
     cancelAnimationFrame(animationFrameId: number): void;
     end(): Promise<void>;
@@ -59,8 +62,44 @@ declare global {
 
   interface XRReferenceSpace extends XRSpace {}
 
+  interface XRInputSourceArray {
+    readonly length: number;
+    readonly [index: number]: XRInputSource;
+    [Symbol.iterator](): IterableIterator<XRInputSource>;
+  }
+
+  interface XRInputSource {
+    readonly handedness: XRHandedness;
+    readonly targetRayMode: XRTargetRayMode;
+    readonly targetRaySpace: XRSpace;
+    readonly gripSpace?: XRSpace;
+    readonly profiles: readonly string[];
+    readonly gamepad?: Gamepad;
+    readonly hand?: XRHand;
+  }
+
+  interface XRHand {
+    readonly size: number;
+  }
+
+  interface XRInputSourceEvent extends Event {
+    readonly frame: XRFrame;
+    readonly inputSource: XRInputSource;
+  }
+
+  interface XRInputSourcesChangeEvent extends Event {
+    readonly added: readonly XRInputSource[];
+    readonly removed: readonly XRInputSource[];
+    readonly session: XRSession;
+  }
+
+  interface XRPose {
+    readonly transform: XRRigidTransform;
+  }
+
   interface XRFrame {
     readonly session: XRSession;
+    getPose(space: XRSpace, baseSpace: XRSpace): XRPose | undefined;
     getViewerPose(referenceSpace: XRReferenceSpace): XRViewerPose | undefined;
   }
 

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -287,6 +287,16 @@ declare global {
     onredraw: ((this: XRCylinderLayer, event: Event) => unknown) | null;
   }
 
+  interface XREquirectLayer extends XRCompositionLayer {
+    space: XRReferenceSpace;
+    transform: XRRigidTransform;
+    radius: number;
+    centralHorizontalAngle: number;
+    upperVerticalAngle: number;
+    lowerVerticalAngle: number;
+    onredraw: ((this: XREquirectLayer, event: Event) => unknown) | null;
+  }
+
   interface XRSubImage {
     readonly viewport: XRViewport;
   }
@@ -326,6 +336,33 @@ declare global {
     radius?: number;
     centralAngle?: number;
     aspectRatio?: number;
+  }
+
+  interface XRMediaLayerInit {
+    space: XRSpace;
+    layout?: XRLayerLayout;
+    invertStereo?: boolean;
+  }
+
+  interface XRMediaQuadLayerInit extends XRMediaLayerInit {
+    transform?: XRRigidTransform;
+    width?: number;
+    height?: number;
+  }
+
+  interface XRMediaCylinderLayerInit extends XRMediaLayerInit {
+    transform?: XRRigidTransform;
+    radius?: number;
+    centralAngle?: number;
+    aspectRatio?: number;
+  }
+
+  interface XRMediaEquirectLayerInit extends XRMediaLayerInit {
+    transform?: XRRigidTransform;
+    radius?: number;
+    centralHorizontalAngle?: number;
+    upperVerticalAngle?: number;
+    lowerVerticalAngle?: number;
   }
 
   interface XRWebGLLayerInit {
@@ -380,6 +417,20 @@ declare global {
     getDepthInformation?(view: XRView): XRWebGLDepthInformation | null;
     getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye): XRWebGLSubImage;
     getViewSubImage(layer: XRProjectionLayer, view: XRView): XRWebGLSubImage;
+  }
+
+  class XRMediaBinding {
+    constructor(session: XRSession);
+
+    createQuadLayer(video: HTMLVideoElement, layerInit: XRMediaQuadLayerInit): XRQuadLayer;
+    createCylinderLayer(
+      video: HTMLVideoElement,
+      layerInit: XRMediaCylinderLayerInit
+    ): XRCylinderLayer;
+    createEquirectLayer(
+      video: HTMLVideoElement,
+      layerInit: XRMediaEquirectLayerInit
+    ): XREquirectLayer;
   }
 
   class XRGPUBinding {

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -31,6 +31,10 @@ declare global {
   type XRHandedness = 'none' | 'left' | 'right';
   type XRTargetRayMode = 'gaze' | 'tracked-pointer' | 'screen';
   type XRHitTestTrackableType = 'point' | 'plane' | 'mesh';
+  type XRDepthDataFormat = 'luminance-alpha' | 'float32' | 'unsigned-short';
+  type XRDepthType = 'raw' | 'smooth';
+  type XRDepthUsage = 'cpu-optimized' | 'gpu-optimized';
+  type XRTextureType = number;
   type XRFrameRequestCallback = (time: DOMHighResTimeStamp, frame: XRFrame) => void;
 
   interface XRSystem extends EventTarget {
@@ -41,6 +45,14 @@ declare global {
   interface XRSessionInit {
     optionalFeatures?: string[];
     requiredFeatures?: string[];
+    depthSensing?: XRDepthStateInit;
+  }
+
+  interface XRDepthStateInit {
+    usagePreference: XRDepthUsage[];
+    dataFormatPreference: XRDepthDataFormat[];
+    depthTypeRequest?: XRDepthType[];
+    matchDepthView?: boolean;
   }
 
   interface XRRenderStateInit {
@@ -51,12 +63,18 @@ declare global {
   interface XRSession extends EventTarget {
     readonly enabledFeatures?: readonly string[];
     readonly inputSources: XRInputSourceArray;
+    readonly depthUsage?: XRDepthUsage;
+    readonly depthDataFormat?: XRDepthDataFormat;
+    readonly depthType?: XRDepthType | null;
+    readonly depthActive?: boolean;
 
     cancelAnimationFrame(animationFrameId: number): void;
     end(): Promise<void>;
+    pauseDepthSensing?(): void;
     requestAnimationFrame(callback: XRFrameRequestCallback): number;
     requestHitTestSource?(options: XRHitTestOptionsInit): Promise<XRHitTestSource | null>;
     requestReferenceSpace(type: XRReferenceSpaceType): Promise<XRReferenceSpace>;
+    resumeDepthSensing?(): void;
     updateRenderState(renderStateInit?: XRRenderStateInit): Promise<void>;
   }
 
@@ -125,10 +143,29 @@ declare global {
     delete(): void;
   }
 
+  interface XRDepthInformation {
+    readonly width: number;
+    readonly height: number;
+    readonly normDepthBufferFromNormView: XRRigidTransform;
+    readonly rawValueToMeters: number;
+  }
+
+  interface XRCPUDepthInformation extends XRDepthInformation {
+    readonly data: ArrayBuffer;
+    getDepthInMeters(x: number, y: number): number;
+  }
+
+  interface XRWebGLDepthInformation extends XRDepthInformation {
+    readonly texture: WebGLTexture;
+    readonly textureType: XRTextureType;
+    readonly imageIndex?: number;
+  }
+
   interface XRFrame {
     readonly session: XRSession;
     readonly trackedAnchors?: ReadonlySet<XRAnchor>;
     createAnchor?(pose: XRRigidTransform, space: XRSpace): Promise<XRAnchor>;
+    getDepthInformation?(view: XRView): XRCPUDepthInformation | null;
     getHitTestResults?(hitTestSource: XRHitTestSource): XRHitTestResult[];
     getPose(space: XRSpace, baseSpace: XRSpace): XRPose | undefined;
     getViewerPose(referenceSpace: XRReferenceSpace): XRViewerPose | undefined;
@@ -208,6 +245,7 @@ declare global {
     constructor(session: XRSession, context: WebGLRenderingContext | WebGL2RenderingContext);
 
     getCameraImage(camera: XRCamera): WebGLTexture | null;
+    getDepthInformation?(view: XRView): XRWebGLDepthInformation | null;
   }
 
   class XRGPUBinding {
@@ -218,6 +256,8 @@ declare global {
     getViewSubImage(layer: XRProjectionLayer, view: XRView): XRGPUSubImage;
   }
 }
+
+export type WebXRDepthBinding = Pick<XRWebGLBinding, 'getDepthInformation'>;
 
 /** Experimental v10 raw-camera subset required by WebXRCameraTexture. */
 export type WebXRRawCameraBinding = Pick<XRWebGLBinding, 'getCameraImage'>;

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -25,6 +25,10 @@ declare global {
     makeXRCompatible(): Promise<void>;
   }
 
+  interface GlobalEventHandlers {
+    onbeforexrselect: ((this: GlobalEventHandlers, event: Event) => unknown) | null;
+  }
+
   type XRSessionMode = 'inline' | 'immersive-vr' | 'immersive-ar';
   type XRReferenceSpaceType = 'viewer' | 'local' | 'local-floor' | 'bounded-floor' | 'unbounded';
   type XREye = 'none' | 'left' | 'right';
@@ -35,6 +39,7 @@ declare global {
   type XRDepthType = 'raw' | 'smooth';
   type XRDepthUsage = 'cpu-optimized' | 'gpu-optimized';
   type XRTextureType = number;
+  type XRDOMOverlayType = 'screen' | 'floating' | 'head-locked';
   type XRHandJoint =
     | 'wrist'
     | 'thumb-metacarpal'
@@ -72,6 +77,15 @@ declare global {
     optionalFeatures?: string[];
     requiredFeatures?: string[];
     depthSensing?: XRDepthStateInit;
+    domOverlay?: XRDOMOverlayInit;
+  }
+
+  interface XRDOMOverlayInit {
+    root: Element;
+  }
+
+  interface XRDOMOverlayState {
+    type: XRDOMOverlayType;
   }
 
   interface XRDepthStateInit {
@@ -93,6 +107,7 @@ declare global {
     readonly depthDataFormat?: XRDepthDataFormat;
     readonly depthType?: XRDepthType | null;
     readonly depthActive?: boolean;
+    readonly domOverlayState?: XRDOMOverlayState | null;
 
     cancelAnimationFrame(animationFrameId: number): void;
     end(): Promise<void>;

--- a/modules/experimental/test/webxr/webxr-anchor.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-anchor.node.spec.ts
@@ -1,0 +1,155 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {WebXRAnchorManager} from '../../src/webxr/webxr-anchor';
+
+type MockXRAnchor = XRAnchor & {deleteCount: number};
+
+test('webxr#WebXRAnchorManager creates anchors and resolves tracked poses', async testCase => {
+  const session = new EventTarget() as XRSession;
+  const referenceSpace = {} as XRReferenceSpace;
+  const anchorSpace = {} as XRSpace;
+  const anchor = makeMockXRAnchor(anchorSpace);
+  const anchorPose = makeMockXRPose([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 4, 0, -2, 1]);
+  let receivedAnchorPose: XRRigidTransform | undefined;
+  let receivedAnchorSpace: XRSpace | undefined;
+  const frame = {
+    session,
+    trackedAnchors: new Set<XRAnchor>([anchor]),
+    async createAnchor(pose: XRRigidTransform, space: XRSpace): Promise<XRAnchor> {
+      receivedAnchorPose = pose;
+      receivedAnchorSpace = space;
+      return anchor;
+    },
+    getPose(space: XRSpace, baseSpace: XRReferenceSpace): XRPose | undefined {
+      testCase.equal(space, anchor.anchorSpace, 'queries anchor space');
+      testCase.equal(baseSpace, referenceSpace, 'queries app reference space');
+      return anchorPose;
+    }
+  } as XRFrame;
+  const manager = new WebXRAnchorManager();
+  const createdPose = makeMockXRPose([1]);
+
+  manager.setSession(session, referenceSpace);
+  const createdAnchor = await manager.createAnchor(frame, createdPose.transform);
+  const anchorState = manager.getAnchorState(frame);
+
+  testCase.equal(createdAnchor, anchor, 'returns created anchor');
+  testCase.equal(receivedAnchorPose, createdPose.transform, 'passes pose to XRFrame.createAnchor');
+  testCase.equal(receivedAnchorSpace, referenceSpace, 'defaults to app reference space');
+  testCase.equal(manager.anchors.has(anchor), true, 'tracks created anchor');
+  testCase.equal(anchorState?.xrFrame, frame, 'retains source frame');
+  testCase.equal(anchorState?.anchors.length, 1, 'resolves tracked anchor');
+  testCase.equal(anchorState?.anchors[0]?.anchor, anchor, 'retains raw anchor');
+  testCase.equal(anchorState?.anchors[0]?.pose, anchorPose, 'retains anchor pose');
+  testCase.equal(anchorState?.anchors[0]?.matrix, anchorPose.transform.matrix, 'exposes matrix');
+
+  manager.deleteAnchor(anchor);
+  testCase.equal(anchor.deleteCount, 1, 'deleteAnchor deletes tracked anchors');
+  testCase.equal(manager.anchors.size, 0, 'deleteAnchor removes tracked anchors');
+  testCase.end();
+});
+
+test('webxr#WebXRAnchorManager creates anchors from hit-test results and syncs tracked anchors', async testCase => {
+  const session = new EventTarget() as XRSession;
+  const referenceSpace = {} as XRReferenceSpace;
+  const hitTestAnchor = makeMockXRAnchor({} as XRSpace);
+  const staleAnchor = makeMockXRAnchor({} as XRSpace);
+  const hitTestResult = {
+    async createAnchor(): Promise<XRAnchor> {
+      return hitTestAnchor;
+    },
+    getPose: () => undefined
+  } as XRHitTestResult;
+  const frame = {
+    session,
+    trackedAnchors: new Set<XRAnchor>([hitTestAnchor]),
+    getPose: () => makeMockXRPose([2])
+  } as XRFrame;
+  const manager = new WebXRAnchorManager();
+
+  manager.setSession(session, referenceSpace);
+  manager.anchors.add(staleAnchor);
+  const anchor = await manager.createAnchorFromHitTestResult(hitTestResult);
+  const anchorState = manager.getAnchorState(frame);
+
+  testCase.equal(anchor, hitTestAnchor, 'returns hit-test anchor');
+  testCase.equal(manager.anchors.has(hitTestAnchor), true, 'tracks hit-test anchor');
+  testCase.equal(manager.anchors.has(staleAnchor), false, 'drops anchors missing from tracked set');
+  testCase.equal(anchorState?.anchors.length, 1, 'resolves remaining tracked anchor');
+
+  session.dispatchEvent(new Event('end'));
+  testCase.equal(hitTestAnchor.deleteCount, 1, 'session end deletes tracked anchors');
+  testCase.equal(staleAnchor.deleteCount, 0, 'stale anchors already removed are not deleted');
+  testCase.equal(manager.session, null, 'session end clears session');
+  testCase.end();
+});
+
+test('webxr#WebXRAnchorManager rejects invalid sessions and unsupported anchors', async testCase => {
+  const session = new EventTarget() as XRSession;
+  const referenceSpace = {} as XRReferenceSpace;
+  const manager = new WebXRAnchorManager();
+
+  testCase.throws(
+    () => manager.setSession(session, null),
+    /reference space/,
+    'rejects missing app reference space'
+  );
+  testCase.equal(manager.setSession(null, null), manager, 'clears null sessions');
+  testCase.equal(
+    manager.getAnchorState({session} as XRFrame),
+    null,
+    'inactive sessions return null'
+  );
+
+  manager.setSession(session, referenceSpace);
+  try {
+    await manager.createAnchor({session} as XRFrame, makeMockXRPose([1]).transform);
+    testCase.fail('unsupported XRFrame.createAnchor should be rejected');
+  } catch (error) {
+    testCase.match(error instanceof Error ? error.message : '', /not supported/, 'reports support');
+  }
+
+  try {
+    await manager.createAnchorFromHitTestResult({getPose: () => undefined} as XRHitTestResult);
+    testCase.fail('unsupported hit-test anchors should be rejected');
+  } catch (error) {
+    testCase.match(error instanceof Error ? error.message : '', /not supported/, 'reports support');
+  }
+
+  testCase.throws(
+    () =>
+      manager.getAnchorState({
+        session: new EventTarget() as XRSession,
+        getPose: () => undefined
+      } as XRFrame),
+    /different XRSession/,
+    'rejects foreign frames'
+  );
+
+  manager.clearSession();
+  manager.clearSession();
+  testCase.equal(manager.anchors.size, 0, 'clearSession is idempotent');
+  testCase.end();
+});
+
+function makeMockXRAnchor(anchorSpace: XRSpace): MockXRAnchor {
+  return {
+    anchorSpace,
+    deleteCount: 0,
+    delete() {
+      this.deleteCount++;
+    }
+  };
+}
+
+function makeMockXRPose(matrix: number[]): XRPose {
+  return {
+    transform: {
+      matrix: new Float32Array(matrix),
+      inverse: {matrix: new Float32Array(matrix)}
+    }
+  } as XRPose;
+}

--- a/modules/experimental/test/webxr/webxr-anchor.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-anchor.node.spec.ts
@@ -72,7 +72,11 @@ test('webxr#WebXRAnchorManager creates anchors from hit-test results and syncs t
 
   manager.setSession(session, referenceSpace);
   manager.anchors.add(staleAnchor);
-  const anchor = await manager.createAnchorFromHitTestResult(hitTestResult);
+  const anchor = await manager.createAnchorFromHitTest({
+    xrHitTestResult: hitTestResult,
+    pose: makeMockXRPose([1]),
+    matrix: new Float32Array(16)
+  });
   const anchorState = manager.getAnchorState(frame);
 
   testCase.equal(anchor, hitTestAnchor, 'returns hit-test anchor');
@@ -84,6 +88,38 @@ test('webxr#WebXRAnchorManager creates anchors from hit-test results and syncs t
   testCase.equal(hitTestAnchor.deleteCount, 1, 'session end deletes tracked anchors');
   testCase.equal(staleAnchor.deleteCount, 0, 'stale anchors already removed are not deleted');
   testCase.equal(manager.session, null, 'session end clears session');
+  testCase.end();
+});
+
+test('webxr#WebXRAnchorManager handles nullable hit-test anchor selections', async testCase => {
+  const session = new EventTarget() as XRSession;
+  const referenceSpace = {} as XRReferenceSpace;
+  const hitTestAnchor = makeMockXRAnchor({} as XRSpace);
+  const hitTestResult = {
+    async createAnchor(): Promise<XRAnchor> {
+      return hitTestAnchor;
+    },
+    getPose: () => undefined
+  } as XRHitTestResult;
+  const manager = new WebXRAnchorManager();
+
+  manager.setSession(session, referenceSpace);
+  testCase.equal(
+    await manager.createAnchorFromHitTest(null),
+    null,
+    'missing hit-test selections return null'
+  );
+  testCase.equal(manager.anchors.size, 0, 'nullable selections do not mutate anchors');
+  testCase.equal(
+    await manager.createAnchorFromHitTest({
+      xrHitTestResult: hitTestResult,
+      pose: makeMockXRPose([1]),
+      matrix: new Float32Array(16)
+    }),
+    hitTestAnchor,
+    'creates anchors from wrapped hit-test results'
+  );
+  testCase.equal(manager.anchors.has(hitTestAnchor), true, 'tracks wrapped hit-test anchors');
   testCase.end();
 });
 

--- a/modules/experimental/test/webxr/webxr-bounds.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-bounds.node.spec.ts
@@ -1,0 +1,66 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  getWebXRBoundsState,
+  isPointInWebXRBounds,
+  isWebXRBoundedReferenceSpace
+} from '../../src/webxr/webxr-bounds';
+
+test('webxr#getWebXRBoundsState resolves bounded reference-space geometry', testCase => {
+  const boundsGeometry = [
+    makeDOMPoint(-1, 0, -1),
+    makeDOMPoint(1, 0, -1),
+    makeDOMPoint(1, 0, 1),
+    makeDOMPoint(-1, 0, 1)
+  ];
+  const referenceSpace = {boundsGeometry} as XRBoundedReferenceSpace;
+  const boundsState = getWebXRBoundsState(referenceSpace);
+
+  testCase.ok(isWebXRBoundedReferenceSpace(referenceSpace), 'detects bounded reference spaces');
+  testCase.equal(boundsState?.referenceSpace, referenceSpace, 'retains reference-space identity');
+  testCase.deepEqual(
+    boundsState?.bounds,
+    [
+      [-1, 0, -1],
+      [1, 0, -1],
+      [1, 0, 1],
+      [-1, 0, 1]
+    ],
+    'converts bounds geometry to numeric points'
+  );
+  testCase.deepEqual(boundsState?.center, [0, 0, 0], 'computes bounds center');
+  testCase.deepEqual(boundsState?.size, [2, 0, 2], 'computes bounds size');
+  testCase.equal(boundsState?.radius, Math.SQRT2, 'computes horizontal bounds radius');
+  testCase.equal(
+    isPointInWebXRBounds([0.25, 0, -0.25], boundsState?.bounds || []),
+    true,
+    'accepts points inside bounds'
+  );
+  testCase.equal(
+    isPointInWebXRBounds([2, 0, 0], boundsState?.bounds || []),
+    false,
+    'rejects points outside bounds'
+  );
+  testCase.end();
+});
+
+test('webxr#getWebXRBoundsState handles unbounded reference spaces', testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+
+  testCase.equal(
+    isWebXRBoundedReferenceSpace(referenceSpace),
+    false,
+    'plain reference spaces are not bounded'
+  );
+  testCase.equal(getWebXRBoundsState(referenceSpace), null, 'plain reference spaces have no state');
+  testCase.equal(getWebXRBoundsState(null), null, 'null reference spaces have no state');
+  testCase.equal(isPointInWebXRBounds([0, 0, 0], []), false, 'empty bounds cannot contain points');
+  testCase.end();
+});
+
+function makeDOMPoint(x: number, y: number, z: number): DOMPointReadOnly {
+  return {x, y, z, w: 1} as DOMPointReadOnly;
+}

--- a/modules/experimental/test/webxr/webxr-depth-sensing.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-depth-sensing.node.spec.ts
@@ -1,0 +1,250 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Device, Texture, TextureProps} from '@luma.gl/core';
+import test from 'test/utils/vitest-tape';
+import {
+  getWebXRDepthSensingSessionInit,
+  getWebXRDepthTextureFormat,
+  WebXRDepthSensingManager
+} from '../../src/webxr/webxr-depth-sensing';
+
+type MockTexture = Texture & {
+  destroyCount: number;
+};
+
+type MockTextureProps = TextureProps & {
+  handle?: unknown;
+  _isHandleBorrowed?: boolean;
+};
+
+test('webxr#WebXRDepthSensingManager resolves CPU depth information', testCase => {
+  const session = makeMockXRSession({depthActive: true, depthDataFormat: 'luminance-alpha'});
+  const xrView = makeMockXRView();
+  const emptyView = makeMockXRView();
+  const depthInformation = makeMockCPUDepthInformation({
+    width: 3,
+    height: 2,
+    rawValueToMeters: 0.01
+  });
+  let receivedView: XRView | undefined;
+  const frame = {
+    session,
+    getDepthInformation(view: XRView): XRCPUDepthInformation | null {
+      receivedView = view;
+      return view === xrView ? depthInformation : null;
+    }
+  } as XRFrame;
+  const manager = new WebXRDepthSensingManager();
+
+  manager.setSession(session);
+  const depthState = manager.getDepthState(frame, [xrView, emptyView]);
+
+  testCase.equal(receivedView, emptyView, 'queries supplied views');
+  testCase.equal(depthState?.xrFrame, frame, 'retains source frame');
+  testCase.equal(depthState?.session, session, 'retains source session');
+  testCase.equal(depthState?.views.length, 1, 'filters views without depth information');
+  testCase.equal(depthState?.views[0]?.xrView, xrView, 'retains XR view');
+  testCase.equal(
+    depthState?.views[0]?.depthInformation,
+    depthInformation,
+    'retains depth information'
+  );
+  testCase.equal(
+    depthState?.views[0]?.cpuDepthInformation,
+    depthInformation,
+    'retains CPU depth information'
+  );
+  testCase.equal(depthState?.views[0]?.webGLDepthInformation, null, 'does not invent WebGL depth');
+  testCase.equal(depthState?.views[0]?.texture, null, 'CPU depth does not create a texture');
+  testCase.equal(depthState?.views[0]?.width, 3, 'exposes depth width');
+  testCase.equal(depthState?.views[0]?.height, 2, 'exposes depth height');
+  testCase.equal(depthState?.views[0]?.rawValueToMeters, 0.01, 'exposes raw meter scale');
+  testCase.equal(
+    depthState?.views[0]?.matrix,
+    depthInformation.normDepthBufferFromNormView.matrix,
+    'exposes UV transform matrix'
+  );
+
+  manager.destroy();
+  testCase.end();
+});
+
+test('webxr#WebXRDepthSensingManager wraps borrowed WebGL depth textures', testCase => {
+  const session = makeMockXRSession({depthActive: true, depthDataFormat: 'float32'});
+  const xrView = makeMockXRView();
+  const textureHandle = {} as WebGLTexture;
+  const depthInformation = makeMockWebGLDepthInformation({
+    texture: textureHandle,
+    textureType: 0x8c1a,
+    imageIndex: 2,
+    width: 5,
+    height: 4
+  });
+  const device = makeMockDevice();
+  const xrWebGLBinding = {
+    getDepthInformation(view: XRView): XRWebGLDepthInformation | null {
+      testCase.equal(view, xrView, 'queries depth for supplied view');
+      return depthInformation;
+    }
+  } as XRWebGLBinding;
+  const frame = {
+    session
+  } as XRFrame;
+  const manager = new WebXRDepthSensingManager();
+
+  manager.setWebGLBinding(device, xrWebGLBinding);
+  manager.setSession(session);
+  const depthState = manager.getDepthState(frame, [xrView]);
+  const texture = depthState?.views[0]?.texture as MockTexture | null | undefined;
+  const textureProps = texture?.props as MockTextureProps | undefined;
+  const secondDepthState = manager.getDepthState(frame, [xrView]);
+
+  testCase.equal(depthState?.views.length, 1, 'resolves WebGL depth view');
+  testCase.equal(
+    depthState?.views[0]?.webGLDepthInformation,
+    depthInformation,
+    'retains WebGL depth'
+  );
+  testCase.equal(depthState?.views[0]?.cpuDepthInformation, null, 'does not invent CPU depth');
+  testCase.equal(depthState?.views[0]?.texture, texture, 'exposes borrowed luma texture');
+  testCase.equal(secondDepthState?.views[0]?.texture, texture, 'reuses texture wrapper');
+  testCase.equal(device.createdTextures.length, 1, 'creates one borrowed texture wrapper');
+  testCase.equal(textureProps?.handle, textureHandle, 'wraps browser-owned depth texture handle');
+  testCase.equal(textureProps?._isHandleBorrowed, true, 'marks depth texture handle borrowed');
+  testCase.equal(textureProps?.dimension, '2d-array', 'preserves texture-array depth metadata');
+  testCase.equal(textureProps?.depth, 3, 'uses image index to expose minimum array depth');
+  testCase.equal(textureProps?.format, 'r32float', 'maps selected XR depth data format');
+  testCase.equal(textureProps?.usage, 4, 'defaults to sampled texture usage');
+  testCase.equal(texture?.destroyCount, 0, 'wrapper is live before cleanup');
+
+  session.dispatchEvent(new Event('end'));
+  testCase.equal(texture?.destroyCount, 1, 'session end destroys borrowed wrapper');
+  testCase.equal(manager.session, null, 'session end clears active session');
+  testCase.end();
+});
+
+test('webxr#WebXRDepthSensingManager handles unsupported sessions and helpers', testCase => {
+  const session = makeMockXRSession({depthActive: false});
+  const activeSession = makeMockXRSession({depthActive: true});
+  const xrView = makeMockXRView();
+  const manager = new WebXRDepthSensingManager();
+
+  manager.setSession(session);
+  testCase.equal(
+    manager.getDepthState({session} as XRFrame, [xrView]),
+    null,
+    'paused depth sensing returns null'
+  );
+
+  manager.setSession(activeSession);
+  testCase.equal(
+    manager.getDepthState({session: activeSession} as XRFrame, [xrView]),
+    null,
+    'unsupported frames return null'
+  );
+  testCase.throws(
+    () => manager.getDepthState({session: session as XRSession} as XRFrame, [xrView]),
+    /different XRSession/,
+    'rejects frames from a different session'
+  );
+
+  testCase.deepEqual(
+    getWebXRDepthSensingSessionInit({required: true, usagePreference: ['gpu-optimized']}),
+    {
+      requiredFeatures: ['depth-sensing'],
+      depthSensing: {
+        usagePreference: ['gpu-optimized'],
+        dataFormatPreference: ['luminance-alpha', 'float32', 'unsigned-short'],
+        depthTypeRequest: undefined,
+        matchDepthView: undefined
+      }
+    },
+    'builds required depth-sensing session init'
+  );
+  testCase.equal(
+    getWebXRDepthTextureFormat('luminance-alpha'),
+    'rg8unorm',
+    'maps luminance-alpha depth'
+  );
+  testCase.equal(getWebXRDepthTextureFormat('float32'), 'r32float', 'maps float depth');
+  testCase.equal(getWebXRDepthTextureFormat('unsigned-short'), 'r16uint', 'maps uint depth');
+
+  manager.clearSession();
+  manager.clearSession();
+  testCase.equal(manager.session, null, 'clearSession is idempotent');
+  testCase.end();
+});
+
+function makeMockXRSession(props: Partial<XRSession>): XRSession {
+  return Object.assign(new EventTarget(), {
+    inputSources: [],
+    ...props
+  }) as XRSession;
+}
+
+function makeMockXRView(): XRView {
+  return {
+    eye: 'none',
+    projectionMatrix: new Float32Array(16),
+    transform: makeMockXRRigidTransform([1])
+  } as XRView;
+}
+
+function makeMockCPUDepthInformation(options: {
+  width: number;
+  height: number;
+  rawValueToMeters: number;
+}): XRCPUDepthInformation {
+  return {
+    width: options.width,
+    height: options.height,
+    rawValueToMeters: options.rawValueToMeters,
+    normDepthBufferFromNormView: makeMockXRRigidTransform([1, 0, 0, 0]),
+    data: new ArrayBuffer(options.width * options.height * 2),
+    getDepthInMeters: () => 1.5
+  } as XRCPUDepthInformation;
+}
+
+function makeMockWebGLDepthInformation(
+  options: Partial<XRWebGLDepthInformation> & {texture: WebGLTexture}
+): XRWebGLDepthInformation {
+  return {
+    width: options.width ?? 2,
+    height: options.height ?? 2,
+    rawValueToMeters: options.rawValueToMeters ?? 0.001,
+    normDepthBufferFromNormView: makeMockXRRigidTransform([1, 0, 0, 0]),
+    texture: options.texture,
+    textureType: options.textureType ?? 0x0de1,
+    imageIndex: options.imageIndex
+  } as XRWebGLDepthInformation;
+}
+
+function makeMockXRRigidTransform(matrix: number[]): XRRigidTransform {
+  return {
+    matrix: new Float32Array(matrix),
+    inverse: {matrix: new Float32Array(matrix)}
+  } as XRRigidTransform;
+}
+
+function makeMockDevice(): Device & {createdTextures: MockTexture[]} {
+  const createdTextures: MockTexture[] = [];
+  return {
+    type: 'webgl',
+    createdTextures,
+    createTexture(props: TextureProps): MockTexture {
+      const texture = {
+        props,
+        width: props.width,
+        height: props.height,
+        destroyCount: 0,
+        destroy() {
+          this.destroyCount++;
+        }
+      } as unknown as MockTexture;
+      createdTextures.push(texture);
+      return texture;
+    }
+  } as Device & {createdTextures: MockTexture[]};
+}

--- a/modules/experimental/test/webxr/webxr-dom-overlay.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-dom-overlay.node.spec.ts
@@ -1,0 +1,83 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  getWebXRDOMOverlaySessionInit,
+  WebXRDOMOverlayManager
+} from '../../src/webxr/webxr-dom-overlay';
+
+test('webxr#WebXRDOMOverlayManager resolves overlay state and suppresses XR select', testCase => {
+  const root = new EventTarget() as Element;
+  const session = makeMockXRSession({domOverlayState: {type: 'screen'}});
+  const manager = new WebXRDOMOverlayManager({root});
+
+  manager.setSession(session);
+  const overlayState = manager.getOverlayState();
+  const beforeXRSelectEvent = new Event('beforexrselect', {cancelable: true});
+  root.dispatchEvent(beforeXRSelectEvent);
+
+  testCase.equal(overlayState?.session, session, 'retains source session');
+  testCase.equal(overlayState?.root, root, 'retains overlay root');
+  testCase.equal(overlayState?.type, 'screen', 'reports overlay type');
+  testCase.equal(beforeXRSelectEvent.defaultPrevented, true, 'suppresses overlay select events');
+
+  session.dispatchEvent(new Event('end'));
+  testCase.equal(manager.session, null, 'session end clears session');
+  testCase.equal(manager.root, null, 'session end clears root');
+
+  const detachedEvent = new Event('beforexrselect', {cancelable: true});
+  root.dispatchEvent(detachedEvent);
+  testCase.equal(detachedEvent.defaultPrevented, false, 'cleanup removes overlay listener');
+  testCase.end();
+});
+
+test('webxr#WebXRDOMOverlayManager handles disabled and unsupported overlays', testCase => {
+  const root = new EventTarget() as Element;
+  const session = makeMockXRSession({domOverlayState: null});
+  const manager = new WebXRDOMOverlayManager({root, suppressXRSelectEvents: false});
+
+  testCase.equal(manager.getOverlayState(), null, 'inactive manager returns null');
+
+  manager.setSession(session);
+  const beforeXRSelectEvent = new Event('beforexrselect', {cancelable: true});
+  root.dispatchEvent(beforeXRSelectEvent);
+
+  testCase.equal(manager.getOverlayState(), null, 'unsupported overlay returns null');
+  testCase.equal(beforeXRSelectEvent.defaultPrevented, false, 'suppression can be disabled');
+
+  manager.clearSession();
+  manager.clearSession();
+  testCase.equal(manager.session, null, 'clearSession is idempotent');
+  testCase.end();
+});
+
+test('webxr#getWebXRDOMOverlaySessionInit creates optional and required feature init', testCase => {
+  const root = new EventTarget() as Element;
+
+  testCase.deepEqual(
+    getWebXRDOMOverlaySessionInit(root),
+    {
+      optionalFeatures: ['dom-overlay'],
+      domOverlay: {root}
+    },
+    'creates optional DOM overlay init'
+  );
+  testCase.deepEqual(
+    getWebXRDOMOverlaySessionInit(root, {required: true}),
+    {
+      requiredFeatures: ['dom-overlay'],
+      domOverlay: {root}
+    },
+    'creates required DOM overlay init'
+  );
+  testCase.end();
+});
+
+function makeMockXRSession(props: Partial<XRSession>): XRSession {
+  return Object.assign(new EventTarget(), {
+    inputSources: [],
+    ...props
+  }) as XRSession;
+}

--- a/modules/experimental/test/webxr/webxr-gamepad.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-gamepad.node.spec.ts
@@ -5,6 +5,8 @@
 import test from 'test/utils/vitest-tape';
 import {
   WebXRGamepadActionManager,
+  WebXRGamepadAxisManager,
+  getWebXRGamepadAxisActionState,
   getWebXRGamepadButtonActionState,
   getWebXRGamepadState,
   getWebXRGamepadStates
@@ -230,6 +232,172 @@ test('webxr#WebXRGamepadActionManager trims inactive input sources', testCase =>
   testCase.end();
 });
 
+test('webxr#WebXRGamepadAxisManager reports dead-zone transitions', testCase => {
+  const inputState = makeWebXRInputState({
+    mapping: 'xr-standard',
+    buttons: [],
+    axes: [0.1, 0, 0, 0]
+  });
+  const manager = new WebXRGamepadAxisManager();
+
+  const firstActions = manager.update([inputState], {deadzone: 0.2});
+  testCase.equal(firstActions.length, 4, 'returns one action per current axis');
+  testCase.deepEqual(
+    pickAxisAction(firstActions[0]!),
+    {
+      name: 'touchpad-x',
+      value: 0.1,
+      previousValue: 0,
+      valueDelta: 0.1,
+      deadzone: 0.2,
+      active: false,
+      wasActive: false,
+      activeStarted: false,
+      activeEnded: false
+    },
+    'starts below the configured dead zone'
+  );
+
+  inputState.gamepad!.axes[0] = 0.75;
+  inputState.gamepad!.axes[3] = -0.3;
+  const secondActions = manager.update([inputState], {deadzone: 0.2});
+  testCase.deepEqual(
+    pickAxisAction(secondActions[0]!),
+    {
+      name: 'touchpad-x',
+      value: 0.75,
+      previousValue: 0.1,
+      valueDelta: 0.65,
+      deadzone: 0.2,
+      active: true,
+      wasActive: false,
+      activeStarted: true,
+      activeEnded: false
+    },
+    'reports active start when the value exits the dead zone'
+  );
+  testCase.deepEqual(
+    pickAxisAction(secondActions[3]!),
+    {
+      name: 'thumbstick-y',
+      value: -0.3,
+      previousValue: 0,
+      valueDelta: -0.3,
+      deadzone: 0.2,
+      active: true,
+      wasActive: false,
+      activeStarted: true,
+      activeEnded: false
+    },
+    'tracks negative axis values by magnitude'
+  );
+
+  inputState.gamepad!.axes[0] = 0.2;
+  const thirdActions = manager.update([inputState], {deadzone: 0.2});
+  testCase.deepEqual(
+    pickAxisAction(thirdActions[0]!),
+    {
+      name: 'touchpad-x',
+      value: 0.2,
+      previousValue: 0.75,
+      valueDelta: -0.55,
+      deadzone: 0.2,
+      active: false,
+      wasActive: true,
+      activeStarted: false,
+      activeEnded: true
+    },
+    'dead-zone edge is inactive'
+  );
+
+  manager.reset(inputState.inputSource);
+  inputState.gamepad!.axes[0] = 1;
+  testCase.equal(
+    manager.update([inputState], {deadzone: 0.2})[0]?.wasActive,
+    false,
+    'reset clears previous axis state for one input source'
+  );
+  testCase.end();
+});
+
+test('webxr#WebXRGamepadAxisManager trims inactive input sources', testCase => {
+  const firstInputState = makeWebXRInputState({
+    mapping: 'xr-standard',
+    buttons: [],
+    axes: [1]
+  });
+  const secondInputState = makeWebXRInputState({
+    mapping: 'xr-standard',
+    buttons: [],
+    axes: [0.4]
+  });
+  const manager = new WebXRGamepadAxisManager();
+
+  manager.update([firstInputState, secondInputState]);
+  manager.update([secondInputState]);
+
+  firstInputState.gamepad!.axes[0] = 0;
+  const firstActionAfterTrim = manager.update([firstInputState])[0];
+  testCase.equal(firstActionAfterTrim?.wasActive, false, 'inactive input source state is trimmed');
+  testCase.equal(
+    firstActionAfterTrim?.activeEnded,
+    false,
+    'trimmed source does not report stale inactive transition'
+  );
+
+  manager.reset();
+  secondInputState.gamepad!.axes[0] = 0.5;
+  testCase.equal(
+    manager.update([secondInputState], {deadzone: 0.2})[0]?.activeStarted,
+    true,
+    'global reset clears every input source'
+  );
+  testCase.end();
+});
+
+test('webxr#getWebXRGamepadAxisActionState compares standalone states', testCase => {
+  const inputState = makeWebXRInputState({
+    mapping: 'xr-standard',
+    buttons: [],
+    axes: [-0.25]
+  });
+  const gamepadState = getWebXRGamepadState(inputState)!;
+
+  const actionState = getWebXRGamepadAxisActionState(gamepadState, gamepadState.axes[0]!, {
+    deadzone: 2,
+    previousAxis: {
+      value: -0.75,
+      active: true
+    }
+  });
+
+  testCase.equal(actionState.inputState, inputState, 'keeps input-state identity');
+  testCase.equal(actionState.inputSource, inputState.inputSource, 'keeps input-source identity');
+  testCase.equal(actionState.gamepadState, gamepadState, 'keeps gamepad-state identity');
+  testCase.equal(actionState.axis, gamepadState.axes[0], 'keeps axis-state identity');
+  testCase.deepEqual(
+    pickAxisAction(actionState),
+    {
+      name: 'touchpad-x',
+      value: -0.25,
+      previousValue: -0.75,
+      valueDelta: 0.5,
+      deadzone: 1,
+      active: false,
+      wasActive: true,
+      activeStarted: false,
+      activeEnded: true
+    },
+    'compares standalone previous axis state and clamps dead zone'
+  );
+  testCase.equal(
+    getWebXRGamepadAxisActionState(gamepadState, gamepadState.axes[0]!, {deadzone: -1}).deadzone,
+    0,
+    'dead zone cannot be negative'
+  );
+  testCase.end();
+});
+
 test('webxr#getWebXRGamepadButtonActionState compares standalone states', testCase => {
   const inputState = makeWebXRInputState({
     mapping: 'xr-standard',
@@ -344,5 +512,29 @@ function pickAction(actionState: {
     wasTouched: actionState.wasTouched,
     touchStarted: actionState.touchStarted,
     touchEnded: actionState.touchEnded
+  };
+}
+
+function pickAxisAction(actionState: {
+  name: unknown;
+  value: unknown;
+  previousValue: unknown;
+  valueDelta: unknown;
+  deadzone: unknown;
+  active: unknown;
+  wasActive: unknown;
+  activeStarted: unknown;
+  activeEnded: unknown;
+}): object {
+  return {
+    name: actionState.name,
+    value: actionState.value,
+    previousValue: actionState.previousValue,
+    valueDelta: actionState.valueDelta,
+    deadzone: actionState.deadzone,
+    active: actionState.active,
+    wasActive: actionState.wasActive,
+    activeStarted: actionState.activeStarted,
+    activeEnded: actionState.activeEnded
   };
 }

--- a/modules/experimental/test/webxr/webxr-gamepad.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-gamepad.node.spec.ts
@@ -1,0 +1,135 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {getWebXRGamepadState, getWebXRGamepadStates} from '../../src/webxr/webxr-gamepad';
+import type {WebXRInputState} from '../../src/webxr/webxr-manager';
+
+test('webxr#getWebXRGamepadState snapshots xr-standard buttons and axes', testCase => {
+  const inputState = makeWebXRInputState({
+    mapping: 'xr-standard',
+    buttons: [
+      {value: 0.75, pressed: true, touched: true},
+      {value: 0.25, pressed: false, touched: true},
+      {value: 0, pressed: false, touched: false},
+      {value: 1, pressed: true, touched: true},
+      {value: 0.5, pressed: false, touched: false}
+    ],
+    axes: [0.1, -0.2, 0.3, -0.4, 0.5]
+  });
+
+  const gamepadState = getWebXRGamepadState(inputState);
+
+  testCase.ok(gamepadState, 'returns state when a gamepad is present');
+  testCase.equal(gamepadState?.inputState, inputState, 'keeps input-state identity');
+  testCase.equal(gamepadState?.inputSource, inputState.inputSource, 'keeps input-source identity');
+  testCase.equal(gamepadState?.mapping, 'xr-standard', 'keeps gamepad mapping');
+  testCase.equal(gamepadState?.isXRStandardMapping, true, 'detects xr-standard mapping');
+  testCase.equal(gamepadState?.primaryTrigger?.name, 'trigger', 'names primary trigger');
+  testCase.equal(gamepadState?.primaryTrigger?.value, 0.75, 'snapshots trigger value');
+  testCase.equal(gamepadState?.primaryTrigger?.pressed, true, 'snapshots trigger press state');
+  testCase.equal(gamepadState?.primarySqueeze?.name, 'squeeze', 'names primary squeeze');
+  testCase.equal(gamepadState?.primaryTouchpad?.name, 'touchpad', 'names primary touchpad');
+  testCase.equal(gamepadState?.primaryThumbstick?.name, 'thumbstick', 'names primary thumbstick');
+  testCase.equal(gamepadState?.buttons[4]?.name, 'button-4', 'names extra buttons by index');
+  testCase.deepEqual(gamepadState?.touchpad, [0.1, -0.2], 'snapshots touchpad axes');
+  testCase.deepEqual(gamepadState?.thumbstick, [0.3, -0.4], 'snapshots thumbstick axes');
+  testCase.equal(gamepadState?.axes[4]?.name, 'axis-4', 'names extra axes by index');
+  testCase.deepEqual(
+    gamepadState?.pressed.map(button => button.name),
+    ['trigger', 'thumbstick'],
+    'collects pressed buttons'
+  );
+  testCase.deepEqual(
+    gamepadState?.touched.map(button => button.name),
+    ['trigger', 'squeeze', 'thumbstick'],
+    'collects touched buttons'
+  );
+
+  inputState.gamepad!.buttons[0] = {value: 0, pressed: false, touched: false} as GamepadButton;
+  testCase.equal(
+    gamepadState?.primaryTrigger?.value,
+    0.75,
+    'snapshot is stable when live gamepad object mutates'
+  );
+  testCase.end();
+});
+
+test('webxr#getWebXRGamepadStates filters missing gamepads', testCase => {
+  const gamepadInputState = makeWebXRInputState({
+    mapping: '',
+    buttons: [{value: 0.5, pressed: false, touched: true}],
+    axes: [0.25]
+  });
+  const emptyInputState = {...gamepadInputState, gamepad: null};
+
+  const gamepadState = getWebXRGamepadState(emptyInputState);
+  const gamepadStates = getWebXRGamepadStates([emptyInputState, gamepadInputState]);
+
+  testCase.equal(gamepadState, null, 'missing gamepads return null');
+  testCase.equal(gamepadStates.length, 1, 'batch helper filters missing gamepads');
+  testCase.equal(
+    gamepadStates[0]?.isXRStandardMapping,
+    false,
+    'empty mappings are not xr-standard'
+  );
+  testCase.equal(gamepadStates[0]?.buttons[0]?.name, 'button-0', 'nonstandard buttons are generic');
+  testCase.equal(gamepadStates[0]?.axes[0]?.name, 'axis-0', 'nonstandard axes are generic');
+  testCase.equal(gamepadStates[0]?.primaryTrigger, null, 'nonstandard mappings have no trigger');
+  testCase.equal(gamepadStates[0]?.touchpad, null, 'incomplete axis pairs return null');
+  testCase.equal(
+    getWebXRGamepadStates(null).length,
+    0,
+    'null input-state arrays return empty arrays'
+  );
+  testCase.end();
+});
+
+function makeWebXRInputState(props: {
+  mapping: GamepadMappingType | '';
+  buttons: GamepadButtonInit[];
+  axes: number[];
+}): WebXRInputState {
+  const inputSource = {
+    handedness: 'right',
+    targetRayMode: 'tracked-pointer',
+    targetRaySpace: new EventTarget() as XRSpace,
+    gripSpace: new EventTarget() as XRSpace,
+    profiles: ['generic-trigger']
+  } as XRInputSource;
+
+  return {
+    inputSource,
+    index: 0,
+    handedness: 'right',
+    targetRayMode: 'tracked-pointer',
+    profiles: inputSource.profiles,
+    gamepad: makeGamepad(props),
+    hand: null,
+    targetRayPose: null,
+    targetRayMatrix: null,
+    gripPose: null,
+    gripMatrix: null,
+    selectActive: false,
+    squeezeActive: false
+  };
+}
+
+function makeGamepad(props: {
+  mapping: GamepadMappingType | '';
+  buttons: GamepadButtonInit[];
+  axes: number[];
+}): Gamepad {
+  return {
+    axes: props.axes,
+    buttons: props.buttons.map(button => ({...button}) as GamepadButton),
+    connected: true,
+    hapticActuators: [],
+    id: '',
+    index: -1,
+    mapping: props.mapping,
+    timestamp: 0,
+    vibrationActuator: null
+  } as Gamepad;
+}

--- a/modules/experimental/test/webxr/webxr-gamepad.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-gamepad.node.spec.ts
@@ -3,7 +3,12 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
-import {getWebXRGamepadState, getWebXRGamepadStates} from '../../src/webxr/webxr-gamepad';
+import {
+  WebXRGamepadActionManager,
+  getWebXRGamepadButtonActionState,
+  getWebXRGamepadState,
+  getWebXRGamepadStates
+} from '../../src/webxr/webxr-gamepad';
 import type {WebXRInputState} from '../../src/webxr/webxr-manager';
 
 test('webxr#getWebXRGamepadState snapshots xr-standard buttons and axes', testCase => {
@@ -86,6 +91,184 @@ test('webxr#getWebXRGamepadStates filters missing gamepads', testCase => {
   testCase.end();
 });
 
+test('webxr#WebXRGamepadActionManager reports button transitions', testCase => {
+  const inputState = makeWebXRInputState({
+    mapping: 'xr-standard',
+    buttons: [
+      {value: 0, pressed: false, touched: false},
+      {value: 0, pressed: false, touched: false}
+    ],
+    axes: []
+  });
+  const manager = new WebXRGamepadActionManager();
+
+  const firstActions = manager.update([inputState]);
+  testCase.equal(firstActions.length, 2, 'returns one action per current button');
+  testCase.deepEqual(
+    pickAction(firstActions[0]!),
+    {
+      name: 'trigger',
+      value: 0,
+      previousValue: 0,
+      valueDelta: 0,
+      pressed: false,
+      wasPressed: false,
+      pressStarted: false,
+      pressEnded: false,
+      touched: false,
+      wasTouched: false,
+      touchStarted: false,
+      touchEnded: false
+    },
+    'starts from neutral previous state'
+  );
+
+  inputState.gamepad!.buttons[0] = {value: 1, pressed: true, touched: true} as GamepadButton;
+  inputState.gamepad!.buttons[1] = {value: 0.4, pressed: false, touched: true} as GamepadButton;
+  const secondActions = manager.update([inputState]);
+  testCase.deepEqual(
+    pickAction(secondActions[0]!),
+    {
+      name: 'trigger',
+      value: 1,
+      previousValue: 0,
+      valueDelta: 1,
+      pressed: true,
+      wasPressed: false,
+      pressStarted: true,
+      pressEnded: false,
+      touched: true,
+      wasTouched: false,
+      touchStarted: true,
+      touchEnded: false
+    },
+    'reports press and touch starts'
+  );
+  testCase.deepEqual(
+    pickAction(secondActions[1]!),
+    {
+      name: 'squeeze',
+      value: 0.4,
+      previousValue: 0,
+      valueDelta: 0.4,
+      pressed: false,
+      wasPressed: false,
+      pressStarted: false,
+      pressEnded: false,
+      touched: true,
+      wasTouched: false,
+      touchStarted: true,
+      touchEnded: false
+    },
+    'tracks touch-only actions'
+  );
+
+  inputState.gamepad!.buttons[0] = {value: 0.25, pressed: false, touched: false} as GamepadButton;
+  inputState.gamepad!.buttons[1] = {value: 0, pressed: false, touched: false} as GamepadButton;
+  const thirdActions = manager.update([inputState]);
+  testCase.deepEqual(
+    pickAction(thirdActions[0]!),
+    {
+      name: 'trigger',
+      value: 0.25,
+      previousValue: 1,
+      valueDelta: -0.75,
+      pressed: false,
+      wasPressed: true,
+      pressStarted: false,
+      pressEnded: true,
+      touched: false,
+      wasTouched: true,
+      touchStarted: false,
+      touchEnded: true
+    },
+    'reports press and touch ends'
+  );
+
+  manager.reset(inputState.inputSource);
+  inputState.gamepad!.buttons[0] = {value: 0.5, pressed: true, touched: true} as GamepadButton;
+  testCase.equal(
+    manager.update([inputState])[0]?.wasPressed,
+    false,
+    'reset clears previous state for one input source'
+  );
+  testCase.end();
+});
+
+test('webxr#WebXRGamepadActionManager trims inactive input sources', testCase => {
+  const firstInputState = makeWebXRInputState({
+    mapping: 'xr-standard',
+    buttons: [{value: 1, pressed: true, touched: true}],
+    axes: []
+  });
+  const secondInputState = makeWebXRInputState({
+    mapping: 'xr-standard',
+    buttons: [{value: 0.2, pressed: false, touched: true}],
+    axes: []
+  });
+  const manager = new WebXRGamepadActionManager();
+
+  manager.update([firstInputState, secondInputState]);
+  manager.update([secondInputState]);
+
+  firstInputState.gamepad!.buttons[0] = {value: 0, pressed: false, touched: false} as GamepadButton;
+  const firstActionAfterTrim = manager.update([firstInputState])[0];
+  testCase.equal(firstActionAfterTrim?.wasPressed, false, 'inactive input source state is trimmed');
+  testCase.equal(
+    firstActionAfterTrim?.pressStarted,
+    false,
+    'trimmed source does not report stale release'
+  );
+
+  manager.reset();
+  secondInputState.gamepad!.buttons[0] = {value: 1, pressed: true, touched: true} as GamepadButton;
+  testCase.equal(
+    manager.update([secondInputState])[0]?.pressStarted,
+    true,
+    'global reset clears every input source'
+  );
+  testCase.end();
+});
+
+test('webxr#getWebXRGamepadButtonActionState compares standalone states', testCase => {
+  const inputState = makeWebXRInputState({
+    mapping: 'xr-standard',
+    buttons: [{value: 0.25, pressed: false, touched: false}],
+    axes: []
+  });
+  const gamepadState = getWebXRGamepadState(inputState)!;
+
+  const actionState = getWebXRGamepadButtonActionState(gamepadState, gamepadState.buttons[0]!, {
+    value: 0.75,
+    pressed: true,
+    touched: true
+  });
+
+  testCase.equal(actionState.inputState, inputState, 'keeps input-state identity');
+  testCase.equal(actionState.inputSource, inputState.inputSource, 'keeps input-source identity');
+  testCase.equal(actionState.gamepadState, gamepadState, 'keeps gamepad-state identity');
+  testCase.equal(actionState.button, gamepadState.buttons[0], 'keeps button-state identity');
+  testCase.deepEqual(
+    pickAction(actionState),
+    {
+      name: 'trigger',
+      value: 0.25,
+      previousValue: 0.75,
+      valueDelta: -0.5,
+      pressed: false,
+      wasPressed: true,
+      pressStarted: false,
+      pressEnded: true,
+      touched: false,
+      wasTouched: true,
+      touchStarted: false,
+      touchEnded: true
+    },
+    'compares standalone previous button state'
+  );
+  testCase.end();
+});
+
 function makeWebXRInputState(props: {
   mapping: GamepadMappingType | '';
   buttons: GamepadButtonInit[];
@@ -132,4 +315,34 @@ function makeGamepad(props: {
     timestamp: 0,
     vibrationActuator: null
   } as Gamepad;
+}
+
+function pickAction(actionState: {
+  name: unknown;
+  value: unknown;
+  previousValue: unknown;
+  valueDelta: unknown;
+  pressed: unknown;
+  wasPressed: unknown;
+  pressStarted: unknown;
+  pressEnded: unknown;
+  touched: unknown;
+  wasTouched: unknown;
+  touchStarted: unknown;
+  touchEnded: unknown;
+}): object {
+  return {
+    name: actionState.name,
+    value: actionState.value,
+    previousValue: actionState.previousValue,
+    valueDelta: actionState.valueDelta,
+    pressed: actionState.pressed,
+    wasPressed: actionState.wasPressed,
+    pressStarted: actionState.pressStarted,
+    pressEnded: actionState.pressEnded,
+    touched: actionState.touched,
+    wasTouched: actionState.wasTouched,
+    touchStarted: actionState.touchStarted,
+    touchEnded: actionState.touchEnded
+  };
 }

--- a/modules/experimental/test/webxr/webxr-hand-gestures.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-hand-gestures.node.spec.ts
@@ -1,0 +1,117 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {getWebXRHandPinch} from '../../src/webxr/webxr-hand-gestures';
+import type {
+  WebXRHandJointState,
+  WebXRHandTrackingState
+} from '../../src/webxr/webxr-hand-tracking';
+
+test('webxr#getWebXRHandPinch resolves active thumb-index pinches', testCase => {
+  const inputSource = {} as XRInputSource;
+  const handState = makeHandState({
+    inputSource,
+    handedness: 'left',
+    joints: [makeJoint('thumb-tip', [0, 0, 0]), makeJoint('index-finger-tip', [0.01, 0, 0])]
+  });
+  const pinchState = getWebXRHandPinch(handState);
+
+  testCase.equal(pinchState?.inputSource, inputSource, 'retains source input');
+  testCase.equal(pinchState?.handedness, 'left', 'retains handedness');
+  testCase.equal(pinchState?.thumbJoint.jointName, 'thumb-tip', 'uses thumb tip');
+  testCase.equal(pinchState?.fingerJoint.jointName, 'index-finger-tip', 'uses index tip');
+  testCase.equal(pinchState?.pinchActive, true, 'marks close tips active');
+  testCase.ok(Math.abs((pinchState?.distance || 0) - 0.01) < 1e-6, 'reports tip distance');
+  testCase.ok((pinchState?.strength || 0) > 0.9, 'reports strong pinch');
+  testCase.ok(
+    Math.abs((pinchState?.position[0] || 0) - 0.005) < 1e-6 &&
+      pinchState?.position[1] === 0 &&
+      pinchState?.position[2] === 0,
+    'reports midpoint position'
+  );
+  testCase.end();
+});
+
+test('webxr#getWebXRHandPinch handles falloff, custom joints, and partial data', testCase => {
+  const handState = makeHandState({
+    handedness: 'right',
+    joints: [
+      makeJoint('thumb-tip', [0, 0, 0]),
+      makeJoint('index-finger-tip', [0.05, 0, 0]),
+      makeJoint('middle-finger-tip', [0.018, 0, 0])
+    ]
+  });
+  const inactivePinch = getWebXRHandPinch(handState);
+  const customPinch = getWebXRHandPinch(handState, {
+    fingerJointName: 'middle-finger-tip',
+    activeDistance: 0.02,
+    strengthDistance: 0.04
+  });
+  const missingPinch = getWebXRHandPinch(
+    makeHandState({
+      handedness: 'right',
+      joints: [makeJoint('thumb-tip', [0, 0, 0])]
+    })
+  );
+  const untrackedPinch = getWebXRHandPinch(
+    makeHandState({
+      handedness: 'right',
+      joints: [
+        makeJoint('thumb-tip', [0, 0, 0]),
+        {...makeJoint('index-finger-tip', [0.01, 0, 0]), matrix: null}
+      ]
+    })
+  );
+
+  testCase.equal(inactivePinch?.pinchActive, false, 'marks distant index tip inactive');
+  testCase.ok(
+    (inactivePinch?.strength || 0) > 0 && (inactivePinch?.strength || 0) < 1,
+    'reports falloff strength before release distance'
+  );
+  testCase.equal(customPinch?.pinchActive, true, 'supports custom finger joint');
+  testCase.equal(customPinch?.fingerJoint.jointName, 'middle-finger-tip', 'retains custom joint');
+  testCase.equal(missingPinch, null, 'returns null for missing finger joint');
+  testCase.equal(untrackedPinch, null, 'returns null for untracked finger matrix');
+  testCase.end();
+});
+
+function makeHandState(options: {
+  inputSource?: XRInputSource;
+  handedness: XRHandedness;
+  joints: WebXRHandJointState[];
+}): WebXRHandTrackingState {
+  return {
+    xrFrame: {} as XRFrame,
+    inputSource: options.inputSource || ({} as XRInputSource),
+    handedness: options.handedness,
+    hand: {} as XRHand,
+    joints: options.joints,
+    matrices: new Float32Array(0),
+    radii: new Float32Array(0),
+    allJointsTracked: true
+  };
+}
+
+function makeJoint(
+  jointName: XRHandJoint,
+  position: [number, number, number]
+): WebXRHandJointState {
+  const matrix = new Float32Array(16);
+  matrix[0] = 1;
+  matrix[5] = 1;
+  matrix[10] = 1;
+  matrix[12] = position[0];
+  matrix[13] = position[1];
+  matrix[14] = position[2];
+  matrix[15] = 1;
+
+  return {
+    jointName,
+    jointSpace: {jointName} as XRJointSpace,
+    pose: null,
+    matrix,
+    radius: 0.01
+  };
+}

--- a/modules/experimental/test/webxr/webxr-hand-tracking.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-hand-tracking.node.spec.ts
@@ -1,0 +1,200 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {WEBXR_HAND_JOINTS, WebXRHandTrackingManager} from '../../src/webxr/webxr-hand-tracking';
+
+test('webxr#WebXRHandTrackingManager resolves batched hand joint poses and radii', testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const jointSpaces = new Map<XRHandJoint, XRJointSpace>([
+    ['wrist', makeMockXRJointSpace('wrist')],
+    ['index-finger-tip', makeMockXRJointSpace('index-finger-tip')]
+  ]);
+  const hand = makeMockXRHand(jointSpaces);
+  const handInputSource = makeMockXRInputSource({handedness: 'left', hand});
+  const controllerInputSource = makeMockXRInputSource({handedness: 'right'});
+  const session = makeMockXRSession(referenceSpace, [handInputSource, controllerInputSource]);
+  const frame = {
+    session,
+    fillPoses(spaces: readonly XRSpace[], baseSpace: XRSpace, transforms: Float32Array): boolean {
+      testCase.deepEqual(spaces, Array.from(jointSpaces.values()), 'fills discovered joint spaces');
+      testCase.equal(baseSpace, referenceSpace, 'fills matrices in app reference space');
+      for (let jointIndex = 0; jointIndex < spaces.length; jointIndex++) {
+        const matrixOffset = jointIndex * 16;
+        transforms[matrixOffset] = 1;
+        transforms[matrixOffset + 5] = 1;
+        transforms[matrixOffset + 10] = 1;
+        transforms[matrixOffset + 12] = jointIndex + 1;
+        transforms[matrixOffset + 15] = 1;
+      }
+      return true;
+    },
+    fillJointRadii(spaces: readonly XRJointSpace[], radii: Float32Array): boolean {
+      testCase.deepEqual(spaces, Array.from(jointSpaces.values()), 'fills radii for joint spaces');
+      radii[0] = 0.01;
+      radii[1] = 0.02;
+      return true;
+    }
+  } as XRFrame;
+  const manager = new WebXRHandTrackingManager();
+
+  manager.setSession(session, referenceSpace);
+  const handStates = manager.getHandsState(frame);
+
+  testCase.equal(WEBXR_HAND_JOINTS.length, 25, 'exports the standard WebXR joint list');
+  testCase.equal(handStates?.length, 1, 'filters non-hand input sources');
+  testCase.equal(handStates?.[0]?.inputSource, handInputSource, 'retains input source');
+  testCase.equal(handStates?.[0]?.handedness, 'left', 'retains handedness');
+  testCase.equal(handStates?.[0]?.hand, hand, 'retains hand object');
+  testCase.equal(handStates?.[0]?.joints.length, 2, 'keeps discovered joints');
+  testCase.equal(handStates?.[0]?.joints[0]?.jointName, 'wrist', 'keeps joint ordering');
+  testCase.deepEqual(
+    Array.from(handStates?.[0]?.joints[0]?.matrix || []),
+    Array.from(handStates?.[0]?.matrices.subarray(0, 16) || []),
+    'joint matrix references batched matrix storage'
+  );
+  testCase.ok(
+    Math.abs((handStates?.[0]?.joints[0]?.radius || 0) - 0.01) < 1e-6,
+    'keeps wrist radius'
+  );
+  testCase.equal(handStates?.[0]?.joints[1]?.matrix?.[12], 2, 'keeps index-tip matrix');
+  testCase.ok(
+    Math.abs((handStates?.[0]?.joints[1]?.radius || 0) - 0.02) < 1e-6,
+    'keeps index-tip radius'
+  );
+  testCase.equal(handStates?.[0]?.allJointsTracked, true, 'reports complete tracked batch');
+
+  session.dispatchEvent(new Event('end'));
+  testCase.equal(manager.session, null, 'session end clears session');
+  testCase.end();
+});
+
+test('webxr#WebXRHandTrackingManager falls back to getJointPose', testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const wristSpace = makeMockXRJointSpace('wrist');
+  const hand = makeMockXRHand(new Map([['wrist', wristSpace]]));
+  const handInputSource = makeMockXRInputSource({handedness: 'right', hand});
+  const session = makeMockXRSession(referenceSpace, [handInputSource]);
+  const jointPose = makeMockXRJointPose([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 3, 4, 5, 1], 0.04);
+  const frame = {
+    session,
+    getJointPose(joint: XRJointSpace, baseSpace: XRSpace): XRJointPose | null {
+      testCase.equal(joint, wristSpace, 'queries fallback joint space');
+      testCase.equal(baseSpace, referenceSpace, 'queries fallback reference space');
+      return jointPose;
+    }
+  } as XRFrame;
+  const manager = new WebXRHandTrackingManager();
+
+  manager.setSession(session, referenceSpace);
+  const handState = manager.getHandState(frame, handInputSource);
+
+  testCase.equal(handState?.joints.length, 1, 'resolves fallback joint');
+  testCase.equal(handState?.joints[0]?.pose, jointPose, 'retains fallback joint pose');
+  testCase.equal(handState?.joints[0]?.matrix, jointPose.transform.matrix, 'uses fallback matrix');
+  testCase.equal(handState?.joints[0]?.radius, 0.04, 'uses fallback radius');
+  testCase.equal(handState?.allJointsTracked, true, 'fallback pose marks joint tracked');
+  testCase.end();
+});
+
+test('webxr#WebXRHandTrackingManager handles invalid and partial hand sessions', testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const session = makeMockXRSession(referenceSpace, []);
+  const inactiveManager = new WebXRHandTrackingManager();
+  const manager = new WebXRHandTrackingManager();
+  const inputSource = makeMockXRInputSource({handedness: 'none'});
+  const handInputSource = makeMockXRInputSource({
+    handedness: 'left',
+    hand: makeMockXRHand(new Map([['wrist', makeMockXRJointSpace('wrist')]]))
+  });
+  const frame = {
+    session,
+    fillPoses: () => false,
+    fillJointRadii(spaces: readonly XRJointSpace[], radii: Float32Array): boolean {
+      radii[0] = Number.NaN;
+      return false;
+    }
+  } as XRFrame;
+
+  testCase.throws(
+    () => manager.setSession(session, null),
+    /reference space/,
+    'rejects missing app reference space'
+  );
+  testCase.equal(
+    inactiveManager.getHandsState(frame),
+    null,
+    'inactive manager returns null hand snapshots'
+  );
+
+  manager.setSession(session, referenceSpace);
+  testCase.equal(manager.getHandState(frame, inputSource), null, 'non-hand input returns null');
+  const handState = manager.getHandState(frame, handInputSource);
+  testCase.equal(handState?.joints[0]?.matrix, null, 'invalid batch matrix becomes null');
+  testCase.equal(handState?.joints[0]?.radius, null, 'invalid radius becomes null');
+  testCase.equal(handState?.allJointsTracked, false, 'partial hand is marked incomplete');
+  testCase.throws(
+    () =>
+      manager.getHandsState({
+        session: makeMockXRSession(referenceSpace, [])
+      } as XRFrame),
+    /different XRSession/,
+    'rejects foreign frames'
+  );
+
+  manager.clearSession();
+  manager.clearSession();
+  testCase.equal(manager.session, null, 'clearSession is idempotent');
+  testCase.end();
+});
+
+function makeMockXRSession(
+  referenceSpace: XRReferenceSpace,
+  inputSources: XRInputSource[]
+): XRSession & {inputSources: XRInputSource[]} {
+  return Object.assign(new EventTarget(), {
+    inputSources,
+    async requestReferenceSpace(): Promise<XRReferenceSpace> {
+      return referenceSpace;
+    }
+  }) as XRSession & {inputSources: XRInputSource[]};
+}
+
+function makeMockXRInputSource(options: {handedness: XRHandedness; hand?: XRHand}): XRInputSource {
+  return {
+    handedness: options.handedness,
+    targetRayMode: 'tracked-pointer',
+    targetRaySpace: {} as XRSpace,
+    profiles: options.hand ? ['generic-hand-select'] : ['generic-trigger'],
+    hand: options.hand
+  } as XRInputSource;
+}
+
+function makeMockXRHand(jointSpaces: Map<XRHandJoint, XRJointSpace>): XRHand {
+  return {
+    size: jointSpaces.size,
+    get(jointName: XRHandJoint): XRJointSpace | undefined {
+      return jointSpaces.get(jointName);
+    },
+    [Symbol.iterator](): IterableIterator<[XRHandJoint, XRJointSpace]> {
+      return jointSpaces[Symbol.iterator]();
+    }
+  };
+}
+
+function makeMockXRJointSpace(jointName: XRHandJoint): XRJointSpace {
+  return {
+    jointName
+  } as XRJointSpace;
+}
+
+function makeMockXRJointPose(matrix: number[], radius: number): XRJointPose {
+  return {
+    radius,
+    transform: {
+      matrix: new Float32Array(matrix),
+      inverse: {matrix: new Float32Array(matrix)}
+    }
+  } as XRJointPose;
+}

--- a/modules/experimental/test/webxr/webxr-haptics.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-haptics.node.spec.ts
@@ -1,0 +1,105 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  getWebXRInputHapticActuator,
+  pulseWebXRInputHaptics,
+  type WebXRGamepadHapticActuator
+} from '../../src/webxr/webxr-haptics';
+import type {WebXRInputState} from '../../src/webxr/webxr-manager';
+
+test('webxr#pulseWebXRInputHaptics pulses the first gamepad haptic actuator', async testCase => {
+  const actuator = makeMockHapticActuator();
+  const inputState = makeMockWebXRInputState({
+    hapticActuators: [{} as WebXRGamepadHapticActuator, actuator]
+  });
+
+  const result = await pulseWebXRInputHaptics(inputState, {
+    intensity: 1.7,
+    duration: 25
+  });
+
+  testCase.equal(getWebXRInputHapticActuator(inputState), actuator, 'uses first pulse actuator');
+  testCase.equal(result?.inputState, inputState, 'retains source input state');
+  testCase.equal(result?.actuator, actuator, 'retains selected actuator');
+  testCase.equal(result?.intensity, 1, 'clamps intensity');
+  testCase.equal(result?.duration, 25, 'keeps supplied duration');
+  testCase.equal(result?.value, 'ok', 'returns actuator pulse result');
+  testCase.deepEqual(actuator.pulses, [{intensity: 1, duration: 25}], 'pulses actuator');
+  testCase.end();
+});
+
+test('webxr#pulseWebXRInputHaptics handles fallbacks and unsupported inputs', async testCase => {
+  const vibrationActuator = makeMockHapticActuator();
+  const fallbackInputState = makeMockWebXRInputState({vibrationActuator});
+  const emptyInputState = makeMockWebXRInputState({});
+  const noGamepadInputState = makeMockWebXRInputState(null);
+
+  const fallbackResult = await pulseWebXRInputHaptics(fallbackInputState, {
+    intensity: -1,
+    duration: -4
+  });
+
+  testCase.equal(
+    getWebXRInputHapticActuator(fallbackInputState),
+    vibrationActuator,
+    'falls back to vibrationActuator'
+  );
+  testCase.equal(fallbackResult?.intensity, 0, 'clamps low intensity');
+  testCase.equal(fallbackResult?.duration, 0, 'clamps low duration');
+  testCase.deepEqual(
+    vibrationActuator.pulses,
+    [{intensity: 0, duration: 0}],
+    'pulses fallback actuator'
+  );
+  testCase.equal(
+    await pulseWebXRInputHaptics(emptyInputState),
+    null,
+    'returns null without actuator'
+  );
+  testCase.equal(
+    await pulseWebXRInputHaptics(noGamepadInputState),
+    null,
+    'returns null without gamepad'
+  );
+  testCase.end();
+});
+
+function makeMockHapticActuator(): WebXRGamepadHapticActuator & {
+  pulses: {intensity: number; duration: number}[];
+} {
+  return {
+    pulses: [],
+    pulse(intensity: number, duration: number): string {
+      this.pulses.push({intensity, duration});
+      return 'ok';
+    }
+  };
+}
+
+function makeMockWebXRInputState(
+  gamepad:
+    | (Partial<Gamepad> & {
+        hapticActuators?: readonly WebXRGamepadHapticActuator[];
+        vibrationActuator?: WebXRGamepadHapticActuator;
+      })
+    | null
+): WebXRInputState {
+  return {
+    inputSource: {} as XRInputSource,
+    index: 0,
+    handedness: 'right',
+    targetRayMode: 'tracked-pointer',
+    profiles: [],
+    gamepad: gamepad as Gamepad | null,
+    hand: null,
+    targetRayPose: null,
+    targetRayMatrix: null,
+    gripPose: null,
+    gripMatrix: null,
+    selectActive: false,
+    squeezeActive: false
+  };
+}

--- a/modules/experimental/test/webxr/webxr-hit-test.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-hit-test.node.spec.ts
@@ -4,6 +4,7 @@
 
 import test from 'test/utils/vitest-tape';
 import {
+  getWebXRHitTestPlacementResult,
   getWebXRHitTestResult,
   getWebXRTransientInputHitTestResult,
   WebXRHitTestManager
@@ -71,6 +72,11 @@ test('webxr#WebXRHitTestManager resolves AR hit-test poses', async testCase => {
   testCase.equal(hitTestState?.hits[0]?.pose, firstPose, 'retains hit pose');
   testCase.equal(hitTestState?.hits[0]?.matrix, firstPose.transform.matrix, 'exposes hit matrix');
   testCase.equal(getWebXRHitTestResult(hitTestState), hitTestState?.hits[0], 'selects first hit');
+  testCase.equal(
+    getWebXRHitTestPlacementResult(hitTestState),
+    hitTestState?.hits[0],
+    'placement selection falls back to regular hits'
+  );
   testCase.equal(
     getWebXRHitTestResult(hitTestState, {index: 1}),
     null,
@@ -195,6 +201,16 @@ test('webxr#WebXRHitTestManager resolves transient input hit-test poses', async 
     getWebXRTransientInputHitTestResult(null),
     null,
     'null transient hit states return null'
+  );
+  testCase.equal(
+    getWebXRHitTestPlacementResult(hitTestState),
+    hitTestState?.transientInput[0]?.results[0],
+    'placement selection prefers transient input hits'
+  );
+  testCase.equal(
+    getWebXRHitTestPlacementResult(hitTestState, {preferTransientInput: false}),
+    hitTestState?.transientInput[0]?.results[0],
+    'placement selection falls back to transient input hits'
   );
 
   session.dispatchEvent(new Event('end'));

--- a/modules/experimental/test/webxr/webxr-hit-test.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-hit-test.node.spec.ts
@@ -3,7 +3,11 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
-import {WebXRHitTestManager} from '../../src/webxr/webxr-hit-test';
+import {
+  getWebXRHitTestResult,
+  getWebXRTransientInputHitTestResult,
+  WebXRHitTestManager
+} from '../../src/webxr/webxr-hit-test';
 
 type MockXRHitTestSource = XRHitTestSource & {cancelCount: number};
 type MockXRTransientInputHitTestSource = XRTransientInputHitTestSource & {cancelCount: number};
@@ -66,6 +70,13 @@ test('webxr#WebXRHitTestManager resolves AR hit-test poses', async testCase => {
   testCase.equal(hitTestState?.hits[0]?.xrHitTestResult, firstResult, 'retains raw hit result');
   testCase.equal(hitTestState?.hits[0]?.pose, firstPose, 'retains hit pose');
   testCase.equal(hitTestState?.hits[0]?.matrix, firstPose.transform.matrix, 'exposes hit matrix');
+  testCase.equal(getWebXRHitTestResult(hitTestState), hitTestState?.hits[0], 'selects first hit');
+  testCase.equal(
+    getWebXRHitTestResult(hitTestState, {index: 1}),
+    null,
+    'missing hit indices return null'
+  );
+  testCase.equal(getWebXRHitTestResult(null), null, 'null hit states return null');
   testCase.deepEqual(hitTestState?.transientInput, [], 'exposes empty transient input results');
 
   session.dispatchEvent(new Event('end'));
@@ -159,6 +170,31 @@ test('webxr#WebXRHitTestManager resolves transient input hit-test poses', async 
     hitTestState?.transientInput[0]?.results[0]?.matrix,
     firstPose.transform.matrix,
     'exposes transient hit matrix'
+  );
+  testCase.equal(
+    getWebXRTransientInputHitTestResult(hitTestState),
+    hitTestState?.transientInput[0]?.results[0],
+    'selects first transient input hit'
+  );
+  testCase.equal(
+    getWebXRTransientInputHitTestResult(hitTestState, {inputSource}),
+    hitTestState?.transientInput[0]?.results[0],
+    'selects transient input hit by source'
+  );
+  testCase.equal(
+    getWebXRTransientInputHitTestResult(hitTestState, {inputSource: {} as XRInputSource}),
+    null,
+    'missing transient input sources return null'
+  );
+  testCase.equal(
+    getWebXRTransientInputHitTestResult(hitTestState, {index: 1}),
+    null,
+    'missing transient hit indices return null'
+  );
+  testCase.equal(
+    getWebXRTransientInputHitTestResult(null),
+    null,
+    'null transient hit states return null'
   );
 
   session.dispatchEvent(new Event('end'));

--- a/modules/experimental/test/webxr/webxr-hit-test.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-hit-test.node.spec.ts
@@ -6,10 +6,13 @@ import test from 'test/utils/vitest-tape';
 import {WebXRHitTestManager} from '../../src/webxr/webxr-hit-test';
 
 type MockXRHitTestSource = XRHitTestSource & {cancelCount: number};
+type MockXRTransientInputHitTestSource = XRTransientInputHitTestSource & {cancelCount: number};
 type MockXRSession = XRSession & {
   requestedReferenceSpaceTypes: XRReferenceSpaceType[];
   receivedHitTestOptions: XRHitTestOptionsInit | null;
+  receivedTransientInputHitTestOptions: XRTransientInputHitTestOptionsInit | null;
   nextHitTestSource: XRHitTestSource | null;
+  nextTransientInputHitTestSource: XRTransientInputHitTestSource | null;
 };
 
 test('webxr#WebXRHitTestManager resolves AR hit-test poses', async testCase => {
@@ -63,10 +66,108 @@ test('webxr#WebXRHitTestManager resolves AR hit-test poses', async testCase => {
   testCase.equal(hitTestState?.hits[0]?.xrHitTestResult, firstResult, 'retains raw hit result');
   testCase.equal(hitTestState?.hits[0]?.pose, firstPose, 'retains hit pose');
   testCase.equal(hitTestState?.hits[0]?.matrix, firstPose.transform.matrix, 'exposes hit matrix');
+  testCase.deepEqual(hitTestState?.transientInput, [], 'exposes empty transient input results');
 
   session.dispatchEvent(new Event('end'));
   testCase.equal(hitTestSource.cancelCount, 1, 'session end cancels source');
   testCase.equal(manager.getHitTestState(frame), null, 'ended sessions expose no hit state');
+  testCase.end();
+});
+
+test('webxr#WebXRHitTestManager resolves transient input hit-test poses', async testCase => {
+  const appReferenceSpace = {} as XRReferenceSpace;
+  const viewerReferenceSpace = {} as XRReferenceSpace;
+  const offsetRay = {} as XRRay;
+  const hitTestSource = makeMockXRHitTestSource();
+  const transientInputHitTestSource = makeMockXRTransientInputHitTestSource();
+  const inputSource = {targetRayMode: 'screen', profiles: ['generic-touchscreen']} as XRInputSource;
+  const firstPose = makeMockXRPose([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.5, 0, -1.5, 1]);
+  const firstResult = makeMockXRHitTestResult(firstPose);
+  const missingPoseResult = makeMockXRHitTestResult(undefined);
+  const session = makeMockXRSession({
+    appReferenceSpace,
+    viewerReferenceSpace,
+    hitTestSource,
+    transientInputHitTestSource
+  });
+  const frame = {
+    session,
+    getHitTestResults(receivedHitTestSource: XRHitTestSource): XRHitTestResult[] {
+      testCase.equal(receivedHitTestSource, hitTestSource, 'queries configured hit-test source');
+      return [];
+    },
+    getHitTestResultsForTransientInput(
+      receivedTransientInputHitTestSource: XRTransientInputHitTestSource
+    ): XRTransientInputHitTestResult[] {
+      testCase.equal(
+        receivedTransientInputHitTestSource,
+        transientInputHitTestSource,
+        'queries configured transient input source'
+      );
+      return [
+        {
+          inputSource,
+          results: [firstResult, missingPoseResult]
+        }
+      ];
+    }
+  } as XRFrame;
+
+  const manager = new WebXRHitTestManager();
+  await manager.setSession(session, appReferenceSpace, {
+    entityTypes: ['plane', 'point'],
+    transientInput: {
+      profile: 'generic-touchscreen',
+      entityTypes: ['plane', 'mesh'],
+      offsetRay
+    }
+  });
+  const hitTestState = manager.getHitTestState(frame);
+
+  testCase.deepEqual(
+    session.receivedTransientInputHitTestOptions,
+    {
+      profile: 'generic-touchscreen',
+      offsetRay,
+      entityTypes: ['plane', 'mesh']
+    },
+    'requests transient input hit-test source with caller options'
+  );
+  testCase.equal(
+    manager.transientInputHitTestSource,
+    transientInputHitTestSource,
+    'retains transient input hit-test source'
+  );
+  testCase.equal(hitTestState?.hits.length, 0, 'keeps regular hit results separate');
+  testCase.equal(hitTestState?.transientInput.length, 1, 'returns one transient input group');
+  testCase.equal(
+    hitTestState?.transientInput[0]?.inputSource,
+    inputSource,
+    'retains transient input source'
+  );
+  testCase.equal(
+    hitTestState?.transientInput[0]?.results.length,
+    1,
+    'filters transient hits without poses'
+  );
+  testCase.equal(
+    hitTestState?.transientInput[0]?.results[0]?.xrHitTestResult,
+    firstResult,
+    'retains raw transient hit result'
+  );
+  testCase.equal(
+    hitTestState?.transientInput[0]?.results[0]?.matrix,
+    firstPose.transform.matrix,
+    'exposes transient hit matrix'
+  );
+
+  session.dispatchEvent(new Event('end'));
+  testCase.equal(hitTestSource.cancelCount, 1, 'session end cancels hit-test source');
+  testCase.equal(
+    transientInputHitTestSource.cancelCount,
+    1,
+    'session end cancels transient input source'
+  );
   testCase.end();
 });
 
@@ -139,13 +240,16 @@ function makeMockXRSession(props: {
   appReferenceSpace: XRReferenceSpace;
   viewerReferenceSpace: XRReferenceSpace;
   hitTestSource: XRHitTestSource;
+  transientInputHitTestSource?: XRTransientInputHitTestSource;
 }): MockXRSession {
   const session = Object.assign(new EventTarget(), {
     enabledFeatures: ['hit-test'],
     inputSources: [],
     requestedReferenceSpaceTypes: [] as XRReferenceSpaceType[],
     receivedHitTestOptions: null as XRHitTestOptionsInit | null,
+    receivedTransientInputHitTestOptions: null as XRTransientInputHitTestOptionsInit | null,
     nextHitTestSource: props.hitTestSource,
+    nextTransientInputHitTestSource: props.transientInputHitTestSource || null,
     async requestReferenceSpace(type: XRReferenceSpaceType): Promise<XRReferenceSpace> {
       session.requestedReferenceSpaceTypes.push(type);
       return type === 'viewer' ? props.viewerReferenceSpace : props.appReferenceSpace;
@@ -153,6 +257,12 @@ function makeMockXRSession(props: {
     async requestHitTestSource(options: XRHitTestOptionsInit): Promise<XRHitTestSource | null> {
       session.receivedHitTestOptions = options;
       return session.nextHitTestSource;
+    },
+    async requestHitTestSourceForTransientInput(
+      options: XRTransientInputHitTestOptionsInit
+    ): Promise<XRTransientInputHitTestSource | null> {
+      session.receivedTransientInputHitTestOptions = options;
+      return session.nextTransientInputHitTestSource;
     }
   }) as MockXRSession;
 
@@ -160,6 +270,15 @@ function makeMockXRSession(props: {
 }
 
 function makeMockXRHitTestSource(): MockXRHitTestSource {
+  return {
+    cancelCount: 0,
+    cancel() {
+      this.cancelCount++;
+    }
+  };
+}
+
+function makeMockXRTransientInputHitTestSource(): MockXRTransientInputHitTestSource {
   return {
     cancelCount: 0,
     cancel() {

--- a/modules/experimental/test/webxr/webxr-hit-test.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-hit-test.node.spec.ts
@@ -1,0 +1,186 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {WebXRHitTestManager} from '../../src/webxr/webxr-hit-test';
+
+type MockXRHitTestSource = XRHitTestSource & {cancelCount: number};
+type MockXRSession = XRSession & {
+  requestedReferenceSpaceTypes: XRReferenceSpaceType[];
+  receivedHitTestOptions: XRHitTestOptionsInit | null;
+  nextHitTestSource: XRHitTestSource | null;
+};
+
+test('webxr#WebXRHitTestManager resolves AR hit-test poses', async testCase => {
+  const appReferenceSpace = {} as XRReferenceSpace;
+  const viewerReferenceSpace = {} as XRReferenceSpace;
+  const offsetRay = {} as XRRay;
+  const hitTestSource = makeMockXRHitTestSource();
+  const firstPose = makeMockXRPose([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 2, 0, -3, 1]);
+  const firstResult = makeMockXRHitTestResult(firstPose);
+  const missingPoseResult = makeMockXRHitTestResult(undefined);
+  const session = makeMockXRSession({
+    appReferenceSpace,
+    viewerReferenceSpace,
+    hitTestSource
+  });
+  const frame = {
+    session,
+    getHitTestResults(receivedHitTestSource: XRHitTestSource): XRHitTestResult[] {
+      testCase.equal(receivedHitTestSource, hitTestSource, 'queries configured hit-test source');
+      return [firstResult, missingPoseResult];
+    }
+  } as XRFrame;
+
+  const manager = new WebXRHitTestManager({
+    entityTypes: ['plane', 'point'],
+    offsetRay
+  });
+  await manager.setSession(session, appReferenceSpace);
+  const hitTestState = manager.getHitTestState(frame);
+
+  testCase.deepEqual(
+    session.requestedReferenceSpaceTypes,
+    ['viewer'],
+    'requests viewer space for hit tests'
+  );
+  testCase.deepEqual(
+    session.receivedHitTestOptions,
+    {
+      space: viewerReferenceSpace,
+      offsetRay,
+      entityTypes: ['plane', 'point']
+    },
+    'requests hit-test source with caller options'
+  );
+  testCase.equal(manager.session, session, 'retains active session');
+  testCase.equal(manager.referenceSpace, appReferenceSpace, 'retains app reference space');
+  testCase.equal(manager.viewerSpace, viewerReferenceSpace, 'retains viewer space');
+  testCase.equal(manager.hitTestSource, hitTestSource, 'retains hit-test source');
+  testCase.equal(hitTestState?.xrFrame, frame, 'retains source frame');
+  testCase.equal(hitTestState?.hits.length, 1, 'filters hits without poses');
+  testCase.equal(hitTestState?.hits[0]?.xrHitTestResult, firstResult, 'retains raw hit result');
+  testCase.equal(hitTestState?.hits[0]?.pose, firstPose, 'retains hit pose');
+  testCase.equal(hitTestState?.hits[0]?.matrix, firstPose.transform.matrix, 'exposes hit matrix');
+
+  session.dispatchEvent(new Event('end'));
+  testCase.equal(hitTestSource.cancelCount, 1, 'session end cancels source');
+  testCase.equal(manager.getHitTestState(frame), null, 'ended sessions expose no hit state');
+  testCase.end();
+});
+
+test('webxr#WebXRHitTestManager handles unsupported and invalid hit-test sessions', async testCase => {
+  const appReferenceSpace = {} as XRReferenceSpace;
+  const viewerReferenceSpace = {} as XRReferenceSpace;
+  const hitTestSource = makeMockXRHitTestSource();
+  const session = makeMockXRSession({appReferenceSpace, viewerReferenceSpace, hitTestSource});
+  const manager = new WebXRHitTestManager();
+
+  try {
+    await manager.setSession(session, null);
+    testCase.fail('missing app reference space should be rejected');
+  } catch (error) {
+    testCase.match(
+      error instanceof Error ? error.message : '',
+      /reference space/,
+      'reports missing app reference space'
+    );
+  }
+
+  const unsupportedSession = {
+    ...makeMockXRSession({appReferenceSpace, viewerReferenceSpace, hitTestSource}),
+    requestHitTestSource: undefined
+  } as unknown as XRSession;
+  try {
+    await manager.setSession(unsupportedSession, appReferenceSpace);
+    testCase.fail('unsupported hit-test source requests should be rejected');
+  } catch (error) {
+    testCase.match(
+      error instanceof Error ? error.message : '',
+      /not supported/,
+      'reports unsupported hit-test source requests'
+    );
+  }
+
+  session.nextHitTestSource = null;
+  try {
+    await manager.setSession(session, appReferenceSpace);
+    testCase.fail('null hit-test source should be rejected');
+  } catch (error) {
+    testCase.match(error instanceof Error ? error.message : '', /no source/, 'reports null source');
+  }
+
+  const validSession = makeMockXRSession({appReferenceSpace, viewerReferenceSpace, hitTestSource});
+  await manager.setSession(validSession, appReferenceSpace);
+  testCase.equal(
+    manager.getHitTestState({session: validSession} as XRFrame),
+    null,
+    'frames without getHitTestResults expose no hit state'
+  );
+  testCase.throws(
+    () =>
+      manager.getHitTestState({
+        session: makeMockXRSession({appReferenceSpace, viewerReferenceSpace, hitTestSource}),
+        getHitTestResults: () => []
+      } as XRFrame),
+    /different XRSession/,
+    'rejects foreign frames'
+  );
+
+  manager.clearSession();
+  manager.clearSession();
+  testCase.equal(hitTestSource.cancelCount, 1, 'clearSession cancels source once');
+  testCase.equal(manager.session, null, 'clears session');
+  testCase.end();
+});
+
+function makeMockXRSession(props: {
+  appReferenceSpace: XRReferenceSpace;
+  viewerReferenceSpace: XRReferenceSpace;
+  hitTestSource: XRHitTestSource;
+}): MockXRSession {
+  const session = Object.assign(new EventTarget(), {
+    enabledFeatures: ['hit-test'],
+    inputSources: [],
+    requestedReferenceSpaceTypes: [] as XRReferenceSpaceType[],
+    receivedHitTestOptions: null as XRHitTestOptionsInit | null,
+    nextHitTestSource: props.hitTestSource,
+    async requestReferenceSpace(type: XRReferenceSpaceType): Promise<XRReferenceSpace> {
+      session.requestedReferenceSpaceTypes.push(type);
+      return type === 'viewer' ? props.viewerReferenceSpace : props.appReferenceSpace;
+    },
+    async requestHitTestSource(options: XRHitTestOptionsInit): Promise<XRHitTestSource | null> {
+      session.receivedHitTestOptions = options;
+      return session.nextHitTestSource;
+    }
+  }) as MockXRSession;
+
+  return session;
+}
+
+function makeMockXRHitTestSource(): MockXRHitTestSource {
+  return {
+    cancelCount: 0,
+    cancel() {
+      this.cancelCount++;
+    }
+  };
+}
+
+function makeMockXRHitTestResult(pose: XRPose | undefined): XRHitTestResult {
+  return {
+    getPose() {
+      return pose;
+    }
+  };
+}
+
+function makeMockXRPose(matrix: number[]): XRPose {
+  return {
+    transform: {
+      matrix: new Float32Array(matrix),
+      inverse: {matrix: new Float32Array(matrix)}
+    }
+  } as XRPose;
+}

--- a/modules/experimental/test/webxr/webxr-image-tracking.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-image-tracking.node.spec.ts
@@ -1,0 +1,198 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  getWebXRImageTrackingSessionInit,
+  WebXRImageTrackingManager
+} from '../../src/webxr/webxr-image-tracking';
+
+type MockXRSession = XRSession & {
+  imageTrackability: readonly XRImageTrackability[];
+};
+
+test('webxr#WebXRImageTrackingManager resolves tracked image poses and frame diffs', testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const firstResult = makeMockXRImageTrackingResult({
+    index: 0,
+    trackingState: 'tracked',
+    measuredWidthInMeters: 0.25
+  });
+  const secondResult = makeMockXRImageTrackingResult({
+    index: 1,
+    trackingState: 'emulated',
+    measuredWidthInMeters: 0.4
+  });
+  const firstPose = makeMockXRPose([1, 0, 0, 0]);
+  const secondPose = makeMockXRPose([2, 0, 0, 0]);
+  const session = makeMockXRSession(['trackable', 'trackable']);
+  const frame = makeMockXRFrame(
+    session,
+    [firstResult, secondResult],
+    new Map([
+      [firstResult.imageSpace, firstPose],
+      [secondResult.imageSpace, secondPose]
+    ])
+  );
+  const updatedFirstResult = makeMockXRImageTrackingResult({
+    imageSpace: firstResult.imageSpace,
+    index: 0,
+    trackingState: 'emulated',
+    measuredWidthInMeters: 0.25
+  });
+  const nextFrame = makeMockXRFrame(
+    session,
+    [updatedFirstResult],
+    new Map([[updatedFirstResult.imageSpace, firstPose]])
+  );
+  const manager = new WebXRImageTrackingManager();
+
+  manager.setSession(session, referenceSpace);
+  const imageState = manager.getImageTrackingState(frame);
+  const nextImageState = manager.getImageTrackingState(nextFrame);
+
+  testCase.equal(manager.session, session, 'retains active session');
+  testCase.equal(manager.referenceSpace, referenceSpace, 'retains app reference space');
+  testCase.equal(imageState?.xrFrame, frame, 'retains source frame');
+  testCase.equal(imageState?.session, session, 'retains source session');
+  testCase.equal(imageState?.images.length, 2, 'resolves tracked images with poses');
+  testCase.equal(imageState?.added.length, 2, 'initial images are added');
+  testCase.equal(imageState?.updated.length, 0, 'initial images are not updated');
+  testCase.equal(imageState?.removed.length, 0, 'initial images are not removed');
+  testCase.equal(imageState?.images[0]?.result, firstResult, 'retains raw result');
+  testCase.equal(imageState?.images[0]?.pose, firstPose, 'retains image pose');
+  testCase.equal(imageState?.images[0]?.matrix, firstPose.transform.matrix, 'exposes pose matrix');
+  testCase.equal(imageState?.images[0]?.index, 0, 'exposes tracked image index');
+  testCase.equal(imageState?.images[0]?.trackingState, 'tracked', 'exposes tracking state');
+  testCase.equal(imageState?.images[0]?.measuredWidthInMeters, 0.25, 'exposes measured width');
+  testCase.equal(nextImageState?.images.length, 1, 'tracks next frame results');
+  testCase.equal(nextImageState?.added.length, 0, 'same index is not added');
+  testCase.equal(nextImageState?.updated.length, 1, 'same index can be updated');
+  testCase.equal(nextImageState?.removed.length, 1, 'missing index is removed');
+
+  session.dispatchEvent(new Event('end'));
+  testCase.equal(manager.getImageTrackingState(frame), null, 'ended sessions expose no images');
+  testCase.end();
+});
+
+test('webxr#WebXRImageTrackingManager forwards trackability and builds session init', async testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const trackedImages = [
+    {image: {} as ImageBitmap, widthInMeters: 0.2},
+    {image: {} as ImageBitmap, widthInMeters: 0.4}
+  ];
+  const session = makeMockXRSession(['trackable', 'untrackable']);
+  const manager = new WebXRImageTrackingManager({trackedImages});
+
+  manager.setSession(session, referenceSpace);
+  testCase.deepEqual(
+    await manager.getImageTrackability(),
+    ['trackable', 'untrackable'],
+    'forwards image trackability'
+  );
+  testCase.deepEqual(
+    getWebXRImageTrackingSessionInit({required: true, trackedImages}),
+    {requiredFeatures: ['image-tracking'], trackedImages},
+    'builds required image-tracking session init'
+  );
+  testCase.deepEqual(
+    getWebXRImageTrackingSessionInit(),
+    {optionalFeatures: ['image-tracking'], trackedImages: undefined},
+    'builds optional image-tracking session init'
+  );
+
+  manager.clearSession();
+  testCase.equal(await manager.getImageTrackability(), null, 'missing session returns null');
+  testCase.end();
+});
+
+test('webxr#WebXRImageTrackingManager handles unsupported and invalid frames', testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const session = makeMockXRSession([]);
+  const otherSession = makeMockXRSession([]);
+  const manager = new WebXRImageTrackingManager();
+
+  try {
+    manager.setSession(session, null);
+    testCase.fail('missing reference space should reject');
+  } catch (error) {
+    testCase.match(
+      error instanceof Error ? error.message : '',
+      /reference space/,
+      'reports missing reference space'
+    );
+  }
+
+  manager.setSession(session, referenceSpace);
+  testCase.equal(
+    manager.getImageTrackingState({session} as XRFrame),
+    null,
+    'frames without getImageTrackingResults expose no state'
+  );
+  testCase.throws(
+    () =>
+      manager.getImageTrackingState({
+        session: otherSession,
+        getImageTrackingResults: () => []
+      } as XRFrame),
+    /different XRSession/,
+    'rejects foreign frames'
+  );
+
+  manager.clearSession();
+  manager.clearSession();
+  testCase.equal(manager.session, null, 'clearSession is idempotent');
+  testCase.end();
+});
+
+function makeMockXRSession(imageTrackability: readonly XRImageTrackability[]): MockXRSession {
+  return Object.assign(new EventTarget(), {
+    enabledFeatures: ['image-tracking'],
+    imageTrackability,
+    inputSources: [],
+    async getImageTrackability(): Promise<readonly XRImageTrackability[]> {
+      return this.imageTrackability;
+    }
+  }) as MockXRSession;
+}
+
+function makeMockXRFrame(
+  session: XRSession,
+  results: readonly XRImageTrackingResult[],
+  poses: Map<XRSpace, XRPose>
+): XRFrame {
+  return {
+    session,
+    getImageTrackingResults(): readonly XRImageTrackingResult[] {
+      return results;
+    },
+    getPose(space: XRSpace): XRPose | undefined {
+      return poses.get(space);
+    }
+  } as XRFrame;
+}
+
+function makeMockXRImageTrackingResult(
+  props: Partial<XRImageTrackingResult> & {
+    index: number;
+    trackingState: XRImageTrackingState;
+    measuredWidthInMeters: number;
+  }
+): XRImageTrackingResult {
+  return {
+    imageSpace: props.imageSpace || ({} as XRSpace),
+    index: props.index,
+    trackingState: props.trackingState,
+    measuredWidthInMeters: props.measuredWidthInMeters
+  } as XRImageTrackingResult;
+}
+
+function makeMockXRPose(matrix: number[]): XRPose {
+  return {
+    transform: {
+      matrix: new Float32Array(matrix),
+      inverse: {matrix: new Float32Array(matrix)}
+    } as XRRigidTransform
+  } as XRPose;
+}

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -4,6 +4,8 @@
 
 import test from 'test/utils/vitest-tape';
 import {
+  WebXRInputActionManager,
+  getWebXRInputActionState,
   getWebXRInputActivationState,
   getWebXRInputGrip,
   getWebXRInputRay,
@@ -114,6 +116,11 @@ test('webxr#getWebXRInputActivationState normalizes events and gamepad buttons',
   const eventActivationState = getWebXRInputActivationState(eventInputState);
 
   testCase.equal(eventActivationState.inputState, eventInputState, 'retains source input state');
+  testCase.equal(
+    eventActivationState.inputSource,
+    eventInputState.inputSource,
+    'keeps input source'
+  );
   testCase.equal(eventActivationState.primaryAction, 1, 'select events drive primary action');
   testCase.equal(eventActivationState.squeezeAction, 1, 'squeeze events drive squeeze action');
   testCase.equal(eventActivationState.isPrimaryActive, true, 'marks primary action active');
@@ -152,6 +159,111 @@ test('webxr#getWebXRInputActivationState normalizes events and gamepad buttons',
 
   testCase.equal(clampedActivationState.triggerValue, 1, 'clamps trigger values to one');
   testCase.equal(clampedActivationState.squeezeValue, 0, 'clamps squeeze values to zero');
+  testCase.equal(
+    getWebXRInputActivationState(
+      makeMockWebXRInputState(null, null, {
+        gamepad: makeMockXRStandardGamepad([{value: 0.04, pressed: false, touched: false}])
+      }),
+      {activationThreshold: 0.05}
+    ).isPrimaryActive,
+    false,
+    'optional threshold filters low activation values'
+  );
+  testCase.end();
+});
+
+test('webxr#WebXRInputActionManager reports action transitions', testCase => {
+  const inputSource = {} as XRInputSource;
+  const manager = new WebXRInputActionManager();
+
+  testCase.deepEqual(manager.update(null), [], 'null input snapshots become empty actions');
+
+  const inactiveActionStates = manager.update([makeMockWebXRInputState(null, null, {inputSource})]);
+  testCase.equal(
+    inactiveActionStates[0]?.primaryActionStarted,
+    false,
+    'inactive sources do not start'
+  );
+
+  const activeActionStates = manager.update([
+    makeMockWebXRInputState(null, null, {
+      inputSource,
+      gamepad: makeMockXRStandardGamepad([{value: 0.35, pressed: true, touched: true}])
+    })
+  ]);
+  testCase.equal(
+    activeActionStates[0]?.primaryActionStarted,
+    true,
+    'trigger press starts primary action'
+  );
+  testCase.equal(
+    activeActionStates[0]?.primaryActionEnded,
+    false,
+    'trigger press does not end action'
+  );
+  testCase.equal(activeActionStates[0]?.previousPrimaryAction, 0, 'keeps previous primary action');
+  testCase.equal(activeActionStates[0]?.primaryActionDelta, 0.35, 'reports primary action delta');
+
+  const heldActionStates = manager.update([
+    makeMockWebXRInputState(null, null, {
+      inputSource,
+      gamepad: makeMockXRStandardGamepad([{value: 0.7, pressed: true, touched: true}])
+    })
+  ]);
+  testCase.equal(heldActionStates[0]?.primaryActionStarted, false, 'held action does not restart');
+  testCase.equal(heldActionStates[0]?.wasPrimaryActive, true, 'keeps previous active flag');
+  testCase.equal(heldActionStates[0]?.primaryActionDelta, 0.35, 'reports held action delta');
+
+  const endedActionStates = manager.update([makeMockWebXRInputState(null, null, {inputSource})]);
+  testCase.equal(endedActionStates[0]?.primaryActionEnded, true, 'release ends primary action');
+  testCase.equal(endedActionStates[0]?.previousPrimaryAction, 0.7, 'keeps previous release value');
+
+  const squeezeAction = getWebXRInputActionState(
+    makeMockWebXRInputState(null, null, {
+      inputSource,
+      squeezeActive: true
+    }),
+    {
+      previousAction: {
+        primaryAction: 0,
+        squeezeAction: 0,
+        isPrimaryActive: false,
+        isSqueezeActive: false
+      }
+    }
+  );
+  testCase.equal(
+    squeezeAction.squeezeActionStarted,
+    true,
+    'standalone helper tracks squeeze starts'
+  );
+  testCase.equal(
+    squeezeAction.activationThreshold,
+    0.05,
+    'standalone helper uses default threshold'
+  );
+
+  manager.update([]);
+  const newActionStates = manager.update([
+    makeMockWebXRInputState(null, null, {
+      inputSource,
+      gamepad: makeMockXRStandardGamepad([{value: 0.35, pressed: true, touched: true}])
+    })
+  ]);
+  testCase.equal(
+    newActionStates[0]?.wasPrimaryActive,
+    false,
+    'missing sources trim previous state'
+  );
+
+  manager.reset(inputSource);
+  const resetActionStates = manager.update([
+    makeMockWebXRInputState(null, null, {
+      inputSource,
+      gamepad: makeMockXRStandardGamepad([{value: 0.35, pressed: true, touched: true}])
+    })
+  ]);
+  testCase.equal(resetActionStates[0]?.wasPrimaryActive, false, 'reset clears previous state');
   testCase.end();
 });
 
@@ -226,7 +338,7 @@ function makeMockWebXRInputState(
   props: Partial<WebXRInputState> = {}
 ): WebXRInputState {
   return {
-    inputSource: {} as XRInputSource,
+    inputSource: props.inputSource ?? ({} as XRInputSource),
     index: 0,
     handedness: props.handedness ?? 'right',
     targetRayMode: props.targetRayMode ?? 'tracked-pointer',

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -19,6 +19,7 @@ import {
   getWebXRInputGrip,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
+  getWebXRInputStateByInputSource,
   getWebXRInputSourceState
 } from '../../src/webxr/webxr-input';
 import type {WebXRInputState} from '../../src/webxr/webxr-manager';
@@ -211,6 +212,41 @@ test('webxr#getWebXRControllerStates filters controller snapshots', testCase => 
     'keeps later controller input source'
   );
   testCase.equal(controllerStates[1]?.primaryAction, 1, 'keeps controller activation state');
+  testCase.end();
+});
+
+test('webxr#getWebXRInputStateByInputSource selects input identity', testCase => {
+  const firstInputSource = {} as XRInputSource;
+  const secondInputSource = {} as XRInputSource;
+  const missingInputSource = {} as XRInputSource;
+  const firstInputState = makeMockWebXRInputState(null, null, {
+    inputSource: firstInputSource
+  });
+  const secondInputState = makeMockWebXRInputState(null, null, {
+    inputSource: secondInputSource
+  });
+  const inputStates = [firstInputState, secondInputState];
+
+  testCase.equal(
+    getWebXRInputStateByInputSource(inputStates, secondInputSource),
+    secondInputState,
+    'selects input state by exact input source identity'
+  );
+  testCase.equal(
+    getWebXRInputStateByInputSource(inputStates, missingInputSource),
+    null,
+    'missing input sources return null'
+  );
+  testCase.equal(
+    getWebXRInputStateByInputSource(null, secondInputSource),
+    null,
+    'null input lists return null'
+  );
+  testCase.equal(
+    getWebXRInputStateByInputSource(inputStates, null),
+    null,
+    'null input sources return null'
+  );
   testCase.end();
 });
 

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
-import {getWebXRInputRay} from '../../src/webxr/webxr-input';
+import {getWebXRInputRay, getWebXRInputRayPlaneIntersection} from '../../src/webxr/webxr-input';
 import type {WebXRInputState} from '../../src/webxr/webxr-manager';
 
 test('webxr#getWebXRInputRay resolves origin and normalized target-ray direction', testCase => {
@@ -30,6 +30,71 @@ test('webxr#getWebXRInputRay handles missing and degenerate target rays', testCa
   );
   testCase.deepEqual(ray?.origin, [3, 4, 5], 'still resolves origin');
   testCase.deepEqual(ray?.direction, [0, 0, -1], 'falls back to forward direction');
+  testCase.end();
+});
+
+test('webxr#getWebXRInputRayPlaneIntersection resolves floor hits and custom planes', testCase => {
+  const floorRay = {
+    inputState: makeMockWebXRInputState(null),
+    origin: [0, 1.6, 0],
+    direction: [0, -0.8, -0.6],
+    matrix: new Float32Array(16)
+  };
+  const floorHit = getWebXRInputRayPlaneIntersection(floorRay);
+
+  testCase.equal(floorHit?.ray, floorRay, 'retains source ray');
+  testCase.equal(floorHit?.distance, 2, 'returns normalized ray distance');
+  testCase.deepEqual(floorHit?.point, [0, 0, -1.2], 'intersects default y=0 floor plane');
+
+  const wallRay = {
+    inputState: makeMockWebXRInputState(null),
+    origin: [1, 2, 3],
+    direction: [0, 0, -1],
+    matrix: new Float32Array(16)
+  };
+  const wallHit = getWebXRInputRayPlaneIntersection(wallRay, {
+    planePoint: [0, 0, 1],
+    planeNormal: [0, 0, 2]
+  });
+
+  testCase.equal(wallHit?.distance, 2, 'normalizes custom plane normals');
+  testCase.deepEqual(wallHit?.point, [1, 2, 1], 'intersects custom plane');
+  testCase.end();
+});
+
+test('webxr#getWebXRInputRayPlaneIntersection rejects unusable hits', testCase => {
+  const ray = {
+    inputState: makeMockWebXRInputState(null),
+    origin: [0, 1, 0],
+    direction: [0, -1, 0],
+    matrix: new Float32Array(16)
+  };
+
+  testCase.equal(
+    getWebXRInputRayPlaneIntersection(ray, {minDistance: 1.5}),
+    null,
+    'rejects hits before minDistance'
+  );
+  testCase.equal(
+    getWebXRInputRayPlaneIntersection(ray, {maxDistance: 0.5}),
+    null,
+    'rejects hits after maxDistance'
+  );
+  testCase.equal(
+    getWebXRInputRayPlaneIntersection({...ray, direction: [0, 1, 0]}),
+    null,
+    'rejects intersections behind the ray origin'
+  );
+  testCase.equal(
+    getWebXRInputRayPlaneIntersection({...ray, direction: [1, 0, 0]}),
+    null,
+    'rejects rays parallel to the plane'
+  );
+  testCase.equal(
+    getWebXRInputRayPlaneIntersection(ray, {planeNormal: [0, 0, 0]}),
+    null,
+    'rejects degenerate plane normals'
+  );
   testCase.end();
 });
 

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -7,6 +7,8 @@ import {
   WebXRInputActionManager,
   getWebXRControllerRayPlaneIntersection,
   getWebXRControllerRayPlaneIntersections,
+  getWebXRControllerRayPlaneTarget,
+  getWebXRControllerRayPlaneTargets,
   getWebXRControllerState,
   getWebXRControllerStateByHandedness,
   getWebXRControllerStates,
@@ -306,6 +308,54 @@ test('webxr#getWebXRControllerRayPlaneIntersection resolves controller target hi
   );
   testCase.equal(controllerRayHits.length, 1, 'filters controllers without ray-plane hits');
   testCase.equal(controllerRayHits[0]?.controllerState, controllerState, 'keeps hit controller');
+  testCase.end();
+});
+
+test('webxr#getWebXRControllerRayPlaneTarget validates controller targets against bounds', testCase => {
+  const floorRayMatrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0.8, 0.6, 0, 0, 1.6, 0, 1]);
+  const controllerState = getWebXRControllerState(makeMockWebXRInputState(floorRayMatrix))!;
+  const bounds = [
+    [-1, 0, -2],
+    [1, 0, -2],
+    [1, 0, 1],
+    [-1, 0, 1]
+  ] as const;
+  const target = getWebXRControllerRayPlaneTarget(controllerState, {bounds});
+
+  testCase.equal(target?.controllerState, controllerState, 'retains controller state');
+  testCase.equal(target?.allowed, true, 'marks in-bounds target allowed');
+  testCase.deepEqual(target?.point, target?.rayIntersection.point, 'uses ray hit as target point');
+  testCase.equal(
+    getWebXRControllerRayPlaneTarget(controllerState, {
+      bounds: {
+        bounds: [
+          [1, 0, 1],
+          [2, 0, 1],
+          [2, 0, 2],
+          [1, 0, 2]
+        ]
+      } as any
+    })?.allowed,
+    false,
+    'marks out-of-bounds target blocked'
+  );
+  testCase.equal(
+    getWebXRControllerRayPlaneTarget(controllerState, {maxDistance: 1}),
+    null,
+    'missing intersections do not produce target states'
+  );
+
+  const targets = getWebXRControllerRayPlaneTargets(
+    [getWebXRControllerState(makeMockWebXRInputState(null))!, controllerState],
+    {bounds}
+  );
+  testCase.equal(
+    getWebXRControllerRayPlaneTargets(null).length,
+    0,
+    'null controller lists become empty target lists'
+  );
+  testCase.equal(targets.length, 1, 'filters controllers without target hits');
+  testCase.equal(targets[0]?.allowed, true, 'keeps allowed flag in target collections');
   testCase.end();
 });
 

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -5,6 +5,8 @@
 import test from 'test/utils/vitest-tape';
 import {
   WebXRInputActionManager,
+  getWebXRControllerRayPlaneIntersection,
+  getWebXRControllerRayPlaneIntersections,
   getWebXRControllerState,
   getWebXRControllerStateByHandedness,
   getWebXRControllerStates,
@@ -260,6 +262,50 @@ test('webxr#getWebXRControllerStateByHandedness selects controller hands', testC
     null,
     'null controller lists return null'
   );
+  testCase.end();
+});
+
+test('webxr#getWebXRControllerRayPlaneIntersection resolves controller target hits', testCase => {
+  const floorRayMatrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0.8, 0.6, 0, 0, 1.6, 0, 1]);
+  const controllerState = getWebXRControllerState(makeMockWebXRInputState(floorRayMatrix))!;
+  const floorHit = getWebXRControllerRayPlaneIntersection(controllerState);
+
+  testCase.equal(floorHit?.controllerState, controllerState, 'retains controller state');
+  testCase.equal(floorHit?.rayIntersection.ray, controllerState.ray, 'retains ray intersection');
+  testCase.ok(
+    Math.abs((floorHit?.distance || 0) - 2) < 1e-6,
+    'returns normalized controller ray distance'
+  );
+  testCase.ok(
+    Math.abs((floorHit?.point[0] || 0) - 0) < 1e-6 &&
+      Math.abs((floorHit?.point[1] || 0) - 0) < 1e-6 &&
+      Math.abs((floorHit?.point[2] || 0) + 1.2) < 1e-6,
+    'returns controller ray hit point'
+  );
+
+  const noRayControllerState = getWebXRControllerState(makeMockWebXRInputState(null))!;
+  testCase.equal(
+    getWebXRControllerRayPlaneIntersection(noRayControllerState),
+    null,
+    'controllers without target rays do not produce hits'
+  );
+  testCase.equal(
+    getWebXRControllerRayPlaneIntersection(controllerState, {maxDistance: 1}),
+    null,
+    'rejects hits outside supplied ray range'
+  );
+
+  const controllerRayHits = getWebXRControllerRayPlaneIntersections([
+    noRayControllerState,
+    controllerState
+  ]);
+  testCase.equal(
+    getWebXRControllerRayPlaneIntersections(null).length,
+    0,
+    'null controller lists become empty hit lists'
+  );
+  testCase.equal(controllerRayHits.length, 1, 'filters controllers without ray-plane hits');
+  testCase.equal(controllerRayHits[0]?.controllerState, controllerState, 'keeps hit controller');
   testCase.end();
 });
 

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -110,6 +110,7 @@ function makeMockWebXRInputState(targetRayMatrix: Float32Array | null): WebXRInp
     targetRayMatrix,
     gripPose: null,
     gripMatrix: null,
-    selectActive: false
+    selectActive: false,
+    squeezeActive: false
   };
 }

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -6,6 +6,7 @@ import test from 'test/utils/vitest-tape';
 import {
   WebXRInputActionManager,
   getWebXRControllerState,
+  getWebXRControllerStates,
   getWebXRInputActionState,
   getWebXRInputActivationState,
   getWebXRInputGrip,
@@ -161,6 +162,48 @@ test('webxr#getWebXRControllerState consolidates tracked-pointer controller stat
     null,
     'screen input is not a controller state'
   );
+  testCase.end();
+});
+
+test('webxr#getWebXRControllerStates filters controller snapshots', testCase => {
+  const firstInputSource = {} as XRInputSource;
+  const secondInputSource = {} as XRInputSource;
+  const controllerInputState = makeMockWebXRInputState(null, null, {
+    inputSource: firstInputSource,
+    gamepad: makeMockXRStandardGamepad([{value: 0.04, pressed: false, touched: false}])
+  });
+  const handInputState = makeMockWebXRInputState(null, null, {
+    hand: {} as XRHand,
+    profiles: ['generic-hand-select']
+  });
+  const screenInputState = makeMockWebXRInputState(null, null, {
+    targetRayMode: 'screen',
+    profiles: ['generic-touchscreen']
+  });
+  const secondControllerInputState = makeMockWebXRInputState(null, null, {
+    inputSource: secondInputSource,
+    profiles: ['generic-trigger-squeeze-thumbstick'],
+    selectActive: true
+  });
+  const controllerStates = getWebXRControllerStates(
+    [controllerInputState, handInputState, screenInputState, secondControllerInputState],
+    {activationThreshold: 0.05}
+  );
+
+  testCase.deepEqual(getWebXRControllerStates(null), [], 'null input snapshots become empty list');
+  testCase.equal(controllerStates.length, 2, 'filters out hands and screen input');
+  testCase.equal(controllerStates[0]?.inputSource, firstInputSource, 'preserves controller order');
+  testCase.equal(
+    controllerStates[0]?.isPrimaryActive,
+    false,
+    'passes activation props to each controller'
+  );
+  testCase.equal(
+    controllerStates[1]?.inputSource,
+    secondInputSource,
+    'keeps later controller input source'
+  );
+  testCase.equal(controllerStates[1]?.primaryAction, 1, 'keeps controller activation state');
   testCase.end();
 });
 

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -8,6 +8,7 @@ import {
   getWebXRControllerRayPlaneIntersection,
   getWebXRControllerRayPlaneIntersections,
   getWebXRControllerRayPlaneTarget,
+  getWebXRControllerRayPlaneTargetByHandedness,
   getWebXRControllerRayPlaneTargets,
   getWebXRControllerState,
   getWebXRControllerStateByHandedness,
@@ -356,6 +357,65 @@ test('webxr#getWebXRControllerRayPlaneTarget validates controller targets agains
   );
   testCase.equal(targets.length, 1, 'filters controllers without target hits');
   testCase.equal(targets[0]?.allowed, true, 'keeps allowed flag in target collections');
+  testCase.end();
+});
+
+test('webxr#getWebXRControllerRayPlaneTargetByHandedness selects target hands', testCase => {
+  const floorRayMatrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0.8, 0.6, 0, 0, 1.6, 0, 1]);
+  const leftInputSource = {} as XRInputSource;
+  const rightInputSource = {} as XRInputSource;
+  const noneInputSource = {} as XRInputSource;
+  const targets = getWebXRControllerRayPlaneTargets([
+    getWebXRControllerState(
+      makeMockWebXRInputState(floorRayMatrix, null, {
+        inputSource: leftInputSource,
+        handedness: 'left'
+      })
+    )!,
+    getWebXRControllerState(
+      makeMockWebXRInputState(floorRayMatrix, null, {
+        inputSource: rightInputSource,
+        handedness: 'right'
+      })
+    )!,
+    getWebXRControllerState(
+      makeMockWebXRInputState(floorRayMatrix, null, {
+        inputSource: noneInputSource,
+        handedness: 'none'
+      })
+    )!
+  ]);
+
+  testCase.equal(
+    getWebXRControllerRayPlaneTargetByHandedness(targets)?.controllerState.inputSource,
+    leftInputSource,
+    'default any returns first target'
+  );
+  testCase.equal(
+    getWebXRControllerRayPlaneTargetByHandedness(targets, 'right')?.controllerState.inputSource,
+    rightInputSource,
+    'selects right-hand targets'
+  );
+  testCase.equal(
+    getWebXRControllerRayPlaneTargetByHandedness(targets, 'none')?.controllerState.inputSource,
+    noneInputSource,
+    'selects unhanded targets'
+  );
+  testCase.equal(
+    getWebXRControllerRayPlaneTargetByHandedness(targets, 'left')?.controllerState.inputSource,
+    leftInputSource,
+    'selects left-hand targets'
+  );
+  testCase.equal(
+    getWebXRControllerRayPlaneTargetByHandedness([], 'right'),
+    null,
+    'empty target lists return null'
+  );
+  testCase.equal(
+    getWebXRControllerRayPlaneTargetByHandedness(null, 'right'),
+    null,
+    'null target lists return null'
+  );
   testCase.end();
 });
 

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -4,6 +4,7 @@
 
 import test from 'test/utils/vitest-tape';
 import {
+  getWebXRInputActivationState,
   getWebXRInputGrip,
   getWebXRInputRay,
   getWebXRInputRayPlaneIntersection,
@@ -105,6 +106,55 @@ test('webxr#getWebXRInputSourceState classifies input source capabilities', test
   testCase.end();
 });
 
+test('webxr#getWebXRInputActivationState normalizes events and gamepad buttons', testCase => {
+  const eventInputState = makeMockWebXRInputState(null, null, {
+    selectActive: true,
+    squeezeActive: true
+  });
+  const eventActivationState = getWebXRInputActivationState(eventInputState);
+
+  testCase.equal(eventActivationState.inputState, eventInputState, 'retains source input state');
+  testCase.equal(eventActivationState.primaryAction, 1, 'select events drive primary action');
+  testCase.equal(eventActivationState.squeezeAction, 1, 'squeeze events drive squeeze action');
+  testCase.equal(eventActivationState.isPrimaryActive, true, 'marks primary action active');
+  testCase.equal(eventActivationState.isSqueezeActive, true, 'marks squeeze action active');
+
+  const gamepadInputState = makeMockWebXRInputState(null, null, {
+    gamepad: makeMockXRStandardGamepad([
+      {value: 0.42, pressed: false, touched: true},
+      {value: 0.7, pressed: true, touched: true}
+    ])
+  });
+  const gamepadActivationState = getWebXRInputActivationState(gamepadInputState);
+
+  testCase.equal(gamepadActivationState.selectActive, false, 'keeps select event state');
+  testCase.equal(gamepadActivationState.triggerValue, 0.42, 'uses xr-standard trigger value');
+  testCase.equal(gamepadActivationState.squeezeValue, 0.7, 'uses xr-standard squeeze value');
+  testCase.equal(
+    gamepadActivationState.primaryAction,
+    0.42,
+    'gamepad triggers drive primary action'
+  );
+  testCase.equal(
+    gamepadActivationState.squeezeAction,
+    0.7,
+    'gamepad squeeze drives squeeze action'
+  );
+
+  const clampedActivationState = getWebXRInputActivationState(
+    makeMockWebXRInputState(null, null, {
+      gamepad: makeMockXRStandardGamepad([
+        {value: 1.5, pressed: true, touched: true},
+        {value: -0.2, pressed: false, touched: false}
+      ])
+    })
+  );
+
+  testCase.equal(clampedActivationState.triggerValue, 1, 'clamps trigger values to one');
+  testCase.equal(clampedActivationState.squeezeValue, 0, 'clamps squeeze values to zero');
+  testCase.end();
+});
+
 test('webxr#getWebXRInputRayPlaneIntersection resolves floor hits and custom planes', testCase => {
   const floorRay = {
     inputState: makeMockWebXRInputState(null),
@@ -187,7 +237,17 @@ function makeMockWebXRInputState(
     targetRayMatrix,
     gripPose: null,
     gripMatrix,
-    selectActive: false,
-    squeezeActive: false
+    selectActive: props.selectActive ?? false,
+    squeezeActive: props.squeezeActive ?? false
   };
+}
+
+function makeMockXRStandardGamepad(
+  buttons: {value: number; pressed: boolean; touched: boolean}[]
+): Gamepad {
+  return {
+    mapping: 'xr-standard',
+    buttons: buttons as GamepadButton[],
+    axes: []
+  } as Gamepad;
 }

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -21,6 +21,9 @@ import {
   getWebXRInputRayByInputSource,
   getWebXRInputRayPlaneIntersection,
   getWebXRInputRayPlaneIntersections,
+  getWebXRInputRayPlaneTarget,
+  getWebXRInputRayPlaneTargetByInputSource,
+  getWebXRInputRayPlaneTargets,
   getWebXRInputRays,
   getWebXRInputStateByInputSource,
   getWebXRInputSourceState
@@ -401,6 +404,105 @@ test('webxr#getWebXRControllerRayPlaneIntersection resolves controller target hi
   testCase.end();
 });
 
+test('webxr#getWebXRInputRayPlaneTarget validates input ray targets against bounds', testCase => {
+  const floorRay = getWebXRInputRay(
+    makeMockWebXRInputState(
+      new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0.8, 0.6, 0, 0, 1.6, 0, 1])
+    )
+  )!;
+  const bounds = [
+    [-1, 0, -2],
+    [1, 0, -2],
+    [1, 0, 1],
+    [-1, 0, 1]
+  ] as const;
+  const target = getWebXRInputRayPlaneTarget(floorRay, {bounds});
+
+  testCase.equal(target?.ray, floorRay, 'retains source input ray');
+  testCase.equal(target?.allowed, true, 'marks in-bounds input ray target allowed');
+  testCase.ok(Math.abs((target?.point[2] || 0) + 1.2) < 1e-6, 'uses ray-plane hit as target point');
+  testCase.equal(
+    getWebXRInputRayPlaneTarget(floorRay, {
+      bounds: {
+        bounds: [
+          [1, 0, 1],
+          [2, 0, 1],
+          [2, 0, 2],
+          [1, 0, 2]
+        ]
+      } as any
+    })?.allowed,
+    false,
+    'marks out-of-bounds input ray target blocked'
+  );
+  testCase.equal(
+    getWebXRInputRayPlaneTarget(floorRay, {maxDistance: 1}),
+    null,
+    'missing intersections do not produce input ray targets'
+  );
+  testCase.end();
+});
+
+test('webxr#getWebXRInputRayPlaneTargets filters and selects bounded targets', testCase => {
+  const firstInputSource = {} as XRInputSource;
+  const secondInputSource = {} as XRInputSource;
+  const missingInputSource = {} as XRInputSource;
+  const firstRay = getWebXRInputRay(
+    makeMockWebXRInputState(
+      new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0.8, 0.6, 0, 0, 1.6, 0, 1]),
+      null,
+      {inputSource: firstInputSource}
+    )
+  )!;
+  const secondRay = getWebXRInputRay(
+    makeMockWebXRInputState(
+      new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0.8, 0.6, 0, 0.5, 1.6, 0, 1]),
+      null,
+      {inputSource: secondInputSource}
+    )
+  )!;
+  const parallelRay = {
+    inputState: makeMockWebXRInputState(null),
+    origin: [0, 1, 0],
+    direction: [1, 0, 0],
+    matrix: new Float32Array(16)
+  };
+  const targets = getWebXRInputRayPlaneTargets([firstRay, secondRay, parallelRay], {
+    bounds: [
+      [-1, 0, -2],
+      [1, 0, -2],
+      [1, 0, 1],
+      [-1, 0, 1]
+    ]
+  });
+
+  testCase.deepEqual(getWebXRInputRayPlaneTargets(null), [], 'null ray lists become empty');
+  testCase.equal(targets.length, 2, 'filters rays without usable target hits');
+  testCase.equal(targets[0]?.ray, firstRay, 'keeps first target ray');
+  testCase.equal(targets[0]?.allowed, true, 'keeps allowed state');
+  testCase.equal(
+    getWebXRInputRayPlaneTargetByInputSource(targets, secondInputSource)?.ray,
+    secondRay,
+    'selects targets by exact input source identity'
+  );
+  testCase.equal(
+    getWebXRInputRayPlaneTargetByInputSource(targets, missingInputSource),
+    null,
+    'missing input sources return null'
+  );
+  testCase.equal(
+    getWebXRInputRayPlaneTargetByInputSource(null, secondInputSource),
+    null,
+    'null target lists return null'
+  );
+  testCase.equal(
+    getWebXRInputRayPlaneTargetByInputSource(targets, null),
+    null,
+    'null input sources return null'
+  );
+  testCase.end();
+});
+
 test('webxr#getWebXRControllerRayPlaneTarget validates controller targets against bounds', testCase => {
   const floorRayMatrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0.8, 0.6, 0, 0, 1.6, 0, 1]);
   const controllerState = getWebXRControllerState(makeMockWebXRInputState(floorRayMatrix))!;
@@ -411,9 +513,11 @@ test('webxr#getWebXRControllerRayPlaneTarget validates controller targets agains
     [-1, 0, 1]
   ] as const;
   const target = getWebXRControllerRayPlaneTarget(controllerState, {bounds});
+  const inputTarget = getWebXRInputRayPlaneTarget(controllerState.ray!, {bounds});
 
   testCase.equal(target?.controllerState, controllerState, 'retains controller state');
   testCase.equal(target?.allowed, true, 'marks in-bounds target allowed');
+  testCase.equal(target?.allowed, inputTarget?.allowed, 'matches generic input ray target bounds');
   testCase.deepEqual(target?.point, target?.rayIntersection.point, 'uses ray hit as target point');
   testCase.equal(
     getWebXRControllerRayPlaneTarget(controllerState, {

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -9,6 +9,7 @@ import {
   getWebXRControllerRayPlaneIntersections,
   getWebXRControllerRayPlaneTarget,
   getWebXRControllerRayPlaneTargetByHandedness,
+  getWebXRControllerRayPlaneTargetByInputSource,
   getWebXRControllerRayPlaneTargets,
   getWebXRControllerState,
   getWebXRControllerStateByHandedness,
@@ -415,6 +416,50 @@ test('webxr#getWebXRControllerRayPlaneTargetByHandedness selects target hands', 
     getWebXRControllerRayPlaneTargetByHandedness(null, 'right'),
     null,
     'null target lists return null'
+  );
+  testCase.end();
+});
+
+test('webxr#getWebXRControllerRayPlaneTargetByInputSource selects target identity', testCase => {
+  const floorRayMatrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0.8, 0.6, 0, 0, 1.6, 0, 1]);
+  const firstInputSource = {} as XRInputSource;
+  const secondInputSource = {} as XRInputSource;
+  const missingInputSource = {} as XRInputSource;
+  const targets = getWebXRControllerRayPlaneTargets([
+    getWebXRControllerState(
+      makeMockWebXRInputState(floorRayMatrix, null, {
+        inputSource: firstInputSource,
+        handedness: 'left'
+      })
+    )!,
+    getWebXRControllerState(
+      makeMockWebXRInputState(floorRayMatrix, null, {
+        inputSource: secondInputSource,
+        handedness: 'right'
+      })
+    )!
+  ]);
+
+  testCase.equal(
+    getWebXRControllerRayPlaneTargetByInputSource(targets, secondInputSource)?.controllerState
+      .inputSource,
+    secondInputSource,
+    'selects target by exact input source identity'
+  );
+  testCase.equal(
+    getWebXRControllerRayPlaneTargetByInputSource(targets, missingInputSource),
+    null,
+    'missing input sources return null'
+  );
+  testCase.equal(
+    getWebXRControllerRayPlaneTargetByInputSource(null, secondInputSource),
+    null,
+    'null target lists return null'
+  );
+  testCase.equal(
+    getWebXRControllerRayPlaneTargetByInputSource(targets, null),
+    null,
+    'null input sources return null'
   );
   testCase.end();
 });

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -6,6 +6,7 @@ import test from 'test/utils/vitest-tape';
 import {
   WebXRInputActionManager,
   getWebXRControllerState,
+  getWebXRControllerStateByHandedness,
   getWebXRControllerStates,
   getWebXRInputActionState,
   getWebXRInputActivationState,
@@ -204,6 +205,61 @@ test('webxr#getWebXRControllerStates filters controller snapshots', testCase => 
     'keeps later controller input source'
   );
   testCase.equal(controllerStates[1]?.primaryAction, 1, 'keeps controller activation state');
+  testCase.end();
+});
+
+test('webxr#getWebXRControllerStateByHandedness selects controller hands', testCase => {
+  const leftInputSource = {} as XRInputSource;
+  const rightInputSource = {} as XRInputSource;
+  const noneInputSource = {} as XRInputSource;
+  const controllerStates = getWebXRControllerStates([
+    makeMockWebXRInputState(null, null, {
+      inputSource: leftInputSource,
+      handedness: 'left',
+      profiles: ['generic-trigger-squeeze-thumbstick']
+    }),
+    makeMockWebXRInputState(null, null, {
+      inputSource: rightInputSource,
+      handedness: 'right',
+      profiles: ['generic-trigger-squeeze-thumbstick']
+    }),
+    makeMockWebXRInputState(null, null, {
+      inputSource: noneInputSource,
+      handedness: 'none',
+      profiles: ['generic-trigger-squeeze-thumbstick']
+    })
+  ]);
+
+  testCase.equal(
+    getWebXRControllerStateByHandedness(controllerStates)?.inputSource,
+    leftInputSource,
+    'default any returns first controller'
+  );
+  testCase.equal(
+    getWebXRControllerStateByHandedness(controllerStates, 'right')?.inputSource,
+    rightInputSource,
+    'selects right-hand controllers'
+  );
+  testCase.equal(
+    getWebXRControllerStateByHandedness(controllerStates, 'none')?.inputSource,
+    noneInputSource,
+    'selects unhanded controllers'
+  );
+  testCase.equal(
+    getWebXRControllerStateByHandedness(controllerStates, 'left')?.inputSource,
+    leftInputSource,
+    'selects left-hand controllers'
+  );
+  testCase.equal(
+    getWebXRControllerStateByHandedness([], 'right'),
+    null,
+    'empty controller lists return null'
+  );
+  testCase.equal(
+    getWebXRControllerStateByHandedness(null, 'right'),
+    null,
+    'null controller lists return null'
+  );
   testCase.end();
 });
 

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -5,6 +5,7 @@
 import test from 'test/utils/vitest-tape';
 import {
   WebXRInputActionManager,
+  getWebXRControllerState,
   getWebXRInputActionState,
   getWebXRInputActivationState,
   getWebXRInputGrip,
@@ -105,6 +106,61 @@ test('webxr#getWebXRInputSourceState classifies input source capabilities', test
   testCase.equal(gazeState.kind, 'gaze', 'gaze target rays classify as gaze input');
   testCase.equal(gazeState.primaryProfile, null, 'empty profile lists return null');
   testCase.equal(gazeState.isGaze, true, 'marks gaze input');
+  testCase.end();
+});
+
+test('webxr#getWebXRControllerState consolidates tracked-pointer controller state', testCase => {
+  const targetRayMatrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, -3, 4, 0, 2, 5, 7, 1]);
+  const gripMatrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -0.25, 1.125, -0.75, 1]);
+  const inputState = makeMockWebXRInputState(targetRayMatrix, gripMatrix, {
+    handedness: 'left',
+    gamepad: makeMockXRStandardGamepad([
+      {value: 0.4, pressed: true, touched: true},
+      {value: 0.8, pressed: true, touched: true}
+    ]),
+    profiles: ['oculus-touch-v3']
+  });
+  const controllerState = getWebXRControllerState(inputState);
+
+  testCase.equal(controllerState?.inputState, inputState, 'retains source input state');
+  testCase.equal(controllerState?.inputSource, inputState.inputSource, 'retains input source');
+  testCase.equal(controllerState?.primaryProfile, 'oculus-touch-v3', 'keeps primary profile');
+  testCase.equal(controllerState?.handedness, 'left', 'keeps handedness');
+  testCase.equal(controllerState?.sourceState.isController, true, 'includes input source state');
+  testCase.equal(controllerState?.activationState.triggerValue, 0.4, 'includes activation state');
+  testCase.equal(controllerState?.primaryAction, 0.4, 'aliases primary action');
+  testCase.equal(controllerState?.squeezeAction, 0.8, 'aliases squeeze action');
+  testCase.deepEqual(controllerState?.ray?.origin, [2, 5, 7], 'includes target ray state');
+  testCase.deepEqual(controllerState?.grip?.position, [-0.25, 1.125, -0.75], 'includes grip state');
+
+  const partialControllerState = getWebXRControllerState(
+    makeMockWebXRInputState(null, null, {
+      profiles: ['generic-trigger-squeeze-thumbstick']
+    })
+  );
+  testCase.equal(partialControllerState?.ray, null, 'allows controller state without target ray');
+  testCase.equal(partialControllerState?.grip, null, 'allows controller state without grip pose');
+
+  testCase.equal(
+    getWebXRControllerState(
+      makeMockWebXRInputState(targetRayMatrix, null, {
+        hand: {} as XRHand,
+        profiles: ['generic-hand-select']
+      })
+    ),
+    null,
+    'hands are not controller states'
+  );
+  testCase.equal(
+    getWebXRControllerState(
+      makeMockWebXRInputState(null, null, {
+        targetRayMode: 'screen',
+        profiles: ['generic-touchscreen']
+      })
+    ),
+    null,
+    'screen input is not a controller state'
+  );
   testCase.end();
 });
 

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -18,7 +18,10 @@ import {
   getWebXRInputActivationState,
   getWebXRInputGrip,
   getWebXRInputRay,
+  getWebXRInputRayByInputSource,
   getWebXRInputRayPlaneIntersection,
+  getWebXRInputRayPlaneIntersections,
+  getWebXRInputRays,
   getWebXRInputStateByInputSource,
   getWebXRInputSourceState
 } from '../../src/webxr/webxr-input';
@@ -48,6 +51,55 @@ test('webxr#getWebXRInputRay handles missing and degenerate target rays', testCa
   );
   testCase.deepEqual(ray?.origin, [3, 4, 5], 'still resolves origin');
   testCase.deepEqual(ray?.direction, [0, 0, -1], 'falls back to forward direction');
+  testCase.end();
+});
+
+test('webxr#getWebXRInputRays filters input snapshots with target rays', testCase => {
+  const firstInputSource = {} as XRInputSource;
+  const secondInputSource = {} as XRInputSource;
+  const firstRayMatrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 1, 2, 3, 1]);
+  const secondRayMatrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -1, 0.5, 2, 1]);
+  const rays = getWebXRInputRays([
+    makeMockWebXRInputState(firstRayMatrix, null, {inputSource: firstInputSource}),
+    makeMockWebXRInputState(null, null),
+    makeMockWebXRInputState(secondRayMatrix, null, {inputSource: secondInputSource})
+  ]);
+
+  testCase.deepEqual(getWebXRInputRays(null), [], 'null input snapshots become empty list');
+  testCase.equal(rays.length, 2, 'filters out missing target-ray poses');
+  testCase.equal(rays[0]?.inputState.inputSource, firstInputSource, 'preserves ray order');
+  testCase.deepEqual(rays[0]?.origin, [1, 2, 3], 'resolves first ray origin');
+  testCase.equal(rays[1]?.inputState.inputSource, secondInputSource, 'keeps later ray');
+  testCase.deepEqual(rays[1]?.origin, [-1, 0.5, 2], 'resolves second ray origin');
+  testCase.end();
+});
+
+test('webxr#getWebXRInputRayByInputSource selects ray identity', testCase => {
+  const firstInputSource = {} as XRInputSource;
+  const secondInputSource = {} as XRInputSource;
+  const missingInputSource = {} as XRInputSource;
+  const rayMatrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 0, 1, 0, 1]);
+  const rays = getWebXRInputRays([
+    makeMockWebXRInputState(rayMatrix, null, {inputSource: firstInputSource}),
+    makeMockWebXRInputState(rayMatrix, null, {inputSource: secondInputSource})
+  ]);
+
+  testCase.equal(
+    getWebXRInputRayByInputSource(rays, secondInputSource)?.inputState.inputSource,
+    secondInputSource,
+    'selects ray by exact input source identity'
+  );
+  testCase.equal(
+    getWebXRInputRayByInputSource(rays, missingInputSource),
+    null,
+    'missing input sources return null'
+  );
+  testCase.equal(
+    getWebXRInputRayByInputSource(null, secondInputSource),
+    null,
+    'null ray lists return null'
+  );
+  testCase.equal(getWebXRInputRayByInputSource(rays, null), null, 'null input sources return null');
   testCase.end();
 });
 
@@ -685,6 +737,38 @@ test('webxr#getWebXRInputRayPlaneIntersection resolves floor hits and custom pla
 
   testCase.equal(wallHit?.distance, 2, 'normalizes custom plane normals');
   testCase.deepEqual(wallHit?.point, [1, 2, 1], 'intersects custom plane');
+  testCase.end();
+});
+
+test('webxr#getWebXRInputRayPlaneIntersections filters batch ray hits', testCase => {
+  const floorRay = {
+    inputState: makeMockWebXRInputState(null),
+    origin: [0, 1.6, 0],
+    direction: [0, -0.8, -0.6],
+    matrix: new Float32Array(16)
+  };
+  const farRay = {
+    inputState: makeMockWebXRInputState(null),
+    origin: [1, 1.6, 0],
+    direction: [0, -0.8, -0.6],
+    matrix: new Float32Array(16)
+  };
+  const parallelRay = {
+    inputState: makeMockWebXRInputState(null),
+    origin: [0, 1, 0],
+    direction: [1, 0, 0],
+    matrix: new Float32Array(16)
+  };
+  const hits = getWebXRInputRayPlaneIntersections([floorRay, farRay, parallelRay], {
+    maxDistance: 2.1
+  });
+
+  testCase.deepEqual(getWebXRInputRayPlaneIntersections(null), [], 'null ray lists become empty');
+  testCase.equal(hits.length, 2, 'filters out rays without usable intersections');
+  testCase.equal(hits[0]?.ray, floorRay, 'keeps first intersecting ray');
+  testCase.deepEqual(hits[0]?.point, [0, 0, -1.2], 'keeps first floor hit');
+  testCase.equal(hits[1]?.ray, farRay, 'keeps later intersecting ray');
+  testCase.deepEqual(hits[1]?.point, [1, 0, -1.2], 'keeps later floor hit');
   testCase.end();
 });
 

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -1,0 +1,50 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {getWebXRInputRay} from '../../src/webxr/webxr-input';
+import type {WebXRInputState} from '../../src/webxr/webxr-manager';
+
+test('webxr#getWebXRInputRay resolves origin and normalized target-ray direction', testCase => {
+  const matrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, -3, 4, 0, 2, 5, 7, 1]);
+  const inputState = makeMockWebXRInputState(matrix);
+  const ray = getWebXRInputRay(inputState);
+
+  testCase.equal(ray?.inputState, inputState, 'retains source input state');
+  testCase.equal(ray?.matrix, matrix, 'retains source target-ray matrix');
+  testCase.deepEqual(ray?.origin, [2, 5, 7], 'uses matrix translation as origin');
+  testCase.deepEqual(ray?.direction, [0, 0.6, -0.8], 'normalizes negative local z');
+  testCase.end();
+});
+
+test('webxr#getWebXRInputRay handles missing and degenerate target rays', testCase => {
+  testCase.equal(
+    getWebXRInputRay(makeMockWebXRInputState(null)),
+    null,
+    'missing target ray matrices do not produce rays'
+  );
+
+  const ray = getWebXRInputRay(
+    makeMockWebXRInputState(new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 3, 4, 5, 1]))
+  );
+  testCase.deepEqual(ray?.origin, [3, 4, 5], 'still resolves origin');
+  testCase.deepEqual(ray?.direction, [0, 0, -1], 'falls back to forward direction');
+  testCase.end();
+});
+
+function makeMockWebXRInputState(targetRayMatrix: Float32Array | null): WebXRInputState {
+  return {
+    inputSource: {} as XRInputSource,
+    index: 0,
+    handedness: 'right',
+    targetRayMode: 'tracked-pointer',
+    profiles: [],
+    gamepad: null,
+    targetRayPose: null,
+    targetRayMatrix,
+    gripPose: null,
+    gripMatrix: null,
+    selectActive: false
+  };
+}

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -6,7 +6,8 @@ import test from 'test/utils/vitest-tape';
 import {
   getWebXRInputGrip,
   getWebXRInputRay,
-  getWebXRInputRayPlaneIntersection
+  getWebXRInputRayPlaneIntersection,
+  getWebXRInputSourceState
 } from '../../src/webxr/webxr-input';
 import type {WebXRInputState} from '../../src/webxr/webxr-manager';
 
@@ -50,6 +51,57 @@ test('webxr#getWebXRInputGrip resolves tracked controller grip poses', testCase 
     null,
     'missing grip matrices do not produce grips'
   );
+  testCase.end();
+});
+
+test('webxr#getWebXRInputSourceState classifies input source capabilities', testCase => {
+  const targetRayMatrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1]);
+  const gripMatrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 3, 2, 1, 1]);
+  const controllerState = getWebXRInputSourceState(
+    makeMockWebXRInputState(targetRayMatrix, gripMatrix, {
+      gamepad: {} as Gamepad,
+      profiles: ['oculus-touch-v3', 'generic-trigger-squeeze-thumbstick']
+    })
+  );
+
+  testCase.equal(controllerState.kind, 'controller', 'tracked pointer without hand is controller');
+  testCase.equal(controllerState.primaryProfile, 'oculus-touch-v3', 'keeps primary profile');
+  testCase.equal(controllerState.isController, true, 'marks controllers');
+  testCase.equal(controllerState.usesTrackedPointer, true, 'marks tracked pointers');
+  testCase.equal(controllerState.hasTargetRay, true, 'detects target ray matrices');
+  testCase.equal(controllerState.hasGrip, true, 'detects grip matrices');
+  testCase.equal(controllerState.hasGamepad, true, 'detects gamepads');
+
+  const handState = getWebXRInputSourceState(
+    makeMockWebXRInputState(targetRayMatrix, null, {
+      hand: {} as XRHand,
+      profiles: ['generic-hand-select']
+    })
+  );
+  testCase.equal(handState.kind, 'hand', 'hand sources take precedence over tracked pointers');
+  testCase.equal(handState.isHand, true, 'marks hands');
+  testCase.equal(handState.isController, false, 'hands are not classified as controllers');
+
+  const screenState = getWebXRInputSourceState(
+    makeMockWebXRInputState(null, null, {
+      handedness: 'none',
+      targetRayMode: 'screen',
+      profiles: ['generic-touchscreen']
+    })
+  );
+  testCase.equal(screenState.kind, 'screen', 'screen target rays classify as screen input');
+  testCase.equal(screenState.isScreen, true, 'marks screen input');
+  testCase.equal(screenState.hasTargetRay, false, 'missing target rays are reflected');
+
+  const gazeState = getWebXRInputSourceState(
+    makeMockWebXRInputState(null, null, {
+      targetRayMode: 'gaze',
+      profiles: []
+    })
+  );
+  testCase.equal(gazeState.kind, 'gaze', 'gaze target rays classify as gaze input');
+  testCase.equal(gazeState.primaryProfile, null, 'empty profile lists return null');
+  testCase.equal(gazeState.isGaze, true, 'marks gaze input');
   testCase.end();
 });
 
@@ -120,15 +172,17 @@ test('webxr#getWebXRInputRayPlaneIntersection rejects unusable hits', testCase =
 
 function makeMockWebXRInputState(
   targetRayMatrix: Float32Array | null,
-  gripMatrix: Float32Array | null = null
+  gripMatrix: Float32Array | null = null,
+  props: Partial<WebXRInputState> = {}
 ): WebXRInputState {
   return {
     inputSource: {} as XRInputSource,
     index: 0,
-    handedness: 'right',
-    targetRayMode: 'tracked-pointer',
-    profiles: [],
-    gamepad: null,
+    handedness: props.handedness ?? 'right',
+    targetRayMode: props.targetRayMode ?? 'tracked-pointer',
+    profiles: props.profiles ?? [],
+    gamepad: props.gamepad ?? null,
+    hand: props.hand ?? null,
     targetRayPose: null,
     targetRayMatrix,
     gripPose: null,

--- a/modules/experimental/test/webxr/webxr-input.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-input.node.spec.ts
@@ -3,7 +3,11 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
-import {getWebXRInputRay, getWebXRInputRayPlaneIntersection} from '../../src/webxr/webxr-input';
+import {
+  getWebXRInputGrip,
+  getWebXRInputRay,
+  getWebXRInputRayPlaneIntersection
+} from '../../src/webxr/webxr-input';
 import type {WebXRInputState} from '../../src/webxr/webxr-manager';
 
 test('webxr#getWebXRInputRay resolves origin and normalized target-ray direction', testCase => {
@@ -30,6 +34,22 @@ test('webxr#getWebXRInputRay handles missing and degenerate target rays', testCa
   );
   testCase.deepEqual(ray?.origin, [3, 4, 5], 'still resolves origin');
   testCase.deepEqual(ray?.direction, [0, 0, -1], 'falls back to forward direction');
+  testCase.end();
+});
+
+test('webxr#getWebXRInputGrip resolves tracked controller grip poses', testCase => {
+  const matrix = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -0.25, 1.125, -0.75, 1]);
+  const inputState = makeMockWebXRInputState(null, matrix);
+  const grip = getWebXRInputGrip(inputState);
+
+  testCase.equal(grip?.inputState, inputState, 'retains source input state');
+  testCase.equal(grip?.matrix, matrix, 'retains source grip matrix');
+  testCase.deepEqual(grip?.position, [-0.25, 1.125, -0.75], 'uses matrix translation as position');
+  testCase.equal(
+    getWebXRInputGrip(makeMockWebXRInputState(null, null)),
+    null,
+    'missing grip matrices do not produce grips'
+  );
   testCase.end();
 });
 
@@ -98,7 +118,10 @@ test('webxr#getWebXRInputRayPlaneIntersection rejects unusable hits', testCase =
   testCase.end();
 });
 
-function makeMockWebXRInputState(targetRayMatrix: Float32Array | null): WebXRInputState {
+function makeMockWebXRInputState(
+  targetRayMatrix: Float32Array | null,
+  gripMatrix: Float32Array | null = null
+): WebXRInputState {
   return {
     inputSource: {} as XRInputSource,
     index: 0,
@@ -109,7 +132,7 @@ function makeMockWebXRInputState(targetRayMatrix: Float32Array | null): WebXRInp
     targetRayPose: null,
     targetRayMatrix,
     gripPose: null,
-    gripMatrix: null,
+    gripMatrix,
     selectActive: false,
     squeezeActive: false
   };

--- a/modules/experimental/test/webxr/webxr-layers.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-layers.node.spec.ts
@@ -1,0 +1,301 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Device, Framebuffer, FramebufferProps, Texture, TextureProps} from '@luma.gl/core';
+import test from 'test/utils/vitest-tape';
+import {
+  getWebXRLayersSessionInit,
+  WebXRCompositionLayerManager
+} from '../../src/webxr/webxr-layers';
+
+type MockFramebuffer = Framebuffer & {
+  destroyCount: number;
+};
+
+type MockTexture = Texture & {
+  destroyCount: number;
+};
+
+type MockTextureProps = TextureProps & {
+  handle?: unknown;
+  _isHandleBorrowed?: boolean;
+};
+
+test('webxr#WebXRCompositionLayerManager creates quad layers and resolves subimages', async testCase => {
+  const originalXRWebGLBinding = globalThis.XRWebGLBinding;
+  const session = makeMockXRSession();
+  const device = makeMockDevice();
+  const xrSpace = {} as XRSpace;
+  const colorTextureHandle = {} as WebGLTexture;
+  const depthStencilTextureHandle = {} as WebGLTexture;
+  const subImage = makeMockXRWebGLSubImage({
+    colorTexture: colorTextureHandle,
+    depthStencilTexture: depthStencilTextureHandle,
+    imageIndex: 2,
+    colorTextureWidth: 512,
+    colorTextureHeight: 256,
+    depthStencilTextureWidth: 512,
+    depthStencilTextureHeight: 256
+  });
+  const frame = {session} as XRFrame;
+
+  globalThis.XRWebGLBinding = makeMockXRWebGLBindingClass(subImage);
+
+  try {
+    const manager = new WebXRCompositionLayerManager(device);
+    await manager.setSession(session);
+    const layer = manager.createQuadLayer({
+      space: xrSpace,
+      viewPixelWidth: 512,
+      viewPixelHeight: 256,
+      width: 1.5,
+      height: 0.75
+    });
+    await manager.updateRenderState([layer]);
+
+    const state = manager.getLayerState(frame, layer);
+    const secondState = manager.getLayerState(frame, layer);
+    const colorTexture = state?.colorTexture as MockTexture | null | undefined;
+    const depthStencilTexture = state?.depthStencilTexture as MockTexture | null | undefined;
+    const colorTextureProps = colorTexture?.props as MockTextureProps | undefined;
+    const depthStencilTextureProps = depthStencilTexture?.props as MockTextureProps | undefined;
+
+    testCase.equal(device.compatibilityCallCount, 1, 'makes WebGL context XR compatible');
+    testCase.equal(session.updatedLayers[0], layer, 'updates render state with layer');
+    testCase.equal(state?.session, session, 'retains source session');
+    testCase.equal(state?.xrFrame, frame, 'retains source frame');
+    testCase.equal(state?.layer, layer, 'retains composition layer');
+    testCase.equal(state?.subImage, subImage, 'retains source subimage');
+    testCase.deepEqual(state?.viewport, [4, 8, 128, 64], 'exposes subimage viewport');
+    testCase.equal(state?.layout, 'mono', 'exposes layer layout');
+    testCase.equal(state?.imageIndex, 2, 'exposes texture-array image index');
+    testCase.equal(secondState?.framebuffer, state?.framebuffer, 'reuses stable framebuffer');
+    testCase.equal(secondState?.colorTexture, state?.colorTexture, 'reuses stable color texture');
+    testCase.equal(device.createdTextures.length, 2, 'wraps color and depth textures once');
+    testCase.equal(device.createdFramebuffers.length, 1, 'creates one framebuffer');
+    testCase.equal(
+      colorTextureProps?.handle,
+      colorTextureHandle,
+      'wraps browser-owned color texture'
+    );
+    testCase.equal(
+      depthStencilTextureProps?.handle,
+      depthStencilTextureHandle,
+      'wraps browser-owned depth texture'
+    );
+    testCase.equal(colorTextureProps?._isHandleBorrowed, true, 'marks color texture borrowed');
+    testCase.equal(
+      depthStencilTextureProps?._isHandleBorrowed,
+      true,
+      'marks depth texture borrowed'
+    );
+    testCase.equal(colorTextureProps?.dimension, '2d-array', 'uses array texture for image index');
+    testCase.equal(colorTextureProps?.depth, 3, 'exposes minimum array depth');
+    testCase.equal(state?.framebuffer.colorAttachments[0], colorTexture?.view, 'binds color view');
+    testCase.equal(
+      state?.framebuffer.depthStencilAttachment,
+      depthStencilTexture?.view,
+      'binds depth view'
+    );
+
+    layer.dispatchEvent(new Event('redraw'));
+    testCase.equal(manager.getLayerState(frame, layer)?.needsRedraw, true, 'tracks redraw events');
+    testCase.equal(
+      manager.getLayerState(frame, layer)?.needsRedraw,
+      false,
+      'redraw event is consumed once'
+    );
+
+    session.dispatchEvent(new Event('end'));
+    testCase.equal(colorTexture?.destroyCount, 1, 'session end destroys color wrapper');
+    testCase.equal(depthStencilTexture?.destroyCount, 1, 'session end destroys depth wrapper');
+    testCase.equal(
+      (state?.framebuffer as MockFramebuffer | undefined)?.destroyCount,
+      1,
+      'session end destroys framebuffer'
+    );
+    testCase.equal(manager.session, null, 'session end clears active session');
+  } finally {
+    globalThis.XRWebGLBinding = originalXRWebGLBinding;
+  }
+
+  testCase.end();
+});
+
+test('webxr#WebXRCompositionLayerManager handles cylinder layers and helpers', async testCase => {
+  const originalXRWebGLBinding = globalThis.XRWebGLBinding;
+  const session = makeMockXRSession();
+  const device = makeMockDevice();
+  const xrSpace = {} as XRSpace;
+  const subImage = makeMockXRWebGLSubImage({
+    colorTexture: {} as WebGLTexture,
+    depthStencilTexture: null,
+    imageIndex: undefined
+  });
+
+  globalThis.XRWebGLBinding = makeMockXRWebGLBindingClass(subImage);
+
+  try {
+    const manager = new WebXRCompositionLayerManager(device, {
+      colorTextureFormat: 'rgba16float'
+    });
+    await manager.setSession(session);
+    const layer = manager.createCylinderLayer({
+      space: xrSpace,
+      viewPixelWidth: 1024,
+      viewPixelHeight: 512,
+      radius: 2,
+      centralAngle: Math.PI / 3,
+      aspectRatio: 2
+    });
+    const state = manager.getLayerState({session} as XRFrame, layer, 'left');
+    const textureProps = state?.colorTexture.props as MockTextureProps | undefined;
+
+    testCase.equal(state?.eye, 'left', 'retains requested eye');
+    testCase.equal(state?.depthStencilTexture, null, 'depth texture is optional');
+    testCase.equal(textureProps?.dimension, '2d', 'uses 2d texture without image index');
+    testCase.equal(textureProps?.format, 'rgba16float', 'uses configured color texture format');
+    testCase.throws(
+      () => manager.getLayerState({session: makeMockXRSession()} as XRFrame, layer),
+      /different XRSession/,
+      'rejects frames from another session'
+    );
+  } finally {
+    globalThis.XRWebGLBinding = originalXRWebGLBinding;
+  }
+
+  testCase.deepEqual(
+    getWebXRLayersSessionInit(),
+    {optionalFeatures: ['layers']},
+    'creates optional layers session init'
+  );
+  testCase.deepEqual(
+    getWebXRLayersSessionInit({required: true}),
+    {requiredFeatures: ['layers']},
+    'creates required layers session init'
+  );
+  testCase.end();
+});
+
+function makeMockDevice(): Device & {
+  compatibilityCallCount: number;
+  createdFramebuffers: MockFramebuffer[];
+  createdTextures: MockTexture[];
+  gl: WebGL2RenderingContext & {makeXRCompatible(): Promise<void>};
+} {
+  const createdFramebuffers: MockFramebuffer[] = [];
+  const createdTextures: MockTexture[] = [];
+  const device = {
+    type: 'webgl',
+    compatibilityCallCount: 0,
+    createdFramebuffers,
+    createdTextures,
+    gl: {
+      async makeXRCompatible(): Promise<void> {
+        device.compatibilityCallCount++;
+      }
+    },
+    createFramebuffer(props: FramebufferProps): MockFramebuffer {
+      const framebuffer = {
+        props,
+        width: props.width,
+        height: props.height,
+        colorAttachments: props.colorAttachments || [],
+        depthStencilAttachment: props.depthStencilAttachment || null,
+        destroyCount: 0,
+        destroy() {
+          this.destroyCount++;
+        }
+      } as unknown as MockFramebuffer;
+      createdFramebuffers.push(framebuffer);
+      return framebuffer;
+    },
+    createTexture(props: TextureProps): MockTexture {
+      const texture = {
+        props,
+        width: props.width,
+        height: props.height,
+        destroyCount: 0,
+        destroy() {
+          this.destroyCount++;
+        }
+      } as unknown as MockTexture;
+      texture.view = {texture, props: props.view} as Texture['view'];
+      createdTextures.push(texture);
+      return texture;
+    }
+  } as Device & {
+    compatibilityCallCount: number;
+    createdFramebuffers: MockFramebuffer[];
+    createdTextures: MockTexture[];
+    gl: WebGL2RenderingContext & {makeXRCompatible(): Promise<void>};
+  };
+
+  return device;
+}
+
+function makeMockXRSession(): XRSession & {updatedLayers: XRLayer[]} {
+  return Object.assign(new EventTarget(), {
+    inputSources: [],
+    updatedLayers: [] as XRLayer[],
+    async updateRenderState(renderStateInit: XRRenderStateInit = {}) {
+      this.updatedLayers = [...(renderStateInit.layers || [])];
+    }
+  }) as XRSession & {updatedLayers: XRLayer[]};
+}
+
+function makeMockXRWebGLBindingClass(subImage: XRWebGLSubImage): typeof XRWebGLBinding {
+  return class MockXRWebGLBinding {
+    constructor(
+      public session: XRSession,
+      public context: WebGLRenderingContext | WebGL2RenderingContext
+    ) {}
+
+    createQuadLayer(init: XRQuadLayerInit): XRQuadLayer {
+      return makeMockCompositionLayer('mono', init) as XRQuadLayer;
+    }
+
+    createCylinderLayer(init: XRCylinderLayerInit): XRCylinderLayer {
+      return makeMockCompositionLayer('mono', init) as XRCylinderLayer;
+    }
+
+    getSubImage(): XRWebGLSubImage {
+      return subImage;
+    }
+  } as unknown as typeof XRWebGLBinding;
+}
+
+function makeMockCompositionLayer(
+  layout: XRLayerLayout,
+  init: XRQuadLayerInit | XRCylinderLayerInit
+): XRCompositionLayer {
+  return Object.assign(new EventTarget(), {
+    layout,
+    blendTextureSourceAlpha: true,
+    forceMonoPresentation: false,
+    opacity: 1,
+    mipLevels: init.mipLevels || 1,
+    quality: 'default' as XRLayerQuality,
+    needsRedraw: false,
+    space: init.space,
+    transform: init.transform,
+    destroy() {}
+  }) as XRCompositionLayer;
+}
+
+function makeMockXRWebGLSubImage(
+  props: Partial<XRWebGLSubImage> & {colorTexture: WebGLTexture}
+): XRWebGLSubImage {
+  return {
+    colorTexture: props.colorTexture,
+    depthStencilTexture: props.depthStencilTexture === undefined ? null : props.depthStencilTexture,
+    motionVectorTexture: props.motionVectorTexture || null,
+    imageIndex: props.imageIndex,
+    colorTextureWidth: props.colorTextureWidth || 256,
+    colorTextureHeight: props.colorTextureHeight || 128,
+    depthStencilTextureWidth: props.depthStencilTextureWidth,
+    depthStencilTextureHeight: props.depthStencilTextureHeight,
+    viewport: props.viewport || {x: 4, y: 8, width: 128, height: 64}
+  } as XRWebGLSubImage;
+}

--- a/modules/experimental/test/webxr/webxr-layers.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-layers.node.spec.ts
@@ -5,7 +5,9 @@
 import type {Device, Framebuffer, FramebufferProps, Texture, TextureProps} from '@luma.gl/core';
 import test from 'test/utils/vitest-tape';
 import {
+  getWebXRCompositionLayerControls,
   getWebXRLayersSessionInit,
+  setWebXRCompositionLayerControls,
   WebXRCompositionLayerManager
 } from '../../src/webxr/webxr-layers';
 
@@ -20,6 +22,10 @@ type MockTexture = Texture & {
 type MockTextureProps = TextureProps & {
   handle?: unknown;
   _isHandleBorrowed?: boolean;
+};
+
+type MockXRCompositionLayer = XRCompositionLayer & {
+  destroyCount: number;
 };
 
 test('webxr#WebXRCompositionLayerManager creates quad layers and resolves subimages', async testCase => {
@@ -66,6 +72,11 @@ test('webxr#WebXRCompositionLayerManager creates quad layers and resolves subima
     testCase.equal(state?.session, session, 'retains source session');
     testCase.equal(state?.xrFrame, frame, 'retains source frame');
     testCase.equal(state?.layer, layer, 'retains composition layer');
+    testCase.deepEqual(
+      state?.controls,
+      getWebXRCompositionLayerControls(layer),
+      'exposes common layer controls'
+    );
     testCase.equal(state?.subImage, subImage, 'retains source subimage');
     testCase.deepEqual(state?.viewport, [4, 8, 128, 64], 'exposes subimage viewport');
     testCase.equal(state?.layout, 'mono', 'exposes layer layout');
@@ -151,8 +162,33 @@ test('webxr#WebXRCompositionLayerManager handles cylinder layers and helpers', a
     });
     const state = manager.getLayerState({session} as XRFrame, layer, 'left');
     const textureProps = state?.colorTexture.props as MockTextureProps | undefined;
+    const controls = manager.setLayerControls(layer, {
+      blendTextureSourceAlpha: false,
+      forceMonoPresentation: true,
+      opacity: 0.42,
+      quality: 'text-optimized'
+    });
 
     testCase.equal(state?.eye, 'left', 'retains requested eye');
+    testCase.deepEqual(
+      controls,
+      {
+        layer,
+        blendTextureSourceAlpha: false,
+        forceMonoPresentation: true,
+        opacity: 0.42,
+        mipLevels: 1,
+        quality: 'text-optimized',
+        needsRedraw: false
+      },
+      'updates and snapshots common layer controls'
+    );
+    layer.dispatchEvent(new Event('redraw'));
+    testCase.equal(
+      manager.getLayerControls(layer).needsRedraw,
+      true,
+      'controls include redraw state'
+    );
     testCase.equal(state?.depthStencilTexture, null, 'depth texture is optional');
     testCase.equal(textureProps?.dimension, '2d', 'uses 2d texture without image index');
     testCase.equal(textureProps?.format, 'rgba16float', 'uses configured color texture format');
@@ -160,6 +196,13 @@ test('webxr#WebXRCompositionLayerManager handles cylinder layers and helpers', a
       () => manager.getLayerState({session: makeMockXRSession()} as XRFrame, layer),
       /different XRSession/,
       'rejects frames from another session'
+    );
+    manager.destroyLayer(layer);
+    testCase.equal((layer as MockXRCompositionLayer).destroyCount, 1, 'destroys tracked layer');
+    testCase.equal(
+      (state?.colorTexture as MockTexture | undefined)?.destroyCount,
+      1,
+      'destroys layer color wrapper'
     );
   } finally {
     globalThis.XRWebGLBinding = originalXRWebGLBinding;
@@ -174,6 +217,15 @@ test('webxr#WebXRCompositionLayerManager handles cylinder layers and helpers', a
     getWebXRLayersSessionInit({required: true}),
     {requiredFeatures: ['layers']},
     'creates required layers session init'
+  );
+  const standaloneLayer = makeMockCompositionLayer('mono', {
+    viewPixelWidth: 1,
+    viewPixelHeight: 1
+  } as XRQuadLayerInit);
+  testCase.equal(
+    setWebXRCompositionLayerControls(standaloneLayer, {opacity: 0.75}).opacity,
+    0.75,
+    'standalone helper updates common controls'
   );
   testCase.end();
 });
@@ -332,7 +384,7 @@ function makeMockXRWebGLBindingClass(subImage: XRWebGLSubImage): typeof XRWebGLB
 function makeMockCompositionLayer(
   layout: XRLayerLayout,
   init: XRQuadLayerInit | XRCylinderLayerInit | XREquirectLayerInit | XRCubeLayerInit
-): XRCompositionLayer {
+): MockXRCompositionLayer {
   return Object.assign(new EventTarget(), {
     layout,
     blendTextureSourceAlpha: true,
@@ -341,10 +393,13 @@ function makeMockCompositionLayer(
     mipLevels: init.mipLevels || 1,
     quality: 'default' as XRLayerQuality,
     needsRedraw: false,
+    destroyCount: 0,
     space: init.space,
     transform: init.transform,
-    destroy() {}
-  }) as XRCompositionLayer;
+    destroy() {
+      this.destroyCount++;
+    }
+  }) as MockXRCompositionLayer;
 }
 
 function makeMockXRWebGLSubImage(

--- a/modules/experimental/test/webxr/webxr-layers.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-layers.node.spec.ts
@@ -178,6 +178,59 @@ test('webxr#WebXRCompositionLayerManager handles cylinder layers and helpers', a
   testCase.end();
 });
 
+test('webxr#WebXRCompositionLayerManager handles equirect and cube layers', async testCase => {
+  const originalXRWebGLBinding = globalThis.XRWebGLBinding;
+  const session = makeMockXRSession();
+  const device = makeMockDevice();
+  const referenceSpace = {} as XRReferenceSpace;
+  const orientation = {x: 0, y: 0, z: 0, w: 1} as DOMPointReadOnly;
+  const subImage = makeMockXRWebGLSubImage({
+    colorTexture: {} as WebGLTexture,
+    depthStencilTexture: null,
+    imageIndex: undefined,
+    colorTextureWidth: 2048,
+    colorTextureHeight: 1024
+  });
+
+  globalThis.XRWebGLBinding = makeMockXRWebGLBindingClass(subImage);
+
+  try {
+    const manager = new WebXRCompositionLayerManager(device);
+    await manager.setSession(session);
+    const equirectLayer = manager.createEquirectLayer({
+      space: referenceSpace,
+      viewPixelWidth: 2048,
+      viewPixelHeight: 1024,
+      radius: 0,
+      centralHorizontalAngle: Math.PI * 2,
+      upperVerticalAngle: Math.PI / 2,
+      lowerVerticalAngle: -Math.PI / 2
+    });
+    const cubeLayer = manager.createCubeLayer({
+      space: referenceSpace,
+      viewPixelWidth: 1024,
+      viewPixelHeight: 1024,
+      orientation
+    });
+    await manager.updateRenderState([equirectLayer, cubeLayer]);
+
+    const equirectState = manager.getLayerState({session} as XRFrame, equirectLayer);
+    const cubeState = manager.getLayerState({session} as XRFrame, cubeLayer);
+
+    testCase.equal(session.updatedLayers[0], equirectLayer, 'updates render state with equirect');
+    testCase.equal(session.updatedLayers[1], cubeLayer, 'updates render state with cube');
+    testCase.equal(equirectState?.layer, equirectLayer, 'resolves equirect subimage state');
+    testCase.equal(cubeState?.layer, cubeLayer, 'resolves cube subimage state');
+    testCase.equal(equirectState?.colorTexture.width, 2048, 'uses equirect subimage width');
+    testCase.equal(equirectState?.colorTexture.height, 1024, 'uses equirect subimage height');
+    testCase.equal((cubeLayer as XRCubeLayer).orientation, orientation, 'retains cube orientation');
+  } finally {
+    globalThis.XRWebGLBinding = originalXRWebGLBinding;
+  }
+
+  testCase.end();
+});
+
 function makeMockDevice(): Device & {
   compatibilityCallCount: number;
   createdFramebuffers: MockFramebuffer[];
@@ -260,6 +313,16 @@ function makeMockXRWebGLBindingClass(subImage: XRWebGLSubImage): typeof XRWebGLB
       return makeMockCompositionLayer('mono', init) as XRCylinderLayer;
     }
 
+    createEquirectLayer(init: XREquirectLayerInit): XREquirectLayer {
+      return makeMockCompositionLayer('mono', init) as XREquirectLayer;
+    }
+
+    createCubeLayer(init: XRCubeLayerInit): XRCubeLayer {
+      return Object.assign(makeMockCompositionLayer('mono', init), {
+        orientation: init.orientation || null
+      }) as XRCubeLayer;
+    }
+
     getSubImage(): XRWebGLSubImage {
       return subImage;
     }
@@ -268,7 +331,7 @@ function makeMockXRWebGLBindingClass(subImage: XRWebGLSubImage): typeof XRWebGLB
 
 function makeMockCompositionLayer(
   layout: XRLayerLayout,
-  init: XRQuadLayerInit | XRCylinderLayerInit
+  init: XRQuadLayerInit | XRCylinderLayerInit | XREquirectLayerInit | XRCubeLayerInit
 ): XRCompositionLayer {
   return Object.assign(new EventTarget(), {
     layout,

--- a/modules/experimental/test/webxr/webxr-light-estimation.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-light-estimation.node.spec.ts
@@ -1,0 +1,285 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Device, Texture, TextureProps} from '@luma.gl/core';
+import test from 'test/utils/vitest-tape';
+import {
+  getWebXRLightEstimationSessionInit,
+  getWebXRReflectionTextureFormat,
+  WebXRLightEstimationManager
+} from '../../src/webxr/webxr-light-estimation';
+
+type MockTexture = Texture & {
+  destroyCount: number;
+};
+
+type MockTextureProps = TextureProps & {
+  handle?: unknown;
+  _isHandleBorrowed?: boolean;
+};
+
+test('webxr#WebXRLightEstimationManager resolves light estimates and probe poses', async testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const probeSpace = {} as XRSpace;
+  const lightProbe = makeMockXRLightProbe(probeSpace);
+  const requestLightProbeOptions: XRLightProbeInit[] = [];
+  const session = makeMockXRSession({
+    preferredReflectionFormat: 'rgba16f',
+    async requestLightProbe(options?: XRLightProbeInit): Promise<XRLightProbe> {
+      requestLightProbeOptions.push(options || {});
+      return lightProbe;
+    }
+  });
+  const estimate = makeMockXRLightEstimate({
+    sphericalHarmonicsCoefficients: new Float32Array([1, 2, 3]),
+    primaryLightDirection: makeMockDOMPoint(0.25, 0.5, -0.75),
+    primaryLightIntensity: makeMockDOMPoint(1.5, 1.25, 1)
+  });
+  const pose = makeMockXRPose([1, 0, 0, 0]);
+  let receivedProbe: XRLightProbe | undefined;
+  let receivedProbeSpace: XRSpace | undefined;
+  let receivedReferenceSpace: XRReferenceSpace | undefined;
+  const frame = {
+    session,
+    getLightEstimate(xrLightProbe: XRLightProbe): XRLightEstimate | null {
+      receivedProbe = xrLightProbe;
+      return estimate;
+    },
+    getPose(space: XRSpace, baseSpace: XRSpace): XRPose | undefined {
+      receivedProbeSpace = space;
+      receivedReferenceSpace = baseSpace as XRReferenceSpace;
+      return pose;
+    }
+  } as XRFrame;
+  const manager = new WebXRLightEstimationManager({reflectionFormat: 'preferred'});
+
+  await manager.setSession(session, referenceSpace);
+  const lightState = manager.getLightEstimationState(frame);
+
+  testCase.deepEqual(
+    requestLightProbeOptions,
+    [{reflectionFormat: 'rgba16f'}],
+    'requests preferred reflection format'
+  );
+  testCase.equal(receivedProbe, lightProbe, 'queries the active light probe');
+  testCase.equal(receivedProbeSpace, probeSpace, 'queries probe pose');
+  testCase.equal(receivedReferenceSpace, referenceSpace, 'uses app reference space for probe pose');
+  testCase.equal(lightState?.xrFrame, frame, 'retains source frame');
+  testCase.equal(lightState?.session, session, 'retains source session');
+  testCase.equal(lightState?.lightProbe, lightProbe, 'retains light probe');
+  testCase.equal(lightState?.lightEstimate, estimate, 'retains light estimate');
+  testCase.equal(lightState?.probePose, pose, 'retains probe pose');
+  testCase.equal(lightState?.matrix, pose.transform.matrix, 'exposes pose matrix');
+  testCase.equal(
+    lightState?.sphericalHarmonicsCoefficients,
+    estimate.sphericalHarmonicsCoefficients,
+    'exposes spherical harmonics'
+  );
+  testCase.deepEqual(
+    lightState?.primaryLightDirection,
+    [0.25, 0.5, -0.75],
+    'exposes primary light direction'
+  );
+  testCase.deepEqual(
+    lightState?.primaryLightIntensity,
+    [1.5, 1.25, 1],
+    'exposes primary light intensity'
+  );
+  testCase.equal(lightState?.reflectionCubeMap, null, 'reflection map is optional');
+  testCase.equal(lightState?.reflectionCubeMapTexture, null, 'does not invent texture wrappers');
+  testCase.equal(lightState?.reflectionRevision, 0, 'starts at reflection revision zero');
+
+  manager.destroy();
+  testCase.end();
+});
+
+test('webxr#WebXRLightEstimationManager wraps reflection cube maps when size is supplied', async testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const lightProbe = makeMockXRLightProbe({} as XRSpace);
+  const reflectionCubeMap = {} as WebGLTexture;
+  const session = makeMockXRSession({
+    async requestLightProbe(): Promise<XRLightProbe> {
+      return lightProbe;
+    }
+  });
+  const frame = {
+    session,
+    getLightEstimate(): XRLightEstimate | null {
+      return makeMockXRLightEstimate({});
+    },
+    getPose(): XRPose | undefined {
+      return undefined;
+    }
+  } as XRFrame;
+  const device = makeMockDevice();
+  const xrWebGLBinding = {
+    getReflectionCubeMap(xrLightProbe: XRLightProbe): WebGLTexture | null {
+      testCase.equal(xrLightProbe, lightProbe, 'queries reflection map for active probe');
+      return reflectionCubeMap;
+    }
+  } as XRWebGLBinding;
+  const manager = new WebXRLightEstimationManager({
+    reflectionCubeMapSize: 64,
+    reflectionFormat: 'rgba16f'
+  });
+
+  manager.setWebGLBinding(device, xrWebGLBinding);
+  await manager.setSession(session, referenceSpace);
+  lightProbe.dispatchEvent(new Event('reflectionchange'));
+  const lightState = manager.getLightEstimationState(frame);
+  const secondLightState = manager.getLightEstimationState(frame);
+  const texture = lightState?.reflectionCubeMapTexture as MockTexture | null | undefined;
+  const textureProps = texture?.props as MockTextureProps | undefined;
+
+  testCase.equal(lightState?.reflectionCubeMap, reflectionCubeMap, 'exposes raw cubemap handle');
+  testCase.equal(secondLightState?.reflectionCubeMapTexture, texture, 'reuses texture wrapper');
+  testCase.equal(device.createdTextures.length, 1, 'creates one borrowed cubemap wrapper');
+  testCase.equal(textureProps?.handle, reflectionCubeMap, 'wraps browser-owned cubemap handle');
+  testCase.equal(textureProps?._isHandleBorrowed, true, 'marks cubemap handle borrowed');
+  testCase.equal(textureProps?.dimension, 'cube', 'wraps as a cube texture');
+  testCase.equal(textureProps?.width, 64, 'uses supplied cubemap size');
+  testCase.equal(textureProps?.height, 64, 'uses supplied cubemap size');
+  testCase.equal(textureProps?.depth, 6, 'exposes six cube faces');
+  testCase.equal(textureProps?.format, 'rgba16float', 'maps rgba16f reflection format');
+  testCase.equal(textureProps?.usage, 4, 'defaults to sampled texture usage');
+  testCase.equal(lightState?.reflectionRevision, 1, 'tracks reflectionchange events');
+  testCase.equal(texture?.destroyCount, 0, 'wrapper is live before cleanup');
+
+  session.dispatchEvent(new Event('end'));
+  testCase.equal(texture?.destroyCount, 1, 'session end destroys borrowed wrapper');
+  testCase.equal(manager.session, null, 'session end clears active session');
+  testCase.end();
+});
+
+test('webxr#WebXRLightEstimationManager handles unsupported sessions and helpers', async testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const session = makeMockXRSession({});
+  const activeSession = makeMockXRSession({
+    async requestLightProbe(): Promise<XRLightProbe> {
+      return makeMockXRLightProbe({} as XRSpace);
+    }
+  });
+  const manager = new WebXRLightEstimationManager();
+
+  try {
+    await manager.setSession(session, referenceSpace);
+    testCase.fail('unsupported light probes should reject');
+  } catch (error) {
+    testCase.ok(/light-estimation probes/.test(String(error)), 'rejects unsupported sessions');
+  }
+
+  try {
+    await manager.setSession(activeSession, null);
+    testCase.fail('missing reference space should reject');
+  } catch (error) {
+    testCase.ok(
+      /requires an app reference space/.test(String(error)),
+      'rejects missing reference space'
+    );
+  }
+
+  await manager.setSession(activeSession, referenceSpace);
+  testCase.equal(
+    manager.getLightEstimationState({session: activeSession} as XRFrame),
+    null,
+    'unsupported frames return null'
+  );
+  testCase.throws(
+    () =>
+      manager.getLightEstimationState({
+        session,
+        getLightEstimate(): XRLightEstimate | null {
+          return makeMockXRLightEstimate({});
+        }
+      } as XRFrame),
+    /different XRSession/,
+    'rejects frames from a different session'
+  );
+  testCase.deepEqual(
+    getWebXRLightEstimationSessionInit({required: true}),
+    {requiredFeatures: ['light-estimation']},
+    'builds required light-estimation session init'
+  );
+  testCase.deepEqual(
+    getWebXRLightEstimationSessionInit(),
+    {optionalFeatures: ['light-estimation']},
+    'builds optional light-estimation session init'
+  );
+  testCase.equal(
+    getWebXRReflectionTextureFormat('srgba8'),
+    'rgba8unorm-srgb',
+    'maps srgba8 reflections'
+  );
+  testCase.equal(
+    getWebXRReflectionTextureFormat('rgba16f'),
+    'rgba16float',
+    'maps rgba16f reflections'
+  );
+  testCase.equal(
+    getWebXRReflectionTextureFormat('preferred'),
+    'rgba8unorm-srgb',
+    'uses srgba8 metadata for unresolved preferred format'
+  );
+
+  manager.clearSession();
+  manager.clearSession();
+  testCase.equal(manager.session, null, 'clearSession is idempotent');
+  testCase.end();
+});
+
+function makeMockXRSession(props: Partial<XRSession>): XRSession {
+  return Object.assign(new EventTarget(), {
+    inputSources: [],
+    ...props
+  }) as XRSession;
+}
+
+function makeMockXRLightProbe(probeSpace: XRSpace): XRLightProbe {
+  return Object.assign(new EventTarget(), {
+    probeSpace,
+    onreflectionchange: null
+  }) as XRLightProbe;
+}
+
+function makeMockXRLightEstimate(props: Partial<XRLightEstimate>): XRLightEstimate {
+  return {
+    sphericalHarmonicsCoefficients: props.sphericalHarmonicsCoefficients || new Float32Array(27),
+    primaryLightDirection: props.primaryLightDirection || makeMockDOMPoint(0, 1, 0),
+    primaryLightIntensity: props.primaryLightIntensity || makeMockDOMPoint(1, 1, 1)
+  };
+}
+
+function makeMockXRPose(matrix: number[]): XRPose {
+  return {
+    transform: {
+      matrix: new Float32Array(matrix),
+      inverse: {matrix: new Float32Array(matrix)}
+    } as XRRigidTransform
+  } as XRPose;
+}
+
+function makeMockDOMPoint(x: number, y: number, z: number): DOMPointReadOnly {
+  return {x, y, z, w: 1} as DOMPointReadOnly;
+}
+
+function makeMockDevice(): Device & {createdTextures: MockTexture[]} {
+  const createdTextures: MockTexture[] = [];
+  return {
+    type: 'webgl',
+    createdTextures,
+    createTexture(props: TextureProps): MockTexture {
+      const texture = {
+        props,
+        width: props.width,
+        height: props.height,
+        destroyCount: 0,
+        destroy() {
+          this.destroyCount++;
+        }
+      } as unknown as MockTexture;
+      createdTextures.push(texture);
+      return texture;
+    }
+  } as Device & {createdTextures: MockTexture[]};
+}

--- a/modules/experimental/test/webxr/webxr-locomotion.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-locomotion.node.spec.ts
@@ -1,0 +1,143 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {getWebXRGamepadStates} from '../../src/webxr/webxr-gamepad';
+import {
+  getWebXRLocomotionAxes,
+  getWebXRLocomotionAxisValue,
+  getWebXRLocomotionGamepadState,
+  getWebXRLocomotionState
+} from '../../src/webxr/webxr-locomotion';
+import type {WebXRInputState} from '../../src/webxr/webxr-manager';
+
+test('webxr#getWebXRLocomotionState resolves default thumbstick movement and turning', testCase => {
+  const leftInputState = makeWebXRInputState('left', [0, 0, 0.575, -1]);
+  const rightInputState = makeWebXRInputState('right', [0, 0, 0.7875, 0]);
+
+  const locomotionState = getWebXRLocomotionState([leftInputState, rightInputState], {
+    deadzone: 0.15,
+    snapTurnThreshold: 0.7
+  });
+
+  testCase.equal(locomotionState.moveInputState, leftInputState, 'uses left input for movement');
+  testCase.equal(locomotionState.turnInputState, rightInputState, 'uses right input for turning');
+  testCase.deepEqual(
+    locomotionState.move,
+    [0.49999999999999994, 1],
+    'returns strafe and forward movement'
+  );
+  testCase.equal(locomotionState.turn, 0.75, 'returns normalized turn input');
+  testCase.equal(locomotionState.snapTurn, 1, 'reports positive snap-turn intent');
+  testCase.equal(locomotionState.moveActive, true, 'movement is active');
+  testCase.equal(locomotionState.turnActive, true, 'turning is active');
+  testCase.equal(locomotionState.axis, 'thumbstick', 'defaults to thumbstick axes');
+  testCase.end();
+});
+
+test('webxr#getWebXRLocomotionState supports touchpads and inverted conventions', testCase => {
+  const inputState = makeWebXRInputState('right', [-1, 0.5, 0, 0]);
+
+  const locomotionState = getWebXRLocomotionState([inputState], {
+    axis: 'touchpad',
+    moveHandedness: 'any',
+    turnHandedness: 'right',
+    deadzone: 0,
+    snapTurnThreshold: 1,
+    invertMoveY: false,
+    invertTurnX: true
+  });
+
+  testCase.equal(
+    locomotionState.moveInputState,
+    inputState,
+    'uses any matching input for movement'
+  );
+  testCase.equal(locomotionState.turnInputState, inputState, 'uses matching input for turn');
+  testCase.deepEqual(locomotionState.move, [-1, 0.5], 'can keep Y movement sign');
+  testCase.equal(locomotionState.turn, 1, 'can invert turn sign');
+  testCase.equal(locomotionState.snapTurn, 1, 'snap threshold includes the edge value');
+  testCase.deepEqual(locomotionState.gamepadStates.length, 1, 'keeps gamepad snapshots');
+  testCase.end();
+});
+
+test('webxr#locomotion helpers handle dead zones and missing axes', testCase => {
+  const inputState = makeWebXRInputState('none', [0.2, -0.2]);
+  const gamepadState = getWebXRGamepadStates([inputState])[0]!;
+
+  testCase.equal(getWebXRLocomotionAxisValue(0.2, 0.2), 0, 'dead-zone edge returns zero');
+  testCase.equal(
+    getWebXRLocomotionAxisValue(0.6, 0.2),
+    0.49999999999999994,
+    'values outside the dead zone are rescaled'
+  );
+  testCase.equal(getWebXRLocomotionAxisValue(-1, 1), 0, 'dead zone clamps to one');
+  testCase.equal(
+    getWebXRLocomotionGamepadState([gamepadState], 'left'),
+    null,
+    'handedness mismatches return null'
+  );
+  testCase.equal(
+    getWebXRLocomotionGamepadState([gamepadState], 'any', 'touchpad'),
+    gamepadState,
+    'any handedness can select a matching touchpad'
+  );
+  testCase.deepEqual(
+    getWebXRLocomotionAxes(gamepadState, 'touchpad'),
+    [0.2, -0.2],
+    'returns touchpad axes'
+  );
+  testCase.equal(
+    getWebXRLocomotionAxes(gamepadState, 'thumbstick'),
+    null,
+    'missing axis pairs return null'
+  );
+
+  const locomotionState = getWebXRLocomotionState(null);
+  testCase.deepEqual(locomotionState.inputStates, [], 'null inputs become an empty list');
+  testCase.deepEqual(locomotionState.gamepadStates, [], 'null inputs have no gamepad states');
+  testCase.deepEqual(locomotionState.move, [0, 0], 'missing gamepads have no movement');
+  testCase.equal(locomotionState.snapTurn, 0, 'missing gamepads have no snap turn');
+  testCase.end();
+});
+
+function makeWebXRInputState(handedness: XRHandedness, axes: number[]): WebXRInputState {
+  const inputSource = {
+    handedness,
+    targetRayMode: 'tracked-pointer',
+    targetRaySpace: new EventTarget() as XRSpace,
+    gripSpace: new EventTarget() as XRSpace,
+    profiles: ['generic-trigger-squeeze-thumbstick']
+  } as XRInputSource;
+
+  return {
+    inputSource,
+    index: 0,
+    handedness,
+    targetRayMode: 'tracked-pointer',
+    profiles: inputSource.profiles,
+    gamepad: makeGamepad(axes),
+    hand: null,
+    targetRayPose: null,
+    targetRayMatrix: null,
+    gripPose: null,
+    gripMatrix: null,
+    selectActive: false,
+    squeezeActive: false
+  };
+}
+
+function makeGamepad(axes: number[]): Gamepad {
+  return {
+    axes,
+    buttons: [],
+    connected: true,
+    hapticActuators: [],
+    id: '',
+    index: -1,
+    mapping: 'xr-standard',
+    timestamp: 0,
+    vibrationActuator: null
+  } as Gamepad;
+}

--- a/modules/experimental/test/webxr/webxr-manager.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-manager.node.spec.ts
@@ -512,18 +512,30 @@ test('webxr#WebXRManager resolves input source poses and select activity', async
     testCase.equal(inputState?.[0]?.gripPose, gripPose, 'keeps grip pose');
     testCase.equal(inputState?.[0]?.gripMatrix, gripPose.transform.matrix, 'keeps grip');
     testCase.equal(inputState?.[0]?.selectActive, false, 'select starts inactive');
+    testCase.equal(inputState?.[0]?.squeezeActive, false, 'squeeze starts inactive');
     testCase.equal(inputState?.[1]?.targetRayPose, null, 'missing poses become null');
     testCase.equal(inputState?.[1]?.gripPose, null, 'missing grip spaces become null');
 
     session.dispatchEvent(makeMockXRInputSourceEvent('selectstart', controllerInputSource, frame));
     inputState = manager.getInputState(frame);
     testCase.equal(inputState?.[0]?.selectActive, true, 'selectstart marks the source active');
+    testCase.equal(inputState?.[0]?.squeezeActive, false, 'select does not affect squeeze');
+
+    session.dispatchEvent(makeMockXRInputSourceEvent('squeezestart', controllerInputSource, frame));
+    inputState = manager.getInputState(frame);
+    testCase.equal(inputState?.[0]?.squeezeActive, true, 'squeezestart marks the source active');
+    testCase.equal(inputState?.[0]?.selectActive, true, 'squeeze does not affect select');
+
+    session.dispatchEvent(makeMockXRInputSourceEvent('squeezeend', controllerInputSource, frame));
+    inputState = manager.getInputState(frame);
+    testCase.equal(inputState?.[0]?.squeezeActive, false, 'squeezeend marks the source inactive');
 
     session.dispatchEvent(makeMockXRInputSourceEvent('selectend', controllerInputSource, frame));
     inputState = manager.getInputState(frame);
     testCase.equal(inputState?.[0]?.selectActive, false, 'selectend marks the source inactive');
 
     session.dispatchEvent(makeMockXRInputSourceEvent('selectstart', controllerInputSource, frame));
+    session.dispatchEvent(makeMockXRInputSourceEvent('squeezestart', controllerInputSource, frame));
     session.inputSources = [screenInputSource];
     session.dispatchEvent(
       Object.assign(new Event('inputsourceschange'), {
@@ -536,6 +548,7 @@ test('webxr#WebXRManager resolves input source poses and select activity', async
     testCase.equal(inputState?.length, 1, 'removed sources disappear from snapshots');
     testCase.equal(inputState?.[0]?.inputSource, screenInputSource, 'keeps remaining source');
     testCase.equal(inputState?.[0]?.selectActive, false, 'removed source cannot stay selected');
+    testCase.equal(inputState?.[0]?.squeezeActive, false, 'removed source cannot stay squeezed');
 
     const foreignFrame = {
       session: makeMockXRSession(referenceSpace, []),
@@ -736,7 +749,7 @@ function makeMockXRPose(matrix: number[]): XRPose {
 }
 
 function makeMockXRInputSourceEvent(
-  type: 'selectstart' | 'selectend',
+  type: 'selectstart' | 'selectend' | 'squeezestart' | 'squeezeend',
   inputSource: XRInputSource,
   frame: XRFrame
 ): XRInputSourceEvent {

--- a/modules/experimental/test/webxr/webxr-manager.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-manager.node.spec.ts
@@ -11,7 +11,12 @@ import type {
   TextureView
 } from '@luma.gl/core';
 import test from 'test/utils/vitest-tape';
-import {WebXRManager, getWebXRReferenceSpaceTypes} from '../../src/webxr/webxr-manager';
+import {
+  WebXRManager,
+  getWebXRProjectionLayerState,
+  getWebXRReferenceSpaceTypes,
+  setWebXRProjectionLayerControls
+} from '../../src/webxr/webxr-manager';
 
 type MockTextureHandle = GPUTexture & {destroyCount: number};
 type MockTexture = Texture & {destroyCount: number};
@@ -35,9 +40,16 @@ test('webxr#WebXRManager resolves independent borrowed WebGPU stereo framebuffer
   const session = makeMockXRSession(referenceSpace, ['webgpu']);
   const leftView = makeMockXRView('left', 0);
   const rightView = makeMockXRView('right', 1);
-  const projectionLayer = new EventTarget() as XRProjectionLayer;
+  const projectionLayer = makeMockXRProjectionLayer({
+    textureWidth: 1024,
+    textureHeight: 768,
+    textureArrayLength: 2,
+    ignoreDepthValues: false,
+    fixedFoveation: 0.25
+  });
   const colorTextureHandle = makeMockTextureHandle('bgra8unorm', 2);
   const depthTextureHandle = makeMockTextureHandle('depth24plus', 2);
+  const deltaPose = {matrix: new Float32Array([1, 0, 0, 0]), inverse: {}} as XRRigidTransform;
   let activeViews = [leftView, rightView];
   let receivedProjectionLayerInit: XRProjectionLayerInit | undefined;
   let receivedBindingSession: XRSession | undefined;
@@ -101,6 +113,24 @@ test('webxr#WebXRManager resolves independent borrowed WebGPU stereo framebuffer
     testCase.equal(session.updatedBaseLayer, null, 'WebGPU does not install a legacy WebGL layer');
     testCase.equal(manager.baseLayer, null, 'legacy layer remains unset');
     testCase.equal(manager.projectionLayer, projectionLayer, 'exposes the native projection layer');
+    testCase.deepEqual(
+      manager.getProjectionLayerState(),
+      getWebXRProjectionLayerState(projectionLayer),
+      'snapshots native projection layer metadata'
+    );
+    testCase.deepEqual(
+      manager.setProjectionLayerControls({fixedFoveation: 0.6, deltaPose}),
+      {
+        layer: projectionLayer,
+        textureWidth: 1024,
+        textureHeight: 768,
+        textureArrayLength: 2,
+        ignoreDepthValues: false,
+        fixedFoveation: 0.6,
+        deltaPose
+      },
+      'updates and snapshots projection layer controls'
+    );
     testCase.equal(frameState?.views.length, 2, 'resolves both stereo views');
     testCase.equal(
       frameState?.framebuffer,
@@ -182,11 +212,58 @@ test('webxr#WebXRManager resolves independent borrowed WebGPU stereo framebuffer
       'never destroys browser-owned depth texture'
     );
     testCase.equal(manager.projectionLayer, null, 'clears native projection layer');
+    testCase.equal(
+      manager.getProjectionLayerState(),
+      null,
+      'cleared projection layer has no state'
+    );
+    testCase.equal(
+      manager.setProjectionLayerControls({fixedFoveation: 0.5}),
+      null,
+      'cleared projection layer ignores control updates'
+    );
     testCase.equal(manager.webGPUBinding, null, 'clears native GPU binding');
   } finally {
     globalThis.XRGPUBinding = originalXRGPUBinding;
   }
 
+  testCase.end();
+});
+
+test('webxr#projection layer control helpers update standalone layers', testCase => {
+  const deltaPose = {matrix: new Float32Array([1]), inverse: {}} as XRRigidTransform;
+  const projectionLayer = makeMockXRProjectionLayer({
+    textureWidth: 512,
+    textureHeight: 256,
+    textureArrayLength: 1,
+    ignoreDepthValues: true,
+    fixedFoveation: null,
+    deltaPose: null
+  });
+
+  const projectionLayerState = setWebXRProjectionLayerControls(projectionLayer, {
+    fixedFoveation: 0.75,
+    deltaPose
+  });
+
+  testCase.deepEqual(
+    projectionLayerState,
+    {
+      layer: projectionLayer,
+      textureWidth: 512,
+      textureHeight: 256,
+      textureArrayLength: 1,
+      ignoreDepthValues: true,
+      fixedFoveation: 0.75,
+      deltaPose
+    },
+    'updates standalone projection layer controls'
+  );
+  testCase.deepEqual(
+    getWebXRProjectionLayerState(projectionLayer),
+    projectionLayerState,
+    'snapshots standalone projection layer state'
+  );
   testCase.end();
 });
 
@@ -764,6 +841,32 @@ function makeMockTextureHandle(
       return undefined;
     }
   } as unknown as MockTextureHandle;
+}
+
+function makeMockXRProjectionLayer(props: {
+  textureWidth: number;
+  textureHeight: number;
+  textureArrayLength: number;
+  ignoreDepthValues: boolean;
+  fixedFoveation?: number | null;
+  deltaPose?: XRRigidTransform | null;
+}): XRProjectionLayer {
+  return Object.assign(new EventTarget(), {
+    layout: 'stereo' as XRLayerLayout,
+    blendTextureSourceAlpha: true,
+    forceMonoPresentation: false,
+    opacity: 1,
+    mipLevels: 1,
+    quality: 'default' as XRLayerQuality,
+    needsRedraw: false,
+    textureWidth: props.textureWidth,
+    textureHeight: props.textureHeight,
+    textureArrayLength: props.textureArrayLength,
+    ignoreDepthValues: props.ignoreDepthValues,
+    fixedFoveation: props.fixedFoveation ?? null,
+    deltaPose: props.deltaPose ?? null,
+    destroy() {}
+  }) as XRProjectionLayer;
 }
 
 function makeMockXRSession(

--- a/modules/experimental/test/webxr/webxr-manager.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-manager.node.spec.ts
@@ -11,7 +11,7 @@ import type {
   TextureView
 } from '@luma.gl/core';
 import test from 'test/utils/vitest-tape';
-import {WebXRManager} from '../../src/webxr/webxr-manager';
+import {WebXRManager, getWebXRReferenceSpaceTypes} from '../../src/webxr/webxr-manager';
 
 type MockTextureHandle = GPUTexture & {destroyCount: number};
 type MockTexture = Texture & {destroyCount: number};
@@ -24,6 +24,7 @@ type MockWebGPUDevice = Device & {
 };
 type MockXRSession = XRSession & {
   inputSources: XRInputSource[];
+  requestedReferenceSpaceTypes: XRReferenceSpaceType[];
   updatedBaseLayer: XRWebGLLayer | null;
   updatedLayers: XRProjectionLayer[] | null;
 };
@@ -438,6 +439,74 @@ test('webxr#WebXRManager rejects unsupported WebGPU sessions and foreign frames'
   testCase.end();
 });
 
+test('webxr#WebXRManager negotiates reference-space fallbacks', async testCase => {
+  const boundedReferenceSpace = {} as XRReferenceSpace;
+  const localReferenceSpace = {} as XRReferenceSpace;
+  const session = makeMockXRSession(boundedReferenceSpace, [], [], {
+    rejectedReferenceSpaceTypes: ['bounded-floor', 'local-floor'],
+    referenceSpacesByType: {
+      local: localReferenceSpace
+    }
+  });
+  const gl = {
+    async makeXRCompatible() {}
+  } as WebGL2RenderingContext;
+  const device = {
+    type: 'webgl',
+    gl,
+    createFramebuffer: (props: FramebufferProps) => makeMockFramebuffer(props)
+  } as unknown as Device;
+  const originalXRWebGLLayer = globalThis.XRWebGLLayer;
+
+  globalThis.XRWebGLLayer = class {
+    readonly framebuffer = null;
+    readonly framebufferWidth = 1;
+    readonly framebufferHeight = 1;
+
+    getViewport(): XRViewport {
+      return {x: 0, y: 0, width: 1, height: 1};
+    }
+  } as typeof XRWebGLLayer;
+
+  try {
+    const manager = new WebXRManager(device, {
+      referenceSpaceTypes: ['bounded-floor', 'local-floor', 'local-floor', 'local']
+    });
+    await manager.setSession(session);
+
+    testCase.deepEqual(
+      getWebXRReferenceSpaceTypes({
+        referenceSpaceTypes: ['bounded-floor', 'local-floor', 'local-floor', 'local']
+      }),
+      ['bounded-floor', 'local-floor', 'local'],
+      'normalizes duplicate reference-space fallback entries'
+    );
+    testCase.deepEqual(
+      getWebXRReferenceSpaceTypes({referenceSpaceType: 'unbounded'}),
+      ['unbounded'],
+      'keeps backwards-compatible single reference-space setup'
+    );
+    testCase.deepEqual(
+      session.requestedReferenceSpaceTypes,
+      ['bounded-floor', 'local-floor', 'local'],
+      'tries reference spaces in caller order until one succeeds'
+    );
+    testCase.equal(
+      manager.referenceSpace,
+      localReferenceSpace,
+      'stores the first supported reference space'
+    );
+    testCase.equal(manager.referenceSpaceType, 'local', 'stores the first supported type');
+
+    manager.clearSession();
+    testCase.equal(manager.referenceSpaceType, null, 'clears resolved reference-space type');
+  } finally {
+    globalThis.XRWebGLLayer = originalXRWebGLLayer;
+  }
+
+  testCase.end();
+});
+
 test('webxr#WebXRManager resolves input source poses and select activity', async testCase => {
   const referenceSpace = {} as XRReferenceSpace;
   const targetRaySpace = {} as XRSpace;
@@ -700,19 +769,29 @@ function makeMockTextureHandle(
 function makeMockXRSession(
   referenceSpace: XRReferenceSpace,
   enabledFeatures: readonly string[],
-  inputSources: XRInputSource[] = []
+  inputSources: XRInputSource[] = [],
+  props: {
+    rejectedReferenceSpaceTypes?: readonly XRReferenceSpaceType[];
+    referenceSpacesByType?: Partial<Record<XRReferenceSpaceType, XRReferenceSpace>>;
+  } = {}
 ): MockXRSession {
+  const rejectedReferenceSpaceTypes = new Set(props.rejectedReferenceSpaceTypes || []);
   const session = Object.assign(new EventTarget(), {
     enabledFeatures,
     inputSources,
+    requestedReferenceSpaceTypes: [] as XRReferenceSpaceType[],
     updatedBaseLayer: null as XRWebGLLayer | null,
     updatedLayers: null as XRProjectionLayer[] | null,
     async updateRenderState(renderStateInit: XRRenderStateInit = {}) {
       session.updatedBaseLayer = renderStateInit.baseLayer || null;
       session.updatedLayers = renderStateInit.layers || null;
     },
-    async requestReferenceSpace() {
-      return referenceSpace;
+    async requestReferenceSpace(type: XRReferenceSpaceType) {
+      session.requestedReferenceSpaceTypes.push(type);
+      if (rejectedReferenceSpaceTypes.has(type)) {
+        throw new Error(`Unsupported reference space: ${type}`);
+      }
+      return props.referenceSpacesByType?.[type] || referenceSpace;
     }
   }) as MockXRSession;
 

--- a/modules/experimental/test/webxr/webxr-manager.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-manager.node.spec.ts
@@ -23,6 +23,7 @@ type MockWebGPUDevice = Device & {
   createdFramebuffers: MockFramebuffer[];
 };
 type MockXRSession = XRSession & {
+  inputSources: XRInputSource[];
   updatedBaseLayer: XRWebGLLayer | null;
   updatedLayers: XRProjectionLayer[] | null;
 };
@@ -437,6 +438,125 @@ test('webxr#WebXRManager rejects unsupported WebGPU sessions and foreign frames'
   testCase.end();
 });
 
+test('webxr#WebXRManager resolves input source poses and select activity', async testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const targetRaySpace = {} as XRSpace;
+  const gripSpace = {} as XRSpace;
+  const screenTargetRaySpace = {} as XRSpace;
+  const targetRayPose = makeMockXRPose([1, 2, 3, 4]);
+  const gripPose = makeMockXRPose([5, 6, 7, 8]);
+  const poseBySpace = new Map<XRSpace, XRPose>([
+    [targetRaySpace, targetRayPose],
+    [gripSpace, gripPose]
+  ]);
+  const controllerInputSource = makeMockXRInputSource({
+    handedness: 'left',
+    targetRayMode: 'tracked-pointer',
+    targetRaySpace,
+    gripSpace,
+    profiles: ['oculus-touch-v3', 'generic-trigger-squeeze-thumbstick'],
+    gamepad: {} as Gamepad
+  });
+  const screenInputSource = makeMockXRInputSource({
+    handedness: 'none',
+    targetRayMode: 'screen',
+    targetRaySpace: screenTargetRaySpace,
+    profiles: ['generic-screen']
+  });
+  const session = makeMockXRSession(referenceSpace, [], [controllerInputSource, screenInputSource]);
+  const gl = {
+    async makeXRCompatible() {}
+  } as WebGL2RenderingContext;
+  const device = {
+    type: 'webgl',
+    gl,
+    createFramebuffer: (props: FramebufferProps) => makeMockFramebuffer(props)
+  } as unknown as Device;
+  const originalXRWebGLLayer = globalThis.XRWebGLLayer;
+
+  globalThis.XRWebGLLayer = class {
+    readonly framebuffer = null;
+    readonly framebufferWidth = 1;
+    readonly framebufferHeight = 1;
+
+    getViewport(): XRViewport {
+      return {x: 0, y: 0, width: 1, height: 1};
+    }
+  } as typeof XRWebGLLayer;
+
+  try {
+    const manager = new WebXRManager(device);
+    await manager.setSession(session);
+    const frame = {
+      session,
+      getPose(space: XRSpace, baseSpace: XRReferenceSpace): XRPose | undefined {
+        testCase.equal(baseSpace, referenceSpace, 'queries poses in the manager reference space');
+        return poseBySpace.get(space);
+      },
+      getViewerPose: () => undefined
+    } as XRFrame;
+    let inputState = manager.getInputState(frame);
+
+    testCase.equal(inputState?.length, 2, 'reports every active input source');
+    testCase.equal(inputState?.[0]?.inputSource, controllerInputSource, 'retains input identity');
+    testCase.equal(inputState?.[0]?.handedness, 'left', 'keeps handedness');
+    testCase.equal(inputState?.[0]?.targetRayMode, 'tracked-pointer', 'keeps target ray mode');
+    testCase.deepEqual(
+      inputState?.[0]?.profiles,
+      ['oculus-touch-v3', 'generic-trigger-squeeze-thumbstick'],
+      'keeps profile order'
+    );
+    testCase.equal(inputState?.[0]?.gamepad, controllerInputSource.gamepad, 'keeps gamepad');
+    testCase.equal(inputState?.[0]?.targetRayPose, targetRayPose, 'keeps target ray pose');
+    testCase.equal(inputState?.[0]?.targetRayMatrix, targetRayPose.transform.matrix, 'keeps ray');
+    testCase.equal(inputState?.[0]?.gripPose, gripPose, 'keeps grip pose');
+    testCase.equal(inputState?.[0]?.gripMatrix, gripPose.transform.matrix, 'keeps grip');
+    testCase.equal(inputState?.[0]?.selectActive, false, 'select starts inactive');
+    testCase.equal(inputState?.[1]?.targetRayPose, null, 'missing poses become null');
+    testCase.equal(inputState?.[1]?.gripPose, null, 'missing grip spaces become null');
+
+    session.dispatchEvent(makeMockXRInputSourceEvent('selectstart', controllerInputSource, frame));
+    inputState = manager.getInputState(frame);
+    testCase.equal(inputState?.[0]?.selectActive, true, 'selectstart marks the source active');
+
+    session.dispatchEvent(makeMockXRInputSourceEvent('selectend', controllerInputSource, frame));
+    inputState = manager.getInputState(frame);
+    testCase.equal(inputState?.[0]?.selectActive, false, 'selectend marks the source inactive');
+
+    session.dispatchEvent(makeMockXRInputSourceEvent('selectstart', controllerInputSource, frame));
+    session.inputSources = [screenInputSource];
+    session.dispatchEvent(
+      Object.assign(new Event('inputsourceschange'), {
+        added: [],
+        removed: [controllerInputSource],
+        session
+      }) as XRInputSourcesChangeEvent
+    );
+    inputState = manager.getInputState(frame);
+    testCase.equal(inputState?.length, 1, 'removed sources disappear from snapshots');
+    testCase.equal(inputState?.[0]?.inputSource, screenInputSource, 'keeps remaining source');
+    testCase.equal(inputState?.[0]?.selectActive, false, 'removed source cannot stay selected');
+
+    const foreignFrame = {
+      session: makeMockXRSession(referenceSpace, []),
+      getPose: () => undefined,
+      getViewerPose: () => undefined
+    } as XRFrame;
+    testCase.throws(
+      () => manager.getInputState(foreignFrame),
+      /different XRSession/,
+      'rejects foreign frames for input snapshots'
+    );
+
+    manager.clearSession();
+    testCase.equal(manager.getInputState(frame), null, 'cleared sessions expose no inputs');
+  } finally {
+    globalThis.XRWebGLLayer = originalXRWebGLLayer;
+  }
+
+  testCase.end();
+});
+
 test('webxr#WebXRManager preserves shared WebGL framebuffers in a mocked Node session', async testCase => {
   const referenceSpace = {} as XRReferenceSpace;
   const session = makeMockXRSession(referenceSpace, []);
@@ -566,10 +686,12 @@ function makeMockTextureHandle(
 
 function makeMockXRSession(
   referenceSpace: XRReferenceSpace,
-  enabledFeatures: readonly string[]
+  enabledFeatures: readonly string[],
+  inputSources: XRInputSource[] = []
 ): MockXRSession {
   const session = Object.assign(new EventTarget(), {
     enabledFeatures,
+    inputSources,
     updatedBaseLayer: null as XRWebGLLayer | null,
     updatedLayers: null as XRProjectionLayer[] | null,
     async updateRenderState(renderStateInit: XRRenderStateInit = {}) {
@@ -591,4 +713,32 @@ function makeMockXRView(eye: XREye, index: number): XRView {
     projectionMatrix: new Float32Array([index + 1]),
     transform: {inverse: {matrix: new Float32Array([index + 10])}}
   } as XRView;
+}
+
+function makeMockXRInputSource(props: {
+  handedness: XRHandedness;
+  targetRayMode: XRTargetRayMode;
+  targetRaySpace: XRSpace;
+  gripSpace?: XRSpace;
+  profiles: readonly string[];
+  gamepad?: Gamepad;
+}): XRInputSource {
+  return props as XRInputSource;
+}
+
+function makeMockXRPose(matrix: number[]): XRPose {
+  return {
+    transform: {
+      matrix: new Float32Array(matrix),
+      inverse: {matrix: new Float32Array(matrix)}
+    }
+  } as XRPose;
+}
+
+function makeMockXRInputSourceEvent(
+  type: 'selectstart' | 'selectend',
+  inputSource: XRInputSource,
+  frame: XRFrame
+): XRInputSourceEvent {
+  return Object.assign(new Event(type), {inputSource, frame}) as XRInputSourceEvent;
 }

--- a/modules/experimental/test/webxr/webxr-manager.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-manager.node.spec.ts
@@ -92,9 +92,13 @@ test('webxr#WebXRManager resolves independent borrowed WebGPU stereo framebuffer
   try {
     const manager = new WebXRManager(device, {projectionLayerInit: {scaleFactor: 0.8}});
     await manager.setSession(session);
+    let viewerPose = makeMockXRViewerPose(activeViews);
     const frame = {
       session,
-      getViewerPose: () => ({views: activeViews})
+      getViewerPose: () => {
+        viewerPose = makeMockXRViewerPose(activeViews);
+        return viewerPose;
+      }
     } as XRFrame;
     const frameState = manager.getFrameState(frame);
 
@@ -113,6 +117,14 @@ test('webxr#WebXRManager resolves independent borrowed WebGPU stereo framebuffer
     testCase.equal(session.updatedBaseLayer, null, 'WebGPU does not install a legacy WebGL layer');
     testCase.equal(manager.baseLayer, null, 'legacy layer remains unset');
     testCase.equal(manager.projectionLayer, projectionLayer, 'exposes the native projection layer');
+    testCase.equal(frameState?.viewer.pose, viewerPose, 'retains WebGPU viewer pose');
+    testCase.equal(frameState?.viewer.matrix, viewerPose.transform.matrix, 'exposes viewer matrix');
+    testCase.equal(
+      frameState?.viewer.viewMatrix,
+      viewerPose.transform.inverse.matrix,
+      'exposes inverse viewer matrix'
+    );
+    testCase.deepEqual(frameState?.viewer.position, [1, 1.5, -2], 'exposes viewer position');
     testCase.deepEqual(
       manager.getProjectionLayerState(),
       getWebXRProjectionLayerState(projectionLayer),
@@ -301,7 +313,7 @@ test('webxr#WebXRManager handles legacy image indices and rotating GPU composito
   try {
     const manager = new WebXRManager(device);
     await manager.setSession(session);
-    const frame = {session, getViewerPose: () => ({views: [view]})} as XRFrame;
+    const frame = {session, getViewerPose: () => makeMockXRViewerPose([view])} as XRFrame;
     const firstFrameState = manager.getFrameState(frame);
 
     testCase.equal(device.createdTextures.length, 1, 'depth attachment remains optional');
@@ -389,7 +401,7 @@ test('webxr#WebXRManager shares identical WebGPU atlas attachments across stereo
     await manager.setSession(session);
     const frame = {
       session,
-      getViewerPose: () => ({views: activeViews})
+      getViewerPose: () => makeMockXRViewerPose(activeViews)
     } as XRFrame;
     const frameState = manager.getFrameState(frame);
 
@@ -482,7 +494,7 @@ test('webxr#WebXRManager rejects unsupported WebGPU sessions and foreign frames'
     const foreignSession = makeMockXRSession(referenceSpace, ['webgpu']);
     const foreignFrame = {
       session: foreignSession,
-      getViewerPose: () => ({views: [makeMockXRView('left', 0)]})
+      getViewerPose: () => makeMockXRViewerPose([makeMockXRView('left', 0)])
     } as XRFrame;
 
     testCase.throws(
@@ -750,7 +762,7 @@ test('webxr#WebXRManager preserves shared WebGL framebuffers in a mocked Node se
     await manager.setSession(session);
     const frameState = manager.getFrameState({
       session,
-      getViewerPose: () => ({views: [leftView, rightView]})
+      getViewerPose: () => makeMockXRViewerPose([leftView, rightView])
     } as XRFrame);
 
     testCase.equal(compatibilityCallCount, 1, 'makes WebGL context XR compatible');
@@ -908,6 +920,22 @@ function makeMockXRView(eye: XREye, index: number): XRView {
     projectionMatrix: new Float32Array([index + 1]),
     transform: {inverse: {matrix: new Float32Array([index + 10])}}
   } as XRView;
+}
+
+function makeMockXRViewerPose(views: readonly XRView[]): XRViewerPose {
+  return {
+    transform: {
+      position: {x: 1, y: 1.5, z: -2, w: 1} as DOMPointReadOnly,
+      orientation: {x: 0, y: 0, z: 0, w: 1} as DOMPointReadOnly,
+      matrix: new Float32Array([7]),
+      inverse: {
+        position: {x: -1, y: -1.5, z: 2, w: 1} as DOMPointReadOnly,
+        orientation: {x: 0, y: 0, z: 0, w: 1} as DOMPointReadOnly,
+        matrix: new Float32Array([8])
+      } as XRRigidTransform
+    } as XRRigidTransform,
+    views
+  } as XRViewerPose;
 }
 
 function makeMockXRInputSource(props: {

--- a/modules/experimental/test/webxr/webxr-manager.spec.ts
+++ b/modules/experimental/test/webxr/webxr-manager.spec.ts
@@ -14,11 +14,12 @@ test('webxr#WebXRManager resolves WebGL XR frame state without owning XR framebu
   const session = makeXRSession(referenceSpace);
   const leftView = makeXRView('left', 0);
   const rightView = makeXRView('right', 1);
+  const viewerPose = makeXRViewerPose([leftView, rightView]);
   const xrFrame = {
     session,
     getViewerPose: (receivedReferenceSpace: XRReferenceSpace) => {
       t.equal(receivedReferenceSpace, referenceSpace, 'queries configured reference space');
-      return {views: [leftView, rightView]} as XRViewerPose;
+      return viewerPose;
     }
   } as XRFrame;
 
@@ -62,6 +63,14 @@ test('webxr#WebXRManager resolves WebGL XR frame state without owning XR framebu
     t.equal(makeXRCompatibleCallCount, 1, 'makes WebGL context XR compatible');
     t.equal(session.updatedBaseLayer, webXRManager.baseLayer, 'updates session render state');
     t.ok(frameState, 'active XR frame resolves state');
+    t.equal(frameState?.viewer.pose, viewerPose, 'retains the source viewer pose');
+    t.equal(frameState?.viewer.matrix, viewerPose.transform.matrix, 'exposes viewer matrix');
+    t.equal(
+      frameState?.viewer.viewMatrix,
+      viewerPose.transform.inverse.matrix,
+      'exposes inverse viewer matrix'
+    );
+    t.deepEqual(frameState?.viewer.position, [1, 1.5, -2], 'exposes viewer position');
     t.equal(frameState?.framebuffer.props.handle, xrFramebufferHandle, 'wraps XR framebuffer');
     t.equal(
       frameState?.views[0]?.framebuffer,
@@ -102,9 +111,10 @@ test('webxr#WebXRManager accepts null XRWebGLLayer framebuffer handles', async t
   const referenceSpace = {} as XRReferenceSpace;
   const session = makeXRSession(referenceSpace);
   const view = makeXRView('none', 0);
+  const viewerPose = makeXRViewerPose([view]);
   const xrFrame = {
     session,
-    getViewerPose: () => ({views: [view]}) as XRViewerPose
+    getViewerPose: () => viewerPose
   } as XRFrame;
 
   const originalMakeXRCompatible = gl.makeXRCompatible;
@@ -126,6 +136,7 @@ test('webxr#WebXRManager accepts null XRWebGLLayer framebuffer handles', async t
     const frameState = webXRManager.getFrameState(xrFrame);
 
     t.ok(frameState, 'active XR frame resolves state');
+    t.equal(frameState?.viewer.pose, viewerPose, 'retains viewer pose with null framebuffers');
     t.equal(frameState?.framebuffer.props.handle, null, 'wraps null as the default framebuffer');
     t.equal(
       frameState?.views[0]?.framebuffer,
@@ -168,4 +179,20 @@ function makeXRView(eye: XREye, index: number): XRView {
       inverse: {matrix: new Float32Array([index + 10])}
     }
   } as XRView;
+}
+
+function makeXRViewerPose(views: readonly XRView[]): XRViewerPose {
+  return {
+    transform: {
+      position: {x: 1, y: 1.5, z: -2, w: 1} as DOMPointReadOnly,
+      orientation: {x: 0, y: 0, z: 0, w: 1} as DOMPointReadOnly,
+      matrix: new Float32Array([7]),
+      inverse: {
+        position: {x: -1, y: -1.5, z: 2, w: 1} as DOMPointReadOnly,
+        orientation: {x: 0, y: 0, z: 0, w: 1} as DOMPointReadOnly,
+        matrix: new Float32Array([8])
+      } as XRRigidTransform
+    } as XRRigidTransform,
+    views
+  } as XRViewerPose;
 }

--- a/modules/experimental/test/webxr/webxr-media-layers.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-media-layers.node.spec.ts
@@ -1,0 +1,179 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {WebXRMediaLayerManager} from '../../src/webxr/webxr-media-layers';
+
+test('webxr#WebXRMediaLayerManager creates media layers and exposes state', testCase => {
+  const originalXRMediaBinding = globalThis.XRMediaBinding;
+  const session = makeMockXRSession();
+  const referenceSpace = {} as XRReferenceSpace;
+  const video = makeMockVideo();
+
+  globalThis.XRMediaBinding = makeMockXRMediaBindingClass();
+
+  try {
+    const manager = new WebXRMediaLayerManager();
+    manager.setSession(session);
+
+    const quadLayer = manager.createQuadLayer(video, {
+      space: referenceSpace,
+      layout: 'stereo-left-right',
+      invertStereo: true,
+      width: 1.5,
+      height: 0.75
+    });
+    const cylinderLayer = manager.createCylinderLayer(video, {
+      space: referenceSpace,
+      radius: 2,
+      centralAngle: Math.PI / 3,
+      aspectRatio: 2
+    });
+    const equirectLayer = manager.createEquirectLayer(video, {
+      space: referenceSpace,
+      radius: 0,
+      centralHorizontalAngle: Math.PI * 2
+    });
+
+    void manager.updateRenderState([quadLayer, cylinderLayer, equirectLayer]);
+
+    const quadState = manager.getLayerState(quadLayer);
+    const cylinderState = manager.getLayerState(cylinderLayer);
+    const equirectState = manager.getLayerState(equirectLayer);
+
+    testCase.equal(session.updatedLayers[0], quadLayer, 'updates render state with quad layer');
+    testCase.equal(
+      session.updatedLayers[1],
+      cylinderLayer,
+      'updates render state with cylinder layer'
+    );
+    testCase.equal(
+      session.updatedLayers[2],
+      equirectLayer,
+      'updates render state with equirect layer'
+    );
+    testCase.equal(quadState?.session, session, 'retains source session');
+    testCase.equal(quadState?.layer, quadLayer, 'retains source layer');
+    testCase.equal(quadState?.video, video, 'retains source video');
+    testCase.equal(quadState?.type, 'quad', 'reports quad layer type');
+    testCase.equal(cylinderState?.type, 'cylinder', 'reports cylinder layer type');
+    testCase.equal(equirectState?.type, 'equirect', 'reports equirect layer type');
+    testCase.equal(quadState?.layout, 'stereo-left-right', 'exposes stereo layout');
+    testCase.equal(quadState?.invertStereo, true, 'exposes inverted stereo metadata');
+    testCase.equal(cylinderState?.invertStereo, false, 'defaults invertStereo to false');
+
+    quadLayer.dispatchEvent(new Event('redraw'));
+    testCase.equal(manager.getLayerState(quadLayer)?.needsRedraw, true, 'tracks redraw events');
+    testCase.equal(manager.getLayerState(quadLayer)?.needsRedraw, false, 'consumes redraw events');
+
+    session.dispatchEvent(new Event('end'));
+    testCase.equal(manager.session, null, 'session end clears session');
+    testCase.equal(manager.getLayerState(quadLayer), null, 'inactive manager returns null');
+  } finally {
+    globalThis.XRMediaBinding = originalXRMediaBinding;
+  }
+
+  testCase.end();
+});
+
+test('webxr#WebXRMediaLayerManager handles unsupported and untracked layers', testCase => {
+  const originalXRMediaBinding = globalThis.XRMediaBinding;
+  const session = makeMockXRSession();
+  const layer = makeMockCompositionLayer('mono');
+  const manager = new WebXRMediaLayerManager();
+
+  try {
+    globalThis.XRMediaBinding = undefined!;
+    testCase.throws(
+      () => manager.setSession(session),
+      /XRMediaBinding/,
+      'throws when XRMediaBinding is unavailable'
+    );
+
+    globalThis.XRMediaBinding = makeMockXRMediaBindingClass();
+    manager.setSession(session);
+    testCase.throws(
+      () => manager.getLayerState(layer),
+      /not tracked/,
+      'rejects untracked composition layers'
+    );
+
+    manager.clearSession();
+    manager.clearSession();
+    testCase.equal(manager.session, null, 'clearSession is idempotent');
+  } finally {
+    globalThis.XRMediaBinding = originalXRMediaBinding;
+  }
+
+  testCase.end();
+});
+
+function makeMockVideo(): HTMLVideoElement {
+  return {
+    videoWidth: 3840,
+    videoHeight: 1920
+  } as HTMLVideoElement;
+}
+
+function makeMockXRSession(): XRSession & {updatedLayers: XRLayer[]} {
+  return Object.assign(new EventTarget(), {
+    inputSources: [],
+    updatedLayers: [] as XRLayer[],
+    async updateRenderState(renderStateInit: XRRenderStateInit = {}) {
+      this.updatedLayers = [...(renderStateInit.layers || [])];
+    }
+  }) as XRSession & {updatedLayers: XRLayer[]};
+}
+
+function makeMockXRMediaBindingClass(): typeof XRMediaBinding {
+  return class MockXRMediaBinding {
+    constructor(public session: XRSession) {}
+
+    createQuadLayer(video: HTMLVideoElement, init: XRMediaQuadLayerInit): XRQuadLayer {
+      return Object.assign(makeMockCompositionLayer(init.layout || 'mono'), {
+        video,
+        space: init.space,
+        width: init.width,
+        height: init.height,
+        transform: init.transform
+      }) as XRQuadLayer;
+    }
+
+    createCylinderLayer(video: HTMLVideoElement, init: XRMediaCylinderLayerInit): XRCylinderLayer {
+      return Object.assign(makeMockCompositionLayer(init.layout || 'mono'), {
+        video,
+        space: init.space,
+        radius: init.radius,
+        centralAngle: init.centralAngle,
+        aspectRatio: init.aspectRatio,
+        transform: init.transform
+      }) as XRCylinderLayer;
+    }
+
+    createEquirectLayer(video: HTMLVideoElement, init: XRMediaEquirectLayerInit): XREquirectLayer {
+      return Object.assign(makeMockCompositionLayer(init.layout || 'mono'), {
+        video,
+        space: init.space,
+        radius: init.radius,
+        centralHorizontalAngle: init.centralHorizontalAngle,
+        upperVerticalAngle: init.upperVerticalAngle,
+        lowerVerticalAngle: init.lowerVerticalAngle,
+        transform: init.transform
+      }) as XREquirectLayer;
+    }
+  } as unknown as typeof XRMediaBinding;
+}
+
+function makeMockCompositionLayer(layout: XRLayerLayout): XRCompositionLayer {
+  return Object.assign(new EventTarget(), {
+    layout,
+    blendTextureSourceAlpha: true,
+    forceMonoPresentation: false,
+    opacity: 1,
+    mipLevels: 1,
+    quality: 'default' as XRLayerQuality,
+    needsRedraw: false,
+    destroy() {}
+  }) as XRCompositionLayer;
+}

--- a/modules/experimental/test/webxr/webxr-mesh-detection.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-mesh-detection.node.spec.ts
@@ -1,0 +1,196 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  getWebXRMeshDetectionSessionInit,
+  WebXRMeshDetectionManager
+} from '../../src/webxr/webxr-mesh-detection';
+
+test('webxr#WebXRMeshDetectionManager resolves mesh poses, buffers, and frame diffs', testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const firstMesh = makeMockXRMesh({
+    vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    indices: new Uint32Array([0, 1, 2]),
+    lastChangedTime: 1,
+    semanticLabel: 'floor'
+  });
+  const secondMesh = makeMockXRMesh({
+    vertices: new Float32Array([0, 0, 0, 0, 1, 0, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    lastChangedTime: 2,
+    semanticLabel: 'wall'
+  });
+  const firstPose = makeMockXRPose([1, 0, 0, 0]);
+  const secondPose = makeMockXRPose([2, 0, 0, 0]);
+  const session = makeMockXRSession();
+  const frame = makeMockXRFrame(
+    session,
+    new Set([firstMesh, secondMesh]),
+    new Map([
+      [firstMesh.meshSpace, firstPose],
+      [secondMesh.meshSpace, secondPose]
+    ])
+  );
+  const updatedFirstMesh = makeMockXRMesh({
+    meshSpace: firstMesh.meshSpace,
+    vertices: new Float32Array([0, 0, 0, 2, 0, 0, 0, 2, 0]),
+    indices: new Uint32Array([0, 1, 2]),
+    lastChangedTime: 3,
+    semanticLabel: 'floor'
+  });
+  const nextFrame = makeMockXRFrame(
+    session,
+    new Set([updatedFirstMesh]),
+    new Map([[updatedFirstMesh.meshSpace, firstPose]])
+  );
+  const manager = new WebXRMeshDetectionManager();
+
+  manager.setSession(session, referenceSpace);
+  const meshState = manager.getMeshDetectionState(frame);
+  const nextMeshState = manager.getMeshDetectionState(nextFrame);
+
+  testCase.equal(manager.session, session, 'retains active session');
+  testCase.equal(manager.referenceSpace, referenceSpace, 'retains app reference space');
+  testCase.equal(meshState?.xrFrame, frame, 'retains source frame');
+  testCase.equal(meshState?.session, session, 'retains source session');
+  testCase.equal(meshState?.meshes.length, 2, 'resolves all detected meshes with poses');
+  testCase.equal(meshState?.added.length, 2, 'initial meshes are added');
+  testCase.equal(meshState?.updated.length, 0, 'initial meshes are not updated');
+  testCase.equal(meshState?.removed.length, 0, 'initial meshes are not removed');
+  testCase.equal(meshState?.meshes[0]?.xrMesh, firstMesh, 'retains raw mesh');
+  testCase.equal(meshState?.meshes[0]?.pose, firstPose, 'retains mesh pose');
+  testCase.equal(meshState?.meshes[0]?.matrix, firstPose.transform.matrix, 'exposes pose matrix');
+  testCase.equal(meshState?.meshes[0]?.vertices, firstMesh.vertices, 'exposes vertices');
+  testCase.equal(meshState?.meshes[0]?.indices, firstMesh.indices, 'exposes indices');
+  testCase.equal(meshState?.meshes[0]?.vertexCount, 3, 'computes vertex count');
+  testCase.equal(meshState?.meshes[0]?.triangleCount, 1, 'computes triangle count');
+  testCase.equal(meshState?.meshes[0]?.semanticLabel, 'floor', 'exposes semantic label');
+  testCase.equal(meshState?.meshes[0]?.lastChangedTime, 1, 'exposes changed time');
+  testCase.equal(nextMeshState?.meshes.length, 1, 'tracks next frame meshes');
+  testCase.equal(nextMeshState?.added.length, 1, 'changed object identity is added');
+  testCase.equal(nextMeshState?.updated.length, 0, 'new object identity is not updated');
+  testCase.equal(nextMeshState?.removed.length, 2, 'previous mesh identities are removed');
+
+  session.dispatchEvent(new Event('end'));
+  testCase.equal(manager.getMeshDetectionState(frame), null, 'ended sessions expose no meshes');
+  testCase.end();
+});
+
+test('webxr#WebXRMeshDetectionManager filters meshes and tracks updates by identity', testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const mesh = makeMockXRMesh({semanticLabel: 'table', lastChangedTime: 4});
+  const wallMesh = makeMockXRMesh({semanticLabel: 'wall', lastChangedTime: 4});
+  const pose = makeMockXRPose([1, 0, 0, 0]);
+  const session = makeMockXRSession();
+  const frame = makeMockXRFrame(
+    session,
+    new Set([mesh, wallMesh]),
+    new Map([
+      [mesh.meshSpace, pose],
+      [wallMesh.meshSpace, pose]
+    ])
+  );
+  const manager = new WebXRMeshDetectionManager({semanticLabels: ['table']});
+
+  manager.setSession(session, referenceSpace);
+  const meshState = manager.getMeshDetectionState(frame);
+  (mesh as {lastChangedTime: number}).lastChangedTime = 5;
+  const updatedMeshState = manager.getMeshDetectionState(frame);
+
+  testCase.equal(meshState?.meshes.length, 1, 'keeps matching meshes');
+  testCase.equal(meshState?.meshes[0]?.xrMesh, mesh, 'keeps requested mesh');
+  testCase.equal(updatedMeshState?.updated.length, 1, 'same mesh identity can be updated');
+  testCase.equal(updatedMeshState?.updated[0]?.lastChangedTime, 5, 'captures updated timestamp');
+  testCase.end();
+});
+
+test('webxr#WebXRMeshDetectionManager handles unsupported and invalid frames', testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const session = makeMockXRSession();
+  const otherSession = makeMockXRSession();
+  const manager = new WebXRMeshDetectionManager();
+
+  try {
+    manager.setSession(session, null);
+    testCase.fail('missing reference space should reject');
+  } catch (error) {
+    testCase.match(
+      error instanceof Error ? error.message : '',
+      /reference space/,
+      'reports missing reference space'
+    );
+  }
+
+  manager.setSession(session, referenceSpace);
+  testCase.equal(
+    manager.getMeshDetectionState({session} as XRFrame),
+    null,
+    'frames without detected meshes expose no state'
+  );
+  testCase.throws(
+    () =>
+      manager.getMeshDetectionState({
+        session: otherSession,
+        detectedMeshes: new Set()
+      } as XRFrame),
+    /different XRSession/,
+    'rejects foreign frames'
+  );
+  testCase.deepEqual(
+    getWebXRMeshDetectionSessionInit({required: true}),
+    {requiredFeatures: ['mesh-detection']},
+    'builds required mesh-detection session init'
+  );
+  testCase.deepEqual(
+    getWebXRMeshDetectionSessionInit(),
+    {optionalFeatures: ['mesh-detection']},
+    'builds optional mesh-detection session init'
+  );
+
+  manager.clearSession();
+  manager.clearSession();
+  testCase.equal(manager.session, null, 'clearSession is idempotent');
+  testCase.end();
+});
+
+function makeMockXRSession(): XRSession {
+  return Object.assign(new EventTarget(), {
+    enabledFeatures: ['mesh-detection'],
+    inputSources: []
+  }) as XRSession;
+}
+
+function makeMockXRFrame(
+  session: XRSession,
+  detectedMeshes: XRMeshSet,
+  poses: Map<XRSpace, XRPose>
+): XRFrame {
+  return {
+    session,
+    detectedMeshes,
+    getPose(space: XRSpace): XRPose | undefined {
+      return poses.get(space);
+    }
+  } as XRFrame;
+}
+
+function makeMockXRMesh(props: Partial<XRMesh>): XRMesh {
+  return {
+    meshSpace: props.meshSpace || ({} as XRSpace),
+    vertices: props.vertices || new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    indices: props.indices || new Uint32Array([0, 1, 2]),
+    semanticLabel: props.semanticLabel,
+    lastChangedTime: props.lastChangedTime ?? 1
+  } as XRMesh;
+}
+
+function makeMockXRPose(matrix: number[]): XRPose {
+  return {
+    transform: {
+      matrix: new Float32Array(matrix),
+      inverse: {matrix: new Float32Array(matrix)}
+    } as XRRigidTransform
+  } as XRPose;
+}

--- a/modules/experimental/test/webxr/webxr-plane-detection.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-plane-detection.node.spec.ts
@@ -1,0 +1,241 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  getWebXRPlaneDetectionSessionInit,
+  WebXRPlaneDetectionManager
+} from '../../src/webxr/webxr-plane-detection';
+
+type MockXRSession = XRSession & {
+  roomCaptureCount: number;
+};
+
+test('webxr#WebXRPlaneDetectionManager resolves plane poses, polygons, and frame diffs', testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const firstPlane = makeMockXRPlane({
+    orientation: 'horizontal',
+    lastChangedTime: 1,
+    semanticLabel: 'floor',
+    polygon: [
+      makeMockDOMPoint(-1, 0, -1),
+      makeMockDOMPoint(1, 0, -1),
+      makeMockDOMPoint(1, 0, 1),
+      makeMockDOMPoint(-1, 0, 1)
+    ]
+  });
+  const secondPlane = makeMockXRPlane({
+    orientation: 'vertical',
+    lastChangedTime: 2,
+    semanticLabel: 'wall'
+  });
+  const firstPose = makeMockXRPose([1, 0, 0, 0]);
+  const secondPose = makeMockXRPose([2, 0, 0, 0]);
+  const session = makeMockXRSession();
+  const frame = makeMockXRFrame(
+    session,
+    new Set([firstPlane, secondPlane]),
+    new Map([
+      [firstPlane.planeSpace, firstPose],
+      [secondPlane.planeSpace, secondPose]
+    ])
+  );
+  const updatedFirstPlane = makeMockXRPlane({
+    planeSpace: firstPlane.planeSpace,
+    orientation: 'horizontal',
+    lastChangedTime: 3,
+    semanticLabel: 'floor'
+  });
+  const nextFrame = makeMockXRFrame(
+    session,
+    new Set([updatedFirstPlane]),
+    new Map([[updatedFirstPlane.planeSpace, firstPose]])
+  );
+  const manager = new WebXRPlaneDetectionManager();
+
+  manager.setSession(session, referenceSpace);
+  const planeState = manager.getPlaneDetectionState(frame);
+  const nextPlaneState = manager.getPlaneDetectionState(nextFrame);
+
+  testCase.equal(manager.session, session, 'retains active session');
+  testCase.equal(manager.referenceSpace, referenceSpace, 'retains app reference space');
+  testCase.equal(planeState?.xrFrame, frame, 'retains source frame');
+  testCase.equal(planeState?.session, session, 'retains source session');
+  testCase.equal(planeState?.planes.length, 2, 'resolves all detected planes with poses');
+  testCase.equal(planeState?.added.length, 2, 'initial planes are added');
+  testCase.equal(planeState?.updated.length, 0, 'initial planes are not updated');
+  testCase.equal(planeState?.removed.length, 0, 'initial planes are not removed');
+  testCase.equal(planeState?.planes[0]?.xrPlane, firstPlane, 'retains raw plane');
+  testCase.equal(planeState?.planes[0]?.pose, firstPose, 'retains plane pose');
+  testCase.equal(planeState?.planes[0]?.matrix, firstPose.transform.matrix, 'exposes pose matrix');
+  testCase.deepEqual(
+    planeState?.planes[0]?.polygon,
+    [
+      [-1, 0, -1],
+      [1, 0, -1],
+      [1, 0, 1],
+      [-1, 0, 1]
+    ],
+    'converts polygon points'
+  );
+  testCase.equal(planeState?.planes[0]?.orientation, 'horizontal', 'exposes orientation');
+  testCase.equal(planeState?.planes[0]?.semanticLabel, 'floor', 'exposes semantic label');
+  testCase.equal(planeState?.planes[0]?.lastChangedTime, 1, 'exposes changed time');
+  testCase.equal(nextPlaneState?.planes.length, 1, 'tracks next frame planes');
+  testCase.equal(nextPlaneState?.added.length, 1, 'changed object identity is added');
+  testCase.equal(nextPlaneState?.updated.length, 0, 'new object identity is not updated');
+  testCase.equal(nextPlaneState?.removed.length, 2, 'previous plane identities are removed');
+
+  session.dispatchEvent(new Event('end'));
+  testCase.equal(manager.getPlaneDetectionState(frame), null, 'ended sessions expose no planes');
+  testCase.end();
+});
+
+test('webxr#WebXRPlaneDetectionManager filters planes and tracks updates by identity', testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const plane = makeMockXRPlane({
+    orientation: 'horizontal',
+    semanticLabel: 'table',
+    lastChangedTime: 4
+  });
+  const verticalPlane = makeMockXRPlane({
+    orientation: 'vertical',
+    semanticLabel: 'wall',
+    lastChangedTime: 4
+  });
+  const pose = makeMockXRPose([1, 0, 0, 0]);
+  const session = makeMockXRSession();
+  const frame = makeMockXRFrame(
+    session,
+    new Set([plane, verticalPlane]),
+    new Map([
+      [plane.planeSpace, pose],
+      [verticalPlane.planeSpace, pose]
+    ])
+  );
+  const manager = new WebXRPlaneDetectionManager({
+    orientations: ['horizontal'],
+    semanticLabels: ['table']
+  });
+
+  manager.setSession(session, referenceSpace);
+  const planeState = manager.getPlaneDetectionState(frame);
+  (plane as {lastChangedTime: number}).lastChangedTime = 5;
+  const updatedPlaneState = manager.getPlaneDetectionState(frame);
+
+  testCase.equal(planeState?.planes.length, 1, 'keeps matching planes');
+  testCase.equal(planeState?.planes[0]?.xrPlane, plane, 'keeps requested plane');
+  testCase.equal(updatedPlaneState?.updated.length, 1, 'same plane identity can be updated');
+  testCase.equal(updatedPlaneState?.updated[0]?.lastChangedTime, 5, 'captures updated timestamp');
+  testCase.end();
+});
+
+test('webxr#WebXRPlaneDetectionManager handles unsupported frames and room capture', async testCase => {
+  const referenceSpace = {} as XRReferenceSpace;
+  const session = makeMockXRSession();
+  const otherSession = makeMockXRSession();
+  const manager = new WebXRPlaneDetectionManager();
+
+  try {
+    manager.setSession(session, null);
+    testCase.fail('missing reference space should reject');
+  } catch (error) {
+    testCase.match(
+      error instanceof Error ? error.message : '',
+      /reference space/,
+      'reports missing reference space'
+    );
+  }
+
+  manager.setSession(session, referenceSpace);
+  testCase.equal(
+    manager.getPlaneDetectionState({session} as XRFrame),
+    null,
+    'frames without detected planes expose no state'
+  );
+  testCase.throws(
+    () =>
+      manager.getPlaneDetectionState({
+        session: otherSession,
+        detectedPlanes: new Set()
+      } as XRFrame),
+    /different XRSession/,
+    'rejects foreign frames'
+  );
+  testCase.equal(await manager.initiateRoomCapture(), true, 'initiates room capture');
+  testCase.equal(session.roomCaptureCount, 1, 'forwards room capture to session');
+  testCase.deepEqual(
+    getWebXRPlaneDetectionSessionInit({required: true}),
+    {requiredFeatures: ['plane-detection']},
+    'builds required plane-detection session init'
+  );
+  testCase.deepEqual(
+    getWebXRPlaneDetectionSessionInit(),
+    {optionalFeatures: ['plane-detection']},
+    'builds optional plane-detection session init'
+  );
+
+  manager.clearSession();
+  testCase.equal(await manager.initiateRoomCapture(), false, 'reports missing room capture');
+  manager.clearSession();
+  testCase.equal(manager.session, null, 'clearSession is idempotent');
+  testCase.end();
+});
+
+function makeMockXRSession(): MockXRSession {
+  return Object.assign(new EventTarget(), {
+    enabledFeatures: ['plane-detection'],
+    inputSources: [],
+    roomCaptureCount: 0,
+    async initiateRoomCapture(): Promise<void> {
+      this.roomCaptureCount++;
+    }
+  }) as MockXRSession;
+}
+
+function makeMockXRFrame(
+  session: XRSession,
+  detectedPlanes: XRPlaneSet,
+  poses: Map<XRSpace, XRPose>
+): XRFrame {
+  return {
+    session,
+    detectedPlanes,
+    getPose(space: XRSpace): XRPose | undefined {
+      return poses.get(space);
+    }
+  } as XRFrame;
+}
+
+function makeMockXRPlane(
+  props: Partial<XRPlane> & {
+    orientation: XRPlaneOrientation;
+    lastChangedTime: number;
+  }
+): XRPlane {
+  return {
+    planeSpace: props.planeSpace || ({} as XRSpace),
+    polygon: props.polygon || [
+      makeMockDOMPoint(0, 0, 0),
+      makeMockDOMPoint(1, 0, 0),
+      makeMockDOMPoint(1, 0, 1)
+    ],
+    orientation: props.orientation,
+    semanticLabel: props.semanticLabel,
+    lastChangedTime: props.lastChangedTime
+  } as XRPlane;
+}
+
+function makeMockXRPose(matrix: number[]): XRPose {
+  return {
+    transform: {
+      matrix: new Float32Array(matrix),
+      inverse: {matrix: new Float32Array(matrix)}
+    } as XRRigidTransform
+  } as XRPose;
+}
+
+function makeMockDOMPoint(x: number, y: number, z: number): DOMPointReadOnly {
+  return {x, y, z, w: 1} as DOMPointReadOnly;
+}

--- a/modules/experimental/test/webxr/webxr-reference-space.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-reference-space.node.spec.ts
@@ -5,11 +5,20 @@
 import test from 'test/utils/vitest-tape';
 import {
   WebXRReferenceSpaceManager,
+  getWebXRTeleportState,
+  getWebXRTeleportTranslation,
+  isWebXRTeleportTargetAllowed,
+  makeWebXRTeleportOffset,
   makeWebXRReferenceSpaceState
 } from '../../src/webxr/webxr-reference-space';
 
 type MockXRReferenceSpace = XRReferenceSpace & {
   requestedOriginOffsets: XRRigidTransform[];
+};
+
+type MockXRRigidTransform = XRRigidTransform & {
+  position?: DOMPointInit;
+  orientation?: DOMPointInit;
 };
 
 test('webxr#WebXRReferenceSpaceManager tracks reset events', testCase => {
@@ -90,6 +99,124 @@ test('webxr#WebXRReferenceSpaceManager handles clear and unsupported offsets', t
   testCase.end();
 });
 
+test('webxr#teleport helpers create bounded offset reference spaces', testCase => {
+  const originalXRRigidTransform = globalThis.XRRigidTransform;
+  globalThis.XRRigidTransform = MockXRRigidTransformConstructor;
+
+  try {
+    const referenceSpace = makeMockXRReferenceSpace();
+    const manager = new WebXRReferenceSpaceManager().setReferenceSpace(referenceSpace);
+    const bounds = [
+      [-1, 0, -1],
+      [1, 0, -1],
+      [1, 0, 1],
+      [-1, 0, 1]
+    ] as const;
+    const teleportState = manager.getTeleportReferenceSpace([0.25, 1.8, -0.5], {bounds});
+
+    testCase.ok(teleportState, 'creates teleport state for in-bounds target');
+    testCase.equal(
+      teleportState?.referenceSpace,
+      referenceSpace,
+      'keeps source reference-space identity'
+    );
+    testCase.equal(
+      teleportState?.offsetReferenceSpace,
+      referenceSpace,
+      'returns offset reference space'
+    );
+    testCase.deepEqual(teleportState?.target, [0.25, 1.8, -0.5], 'copies teleport target');
+    testCase.deepEqual(
+      teleportState?.translation,
+      [-0.25, 0, 0.5],
+      'defaults to inverted X/Z translation while preserving height'
+    );
+    testCase.deepEqual(
+      (teleportState?.originOffset as MockXRRigidTransform | undefined)?.position,
+      {x: -0.25, y: 0, z: 0.5},
+      'creates XRRigidTransform with teleport translation'
+    );
+    testCase.deepEqual(
+      referenceSpace.requestedOriginOffsets,
+      [teleportState?.originOffset],
+      'passes origin offset to reference-space API'
+    );
+    testCase.equal(
+      manager.getTeleportReferenceSpace([2, 0, 0], {bounds}),
+      null,
+      'rejects out-of-bounds targets'
+    );
+  } finally {
+    globalThis.XRRigidTransform = originalXRRigidTransform;
+  }
+
+  testCase.end();
+});
+
+test('webxr#teleport helpers handle constructor, offset, and option variants', testCase => {
+  const originalXRRigidTransform = globalThis.XRRigidTransform;
+  globalThis.XRRigidTransform = MockXRRigidTransformConstructor;
+
+  try {
+    const referenceSpace = makeMockXRReferenceSpace();
+    const orientation = {x: 0, y: 0.707, z: 0, w: 0.707};
+    const originOffset = makeWebXRTeleportOffset([1, 2, 3], {
+      invert: false,
+      preserveY: false,
+      orientation
+    }) as MockXRRigidTransform;
+
+    testCase.deepEqual(
+      getWebXRTeleportTranslation([1, 2, 3]),
+      [-1, 0, -3],
+      'defaults to inverted horizontal translation'
+    );
+    testCase.deepEqual(
+      getWebXRTeleportTranslation([1, 2, 3], {invert: false, preserveY: false}),
+      [1, 2, 3],
+      'can keep sign and include Y translation'
+    );
+    testCase.deepEqual(
+      originOffset.position,
+      {x: 1, y: 2, z: 3},
+      'creates non-inverted full-position offset'
+    );
+    testCase.equal(originOffset.orientation, orientation, 'passes orientation through');
+    testCase.equal(
+      isWebXRTeleportTargetAllowed([0, 0, 0], null),
+      true,
+      'missing bounds allow teleport targets'
+    );
+    testCase.equal(
+      getWebXRTeleportState(referenceSpace, [0, 0, 0])?.offsetReferenceSpace,
+      referenceSpace,
+      'standalone helper applies teleport offset'
+    );
+
+    const referenceSpaceWithoutOffset = {} as XRReferenceSpace;
+    testCase.equal(
+      getWebXRTeleportState(referenceSpaceWithoutOffset, [0, 0, 0]),
+      null,
+      'returns null without offset-reference-space support'
+    );
+  } finally {
+    globalThis.XRRigidTransform = originalXRRigidTransform;
+  }
+
+  globalThis.XRRigidTransform = undefined;
+  try {
+    testCase.equal(
+      makeWebXRTeleportOffset([0, 0, 0]),
+      null,
+      'returns null when XRRigidTransform is unavailable'
+    );
+  } finally {
+    globalThis.XRRigidTransform = originalXRRigidTransform;
+  }
+
+  testCase.end();
+});
+
 function makeMockXRReferenceSpace(): MockXRReferenceSpace {
   const referenceSpace = Object.assign(new EventTarget(), {
     requestedOriginOffsets: [] as XRRigidTransform[],
@@ -117,4 +244,15 @@ function makeMockXRRigidTransform(matrix: number[]): XRRigidTransform {
     matrix: new Float32Array(matrix),
     inverse: {} as XRRigidTransform
   };
+}
+
+function MockXRRigidTransformConstructor(
+  this: MockXRRigidTransform,
+  position?: DOMPointInit,
+  orientation?: DOMPointInit
+): void {
+  this.position = position;
+  this.orientation = orientation;
+  this.matrix = new Float32Array([position?.x || 0, position?.y || 0, position?.z || 0, 1]);
+  this.inverse = {} as XRRigidTransform;
 }

--- a/modules/experimental/test/webxr/webxr-reference-space.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-reference-space.node.spec.ts
@@ -1,0 +1,120 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  WebXRReferenceSpaceManager,
+  makeWebXRReferenceSpaceState
+} from '../../src/webxr/webxr-reference-space';
+
+type MockXRReferenceSpace = XRReferenceSpace & {
+  requestedOriginOffsets: XRRigidTransform[];
+};
+
+test('webxr#WebXRReferenceSpaceManager tracks reset events', testCase => {
+  const referenceSpace = makeMockXRReferenceSpace();
+  const transform = makeMockXRRigidTransform([1, 0, 0, 0]);
+  const manager = new WebXRReferenceSpaceManager();
+
+  manager.setReferenceSpace(referenceSpace);
+  referenceSpace.dispatchEvent(makeMockXRReferenceSpaceEvent(referenceSpace, transform));
+  const referenceSpaceState = manager.getReferenceSpaceState();
+
+  testCase.equal(manager.referenceSpace, referenceSpace, 'retains active reference space');
+  testCase.equal(
+    referenceSpaceState?.referenceSpace,
+    referenceSpace,
+    'keeps reference-space identity'
+  );
+  testCase.equal(referenceSpaceState?.resetCount, 1, 'counts reset events');
+  testCase.equal(referenceSpaceState?.transform, transform, 'keeps the last reset transform');
+  testCase.equal(referenceSpaceState?.matrix, transform.matrix, 'exposes the last reset matrix');
+
+  const originOffset = makeMockXRRigidTransform([2, 0, 0, 0]);
+  const offsetReferenceSpace = manager.getOffsetReferenceSpace(originOffset);
+  testCase.equal(
+    offsetReferenceSpace,
+    referenceSpace,
+    'forwards offset reference-space creation to the active reference space'
+  );
+  testCase.deepEqual(
+    referenceSpace.requestedOriginOffsets,
+    [originOffset],
+    'passes the origin offset through unchanged'
+  );
+
+  manager.destroy();
+  referenceSpace.dispatchEvent(makeMockXRReferenceSpaceEvent(referenceSpace, transform));
+  testCase.equal(manager.getReferenceSpaceState(), null, 'destroy removes reset state');
+  testCase.end();
+});
+
+test('webxr#WebXRReferenceSpaceManager handles clear and unsupported offsets', testCase => {
+  const referenceSpace = Object.assign(new EventTarget(), {}) as XRReferenceSpace;
+  const otherReferenceSpace = makeMockXRReferenceSpace();
+  const manager = new WebXRReferenceSpaceManager();
+
+  manager.setReferenceSpace(referenceSpace);
+  referenceSpace.dispatchEvent(makeMockXRReferenceSpaceEvent(otherReferenceSpace, null));
+  testCase.equal(
+    manager.getReferenceSpaceState()?.resetCount,
+    0,
+    'ignores reset events for another reference space'
+  );
+  testCase.equal(
+    manager.getOffsetReferenceSpace(makeMockXRRigidTransform([1])),
+    null,
+    'missing offset API returns null'
+  );
+
+  referenceSpace.dispatchEvent(makeMockXRReferenceSpaceEvent(referenceSpace, null));
+  testCase.equal(manager.getReferenceSpaceState()?.resetCount, 1, 'counts active reference reset');
+
+  manager.clearReferenceSpace();
+  referenceSpace.dispatchEvent(makeMockXRReferenceSpaceEvent(referenceSpace, null));
+  testCase.equal(manager.referenceSpace, null, 'clearReferenceSpace is idempotent');
+  testCase.equal(manager.getReferenceSpaceState(), null, 'cleared manager has no state');
+
+  testCase.deepEqual(
+    makeWebXRReferenceSpaceState(referenceSpace, 2, null),
+    {
+      referenceSpace,
+      resetCount: 2,
+      lastResetEvent: null,
+      transform: null,
+      matrix: null
+    },
+    'state helper handles missing reset event'
+  );
+  testCase.end();
+});
+
+function makeMockXRReferenceSpace(): MockXRReferenceSpace {
+  const referenceSpace = Object.assign(new EventTarget(), {
+    requestedOriginOffsets: [] as XRRigidTransform[],
+    getOffsetReferenceSpace(originOffset: XRRigidTransform): XRReferenceSpace {
+      referenceSpace.requestedOriginOffsets.push(originOffset);
+      return referenceSpace;
+    }
+  }) as MockXRReferenceSpace;
+
+  return referenceSpace;
+}
+
+function makeMockXRReferenceSpaceEvent(
+  referenceSpace: XRReferenceSpace,
+  transform: XRRigidTransform | null
+): XRReferenceSpaceEvent {
+  return Object.assign(new Event('reset'), {
+    referenceSpace,
+    transform
+  }) as XRReferenceSpaceEvent;
+}
+
+function makeMockXRRigidTransform(matrix: number[]): XRRigidTransform {
+  return {
+    matrix: new Float32Array(matrix),
+    inverse: {} as XRRigidTransform
+  };
+}

--- a/modules/experimental/test/webxr/webxr-render-state.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-render-state.node.spec.ts
@@ -1,0 +1,112 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  WebXRRenderStateManager,
+  getWebXRRenderStateInit,
+  makeWebXRRenderState
+} from '../../src/webxr/webxr-render-state';
+
+type MockXRSession = XRSession & {
+  renderState: XRRenderState;
+  renderStateUpdates: XRRenderStateInit[];
+};
+
+test('webxr#WebXRRenderStateManager updates and snapshots render state', async testCase => {
+  const baseLayer = {} as XRWebGLLayer;
+  const layers = [{} as XRLayer];
+  const session = makeMockXRSession({baseLayer, layers});
+  const manager = new WebXRRenderStateManager({depthNear: 0.05, depthFar: 100});
+
+  await manager.setSession(session);
+  let renderState = manager.getRenderState();
+
+  testCase.equal(manager.session, session, 'retains active session');
+  testCase.deepEqual(
+    session.renderStateUpdates,
+    [{depthNear: 0.05, depthFar: 100}],
+    'queues configured render-state update'
+  );
+  testCase.equal(renderState?.session, session, 'keeps session identity');
+  testCase.equal(renderState?.depthNear, 0.05, 'snapshots depthNear');
+  testCase.equal(renderState?.depthFar, 100, 'snapshots depthFar');
+  testCase.equal(renderState?.inlineVerticalFieldOfView, null, 'keeps immersive inline FOV null');
+  testCase.equal(renderState?.baseLayer, baseLayer, 'snapshots base layer');
+  testCase.deepEqual(renderState?.layers, layers, 'snapshots layers');
+
+  renderState = await manager.updateRenderState({inlineVerticalFieldOfView: Math.PI * 0.5});
+  testCase.deepEqual(
+    session.renderStateUpdates[1],
+    {depthNear: 0.05, depthFar: 100, inlineVerticalFieldOfView: Math.PI * 0.5},
+    'queues merged render-state props'
+  );
+  testCase.equal(
+    renderState?.inlineVerticalFieldOfView,
+    Math.PI * 0.5,
+    'snapshots updated inline FOV'
+  );
+
+  session.dispatchEvent(new Event('end'));
+  testCase.equal(manager.getRenderState(), null, 'ended sessions expose no render state');
+  testCase.end();
+});
+
+test('webxr#WebXRRenderState helpers filter null values', async testCase => {
+  const session = makeMockXRSession({});
+  const manager = new WebXRRenderStateManager();
+
+  testCase.deepEqual(
+    getWebXRRenderStateInit({depthNear: 0.1, depthFar: null, inlineVerticalFieldOfView: undefined}),
+    {depthNear: 0.1},
+    'render-state init includes only defined values'
+  );
+  testCase.equal(
+    await manager.updateRenderState({depthNear: 0.1}),
+    null,
+    'inactive updates return null'
+  );
+
+  await manager.setSession(session);
+  testCase.deepEqual(session.renderStateUpdates, [], 'default props do not queue empty updates');
+  testCase.deepEqual(makeWebXRRenderState(session), {
+    session,
+    depthNear: 0.1,
+    depthFar: 1000,
+    inlineVerticalFieldOfView: null,
+    baseLayer: null,
+    layers: []
+  });
+
+  manager.clearSession();
+  testCase.equal(manager.session, null, 'clearSession is idempotent');
+  testCase.end();
+});
+
+function makeMockXRSession(props: {
+  baseLayer?: XRWebGLLayer;
+  layers?: readonly XRLayer[];
+}): MockXRSession {
+  const session = Object.assign(new EventTarget(), {
+    inputSources: [],
+    renderState: {
+      depthNear: 0.1,
+      depthFar: 1000,
+      inlineVerticalFieldOfView: null,
+      baseLayer: props.baseLayer || null,
+      layers: props.layers || []
+    },
+    renderStateUpdates: [] as XRRenderStateInit[],
+    requestReferenceSpace: async () => ({}) as XRReferenceSpace,
+    requestAnimationFrame: () => 1,
+    cancelAnimationFrame: () => {},
+    async end() {},
+    async updateRenderState(renderStateInit: XRRenderStateInit = {}) {
+      session.renderStateUpdates.push(renderStateInit);
+      session.renderState = {...session.renderState, ...renderStateInit};
+    }
+  }) as MockXRSession;
+
+  return session;
+}

--- a/modules/experimental/test/webxr/webxr-session-init.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-session-init.node.spec.ts
@@ -1,0 +1,105 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  WEBXR_DEFAULT_SESSION_SUPPORT_MODES,
+  getWebXRSessionFeatures,
+  getWebXRSessionSupport,
+  isWebXRSessionFeatureEnabled,
+  mergeWebXRSessionInit
+} from '../../src/webxr/webxr-session-init';
+
+test('webxr#mergeWebXRSessionInit composes feature lists and extension fields', testCase => {
+  const domOverlayRoot = new EventTarget() as unknown as Element;
+  const trackedImages = [{image: {} as ImageBitmap, widthInMeters: 0.5}];
+  const depthSensing: XRDepthStateInit = {
+    usagePreference: ['gpu-optimized'],
+    dataFormatPreference: ['float32']
+  };
+
+  const sessionInit = mergeWebXRSessionInit(
+    {requiredFeatures: ['webgpu'], optionalFeatures: ['local-floor', 'depth-sensing']},
+    {requiredFeatures: ['depth-sensing'], depthSensing},
+    {optionalFeatures: ['dom-overlay', 'local-floor'], domOverlay: {root: domOverlayRoot}},
+    {optionalFeatures: ['image-tracking'], trackedImages}
+  );
+
+  testCase.deepEqual(
+    sessionInit.requiredFeatures,
+    ['webgpu', 'depth-sensing'],
+    'deduplicates required features in insertion order'
+  );
+  testCase.deepEqual(
+    sessionInit.optionalFeatures,
+    ['local-floor', 'dom-overlay', 'image-tracking'],
+    'deduplicates optional features and removes required features'
+  );
+  testCase.equal(sessionInit.depthSensing, depthSensing, 'preserves depth sensing init');
+  testCase.deepEqual(sessionInit.domOverlay, {root: domOverlayRoot}, 'preserves DOM overlay init');
+  testCase.equal(sessionInit.trackedImages, trackedImages, 'preserves tracked image init');
+  testCase.deepEqual(getWebXRSessionFeatures(sessionInit), {
+    requiredFeatures: ['webgpu', 'depth-sensing'],
+    optionalFeatures: ['local-floor', 'dom-overlay', 'image-tracking'],
+    requestedFeatures: ['webgpu', 'depth-sensing', 'local-floor', 'dom-overlay', 'image-tracking']
+  });
+  testCase.end();
+});
+
+test('webxr#WebXRSessionInit helpers handle support checks and enabled features', async testCase => {
+  const xr = makeMockXRSystem({
+    'immersive-vr': true,
+    'immersive-ar': false,
+    inline: 'reject'
+  });
+  const session = {enabledFeatures: ['local-floor', 'hand-tracking']} as XRSession;
+
+  const support = await getWebXRSessionSupport({xr});
+
+  testCase.deepEqual(
+    WEBXR_DEFAULT_SESSION_SUPPORT_MODES,
+    ['immersive-vr', 'immersive-ar', 'inline'],
+    'keeps default support probe order'
+  );
+  testCase.equal(support.xr, xr, 'keeps XR system identity');
+  testCase.equal(support.isSupported, true, 'reports support when at least one mode works');
+  testCase.deepEqual(
+    support.modes,
+    {'immersive-vr': true, 'immersive-ar': false, inline: false},
+    'maps rejected probes to unsupported'
+  );
+  testCase.deepEqual(support.supportedModes, ['immersive-vr'], 'filters supported modes');
+  testCase.equal(
+    isWebXRSessionFeatureEnabled(session, 'hand-tracking'),
+    true,
+    'detects enabled features'
+  );
+  testCase.equal(
+    isWebXRSessionFeatureEnabled(session, 'depth-sensing'),
+    false,
+    'rejects missing enabled features'
+  );
+
+  const missingSupport = await getWebXRSessionSupport({xr: null, modes: ['immersive-ar']});
+  testCase.deepEqual(
+    missingSupport,
+    {xr: null, isSupported: false, modes: {}, supportedModes: []},
+    'missing XR system reports unsupported'
+  );
+  testCase.end();
+});
+
+function makeMockXRSystem(support: Partial<Record<XRSessionMode, boolean | 'reject'>>): XRSystem {
+  return Object.assign(new EventTarget(), {
+    async isSessionSupported(mode: XRSessionMode): Promise<boolean> {
+      if (support[mode] === 'reject') {
+        throw new Error('unsupported');
+      }
+      return Boolean(support[mode]);
+    },
+    async requestSession(): Promise<XRSession> {
+      throw new Error('not implemented');
+    }
+  }) as XRSystem;
+}

--- a/modules/experimental/test/webxr/webxr-session-state.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-session-state.node.spec.ts
@@ -1,0 +1,123 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  WebXRSessionStateManager,
+  getWebXRSupportedFrameRates,
+  getWebXRTargetFrameRate,
+  makeWebXRSessionState
+} from '../../src/webxr/webxr-session-state';
+
+type MockXRSession = XRSession & {
+  visibilityState: XRVisibilityState;
+  frameRate: number;
+  supportedFrameRates: Float32Array;
+  updatedTargetFrameRates: number[];
+};
+
+test('webxr#WebXRSessionStateManager tracks visibility and frame-rate state', async testCase => {
+  const session = makeMockXRSession({
+    visibilityState: 'visible-blurred',
+    frameRate: 72,
+    supportedFrameRates: [72, 90, 120],
+    isSystemKeyboardSupported: true
+  });
+  const manager = new WebXRSessionStateManager({targetFrameRate: 'highest'});
+
+  await manager.setSession(session);
+  let sessionState = manager.getSessionState();
+
+  testCase.equal(manager.session, session, 'retains active session');
+  testCase.deepEqual(session.updatedTargetFrameRates, [120], 'requests highest frame rate');
+  testCase.equal(sessionState?.visibilityState, 'visible-blurred', 'keeps visibility state');
+  testCase.equal(sessionState?.isVisible, true, 'visible-blurred sessions still render');
+  testCase.equal(sessionState?.isFocused, false, 'visible-blurred sessions are not focused');
+  testCase.equal(sessionState?.frameRate, 120, 'keeps current frame rate');
+  testCase.deepEqual(
+    sessionState?.supportedFrameRates,
+    [72, 90, 120],
+    'normalizes supported frame rates'
+  );
+  testCase.equal(
+    sessionState?.isSystemKeyboardSupported,
+    true,
+    'keeps system-keyboard support state'
+  );
+
+  session.visibilityState = 'hidden';
+  session.dispatchEvent(new Event('visibilitychange'));
+  sessionState = manager.getSessionState();
+  testCase.equal(sessionState?.isVisible, false, 'visibility changes update cached state');
+
+  await manager.updateTargetFrameRate(90);
+  testCase.deepEqual(session.updatedTargetFrameRates, [120, 90], 'requests explicit frame rate');
+
+  session.dispatchEvent(new Event('end'));
+  testCase.equal(manager.getSessionState(), null, 'ended sessions expose no state');
+  testCase.end();
+});
+
+test('webxr#WebXRSessionState helpers handle unsupported frame-rate controls', async testCase => {
+  const session = Object.assign(new EventTarget(), {
+    inputSources: [],
+    visibilityState: 'visible',
+    frameRate: undefined,
+    supportedFrameRates: undefined,
+    isSystemKeyboardSupported: undefined,
+    requestReferenceSpace: async () => ({}) as XRReferenceSpace,
+    updateRenderState: async () => {},
+    requestAnimationFrame: () => 1,
+    cancelAnimationFrame: () => {},
+    end: async () => {}
+  }) as unknown as XRSession;
+  const manager = new WebXRSessionStateManager();
+
+  await manager.setSession(session);
+
+  testCase.deepEqual(getWebXRSupportedFrameRates(session), [], 'missing rates become empty list');
+  testCase.equal(getWebXRTargetFrameRate(session, 'highest'), null, 'no highest rate is available');
+  testCase.equal(getWebXRTargetFrameRate(session, 80), 80, 'explicit rates can be requested');
+  testCase.equal(await manager.updateTargetFrameRate(80), null, 'missing updater returns null');
+  testCase.deepEqual(makeWebXRSessionState(session), {
+    session,
+    visibilityState: 'visible',
+    frameRate: null,
+    supportedFrameRates: [],
+    isVisible: true,
+    isFocused: true,
+    isSystemKeyboardSupported: null
+  });
+  manager.clearSession();
+  testCase.equal(manager.session, null, 'clearSession is idempotent');
+  testCase.end();
+});
+
+function makeMockXRSession(props: {
+  visibilityState: XRVisibilityState;
+  frameRate: number;
+  supportedFrameRates: number[];
+  isSystemKeyboardSupported: boolean;
+}): MockXRSession {
+  const session = Object.assign(new EventTarget(), {
+    inputSources: [],
+    visibilityState: props.visibilityState,
+    frameRate: props.frameRate,
+    supportedFrameRates: new Float32Array(props.supportedFrameRates),
+    isSystemKeyboardSupported: props.isSystemKeyboardSupported,
+    updatedTargetFrameRates: [] as number[],
+    requestReferenceSpace: async () => ({}) as XRReferenceSpace,
+    async updateRenderState() {},
+    requestAnimationFrame: () => 1,
+    cancelAnimationFrame: () => {},
+    async end() {},
+    async updateTargetFrameRate(frameRate: number) {
+      session.updatedTargetFrameRates.push(frameRate);
+      session.frameRate = frameRate;
+      session.dispatchEvent(new Event('frameratechange'));
+    }
+  }) as MockXRSession;
+
+  return session;
+}

--- a/modules/experimental/test/webxr/webxr-session-state.node.spec.ts
+++ b/modules/experimental/test/webxr/webxr-session-state.node.spec.ts
@@ -5,6 +5,7 @@
 import test from 'test/utils/vitest-tape';
 import {
   WebXRSessionStateManager,
+  getWebXRSessionRenderState,
   getWebXRSupportedFrameRates,
   getWebXRTargetFrameRate,
   makeWebXRSessionState
@@ -50,12 +51,66 @@ test('webxr#WebXRSessionStateManager tracks visibility and frame-rate state', as
   session.dispatchEvent(new Event('visibilitychange'));
   sessionState = manager.getSessionState();
   testCase.equal(sessionState?.isVisible, false, 'visibility changes update cached state');
+  testCase.deepEqual(
+    getWebXRSessionRenderState(sessionState),
+    {isRenderable: false, acceptsInput: false, intensityScale: 0},
+    'hidden sessions are not renderable or interactive'
+  );
 
   await manager.updateTargetFrameRate(90);
   testCase.deepEqual(session.updatedTargetFrameRates, [120, 90], 'requests explicit frame rate');
 
   session.dispatchEvent(new Event('end'));
   testCase.equal(manager.getSessionState(), null, 'ended sessions expose no state');
+  testCase.end();
+});
+
+test('webxr#getWebXRSessionRenderState maps visibility to render behavior', testCase => {
+  const visibleSessionState = makeWebXRSessionState(
+    makeMockXRSession({
+      visibilityState: 'visible',
+      frameRate: 90,
+      supportedFrameRates: [90],
+      isSystemKeyboardSupported: false
+    })
+  );
+  const blurredSessionState = makeWebXRSessionState(
+    makeMockXRSession({
+      visibilityState: 'visible-blurred',
+      frameRate: 90,
+      supportedFrameRates: [90],
+      isSystemKeyboardSupported: false
+    })
+  );
+  const hiddenSessionState = makeWebXRSessionState(
+    makeMockXRSession({
+      visibilityState: 'hidden',
+      frameRate: 90,
+      supportedFrameRates: [90],
+      isSystemKeyboardSupported: false
+    })
+  );
+
+  testCase.deepEqual(
+    getWebXRSessionRenderState(null),
+    {isRenderable: true, acceptsInput: true, intensityScale: 1},
+    'missing session state keeps non-XR rendering behavior enabled'
+  );
+  testCase.deepEqual(
+    getWebXRSessionRenderState(visibleSessionState),
+    {isRenderable: true, acceptsInput: true, intensityScale: 1},
+    'focused visible sessions render normally'
+  );
+  testCase.deepEqual(
+    getWebXRSessionRenderState(blurredSessionState),
+    {isRenderable: true, acceptsInput: false, intensityScale: 0.62},
+    'visible-blurred sessions render dimmed without accepting input'
+  );
+  testCase.deepEqual(
+    getWebXRSessionRenderState(hiddenSessionState),
+    {isRenderable: false, acceptsInput: false, intensityScale: 0},
+    'hidden sessions do not render'
+  );
   testCase.end();
 });
 

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -259,6 +259,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('type WebXRInputState');
     expect(applicationSource).toContain('getWebXRBoundsState');
     expect(applicationSource).toContain('WebXRInputActionManager');
+    expect(applicationSource).toContain('getWebXRControllerStateByHandedness');
     expect(applicationSource).toContain('getWebXRControllerStates');
     expect(applicationSource).toContain('getWebXRInputRayPlaneIntersection');
     expect(applicationSource).toContain('getWebXRLocomotionState');
@@ -285,16 +286,18 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain('this.updateXRInputActions(inputState)');
     expect(rayMethodStart).toBeGreaterThan(0);
     expect(rayMethodEnd).toBeGreaterThan(rayMethodStart);
+    expect(rayMethod).toContain('const controllerStates = getWebXRControllerStates(inputState)');
     expect(rayMethod).toContain(
-      'for (const controllerState of getWebXRControllerStates(inputState))'
+      "const dominantControllerState = getWebXRControllerStateByHandedness(controllerStates, 'right')"
     );
+    expect(rayMethod).toContain('for (const controllerState of controllerStates)');
     expect(rayMethod).toContain('if (controllerState.grip)');
     expect(rayMethod).toContain('this.controllerGripMatrix.copy(controllerState.grip.matrix)');
     expect(rayMethod).toContain(
       'multiplyRight(this.controllerGripMatrix.copy(controllerState.grip.matrix))'
     );
     expect(rayMethod).toContain('cameraMix: controllerState.isSqueezeActive');
-    expect(rayMethod).toContain("controllerState.handedness === 'right'");
+    expect(rayMethod).toContain('controllerState === dominantControllerState');
     expect(rayMethod).toContain('this.controllerGripModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerGripModel.draw(renderPass)');
     expect(rayMethod).toContain('if (!controllerState.ray)');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -403,8 +403,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
 
     expect(applicationSource).toContain('WebXRHitTestManager');
     expect(applicationSource).toContain('type WebXRHitTestState');
-    expect(applicationSource).toContain('getWebXRHitTestResult');
-    expect(applicationSource).toContain('getWebXRTransientInputHitTestResult');
+    expect(applicationSource).toContain('getWebXRHitTestPlacementResult');
     expect(applicationSource).toContain('readonly webXRHitTestManager = new WebXRHitTestManager()');
     expect(applicationSource).toContain('this.webXRHitTestManager.getHitTestState(xrFrame)');
     expect(enterMethod).toContain("sessionMode === 'immersive-ar'");
@@ -418,10 +417,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       'this.updateModelMatrix(time, true, hitTestState, planeDetectionState, meshDetectionState)'
     );
     expect(updateModelMethod).toContain('const hitTestMatrix =');
-    expect(updateModelMethod).toContain(
-      'getWebXRTransientInputHitTestResult(hitTestState)?.matrix'
-    );
-    expect(updateModelMethod).toContain('getWebXRHitTestResult(hitTestState)?.matrix');
+    expect(updateModelMethod).toContain('getWebXRHitTestPlacementResult(hitTestState)?.matrix');
     expect(updateModelMethod).toContain("this.xrSessionMode === 'immersive-ar' && hitTestMatrix");
     expect(updateModelMethod).toContain('this.modelMatrix.copy(hitTestMatrix)');
     expect(updateModelMethod).toContain('scale([0.54, 0.54, 0.54])');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -109,6 +109,8 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain(
       'readonly webXRHandTrackingManager = new WebXRHandTrackingManager()'
     );
+    expect(applicationSource).toContain("'light-estimation',");
+    expect(applicationSource).toContain('WebXRLightEstimationManager');
     expect(applicationSource).toContain(
       'this.webXRHandTrackingManager.setSession(session, this.webXRManager.referenceSpace)'
     );
@@ -330,6 +332,45 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(updateModelMethod).toContain('scale([0.54, 0.54, 0.54])');
     expect(clearMethod).toContain('this.webXRHitTestManager.clearSession()');
     expect(applicationSource).toContain('this.webXRHitTestManager.destroy()');
+  });
+
+  test('uses optional AR light estimation to modulate portal intensity', () => {
+    const applicationSource = readFileSync(APPLICATION_PATH, 'utf8');
+    const renderMethodStart = applicationSource.indexOf('private renderXRFrame(');
+    const renderMethodEnd = applicationSource.indexOf(
+      '\n  private preparePortal(',
+      renderMethodStart
+    );
+    const renderMethod = applicationSource.slice(renderMethodStart, renderMethodEnd);
+    const enterMethodStart = applicationSource.indexOf('async enterXR(');
+    const enterMethodEnd = applicationSource.indexOf('\n  async exitAR(', enterMethodStart);
+    const enterMethod = applicationSource.slice(enterMethodStart, enterMethodEnd);
+    const clearMethodStart = applicationSource.indexOf('private _clearXRSession(');
+    const clearMethod = applicationSource.slice(clearMethodStart);
+
+    expect(applicationSource).toContain('type WebXRLightEstimationState');
+    expect(applicationSource).toContain('WebXRLightEstimationManager');
+    expect(applicationSource).toContain(
+      'readonly webXRLightEstimationManager = new WebXRLightEstimationManager({'
+    );
+    expect(applicationSource).toContain("reflectionFormat: 'preferred'");
+    expect(applicationSource).toContain('lightIntensity: number');
+    expect(applicationSource).toContain("lightIntensity: 'f32'");
+    expect(applicationSource).toContain('color *= app.lightIntensity');
+    expect(applicationSource).toContain('function getXRLightIntensity(');
+    expect(applicationSource).toContain('lightState.primaryLightIntensity');
+    expect(applicationSource).toContain("'light-estimation',");
+    expect(applicationSource).toContain(
+      'this.webXRLightEstimationManager.getLightEstimationState(xrFrame)'
+    );
+    expect(enterMethod).toContain('this.webXRLightEstimationManager');
+    expect(enterMethod).toContain('.setSession(session, this.webXRManager.referenceSpace)');
+    expect(enterMethod).toContain('.catch(() => this.webXRLightEstimationManager.clearSession())');
+    expect(renderMethod).toContain('lightEstimationState: WebXRLightEstimationState | null');
+    expect(renderMethod).toContain('const lightIntensity = getXRLightIntensity(');
+    expect(renderMethod).toContain('lightIntensity,');
+    expect(clearMethod).toContain('this.webXRLightEstimationManager.clearSession()');
+    expect(applicationSource).toContain('this.webXRLightEstimationManager.destroy()');
   });
 
   test('uses select for teleport candidates and squeeze or keyboard for exit', () => {

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -96,7 +96,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     );
     expect(applicationSource).toContain("'depth-sensing',\n              ...domOverlayFeatures,");
     expect(applicationSource).toContain(
-      ": [...domOverlayFeatures, 'hand-tracking', 'local-floor']"
+      ": [...domOverlayFeatures, 'bounded-floor', 'hand-tracking', 'local-floor']"
     );
     expect(applicationSource).toContain('optionalFeatures: [...domOverlayFeatures,');
     expect(applicationSource).toContain('...domOverlayInit');
@@ -123,7 +123,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     );
     expect(applicationSource).toContain('this.webXRDOMOverlayManager.clearSession()');
     expect(applicationSource).toContain('this.webXRHandTrackingManager.clearSession()');
-    expect(applicationSource).toContain("referenceSpaceTypes: ['local-floor', 'local']");
+    expect(applicationSource).toContain(
+      "referenceSpaceTypes: ['bounded-floor', 'local-floor', 'local']"
+    );
     expect(applicationSource).toContain('function getDOMOverlayRoot(): Element | null');
     expect(applicationSource).toContain("usagePreference: ['gpu-optimized', 'cpu-optimized']");
     expect(applicationSource).toContain(
@@ -217,8 +219,10 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     const rayMethod = applicationSource.slice(rayMethodStart, rayMethodEnd);
 
     expect(applicationSource).toContain('type WebXRInputState');
+    expect(applicationSource).toContain('getWebXRBoundsState');
     expect(applicationSource).toContain('getWebXRInputRay');
     expect(applicationSource).toContain('getWebXRInputRayPlaneIntersection');
+    expect(applicationSource).toContain('isPointInWebXRBounds');
     expect(applicationSource).toContain('pulseWebXRInputHaptics');
     expect(applicationSource).toContain('this.webXRManager.getInputState(xrFrame)');
     expect(applicationSource).toContain("id: 'immersive-prism-controller-rays'");
@@ -515,6 +519,8 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     );
     expect(updateModelMethod).toContain('translate(this.xrSceneOffset)');
     expect(teleportMethod).toContain('this._floorHitByInputSource.get(inputSource)');
+    expect(teleportMethod).toContain('getWebXRBoundsState(this.webXRManager.referenceSpace)');
+    expect(teleportMethod).toContain('!isPointInWebXRBounds(floorHit, boundsState.bounds)');
     expect(teleportMethod).toContain('this.xrSceneOffset[0] -= floorHit[0]');
     expect(teleportMethod).toContain('this.xrSceneOffset[2] -= floorHit[2]');
     expect(teleportMethod).toContain('this._inputStateByInputSource.get(inputSource)');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -324,15 +324,18 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(enterMethod).toContain("sessionMode === 'immersive-ar'");
     expect(enterMethod).toContain('this.webXRHitTestManager');
     expect(enterMethod).toContain("entityTypes: ['plane', 'point', 'mesh']");
+    expect(enterMethod).toContain('transientInput: {');
+    expect(enterMethod).toContain("profile: 'generic-touchscreen'");
     expect(enterMethod).toContain('.catch(() => this.webXRHitTestManager.clearSession())');
     expect(renderMethod).toContain('hitTestState: WebXRHitTestState | null');
     expect(renderMethod).toContain(
       'this.updateModelMatrix(time, true, hitTestState, planeDetectionState, meshDetectionState)'
     );
-    expect(updateModelMethod).toContain(
-      "this.xrSessionMode === 'immersive-ar' && hitTestState?.hits[0]"
-    );
-    expect(updateModelMethod).toContain('this.modelMatrix.copy(hitTestState.hits[0].matrix)');
+    expect(updateModelMethod).toContain('const hitTestMatrix =');
+    expect(updateModelMethod).toContain('hitTestState?.transientInput[0]?.results[0]?.matrix');
+    expect(updateModelMethod).toContain('hitTestState?.hits[0]?.matrix');
+    expect(updateModelMethod).toContain("this.xrSessionMode === 'immersive-ar' && hitTestMatrix");
+    expect(updateModelMethod).toContain('this.modelMatrix.copy(hitTestMatrix)');
     expect(updateModelMethod).toContain('scale([0.54, 0.54, 0.54])');
     expect(clearMethod).toContain('this.webXRHitTestManager.clearSession()');
     expect(applicationSource).toContain('this.webXRHitTestManager.destroy()');
@@ -413,9 +416,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain(
       'this.updateModelMatrix(time, true, hitTestState, planeDetectionState, meshDetectionState)'
     );
-    expect(updateModelMethod).toContain(
-      "this.xrSessionMode === 'immersive-ar' && hitTestState?.hits[0]"
-    );
+    expect(updateModelMethod).toContain("this.xrSessionMode === 'immersive-ar' && hitTestMatrix");
     expect(updateModelMethod).toContain(
       "this.xrSessionMode === 'immersive-ar' && planeDetectionState?.planes[0]"
     );
@@ -461,9 +462,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain(
       'this.updateModelMatrix(time, true, hitTestState, planeDetectionState, meshDetectionState)'
     );
-    expect(updateModelMethod).toContain(
-      "this.xrSessionMode === 'immersive-ar' && hitTestState?.hits[0]"
-    );
+    expect(updateModelMethod).toContain("this.xrSessionMode === 'immersive-ar' && hitTestMatrix");
     expect(updateModelMethod).toContain(
       "this.xrSessionMode === 'immersive-ar' && planeDetectionState?.planes[0]"
     );

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -123,6 +123,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     );
     expect(applicationSource).toContain('this.webXRDOMOverlayManager.clearSession()');
     expect(applicationSource).toContain('this.webXRHandTrackingManager.clearSession()');
+    expect(applicationSource).toContain("referenceSpaceTypes: ['local-floor', 'local']");
     expect(applicationSource).toContain('function getDOMOverlayRoot(): Element | null');
     expect(applicationSource).toContain("usagePreference: ['gpu-optimized', 'cpu-optimized']");
     expect(applicationSource).toContain(

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -258,6 +258,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
 
     expect(applicationSource).toContain('type WebXRInputState');
     expect(applicationSource).toContain('getWebXRBoundsState');
+    expect(applicationSource).toContain('WebXRInputActionManager');
     expect(applicationSource).toContain('getWebXRInputActivationState');
     expect(applicationSource).toContain('getWebXRInputGrip');
     expect(applicationSource).toContain('getWebXRInputRay');
@@ -284,6 +285,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain('this._inputStateByInputSource.clear()');
     expect(renderMethod).toContain('this._inputStateByInputSource.set(input.inputSource, input)');
     expect(renderMethod).toContain('renderPass.end()');
+    expect(renderMethod).toContain('this.updateXRInputActions(inputState)');
     expect(rayMethodStart).toBeGreaterThan(0);
     expect(rayMethodEnd).toBeGreaterThan(rayMethodStart);
     expect(rayMethod).toContain('const inputSourceState = getWebXRInputSourceState(input)');
@@ -587,6 +589,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('private _lastXRSnapTurn = 0');
     expect(applicationSource).toContain('new Map<XRInputSource, [number, number, number]>()');
     expect(applicationSource).toContain('new Map<XRInputSource, WebXRInputState>()');
+    expect(applicationSource).toContain(
+      'readonly webXRInputActionManager = new WebXRInputActionManager()'
+    );
     expect(applicationSource).not.toContain(
       'private _xrSelectEndListener = () => void this.exitXR()'
     );
@@ -646,6 +651,12 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       'void pulseWebXRInputHaptics(inputState, {intensity: 0.5, duration: 45})'
     );
     expect(teleportMethod).toContain('this._floorHitByInputSource.clear()');
+    expect(teleportMethod).toContain('private updateXRInputActions(');
+    expect(teleportMethod).toContain('this.webXRInputActionManager.update(inputState)');
+    expect(teleportMethod).toContain('actionState.primaryActionEnded');
+    expect(teleportMethod).toContain('this.teleportToInputSource(actionState.inputSource)');
+    expect(teleportMethod).toContain('actionState.squeezeActionEnded');
+    expect(teleportMethod).toContain('void this.exitXR()');
     expect(clearMethod).toContain(
       "session?.removeEventListener('selectend', this._xrSelectEndListener)"
     );
@@ -656,6 +667,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(clearMethod).toContain('this.xrSceneYaw = 0');
     expect(clearMethod).toContain('this.clearXRInteractionState()');
     expect(applicationSource).toContain('private clearXRInteractionState(): void');
+    expect(applicationSource).toContain('this.webXRInputActionManager.reset()');
     expect(applicationSource).toContain('this._lastXRLocomotionTimeMilliseconds = null');
     expect(applicationSource).toContain('this._lastXRSnapTurn = 0');
     expect(applicationSource).toContain('this._floorHitByInputSource.clear()');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -10,6 +10,7 @@ import {
   applyXRSnapTurn,
   applyXRSceneOffset,
   getXRLocomotionSceneOffset,
+  getXRViewerHeightLightScale,
   getXRTeleportTargetState
 } from '../../examples/experimental/webxr-kaleidoscope/app';
 
@@ -201,6 +202,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toMatch(
       /this\.xrSessionMode\s*===\s*'immersive-ar'\s*\?\s*\[0,\s*0,\s*0,\s*0\]/
     );
+    expect(renderMethod).toContain('getXRViewerHeightLightScale(frameState.viewer.position)');
     expect(renderMethod.indexOf('this.preparePortal({')).toBeLessThan(
       renderMethod.indexOf('this.device.beginRenderPass({')
     );
@@ -438,7 +440,8 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(enterMethod).toContain('.setSession(session, this.webXRManager.referenceSpace)');
     expect(enterMethod).toContain('.catch(() => this.webXRLightEstimationManager.clearSession())');
     expect(renderMethod).toContain('lightEstimationState: WebXRLightEstimationState | null');
-    expect(renderMethod).toContain('const lightIntensity = getXRLightIntensity(');
+    expect(renderMethod).toContain('getXRLightIntensity(lightEstimationState) *');
+    expect(renderMethod).toContain('getXRViewerHeightLightScale(frameState.viewer.position)');
     expect(renderMethod).toContain('lightIntensity,');
     expect(clearMethod).toContain('this.webXRLightEstimationManager.clearSession()');
     expect(applicationSource).toContain('this.webXRLightEstimationManager.destroy()');
@@ -653,6 +656,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(getXRLocomotionSceneOffset([0, 1], 1, 0, 2)).toEqual([0, 0, -2]);
     expect(getXRLocomotionSceneOffset([0, 1], 1, Math.PI / 2, 2)).toEqual([2, 0, 0]);
     expect(getXRLocomotionSceneOffset([1, 0], 0.5, Math.PI / 2, 2)).toEqual([0, 0, 1]);
+    expect(getXRViewerHeightLightScale([0, 0, 0])).toBe(0.85);
+    expect(getXRViewerHeightLightScale([0, 1.5, 0])).toBeCloseTo(1.03);
+    expect(getXRViewerHeightLightScale([0, 4, 0])).toBe(1.15);
     const boundsState = {
       bounds: [
         [-1, 0, -1],

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -178,6 +178,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
   });
 
   test('keeps standalone launch, sidebar, and backend metadata accurate', () => {
+    const applicationSource = readFileSync(APPLICATION_PATH, 'utf8');
     const standaloneSource = readFileSync(STANDALONE_PATH, 'utf8');
     const metadataSource = readFileSync(EXAMPLE_METADATA_PATH, 'utf8');
     const packageSource = JSON.parse(readFileSync(PACKAGE_PATH, 'utf8')) as {
@@ -194,6 +195,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(standaloneSource).toContain("toggleSession('immersive-vr')");
     expect(standaloneSource).toContain("toggleSession('immersive-ar')");
     expect(standaloneSource).toContain('switch-backend');
+    expect(applicationSource).toContain(
+      'https://chromewebstore.google.com/detail/codex/hehggadaopoacecdllhhajmbjkdcmajg?pli=1'
+    );
     expect(metadataSource).toContain('backends: [webgpu, webgl2]');
     expect(metadataSource).toContain('Immersive Prism Portal');
     expect(packageSource.dependencies).toHaveProperty('@luma.gl/webgpu');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -259,7 +259,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('type WebXRInputState');
     expect(applicationSource).toContain('getWebXRBoundsState');
     expect(applicationSource).toContain('WebXRInputActionManager');
-    expect(applicationSource).toContain('getWebXRControllerRayPlaneIntersection');
+    expect(applicationSource).toContain('getWebXRControllerRayPlaneTarget');
     expect(applicationSource).toContain('getWebXRControllerStateByHandedness');
     expect(applicationSource).toContain('getWebXRControllerStates');
     expect(applicationSource).toContain('getWebXRLocomotionState');
@@ -310,15 +310,14 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethod).toContain('this.controllerRayModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerRayModel.draw(renderPass)');
     expect(rayMethod).toContain(
-      'getWebXRControllerRayPlaneIntersection(controllerState, {maxDistance: 8})'
+      'const teleportTarget = getWebXRControllerRayPlaneTarget(controllerState, {'
     );
+    expect(rayMethod).toContain('maxDistance: 8');
+    expect(rayMethod).toContain('bounds: boundsState');
     expect(rayMethod).toContain('boundsState: WebXRBoundsState | null');
-    expect(rayMethod).toContain(
-      'const teleportTarget = getXRTeleportTargetState(floorHit.point, boundsState)'
-    );
     expect(rayMethod).toContain('if (teleportTarget.allowed)');
     expect(rayMethod).toContain(
-      'this._floorHitByInputSource.set(controllerState.inputSource, floorHit.point)'
+      'this._floorHitByInputSource.set(controllerState.inputSource, teleportTarget.point)'
     );
     expect(rayMethod).toContain(
       'this.controllerReticleMatrix.identity().translate(teleportTarget.point)'

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -261,6 +261,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     const clearMethod = applicationSource.slice(clearMethodStart);
 
     expect(applicationSource).toContain('type WebXRHandTrackingState');
+    expect(applicationSource).toContain('getWebXRHandPinch');
     expect(applicationSource).toContain('this.webXRHandTrackingManager.getHandsState(');
     expect(applicationSource).toContain('(inputState || []).map(input => input.inputSource)');
     expect(applicationSource).toContain("id: 'immersive-prism-hand-joints'");
@@ -273,12 +274,14 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(handMethodStart).toBeGreaterThan(0);
     expect(handMethodEnd).toBeGreaterThan(handMethodStart);
     expect(handMethod).toContain('for (const hand of handState)');
+    expect(handMethod).toContain('const pinchState = getWebXRHandPinch(hand)');
+    expect(handMethod).toContain('pinchState?.pinchActive ? 1');
     expect(handMethod).toContain('for (const joint of hand.joints)');
     expect(handMethod).toContain('if (!joint.matrix)');
     expect(handMethod).toContain('Math.max(joint.radius ?? 0.008, 0.006) * 1.8');
     expect(handMethod).toContain('this.handJointMatrix.copy(joint.matrix)');
     expect(handMethod).toContain('multiplyRight(this.handJointMatrix)');
-    expect(handMethod).toContain("hand.handedness === 'right' ? 1 : 0");
+    expect(handMethod).toContain("hand.handedness === 'right' ? 0.45 : 0");
     expect(handMethod).toContain('this.handJointModel.predraw(this.device.commandEncoder)');
     expect(handMethod).toContain('this.handJointModel.draw(renderPass)');
     expect(clearMethod).toContain('this.webXRHandTrackingManager.clearSession()');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -115,8 +115,15 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('WebXRLightEstimationManager');
     expect(applicationSource).toContain('WebXRMeshDetectionManager');
     expect(applicationSource).toContain('WebXRPlaneDetectionManager');
+    expect(applicationSource).toContain('WebXRReferenceSpaceManager');
     expect(applicationSource).toContain('WebXRSessionStateManager');
     expect(applicationSource).toContain("targetFrameRate: 'highest'");
+    expect(applicationSource).toContain(
+      'readonly webXRReferenceSpaceManager = new WebXRReferenceSpaceManager()'
+    );
+    expect(applicationSource).toContain(
+      'this.webXRReferenceSpaceManager.setReferenceSpace(this.webXRManager.referenceSpace)'
+    );
     expect(applicationSource).toContain(
       'this.webXRHandTrackingManager.setSession(session, this.webXRManager.referenceSpace)'
     );
@@ -127,6 +134,8 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     );
     expect(applicationSource).toContain('this.webXRDOMOverlayManager.clearSession()');
     expect(applicationSource).toContain('this.webXRHandTrackingManager.clearSession()');
+    expect(applicationSource).toContain('this.webXRReferenceSpaceManager.clearReferenceSpace()');
+    expect(applicationSource).toContain('this.webXRReferenceSpaceManager.destroy()');
     expect(applicationSource).toContain('this.webXRSessionStateManager.clearSession()');
     expect(applicationSource).toContain('this.webXRSessionStateManager.destroy()');
     expect(applicationSource).toContain(

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -8,7 +8,8 @@ import {describe, expect, test} from 'vitest';
 import {WgslReflect} from 'wgsl_reflect';
 import {
   applyXRSnapTurn,
-  applyXRSceneOffset
+  applyXRSceneOffset,
+  getXRLocomotionSceneOffset
 } from '../../examples/experimental/webxr-kaleidoscope/app';
 
 const APPLICATION_PATH = path.join(
@@ -576,7 +577,8 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(locomotionMethod).toContain('duration: 30');
     expect(locomotionMethod).toContain('this._lastXRSnapTurn = locomotionState.snapTurn');
     expect(locomotionMethod).toContain('Math.min(0.05, Math.max(0,');
-    expect(locomotionMethod).toContain('this.applyXRSceneOffset([');
+    expect(locomotionMethod).toContain('getXRLocomotionSceneOffset(');
+    expect(locomotionMethod).toContain('[strafe, forward], deltaSeconds, this.xrSceneYaw');
     expect(updateModelMethod).toContain('translate(this.xrSceneOffset)');
     expect(updateModelMethod).toContain('rotateY(this.xrSceneYaw)');
     expect(teleportMethod).toContain('this._floorHitByInputSource.get(inputSource)');
@@ -612,6 +614,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applyXRSnapTurn(0.25, 1, 0.5)).toBe(0.75);
     expect(applyXRSnapTurn(0.25, -1, 0.5)).toBe(-0.25);
     expect(applyXRSnapTurn(0.25, 0, 0.5)).toBe(0.25);
+    expect(getXRLocomotionSceneOffset([0, 1], 1, 0, 2)).toEqual([0, 0, -2]);
+    expect(getXRLocomotionSceneOffset([0, 1], 1, Math.PI / 2, 2)).toEqual([2, 0, 0]);
+    expect(getXRLocomotionSceneOffset([1, 0], 0.5, Math.PI / 2, 2)).toEqual([0, 0, 1]);
   });
 
   test('requests isolated XR-compatible website devices while preserving preview fallback', () => {

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -57,6 +57,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('source: WGSL_SHADER');
     expect(applicationSource).toContain('vs: VS_GLSL');
     expect(applicationSource).toContain('fs: FS_GLSL');
+    expect(applicationSource).toContain('source: CONTROLLER_RAY_WGSL_SHADER');
+    expect(applicationSource).toContain('vs: CONTROLLER_RAY_VS_GLSL');
+    expect(applicationSource).toContain('fs: CONTROLLER_RAY_FS_GLSL');
     expect(applicationSource).not.toContain('WebXR Kaleidoscope requires WebGL2');
   });
 
@@ -102,6 +105,12 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       renderMethodStart
     );
     const renderMethod = applicationSource.slice(renderMethodStart, renderMethodEnd);
+    const previewMethodStart = applicationSource.indexOf('private renderPreviewFrame(');
+    const previewMethodEnd = applicationSource.indexOf(
+      '\n  private renderXRFrame(',
+      previewMethodStart
+    );
+    const previewMethod = applicationSource.slice(previewMethodStart, previewMethodEnd);
     const prepareMethodStart = applicationSource.indexOf('private preparePortal(');
     const prepareMethodEnd = applicationSource.indexOf(
       '\n  private drawPortal(',
@@ -111,10 +120,16 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
 
     expect(renderMethodStart).toBeGreaterThan(0);
     expect(renderMethodEnd).toBeGreaterThan(renderMethodStart);
+    expect(previewMethodStart).toBeGreaterThan(0);
+    expect(previewMethodEnd).toBeGreaterThan(previewMethodStart);
+    expect(previewMethod).toContain('const renderPass = device.beginRenderPass(');
+    expect(previewMethod).toContain('this.drawPortal(renderPass)');
+    expect(previewMethod).toContain('renderPass.end()');
     expect(renderMethod).toContain('view.framebuffer ?? frameState.framebuffer');
     expect(renderMethod).toContain('new Set<Framebuffer>()');
     expect(renderMethod).toContain('!renderedFramebuffers.has(framebuffer)');
     expect(renderMethod).toContain('renderedFramebuffers.add(framebuffer)');
+    expect(renderMethod).toContain('this.drawControllerRays(renderPass, view, inputState, time)');
     expect(renderMethod).toMatch(
       /this\.xrSessionMode\s*===\s*'immersive-ar'\s*\?\s*\[0,\s*0,\s*0,\s*0\]/
     );
@@ -128,12 +143,48 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(
       renderMethod.indexOf('renderPass.setParameters({viewport: view.viewport})')
     ).toBeLessThan(renderMethod.indexOf('this.drawPortal(renderPass)'));
+    expect(renderMethod.indexOf('this.drawPortal(renderPass)')).toBeLessThan(
+      renderMethod.indexOf('this.drawControllerRays(renderPass, view, inputState, time)')
+    );
     expect(prepareMethod).toContain('this.uniformStore.setUniforms(');
     expect(prepareMethod).toContain('this.device.commandEncoder');
     expect(prepareMethod).toContain('this.model.predraw(this.device.commandEncoder)');
     expect(prepareMethod.indexOf('this.uniformStore.setUniforms(')).toBeLessThan(
       prepareMethod.indexOf('this.model.predraw(this.device.commandEncoder)')
     );
+  });
+
+  test('renders tracked-pointer controller rays from WebXR input snapshots', () => {
+    const applicationSource = readFileSync(APPLICATION_PATH, 'utf8');
+    const renderMethodStart = applicationSource.indexOf('private renderXRFrame(');
+    const renderMethodEnd = applicationSource.indexOf(
+      '\n  private preparePortal(',
+      renderMethodStart
+    );
+    const renderMethod = applicationSource.slice(renderMethodStart, renderMethodEnd);
+    const rayMethodStart = applicationSource.indexOf('private drawControllerRays(');
+    const rayMethodEnd = applicationSource.indexOf(
+      '\n  private updateModelMatrix(',
+      rayMethodStart
+    );
+    const rayMethod = applicationSource.slice(rayMethodStart, rayMethodEnd);
+
+    expect(applicationSource).toContain('type WebXRInputState');
+    expect(applicationSource).toContain('this.webXRManager.getInputState(xrFrame)');
+    expect(applicationSource).toContain("id: 'immersive-prism-controller-rays'");
+    expect(applicationSource).toContain("topology: 'line-list'");
+    expect(applicationSource).toContain('new Float32Array([0, 0, 0, 0, 0, -3.2])');
+    expect(renderMethod).toContain('inputState: readonly WebXRInputState[]');
+    expect(renderMethod).toContain('renderPass.end()');
+    expect(rayMethodStart).toBeGreaterThan(0);
+    expect(rayMethodEnd).toBeGreaterThan(rayMethodStart);
+    expect(rayMethod).toContain("input.targetRayMode !== 'tracked-pointer'");
+    expect(rayMethod).toContain('!input.targetRayMatrix');
+    expect(rayMethod).toContain('this.controllerRayMatrix.copy(input.targetRayMatrix)');
+    expect(rayMethod).toContain('multiplyRight(this.controllerRayMatrix)');
+    expect(rayMethod).toContain('cameraMix: input.selectActive ? 1 : 0');
+    expect(rayMethod).toContain('this.controllerRayModel.predraw(this.device.commandEncoder)');
+    expect(rayMethod).toContain('this.controllerRayModel.draw(renderPass)');
   });
 
   test('requests isolated XR-compatible website devices while preserving preview fallback', () => {

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -115,14 +115,20 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('WebXRLightEstimationManager');
     expect(applicationSource).toContain('WebXRMeshDetectionManager');
     expect(applicationSource).toContain('WebXRPlaneDetectionManager');
+    expect(applicationSource).toContain('WebXRSessionStateManager');
+    expect(applicationSource).toContain("targetFrameRate: 'highest'");
     expect(applicationSource).toContain(
       'this.webXRHandTrackingManager.setSession(session, this.webXRManager.referenceSpace)'
     );
+    expect(applicationSource).toContain('this.webXRSessionStateManager');
+    expect(applicationSource).toContain('.setSession(session)');
     expect(applicationSource).toContain(
       'this.webXRDOMOverlayManager.setSession(session, {root: getDOMOverlayRoot()})'
     );
     expect(applicationSource).toContain('this.webXRDOMOverlayManager.clearSession()');
     expect(applicationSource).toContain('this.webXRHandTrackingManager.clearSession()');
+    expect(applicationSource).toContain('this.webXRSessionStateManager.clearSession()');
+    expect(applicationSource).toContain('this.webXRSessionStateManager.destroy()');
     expect(applicationSource).toContain(
       "referenceSpaceTypes: ['bounded-floor', 'local-floor', 'local']"
     );

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -250,6 +250,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('type WebXRInputState');
     expect(applicationSource).toContain('getWebXRBoundsState');
     expect(applicationSource).toContain('getWebXRGamepadState');
+    expect(applicationSource).toContain('getWebXRInputGrip');
     expect(applicationSource).toContain('getWebXRInputRay');
     expect(applicationSource).toContain('getWebXRInputRayPlaneIntersection');
     expect(applicationSource).toContain('getWebXRLocomotionState');
@@ -260,8 +261,10 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('this.webXRManager.getInputState(xrFrame)');
     expect(applicationSource).toContain("id: 'immersive-prism-controller-rays'");
     expect(applicationSource).toContain("id: 'immersive-prism-controller-reticles'");
+    expect(applicationSource).toContain("id: 'immersive-prism-controller-grips'");
     expect(applicationSource).toContain("topology: 'line-list'");
     expect(applicationSource).toContain('new Float32Array([0, 0, 0, 0, 0, -3.2])');
+    expect(applicationSource).toContain('function makeControllerGripGeometry()');
     expect(applicationSource).toContain('function makeControllerReticleGeometry()');
     expect(applicationSource).toContain('const segmentCount = 32');
     expect(renderMethod).toContain('inputState: readonly WebXRInputState[]');
@@ -273,6 +276,15 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain('renderPass.end()');
     expect(rayMethodStart).toBeGreaterThan(0);
     expect(rayMethodEnd).toBeGreaterThan(rayMethodStart);
+    expect(rayMethod).toContain('const inputGrip = getWebXRInputGrip(input)');
+    expect(rayMethod).toContain('if (inputGrip)');
+    expect(rayMethod).toContain('this.controllerGripMatrix.copy(inputGrip.matrix)');
+    expect(rayMethod).toContain('multiplyRight(this.controllerGripMatrix.copy(inputGrip.matrix))');
+    expect(rayMethod).toContain(
+      "cameraMix: input.squeezeActive ? 1 : input.handedness === 'right' ? 0.45 : 0"
+    );
+    expect(rayMethod).toContain('this.controllerGripModel.predraw(this.device.commandEncoder)');
+    expect(rayMethod).toContain('this.controllerGripModel.draw(renderPass)');
     expect(rayMethod).toContain('const inputRay = getWebXRInputRay(input)');
     expect(rayMethod).toContain('const gamepadState = getWebXRGamepadState(input)');
     expect(rayMethod).toContain('gamepadState?.primaryTrigger?.value || 0');
@@ -301,6 +313,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethod).toContain('this.controllerReticleModel.draw(renderPass)');
     expect(applicationSource).toContain('let blockedColor = vec3<f32>(1.0, 0.08, 0.10)');
     expect(applicationSource).toContain('app.cameraMix < 0.0 ? blockedColor : targetColor');
+    expect(applicationSource).toContain('this.controllerGripModel.destroy()');
   });
 
   test('renders tracked hand joints from WebXR hand snapshots', () => {

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -119,6 +119,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('WebXRReferenceSpaceManager');
     expect(applicationSource).toContain('WebXRRenderStateManager');
     expect(applicationSource).toContain('WebXRSessionStateManager');
+    expect(applicationSource).toContain('getWebXRSessionRenderState');
     expect(applicationSource).toContain('depthNear: 0.05');
     expect(applicationSource).toContain('depthFar: 100');
     expect(applicationSource).toContain("targetFrameRate: 'highest'");
@@ -135,6 +136,10 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     );
     expect(applicationSource).toContain('this.webXRSessionStateManager');
     expect(applicationSource).toContain('.setSession(session)');
+    expect(applicationSource).toContain('const sessionRenderState = getWebXRSessionRenderState(');
+    expect(applicationSource).toContain(
+      'this.xrSession ? this.webXRSessionStateManager.getSessionState() : null'
+    );
     expect(applicationSource).toContain(
       'this.webXRDOMOverlayManager.setSession(session, {root: getDOMOverlayRoot()})'
     );
@@ -192,6 +197,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(previewMethod).toContain('this.drawPortal(renderPass)');
     expect(previewMethod).toContain('renderPass.end()');
     expect(renderMethod).toContain('view.framebuffer ?? frameState.framebuffer');
+    expect(renderMethod).toContain('sessionIntensityScale: number');
     expect(renderMethod).toContain('new Set<Framebuffer>()');
     expect(renderMethod).toContain('!renderedFramebuffers.has(framebuffer)');
     expect(renderMethod).toContain('renderedFramebuffers.add(framebuffer)');
@@ -203,6 +209,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       /this\.xrSessionMode\s*===\s*'immersive-ar'\s*\?\s*\[0,\s*0,\s*0,\s*0\]/
     );
     expect(renderMethod).toContain('getXRViewerHeightLightScale(frameState.viewer.position)');
+    expect(renderMethod).toContain('sessionIntensityScale');
     expect(renderMethod.indexOf('this.preparePortal({')).toBeLessThan(
       renderMethod.indexOf('this.device.beginRenderPass({')
     );
@@ -592,9 +599,16 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(enterMethod).toContain(
       "session.addEventListener('squeezeend', this._xrSqueezeEndListener)"
     );
+    expect(applicationSource).toContain('if (!sessionRenderState.isRenderable)');
+    expect(applicationSource).toContain('this.clearXRInteractionState()');
     expect(applicationSource).toContain(
-      'this.updateXRLocomotion(inputState || [], elapsedTimeMilliseconds)'
+      'const activeInputState = sessionRenderState.acceptsInput ? inputState || [] : []'
     );
+    expect(applicationSource).toContain(
+      'this.updateXRLocomotion(activeInputState, elapsedTimeMilliseconds)'
+    );
+    expect(applicationSource).toContain('sessionRenderState.acceptsInput ? handState || [] : []');
+    expect(applicationSource).toContain('sessionRenderState.intensityScale');
     expect(locomotionMethodStart).toBeGreaterThan(0);
     expect(locomotionMethodEnd).toBeGreaterThan(locomotionMethodStart);
     expect(locomotionMethod).toContain("this.xrSessionMode !== 'immersive-vr'");
@@ -639,10 +653,12 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     );
     expect(clearMethod).toContain('this.xrSceneOffset[0] = 0');
     expect(clearMethod).toContain('this.xrSceneYaw = 0');
-    expect(clearMethod).toContain('this._lastXRLocomotionTimeMilliseconds = null');
-    expect(clearMethod).toContain('this._lastXRSnapTurn = 0');
-    expect(clearMethod).toContain('this._floorHitByInputSource.clear()');
-    expect(clearMethod).toContain('this._inputStateByInputSource.clear()');
+    expect(clearMethod).toContain('this.clearXRInteractionState()');
+    expect(applicationSource).toContain('private clearXRInteractionState(): void');
+    expect(applicationSource).toContain('this._lastXRLocomotionTimeMilliseconds = null');
+    expect(applicationSource).toContain('this._lastXRSnapTurn = 0');
+    expect(applicationSource).toContain('this._floorHitByInputSource.clear()');
+    expect(applicationSource).toContain('this._inputStateByInputSource.clear()');
     expect(applicationSource).toContain(
       "event.key === 'Escape' || event.key.toLowerCase() === 'q'"
     );

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -259,9 +259,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('type WebXRInputState');
     expect(applicationSource).toContain('getWebXRBoundsState');
     expect(applicationSource).toContain('WebXRInputActionManager');
+    expect(applicationSource).toContain('getWebXRControllerRayPlaneIntersection');
     expect(applicationSource).toContain('getWebXRControllerStateByHandedness');
     expect(applicationSource).toContain('getWebXRControllerStates');
-    expect(applicationSource).toContain('getWebXRInputRayPlaneIntersection');
     expect(applicationSource).toContain('getWebXRLocomotionState');
     expect(applicationSource).toContain('getWebXRTeleportTranslation');
     expect(applicationSource).toContain('isPointInWebXRBounds');
@@ -310,7 +310,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethod).toContain('this.controllerRayModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerRayModel.draw(renderPass)');
     expect(rayMethod).toContain(
-      'getWebXRInputRayPlaneIntersection(controllerState.ray, {maxDistance: 8})'
+      'getWebXRControllerRayPlaneIntersection(controllerState, {maxDistance: 8})'
     );
     expect(rayMethod).toContain('boundsState: WebXRBoundsState | null');
     expect(rayMethod).toContain(

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -88,19 +88,13 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
 
     expect(applicationSource).toContain("requiredFeatures: ['webgpu']");
     expect(applicationSource).toContain("'hand-tracking',");
+    expect(applicationSource).toContain('mergeWebXRSessionInit');
+    expect(applicationSource).toContain('getWebXRDOMOverlaySessionInit(domOverlayRoot)');
+    expect(applicationSource).toContain('getWebXRDepthSensingSessionInit(AR_DEPTH_SENSING)');
+    expect(applicationSource).toContain("...(deviceType === 'webgl' ? ['camera-access'] : [])");
     expect(applicationSource).toContain(
-      "const domOverlayFeatures = domOverlayRoot ? ['dom-overlay'] : []"
+      "sessionMode === 'immersive-ar'\n          ? [...arOptionalFeatures, ...baseOptionalFeatures]"
     );
-    expect(applicationSource).toContain(
-      'const domOverlayInit = domOverlayRoot ? {domOverlay: {root: domOverlayRoot}} : {}'
-    );
-    expect(applicationSource).toContain("'depth-sensing',\n              ...domOverlayFeatures,");
-    expect(applicationSource).toContain(
-      ": [...domOverlayFeatures, 'bounded-floor', 'hand-tracking', 'local-floor']"
-    );
-    expect(applicationSource).toContain('optionalFeatures: [...domOverlayFeatures,');
-    expect(applicationSource).toContain('...domOverlayInit');
-    expect(applicationSource).toContain('depthSensing: AR_DEPTH_SENSING');
     expect(applicationSource).toContain('WebXRDOMOverlayManager');
     expect(applicationSource).toContain(
       'readonly webXRDOMOverlayManager = new WebXRDOMOverlayManager()'
@@ -111,7 +105,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     );
     expect(applicationSource).toContain("'light-estimation',");
     expect(applicationSource).toContain("'mesh-detection',");
-    expect(applicationSource).toContain("'plane-detection',");
+    expect(applicationSource).toContain("'plane-detection'");
     expect(applicationSource).toContain('WebXRLightEstimationManager');
     expect(applicationSource).toContain('WebXRMeshDetectionManager');
     expect(applicationSource).toContain('WebXRPlaneDetectionManager');
@@ -436,7 +430,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       'readonly webXRPlaneDetectionManager = new WebXRPlaneDetectionManager({'
     );
     expect(applicationSource).toContain("orientations: ['horizontal']");
-    expect(applicationSource).toContain("'plane-detection',");
+    expect(applicationSource).toContain("'plane-detection'");
     expect(applicationSource).toContain(
       'this.webXRPlaneDetectionManager.getPlaneDetectionState(xrFrame)'
     );

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -9,7 +9,8 @@ import {WgslReflect} from 'wgsl_reflect';
 import {
   applyXRSnapTurn,
   applyXRSceneOffset,
-  getXRLocomotionSceneOffset
+  getXRLocomotionSceneOffset,
+  getXRTeleportTargetState
 } from '../../examples/experimental/webxr-kaleidoscope/app';
 
 const APPLICATION_PATH = path.join(
@@ -194,7 +195,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain('!renderedFramebuffers.has(framebuffer)');
     expect(renderMethod).toContain('renderedFramebuffers.add(framebuffer)');
     expect(renderMethod).toContain(
-      'this.drawControllerTargets(renderPass, view, inputState, time)'
+      'this.drawControllerTargets(renderPass, view, inputState, time, boundsState)'
     );
     expect(renderMethod).toContain('this.drawHandJoints(renderPass, view, handState, time)');
     expect(renderMethod).toMatch(
@@ -210,11 +211,18 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(
       renderMethod.indexOf('renderPass.setParameters({viewport: view.viewport})')
     ).toBeLessThan(renderMethod.indexOf('this.drawPortal(renderPass)'));
+    expect(renderMethod).toContain(
+      'this.drawControllerTargets(renderPass, view, inputState, time, boundsState)'
+    );
     expect(renderMethod.indexOf('this.drawPortal(renderPass)')).toBeLessThan(
-      renderMethod.indexOf('this.drawControllerTargets(renderPass, view, inputState, time)')
+      renderMethod.indexOf(
+        'this.drawControllerTargets(renderPass, view, inputState, time, boundsState)'
+      )
     );
     expect(
-      renderMethod.indexOf('this.drawControllerTargets(renderPass, view, inputState, time)')
+      renderMethod.indexOf(
+        'this.drawControllerTargets(renderPass, view, inputState, time, boundsState)'
+      )
     ).toBeLessThan(renderMethod.indexOf('this.drawHandJoints(renderPass, view, handState, time)'));
     expect(prepareMethod).toContain('this.uniformStore.setUniforms(');
     expect(prepareMethod).toContain('this.device.commandEncoder');
@@ -248,6 +256,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('getWebXRTeleportTranslation');
     expect(applicationSource).toContain('isPointInWebXRBounds');
     expect(applicationSource).toContain('pulseWebXRInputHaptics');
+    expect(applicationSource).toContain('type WebXRBoundsState');
     expect(applicationSource).toContain('this.webXRManager.getInputState(xrFrame)');
     expect(applicationSource).toContain("id: 'immersive-prism-controller-rays'");
     expect(applicationSource).toContain("id: 'immersive-prism-controller-reticles'");
@@ -256,6 +265,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('function makeControllerReticleGeometry()');
     expect(applicationSource).toContain('const segmentCount = 32');
     expect(renderMethod).toContain('inputState: readonly WebXRInputState[]');
+    expect(renderMethod).toContain(
+      'const boundsState = getWebXRBoundsState(this.webXRManager.referenceSpace)'
+    );
     expect(renderMethod).toContain('this._inputStateByInputSource.clear()');
     expect(renderMethod).toContain('this._inputStateByInputSource.set(input.inputSource, input)');
     expect(renderMethod).toContain('renderPass.end()');
@@ -272,15 +284,23 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethod).toContain('this.controllerRayModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerRayModel.draw(renderPass)');
     expect(rayMethod).toContain('getWebXRInputRayPlaneIntersection(inputRay, {maxDistance: 8})');
+    expect(rayMethod).toContain('boundsState: WebXRBoundsState | null');
+    expect(rayMethod).toContain(
+      'const teleportTarget = getXRTeleportTargetState(floorHit.point, boundsState)'
+    );
+    expect(rayMethod).toContain('if (teleportTarget.allowed)');
     expect(rayMethod).toContain(
       'this._floorHitByInputSource.set(input.inputSource, floorHit.point)'
     );
     expect(rayMethod).toContain(
-      'this.controllerReticleMatrix.identity().translate(floorHit.point)'
+      'this.controllerReticleMatrix.identity().translate(teleportTarget.point)'
     );
     expect(rayMethod).toContain('multiplyRight(this.controllerReticleMatrix)');
+    expect(rayMethod).toContain('cameraMix: teleportTarget.allowed ? controllerActivation : -1');
     expect(rayMethod).toContain('this.controllerReticleModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerReticleModel.draw(renderPass)');
+    expect(applicationSource).toContain('let blockedColor = vec3<f32>(1.0, 0.08, 0.10)');
+    expect(applicationSource).toContain('app.cameraMix < 0.0 ? blockedColor : targetColor');
   });
 
   test('renders tracked hand joints from WebXR hand snapshots', () => {
@@ -583,9 +603,12 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(updateModelMethod).toContain('rotateY(this.xrSceneYaw)');
     expect(teleportMethod).toContain('this._floorHitByInputSource.get(inputSource)');
     expect(teleportMethod).toContain('getWebXRBoundsState(this.webXRManager.referenceSpace)');
-    expect(teleportMethod).toContain('!isPointInWebXRBounds(floorHit, boundsState.bounds)');
     expect(teleportMethod).toContain(
-      'this.applyXRSceneOffset(getWebXRTeleportTranslation(floorHit))'
+      'const teleportTarget = getXRTeleportTargetState(floorHit, boundsState)'
+    );
+    expect(teleportMethod).toContain('!teleportTarget.allowed');
+    expect(teleportMethod).toContain(
+      'this.applyXRSceneOffset(getWebXRTeleportTranslation(teleportTarget.point))'
     );
     expect(teleportMethod).toContain('this._inputStateByInputSource.get(inputSource)');
     expect(teleportMethod).toContain(
@@ -617,6 +640,26 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(getXRLocomotionSceneOffset([0, 1], 1, 0, 2)).toEqual([0, 0, -2]);
     expect(getXRLocomotionSceneOffset([0, 1], 1, Math.PI / 2, 2)).toEqual([2, 0, 0]);
     expect(getXRLocomotionSceneOffset([1, 0], 0.5, Math.PI / 2, 2)).toEqual([0, 0, 1]);
+    const boundsState = {
+      bounds: [
+        [-1, 0, -1],
+        [1, 0, -1],
+        [1, 0, 1],
+        [-1, 0, 1]
+      ]
+    } as any;
+    expect(getXRTeleportTargetState([0, 0, 0], boundsState)).toEqual({
+      point: [0, 0, 0],
+      allowed: true
+    });
+    expect(getXRTeleportTargetState([2, 0, 0], boundsState)).toEqual({
+      point: [2, 0, 0],
+      allowed: false
+    });
+    expect(getXRTeleportTargetState([8, 0, 8], null)).toEqual({
+      point: [8, 0, 8],
+      allowed: true
+    });
   });
 
   test('requests isolated XR-compatible website devices while preserving preview fallback', () => {

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -259,7 +259,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('type WebXRInputState');
     expect(applicationSource).toContain('getWebXRBoundsState');
     expect(applicationSource).toContain('WebXRInputActionManager');
-    expect(applicationSource).toContain('getWebXRControllerState');
+    expect(applicationSource).toContain('getWebXRControllerStates');
     expect(applicationSource).toContain('getWebXRInputRayPlaneIntersection');
     expect(applicationSource).toContain('getWebXRLocomotionState');
     expect(applicationSource).toContain('getWebXRTeleportTranslation');
@@ -285,8 +285,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain('this.updateXRInputActions(inputState)');
     expect(rayMethodStart).toBeGreaterThan(0);
     expect(rayMethodEnd).toBeGreaterThan(rayMethodStart);
-    expect(rayMethod).toContain('const controllerState = getWebXRControllerState(input)');
-    expect(rayMethod).toContain('if (!controllerState)');
+    expect(rayMethod).toContain(
+      'for (const controllerState of getWebXRControllerStates(inputState))'
+    );
     expect(rayMethod).toContain('if (controllerState.grip)');
     expect(rayMethod).toContain('this.controllerGripMatrix.copy(controllerState.grip.matrix)');
     expect(rayMethod).toContain(
@@ -314,7 +315,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     );
     expect(rayMethod).toContain('if (teleportTarget.allowed)');
     expect(rayMethod).toContain(
-      'this._floorHitByInputSource.set(input.inputSource, floorHit.point)'
+      'this._floorHitByInputSource.set(controllerState.inputSource, floorHit.point)'
     );
     expect(rayMethod).toContain(
       'this.controllerReticleMatrix.identity().translate(teleportTarget.point)'

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -170,6 +170,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     const rayMethod = applicationSource.slice(rayMethodStart, rayMethodEnd);
 
     expect(applicationSource).toContain('type WebXRInputState');
+    expect(applicationSource).toContain('getWebXRInputRay');
     expect(applicationSource).toContain('this.webXRManager.getInputState(xrFrame)');
     expect(applicationSource).toContain("id: 'immersive-prism-controller-rays'");
     expect(applicationSource).toContain("topology: 'line-list'");
@@ -178,9 +179,10 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain('renderPass.end()');
     expect(rayMethodStart).toBeGreaterThan(0);
     expect(rayMethodEnd).toBeGreaterThan(rayMethodStart);
+    expect(rayMethod).toContain('const inputRay = getWebXRInputRay(input)');
     expect(rayMethod).toContain("input.targetRayMode !== 'tracked-pointer'");
-    expect(rayMethod).toContain('!input.targetRayMatrix');
-    expect(rayMethod).toContain('this.controllerRayMatrix.copy(input.targetRayMatrix)');
+    expect(rayMethod).toContain('!inputRay');
+    expect(rayMethod).toContain('this.controllerRayMatrix.copy(inputRay.matrix)');
     expect(rayMethod).toContain('multiplyRight(this.controllerRayMatrix)');
     expect(rayMethod).toContain('cameraMix: input.selectActive ? 1 : 0');
     expect(rayMethod).toContain('this.controllerRayModel.predraw(this.device.commandEncoder)');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -116,7 +116,10 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('WebXRMeshDetectionManager');
     expect(applicationSource).toContain('WebXRPlaneDetectionManager');
     expect(applicationSource).toContain('WebXRReferenceSpaceManager');
+    expect(applicationSource).toContain('WebXRRenderStateManager');
     expect(applicationSource).toContain('WebXRSessionStateManager');
+    expect(applicationSource).toContain('depthNear: 0.05');
+    expect(applicationSource).toContain('depthFar: 100');
     expect(applicationSource).toContain("targetFrameRate: 'highest'");
     expect(applicationSource).toContain(
       'readonly webXRReferenceSpaceManager = new WebXRReferenceSpaceManager()'
@@ -124,6 +127,8 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain(
       'this.webXRReferenceSpaceManager.setReferenceSpace(this.webXRManager.referenceSpace)'
     );
+    expect(applicationSource).toContain('this.webXRRenderStateManager');
+    expect(applicationSource).toContain('.setSession(session)');
     expect(applicationSource).toContain(
       'this.webXRHandTrackingManager.setSession(session, this.webXRManager.referenceSpace)'
     );
@@ -136,6 +141,8 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('this.webXRHandTrackingManager.clearSession()');
     expect(applicationSource).toContain('this.webXRReferenceSpaceManager.clearReferenceSpace()');
     expect(applicationSource).toContain('this.webXRReferenceSpaceManager.destroy()');
+    expect(applicationSource).toContain('this.webXRRenderStateManager.clearSession()');
+    expect(applicationSource).toContain('this.webXRRenderStateManager.destroy()');
     expect(applicationSource).toContain('this.webXRSessionStateManager.clearSession()');
     expect(applicationSource).toContain('this.webXRSessionStateManager.destroy()');
     expect(applicationSource).toContain(

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -212,6 +212,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('type WebXRInputState');
     expect(applicationSource).toContain('getWebXRInputRay');
     expect(applicationSource).toContain('getWebXRInputRayPlaneIntersection');
+    expect(applicationSource).toContain('pulseWebXRInputHaptics');
     expect(applicationSource).toContain('this.webXRManager.getInputState(xrFrame)');
     expect(applicationSource).toContain("id: 'immersive-prism-controller-rays'");
     expect(applicationSource).toContain("id: 'immersive-prism-controller-reticles'");
@@ -220,6 +221,8 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('function makeControllerReticleGeometry()');
     expect(applicationSource).toContain('const segmentCount = 32');
     expect(renderMethod).toContain('inputState: readonly WebXRInputState[]');
+    expect(renderMethod).toContain('this._inputStateByInputSource.clear()');
+    expect(renderMethod).toContain('this._inputStateByInputSource.set(input.inputSource, input)');
     expect(renderMethod).toContain('renderPass.end()');
     expect(rayMethodStart).toBeGreaterThan(0);
     expect(rayMethodEnd).toBeGreaterThan(rayMethodStart);
@@ -351,6 +354,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
 
     expect(applicationSource).toContain('readonly xrSceneOffset: [number, number, number]');
     expect(applicationSource).toContain('new Map<XRInputSource, [number, number, number]>()');
+    expect(applicationSource).toContain('new Map<XRInputSource, WebXRInputState>()');
     expect(applicationSource).not.toContain(
       'private _xrSelectEndListener = () => void this.exitXR()'
     );
@@ -368,6 +372,10 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(teleportMethod).toContain('this._floorHitByInputSource.get(inputSource)');
     expect(teleportMethod).toContain('this.xrSceneOffset[0] -= floorHit[0]');
     expect(teleportMethod).toContain('this.xrSceneOffset[2] -= floorHit[2]');
+    expect(teleportMethod).toContain('this._inputStateByInputSource.get(inputSource)');
+    expect(teleportMethod).toContain(
+      'void pulseWebXRInputHaptics(inputState, {intensity: 0.5, duration: 45})'
+    );
     expect(teleportMethod).toContain('this._floorHitByInputSource.clear()');
     expect(clearMethod).toContain(
       "session?.removeEventListener('selectend', this._xrSelectEndListener)"
@@ -377,6 +385,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     );
     expect(clearMethod).toContain('this.xrSceneOffset[0] = 0');
     expect(clearMethod).toContain('this._floorHitByInputSource.clear()');
+    expect(clearMethod).toContain('this._inputStateByInputSource.clear()');
     expect(applicationSource).toContain(
       "event.key === 'Escape' || event.key.toLowerCase() === 'q'"
     );
@@ -465,6 +474,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(standaloneSource).toContain('id="webxr-dom-overlay"');
     expect(standaloneSource).toContain('.portal-panel:xr-overlay');
     expect(applicationSource).toContain(
+      'https://chromewebstore.google.com/detail/codex/hehggadaopoacecdllhhajmbjkdcmajg?pli=1'
+    );
+    expect(readFileSync(WEBSITE_EXAMPLES_PATH, 'utf8')).toContain(
       'https://chromewebstore.google.com/detail/codex/hehggadaopoacecdllhhajmbjkdcmajg?pli=1'
     );
     expect(metadataSource).toContain('backends: [webgpu, webgl2]');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -258,7 +258,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
 
     expect(applicationSource).toContain('type WebXRInputState');
     expect(applicationSource).toContain('getWebXRBoundsState');
-    expect(applicationSource).toContain('getWebXRGamepadState');
+    expect(applicationSource).toContain('getWebXRInputActivationState');
     expect(applicationSource).toContain('getWebXRInputGrip');
     expect(applicationSource).toContain('getWebXRInputRay');
     expect(applicationSource).toContain('getWebXRInputRayPlaneIntersection');
@@ -287,17 +287,17 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethodStart).toBeGreaterThan(0);
     expect(rayMethodEnd).toBeGreaterThan(rayMethodStart);
     expect(rayMethod).toContain('const inputSourceState = getWebXRInputSourceState(input)');
+    expect(rayMethod).toContain('const inputActivationState = getWebXRInputActivationState(input)');
     expect(rayMethod).toContain('const inputGrip = getWebXRInputGrip(input)');
     expect(rayMethod).toContain('if (inputSourceState.isController && inputGrip)');
     expect(rayMethod).toContain('this.controllerGripMatrix.copy(inputGrip.matrix)');
     expect(rayMethod).toContain('multiplyRight(this.controllerGripMatrix.copy(inputGrip.matrix))');
-    expect(rayMethod).toContain('cameraMix: input.squeezeActive');
+    expect(rayMethod).toContain('cameraMix: inputActivationState.isSqueezeActive');
     expect(rayMethod).toContain("inputSourceState.handedness === 'right'");
     expect(rayMethod).toContain('this.controllerGripModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerGripModel.draw(renderPass)');
     expect(rayMethod).toContain('const inputRay = getWebXRInputRay(input)');
-    expect(rayMethod).toContain('const gamepadState = getWebXRGamepadState(input)');
-    expect(rayMethod).toContain('gamepadState?.primaryTrigger?.value || 0');
+    expect(rayMethod).toContain('const controllerActivation = inputActivationState.primaryAction');
     expect(rayMethod).toContain('!inputSourceState.usesTrackedPointer');
     expect(rayMethod).toContain('!inputRay');
     expect(rayMethod).toContain('this.controllerRayMatrix.copy(inputRay.matrix)');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -259,7 +259,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('type WebXRInputState');
     expect(applicationSource).toContain('getWebXRBoundsState');
     expect(applicationSource).toContain('WebXRInputActionManager');
-    expect(applicationSource).toContain('getWebXRControllerRayPlaneTarget');
+    expect(applicationSource).toContain('getWebXRControllerRayPlaneTargets');
     expect(applicationSource).toContain('getWebXRControllerStateByHandedness');
     expect(applicationSource).toContain('getWebXRControllerStates');
     expect(applicationSource).toContain('getWebXRLocomotionState');
@@ -290,6 +290,12 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethod).toContain(
       "const dominantControllerState = getWebXRControllerStateByHandedness(controllerStates, 'right')"
     );
+    expect(rayMethod).toContain(
+      'const teleportTargets = getWebXRControllerRayPlaneTargets(controllerStates, {'
+    );
+    expect(rayMethod).toContain('const teleportTargetByInputSource = new Map(');
+    expect(rayMethod).toContain('teleportTargets.map(teleportTarget =>');
+    expect(rayMethod).toContain('teleportTarget.controllerState.inputSource');
     expect(rayMethod).toContain('for (const controllerState of controllerStates)');
     expect(rayMethod).toContain('if (controllerState.grip)');
     expect(rayMethod).toContain('this.controllerGripMatrix.copy(controllerState.grip.matrix)');
@@ -310,7 +316,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethod).toContain('this.controllerRayModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerRayModel.draw(renderPass)');
     expect(rayMethod).toContain(
-      'const teleportTarget = getWebXRControllerRayPlaneTarget(controllerState, {'
+      'const teleportTarget = teleportTargetByInputSource.get(controllerState.inputSource)'
     );
     expect(rayMethod).toContain('maxDistance: 8');
     expect(rayMethod).toContain('bounds: boundsState');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -235,6 +235,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
 
     expect(applicationSource).toContain('type WebXRInputState');
     expect(applicationSource).toContain('getWebXRBoundsState');
+    expect(applicationSource).toContain('getWebXRGamepadState');
     expect(applicationSource).toContain('getWebXRInputRay');
     expect(applicationSource).toContain('getWebXRInputRayPlaneIntersection');
     expect(applicationSource).toContain('isPointInWebXRBounds');
@@ -253,11 +254,13 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethodStart).toBeGreaterThan(0);
     expect(rayMethodEnd).toBeGreaterThan(rayMethodStart);
     expect(rayMethod).toContain('const inputRay = getWebXRInputRay(input)');
+    expect(rayMethod).toContain('const gamepadState = getWebXRGamepadState(input)');
+    expect(rayMethod).toContain('gamepadState?.primaryTrigger?.value || 0');
     expect(rayMethod).toContain("input.targetRayMode !== 'tracked-pointer'");
     expect(rayMethod).toContain('!inputRay');
     expect(rayMethod).toContain('this.controllerRayMatrix.copy(inputRay.matrix)');
     expect(rayMethod).toContain('multiplyRight(this.controllerRayMatrix.copy(inputRay.matrix))');
-    expect(rayMethod).toContain('cameraMix: input.selectActive ? 1 : 0');
+    expect(rayMethod).toContain('cameraMix: controllerActivation');
     expect(rayMethod).toContain('this.controllerRayModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerRayModel.draw(renderPass)');
     expect(rayMethod).toContain('getWebXRInputRayPlaneIntersection(inputRay, {maxDistance: 8})');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -263,6 +263,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('getWebXRControllerRayPlaneTargets');
     expect(applicationSource).toContain('getWebXRControllerStateByHandedness');
     expect(applicationSource).toContain('getWebXRControllerStates');
+    expect(applicationSource).toContain('getWebXRInputStateByInputSource');
     expect(applicationSource).toContain('getWebXRLocomotionState');
     expect(applicationSource).toContain('getWebXRTeleportTranslation');
     expect(applicationSource).toContain('isPointInWebXRBounds');
@@ -281,8 +282,6 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain(
       'const boundsState = getWebXRBoundsState(this.webXRManager.referenceSpace)'
     );
-    expect(renderMethod).toContain('this._inputStateByInputSource.clear()');
-    expect(renderMethod).toContain('this._inputStateByInputSource.set(input.inputSource, input)');
     expect(renderMethod).toContain('renderPass.end()');
     expect(renderMethod).toContain('this.updateXRInputActions(inputState)');
     expect(rayMethodStart).toBeGreaterThan(0);
@@ -597,7 +596,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     );
     expect(applicationSource).toContain('private _lastXRSnapTurn = 0');
     expect(applicationSource).toContain('new Map<XRInputSource, [number, number, number]>()');
-    expect(applicationSource).toContain('new Map<XRInputSource, WebXRInputState>()');
+    expect(applicationSource).not.toContain('new Map<XRInputSource, WebXRInputState>()');
     expect(applicationSource).toContain(
       'readonly webXRInputActionManager = new WebXRInputActionManager()'
     );
@@ -605,9 +604,8 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       'private _xrSelectEndListener = () => void this.exitXR()'
     );
     expect(applicationSource).toContain('private _xrSqueezeEndListener = () => void this.exitXR()');
-    expect(applicationSource).toContain(
-      'this.teleportToInputSource((event as XRInputSourceEvent).inputSource)'
-    );
+    expect(applicationSource).toContain('const xrEvent = event as XRInputSourceEvent');
+    expect(applicationSource).toContain('this.webXRManager.getInputState(xrEvent.frame) || []');
     expect(enterMethod).toContain(
       "session.addEventListener('selectend', this._xrSelectEndListener)"
     );
@@ -655,15 +653,19 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(teleportMethod).toContain(
       'this.applyXRSceneOffset(getWebXRTeleportTranslation(teleportTarget.point))'
     );
-    expect(teleportMethod).toContain('this._inputStateByInputSource.get(inputSource)');
     expect(teleportMethod).toContain(
-      'void pulseWebXRInputHaptics(inputState, {intensity: 0.5, duration: 45})'
+      'const sourceInputState = getWebXRInputStateByInputSource(inputState, inputSource)'
+    );
+    expect(teleportMethod).toContain(
+      'void pulseWebXRInputHaptics(sourceInputState, {intensity: 0.5, duration: 45})'
     );
     expect(teleportMethod).toContain('this._floorHitByInputSource.clear()');
     expect(teleportMethod).toContain('private updateXRInputActions(');
     expect(teleportMethod).toContain('this.webXRInputActionManager.update(inputState)');
     expect(teleportMethod).toContain('actionState.primaryActionEnded');
-    expect(teleportMethod).toContain('this.teleportToInputSource(actionState.inputSource)');
+    expect(teleportMethod).toContain(
+      'this.teleportToInputSource(actionState.inputSource, inputState)'
+    );
     expect(teleportMethod).toContain('actionState.squeezeActionEnded');
     expect(teleportMethod).toContain('void this.exitXR()');
     expect(clearMethod).toContain(
@@ -680,7 +682,6 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('this._lastXRLocomotionTimeMilliseconds = null');
     expect(applicationSource).toContain('this._lastXRSnapTurn = 0');
     expect(applicationSource).toContain('this._floorHitByInputSource.clear()');
-    expect(applicationSource).toContain('this._inputStateByInputSource.clear()');
     expect(applicationSource).toContain(
       "event.key === 'Escape' || event.key.toLowerCase() === 'q'"
     );

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -403,6 +403,8 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
 
     expect(applicationSource).toContain('WebXRHitTestManager');
     expect(applicationSource).toContain('type WebXRHitTestState');
+    expect(applicationSource).toContain('getWebXRHitTestResult');
+    expect(applicationSource).toContain('getWebXRTransientInputHitTestResult');
     expect(applicationSource).toContain('readonly webXRHitTestManager = new WebXRHitTestManager()');
     expect(applicationSource).toContain('this.webXRHitTestManager.getHitTestState(xrFrame)');
     expect(enterMethod).toContain("sessionMode === 'immersive-ar'");
@@ -416,8 +418,10 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       'this.updateModelMatrix(time, true, hitTestState, planeDetectionState, meshDetectionState)'
     );
     expect(updateModelMethod).toContain('const hitTestMatrix =');
-    expect(updateModelMethod).toContain('hitTestState?.transientInput[0]?.results[0]?.matrix');
-    expect(updateModelMethod).toContain('hitTestState?.hits[0]?.matrix');
+    expect(updateModelMethod).toContain(
+      'getWebXRTransientInputHitTestResult(hitTestState)?.matrix'
+    );
+    expect(updateModelMethod).toContain('getWebXRHitTestResult(hitTestState)?.matrix');
     expect(updateModelMethod).toContain("this.xrSessionMode === 'immersive-ar' && hitTestMatrix");
     expect(updateModelMethod).toContain('this.modelMatrix.copy(hitTestMatrix)');
     expect(updateModelMethod).toContain('scale([0.54, 0.54, 0.54])');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -129,7 +129,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain('new Set<Framebuffer>()');
     expect(renderMethod).toContain('!renderedFramebuffers.has(framebuffer)');
     expect(renderMethod).toContain('renderedFramebuffers.add(framebuffer)');
-    expect(renderMethod).toContain('this.drawControllerRays(renderPass, view, inputState, time)');
+    expect(renderMethod).toContain(
+      'this.drawControllerTargets(renderPass, view, inputState, time)'
+    );
     expect(renderMethod).toMatch(
       /this\.xrSessionMode\s*===\s*'immersive-ar'\s*\?\s*\[0,\s*0,\s*0,\s*0\]/
     );
@@ -144,7 +146,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       renderMethod.indexOf('renderPass.setParameters({viewport: view.viewport})')
     ).toBeLessThan(renderMethod.indexOf('this.drawPortal(renderPass)'));
     expect(renderMethod.indexOf('this.drawPortal(renderPass)')).toBeLessThan(
-      renderMethod.indexOf('this.drawControllerRays(renderPass, view, inputState, time)')
+      renderMethod.indexOf('this.drawControllerTargets(renderPass, view, inputState, time)')
     );
     expect(prepareMethod).toContain('this.uniformStore.setUniforms(');
     expect(prepareMethod).toContain('this.device.commandEncoder');
@@ -162,7 +164,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       renderMethodStart
     );
     const renderMethod = applicationSource.slice(renderMethodStart, renderMethodEnd);
-    const rayMethodStart = applicationSource.indexOf('private drawControllerRays(');
+    const rayMethodStart = applicationSource.indexOf('private drawControllerTargets(');
     const rayMethodEnd = applicationSource.indexOf(
       '\n  private updateModelMatrix(',
       rayMethodStart
@@ -171,10 +173,14 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
 
     expect(applicationSource).toContain('type WebXRInputState');
     expect(applicationSource).toContain('getWebXRInputRay');
+    expect(applicationSource).toContain('getWebXRInputRayPlaneIntersection');
     expect(applicationSource).toContain('this.webXRManager.getInputState(xrFrame)');
     expect(applicationSource).toContain("id: 'immersive-prism-controller-rays'");
+    expect(applicationSource).toContain("id: 'immersive-prism-controller-reticles'");
     expect(applicationSource).toContain("topology: 'line-list'");
     expect(applicationSource).toContain('new Float32Array([0, 0, 0, 0, 0, -3.2])');
+    expect(applicationSource).toContain('function makeControllerReticleGeometry()');
+    expect(applicationSource).toContain('const segmentCount = 32');
     expect(renderMethod).toContain('inputState: readonly WebXRInputState[]');
     expect(renderMethod).toContain('renderPass.end()');
     expect(rayMethodStart).toBeGreaterThan(0);
@@ -183,10 +189,17 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethod).toContain("input.targetRayMode !== 'tracked-pointer'");
     expect(rayMethod).toContain('!inputRay');
     expect(rayMethod).toContain('this.controllerRayMatrix.copy(inputRay.matrix)');
-    expect(rayMethod).toContain('multiplyRight(this.controllerRayMatrix)');
+    expect(rayMethod).toContain('multiplyRight(this.controllerRayMatrix.copy(inputRay.matrix))');
     expect(rayMethod).toContain('cameraMix: input.selectActive ? 1 : 0');
     expect(rayMethod).toContain('this.controllerRayModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerRayModel.draw(renderPass)');
+    expect(rayMethod).toContain('getWebXRInputRayPlaneIntersection(inputRay, {maxDistance: 8})');
+    expect(rayMethod).toContain(
+      'this.controllerReticleMatrix.identity().translate(floorHit.point)'
+    );
+    expect(rayMethod).toContain('multiplyRight(this.controllerReticleMatrix)');
+    expect(rayMethod).toContain('this.controllerReticleModel.predraw(this.device.commandEncoder)');
+    expect(rayMethod).toContain('this.controllerReticleModel.draw(renderPass)');
   });
 
   test('requests isolated XR-compatible website devices while preserving preview fallback', () => {

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -259,11 +259,8 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('type WebXRInputState');
     expect(applicationSource).toContain('getWebXRBoundsState');
     expect(applicationSource).toContain('WebXRInputActionManager');
-    expect(applicationSource).toContain('getWebXRInputActivationState');
-    expect(applicationSource).toContain('getWebXRInputGrip');
-    expect(applicationSource).toContain('getWebXRInputRay');
+    expect(applicationSource).toContain('getWebXRControllerState');
     expect(applicationSource).toContain('getWebXRInputRayPlaneIntersection');
-    expect(applicationSource).toContain('getWebXRInputSourceState');
     expect(applicationSource).toContain('getWebXRLocomotionState');
     expect(applicationSource).toContain('getWebXRTeleportTranslation');
     expect(applicationSource).toContain('isPointInWebXRBounds');
@@ -288,26 +285,29 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain('this.updateXRInputActions(inputState)');
     expect(rayMethodStart).toBeGreaterThan(0);
     expect(rayMethodEnd).toBeGreaterThan(rayMethodStart);
-    expect(rayMethod).toContain('const inputSourceState = getWebXRInputSourceState(input)');
-    expect(rayMethod).toContain('const inputActivationState = getWebXRInputActivationState(input)');
-    expect(rayMethod).toContain('const inputGrip = getWebXRInputGrip(input)');
-    expect(rayMethod).toContain('if (inputSourceState.isController && inputGrip)');
-    expect(rayMethod).toContain('this.controllerGripMatrix.copy(inputGrip.matrix)');
-    expect(rayMethod).toContain('multiplyRight(this.controllerGripMatrix.copy(inputGrip.matrix))');
-    expect(rayMethod).toContain('cameraMix: inputActivationState.isSqueezeActive');
-    expect(rayMethod).toContain("inputSourceState.handedness === 'right'");
+    expect(rayMethod).toContain('const controllerState = getWebXRControllerState(input)');
+    expect(rayMethod).toContain('if (!controllerState)');
+    expect(rayMethod).toContain('if (controllerState.grip)');
+    expect(rayMethod).toContain('this.controllerGripMatrix.copy(controllerState.grip.matrix)');
+    expect(rayMethod).toContain(
+      'multiplyRight(this.controllerGripMatrix.copy(controllerState.grip.matrix))'
+    );
+    expect(rayMethod).toContain('cameraMix: controllerState.isSqueezeActive');
+    expect(rayMethod).toContain("controllerState.handedness === 'right'");
     expect(rayMethod).toContain('this.controllerGripModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerGripModel.draw(renderPass)');
-    expect(rayMethod).toContain('const inputRay = getWebXRInputRay(input)');
-    expect(rayMethod).toContain('const controllerActivation = inputActivationState.primaryAction');
-    expect(rayMethod).toContain('!inputSourceState.usesTrackedPointer');
-    expect(rayMethod).toContain('!inputRay');
-    expect(rayMethod).toContain('this.controllerRayMatrix.copy(inputRay.matrix)');
-    expect(rayMethod).toContain('multiplyRight(this.controllerRayMatrix.copy(inputRay.matrix))');
+    expect(rayMethod).toContain('if (!controllerState.ray)');
+    expect(rayMethod).toContain('const controllerActivation = controllerState.primaryAction');
+    expect(rayMethod).toContain('this.controllerRayMatrix.copy(controllerState.ray.matrix)');
+    expect(rayMethod).toContain(
+      'multiplyRight(this.controllerRayMatrix.copy(controllerState.ray.matrix))'
+    );
     expect(rayMethod).toContain('cameraMix: controllerActivation');
     expect(rayMethod).toContain('this.controllerRayModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerRayModel.draw(renderPass)');
-    expect(rayMethod).toContain('getWebXRInputRayPlaneIntersection(inputRay, {maxDistance: 8})');
+    expect(rayMethod).toContain(
+      'getWebXRInputRayPlaneIntersection(controllerState.ray, {maxDistance: 8})'
+    );
     expect(rayMethod).toContain('boundsState: WebXRBoundsState | null');
     expect(rayMethod).toContain(
       'const teleportTarget = getXRTeleportTargetState(floorHit.point, boundsState)'

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -262,6 +262,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('getWebXRInputGrip');
     expect(applicationSource).toContain('getWebXRInputRay');
     expect(applicationSource).toContain('getWebXRInputRayPlaneIntersection');
+    expect(applicationSource).toContain('getWebXRInputSourceState');
     expect(applicationSource).toContain('getWebXRLocomotionState');
     expect(applicationSource).toContain('getWebXRTeleportTranslation');
     expect(applicationSource).toContain('isPointInWebXRBounds');
@@ -285,19 +286,19 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain('renderPass.end()');
     expect(rayMethodStart).toBeGreaterThan(0);
     expect(rayMethodEnd).toBeGreaterThan(rayMethodStart);
+    expect(rayMethod).toContain('const inputSourceState = getWebXRInputSourceState(input)');
     expect(rayMethod).toContain('const inputGrip = getWebXRInputGrip(input)');
-    expect(rayMethod).toContain('if (inputGrip)');
+    expect(rayMethod).toContain('if (inputSourceState.isController && inputGrip)');
     expect(rayMethod).toContain('this.controllerGripMatrix.copy(inputGrip.matrix)');
     expect(rayMethod).toContain('multiplyRight(this.controllerGripMatrix.copy(inputGrip.matrix))');
-    expect(rayMethod).toContain(
-      "cameraMix: input.squeezeActive ? 1 : input.handedness === 'right' ? 0.45 : 0"
-    );
+    expect(rayMethod).toContain('cameraMix: input.squeezeActive');
+    expect(rayMethod).toContain("inputSourceState.handedness === 'right'");
     expect(rayMethod).toContain('this.controllerGripModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerGripModel.draw(renderPass)');
     expect(rayMethod).toContain('const inputRay = getWebXRInputRay(input)');
     expect(rayMethod).toContain('const gamepadState = getWebXRGamepadState(input)');
     expect(rayMethod).toContain('gamepadState?.primaryTrigger?.value || 0');
-    expect(rayMethod).toContain("input.targetRayMode !== 'tracked-pointer'");
+    expect(rayMethod).toContain('!inputSourceState.usesTrackedPointer');
     expect(rayMethod).toContain('!inputRay');
     expect(rayMethod).toContain('this.controllerRayMatrix.copy(inputRay.matrix)');
     expect(rayMethod).toContain('multiplyRight(this.controllerRayMatrix.copy(inputRay.matrix))');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -6,6 +6,7 @@ import {readFileSync} from 'node:fs';
 import path from 'node:path';
 import {describe, expect, test} from 'vitest';
 import {WgslReflect} from 'wgsl_reflect';
+import {applyXRSceneOffset} from '../../examples/experimental/webxr-kaleidoscope/app';
 
 const APPLICATION_PATH = path.join(
   process.cwd(),
@@ -239,6 +240,8 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('getWebXRGamepadState');
     expect(applicationSource).toContain('getWebXRInputRay');
     expect(applicationSource).toContain('getWebXRInputRayPlaneIntersection');
+    expect(applicationSource).toContain('getWebXRLocomotionState');
+    expect(applicationSource).toContain('getWebXRTeleportTranslation');
     expect(applicationSource).toContain('isPointInWebXRBounds');
     expect(applicationSource).toContain('pulseWebXRInputHaptics');
     expect(applicationSource).toContain('this.webXRManager.getInputState(xrFrame)');
@@ -517,10 +520,20 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       teleportMethodStart
     );
     const teleportMethod = applicationSource.slice(teleportMethodStart, teleportMethodEnd);
+    const locomotionMethodStart = applicationSource.indexOf('private updateXRLocomotion(');
+    const locomotionMethodEnd = applicationSource.indexOf(
+      '\n  private preparePortal(',
+      locomotionMethodStart
+    );
+    const locomotionMethod = applicationSource.slice(locomotionMethodStart, locomotionMethodEnd);
     const clearMethodStart = applicationSource.indexOf('private _clearXRSession(');
     const clearMethod = applicationSource.slice(clearMethodStart);
 
     expect(applicationSource).toContain('readonly xrSceneOffset: [number, number, number]');
+    expect(applicationSource).toContain('const XR_LOCOMOTION_SPEED = 1.4');
+    expect(applicationSource).toContain(
+      'private _lastXRLocomotionTimeMilliseconds: number | null = null'
+    );
     expect(applicationSource).toContain('new Map<XRInputSource, [number, number, number]>()');
     expect(applicationSource).toContain('new Map<XRInputSource, WebXRInputState>()');
     expect(applicationSource).not.toContain(
@@ -536,12 +549,24 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(enterMethod).toContain(
       "session.addEventListener('squeezeend', this._xrSqueezeEndListener)"
     );
+    expect(applicationSource).toContain(
+      'this.updateXRLocomotion(inputState || [], elapsedTimeMilliseconds)'
+    );
+    expect(locomotionMethodStart).toBeGreaterThan(0);
+    expect(locomotionMethodEnd).toBeGreaterThan(locomotionMethodStart);
+    expect(locomotionMethod).toContain("this.xrSessionMode !== 'immersive-vr'");
+    expect(locomotionMethod).toContain('getWebXRLocomotionState(inputState');
+    expect(locomotionMethod).toContain('deadzone: 0.22');
+    expect(locomotionMethod).toContain('snapTurnThreshold: 0.86');
+    expect(locomotionMethod).toContain('Math.min(0.05, Math.max(0,');
+    expect(locomotionMethod).toContain('this.applyXRSceneOffset([');
     expect(updateModelMethod).toContain('translate(this.xrSceneOffset)');
     expect(teleportMethod).toContain('this._floorHitByInputSource.get(inputSource)');
     expect(teleportMethod).toContain('getWebXRBoundsState(this.webXRManager.referenceSpace)');
     expect(teleportMethod).toContain('!isPointInWebXRBounds(floorHit, boundsState.bounds)');
-    expect(teleportMethod).toContain('this.xrSceneOffset[0] -= floorHit[0]');
-    expect(teleportMethod).toContain('this.xrSceneOffset[2] -= floorHit[2]');
+    expect(teleportMethod).toContain(
+      'this.applyXRSceneOffset(getWebXRTeleportTranslation(floorHit))'
+    );
     expect(teleportMethod).toContain('this._inputStateByInputSource.get(inputSource)');
     expect(teleportMethod).toContain(
       'void pulseWebXRInputHaptics(inputState, {intensity: 0.5, duration: 45})'
@@ -554,11 +579,16 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       "session?.removeEventListener('squeezeend', this._xrSqueezeEndListener)"
     );
     expect(clearMethod).toContain('this.xrSceneOffset[0] = 0');
+    expect(clearMethod).toContain('this._lastXRLocomotionTimeMilliseconds = null');
     expect(clearMethod).toContain('this._floorHitByInputSource.clear()');
     expect(clearMethod).toContain('this._inputStateByInputSource.clear()');
     expect(applicationSource).toContain(
       "event.key === 'Escape' || event.key.toLowerCase() === 'q'"
     );
+
+    const sceneOffset: [number, number, number] = [1, 2, 3];
+    expect(applyXRSceneOffset(sceneOffset, [-0.5, 0, 1.25])).toBe(sceneOffset);
+    expect(sceneOffset).toEqual([0.5, 2, 4.25]);
   });
 
   test('requests isolated XR-compatible website devices while preserving preview fallback', () => {

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -110,7 +110,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       'readonly webXRHandTrackingManager = new WebXRHandTrackingManager()'
     );
     expect(applicationSource).toContain("'light-estimation',");
+    expect(applicationSource).toContain("'plane-detection',");
     expect(applicationSource).toContain('WebXRLightEstimationManager');
+    expect(applicationSource).toContain('WebXRPlaneDetectionManager');
     expect(applicationSource).toContain(
       'this.webXRHandTrackingManager.setSession(session, this.webXRManager.referenceSpace)'
     );
@@ -324,7 +326,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     );
     expect(enterMethod).toContain('.catch(() => this.webXRHitTestManager.clearSession())');
     expect(renderMethod).toContain('hitTestState: WebXRHitTestState | null');
-    expect(renderMethod).toContain('this.updateModelMatrix(time, true, hitTestState)');
+    expect(renderMethod).toContain(
+      'this.updateModelMatrix(time, true, hitTestState, planeDetectionState)'
+    );
     expect(updateModelMethod).toContain(
       "this.xrSessionMode === 'immersive-ar' && hitTestState?.hits[0]"
     );
@@ -371,6 +375,55 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain('lightIntensity,');
     expect(clearMethod).toContain('this.webXRLightEstimationManager.clearSession()');
     expect(applicationSource).toContain('this.webXRLightEstimationManager.destroy()');
+  });
+
+  test('uses optional AR plane detection as placement fallback', () => {
+    const applicationSource = readFileSync(APPLICATION_PATH, 'utf8');
+    const renderMethodStart = applicationSource.indexOf('private renderXRFrame(');
+    const renderMethodEnd = applicationSource.indexOf(
+      '\n  private preparePortal(',
+      renderMethodStart
+    );
+    const renderMethod = applicationSource.slice(renderMethodStart, renderMethodEnd);
+    const enterMethodStart = applicationSource.indexOf('async enterXR(');
+    const enterMethodEnd = applicationSource.indexOf('\n  async exitAR(', enterMethodStart);
+    const enterMethod = applicationSource.slice(enterMethodStart, enterMethodEnd);
+    const updateModelStart = applicationSource.indexOf('private updateModelMatrix(');
+    const updateModelEnd = applicationSource.indexOf(
+      '\n  private teleportToInputSource(',
+      updateModelStart
+    );
+    const updateModelMethod = applicationSource.slice(updateModelStart, updateModelEnd);
+    const clearMethodStart = applicationSource.indexOf('private _clearXRSession(');
+    const clearMethod = applicationSource.slice(clearMethodStart);
+
+    expect(applicationSource).toContain('type WebXRPlaneDetectionState');
+    expect(applicationSource).toContain('WebXRPlaneDetectionManager');
+    expect(applicationSource).toContain(
+      'readonly webXRPlaneDetectionManager = new WebXRPlaneDetectionManager({'
+    );
+    expect(applicationSource).toContain("orientations: ['horizontal']");
+    expect(applicationSource).toContain("'plane-detection',");
+    expect(applicationSource).toContain(
+      'this.webXRPlaneDetectionManager.getPlaneDetectionState(xrFrame)'
+    );
+    expect(enterMethod).toContain('this.webXRPlaneDetectionManager.setSession(');
+    expect(enterMethod).toContain("orientations: ['horizontal']");
+    expect(renderMethod).toContain('planeDetectionState: WebXRPlaneDetectionState | null');
+    expect(renderMethod).toContain(
+      'this.updateModelMatrix(time, true, hitTestState, planeDetectionState)'
+    );
+    expect(updateModelMethod).toContain(
+      "this.xrSessionMode === 'immersive-ar' && hitTestState?.hits[0]"
+    );
+    expect(updateModelMethod).toContain(
+      "this.xrSessionMode === 'immersive-ar' && planeDetectionState?.planes[0]"
+    );
+    expect(updateModelMethod).toContain(
+      'this.modelMatrix.copy(planeDetectionState.planes[0].matrix)'
+    );
+    expect(clearMethod).toContain('this.webXRPlaneDetectionManager.clearSession()');
+    expect(applicationSource).toContain('this.webXRPlaneDetectionManager.destroy()');
   });
 
   test('uses select for teleport candidates and squeeze or keyboard for exit', () => {

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -110,8 +110,10 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       'readonly webXRHandTrackingManager = new WebXRHandTrackingManager()'
     );
     expect(applicationSource).toContain("'light-estimation',");
+    expect(applicationSource).toContain("'mesh-detection',");
     expect(applicationSource).toContain("'plane-detection',");
     expect(applicationSource).toContain('WebXRLightEstimationManager');
+    expect(applicationSource).toContain('WebXRMeshDetectionManager');
     expect(applicationSource).toContain('WebXRPlaneDetectionManager');
     expect(applicationSource).toContain(
       'this.webXRHandTrackingManager.setSession(session, this.webXRManager.referenceSpace)'
@@ -321,13 +323,11 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('this.webXRHitTestManager.getHitTestState(xrFrame)');
     expect(enterMethod).toContain("sessionMode === 'immersive-ar'");
     expect(enterMethod).toContain('this.webXRHitTestManager');
-    expect(enterMethod).toContain(
-      ".setSession(session, this.webXRManager.referenceSpace, {entityTypes: ['plane', 'point']})"
-    );
+    expect(enterMethod).toContain("entityTypes: ['plane', 'point', 'mesh']");
     expect(enterMethod).toContain('.catch(() => this.webXRHitTestManager.clearSession())');
     expect(renderMethod).toContain('hitTestState: WebXRHitTestState | null');
     expect(renderMethod).toContain(
-      'this.updateModelMatrix(time, true, hitTestState, planeDetectionState)'
+      'this.updateModelMatrix(time, true, hitTestState, planeDetectionState, meshDetectionState)'
     );
     expect(updateModelMethod).toContain(
       "this.xrSessionMode === 'immersive-ar' && hitTestState?.hits[0]"
@@ -411,7 +411,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(enterMethod).toContain("orientations: ['horizontal']");
     expect(renderMethod).toContain('planeDetectionState: WebXRPlaneDetectionState | null');
     expect(renderMethod).toContain(
-      'this.updateModelMatrix(time, true, hitTestState, planeDetectionState)'
+      'this.updateModelMatrix(time, true, hitTestState, planeDetectionState, meshDetectionState)'
     );
     expect(updateModelMethod).toContain(
       "this.xrSessionMode === 'immersive-ar' && hitTestState?.hits[0]"
@@ -424,6 +424,57 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     );
     expect(clearMethod).toContain('this.webXRPlaneDetectionManager.clearSession()');
     expect(applicationSource).toContain('this.webXRPlaneDetectionManager.destroy()');
+  });
+
+  test('uses optional AR mesh detection as final placement fallback', () => {
+    const applicationSource = readFileSync(APPLICATION_PATH, 'utf8');
+    const renderMethodStart = applicationSource.indexOf('private renderXRFrame(');
+    const renderMethodEnd = applicationSource.indexOf(
+      '\n  private preparePortal(',
+      renderMethodStart
+    );
+    const renderMethod = applicationSource.slice(renderMethodStart, renderMethodEnd);
+    const enterMethodStart = applicationSource.indexOf('async enterXR(');
+    const enterMethodEnd = applicationSource.indexOf('\n  async exitAR(', enterMethodStart);
+    const enterMethod = applicationSource.slice(enterMethodStart, enterMethodEnd);
+    const updateModelStart = applicationSource.indexOf('private updateModelMatrix(');
+    const updateModelEnd = applicationSource.indexOf(
+      '\n  private teleportToInputSource(',
+      updateModelStart
+    );
+    const updateModelMethod = applicationSource.slice(updateModelStart, updateModelEnd);
+    const clearMethodStart = applicationSource.indexOf('private _clearXRSession(');
+    const clearMethod = applicationSource.slice(clearMethodStart);
+
+    expect(applicationSource).toContain('type WebXRMeshDetectionState');
+    expect(applicationSource).toContain('WebXRMeshDetectionManager');
+    expect(applicationSource).toContain(
+      'readonly webXRMeshDetectionManager = new WebXRMeshDetectionManager()'
+    );
+    expect(applicationSource).toContain("'mesh-detection',");
+    expect(applicationSource).toContain("entityTypes: ['plane', 'point', 'mesh']");
+    expect(applicationSource).toContain(
+      'this.webXRMeshDetectionManager.getMeshDetectionState(xrFrame)'
+    );
+    expect(enterMethod).toContain('this.webXRMeshDetectionManager.setSession(');
+    expect(renderMethod).toContain('meshDetectionState: WebXRMeshDetectionState | null');
+    expect(renderMethod).toContain(
+      'this.updateModelMatrix(time, true, hitTestState, planeDetectionState, meshDetectionState)'
+    );
+    expect(updateModelMethod).toContain(
+      "this.xrSessionMode === 'immersive-ar' && hitTestState?.hits[0]"
+    );
+    expect(updateModelMethod).toContain(
+      "this.xrSessionMode === 'immersive-ar' && planeDetectionState?.planes[0]"
+    );
+    expect(updateModelMethod).toContain(
+      "this.xrSessionMode === 'immersive-ar' && meshDetectionState?.meshes[0]"
+    );
+    expect(updateModelMethod).toContain(
+      'this.modelMatrix.copy(meshDetectionState.meshes[0].matrix)'
+    );
+    expect(clearMethod).toContain('this.webXRMeshDetectionManager.clearSession()');
+    expect(applicationSource).toContain('this.webXRMeshDetectionManager.destroy()');
   });
 
   test('uses select for teleport candidates and squeeze or keyboard for exit', () => {

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -88,10 +88,15 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
 
     expect(applicationSource).toContain("requiredFeatures: ['webgpu']");
     expect(applicationSource).toContain(
-      "optionalFeatures: ['anchors', 'camera-access', 'hit-test', 'local-floor']"
+      "optionalFeatures: ['anchors', 'camera-access', 'depth-sensing', 'hit-test', 'local-floor']"
     );
     expect(applicationSource).toContain(
-      "sessionMode === 'immersive-ar' ? ['anchors', 'hit-test', 'local-floor'] : ['local-floor']"
+      "? ['anchors', 'depth-sensing', 'hit-test', 'local-floor']"
+    );
+    expect(applicationSource).toContain('depthSensing: AR_DEPTH_SENSING');
+    expect(applicationSource).toContain("usagePreference: ['gpu-optimized', 'cpu-optimized']");
+    expect(applicationSource).toContain(
+      "dataFormatPreference: ['luminance-alpha', 'float32', 'unsigned-short']"
     );
     expect(applicationSource).toMatch(
       /sessionMode\s*===\s*'immersive-ar'\s*&&\s*this\.device\.type\s*===\s*'webgl'/

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -87,12 +87,12 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     const applicationSource = readFileSync(APPLICATION_PATH, 'utf8');
 
     expect(applicationSource).toContain("requiredFeatures: ['webgpu']");
+    expect(applicationSource).toContain("'hand-tracking',");
     expect(applicationSource).toContain(
-      "optionalFeatures: ['anchors', 'camera-access', 'depth-sensing', 'hit-test', 'local-floor']"
+      "? ['anchors', 'depth-sensing', 'hand-tracking', 'hit-test', 'local-floor']"
     );
-    expect(applicationSource).toContain(
-      "? ['anchors', 'depth-sensing', 'hit-test', 'local-floor']"
-    );
+    expect(applicationSource).toContain(": ['hand-tracking', 'local-floor']");
+    expect(applicationSource).toContain(": {optionalFeatures: ['hand-tracking', 'local-floor']}");
     expect(applicationSource).toContain('depthSensing: AR_DEPTH_SENSING');
     expect(applicationSource).toContain("usagePreference: ['gpu-optimized', 'cpu-optimized']");
     expect(applicationSource).toContain(

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -259,6 +259,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('type WebXRInputState');
     expect(applicationSource).toContain('getWebXRBoundsState');
     expect(applicationSource).toContain('WebXRInputActionManager');
+    expect(applicationSource).toContain('getWebXRControllerRayPlaneTargetByInputSource');
     expect(applicationSource).toContain('getWebXRControllerRayPlaneTargets');
     expect(applicationSource).toContain('getWebXRControllerStateByHandedness');
     expect(applicationSource).toContain('getWebXRControllerStates');
@@ -293,9 +294,6 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethod).toContain(
       'const teleportTargets = getWebXRControllerRayPlaneTargets(controllerStates, {'
     );
-    expect(rayMethod).toContain('const teleportTargetByInputSource = new Map(');
-    expect(rayMethod).toContain('teleportTargets.map(teleportTarget =>');
-    expect(rayMethod).toContain('teleportTarget.controllerState.inputSource');
     expect(rayMethod).toContain('for (const controllerState of controllerStates)');
     expect(rayMethod).toContain('if (controllerState.grip)');
     expect(rayMethod).toContain('this.controllerGripMatrix.copy(controllerState.grip.matrix)');
@@ -316,8 +314,10 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethod).toContain('this.controllerRayModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerRayModel.draw(renderPass)');
     expect(rayMethod).toContain(
-      'const teleportTarget = teleportTargetByInputSource.get(controllerState.inputSource)'
+      'const teleportTarget = getWebXRControllerRayPlaneTargetByInputSource('
     );
+    expect(rayMethod).toContain('teleportTargets,');
+    expect(rayMethod).toContain('controllerState.inputSource');
     expect(rayMethod).toContain('maxDistance: 8');
     expect(rayMethod).toContain('bounds: boundsState');
     expect(rayMethod).toContain('boundsState: WebXRBoundsState | null');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -6,7 +6,10 @@ import {readFileSync} from 'node:fs';
 import path from 'node:path';
 import {describe, expect, test} from 'vitest';
 import {WgslReflect} from 'wgsl_reflect';
-import {applyXRSceneOffset} from '../../examples/experimental/webxr-kaleidoscope/app';
+import {
+  applyXRSnapTurn,
+  applyXRSceneOffset
+} from '../../examples/experimental/webxr-kaleidoscope/app';
 
 const APPLICATION_PATH = path.join(
   process.cwd(),
@@ -531,9 +534,12 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
 
     expect(applicationSource).toContain('readonly xrSceneOffset: [number, number, number]');
     expect(applicationSource).toContain('const XR_LOCOMOTION_SPEED = 1.4');
+    expect(applicationSource).toContain('const XR_SNAP_TURN_RADIANS = Math.PI / 8');
+    expect(applicationSource).toContain('xrSceneYaw = 0');
     expect(applicationSource).toContain(
       'private _lastXRLocomotionTimeMilliseconds: number | null = null'
     );
+    expect(applicationSource).toContain('private _lastXRSnapTurn = 0');
     expect(applicationSource).toContain('new Map<XRInputSource, [number, number, number]>()');
     expect(applicationSource).toContain('new Map<XRInputSource, WebXRInputState>()');
     expect(applicationSource).not.toContain(
@@ -558,9 +564,21 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(locomotionMethod).toContain('getWebXRLocomotionState(inputState');
     expect(locomotionMethod).toContain('deadzone: 0.22');
     expect(locomotionMethod).toContain('snapTurnThreshold: 0.86');
+    expect(locomotionMethod).toContain('locomotionState.snapTurn && this._lastXRSnapTurn === 0');
+    expect(locomotionMethod).toContain(
+      'this.xrSceneYaw = applyXRSnapTurn(this.xrSceneYaw, locomotionState.snapTurn)'
+    );
+    expect(locomotionMethod).toContain('locomotionState.turnInputState');
+    expect(locomotionMethod).toContain(
+      'void pulseWebXRInputHaptics(locomotionState.turnInputState'
+    );
+    expect(locomotionMethod).toContain('intensity: 0.35');
+    expect(locomotionMethod).toContain('duration: 30');
+    expect(locomotionMethod).toContain('this._lastXRSnapTurn = locomotionState.snapTurn');
     expect(locomotionMethod).toContain('Math.min(0.05, Math.max(0,');
     expect(locomotionMethod).toContain('this.applyXRSceneOffset([');
     expect(updateModelMethod).toContain('translate(this.xrSceneOffset)');
+    expect(updateModelMethod).toContain('rotateY(this.xrSceneYaw)');
     expect(teleportMethod).toContain('this._floorHitByInputSource.get(inputSource)');
     expect(teleportMethod).toContain('getWebXRBoundsState(this.webXRManager.referenceSpace)');
     expect(teleportMethod).toContain('!isPointInWebXRBounds(floorHit, boundsState.bounds)');
@@ -579,7 +597,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       "session?.removeEventListener('squeezeend', this._xrSqueezeEndListener)"
     );
     expect(clearMethod).toContain('this.xrSceneOffset[0] = 0');
+    expect(clearMethod).toContain('this.xrSceneYaw = 0');
     expect(clearMethod).toContain('this._lastXRLocomotionTimeMilliseconds = null');
+    expect(clearMethod).toContain('this._lastXRSnapTurn = 0');
     expect(clearMethod).toContain('this._floorHitByInputSource.clear()');
     expect(clearMethod).toContain('this._inputStateByInputSource.clear()');
     expect(applicationSource).toContain(
@@ -589,6 +609,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     const sceneOffset: [number, number, number] = [1, 2, 3];
     expect(applyXRSceneOffset(sceneOffset, [-0.5, 0, 1.25])).toBe(sceneOffset);
     expect(sceneOffset).toEqual([0.5, 2, 4.25]);
+    expect(applyXRSnapTurn(0.25, 1, 0.5)).toBe(0.75);
+    expect(applyXRSnapTurn(0.25, -1, 0.5)).toBe(-0.25);
+    expect(applyXRSnapTurn(0.25, 0, 0.5)).toBe(0.25);
   });
 
   test('requests isolated XR-compatible website devices while preserving preview fallback', () => {

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -89,11 +89,27 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain("requiredFeatures: ['webgpu']");
     expect(applicationSource).toContain("'hand-tracking',");
     expect(applicationSource).toContain(
-      "? ['anchors', 'depth-sensing', 'hand-tracking', 'hit-test', 'local-floor']"
+      "const domOverlayFeatures = domOverlayRoot ? ['dom-overlay'] : []"
     );
-    expect(applicationSource).toContain(": ['hand-tracking', 'local-floor']");
-    expect(applicationSource).toContain(": {optionalFeatures: ['hand-tracking', 'local-floor']}");
+    expect(applicationSource).toContain(
+      'const domOverlayInit = domOverlayRoot ? {domOverlay: {root: domOverlayRoot}} : {}'
+    );
+    expect(applicationSource).toContain("'depth-sensing',\n              ...domOverlayFeatures,");
+    expect(applicationSource).toContain(
+      ": [...domOverlayFeatures, 'hand-tracking', 'local-floor']"
+    );
+    expect(applicationSource).toContain('optionalFeatures: [...domOverlayFeatures,');
+    expect(applicationSource).toContain('...domOverlayInit');
     expect(applicationSource).toContain('depthSensing: AR_DEPTH_SENSING');
+    expect(applicationSource).toContain('WebXRDOMOverlayManager');
+    expect(applicationSource).toContain(
+      'readonly webXRDOMOverlayManager = new WebXRDOMOverlayManager()'
+    );
+    expect(applicationSource).toContain(
+      'this.webXRDOMOverlayManager.setSession(session, {root: getDOMOverlayRoot()})'
+    );
+    expect(applicationSource).toContain('this.webXRDOMOverlayManager.clearSession()');
+    expect(applicationSource).toContain('function getDOMOverlayRoot(): Element | null');
     expect(applicationSource).toContain("usagePreference: ['gpu-optimized', 'cpu-optimized']");
     expect(applicationSource).toContain(
       "dataFormatPreference: ['luminance-alpha', 'float32', 'unsigned-short']"
@@ -323,6 +339,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(exampleSource).toMatch(/\s+xrCompatible(?:\s|=)/);
     expect(exampleSource).toContain('native stereo projection layers when supported');
     expect(exampleSource).toContain('choose WebGL2 for immersive fallback');
+    expect(exampleSource).toContain('id="webxr-dom-overlay"');
     expect(wrapperSource).toContain('xrCompatible?: boolean');
     expect(wrapperSource).toContain('props.xrCompatible === true');
     expect(wrapperSource).toContain('continuing with desktop preview');
@@ -368,6 +385,8 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(standaloneSource).toContain("toggleSession('immersive-vr')");
     expect(standaloneSource).toContain("toggleSession('immersive-ar')");
     expect(standaloneSource).toContain('switch-backend');
+    expect(standaloneSource).toContain('id="webxr-dom-overlay"');
+    expect(standaloneSource).toContain('.portal-panel:xr-overlay');
     expect(applicationSource).toContain(
       'https://chromewebstore.google.com/detail/codex/hehggadaopoacecdllhhajmbjkdcmajg?pli=1'
     );

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -414,14 +414,27 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain('static subscribeToCurrent(listener: () => void)');
     expect(applicationSource).toContain('AppAnimationLoopTemplate.setCurrent(this)');
     expect(applicationSource).toContain('AppAnimationLoopTemplate.setCurrent(null)');
+    expect(applicationSource).toContain('private static notifyCurrentListeners(): void');
+    expect(applicationSource).toContain('AppAnimationLoopTemplate.notifyCurrentListeners()');
     expect(exampleSource).toContain('useSyncExternalStore(');
     expect(exampleSource).toContain('WebXRKaleidoscopeApp.subscribeToCurrent');
+    expect(exampleSource).toContain(
+      'const activeXRMode = activeApplication?.xrSessionMode ?? null'
+    );
+    expect(exampleSource).toContain(
+      'const isXRLive = Boolean(activeApplication?.xrSession && activeXRMode)'
+    );
     expect(exampleSource).toContain('const effectiveDevice = activeApplication?.device');
     expect(exampleSource).toContain('selectedDevice?.type === effectiveDevice?.type');
     expect(exampleSource).toContain('effectiveDevice?.props.xrCompatible === true');
     expect(exampleSource).toMatch(
       /const backendDescription\s*=\s*usesWebGPU\s*\?\s*hasNativeWebGPUXR/
     );
+    expect(exampleSource).toContain('const handleExitXR = async () =>');
+    expect(exampleSource).toContain('await app.exitXR()');
+    expect(exampleSource).toContain('Exit XR');
+    expect(exampleSource).toContain('disabled={xrStatus ===');
+    expect(exampleSource).toContain('isXRLive');
   });
 
   test('keeps standalone launch, sidebar, and backend metadata accurate', () => {
@@ -441,6 +454,13 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     );
     expect(standaloneSource).toContain("toggleSession('immersive-vr')");
     expect(standaloneSource).toContain("toggleSession('immersive-ar')");
+    expect(standaloneSource).toContain('id="exit-xr"');
+    expect(standaloneSource).toContain("function updateSessionControls(message = '')");
+    expect(standaloneSource).toContain('exitXRButton.hidden = !isLive');
+    expect(standaloneSource).toContain('enterVRButton.disabled = isLive');
+    expect(standaloneSource).toContain('switchBackendButton.disabled = isLive');
+    expect(standaloneSource).toContain("exitXRButton.addEventListener('click'");
+    expect(standaloneSource).toContain('AnimationLoopTemplate.subscribeToCurrent');
     expect(standaloneSource).toContain('switch-backend');
     expect(standaloneSource).toContain('id="webxr-dom-overlay"');
     expect(standaloneSource).toContain('.portal-panel:xr-overlay');

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -88,10 +88,10 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
 
     expect(applicationSource).toContain("requiredFeatures: ['webgpu']");
     expect(applicationSource).toContain(
-      "optionalFeatures: ['camera-access', 'hit-test', 'local-floor']"
+      "optionalFeatures: ['anchors', 'camera-access', 'hit-test', 'local-floor']"
     );
     expect(applicationSource).toContain(
-      "sessionMode === 'immersive-ar' ? ['hit-test', 'local-floor'] : ['local-floor']"
+      "sessionMode === 'immersive-ar' ? ['anchors', 'hit-test', 'local-floor'] : ['local-floor']"
     );
     expect(applicationSource).toMatch(
       /sessionMode\s*===\s*'immersive-ar'\s*&&\s*this\.device\.type\s*===\s*'webgl'/

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -105,10 +105,18 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(applicationSource).toContain(
       'readonly webXRDOMOverlayManager = new WebXRDOMOverlayManager()'
     );
+    expect(applicationSource).toContain('WebXRHandTrackingManager');
+    expect(applicationSource).toContain(
+      'readonly webXRHandTrackingManager = new WebXRHandTrackingManager()'
+    );
+    expect(applicationSource).toContain(
+      'this.webXRHandTrackingManager.setSession(session, this.webXRManager.referenceSpace)'
+    );
     expect(applicationSource).toContain(
       'this.webXRDOMOverlayManager.setSession(session, {root: getDOMOverlayRoot()})'
     );
     expect(applicationSource).toContain('this.webXRDOMOverlayManager.clearSession()');
+    expect(applicationSource).toContain('this.webXRHandTrackingManager.clearSession()');
     expect(applicationSource).toContain('function getDOMOverlayRoot(): Element | null');
     expect(applicationSource).toContain("usagePreference: ['gpu-optimized', 'cpu-optimized']");
     expect(applicationSource).toContain(
@@ -158,6 +166,7 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod).toContain(
       'this.drawControllerTargets(renderPass, view, inputState, time)'
     );
+    expect(renderMethod).toContain('this.drawHandJoints(renderPass, view, handState, time)');
     expect(renderMethod).toMatch(
       /this\.xrSessionMode\s*===\s*'immersive-ar'\s*\?\s*\[0,\s*0,\s*0,\s*0\]/
     );
@@ -174,6 +183,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(renderMethod.indexOf('this.drawPortal(renderPass)')).toBeLessThan(
       renderMethod.indexOf('this.drawControllerTargets(renderPass, view, inputState, time)')
     );
+    expect(
+      renderMethod.indexOf('this.drawControllerTargets(renderPass, view, inputState, time)')
+    ).toBeLessThan(renderMethod.indexOf('this.drawHandJoints(renderPass, view, handState, time)'));
     expect(prepareMethod).toContain('this.uniformStore.setUniforms(');
     expect(prepareMethod).toContain('this.device.commandEncoder');
     expect(prepareMethod).toContain('this.model.predraw(this.device.commandEncoder)');
@@ -229,6 +241,48 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethod).toContain('multiplyRight(this.controllerReticleMatrix)');
     expect(rayMethod).toContain('this.controllerReticleModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerReticleModel.draw(renderPass)');
+  });
+
+  test('renders tracked hand joints from WebXR hand snapshots', () => {
+    const applicationSource = readFileSync(APPLICATION_PATH, 'utf8');
+    const renderMethodStart = applicationSource.indexOf('private renderXRFrame(');
+    const renderMethodEnd = applicationSource.indexOf(
+      '\n  private preparePortal(',
+      renderMethodStart
+    );
+    const renderMethod = applicationSource.slice(renderMethodStart, renderMethodEnd);
+    const handMethodStart = applicationSource.indexOf('private drawHandJoints(');
+    const handMethodEnd = applicationSource.indexOf(
+      '\n  private updateModelMatrix(',
+      handMethodStart
+    );
+    const handMethod = applicationSource.slice(handMethodStart, handMethodEnd);
+    const clearMethodStart = applicationSource.indexOf('private _clearXRSession(');
+    const clearMethod = applicationSource.slice(clearMethodStart);
+
+    expect(applicationSource).toContain('type WebXRHandTrackingState');
+    expect(applicationSource).toContain('this.webXRHandTrackingManager.getHandsState(');
+    expect(applicationSource).toContain('(inputState || []).map(input => input.inputSource)');
+    expect(applicationSource).toContain("id: 'immersive-prism-hand-joints'");
+    expect(applicationSource).toContain('function makeHandJointGeometry()');
+    expect(applicationSource).toMatch(
+      /new Float32Array\(\[\s*-1,\s*0,\s*0,\s*1,\s*0,\s*0,\s*0,\s*-1,\s*0,\s*0,\s*1,\s*0,\s*0,\s*0,\s*-1,\s*0,\s*0,\s*1\s*\]\)/
+    );
+    expect(renderMethod).toContain('handState: readonly WebXRHandTrackingState[]');
+    expect(renderMethod).toContain('this.drawHandJoints(renderPass, view, handState, time)');
+    expect(handMethodStart).toBeGreaterThan(0);
+    expect(handMethodEnd).toBeGreaterThan(handMethodStart);
+    expect(handMethod).toContain('for (const hand of handState)');
+    expect(handMethod).toContain('for (const joint of hand.joints)');
+    expect(handMethod).toContain('if (!joint.matrix)');
+    expect(handMethod).toContain('Math.max(joint.radius ?? 0.008, 0.006) * 1.8');
+    expect(handMethod).toContain('this.handJointMatrix.copy(joint.matrix)');
+    expect(handMethod).toContain('multiplyRight(this.handJointMatrix)');
+    expect(handMethod).toContain("hand.handedness === 'right' ? 1 : 0");
+    expect(handMethod).toContain('this.handJointModel.predraw(this.device.commandEncoder)');
+    expect(handMethod).toContain('this.handJointModel.draw(renderPass)');
+    expect(clearMethod).toContain('this.webXRHandTrackingManager.clearSession()');
+    expect(applicationSource).toContain('this.webXRHandTrackingManager.destroy()');
   });
 
   test('uses AR hit tests for placement while preserving fallback locomotion', () => {

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -87,7 +87,12 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     const applicationSource = readFileSync(APPLICATION_PATH, 'utf8');
 
     expect(applicationSource).toContain("requiredFeatures: ['webgpu']");
-    expect(applicationSource).toContain("optionalFeatures: ['camera-access', 'local-floor']");
+    expect(applicationSource).toContain(
+      "optionalFeatures: ['camera-access', 'hit-test', 'local-floor']"
+    );
+    expect(applicationSource).toContain(
+      "sessionMode === 'immersive-ar' ? ['hit-test', 'local-floor'] : ['local-floor']"
+    );
     expect(applicationSource).toMatch(
       /sessionMode\s*===\s*'immersive-ar'\s*&&\s*this\.device\.type\s*===\s*'webgl'/
     );
@@ -203,6 +208,47 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethod).toContain('multiplyRight(this.controllerReticleMatrix)');
     expect(rayMethod).toContain('this.controllerReticleModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerReticleModel.draw(renderPass)');
+  });
+
+  test('uses AR hit tests for placement while preserving fallback locomotion', () => {
+    const applicationSource = readFileSync(APPLICATION_PATH, 'utf8');
+    const renderMethodStart = applicationSource.indexOf('private renderXRFrame(');
+    const renderMethodEnd = applicationSource.indexOf(
+      '\n  private preparePortal(',
+      renderMethodStart
+    );
+    const renderMethod = applicationSource.slice(renderMethodStart, renderMethodEnd);
+    const enterMethodStart = applicationSource.indexOf('async enterXR(');
+    const enterMethodEnd = applicationSource.indexOf('\n  async exitAR(', enterMethodStart);
+    const enterMethod = applicationSource.slice(enterMethodStart, enterMethodEnd);
+    const updateModelStart = applicationSource.indexOf('private updateModelMatrix(');
+    const updateModelEnd = applicationSource.indexOf(
+      '\n  private teleportToInputSource(',
+      updateModelStart
+    );
+    const updateModelMethod = applicationSource.slice(updateModelStart, updateModelEnd);
+    const clearMethodStart = applicationSource.indexOf('private _clearXRSession(');
+    const clearMethod = applicationSource.slice(clearMethodStart);
+
+    expect(applicationSource).toContain('WebXRHitTestManager');
+    expect(applicationSource).toContain('type WebXRHitTestState');
+    expect(applicationSource).toContain('readonly webXRHitTestManager = new WebXRHitTestManager()');
+    expect(applicationSource).toContain('this.webXRHitTestManager.getHitTestState(xrFrame)');
+    expect(enterMethod).toContain("sessionMode === 'immersive-ar'");
+    expect(enterMethod).toContain('this.webXRHitTestManager');
+    expect(enterMethod).toContain(
+      ".setSession(session, this.webXRManager.referenceSpace, {entityTypes: ['plane', 'point']})"
+    );
+    expect(enterMethod).toContain('.catch(() => this.webXRHitTestManager.clearSession())');
+    expect(renderMethod).toContain('hitTestState: WebXRHitTestState | null');
+    expect(renderMethod).toContain('this.updateModelMatrix(time, true, hitTestState)');
+    expect(updateModelMethod).toContain(
+      "this.xrSessionMode === 'immersive-ar' && hitTestState?.hits[0]"
+    );
+    expect(updateModelMethod).toContain('this.modelMatrix.copy(hitTestState.hits[0].matrix)');
+    expect(updateModelMethod).toContain('scale([0.54, 0.54, 0.54])');
+    expect(clearMethod).toContain('this.webXRHitTestManager.clearSession()');
+    expect(applicationSource).toContain('this.webXRHitTestManager.destroy()');
   });
 
   test('uses select for teleport candidates and squeeze or keyboard for exit', () => {

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -195,11 +195,67 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
     expect(rayMethod).toContain('this.controllerRayModel.draw(renderPass)');
     expect(rayMethod).toContain('getWebXRInputRayPlaneIntersection(inputRay, {maxDistance: 8})');
     expect(rayMethod).toContain(
+      'this._floorHitByInputSource.set(input.inputSource, floorHit.point)'
+    );
+    expect(rayMethod).toContain(
       'this.controllerReticleMatrix.identity().translate(floorHit.point)'
     );
     expect(rayMethod).toContain('multiplyRight(this.controllerReticleMatrix)');
     expect(rayMethod).toContain('this.controllerReticleModel.predraw(this.device.commandEncoder)');
     expect(rayMethod).toContain('this.controllerReticleModel.draw(renderPass)');
+  });
+
+  test('uses select for teleport candidates and squeeze or keyboard for exit', () => {
+    const applicationSource = readFileSync(APPLICATION_PATH, 'utf8');
+    const enterMethodStart = applicationSource.indexOf('async enterXR(');
+    const enterMethodEnd = applicationSource.indexOf('\n  async exitAR(', enterMethodStart);
+    const enterMethod = applicationSource.slice(enterMethodStart, enterMethodEnd);
+    const updateModelStart = applicationSource.indexOf('private updateModelMatrix(');
+    const updateModelEnd = applicationSource.indexOf(
+      '\n  private teleportToInputSource(',
+      updateModelStart
+    );
+    const updateModelMethod = applicationSource.slice(updateModelStart, updateModelEnd);
+    const teleportMethodStart = applicationSource.indexOf('private teleportToInputSource(');
+    const teleportMethodEnd = applicationSource.indexOf(
+      '\n  private createCameraTexture(',
+      teleportMethodStart
+    );
+    const teleportMethod = applicationSource.slice(teleportMethodStart, teleportMethodEnd);
+    const clearMethodStart = applicationSource.indexOf('private _clearXRSession(');
+    const clearMethod = applicationSource.slice(clearMethodStart);
+
+    expect(applicationSource).toContain('readonly xrSceneOffset: [number, number, number]');
+    expect(applicationSource).toContain('new Map<XRInputSource, [number, number, number]>()');
+    expect(applicationSource).not.toContain(
+      'private _xrSelectEndListener = () => void this.exitXR()'
+    );
+    expect(applicationSource).toContain('private _xrSqueezeEndListener = () => void this.exitXR()');
+    expect(applicationSource).toContain(
+      'this.teleportToInputSource((event as XRInputSourceEvent).inputSource)'
+    );
+    expect(enterMethod).toContain(
+      "session.addEventListener('selectend', this._xrSelectEndListener)"
+    );
+    expect(enterMethod).toContain(
+      "session.addEventListener('squeezeend', this._xrSqueezeEndListener)"
+    );
+    expect(updateModelMethod).toContain('translate(this.xrSceneOffset)');
+    expect(teleportMethod).toContain('this._floorHitByInputSource.get(inputSource)');
+    expect(teleportMethod).toContain('this.xrSceneOffset[0] -= floorHit[0]');
+    expect(teleportMethod).toContain('this.xrSceneOffset[2] -= floorHit[2]');
+    expect(teleportMethod).toContain('this._floorHitByInputSource.clear()');
+    expect(clearMethod).toContain(
+      "session?.removeEventListener('selectend', this._xrSelectEndListener)"
+    );
+    expect(clearMethod).toContain(
+      "session?.removeEventListener('squeezeend', this._xrSqueezeEndListener)"
+    );
+    expect(clearMethod).toContain('this.xrSceneOffset[0] = 0');
+    expect(clearMethod).toContain('this._floorHitByInputSource.clear()');
+    expect(applicationSource).toContain(
+      "event.key === 'Escape' || event.key.toLowerCase() === 'q'"
+    );
   });
 
   test('requests isolated XR-compatible website devices while preserving preview fallback', () => {

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -1741,6 +1741,18 @@ export const WebXRKaleidoscopeExample: React.FC = props => {
                   : 'Drag to explore · headset optional'}
             </span>
           </div>
+          <span style={{fontSize: 12, lineHeight: 1.5}}>
+            Desktop XR testing works with the{' '}
+            <a
+              href="https://chromewebstore.google.com/detail/codex/hehggadaopoacecdllhhajmbjkdcmajg?pli=1"
+              target="_blank"
+              rel="noreferrer"
+              style={{color: '#a5f3fc'}}
+            >
+              Immersive Web Emulator Chrome extension
+            </a>
+            .
+          </span>
           {xrError ? (
             <span role="alert" style={{color: '#fda4af', fontSize: 12, lineHeight: 1.5}}>
               {xrError}

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -1655,6 +1655,7 @@ export const WebXRKaleidoscopeExample: React.FC = props => {
       config={exampleConfig}
       headerControls={
         <div
+          id="webxr-dom-overlay"
           style={{
             background: 'linear-gradient(135deg, rgba(8, 15, 32, 0.96), rgba(15, 23, 42, 0.9))',
             border: '1px solid rgba(103, 232, 249, 0.18)',

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -1572,6 +1572,8 @@ export const WebXRKaleidoscopeExample: React.FC = props => {
   const [xrMode, setXRMode] = useState<XRMode | null>(null);
   const [xrError, setXRError] = useState<string | null>(null);
   const effectiveDevice = activeApplication?.device;
+  const activeXRMode = activeApplication?.xrSessionMode ?? null;
+  const isXRLive = Boolean(activeApplication?.xrSession && activeXRMode);
   const usesWebGPU =
     selectedDevice?.type === 'webgpu' || (!selectedDevice && effectiveDevice?.type === 'webgpu');
   const hasWebGPUBinding = typeof window !== 'undefined' && 'XRGPUBinding' in window;
@@ -1598,12 +1600,12 @@ export const WebXRKaleidoscopeExample: React.FC = props => {
     setXRMode(sessionMode);
     setXRError(null);
     try {
-      if (xrStatus === 'live' && xrMode === sessionMode) {
+      if (app.xrSessionMode === sessionMode) {
         await app.exitXR();
         setXRStatus('idle');
         setXRMode(null);
       } else {
-        if (xrStatus === 'live') {
+        if (app.xrSession) {
           await app.exitXR();
         }
         await app.enterXR(sessionMode);
@@ -1616,13 +1618,32 @@ export const WebXRKaleidoscopeExample: React.FC = props => {
       setXRError(getErrorMessage(error));
     }
   };
+  const handleExitXR = async () => {
+    const app = WebXRKaleidoscopeApp.current;
+    if (!app) {
+      return;
+    }
+
+    setXRStatus('pending');
+    setXRMode(app.xrSessionMode);
+    setXRError(null);
+    try {
+      await app.exitXR();
+      setXRStatus('idle');
+      setXRMode(null);
+    } catch (error) {
+      setXRStatus('error');
+      setXRMode(null);
+      setXRError(getErrorMessage(error));
+    }
+  };
   const getXRButtonText = (sessionMode: XRMode) => {
     const label = sessionMode === 'immersive-vr' ? 'VR' : 'AR';
     if (xrStatus === 'pending' && xrMode === sessionMode) {
       return `Starting ${label}`;
     }
-    if (xrStatus === 'live' && xrMode === sessionMode) {
-      return `Exit ${label}`;
+    if (isXRLive && activeXRMode === sessionMode) {
+      return `${label} active`;
     }
     if (xrStatus === 'error' && xrMode === sessionMode) {
       return `Retry ${label}`;
@@ -1633,7 +1654,7 @@ export const WebXRKaleidoscopeExample: React.FC = props => {
     border: '1px solid rgba(103, 232, 249, 0.4)',
     borderRadius: 999,
     background:
-      xrStatus === 'live' && xrMode === sessionMode
+      isXRLive && activeXRMode === sessionMode
         ? 'rgba(34, 211, 238, 0.24)'
         : 'rgba(15, 23, 42, 0.84)',
     color: '#ecfeff',
@@ -1689,7 +1710,7 @@ export const WebXRKaleidoscopeExample: React.FC = props => {
             <button
               type="button"
               onClick={() => void handleXRSession('immersive-vr')}
-              disabled={xrStatus === 'pending'}
+              disabled={xrStatus === 'pending' || isXRLive}
               style={getXRButtonStyle('immersive-vr')}
             >
               {getXRButtonText('immersive-vr')}
@@ -1697,16 +1718,26 @@ export const WebXRKaleidoscopeExample: React.FC = props => {
             <button
               type="button"
               onClick={() => void handleXRSession('immersive-ar')}
-              disabled={xrStatus === 'pending'}
+              disabled={xrStatus === 'pending' || isXRLive}
               style={getXRButtonStyle('immersive-ar')}
             >
               {getXRButtonText('immersive-ar')}
             </button>
+            {isXRLive ? (
+              <button
+                type="button"
+                onClick={() => void handleExitXR()}
+                disabled={xrStatus === 'pending'}
+                style={getXRButtonStyle(activeXRMode || 'immersive-vr')}
+              >
+                Exit XR
+              </button>
+            ) : null}
             <span aria-live="polite" style={{fontSize: 12, lineHeight: 1.5}}>
               {xrStatus === 'pending'
                 ? `Requesting ${xrMode === 'immersive-ar' ? 'AR' : 'VR'} session`
-                : xrStatus === 'live'
-                  ? `${xrMode === 'immersive-ar' ? 'AR' : 'VR'} session active`
+                : isXRLive
+                  ? `${activeXRMode === 'immersive-ar' ? 'AR' : 'VR'} session active`
                   : 'Drag to explore · headset optional'}
             </span>
           </div>


### PR DESCRIPTION
## Summary

This is the Advanced WebXR API RFC/PoC draft stacked on top of #3091.

It intentionally keeps the broad optional capability surface out of the landable basics PR. The draft includes AR hit tests and anchors, depth sensing, hand tracking and pinch gestures, DOM overlay, layers/media layers, haptics, light estimation, plane/mesh/image tracking, transient input hit tests, and later interaction/locomotion helpers.

## Why

These APIs may be useful, but the current shape is much closer to scene/application-framework territory than core luma.gl rendering infrastructure. This PR is for evaluation, API discussion, and extracting smaller future PRs after the desired luma.gl boundary is clear.

## Validation

- Inherited prior focused WebXR test work from the original stack.
- Not intended to be marked ready until the advanced API boundary is agreed and the PR is slimmed or split further.

## Notes

Draft/RFC only. #3091 is the landable basic API PR; this PR should not block #3091.