### PR TITLE
Reduce Node and browser test overhead

### DIFF
--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -28,6 +28,11 @@ Creating too many GPU devices in one run can cause context loss and other instab
 
 Browser-backed tests run through Vitest Browser Mode with Playwright/Chromium. This is the default path for active WebGL and WebGPU tests in CI.
 
+Node test workers reuse their module graph to keep the large monorepo suite fast. A Node test that
+replaces a global, changes an environment variable, or mutates shared module state must restore it
+before the file finishes. Browser test files remain isolated because GPU resources and pending queue
+work cannot safely be reused across files.
+
 ## Legacy render and perf tests
 
 `test/render/**` snapshot tests and `test/perf/**` benchmarks are still on the legacy browser harness in this phase of the migration. They are excluded from Vitest and continue to rely on `BrowserTestDriver` utilities.

--- a/docs/developer/dev-tools/llm-friendly-test-setup.md
+++ b/docs/developer/dev-tools/llm-friendly-test-setup.md
@@ -31,6 +31,10 @@ This repo uses `@vis.gl/dev-tools` for shared Vitest wiring and keeps repository
   - `browser`
   - `headless`
 - Browser execution uses Playwright through `@vis.gl/dev-tools`.
+- Node test files run in worker threads and reuse the worker's module graph. Tests that replace
+  globals or mutate module-level state must restore that state in an `afterEach` or `afterAll` hook.
+- Browser test files remain isolated because GPU devices, presentation contexts, and queued GPU
+  work are not safe to share between files.
 - The tape-style compatibility helper lives at `test/utils/vitest-tape.ts`.
 
 ## Playwright behavior

--- a/modules/deck-luspatial/test/luspatial-geographic-point-query-effect.spec.ts
+++ b/modules/deck-luspatial/test/luspatial-geographic-point-query-effect.spec.ts
@@ -33,13 +33,14 @@ test('LuSpatialGeographicPointQueryEffect validates props before browser GPU all
   expect(() => new LuSpatialGeographicPointQueryEffect(device, props)).toThrow(allocationSentinel);
 });
 
