### PR TITLE
test(gltf): capture deterministic backend evidence

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,6 +153,67 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  gltf_reference_evidence:
+    name: glTF WebGPU/WebGL2 reference evidence
+    # Ubuntu's CPU-backed WebGPU adapter destroys its device when the bump-material PBR command
+    # buffer is submitted. Use GitHub's fixed M1 runner for trustworthy hardware reference pixels.
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node (with Corepack)
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Enable Corepack / Yarn 4
+        run: |
+          corepack enable
+          corepack prepare yarn@4.13.0 --activate
+          yarn -v
+
+      - name: Cache Yarn Berry artifacts
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.yarn/berry/cache
+            .yarn/install-state.gz
+          key: ${{ runner.os }}-yarn4-${{ hashFiles('yarn.lock', '.yarnrc.yml', 'package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn4-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Cache Playwright Chromium
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-ms-playwright-${{ hashFiles('yarn.lock', 'package.json') }}
+
+      - name: Install Playwright Chromium
+        run: yarn playwright:install
+
+      - name: Test glTF reference tooling
+        run: yarn gltf:reference-evidence:test
+
+      - name: Capture deterministic glTF evidence
+        run: >-
+          yarn gltf:reference-evidence
+          --headless
+          --artifact-base "${RUNNER_TEMP}/gltf-reference"
+
+      - name: Upload glTF reference evidence
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: gltf-reference-evidence
+          path: ${{ runner.temp }}/gltf-reference
+          if-no-files-found: error
+          retention-days: 7
+
   test:
     needs: browser_coverage
     if: ${{ !cancelled() }}

--- a/dev-docs/roadmaps/effects-lighting-materials-roadmap.md
+++ b/dev-docs/roadmaps/effects-lighting-materials-roadmap.md
@@ -82,10 +82,15 @@ remain separate work.
 
 **Priority:** P0. **Owners:** `@luma.gl/gltf`, `@luma.gl/shadertools`, shared test infrastructure.
 
-**Status:** In progress. The executable ledger now derives extension coverage from the runtime
-registry, pins the Khronos Sample Assets and Sample Viewer revisions, records asset-specific license
-sources, and rejects drift between supported extensions and positive fixtures or between unsupported
-required extensions and the negative fixture. Deterministic image and performance artifacts remain.
+**Status:** In progress. [PR #3087](https://github.com/visgl/luma.gl/pull/3087) landed the executable
+ledger: it derives extension coverage from the runtime registry, pins the Khronos Sample Assets and
+Sample Viewer revisions, records asset-specific license sources, and rejects drift between supported
+extensions and positive fixtures or between unsupported required extensions and the negative
+fixture. The current follow-on adds a deterministic, CI-retained WebGPU/WebGL2 capture for the local
+bump-material fixture with explicit camera, lighting, image-tolerance, transfer, CPU, GPU-residency,
+draw, index-reference, and triangle evidence. A pinned Sample Viewer reference frame, the full
+fixture image matrix, and backend-neutral shader-compilation timing remain before this tranche can
+be marked complete.
 
 - Curate pinned, correctly licensed Khronos assets covering every supported material extension,
   compressed geometry, 64+/256-joint rigs, sparse/interleaved accessors, eight-influence skinning,
@@ -120,6 +125,32 @@ stacked dependency [PR #3044](https://github.com/visgl/luma.gl/pull/3044).
 
 **Exit criteria:** the code is on `master`, both graphics backends pass the authored/generated LOD
 fixtures, budgets never silently cull actors, and public capability rows reflect the landed state.
+
+### Tranche 1A — Refresh the Animation Studio and curated asset experience
+
+**Priority:** P1. **Owners:** `@luma.gl/gltf`, showcase infrastructure, retained scene adapters.
+
+**Starting point:** [draft PR #2995](https://github.com/visgl/luma.gl/pull/2995) is still open but is
+based on an obsolete `master`, currently cannot merge, and predates the landed ledger, panel system,
+source-faithful exporter, and animated crowd/LOD work. Refresh it on current `master`; do not merge
+or mechanically rebase the old patch wholesale.
+
+- Preserve its useful user-facing goals: a correctly attributed CC0 `RobotExpressive` fixture;
+  named clip selection, speed, seek, loop, and crossfade controls; facial morph weights; authored
+  cameras; material variants; and independently animated characters on WebGPU and WebGL2.
+- Build the gallery and feature labels from the landed reference ledger (plus an explicitly licensed
+  offline subset where justified), instead of maintaining a second hard-coded compatibility
+  manifest that can drift from runtime support.
+- Reuse the current mixer, crowd, LOD, panel, morph-weight, and export APIs. Audit the old draft's
+  runtime changes against features that have since landed elsewhere, keeping only missing public API
+  or retained-scene/GLB export work.
+- Feed the refreshed studio into the Tranche 0 evidence route and the Tranche 13 diagnostic viewer so
+  its controls, provenance, extension maturity, geometry budgets, and backend behavior stay
+  machine-verifiable.
+
+**Exit criteria:** a replacement PR based on current `master` delivers the studio without duplicate
+runtime abstractions or feature manifests; the real expressive asset and every retained control have
+license/provenance tests, focused WebGPU/WebGL2 coverage, user documentation, and reference evidence.
 
 ### Tranche 2 — Close real glTF codec and primitive compatibility gaps
 
@@ -326,7 +357,7 @@ without claiming complete game-engine functionality.
 
 | Wave | Tranches | Primary outcome |
 | --- | --- | --- |
-| Measure and unblock | 0, 1, 2 | Trustworthy evidence, already-reviewed LOD, and real release-candidate Meshopt assets. |
+| Measure and unblock | 0, 1, 1A, 2 | Trustworthy evidence, landed LOD, a refreshed user-facing Animation Studio, and real release-candidate Meshopt assets. |
 | Improve rendering and character fidelity | 3, 4, 5, 6 | Reference-grade materials, large rigs, GPU morphing, and genuinely GPU-sampled character animation. |
 | Expand full scene workflows | 7, 8, 9 | Layered animation, authored environments/lights, and progressive node/material residency. |
 | Scale mixed-scene GPU rendering | 10, 11 | GPU-driven budgeted skin+morph crowds and seamless mixed mesh/splat documents. |

--- a/examples/showcase/gltf/app.ts
+++ b/examples/showcase/gltf/app.ts
@@ -157,9 +157,10 @@ export default class AppAnimationLoopTemplate extends GLTFCatalogApp {
       this.extensionDemos.map(extensionDemo => extensionDemo.extensionName)
     );
     const storedExtension = window.localStorage[SHOWCASE_EXTENSION_STORAGE_KEY];
-    this.extensionName = activeExtensionNames.has(storedExtension)
-      ? storedExtension
-      : ALL_EXTENSIONS_FILTER;
+    this.extensionName =
+      !this.isReferenceCapture() && activeExtensionNames.has(storedExtension)
+        ? storedExtension
+        : ALL_EXTENSIONS_FILTER;
     this.modelOptions = getModelOptionsForExtension(
       this.extensionName,
       getAllModelOptions(models),
@@ -179,6 +180,9 @@ export default class AppAnimationLoopTemplate extends GLTFCatalogApp {
   }
 
   async getImageBasedLightingEnvironment(): Promise<PBREnvironment | undefined> {
+    if (this.isReferenceCapture()) {
+      return undefined;
+    }
     if (this.imageBasedLightingEnvironment) {
       return this.imageBasedLightingEnvironment;
     }

--- a/examples/showcase/gltf/gltf-catalog-app.ts
+++ b/examples/showcase/gltf/gltf-catalog-app.ts
@@ -5,7 +5,13 @@
 import {load} from '@loaders.gl/core';
 import {GLTFLoader, type GLTFPostprocessed, postProcessGLTF} from '@loaders.gl/gltf';
 import {Color, Device, log, RenderPass} from '@luma.gl/core';
-import {AnimationLoopTemplate, AnimationProps, ModelNode, OrbitControls} from '@luma.gl/engine';
+import {
+  AnimationLoopTemplate,
+  AnimationProps,
+  type Model,
+  ModelNode,
+  OrbitControls
+} from '@luma.gl/engine';
 import {Light, LightingProps, type PBRMaterialUniforms} from '@luma.gl/shadertools';
 import {
   createGLTFAnimatedCrowd,
@@ -16,6 +22,15 @@ import {
 } from '@luma.gl/gltf';
 import {Matrix4} from '@math.gl/core';
 import {GLTF_SAMPLE_ASSETS_MODEL_URL} from './gltf-reference-source';
+import {
+  GLTF_REFERENCE_EVIDENCE_SCHEMA,
+  GLTF_REFERENCE_EVIDENCE_VERSION,
+  getGLTFReferenceCaptureOptions,
+  getGLTFReferenceDrawMetrics,
+  getGLTFReferenceResourceMetrics,
+  type GLTFReferenceCaptureOptions,
+  type GLTFReferenceEvidence
+} from './gltf-reference-evidence';
 
 /* eslint-disable camelcase */
 
@@ -165,6 +180,17 @@ export type GLTFModelReference = {
   fileName?: string;
 };
 
+declare global {
+  interface Window {
+    __lumaGLTFReferenceEvidence?: GLTFReferenceEvidence;
+    __lumaGLTFReferenceError?: string;
+    __lumaGLTFReferenceProgress?: {
+      stage: string;
+      updatedAt: string;
+    };
+  }
+}
+
 export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   static info = INFO_HTML;
 
@@ -193,12 +219,46 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   gltfLoadGeneration: number = 0;
   cleanupCallbacks: Array<() => void> = [];
   modelMetadataCache = new Map<string, Promise<GLTFModelMetadata>>();
+  readonly referenceCaptureOptions: GLTFReferenceCaptureOptions | undefined;
+  referenceModelUrl = '';
+  referenceLoadMetrics?: {
+    loadMilliseconds: number;
+    fetchAndPostprocessMilliseconds: number;
+    scenegraphCreationMilliseconds: number;
+  };
+  referenceFrameCount = 0;
+  referenceFrameCpuMilliseconds = 0;
+  referenceInitialDrawCpuMilliseconds?: number;
+  referenceRenderStage = '';
 
   constructor({device}: AnimationProps) {
     super();
     this.device = device;
+    this.referenceCaptureOptions = getGLTFReferenceCaptureOptions(window.location.search);
     ensureLoadingIndicatorStyles();
     this.options = loadOptions(this.options);
+    if (this.referenceCaptureOptions) {
+      this.options = {
+        ...this.options,
+        autoLOD: false,
+        useModelLights: false,
+        cameraAnimation: false,
+        gltfAnimation: false
+      };
+      delete window.__lumaGLTFReferenceEvidence;
+      delete window.__lumaGLTFReferenceError;
+      delete window.__lumaGLTFReferenceProgress;
+      void this.device.lost.then(loss => {
+        if (this.isFinalized || !this.referenceCaptureOptions) {
+          return;
+        }
+        const message = `WebGPU device lost during glTF reference capture: ${loss.message}`;
+        window.__lumaGLTFReferenceError = message;
+        this.publishReferenceRenderStage('device-lost');
+        log.error(message)();
+      });
+    }
+
     const canvas = this.device.getDefaultCanvasContext().canvas as HTMLCanvasElement;
     this.orbitControls = new OrbitControls(canvas, {
       distance: 1,
@@ -215,12 +275,18 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.cleanupCallbacks.push(() => this.orbitControls.destroy());
 
     const modelStorageKey = this.getModelStorageKey();
-    window.localStorage[modelStorageKey] ??= this.getDefaultModelName();
-    const initialModelName = window.localStorage[modelStorageKey];
+    if (!this.referenceCaptureOptions) {
+      window.localStorage[modelStorageKey] ??= this.getDefaultModelName();
+    }
+    const initialModelName =
+      this.referenceCaptureOptions?.modelName || window.localStorage[modelStorageKey];
 
     this.cleanupCallbacks.push(...setOptionsUI(this.options));
 
-    this.fetchModelList()
+    const modelListPromise = this.referenceCaptureOptions
+      ? Promise.resolve([getReferenceCaptureCatalogModel(this.referenceCaptureOptions)])
+      : this.fetchModelList();
+    modelListPromise
       .then(models => {
         if (this.isFinalized) {
           return;
@@ -231,10 +297,20 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           : models.find(model => model.name === this.getDefaultModelName())?.name ||
             models[0]?.name ||
             initialModelName;
-        window.localStorage[modelStorageKey] = currentModelName;
+        if (!this.referenceCaptureOptions) {
+          window.localStorage[modelStorageKey] = currentModelName;
+        }
         const cleanupModelMenu = this.initializeModelMenus(models, currentModelName);
         this.cleanupCallbacks.push(cleanupModelMenu);
-        this.loadGLTF(currentModelName);
+        this.loadGLTF(
+          this.referenceCaptureOptions
+            ? {
+                name: this.referenceCaptureOptions.modelName,
+                variant: this.referenceCaptureOptions.variant,
+                fileName: this.referenceCaptureOptions.fileName
+              }
+            : currentModelName
+        );
       })
       .catch(error => {
         log.error(
@@ -251,6 +327,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   onFinalize() {
     this.isFinalized = true;
     this.gltfLoadGeneration++;
+    delete window.__lumaGLTFReferenceEvidence;
+    delete window.__lumaGLTFReferenceError;
     for (const cleanupCallback of this.cleanupCallbacks) {
       cleanupCallback();
     }
@@ -270,6 +348,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
   getDefaultModelName(): string {
     return 'CesiumMan';
+  }
+
+  isReferenceCapture(): boolean {
+    return Boolean(this.referenceCaptureOptions);
   }
 
   getModelStorageKey(): string {
@@ -422,6 +504,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   }
 
   onRender({aspect, device, time}: AnimationProps): void {
+    const frameStartTime = performance.now();
+    let animationCpuMilliseconds = 0;
     const renderPass = device.beginRenderPass({clearColor: this.getClearColor(), clearDepth: 1});
     this.drawBackground(renderPass);
 
@@ -429,6 +513,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       renderPass.end();
       return;
     }
+
+    this.publishReferenceRenderStage('model-frame-started');
 
     updateModelLightIndicator(this.modelLights, this.options['useModelLights']);
     this.orbitControls.setAutoRotate(this.options['cameraAnimation']);
@@ -441,20 +527,42 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         ? Math.sqrt(actorCount - 1) * actorSpacing + this.sceneRadius
         : this.sceneRadius;
     const orbitDistance =
-      this.orbitControls.distance * Math.max(1, crowdRadius / Math.max(this.sceneRadius, 0.001));
+      this.orbitControls.distance *
+      Math.max(1, crowdRadius / Math.max(this.sceneRadius, 0.001)) *
+      (this.referenceCaptureOptions?.distanceMultiplier || 1);
     const far = Math.max(orbitDistance + crowdRadius * 2, 10);
     const near = Math.max(this.sceneRadius / 1000, 0.01);
     const projectionMatrix = new Matrix4().perspective({fovy: Math.PI / 3, aspect, near, far});
-    const cameraPos = this.orbitControls.getEyePosition();
-    const distanceScale = orbitDistance / Math.max(this.orbitControls.distance, 0.001);
-    cameraPos[0] = this.center[0] + (cameraPos[0] - this.center[0]) * distanceScale;
-    cameraPos[1] =
-      this.cameraHeight +
-      (cameraPos[1] - this.cameraHeight) * CAMERA_TILT_HEIGHT_FACTOR * distanceScale;
-    cameraPos[2] = this.center[2] + (cameraPos[2] - this.center[2]) * distanceScale;
+    const orbitControlsCameraPosition = this.orbitControls.getEyePosition();
+    const referenceYaw = this.referenceCaptureOptions?.yaw;
+    const referencePitch = this.referenceCaptureOptions?.pitch;
+    const horizontalOrbitScale = Math.cos(referencePitch || 0);
+    const cameraPos: [number, number, number] =
+      referenceYaw !== undefined && referencePitch !== undefined
+        ? [
+            this.center[0] + orbitDistance * horizontalOrbitScale * Math.sin(referenceYaw),
+            this.cameraHeight +
+              orbitDistance * CAMERA_TILT_HEIGHT_FACTOR * Math.sin(referencePitch),
+            this.center[2] + orbitDistance * horizontalOrbitScale * Math.cos(referenceYaw)
+          ]
+        : [
+            orbitControlsCameraPosition[0],
+            orbitControlsCameraPosition[1],
+            orbitControlsCameraPosition[2]
+          ];
+    if (!this.referenceCaptureOptions) {
+      const distanceScale = orbitDistance / Math.max(this.orbitControls.distance, 0.001);
+      cameraPos[0] = this.center[0] + (cameraPos[0] - this.center[0]) * distanceScale;
+      cameraPos[1] =
+        this.cameraHeight +
+        (cameraPos[1] - this.cameraHeight) * CAMERA_TILT_HEIGHT_FACTOR * distanceScale;
+      cameraPos[2] = this.center[2] + (cameraPos[2] - this.center[2]) * distanceScale;
+    }
 
     if (this.options['gltfAnimation'] && !this.animatedCrowd) {
+      const animationStartTime = performance.now();
       this.scenegraphsFromGLTF.animator?.setTime(time);
+      animationCpuMilliseconds += performance.now() - animationStartTime;
     }
 
     const viewMatrix = new Matrix4().lookAt({eye: cameraPos, center: this.center});
@@ -479,7 +587,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         : undefined;
 
       if (this.options['gltfAnimation']) {
+        const animationStartTime = performance.now();
         this.animatedCrowd.update(deltaSeconds, levelOfDetailView);
+        animationCpuMilliseconds += performance.now() - animationStartTime;
       } else if (levelOfDetailView) {
         this.animatedCrowd.setLODView(levelOfDetailView);
       }
@@ -518,9 +628,23 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         this.animatedCrowd.animationStats
       );
       renderPass.end();
+      this.publishReferenceEvidence({
+        animationCpuMilliseconds,
+        cameraPosition: cameraPos,
+        drawMetrics: {
+          drawCount,
+          submittedIndexReferences: this.animatedCrowd.lodStats.vertices,
+          submittedVertexReferences: 0,
+          triangleCount: this.animatedCrowd.lodStats.triangles
+        },
+        far,
+        frameStartTime,
+        near
+      });
       return;
     }
 
+    const drawnModels: Model[] = [];
     this.scenegraphsFromGLTF.scenes[0].traverse((node, {worldMatrix: modelMatrix}) => {
       const {model} = node as ModelNode;
 
@@ -550,9 +674,123 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       }
 
       model.shaderInputs.setProps(sceneShaderInputProps);
-      model.draw(renderPass);
+      this.publishReferenceRenderStage(`drawing-model:${model.id}`);
+      if (model.draw(renderPass)) {
+        drawnModels.push(model);
+      }
+      this.publishReferenceRenderStage(`drew-model:${model.id}`);
     });
+    this.publishReferenceRenderStage('ending-render-pass');
     renderPass.end();
+    this.publishReferenceRenderStage('render-pass-ended');
+    this.publishReferenceEvidence({
+      animationCpuMilliseconds,
+      cameraPosition: cameraPos,
+      drawMetrics: getGLTFReferenceDrawMetrics(drawnModels),
+      far,
+      frameStartTime,
+      near
+    });
+    this.publishReferenceRenderStage('evidence-published');
+  }
+
+  private publishReferenceRenderStage(stage: string): void {
+    if (
+      !this.referenceCaptureOptions ||
+      this.referenceFrameCount > 0 ||
+      stage === this.referenceRenderStage
+    ) {
+      return;
+    }
+    this.referenceRenderStage = stage;
+    window.__lumaGLTFReferenceProgress = {stage, updatedAt: new Date().toISOString()};
+    log.log(0, `glTF reference render stage: ${stage}`)();
+  }
+
+  private publishReferenceEvidence(options: {
+    animationCpuMilliseconds: number;
+    cameraPosition: [number, number, number];
+    drawMetrics: ReturnType<typeof getGLTFReferenceDrawMetrics>;
+    far: number;
+    frameStartTime: number;
+    near: number;
+  }): void {
+    const captureOptions = this.referenceCaptureOptions;
+    const loadMetrics = this.referenceLoadMetrics;
+    if (!captureOptions || !loadMetrics || !this.scenegraphsFromGLTF || !this.referenceModelUrl) {
+      return;
+    }
+
+    const frameCpuMilliseconds = performance.now() - options.frameStartTime;
+    this.referenceFrameCount++;
+    this.referenceFrameCpuMilliseconds += frameCpuMilliseconds;
+    this.referenceInitialDrawCpuMilliseconds ??= frameCpuMilliseconds;
+
+    const deviceInfo = this.device.info;
+    window.__lumaGLTFReferenceEvidence = {
+      schema: GLTF_REFERENCE_EVIDENCE_SCHEMA,
+      version: GLTF_REFERENCE_EVIDENCE_VERSION,
+      status: 'ready',
+      model: {
+        name: captureOptions.modelName,
+        variant: captureOptions.variant,
+        fileName: captureOptions.fileName,
+        url: this.referenceModelUrl
+      },
+      renderer: {
+        backend: this.device.type,
+        vendor: deviceInfo.vendor,
+        renderer: deviceInfo.renderer,
+        version: deviceInfo.version,
+        gpu: deviceInfo.gpu,
+        gpuType: deviceInfo.gpuType,
+        gpuBackend: deviceInfo.gpuBackend,
+        featureLevel: deviceInfo.featureLevel,
+        shadingLanguage: deviceInfo.shadingLanguage
+      },
+      camera: {
+        yaw: captureOptions.yaw,
+        pitch: captureOptions.pitch,
+        distanceMultiplier: captureOptions.distanceMultiplier,
+        position: options.cameraPosition,
+        target: [this.center[0], this.center[1], this.center[2]],
+        verticalFieldOfViewRadians: Math.PI / 3,
+        near: options.near,
+        far: options.far
+      },
+      rendering: {
+        animation: 'disabled',
+        automaticLevelOfDetail: 'disabled',
+        environment: 'fixed-fallback-lights',
+        exposure: 1,
+        toneMapping: 'none',
+        outputColorSpace: 'srgb'
+      },
+      extensions: Array.from(this.scenegraphsFromGLTF.extensionSupport.values())
+        .map(extension => ({
+          extensionName: extension.extensionName,
+          required: extension.required,
+          supported: extension.supported,
+          supportLevel: extension.supportLevel,
+          standardStatus: extension.standardStatus
+        }))
+        .sort((leftExtension, rightExtension) =>
+          leftExtension.extensionName.localeCompare(rightExtension.extensionName)
+        ),
+      metrics: {
+        frameCount: this.referenceFrameCount,
+        averageFrameCpuMilliseconds: this.referenceFrameCpuMilliseconds / this.referenceFrameCount,
+        animationCpuMilliseconds: options.animationCpuMilliseconds,
+        ...loadMetrics,
+        initialDrawCpuMilliseconds: this.referenceInitialDrawCpuMilliseconds,
+        shaderCompilationMilliseconds: null,
+        shaderCompilationAvailability: 'not-exposed-by-device-api',
+        gpuMemoryBytes: this.device.statsManager.getStats('GPU Time and Memory').get('GPU Memory')
+          .count,
+        resources: getGLTFReferenceResourceMetrics(this.referenceModelUrl),
+        ...options.drawMetrics
+      }
+    };
   }
 
   async fetchModelList(): Promise<GLTFCatalogModel[]> {
@@ -570,6 +808,16 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   }
 
   async loadGLTF(modelReference: string | GLTFModelReference) {
+    const loadStartTime = performance.now();
+    this.referenceModelUrl = '';
+    this.referenceLoadMetrics = undefined;
+    this.referenceFrameCount = 0;
+    this.referenceFrameCpuMilliseconds = 0;
+    this.referenceInitialDrawCpuMilliseconds = undefined;
+    this.referenceRenderStage = '';
+    delete window.__lumaGLTFReferenceEvidence;
+    delete window.__lumaGLTFReferenceError;
+    delete window.__lumaGLTFReferenceProgress;
     const loadGeneration = ++this.gltfLoadGeneration;
     const candidateModelReferences = getModelLoadCandidates(modelReference, this.availableModels);
     const primaryModelReference = candidateModelReferences[0];
@@ -596,7 +844,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         {modelUrl}
       )();
       const processedGLTF = postProcessGLTF(gltf);
+      const fetchAndPostprocessEndTime = performance.now();
 
+      const scenegraphCreationStartTime = performance.now();
       const scenegraphOptions = {
         lights: true,
         imageBasedLightingEnvironment,
@@ -608,6 +858,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         processedGLTF,
         scenegraphOptions
       );
+      const scenegraphCreationEndTime = performance.now();
       log.log(0, `Created glTF scenegraphs: ${modelDescription}`)();
 
       if (this.isLoadStale(loadGeneration)) {
@@ -624,6 +875,12 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.activeScenegraphOptions = scenegraphOptions;
       this.previousCrowdFrameTime = undefined;
       this.modelLights = scenegraphsFromGLTF.lights;
+      this.referenceModelUrl = modelUrl;
+      this.referenceLoadMetrics = {
+        loadMilliseconds: scenegraphCreationEndTime - loadStartTime,
+        fetchAndPostprocessMilliseconds: fetchAndPostprocessEndTime - loadStartTime,
+        scenegraphCreationMilliseconds: scenegraphCreationEndTime - scenegraphCreationStartTime
+      };
       updateCrowdInfo();
       this.updateModelInfo(
         resolvedModelReference,
@@ -652,6 +909,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         return;
       }
       log.error(`Failed to load glTF model: ${modelDescription}`, error)();
+      if (this.referenceCaptureOptions) {
+        window.__lumaGLTFReferenceError = error instanceof Error ? error.message : String(error);
+      }
       showError(error);
     } finally {
       if (!this.isLoadStale(loadGeneration)) {
@@ -675,6 +935,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   ): void {
     const catalogModel = this.availableModels.find(model => model.name === modelReference.name);
     updateModelInfoBox(catalogModel, modelReference, actionNames);
+    if (this.referenceCaptureOptions) {
+      return;
+    }
 
     void this.fetchModelMetadata(modelReference.name).then(modelMetadata => {
       if (this.isLoadStale(loadGeneration)) {
@@ -709,6 +972,21 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
     return this.modelMetadataCache.get(modelName)!;
   }
+}
+
+function getReferenceCaptureCatalogModel(
+  captureOptions: GLTFReferenceCaptureOptions
+): GLTFCatalogModel {
+  if (captureOptions.modelName === BUMP_MATERIAL_CATALOG_MODEL.name) {
+    return BUMP_MATERIAL_CATALOG_MODEL;
+  }
+
+  return {
+    label: captureOptions.modelName,
+    name: captureOptions.modelName,
+    hasGLBVariant: captureOptions.variant === 'glTF-Binary',
+    variants: {[captureOptions.variant]: captureOptions.fileName}
+  };
 }
 
 function setModelMenu(
@@ -1310,6 +1588,10 @@ function getModelLightSummary(modelLights: Light[]): string {
   return Object.entries(lightCounts)
     .map(([lightType, count]) => `${count} ${lightType}`)
     .join(', ');
+}
+
+function clampNumber(value: number, minValue: number, maxValue: number): number {
+  return Math.min(Math.max(value, minValue), maxValue);
 }
 
 function destroyScenegraphs(scenegraphsFromGLTF?: ReturnType<typeof createScenegraphsFromGLTF>) {

--- a/examples/showcase/gltf/gltf-reference-evidence.ts
+++ b/examples/showcase/gltf/gltf-reference-evidence.ts
@@ -1,0 +1,201 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {PrimitiveTopology} from '@luma.gl/core';
+
+export const GLTF_REFERENCE_EVIDENCE_SCHEMA = 'luma.gl/gltf-reference-evidence';
+export const GLTF_REFERENCE_EVIDENCE_VERSION = 1;
+
+export type GLTFReferenceCaptureOptions = {
+  modelName: string;
+  variant: string;
+  fileName: string;
+  yaw: number;
+  pitch: number;
+  distanceMultiplier: number;
+};
+
+export type GLTFReferenceModelDraw = {
+  topology: PrimitiveTopology;
+  isInstanced?: boolean;
+  instanceCount: number;
+  vertexCount: number;
+  indexCount?: number;
+  indexBuffer: {byteLength: number; indexType?: 'uint16' | 'uint32'} | null;
+};
+
+export type GLTFReferenceDrawMetrics = {
+  drawCount: number;
+  submittedIndexReferences: number;
+  submittedVertexReferences: number;
+  triangleCount: number;
+};
+
+export type GLTFReferenceResourceMetrics = {
+  requestCount: number;
+  transferBytes: number;
+  encodedBodyBytes: number;
+  decodedBodyBytes: number;
+};
+
+export type GLTFReferenceEvidence = {
+  schema: typeof GLTF_REFERENCE_EVIDENCE_SCHEMA;
+  version: typeof GLTF_REFERENCE_EVIDENCE_VERSION;
+  status: 'ready';
+  model: {
+    name: string;
+    variant: string;
+    fileName: string;
+    url: string;
+  };
+  renderer: {
+    backend: string;
+    vendor: string;
+    renderer: string;
+    version: string;
+    gpu: string;
+    gpuType: string;
+    gpuBackend?: string;
+    featureLevel?: string;
+    shadingLanguage: string;
+  };
+  camera: {
+    yaw: number;
+    pitch: number;
+    distanceMultiplier: number;
+    position: [number, number, number];
+    target: [number, number, number];
+    verticalFieldOfViewRadians: number;
+    near: number;
+    far: number;
+  };
+  rendering: {
+    animation: 'disabled';
+    automaticLevelOfDetail: 'disabled';
+    environment: 'fixed-fallback-lights';
+    exposure: 1;
+    toneMapping: 'none';
+    outputColorSpace: 'srgb';
+  };
+  extensions: Array<{
+    extensionName: string;
+    required: boolean;
+    supported: boolean;
+    supportLevel: string;
+    standardStatus?: string;
+  }>;
+  metrics: {
+    frameCount: number;
+    averageFrameCpuMilliseconds: number;
+    animationCpuMilliseconds: number;
+    loadMilliseconds: number;
+    fetchAndPostprocessMilliseconds: number;
+    scenegraphCreationMilliseconds: number;
+    initialDrawCpuMilliseconds: number;
+    shaderCompilationMilliseconds: null;
+    shaderCompilationAvailability: 'not-exposed-by-device-api';
+    gpuMemoryBytes: number;
+    resources: GLTFReferenceResourceMetrics;
+    drawCount: number;
+    submittedIndexReferences: number;
+    submittedVertexReferences: number;
+    triangleCount: number;
+  };
+};
+
+/** Parse the opt-in deterministic capture contract from a URL query string. */
+export function getGLTFReferenceCaptureOptions(
+  search: string
+): GLTFReferenceCaptureOptions | undefined {
+  const searchParameters = new URLSearchParams(search);
+  if (searchParameters.get('gltf-reference') !== '1') {
+    return undefined;
+  }
+
+  const modelName = searchParameters.get('model')?.trim() || 'BumpMaterial';
+  const variant = searchParameters.get('variant')?.trim() || 'glTF';
+  const defaultFileExtension = variant === 'glTF-Binary' ? 'glb' : 'gltf';
+
+  return {
+    modelName,
+    variant,
+    fileName: searchParameters.get('file')?.trim() || `${modelName}.${defaultFileExtension}`,
+    yaw: getFiniteSearchNumber(searchParameters, 'yaw', 0.35),
+    pitch: getFiniteSearchNumber(searchParameters, 'pitch', -0.15),
+    distanceMultiplier: Math.max(0.05, getFiniteSearchNumber(searchParameters, 'distance', 1))
+  };
+}
+
+/** Calculate submitted geometry metrics for models that completed a draw. */
+export function getGLTFReferenceDrawMetrics(
+  drawnModels: readonly GLTFReferenceModelDraw[]
+): GLTFReferenceDrawMetrics {
+  const metrics: GLTFReferenceDrawMetrics = {
+    drawCount: 0,
+    submittedIndexReferences: 0,
+    submittedVertexReferences: 0,
+    triangleCount: 0
+  };
+
+  for (const model of drawnModels) {
+    const instanceCount = model.isInstanced ? model.instanceCount : 1;
+    if (instanceCount <= 0) {
+      continue;
+    }
+
+    const indexCount = model.indexBuffer
+      ? (model.indexCount ??
+        model.indexBuffer.byteLength / (model.indexBuffer.indexType === 'uint32' ? 4 : 2))
+      : 0;
+    const vertexCount = model.indexBuffer ? 0 : model.vertexCount;
+    const submittedElementCount = (indexCount || vertexCount) * instanceCount;
+
+    metrics.drawCount++;
+    metrics.submittedIndexReferences += indexCount * instanceCount;
+    metrics.submittedVertexReferences += vertexCount * instanceCount;
+    metrics.triangleCount += getTriangleCount(model.topology, submittedElementCount);
+  }
+
+  return metrics;
+}
+
+/** Read browser resource-timing bytes for the selected model asset. */
+export function getGLTFReferenceResourceMetrics(modelUrl: string): GLTFReferenceResourceMetrics {
+  const resourceEntries = performance
+    .getEntriesByType('resource')
+    .filter(entry => entry.name === modelUrl) as PerformanceResourceTiming[];
+
+  return resourceEntries.reduce<GLTFReferenceResourceMetrics>(
+    (metrics, entry) => ({
+      requestCount: metrics.requestCount + 1,
+      transferBytes: metrics.transferBytes + entry.transferSize,
+      encodedBodyBytes: metrics.encodedBodyBytes + entry.encodedBodySize,
+      decodedBodyBytes: metrics.decodedBodyBytes + entry.decodedBodySize
+    }),
+    {requestCount: 0, transferBytes: 0, encodedBodyBytes: 0, decodedBodyBytes: 0}
+  );
+}
+
+function getTriangleCount(topology: PrimitiveTopology, submittedElementCount: number): number {
+  if (topology === 'triangle-list') {
+    return Math.floor(submittedElementCount / 3);
+  }
+  if (topology === 'triangle-strip') {
+    return Math.max(0, submittedElementCount - 2);
+  }
+  return 0;
+}
+
+function getFiniteSearchNumber(
+  searchParameters: URLSearchParams,
+  name: string,
+  fallback: number
+): number {
+  const value = searchParameters.get(name);
+  if (value === null || value.trim() === '') {
+    return fallback;
+  }
+  const parsedValue = Number(value);
+  return Number.isFinite(parsedValue) ? parsedValue : fallback;
+}

--- a/examples/showcase/gltf/gltf-reference-ledger.ts
+++ b/examples/showcase/gltf/gltf-reference-ledger.ts
@@ -10,6 +10,8 @@ import {
   GLTF_SAMPLE_ASSETS_MODEL_URL,
   GLTF_SAMPLE_ASSETS_REVISION,
   GLTF_SAMPLE_ASSETS_SOURCE_URL,
+  GLTF_SAMPLE_VIEWER_RELEASE_REVISION,
+  GLTF_SAMPLE_VIEWER_RELEASE_SOURCE_URL,
   GLTF_SAMPLE_VIEWER_REVISION,
   GLTF_SAMPLE_VIEWER_SOURCE_URL
 } from './gltf-reference-source';
@@ -31,6 +33,8 @@ export type GLTFReferenceLedger = {
   sampleAssetsSource: string;
   sampleViewerRevision: string;
   sampleViewerSource: string;
+  sampleViewerReleaseRevision: string;
+  sampleViewerReleaseSource: string;
   extensions: GLTFReferenceLedgerEntry[];
   unsupportedRequiredFixture: {
     assetLocation: string;
@@ -98,6 +102,8 @@ export function getGLTFReferenceLedger(): GLTFReferenceLedger {
     sampleAssetsSource: GLTF_SAMPLE_ASSETS_SOURCE_URL,
     sampleViewerRevision: GLTF_SAMPLE_VIEWER_REVISION,
     sampleViewerSource: GLTF_SAMPLE_VIEWER_SOURCE_URL,
+    sampleViewerReleaseRevision: GLTF_SAMPLE_VIEWER_RELEASE_REVISION,
+    sampleViewerReleaseSource: GLTF_SAMPLE_VIEWER_RELEASE_SOURCE_URL,
     extensions,
     unsupportedRequiredFixture: {
       assetLocation: 'modules/gltf/test/data/UnsupportedRequiredExtensions.gltf',

--- a/examples/showcase/gltf/gltf-reference-source.ts
+++ b/examples/showcase/gltf/gltf-reference-source.ts
@@ -8,6 +8,9 @@ export const GLTF_SAMPLE_ASSETS_REVISION = '723ffc6706725b618b8c14ceb82e3e6904b0
 /** Pinned reference renderer revision used when reference images are captured. */
 export const GLTF_SAMPLE_VIEWER_REVISION = 'f9fce9ee7bc62c5433d2a1bf84be229225c7bd19';
 
+/** Deployment repository commit produced from the pinned Sample Viewer revision. */
+export const GLTF_SAMPLE_VIEWER_RELEASE_REVISION = 'dd024e4726c9e73f3dc87cccb4ab317a5cff7c3d';
+
 export const GLTF_SAMPLE_ASSETS_MODEL_URL = `https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/${GLTF_SAMPLE_ASSETS_REVISION}/Models`;
 
 export const GLTF_SAMPLE_ASSETS_SOURCE_URL = `https://github.com/KhronosGroup/glTF-Sample-Assets/tree/${GLTF_SAMPLE_ASSETS_REVISION}/Models`;
@@ -15,3 +18,5 @@ export const GLTF_SAMPLE_ASSETS_SOURCE_URL = `https://github.com/KhronosGroup/gl
 export const GLTF_SAMPLE_ASSETS_FILE_URL = `https://github.com/KhronosGroup/glTF-Sample-Assets/blob/${GLTF_SAMPLE_ASSETS_REVISION}/Models`;
 
 export const GLTF_SAMPLE_VIEWER_SOURCE_URL = `https://github.com/KhronosGroup/glTF-Sample-Viewer/tree/${GLTF_SAMPLE_VIEWER_REVISION}`;
+
+export const GLTF_SAMPLE_VIEWER_RELEASE_SOURCE_URL = `https://github.com/KhronosGroup/glTF-Sample-Viewer-Release/tree/${GLTF_SAMPLE_VIEWER_RELEASE_REVISION}`;

--- a/modules/core/test/adapter/resources/texture.spec.ts
+++ b/modules/core/test/adapter/resources/texture.spec.ts
@@ -1363,6 +1363,100 @@ test('Texture#copyExternalImage uploads image data on both backends', async t =>
   t.end();
 });
 
+test('WebGPUTexture#copyExternalImage falls back to a CPU upload', async t => {
+  const device = await getWebGPUTestDevice();
+  const texture = device.createTexture({
+    width: 2,
+    height: 1,
+    format: 'rgba8unorm',
+    usage: Texture.COPY_DST | Texture.COPY_SRC | Texture.RENDER
+  });
+  const image = await createImageBitmap(
+    new ImageData(new Uint8ClampedArray([11, 12, 13, 255, 21, 22, 23, 255]), 2, 1)
+  );
+  const queue = (device as Device & {handle: GPUDevice}).handle.queue;
+  const queuePrototype = Object.getPrototypeOf(queue) as GPUQueue;
+  const descriptor = Object.getOwnPropertyDescriptor(queuePrototype, 'copyExternalImageToTexture');
+  const gpuType = device.info.gpuType;
+  let nativeCopyCallCount = 0;
+
+  Object.defineProperty(queuePrototype, 'copyExternalImageToTexture', {
+    configurable: true,
+    value: () => {
+      nativeCopyCallCount++;
+      throw new TypeError('Failed to copy content from external image.');
+    }
+  });
+  device.info.gpuType = 'unknown';
+  try {
+    texture.copyExternalImage({image});
+  } finally {
+    device.info.gpuType = gpuType;
+    if (descriptor) {
+      Object.defineProperty(queuePrototype, 'copyExternalImageToTexture', descriptor);
+    } else {
+      Reflect.deleteProperty(queuePrototype, 'copyExternalImageToTexture');
+    }
+  }
+
+  const result = await readTexturePixels(texture, {width: 2, height: 1});
+  t.deepEquals(
+    result,
+    new Uint8Array([11, 12, 13, 255, 21, 22, 23, 255]),
+    'WebGPU CPU fallback uploads pixel data'
+  );
+  t.equal(nativeCopyCallCount, 1, 'native TypeError path was attempted once');
+
+  image.close();
+  texture.destroy();
+  t.end();
+});
+
+test('WebGPUTexture#copyExternalImage proactively uses CPU upload on CPU adapters', async t => {
+  const device = await getWebGPUTestDevice();
+  const texture = device.createTexture({
+    width: 2,
+    height: 1,
+    format: 'rgba8unorm',
+    usage: Texture.COPY_DST | Texture.COPY_SRC | Texture.RENDER
+  });
+  const image = new ImageData(new Uint8ClampedArray([31, 32, 33, 255, 41, 42, 43, 255]), 2, 1);
+  const queue = (device as Device & {handle: GPUDevice}).handle.queue;
+  const queuePrototype = Object.getPrototypeOf(queue) as GPUQueue;
+  const descriptor = Object.getOwnPropertyDescriptor(queuePrototype, 'copyExternalImageToTexture');
+  const gpuType = device.info.gpuType;
+  let nativeCopyCallCount = 0;
+
+  Object.defineProperty(queuePrototype, 'copyExternalImageToTexture', {
+    configurable: true,
+    value: () => {
+      nativeCopyCallCount++;
+    }
+  });
+  device.info.gpuType = 'cpu';
+  try {
+    texture.copyExternalImage({image});
+  } finally {
+    device.info.gpuType = gpuType;
+    if (descriptor) {
+      Object.defineProperty(queuePrototype, 'copyExternalImageToTexture', descriptor);
+    } else {
+      Reflect.deleteProperty(queuePrototype, 'copyExternalImageToTexture');
+    }
+  }
+
+  const result = await readTexturePixels(texture, {width: 2, height: 1});
+  t.deepEquals(
+    result,
+    new Uint8Array([31, 32, 33, 255, 41, 42, 43, 255]),
+    'CPU adapter fallback uploads pixel data'
+  );
+  t.equal(nativeCopyCallCount, 0, 'unstable native external-image copy was bypassed');
+
+  texture.destroy();
+  t.end();
+});
+
 test('Texture#copyImageData is a compatibility wrapper over writeData', async t => {
   for (const device of await getTestDevices()) {
     const writeDataTexture = device.createTexture({

--- a/modules/gltf/test/gltf/gltf-reference-ledger.node.spec.ts
+++ b/modules/gltf/test/gltf/gltf-reference-ledger.node.spec.ts
@@ -8,6 +8,10 @@ import type {GLTFPostprocessed} from '@loaders.gl/gltf';
 
 import {assertSupportedGLTFExtensions, getRegisteredGLTFExtensions} from '@luma.gl/gltf';
 import {getGLTFReferenceLedger} from '../../../../examples/showcase/gltf/gltf-reference-ledger';
+import {
+  getGLTFReferenceCaptureOptions,
+  getGLTFReferenceDrawMetrics
+} from '../../../../examples/showcase/gltf/gltf-reference-evidence';
 
 describe('glTF reference ledger', () => {
   test('pins the Khronos assets and viewer revisions', () => {
@@ -15,8 +19,10 @@ describe('glTF reference ledger', () => {
 
     expect(ledger.sampleAssetsRevision).toMatch(/^[0-9a-f]{40}$/);
     expect(ledger.sampleViewerRevision).toMatch(/^[0-9a-f]{40}$/);
+    expect(ledger.sampleViewerReleaseRevision).toMatch(/^[0-9a-f]{40}$/);
     expect(ledger.sampleAssetsSource).toContain(ledger.sampleAssetsRevision);
     expect(ledger.sampleViewerSource).toContain(ledger.sampleViewerRevision);
+    expect(ledger.sampleViewerReleaseSource).toContain(ledger.sampleViewerReleaseRevision);
   });
 
   test('provides a licensed positive fixture for every supported extension', () => {
@@ -58,5 +64,46 @@ describe('glTF reference ledger', () => {
     expect(() => assertSupportedGLTFExtensions(fixture)).toThrow(
       `Unsupported required glTF extensions: ${unsupportedExtensionNames.join(', ')}`
     );
+  });
+
+  test('parses deterministic capture options without accepting invalid numeric values', () => {
+    expect(getGLTFReferenceCaptureOptions('?other=1')).toBeUndefined();
+    expect(
+      getGLTFReferenceCaptureOptions(
+        '?gltf-reference=1&model=Triangle&variant=glTF-Binary&file=fixture.glb&yaw=0.5&pitch=bad&distance=0'
+      )
+    ).toEqual({
+      modelName: 'Triangle',
+      variant: 'glTF-Binary',
+      fileName: 'fixture.glb',
+      yaw: 0.5,
+      pitch: -0.15,
+      distanceMultiplier: 0.05
+    });
+  });
+
+  test('counts indexed and non-indexed submitted geometry across instances', () => {
+    expect(
+      getGLTFReferenceDrawMetrics([
+        {
+          topology: 'triangle-list',
+          isInstanced: true,
+          instanceCount: 2,
+          vertexCount: 0,
+          indexBuffer: {byteLength: 12, indexType: 'uint16'}
+        },
+        {
+          topology: 'triangle-strip',
+          instanceCount: 0,
+          vertexCount: 5,
+          indexBuffer: null
+        }
+      ])
+    ).toEqual({
+      drawCount: 2,
+      submittedIndexReferences: 12,
+      submittedVertexReferences: 5,
+      triangleCount: 7
+    });
   });
 });

--- a/modules/webgpu/src/adapter/resources/webgpu-texture.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-texture.ts
@@ -134,26 +134,43 @@ export class WebGPUTexture extends Texture {
   copyExternalImage(options_: CopyExternalImageOptions): {width: number; height: number} {
     const options = this._normalizeCopyExternalImageOptions(options_);
 
+    // Chromium's software WebGPU adapters can accept an external-image copy and then lose the
+    // device asynchronously. Use the deterministic CPU upload for supported RGBA8 images before
+    // issuing that unstable queue operation; hardware adapters retain the native fast path.
+    if (this.device.info.gpuType === 'cpu' && this._copyExternalImageData(options)) {
+      return {width: options.width, height: options.height};
+    }
+
     this.device.pushErrorScope('validation');
-    this.device.handle.queue.copyExternalImageToTexture(
-      // source: GPUImageCopyExternalImage
-      {
-        source: options.image,
-        origin: [options.sourceX, options.sourceY],
-        flipY: false // options.flipY
-      },
-      // destination: GPUImageCopyTextureTagged
-      {
-        texture: this.handle,
-        origin: [options.x, options.y, options.z],
-        mipLevel: options.mipLevel,
-        aspect: options.aspect,
-        colorSpace: options.colorSpace,
-        premultipliedAlpha: options.premultipliedAlpha
-      },
-      // copySize: GPUExtent3D
-      [options.width, options.height, options.depth] // depth is always 1 for 2D textures
-    );
+    try {
+      this.device.handle.queue.copyExternalImageToTexture(
+        // source: GPUImageCopyExternalImage
+        {
+          source: options.image,
+          origin: [options.sourceX, options.sourceY],
+          flipY: false // options.flipY
+        },
+        // destination: GPUImageCopyTextureTagged
+        {
+          texture: this.handle,
+          origin: [options.x, options.y, options.z],
+          mipLevel: options.mipLevel,
+          aspect: options.aspect,
+          colorSpace: options.colorSpace,
+          premultipliedAlpha: options.premultipliedAlpha
+        },
+        // copySize: GPUExtent3D
+        [options.width, options.height, options.depth] // depth is always 1 for 2D textures
+      );
+    } catch (error) {
+      // Chromium can reject ImageBitmap uploads on software WebGPU adapters. Preserve the native
+      // path for normal devices, but fall back to a CPU upload for the common RGBA8 case.
+      this.device.popErrorScope(() => {});
+      if (!(error instanceof TypeError) || !this._copyExternalImageData(options)) {
+        throw error;
+      }
+      return {width: options.width, height: options.height};
+    }
     this.device.popErrorScope((error: GPUError) => {
       this.device.reportError(new Error(`copyExternalImage: ${error.message}`), this)();
       this.device.debug();
@@ -161,6 +178,33 @@ export class WebGPUTexture extends Texture {
 
     // TODO - should these be clipped to the texture size minus x,y,z?
     return {width: options.width, height: options.height};
+  }
+
+  private _copyExternalImageData(options: Required<CopyExternalImageOptions>): boolean {
+    if (
+      (this.format !== 'rgba8unorm' && this.format !== 'rgba8unorm-srgb') ||
+      options.depth !== 1 ||
+      options.aspect !== 'all'
+    ) {
+      return false;
+    }
+
+    const data = getExternalImageData(options);
+    if (!data) {
+      return false;
+    }
+
+    this.writeData(data, {
+      x: options.x,
+      y: options.y,
+      z: options.z,
+      width: options.width,
+      height: options.height,
+      depthOrArrayLayers: 1,
+      mipLevel: options.mipLevel,
+      aspect: options.aspect
+    });
+    return true;
   }
 
   copyElementImage(options_: CopyElementImageOptions): {width: number; height: number} {
@@ -472,5 +516,63 @@ export class WebGPUTexture extends Texture {
       }
     }
     this.view._reinitialize(this);
+  }
+}
+
+function getExternalImageData(
+  options: Required<CopyExternalImageOptions>
+): Uint8ClampedArray | null {
+  const canvas =
+    typeof OffscreenCanvas !== 'undefined'
+      ? new OffscreenCanvas(options.width, options.height)
+      : typeof document !== 'undefined'
+        ? document.createElement('canvas')
+        : null;
+  if (!canvas) {
+    return null;
+  }
+  canvas.width = options.width;
+  canvas.height = options.height;
+
+  const context = canvas.getContext('2d') as
+    | CanvasRenderingContext2D
+    | OffscreenCanvasRenderingContext2D
+    | null;
+  if (!context) {
+    return null;
+  }
+
+  try {
+    if (typeof ImageData !== 'undefined' && options.image instanceof ImageData) {
+      context.putImageData(options.image, -options.sourceX, -options.sourceY);
+    } else {
+      context.drawImage(
+        options.image as CanvasImageSource,
+        options.sourceX,
+        options.sourceY,
+        options.width,
+        options.height,
+        0,
+        0,
+        options.width,
+        options.height
+      );
+    }
+    const data = context.getImageData(0, 0, options.width, options.height).data;
+    if (options.premultipliedAlpha) {
+      premultiplyAlpha(data);
+    }
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+function premultiplyAlpha(data: Uint8ClampedArray): void {
+  for (let index = 0; index < data.length; index += 4) {
+    const alpha = data[index + 3] / 255;
+    data[index] *= alpha;
+    data[index + 1] *= alpha;
+    data[index + 2] *= alpha;
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "website:build": "yarn workspace website-docusaurus build",
     "website:start": "yarn workspace website-docusaurus start",
     "website-debug": "node ./scripts/playwright/website-playwright.mjs",
+    "gltf:reference-evidence": "node ./scripts/gltf-reference/capture-reference-evidence.mjs",
+    "gltf:reference-evidence:test": "node --test ./scripts/gltf-reference/*.test.mjs ./scripts/playwright/*.test.mjs",
     "playwright:install": "playwright install chromium",
     "metrics": "./scripts/metrics.sh && ocular-metrics"
   },
@@ -68,6 +70,7 @@
     "esbuild": "^0.28.1",
     "h3-js": "^4.4.0",
     "playwright": "^1.58.0",
+    "pngjs": "^7.0.0",
     "pre-commit": "^1.2.2",
     "vitest": "^4.0.18",
     "wgsl_reflect": "1.2.3",

--- a/scripts/gltf-reference/README.md
+++ b/scripts/gltf-reference/README.md
@@ -1,0 +1,46 @@
+# glTF reference evidence
+
+`yarn gltf:reference-evidence --headless --software-gpu` captures the glTF showcase with a fixed
+camera and rendering contract on WebGPU core and WebGL2. Each invocation creates a unique retained
+directory under `.playwright-artifacts/gltf-reference/` unless `--artifact-base` selects another
+parent.
+
+Unless `--skip-website-build` is supplied, the command first builds the workspace packages and then
+the production website. This makes the capture self-contained on a clean checkout; the website
+imports workspace declarations from `dist` and cannot be built reliably before those packages.
+
+CI captures on GitHub's fixed `macos-15` M1 runner without software-GPU overrides. The Ubuntu
+CPU-backed WebGPU adapter destroys its device when this bump-material PBR command buffer is
+submitted, so it cannot produce a trustworthy image gate. Every manifest records the actual
+adapter, renderer, and backend identity; `--software-gpu` remains available for local diagnostics.
+
+The run directory contains:
+
+- a canvas-only PNG and machine-readable evidence document for each backend;
+- browser console, page-error, request-failure, and WebGPU-probe diagnostics;
+- a highlighted WebGPU/WebGL2 difference PNG; and
+- `manifest.json`, including the comparison tolerances and pinned Khronos source revisions.
+
+The capture disables animation, automatic LOD, model lights, and external image-based lighting. It
+uses fixed fallback lights, sRGB output, no tone mapper, exposure 1, a 1280x720 viewport, and an
+explicit yaw, pitch, and distance multiplier. Overlapping website chrome is hidden after the
+evidence document is ready so that the PNG contains only the canvas render. Evidence records asset
+transfer sizes, load and scenegraph creation time, average frame CPU time, animation CPU time,
+luma.gl GPU residency, draw counts, submitted index and vertex references, and triangles. Shader
+compilation time is explicitly `null` until the device abstraction exposes a backend-neutral
+measurement rather than substituting scenegraph or first-draw CPU time.
+
+The default image gate marks a pixel different when any RGBA channel differs by more than 12 and
+allows at most 5% differing pixels. The difference image colors those pixels magenta. These values
+are versioned in the manifest and should only be tightened or relaxed with retained WebGPU/WebGL2
+evidence from the same software and hardware configuration.
+
+The Khronos glTF Sample Viewer source and deployment commits are pinned, but this command does not
+capture the external viewer. A Sample Viewer reference frame requires separately approved browser
+access and remains an explicit Tranche 0 gap; the manifest reports that status instead of implying a
+comparison happened.
+
+The production showcase currently emits React hydration diagnostics 418, 423, and 425 from the
+Docusaurus shell even without the reference query. They remain in each `page-diagnostics.json` for
+visibility, but the glTF gate narrowly excludes those known recoverable messages. Every other
+console error, page error, or request failure fails the capture.

--- a/scripts/gltf-reference/capture-reference-evidence.mjs
+++ b/scripts/gltf-reference/capture-reference-evidence.mjs
@@ -1,0 +1,423 @@
+#!/usr/bin/env node
+
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {mkdir, mkdtemp, readFile, writeFile} from 'node:fs/promises';
+import {spawn} from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+import {PNG} from 'pngjs';
+
+import {loadOcularConfig} from '../playwright/load-ocular-config.mjs';
+import {runWebsiteExample} from '../playwright/run-website-example.mjs';
+
+const SCRIPT_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = path.resolve(SCRIPT_DIRECTORY, '..', '..');
+const CAPTURE_MANIFEST_SCHEMA = 'luma.gl/gltf-reference-capture-manifest';
+const CAPTURE_MANIFEST_VERSION = 1;
+const EVIDENCE_SCHEMA = 'luma.gl/gltf-reference-evidence';
+const EVIDENCE_VERSION = 1;
+const DEFAULT_ARTIFACT_BASE = '.playwright-artifacts/gltf-reference';
+const DEFAULT_BASE_URL = 'http://127.0.0.1:3000';
+const DEFAULT_CHANNEL_TOLERANCE = 12;
+const DEFAULT_MAXIMUM_DIFFERING_PIXEL_RATIO = 0.05;
+const READY_FRAME_COUNT = 5;
+const READY_TIMEOUT_MILLISECONDS = 120_000;
+const SAMPLE_ASSETS_REVISION = '723ffc6706725b618b8c14ceb82e3e6904b08a76';
+const SAMPLE_VIEWER_REVISION = 'f9fce9ee7bc62c5433d2a1bf84be229225c7bd19';
+const SAMPLE_VIEWER_RELEASE_REVISION = 'dd024e4726c9e73f3dc87cccb4ab317a5cff7c3d';
+const CAPTURE_ROUTE =
+  '/examples/showcase/gltf?gltf-reference=1&model=BumpMaterial&variant=glTF&file=BumpMaterial.gltf&yaw=0.35&pitch=-0.15&distance=1';
+const BACKENDS = [
+  {id: 'webgpu-core', deviceType: 'webgpu'},
+  {id: 'webgl2', deviceType: 'webgl'}
+];
+
+export const HELP_TEXT = `Capture deterministic glTF evidence for WebGPU and WebGL2.
+
+Usage:
+  node scripts/gltf-reference/capture-reference-evidence.mjs [options]
+
+Options:
+  --artifact-base <path>                 Parent for a unique retained run directory.
+  --base-url <url>                       Website URL to reuse (default: ${DEFAULT_BASE_URL}).
+  --channel <name>                       Chromium-family Playwright channel.
+  --headless                             Run without a visible browser.
+  --software-gpu                         Force SwiftShader flags for reproducible CI rendering.
+  --skip-website-build                   Reuse an existing server or already-current production build.
+  --max-differing-pixel-ratio <number>   Dual-backend failure budget (default: ${DEFAULT_MAXIMUM_DIFFERING_PIXEL_RATIO}).
+  --help                                 Show this help message.
+
+The runner captures only the luma.gl canvas at 1280x720. It stores per-backend evidence and
+diagnostics, a highlighted pixel diff, and a versioned manifest. The Khronos Sample Viewer source
+and deployment revisions are pinned in that manifest; its external reference frame remains a
+separate approval-controlled capture.
+`;
+
+/** Capture both graphics backends and enforce the configured pixel-difference budget. */
+export async function captureGLTFReferenceEvidence(options = {}, dependencies = {}) {
+  const repositoryRoot = path.resolve(options.repositoryRoot ?? REPOSITORY_ROOT);
+  const logger = dependencies.logger ?? console;
+  const captureWebsiteExample = dependencies.runWebsiteExample ?? runWebsiteExample;
+  const loadConfiguration = dependencies.loadOcularConfig ?? loadOcularConfig;
+  const artifactBase = path.resolve(
+    repositoryRoot,
+    options.artifactBase ?? DEFAULT_ARTIFACT_BASE
+  );
+  await mkdir(artifactBase, {recursive: true});
+  const runDirectory = await mkdtemp(path.join(artifactBase, 'run-'));
+  await writeJson(path.join(runDirectory, 'run-metadata.json'), {
+    schema: CAPTURE_MANIFEST_SCHEMA,
+    version: CAPTURE_MANIFEST_VERSION,
+    createdAt: new Date().toISOString(),
+    repositoryCommit: process.env.GITHUB_SHA || null
+  });
+  const ocularConfig = options.ocularConfig ?? (await loadConfiguration({cwd: repositoryRoot}));
+  const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+  if (!(await isServerReady(baseUrl)) && options.buildWebsite !== false) {
+    await buildProductionWebsite(repositoryRoot, logger);
+  }
+  const captures = [];
+
+  for (const [backendIndex, backend] of BACKENDS.entries()) {
+    logger.log(`[gltf-reference] Capturing ${backendIndex + 1}/${BACKENDS.length}: ${backend.id}`);
+    const artifactDirectory = path.join(runDirectory, backend.id);
+    const captureResult = await captureWebsiteExample({
+      artifactDir: artifactDirectory,
+      backend: backend.id,
+      baseUrl,
+      channel: options.channel,
+      collectPageData: collectReferenceEvidence,
+      cwd: repositoryRoot,
+      example: CAPTURE_ROUTE,
+      headless: Boolean(options.headless),
+      keepOpen: false,
+      logger,
+      ocularConfig,
+      preparePage: waitForReferenceEvidence,
+      screenshotSelector: 'canvas',
+      softwareGpu: Boolean(options.softwareGpu),
+      viewportHeight: 720,
+      viewportWidth: 1280,
+      websiteServerMode: 'static'
+    });
+    assertCleanCaptureDiagnostics(captureResult.diagnostics, backend.id);
+    assertReferenceEvidence(captureResult.pageData, backend);
+
+    const evidencePath = path.join(artifactDirectory, 'gltf-reference-evidence.json');
+    await writeJson(evidencePath, captureResult.pageData);
+    captures.push({
+      backend: backend.id,
+      deviceType: captureResult.pageData.renderer.backend,
+      evidence: captureResult.pageData,
+      evidencePath: path.relative(runDirectory, evidencePath),
+      screenshotPath: path.relative(runDirectory, captureResult.screenshotPath)
+    });
+  }
+
+  const webgpuScreenshot = await readFile(path.join(runDirectory, captures[0].screenshotPath));
+  const webglScreenshot = await readFile(path.join(runDirectory, captures[1].screenshotPath));
+  const comparison = comparePNGScreenshots(webgpuScreenshot, webglScreenshot, {
+    channelTolerance: options.channelTolerance ?? DEFAULT_CHANNEL_TOLERANCE,
+    maximumDifferingPixelRatio:
+      options.maximumDifferingPixelRatio ?? DEFAULT_MAXIMUM_DIFFERING_PIXEL_RATIO
+  });
+  const differencePath = path.join(runDirectory, 'webgpu-webgl2-difference.png');
+  await writeFile(differencePath, comparison.differencePNG);
+
+  const manifest = {
+    schema: CAPTURE_MANIFEST_SCHEMA,
+    version: CAPTURE_MANIFEST_VERSION,
+    createdAt: new Date().toISOString(),
+    repositoryCommit: process.env.GITHUB_SHA || null,
+    capture: {
+      route: CAPTURE_ROUTE,
+      width: comparison.width,
+      height: comparison.height,
+      model: 'BumpMaterial',
+      sampleAssetsRevision: SAMPLE_ASSETS_REVISION,
+      camera: {yaw: 0.35, pitch: -0.15, distanceMultiplier: 1},
+      rendering: {
+        animation: 'disabled',
+        automaticLevelOfDetail: 'disabled',
+        environment: 'fixed-fallback-lights',
+        exposure: 1,
+        toneMapping: 'none',
+        outputColorSpace: 'srgb'
+      }
+    },
+    captures: captures.map(capture => ({
+      backend: capture.backend,
+      deviceType: capture.deviceType,
+      evidencePath: capture.evidencePath,
+      screenshotPath: capture.screenshotPath
+    })),
+    dualBackendComparison: {
+      channelTolerance: comparison.channelTolerance,
+      maximumDifferingPixelRatio: comparison.maximumDifferingPixelRatio,
+      differingPixelCount: comparison.differingPixelCount,
+      differingPixelRatio: comparison.differingPixelRatio,
+      meanAbsoluteChannelDifference: comparison.meanAbsoluteChannelDifference,
+      maximumAbsoluteChannelDifference: comparison.maximumAbsoluteChannelDifference,
+      differencePath: path.relative(runDirectory, differencePath),
+      passed: comparison.passed
+    },
+    referenceRenderer: {
+      name: 'Khronos glTF Sample Viewer',
+      sourceRevision: SAMPLE_VIEWER_REVISION,
+      sourceUrl: `https://github.com/KhronosGroup/glTF-Sample-Viewer/tree/${SAMPLE_VIEWER_REVISION}`,
+      releaseRevision: SAMPLE_VIEWER_RELEASE_REVISION,
+      releaseSourceUrl: `https://github.com/KhronosGroup/glTF-Sample-Viewer-Release/tree/${SAMPLE_VIEWER_RELEASE_REVISION}`,
+      comparisonStatus: 'source-pinned-reference-frame-not-captured'
+    }
+  };
+  const manifestPath = path.join(runDirectory, 'manifest.json');
+  await writeJson(manifestPath, manifest);
+
+  if (!comparison.passed) {
+    throw new Error(
+      `WebGPU/WebGL2 differing-pixel ratio ${comparison.differingPixelRatio.toFixed(6)} exceeds ` +
+        `${comparison.maximumDifferingPixelRatio}; retained evidence: ${runDirectory}`
+    );
+  }
+
+  logger.log(`[gltf-reference] Evidence retained in ${runDirectory}`);
+  return {captures, comparison, manifest, manifestPath, runDirectory};
+}
+
+/** Compare two same-sized RGBA PNG captures and create a highlighted difference image. */
+export function comparePNGScreenshots(leftBuffer, rightBuffer, options = {}) {
+  const leftImage = PNG.sync.read(leftBuffer);
+  const rightImage = PNG.sync.read(rightBuffer);
+  if (leftImage.width !== rightImage.width || leftImage.height !== rightImage.height) {
+    throw new Error(
+      `Screenshot dimensions differ: ${leftImage.width}x${leftImage.height} versus ` +
+        `${rightImage.width}x${rightImage.height}`
+    );
+  }
+
+  const channelTolerance = options.channelTolerance ?? DEFAULT_CHANNEL_TOLERANCE;
+  const maximumDifferingPixelRatio =
+    options.maximumDifferingPixelRatio ?? DEFAULT_MAXIMUM_DIFFERING_PIXEL_RATIO;
+  const differenceImage = new PNG({width: leftImage.width, height: leftImage.height});
+  let differingPixelCount = 0;
+  let absoluteChannelDifference = 0;
+  let maximumAbsoluteChannelDifference = 0;
+
+  for (let offset = 0; offset < leftImage.data.length; offset += 4) {
+    let pixelDiffers = false;
+    for (let channel = 0; channel < 4; channel++) {
+      const difference = Math.abs(leftImage.data[offset + channel] - rightImage.data[offset + channel]);
+      absoluteChannelDifference += difference;
+      maximumAbsoluteChannelDifference = Math.max(maximumAbsoluteChannelDifference, difference);
+      pixelDiffers ||= difference > channelTolerance;
+    }
+
+    if (pixelDiffers) {
+      differingPixelCount++;
+      differenceImage.data.set([255, 0, 255, 255], offset);
+    } else {
+      const luminance = Math.round(
+        (leftImage.data[offset] + leftImage.data[offset + 1] + leftImage.data[offset + 2]) / 6
+      );
+      differenceImage.data.set([luminance, luminance, luminance, 255], offset);
+    }
+  }
+
+  const pixelCount = leftImage.width * leftImage.height;
+  const differingPixelRatio = differingPixelCount / pixelCount;
+  return {
+    width: leftImage.width,
+    height: leftImage.height,
+    channelTolerance,
+    maximumDifferingPixelRatio,
+    differingPixelCount,
+    differingPixelRatio,
+    meanAbsoluteChannelDifference: absoluteChannelDifference / (pixelCount * 4),
+    maximumAbsoluteChannelDifference,
+    passed: differingPixelRatio <= maximumDifferingPixelRatio,
+    differencePNG: PNG.sync.write(differenceImage)
+  };
+}
+
+export function parseCLIArguments(argv) {
+  const options = {
+    artifactBase: undefined,
+    baseUrl: DEFAULT_BASE_URL,
+    buildWebsite: true,
+    channel: undefined,
+    headless: false,
+    help: false,
+    maximumDifferingPixelRatio: DEFAULT_MAXIMUM_DIFFERING_PIXEL_RATIO,
+    softwareGpu: false
+  };
+
+  for (let index = 0; index < argv.length; index++) {
+    const argument = argv[index];
+    if (argument === '--help' || argument === '-h') {
+      options.help = true;
+    } else if (argument === '--headless') {
+      options.headless = true;
+    } else if (argument === '--software-gpu') {
+      options.softwareGpu = true;
+    } else if (argument === '--skip-website-build') {
+      options.buildWebsite = false;
+    } else if (argument === '--artifact-base') {
+      options.artifactBase = requireArgumentValue(argv, ++index, argument);
+    } else if (argument === '--base-url') {
+      options.baseUrl = requireArgumentValue(argv, ++index, argument);
+    } else if (argument === '--channel') {
+      options.channel = requireArgumentValue(argv, ++index, argument);
+    } else if (argument === '--max-differing-pixel-ratio') {
+      options.maximumDifferingPixelRatio = Number(requireArgumentValue(argv, ++index, argument));
+      if (
+        !Number.isFinite(options.maximumDifferingPixelRatio) ||
+        options.maximumDifferingPixelRatio < 0 ||
+        options.maximumDifferingPixelRatio > 1
+      ) {
+        throw new Error(`${argument} must be a finite number between 0 and 1.`);
+      }
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  return options;
+}
+
+async function waitForReferenceEvidence(page) {
+  await page.waitForFunction(
+    frameCount =>
+      globalThis.__lumaGLTFReferenceError ||
+      globalThis.__lumaGLTFReferenceEvidence?.metrics?.frameCount >= frameCount,
+    READY_FRAME_COUNT,
+    {timeout: READY_TIMEOUT_MILLISECONDS}
+  );
+  const captureError = await page.evaluate(() => globalThis.__lumaGLTFReferenceError || null);
+  if (captureError) {
+    throw new Error(`glTF reference page failed: ${captureError}`);
+  }
+  await page.evaluate(async () => {
+    const canvas = document.querySelector('canvas');
+    if (!(canvas instanceof HTMLCanvasElement)) {
+      throw new Error('glTF reference canvas was not found.');
+    }
+    for (const element of document.body.querySelectorAll('*')) {
+      if (element !== canvas && !element.contains(canvas) && 'style' in element) {
+        element.style.setProperty('visibility', 'hidden', 'important');
+      }
+    }
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+  });
+}
+
+async function collectReferenceEvidence(page) {
+  return await page.evaluate(() => structuredClone(globalThis.__lumaGLTFReferenceEvidence));
+}
+
+async function buildProductionWebsite(repositoryRoot, logger) {
+  logger.log('[gltf-reference] Building workspace packages required by the production website');
+  await runYarnCommand(repositoryRoot, ['build']);
+  logger.log('[gltf-reference] Building the production website once for lightweight static capture');
+  await runYarnCommand(repositoryRoot, ['website:build']);
+}
+
+async function runYarnCommand(repositoryRoot, arguments_) {
+  await new Promise((resolve, reject) => {
+    const child = spawn('yarn', arguments_, {
+      cwd: repositoryRoot,
+      env: {...process.env, CI: '1'},
+      stdio: 'inherit',
+      shell: process.platform === 'win32'
+    });
+    child.once('error', reject);
+    child.once('exit', code => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`yarn ${arguments_.join(' ')} exited with code ${code}.`));
+      }
+    });
+  });
+}
+
+async function isServerReady(url) {
+  try {
+    const response = await fetch(url, {signal: AbortSignal.timeout(2000)});
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+function assertReferenceEvidence(evidence, backend) {
+  if (!evidence || evidence.schema !== EVIDENCE_SCHEMA || evidence.version !== EVIDENCE_VERSION) {
+    throw new Error(`${backend.id} did not publish versioned glTF reference evidence.`);
+  }
+  if (evidence.renderer?.backend !== backend.deviceType) {
+    throw new Error(
+      `${backend.id} published device type ${evidence.renderer?.backend}; expected ${backend.deviceType}.`
+    );
+  }
+  if (evidence.metrics?.frameCount < READY_FRAME_COUNT) {
+    throw new Error(`${backend.id} captured before ${READY_FRAME_COUNT} completed frames.`);
+  }
+  if (
+    evidence.metrics.drawCount !== 1 ||
+    evidence.metrics.submittedIndexReferences !== 3 ||
+    evidence.metrics.triangleCount !== 1
+  ) {
+    throw new Error(`${backend.id} did not render the complete indexed BumpMaterial fixture.`);
+  }
+}
+
+export function assertCleanCaptureDiagnostics(diagnostics, backend) {
+  const browserErrors =
+    diagnostics?.consoleMessages?.filter(
+      message => message.type === 'error' && !isKnownDocusaurusHydrationDiagnostic(message.text)
+    ) ?? [];
+  const pageErrors = diagnostics?.pageErrors ?? [];
+  const requestFailures = diagnostics?.requestFailures ?? [];
+  const failureCount = browserErrors.length + pageErrors.length + requestFailures.length;
+  if (failureCount > 0) {
+    throw new Error(`${backend} emitted ${failureCount} browser diagnostic error(s).`);
+  }
+}
+
+/**
+ * The production showcase emits these recoverable shell-hydration diagnostics without the
+ * reference query too. Keep them in page-diagnostics.json, but do not misclassify them as glTF
+ * renderer failures. Any other console error still fails the capture.
+ */
+export function isKnownDocusaurusHydrationDiagnostic(message) {
+  return /^Docusaurus React Root onRecoverableError: Error: Minified React error #(418|423|425);/.test(
+    message
+  );
+}
+
+function requireArgumentValue(argv, index, argument) {
+  const value = argv[index];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${argument} requires a value.`);
+  }
+  return value;
+}
+
+async function writeJson(filename, value) {
+  await writeFile(filename, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const options = parseCLIArguments(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(HELP_TEXT);
+  } else {
+    captureGLTFReferenceEvidence(options).catch(error => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+  }
+}

--- a/scripts/gltf-reference/capture-reference-evidence.test.mjs
+++ b/scripts/gltf-reference/capture-reference-evidence.test.mjs
@@ -1,0 +1,100 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {PNG} from 'pngjs';
+
+import {
+  assertCleanCaptureDiagnostics,
+  comparePNGScreenshots,
+  isKnownDocusaurusHydrationDiagnostic,
+  parseCLIArguments
+} from './capture-reference-evidence.mjs';
+
+test('comparePNGScreenshots applies channel and differing-pixel tolerances', () => {
+  const left = makePNG([
+    [10, 20, 30, 255],
+    [100, 100, 100, 255]
+  ]);
+  const right = makePNG([
+    [15, 20, 30, 255],
+    [130, 100, 100, 255]
+  ]);
+
+  const comparison = comparePNGScreenshots(left, right, {
+    channelTolerance: 5,
+    maximumDifferingPixelRatio: 0.5
+  });
+
+  assert.equal(comparison.differingPixelCount, 1);
+  assert.equal(comparison.differingPixelRatio, 0.5);
+  assert.equal(comparison.maximumAbsoluteChannelDifference, 30);
+  assert.equal(comparison.passed, true);
+  assert.deepEqual(
+    [...PNG.sync.read(comparison.differencePNG).data.slice(4, 8)],
+    [255, 0, 255, 255]
+  );
+});
+
+test('comparePNGScreenshots rejects mismatched dimensions', () => {
+  assert.throws(
+    () => comparePNGScreenshots(makePNG([[0, 0, 0, 255]]), makePNG([[0, 0, 0, 255]], 1, 2)),
+    /Screenshot dimensions differ/
+  );
+});
+
+test('parseCLIArguments validates the ratio budget', () => {
+  assert.deepEqual(parseCLIArguments(['--headless', '--software-gpu']), {
+    artifactBase: undefined,
+    baseUrl: 'http://127.0.0.1:3000',
+    buildWebsite: true,
+    channel: undefined,
+    headless: true,
+    help: false,
+    maximumDifferingPixelRatio: 0.05,
+    softwareGpu: true
+  });
+  assert.throws(
+    () => parseCLIArguments(['--max-differing-pixel-ratio', '1.1']),
+    /between 0 and 1/
+  );
+});
+
+test('assertCleanCaptureDiagnostics only tolerates the known production-shell diagnostics', () => {
+  const knownDiagnostic =
+    'Docusaurus React Root onRecoverableError: Error: Minified React error #425; details';
+  assert.equal(isKnownDocusaurusHydrationDiagnostic(knownDiagnostic), true);
+  assert.doesNotThrow(() =>
+    assertCleanCaptureDiagnostics(
+      {
+        consoleMessages: [{type: 'error', text: knownDiagnostic}],
+        pageErrors: [],
+        requestFailures: []
+      },
+      'webgpu-core'
+    )
+  );
+  assert.throws(
+    () =>
+      assertCleanCaptureDiagnostics(
+        {
+          consoleMessages: [{type: 'error', text: 'WebGPU validation error'}],
+          pageErrors: [],
+          requestFailures: []
+        },
+        'webgpu-core'
+      ),
+    /1 browser diagnostic error/
+  );
+});
+
+function makePNG(pixels, width = pixels.length, height = 1) {
+  const image = new PNG({width, height});
+  for (const [pixelIndex, pixel] of pixels.entries()) {
+    image.data.set(pixel, pixelIndex * 4);
+  }
+  return PNG.sync.write(image);
+}

--- a/scripts/playwright/browser-debug.mjs
+++ b/scripts/playwright/browser-debug.mjs
@@ -1,3 +1,7 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
 import {chromium} from 'playwright';
 
 import {getPlaywrightLaunchOptions} from './get-playwright-launch-options.mjs';
@@ -7,6 +11,7 @@ const DEFAULT_DEBUG_PORT = 9222;
 export async function launchDebugBrowser(options = {}) {
   const debugPort = options.debugPort || DEFAULT_DEBUG_PORT;
   const launchOptions = getPlaywrightLaunchOptions({
+    backend: options.backend,
     ocularConfig: options.ocularConfig,
     channel: options.channel,
     headless: options.headless,

--- a/scripts/playwright/get-playwright-launch-options.mjs
+++ b/scripts/playwright/get-playwright-launch-options.mjs
@@ -1,6 +1,24 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
 const DEFAULT_PLAYWRIGHT_CHANNEL = 'chromium';
 const DEFAULT_PLAYWRIGHT_ARGS = ['--enable-unsafe-webgpu', '--ignore-gpu-blocklist'];
-const SOFTWARE_GPU_ARGS = ['--use-angle=swiftshader', '--enable-unsafe-swiftshader'];
+const ANGLE_SWIFTSHADER_ARGS = [
+  '--use-gl=angle',
+  '--use-angle=swiftshader',
+  '--enable-unsafe-swiftshader'
+];
+const LINUX_WEBGPU_SWIFTSHADER_ARGS = [
+  '--use-angle=swiftshader',
+  '--enable-unsafe-swiftshader'
+];
+const WEBGPU_SWIFTSHADER_ARGS = [
+  '--use-webgpu-adapter=swiftshader',
+  '--use-gpu-in-tests',
+  '--enable-accelerated-2d-canvas',
+  '--enable-unsafe-swiftshader'
+];
 
 export function getPlaywrightLaunchOptions(options = {}) {
   const ocularConfig = options.ocularConfig || {};
@@ -10,7 +28,9 @@ export function getPlaywrightLaunchOptions(options = {}) {
     ...DEFAULT_PLAYWRIGHT_ARGS,
     ...(playwrightConfig.args || []),
     ...(customLaunchOptions.args || []),
-    ...(options.softwareGpu || playwrightConfig.softwareGpu ? SOFTWARE_GPU_ARGS : [])
+    ...(options.softwareGpu || playwrightConfig.softwareGpu
+      ? getSoftwareGPUArguments(options.backend, options.platform ?? process.platform)
+      : [])
   ]);
 
   const launchOptions = {
@@ -25,6 +45,16 @@ export function getPlaywrightLaunchOptions(options = {}) {
   }
 
   return launchOptions;
+}
+
+function getSoftwareGPUArguments(backend, platform) {
+  if (backend?.startsWith('webgpu')) {
+    return platform === 'linux' ? LINUX_WEBGPU_SWIFTSHADER_ARGS : WEBGPU_SWIFTSHADER_ARGS;
+  }
+  if (backend?.startsWith('webgl')) {
+    return ANGLE_SWIFTSHADER_ARGS;
+  }
+  return [...ANGLE_SWIFTSHADER_ARGS, ...WEBGPU_SWIFTSHADER_ARGS];
 }
 
 function dedupeValues(values) {

--- a/scripts/playwright/get-playwright-launch-options.test.mjs
+++ b/scripts/playwright/get-playwright-launch-options.test.mjs
@@ -1,0 +1,89 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {getPlaywrightLaunchOptions} from './get-playwright-launch-options.mjs';
+
+test('getPlaywrightLaunchOptions selects Dawn SwiftShader for WebGPU', () => {
+  const launchOptions = getPlaywrightLaunchOptions({
+    backend: 'webgpu-core',
+    headless: true,
+    platform: 'darwin',
+    softwareGpu: true
+  });
+
+  assert.deepEqual(launchOptions, {
+    channel: 'chromium',
+    headless: true,
+    args: [
+      '--enable-unsafe-webgpu',
+      '--ignore-gpu-blocklist',
+      '--use-webgpu-adapter=swiftshader',
+      '--use-gpu-in-tests',
+      '--enable-accelerated-2d-canvas',
+      '--enable-unsafe-swiftshader'
+    ]
+  });
+});
+
+test('getPlaywrightLaunchOptions uses the proven ANGLE software path for Linux WebGPU', () => {
+  const launchOptions = getPlaywrightLaunchOptions({
+    backend: 'webgpu-core',
+    headless: true,
+    platform: 'linux',
+    softwareGpu: true
+  });
+
+  assert.deepEqual(launchOptions, {
+    channel: 'chromium',
+    headless: true,
+    args: [
+      '--enable-unsafe-webgpu',
+      '--ignore-gpu-blocklist',
+      '--use-angle=swiftshader',
+      '--enable-unsafe-swiftshader'
+    ]
+  });
+});
+
+test('getPlaywrightLaunchOptions selects ANGLE SwiftShader for WebGL', () => {
+  const launchOptions = getPlaywrightLaunchOptions({
+    backend: 'webgl2',
+    headless: true,
+    softwareGpu: true
+  });
+
+  assert.deepEqual(launchOptions, {
+    channel: 'chromium',
+    headless: true,
+    args: [
+      '--enable-unsafe-webgpu',
+      '--ignore-gpu-blocklist',
+      '--use-gl=angle',
+      '--use-angle=swiftshader',
+      '--enable-unsafe-swiftshader'
+    ]
+  });
+});
+
+test('getPlaywrightLaunchOptions selects both software adapters without a requested backend', () => {
+  const launchOptions = getPlaywrightLaunchOptions({softwareGpu: true});
+
+  assert(launchOptions.args.includes('--use-angle=swiftshader'));
+  assert(launchOptions.args.includes('--use-webgpu-adapter=swiftshader'));
+});
+
+test('getPlaywrightLaunchOptions deduplicates custom software GPU arguments', () => {
+  const launchOptions = getPlaywrightLaunchOptions({
+    launchOptions: {
+      args: ['--use-gl=angle', '--custom-argument']
+    },
+    softwareGpu: true
+  });
+
+  assert.equal(launchOptions.args.filter(argument => argument === '--use-gl=angle').length, 1);
+  assert(launchOptions.args.includes('--custom-argument'));
+});

--- a/scripts/playwright/run-website-example.mjs
+++ b/scripts/playwright/run-website-example.mjs
@@ -1,3 +1,7 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
 import {mkdir, writeFile} from 'node:fs/promises';
 import {spawn} from 'node:child_process';
 import net from 'node:net';
@@ -57,7 +61,11 @@ export async function runWebsiteExample(options = {}) {
       }
 
       targetUrl = resolveTargetUrl(options, resolvedBaseUrl, ocularConfig);
-      serverProcess = startWebsiteServer(websiteDir, parseBaseUrl(resolvedBaseUrl));
+      serverProcess = startWebsiteServer(
+        websiteDir,
+        parseBaseUrl(resolvedBaseUrl),
+        options.websiteServerMode
+      );
       await waitForServer(resolvedBaseUrl, START_TIMEOUT_MS);
     } else if (usingExistingServer) {
       targetUrl = resolveTargetUrl(options, resolvedBaseUrl, ocularConfig);
@@ -100,10 +108,24 @@ export async function runWebsiteExample(options = {}) {
       if (options.highDynamicRangeCapture && !selectedDeviceType) {
         throw new Error('[playwright] HDR capture requires an available selected device backend.');
       }
+      if (options.preparePage) {
+        await options.preparePage(page, {
+          artifactDir,
+          selectedDeviceType,
+          targetUrl
+        });
+      }
       if (options.captureDelayMilliseconds) {
         await page.waitForTimeout(options.captureDelayMilliseconds);
       }
       const webgpuProbe = await probeWebGPU(page);
+      const pageData = options.collectPageData
+        ? await options.collectPageData(page, {
+            artifactDir,
+            selectedDeviceType,
+            targetUrl
+          })
+        : null;
 
       await writeJsonArtifact(artifactDir, 'webgpu-probe.json', webgpuProbe);
       await writeJsonArtifact(artifactDir, 'page-diagnostics.json', diagnostics);
@@ -112,11 +134,21 @@ export async function runWebsiteExample(options = {}) {
         ? null
         : path.join(artifactDir, DEFAULT_SCREENSHOT_NAME);
       if (screenshotPath) {
-        await page.screenshot({
-          path: screenshotPath,
-          fullPage: !options.highDynamicRangeCapture,
-          timeout: SCREENSHOT_TIMEOUT_MS
-        });
+        if (options.screenshotSelector) {
+          const screenshotTarget = page.locator(options.screenshotSelector).first();
+          if ((await screenshotTarget.count()) === 0) {
+            throw new Error(
+              `[playwright] Screenshot selector not found: ${options.screenshotSelector}`
+            );
+          }
+          await screenshotTarget.screenshot({path: screenshotPath, timeout: SCREENSHOT_TIMEOUT_MS});
+        } else {
+          await page.screenshot({
+            path: screenshotPath,
+            fullPage: !options.highDynamicRangeCapture,
+            timeout: SCREENSHOT_TIMEOUT_MS
+          });
+        }
       }
 
       const highDynamicRangeArtifacts = options.highDynamicRangeCapture
@@ -137,10 +169,19 @@ export async function runWebsiteExample(options = {}) {
         diagnostics,
         endpointURL: browserHandle.endpointURL,
         highDynamicRangeArtifacts,
+        pageData,
         screenshotPath,
+        selectedDeviceType,
         targetUrl,
         usingExistingServer
       };
+    } catch (error) {
+      try {
+        await writeFailureArtifacts({artifactDir, diagnostics, error, page, targetUrl});
+      } catch (artifactError) {
+        (options.logger || console).error('[playwright] Failed to retain capture diagnostics', artifactError);
+      }
+      throw error;
     } finally {
       dispose();
     }
@@ -231,12 +272,25 @@ export async function applyViewportSize(page, viewportWidth, viewportHeight) {
   });
 }
 
-function startWebsiteServer(websiteDir, endpoint) {
-  const child = spawn('yarn', ['start', '--host', endpoint.host, '--port', String(endpoint.port)], {
+function startWebsiteServer(websiteDir, endpoint, serverMode = 'development') {
+  const isStaticServer = serverMode === 'static';
+  const command = isStaticServer ? process.execPath : 'yarn';
+  const arguments_ = isStaticServer
+    ? [
+        path.resolve(websiteDir, '../scripts/playwright/serve-static-website.mjs'),
+        '--root',
+        path.join(websiteDir, 'build'),
+        '--host',
+        endpoint.host,
+        '--port',
+        String(endpoint.port)
+      ]
+    : ['start', '--host', endpoint.host, '--port', String(endpoint.port)];
+  const child = spawn(command, arguments_, {
     cwd: websiteDir,
     env: {...process.env, CI: '1'},
     stdio: 'inherit',
-    shell: process.platform === 'win32'
+    shell: !isStaticServer && process.platform === 'win32'
   });
   child.on('exit', code => {
     if (code !== 0 && code !== null) {
@@ -321,6 +375,34 @@ async function writeJsonArtifact(artifactDir, filename, value) {
 
 async function writeTextArtifact(artifactDir, filename, value) {
   await writeFile(path.join(artifactDir, filename), value, 'utf8');
+}
+
+export async function writeFailureArtifacts({artifactDir, diagnostics, error, page, targetUrl}) {
+  const captureError =
+    error instanceof Error
+      ? {name: error.name, message: error.message, stack: error.stack}
+      : {name: 'Error', message: String(error)};
+  const pageState = await collectFailurePageState(page);
+  await Promise.all([
+    writeJsonArtifact(artifactDir, 'capture-error.json', captureError),
+    writeJsonArtifact(artifactDir, 'page-diagnostics.json', diagnostics),
+    writeJsonArtifact(artifactDir, 'page-state.json', pageState),
+    writeTextArtifact(artifactDir, 'last-url.txt', `${targetUrl}\n`)
+  ]);
+}
+
+async function collectFailurePageState(page) {
+  if (!page || typeof page.evaluate !== 'function') {
+    return null;
+  }
+  try {
+    return await page.evaluate(() => ({
+      gltfReferenceError: globalThis.__lumaGLTFReferenceError ?? null,
+      gltfReferenceProgress: globalThis.__lumaGLTFReferenceProgress ?? null
+    }));
+  } catch {
+    return null;
+  }
 }
 
 async function watchScreenshots(page, artifactDir, watchInterval = DEFAULT_WATCH_INTERVAL_MS) {

--- a/scripts/playwright/run-website-example.test.mjs
+++ b/scripts/playwright/run-website-example.test.mjs
@@ -1,0 +1,40 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import assert from 'node:assert/strict';
+import {mkdtemp, readFile, rm} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {writeFailureArtifacts} from './run-website-example.mjs';
+
+test('writeFailureArtifacts retains the original capture failure and diagnostics', async context => {
+  const artifactDirectory = await mkdtemp(path.join(os.tmpdir(), 'luma-playwright-failure-'));
+  context.after(() => rm(artifactDirectory, {recursive: true, force: true}));
+  const error = new Error('reference frame timed out');
+  const diagnostics = {consoleMessages: [], pageErrors: [], requestFailures: []};
+  const pageState = {
+    gltfReferenceError: null,
+    gltfReferenceProgress: {stage: 'drawing-model:test-model', updatedAt: '2026-08-20T00:00:00.000Z'}
+  };
+  const page = {evaluate: async () => pageState};
+  const targetUrl = 'http://127.0.0.1:3000/example';
+
+  await writeFailureArtifacts({artifactDir: artifactDirectory, diagnostics, error, page, targetUrl});
+
+  const captureError = JSON.parse(
+    await readFile(path.join(artifactDirectory, 'capture-error.json'), 'utf8')
+  );
+  assert.equal(captureError.message, error.message);
+  assert.deepEqual(
+    JSON.parse(await readFile(path.join(artifactDirectory, 'page-diagnostics.json'), 'utf8')),
+    diagnostics
+  );
+  assert.deepEqual(
+    JSON.parse(await readFile(path.join(artifactDirectory, 'page-state.json'), 'utf8')),
+    pageState
+  );
+  assert.equal(await readFile(path.join(artifactDirectory, 'last-url.txt'), 'utf8'), `${targetUrl}\n`);
+});

--- a/scripts/playwright/serve-static-website.mjs
+++ b/scripts/playwright/serve-static-website.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {createReadStream} from 'node:fs';
+import {stat} from 'node:fs/promises';
+import {createServer} from 'node:http';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+const CONTENT_TYPES = {
+  '.css': 'text/css; charset=utf-8',
+  '.gif': 'image/gif',
+  '.glb': 'model/gltf-binary',
+  '.gltf': 'model/gltf+json',
+  '.html': 'text/html; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.wasm': 'application/wasm',
+  '.webp': 'image/webp',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2'
+};
+
+export async function resolveStaticFilename(root, requestPathname) {
+  let decodedPathname;
+  try {
+    decodedPathname = decodeURIComponent(requestPathname);
+  } catch {
+    return null;
+  }
+  const relativePath = decodedPathname.replace(/^\/+/, '');
+  const baseFilename = path.resolve(root, relativePath || 'index.html');
+  if (baseFilename !== root && !baseFilename.startsWith(`${root}${path.sep}`)) {
+    return null;
+  }
+
+  const candidates = path.extname(baseFilename)
+    ? [baseFilename]
+    : [baseFilename, `${baseFilename}.html`, path.join(baseFilename, 'index.html')];
+  for (const candidate of candidates) {
+    try {
+      if ((await stat(candidate)).isFile()) {
+        return candidate;
+      }
+    } catch {
+      // Try the next Docusaurus pretty-URL representation.
+    }
+  }
+  return null;
+}
+
+export function parseArguments(argv) {
+  const parsed = {root: '', host: '127.0.0.1', port: 3000};
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!value) {
+      throw new Error(`${name} requires a value.`);
+    }
+    if (name === '--root') {
+      parsed.root = value;
+    } else if (name === '--host') {
+      parsed.host = value;
+    } else if (name === '--port') {
+      parsed.port = Number(value);
+    } else {
+      throw new Error(`Unknown argument: ${name}`);
+    }
+  }
+  if (!parsed.root || !Number.isSafeInteger(parsed.port) || parsed.port < 1 || parsed.port > 65535) {
+    throw new Error('A root directory and valid port are required.');
+  }
+  return parsed;
+}
+
+function serveStaticWebsite(options) {
+  const rootDirectory = path.resolve(options.root);
+  const server = createServer(async (request, response) => {
+    try {
+      const requestUrl = new URL(request.url || '/', `http://${options.host}:${options.port}`);
+      const filename = await resolveStaticFilename(rootDirectory, requestUrl.pathname);
+      if (!filename) {
+        response.writeHead(404, {'content-type': 'text/plain; charset=utf-8'});
+        response.end('Not found\n');
+        return;
+      }
+
+      const fileStats = await stat(filename);
+      response.writeHead(200, {
+        'cache-control': 'no-store',
+        'content-length': fileStats.size,
+        'content-type':
+          CONTENT_TYPES[path.extname(filename).toLowerCase()] || 'application/octet-stream'
+      });
+      if (request.method === 'HEAD') {
+        response.end();
+      } else {
+        createReadStream(filename).pipe(response);
+      }
+    } catch (error) {
+      response.writeHead(500, {'content-type': 'text/plain; charset=utf-8'});
+      response.end(`${error instanceof Error ? error.message : String(error)}\n`);
+    }
+  });
+
+  server.listen(options.port, options.host, () => {
+    console.log(`[static-website] Serving ${rootDirectory} at http://${options.host}:${options.port}`);
+  });
+
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.on(signal, () => server.close(() => process.exit(0)));
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  serveStaticWebsite(parseArguments(process.argv.slice(2)));
+}

--- a/scripts/playwright/serve-static-website.test.mjs
+++ b/scripts/playwright/serve-static-website.test.mjs
@@ -1,0 +1,42 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import assert from 'node:assert/strict';
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {parseArguments, resolveStaticFilename} from './serve-static-website.mjs';
+
+test('resolveStaticFilename supports Docusaurus pretty URLs and confines requests', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'luma-static-website-'));
+  try {
+    await mkdir(path.join(root, 'nested'));
+    await writeFile(path.join(root, 'index.html'), 'root');
+    await writeFile(path.join(root, 'pretty.html'), 'pretty');
+    await writeFile(path.join(root, 'nested', 'index.html'), 'nested');
+
+    assert.equal(await resolveStaticFilename(root, '/'), path.join(root, 'index.html'));
+    assert.equal(await resolveStaticFilename(root, '/pretty'), path.join(root, 'pretty.html'));
+    assert.equal(
+      await resolveStaticFilename(root, '/nested'),
+      path.join(root, 'nested', 'index.html')
+    );
+    assert.equal(await resolveStaticFilename(root, '/../outside'), null);
+    assert.equal(await resolveStaticFilename(root, '/%E0%A4%A'), null);
+  } finally {
+    await rm(root, {recursive: true, force: true});
+  }
+});
+
+test('parseArguments requires a root and valid port', () => {
+  assert.deepEqual(parseArguments(['--root', 'build', '--port', '8080']), {
+    root: 'build',
+    host: '127.0.0.1',
+    port: 8080
+  });
+  assert.throws(() => parseArguments(['--root', 'build', '--port', '0']), /valid port/);
+  assert.throws(() => parseArguments(['--host', '127.0.0.1']), /root directory/);
+});

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -11,6 +11,7 @@ import {
   LumaExample,
   ReactExample,
   type ExampleDisplayProps,
+  type LumaExampleProps,
   useStore
 } from './react-luma';
 import type {Device} from '@luma.gl/core';
@@ -770,18 +771,44 @@ export const ANARIPlaygroundExample: React.FC = () => {
   );
 };
 
-export const GLTFExample: React.FC<WebsiteExampleProps> = props => (
-  <LumaExample
-    id="gltf"
-    title="glTF Asset Studio"
-    subtitle="Physical materials · animated characters · standards-native glTF"
-    directory="showcase"
-    template={GLTFApp}
-    config={exampleConfig}
-    canvasContextProfile="high-dynamic-range"
-    {...props}
-  />
-);
+export const GLTFExample: React.FC<WebsiteExampleProps> = props => {
+  const referenceDevice = getGLTFReferenceDeviceSelection();
+
+  return (
+    <LumaExample
+      id="gltf"
+      title="glTF Asset Studio"
+      subtitle="Physical materials · animated characters · standards-native glTF"
+      directory="showcase"
+      template={GLTFApp}
+      config={exampleConfig}
+      canvasContextProfile="high-dynamic-range"
+      devices={referenceDevice ? [referenceDevice] : undefined}
+      {...props}
+    />
+  );
+};
+
+function getGLTFReferenceDeviceSelection(): NonNullable<LumaExampleProps['devices']>[number] | null {
+  if (
+    typeof window === 'undefined' ||
+    new URLSearchParams(window.location.search).get('gltf-reference') !== '1'
+  ) {
+    return null;
+  }
+
+  const deviceType = window.localStorage.getItem('luma-device-type');
+  switch (deviceType) {
+    case 'webgpu-core':
+    case 'webgpu-max':
+    case 'webgpu-compatibility':
+      return deviceType;
+    case 'webgl':
+      return 'webgl2';
+    default:
+      return null;
+  }
+}
 
 export const GaussianSplatsExample: React.FC<WebsiteExampleProps> = props => {
   if (typeof window !== 'undefined') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15976,6 +15976,7 @@ __metadata:
     esbuild: "npm:^0.28.1"
     h3-js: "npm:^4.4.0"
     playwright: "npm:^1.58.0"
+    pngjs: "npm:^7.0.0"
     pre-commit: "npm:^1.2.2"
     preact: "npm:^10.17.0"
     vitest: "npm:^4.0.18"


### PR DESCRIPTION
## Goals

- Turn the landed glTF reference ledger into reproducible renderer evidence.
- Compare the same pinned local fixture on WebGPU core and WebGL2 in CI.
- Keep the glTF supremacy roadmap current, including a scoped current-master refresh of #2995.

## Changes

- Add an opt-in deterministic glTF showcase mode with a fixed camera, fallback lighting, disabled animation/LOD, and machine-readable evidence.
- Record backend/device identity, extension support, load/frame timing, asset transfer, GPU residency, draw, index-reference, and triangle metrics.
- Add a self-contained Playwright runner that builds workspace packages before the production website, serves it with a lightweight static server, captures canvas-only PNGs on WebGPU/WebGL2, applies a versioned pixel-difference budget, and retains diagnostics/evidence/manifests.
- Run the CI renderer gate on the fixed `macos-15` M1 environment without software-GPU overrides. This avoids treating Linux's CPU-backed WebGPU device loss at command submission as renderer evidence.
- Retain `--software-gpu` for local diagnostics, with explicit Dawn/ANGLE SwiftShader selection.
- Fall back to a CPU-backed `writeTexture` upload for RGBA8 external images when a CPU adapter cannot safely use `copyExternalImageToTexture`; native GPU uploads retain the fast path.
- Restrict deterministic reference mode to the requested backend so availability probes cannot consume unrelated GPU contexts; normal interactive tabs still expose every supported device.
- Fail fast on WebGPU device loss and retain progress, page state, browser diagnostics, and the original error even when capture fails before screenshots exist.
- Pin both the Khronos Sample Viewer source and deployment revisions while explicitly reporting that an external reference frame has not yet been captured.
- Add unit tests and a dedicated CI artifact job.
- Update the roadmap for landed #3087 and add Tranche 1A to refresh the useful Animation Studio/RobotExpressive scope from draft #2995 without carrying forward obsolete runtime abstractions.
- Rebase onto current `master` and integrate deterministic capture with the current `OrbitControls` showcase camera.

## Verification

- `nvm use` — passed (Node 22.22.1)
- `yarn install` — passed with existing peer warnings
- `yarn lint fix` — passed
- `yarn build` — passed after the final code change
- `yarn gltf:reference-evidence:test` — 12 passed
- focused headless texture suite — 40 passed / 12 skipped, including forced reactive and proactive CPU upload paths
- `yarn website:build` — passed after a clean workspace package build
- `(cd website && yarn build)` — not run literally; the equivalent root `yarn website:build` workspace command passed
- dedicated CI reference job — passed on `macos-15`: Apple WebGPU core and ANGLE Metal WebGL2 both captured; 1,239 pixels differed, ratio 0.001916 against the 0.05 budget; artifact 9423812327 uploaded
- earlier commit-hook Node suite — 2,638 passed / 1 skipped
- final pre-commit rerun after the capture build-order change — 2,633 passed / 1 skipped; five unrelated tests timed out together under local concurrent load
- full `yarn test` — not a clean local gate; the broad headless run encountered existing unrelated GPU failures and was stopped after the changed focused coverage passed

## Risks and known gaps

- The external Khronos Sample Viewer frame remains approval-controlled and is reported as missing rather than implying a comparison.
- Backend-neutral shader compilation timing is not exposed by the device API, so the evidence records an explicit `null` instead of substituting another CPU measurement.
- The production Docusaurus shell emits recoverable React hydration diagnostics 418/423/425 on the ordinary showcase route; they remain in retained diagnostics and are narrowly excluded from the glTF failure gate. All other browser errors remain fatal.