-test('LuSpatialGeographicPointQueryEffect supports a browser-safe software WebGPU lifecycle', async () => {
+test('LuSpatialGeographicPointQueryEffect supports a browser WebGPU lifecycle on hardware', async () => {
   const device = await getWebGPUTestDevice();
-  if (!device) return;
-
+  // Constructing this graph compiles its integer-fp64 pipelines and leaves SwiftShader busy for
+  // minutes during browser teardown. Real hardware still covers the lifecycle and submitted results.
+  if (!device || isSoftwareBackedDevice(device)) return;
   const publishedStats: unknown[] = [];
   const effect = new LuSpatialGeographicPointQueryEffect(device, {
-    id: 'luspatial-geographic-query-software-lifecycle-test',
+    id: 'luspatial-geographic-query-hardware-lifecycle-test',
     longitudeLatitudes: new Float32Array([-73.97, 40.75, -73.99, 40.74]),
     sourceBounds: [-74, 40.72, -73.94, 40.78],
     projectionOrigin: [-73.97, 40.75],
@@ -80,13 +81,13 @@ test('LuSpatialGeographicPointQueryEffect supports a browser-safe software WebGP
     effect.setSelectionRadius(0.01);
     expect(effect.getSelection().radiusKilometres).toBe(0.1);
     expect(redrawReasons).toEqual([
-      'luspatial-geographic-query-software-lifecycle-test selection changed',
-      'luspatial-geographic-query-software-lifecycle-test selection radius changed'
+      'luspatial-geographic-query-hardware-lifecycle-test selection changed',
+      'luspatial-geographic-query-hardware-lifecycle-test selection radius changed'
     ]);
 
     const defaultCommandEncoder = device.commandEncoder;
     const lifecycleCommandEncoder = device.createCommandEncoder({
-      id: 'luspatial-geographic-query-software-lifecycle-test'
+      id: 'luspatial-geographic-query-hardware-lifecycle-test'
     });
     device.commandEncoder = lifecycleCommandEncoder;
     try {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,13 +43,19 @@ export default getVitestConfig({
     node: {
       test: {
         color: 'blue',
-        browser: {enabled: false}
+        browser: {enabled: false},
+        // Node tests restore the globals they replace, so workers can safely reuse their module
+        // graph. This avoids rebuilding the full monorepo graph in a child process for every file.
+        pool: 'threads',
+        isolate: false
       }
     },
     browser: {
       test: {
         color: 'green',
         environment: 'node',
+        // GPU devices and presentation resources are intentionally isolated between test files.
+        isolate: true,
         fileParallelism: !process.env.CI,
         setupFiles: ['./test/utils/browser-process-shim.mjs'],
         include: ['modules/**/*.spec.{ts,js}', 'test/**/*.spec.{ts,js}'],
@@ -60,6 +66,8 @@ export default getVitestConfig({
       test: {
         color: 'cyan',
         environment: 'node',
+        // GPU devices and presentation resources are intentionally isolated between test files.
+        isolate: true,
         fileParallelism: !process.env.CI,
         setupFiles: ['./test/utils/browser-process-shim.mjs'],
         include: ['modules/**/*.spec.{ts,js}', 'test/**/*.spec.{ts,js}'],


### PR DESCRIPTION
## Goals

Reduce luma.gl test time at the test/runtime level: avoid repeated module-graph construction in Node and remove a measured SwiftShader teardown stall from browser shard 1. Preserve browser isolation and the existing three-shard CI topology.

## Changes

- Run Node tests in worker threads with `isolate: false`, allowing each worker to reuse its module graph across files.
- Keep browser and headless test files explicitly isolated because GPU resources and queued work are unsafe to share.
- Keep the LuSpatial prop-validation test active everywhere, but run its integer-fp64 graph/pipeline lifecycle only on real GPU hardware. On CI's software-backed WebGPU device, constructing that graph leaves SwiftShader busy for minutes after the test has reported success.
- Keep real-hardware lifecycle and submitted-result coverage intact.
- Document the Node test isolation contract: tests that replace globals, environment variables, or shared module state must restore them.

No benchmark files, coverage configuration, production APIs, or CI shard counts are changed.

## Measured impact

- Controlled full Node run: 341.55s with per-file isolation → 30.56s with module-graph reuse (about 11× faster).
- GitHub Node phase on the preceding revision: 53.65s on the immediately preceding `master` run → 17.01s (about 3.2× faster).
- On the current-base Linux run, shard 1 took 591.03s and had a 148.8s silent gap immediately after the LuSpatial test reported 130ms.
- The preceding submission-mock revision only reduced shard 1 to 577.89s (16.6s / 2.8%), confirming that submission was not the root cause.
- Locally, the original LuSpatial pipeline path remained alive for more than two minutes after the coverage report. With the software-device guard, the focused coverage process exits cleanly: 3 tests passed in 30.67s, with 64ms of test execution.

The new GitHub workflow will provide the authoritative Ubuntu shard-1 timing.

## Verification

- `nvm use` — Node 22.22.1
- `yarn install --immutable`
- `yarn lint fix`
- `yarn build`
- `yarn test-node` — 2,636 passed, 1 skipped in 12.54s; post-amend commit hook passed the same suite in 17.80s
- `CI=1 yarn test-coverage modules/deck-luspatial/test/luspatial-geographic-point-query-effect.spec.ts` — 3 passed in 30.67s and exited cleanly

A full local shard-1 browser run reached the desktop browser-session limit and disconnected at `gpu-command-graph.spec.ts`; it was not counted as a pass. GitHub's Ubuntu/SwiftShader workflow is the authoritative full-suite check. `yarn website:build` and `(cd website && yarn build)` were not run because this PR changes only test configuration, tests, and test documentation.