### PR TITLE
Reduce browser test overhead

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,47 +209,103 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  node_coverage:
+    name: Node coverage
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node (with Corepack)
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Enable Corepack / Yarn 4
+        run: |
+          corepack enable
+          corepack prepare yarn@4.13.0 --activate
+          yarn -v
+
+      - name: Cache Yarn Berry artifacts
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.yarn/berry/cache
+            .yarn/install-state.gz
+          key: ${{ runner.os }}-yarn4-${{ hashFiles('yarn.lock', '.yarnrc.yml', 'package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn4-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Collect focused Node coverage
+        run: yarn test-node-coverage
+
+      - name: Upload Node coverage artifact
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: node-coverage-lcov
+          path: coverage-node/lcov.info
+          if-no-files-found: error
+          retention-days: 1
+
   test:
-    name: Aggregate browser coverage
-    needs: browser_coverage
+    name: Aggregate test coverage
+    needs: [browser_coverage, node_coverage]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
       - name: Checkout code for coverage reporting
-        if: ${{ needs.browser_coverage.result == 'success' }}
+        if: ${{ needs.browser_coverage.result == 'success' && needs.node_coverage.result == 'success' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download browser coverage artifacts
-        if: ${{ needs.browser_coverage.result == 'success' }}
+        if: ${{ needs.browser_coverage.result == 'success' && needs.node_coverage.result == 'success' }}
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           pattern: browser-coverage-lcov-*
           path: coverage/shards
 
-      - name: Merge browser coverage reports
-        if: ${{ needs.browser_coverage.result == 'success' }}
+      - name: Download Node coverage artifact
+        if: ${{ needs.browser_coverage.result == 'success' && needs.node_coverage.result == 'success' }}
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: node-coverage-lcov
+          path: coverage/shards/node-coverage-lcov
+
+      - name: Merge browser and Node coverage reports
+        if: ${{ needs.browser_coverage.result == 'success' && needs.node_coverage.result == 'success' }}
         run: |
           node ./test/utils/merge-lcov.mjs \
             --output coverage/lcov.info \
             coverage/shards/browser-coverage-lcov-1/lcov.info \
             coverage/shards/browser-coverage-lcov-2/lcov.info \
-            coverage/shards/browser-coverage-lcov-3/lcov.info
+            coverage/shards/browser-coverage-lcov-3/lcov.info \
+            coverage/shards/node-coverage-lcov/lcov.info
 
       - name: Upload combined coverage to Coveralls
-        if: ${{ needs.browser_coverage.result == 'success' }}
+        if: ${{ needs.browser_coverage.result == 'success' && needs.node_coverage.result == 'success' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: coverage/lcov.info
 
-      - name: Verify all browser coverage shards passed
+      - name: Verify all coverage jobs passed
         if: always()
         env:
-          SHARD_RESULT: ${{ needs.browser_coverage.result }}
+          BROWSER_COVERAGE_RESULT: ${{ needs.browser_coverage.result }}
+          NODE_COVERAGE_RESULT: ${{ needs.node_coverage.result }}
         run: |
-          if [ "$SHARD_RESULT" != "success" ]; then
-            echo "::error::Browser coverage shards finished with status: $SHARD_RESULT"
+          if [ "$BROWSER_COVERAGE_RESULT" != "success" ]; then
+            echo "::error::Browser coverage shards finished with status: $BROWSER_COVERAGE_RESULT"
+            exit 1
+          fi
+          if [ "$NODE_COVERAGE_RESULT" != "success" ]; then
+            echo "::error::Node coverage job finished with status: $NODE_COVERAGE_RESULT"
             exit 1
           fi
 
@@ -312,7 +368,7 @@ jobs:
         run: |
           yarn lint
 
-      - name: Run node tests
+      - name: Run Node tests
         run: yarn test-node
 
       - name: Typecheck examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,11 +108,6 @@ jobs:
           df -h .
           du -sh . coverage "${HOME}/.yarn" "${HOME}/.cache/ms-playwright" "${RUNNER_TEMP}" 2>/dev/null || true
 
-      - name: Run node tests
-        if: ${{ matrix.shard == 3 }}
-        run: |
-          yarn test-node
-
       - name: Sanitize lcov for Coveralls
         run: |
           node - <<'NODE'
@@ -215,6 +210,7 @@ jobs:
           retention-days: 7
 
   test:
+    name: Aggregate browser coverage
     needs: browser_coverage
     if: ${{ !cancelled() }}
     runs-on: ubuntu-22.04
@@ -258,6 +254,7 @@ jobs:
           fi
 
   examples:
+    name: Build, lint, Node tests, examples, and website
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
@@ -314,6 +311,9 @@ jobs:
       - name: Run lint
         run: |
           yarn lint
+
+      - name: Run node tests
+        run: yarn test-node
 
       - name: Typecheck examples
         run: |

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -20,6 +20,10 @@ Vitest discovers tests directly from spec files:
 - Use `*.spec.ts` / `*.spec.js` for the default browser-backed test path.
 - Use `*.node.spec.ts` / `*.node.spec.js` only for tests that must stay in the Node project.
 
+`vitest.config.ts` also routes an audited set of existing CPU-only specs to Node. Keep that list for
+tests that do not create a device or access browser globals; new CPU-only tests should use the
+`.node.spec` suffix directly.
+
 ## Test device creation
 
 Creating too many GPU devices in one run can cause context loss and other instability. `@luma.gl/test-utils` exports reusable test devices for WebGL and WebGPU.

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -9,11 +9,13 @@ The primary test runner is Vitest.
 ## Commands
 
 - `yarn test-node` runs the Node-only test suite.
+- `yarn test-node-coverage` collects Istanbul coverage from CPU-only specs moved out of Chromium
+  plus focused native Node suites, and writes Node LCOV.
 - `yarn test-browser` runs browser-backed tests in headed Chromium for local development.
 - `yarn test-headless` runs the browser-backed suite in headless Chromium for CI.
-- `yarn test` runs `test-node` and then `test-browser`.
+- `yarn test` runs `test-node` and then `test-headless`.
 - `yarn test-fast` runs linting and the Node-only suite.
-- `yarn test-coverage` runs the Node-only suite plus the headless browser suite with coverage enabled.
+- `yarn test-coverage` runs the headless browser suite with Istanbul coverage enabled.
 
 Vitest discovers tests directly from spec files:
 

--- a/docs/developer/dev-tools/llm-friendly-test-setup.md
+++ b/docs/developer/dev-tools/llm-friendly-test-setup.md
@@ -6,6 +6,7 @@ This repo uses `@vis.gl/dev-tools` for shared Vitest wiring and keeps repository
 
 - The root package exposes the user-facing commands:
   - `yarn test-node`
+  - `yarn test-node-coverage`
   - `yarn test-browser`
   - `yarn test-browser-benchmarks`
   - `yarn test-headless`
@@ -40,6 +41,9 @@ This repo uses `@vis.gl/dev-tools` for shared Vitest wiring and keeps repository
 - Browser coverage uses weighted sharding so known slow GPU specs are spread across the existing
   three CI jobs. Benchmark-only specs run with `yarn test-browser-benchmarks` instead of adding
   instrumented browser pages to every pull request.
+- CI merges focused Istanbul coverage from CPU-only specs moved to Node and native Node coverage
+  anchors with Istanbul coverage from the three browser shards. The complete Node suite still runs
+  separately without instrumentation so coverage remapping does not slow the build job.
 - The tape-style compatibility helper lives at `test/utils/vitest-tape.ts`.
 
 ## Playwright behavior

--- a/docs/developer/dev-tools/llm-friendly-test-setup.md
+++ b/docs/developer/dev-tools/llm-friendly-test-setup.md
@@ -7,6 +7,7 @@ This repo uses `@vis.gl/dev-tools` for shared Vitest wiring and keeps repository
 - The root package exposes the user-facing commands:
   - `yarn test-node`
   - `yarn test-browser`
+  - `yarn test-browser-benchmarks`
   - `yarn test-headless`
   - `yarn test-coverage`
   - `yarn website-debug`
@@ -33,8 +34,12 @@ This repo uses `@vis.gl/dev-tools` for shared Vitest wiring and keeps repository
 - Browser execution uses Playwright through `@vis.gl/dev-tools`.
 - Node test files run in worker threads and reuse the worker's module graph. Tests that replace
   globals or mutate module-level state must restore that state in an `afterEach` or `afterAll` hook.
+- `nodeOnlyTestPatterns` routes audited CPU-only legacy specs away from browser-page isolation.
 - Browser test files remain isolated because GPU devices, presentation contexts, and queued GPU
   work are not safe to share between files.
+- Browser coverage uses weighted sharding so known slow GPU specs are spread across the existing
+  three CI jobs. Benchmark-only specs run with `yarn test-browser-benchmarks` instead of adding
+  instrumented browser pages to every pull request.
 - The tape-style compatibility helper lives at `test/utils/vitest-tape.ts`.
 
 ## Playwright behavior

--- a/modules/experimental/test/gpu-project/gpu-project.spec.ts
+++ b/modules/experimental/test/gpu-project/gpu-project.spec.ts
@@ -228,6 +228,11 @@ test('GPUProjection subtracts raw binary64 origins before converting local offse
     tapeTest.end();
     return;
   }
+  if (isSoftwareBackedDevice(device)) {
+    tapeTest.comment('Skipping slow raw binary64 projection shader on software WebGPU');
+    tapeTest.end();
+    return;
+  }
 
   const sourceOrigin: Coordinates = [20_000_000.125, 30_000_000.375];
   const projection = (coordinates: number[]): number[] => [
@@ -293,6 +298,11 @@ test('GPUProjection accepts inclusive binary64 patch endpoints after Float32 nor
   const device = await getWebGPUTestDevice();
   if (!device) {
     tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+  if (isSoftwareBackedDevice(device)) {
+    tapeTest.comment('Skipping slow raw binary64 projection shader on software WebGPU');
     tapeTest.end();
     return;
   }
@@ -380,6 +390,10 @@ test('GPUProjection rejects outer-domain positions without removing patch seam t
     tapeTest.end();
     return;
   }
+  const softwareBackedDevice = isSoftwareBackedDevice(device);
+  if (softwareBackedDevice) {
+    tapeTest.comment('Skipping slow raw binary64 projection variants on software WebGPU');
+  }
 
   const minimum = -500_000_000;
   const maximum = 500_000_000;
@@ -453,7 +467,7 @@ test('GPUProjection rejects outer-domain positions without removing patch seam t
       explicitPatchIds: true,
       outputBuffer: createOutputBuffer(device, points.length * 2)
     }
-  ];
+  ].filter(testCase => !softwareBackedDevice || testCase.positions === float32Positions);
   const contributors = cases.map(({name, positions, explicitPatchIds, outputBuffer}) => {
     const contributor = new GPUProjection({
       id: name,
@@ -1096,6 +1110,11 @@ test('GPUProjection updates exact global bounds without rebuilding its graph', a
     tapeTest.end();
     return;
   }
+  if (isSoftwareBackedDevice(device)) {
+    tapeTest.comment('Skipping slow raw binary64 projection shader on software WebGPU');
+    tapeTest.end();
+    return;
+  }
 
   const projection = (coordinates: number[]): number[] => [...coordinates];
   const initialPlan = compileProjectionPlan({
@@ -1172,6 +1191,11 @@ test('GPUProjection retains tolerant raw-binary64 assignment at internal patch s
   const device = await getWebGPUTestDevice();
   if (!device) {
     tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+  if (isSoftwareBackedDevice(device)) {
+    tapeTest.comment('Skipping slow raw binary64 projection shader on software WebGPU');
     tapeTest.end();
     return;
   }
@@ -1346,6 +1370,12 @@ function assertProjectedPoints(
 
 function createBuffer(device: Device, values: Float32Array | Uint32Array): Buffer {
   return device.createBuffer({data: values, usage: Buffer.STORAGE | Buffer.COPY_DST});
+}
+
+function isSoftwareBackedDevice(device: Device): boolean {
+  return (
+    device.info.gpu === 'software' || device.info.gpuType === 'cpu' || Boolean(device.info.fallback)
+  );
 }
 
 function createOutputBuffer(device: Device, elementCount: number): Buffer {

--- a/modules/shadertools/test/modules/math/fp64-arithmetic-compute.spec.ts
+++ b/modules/shadertools/test/modules/math/fp64-arithmetic-compute.spec.ts
@@ -407,6 +407,11 @@ test('fp64 WGSL#sub_fp64u32_to_fp64 preserves binary64 coordinate deltas', async
     tapeTest.end();
     return;
   }
+  if (isSoftwareBackedDevice(webgpuDevice)) {
+    tapeTest.comment('Skipping slow fp64 integer subtraction on software WebGPU');
+    tapeTest.end();
+    return;
+  }
 
   const coordinateCases = [
     {inputA: 20_000_000.123456, inputB: 20_000_000, label: 'projected coordinate offset'},
@@ -540,6 +545,11 @@ test('fp64 WGSL#normalize, classify, sign, and compare double-single values', as
   const webgpuDevice = await getWebGPUTestDevice();
   if (!webgpuDevice) {
     tapeTest.comment('WebGPU unavailable, skipping fp64 comparison diagnostics');
+    tapeTest.end();
+    return;
+  }
+  if (isSoftwareBackedDevice(webgpuDevice)) {
+    tapeTest.comment('Skipping slow fp64 integer classification on software WebGPU');
     tapeTest.end();
     return;
   }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "publish-prod": "ocular-publish version-only-prod",
     "test": "yarn test-node && yarn test-headless",
     "test-node": "ocular-test node",
+    "test-node-coverage": "LUMA_TEST_NODE_COVERAGE=true ocular-test node --coverage.enabled --coverage.provider=istanbul --coverage.reporter=lcovonly --coverage.reportsDirectory=coverage-node",
     "test-browser": "ocular-test browser",
     "test-browser-benchmarks": "LUMA_TEST_BROWSER_BENCHMARKS=true ocular-test headless --no-coverage",
     "test-headless": "ocular-test headless",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test": "yarn test-node && yarn test-headless",
     "test-node": "ocular-test node",
     "test-browser": "ocular-test browser",
+    "test-browser-benchmarks": "LUMA_TEST_BROWSER_BENCHMARKS=true ocular-test headless --no-coverage",
     "test-headless": "ocular-test headless",
     "test-coverage": "ocular-test headless --coverage",
     "test-geospatial-package": "node ./scripts/verify-experimental-geospatial-package.mjs",

--- a/test/utils/browser-test-sequencer.ts
+++ b/test/utils/browser-test-sequencer.ts
@@ -1,0 +1,84 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {relative} from 'node:path';
+import {BaseSequencer, type TestSpecification} from 'vitest/node';
+
+const DEFAULT_BROWSER_TEST_WEIGHT = 3;
+
+// Coarse weights from SwiftShader CI timings. Most browser files spend about three seconds on
+// page setup and execution; these known outliers need explicit weights so Vitest does not place
+// several of them in the same shard. Update only when CI timings materially change.
+const SLOW_BROWSER_TEST_WEIGHTS: Readonly<Record<string, number>> = {
+  'modules/experimental/test/gpu-raster/gpu-raster-tile-halo-parity.spec.ts': 14,
+  'modules/text/test/text-2d/convert-arrow-text-vectors.spec.ts': 14,
+  'modules/arrow-layers/test/gpu-graph-deck.spec.ts': 10,
+  'modules/experimental/test/geospatial/geospatial-projection-distance.spec.ts': 9,
+  'test/examples/gpu-dataframe-analysis.spec.ts': 9,
+  'modules/arrow/test/arrow/arrow-path-model.spec.ts': 9,
+  'modules/experimental/test/gpu-graph/gpu-graph-core-number.spec.ts': 9,
+  'modules/experimental/test/gpu-dataframe/gpu-global-aggregation.spec.ts': 9,
+  'modules/arrow/test/arrow/dggs-gpu-polygons.spec.ts': 8,
+  'modules/experimental/test/gpu-graph/gpu-graph-modularity-optimization.spec.ts': 8
+};
+
+type WeightedTestSpecification = {
+  path: string;
+  specification: TestSpecification;
+  weight: number;
+};
+
+type ShardBucket = {
+  index: number;
+  specifications: TestSpecification[];
+  totalWeight: number;
+};
+
+/** Distributes expensive browser specs across shards instead of hashing paths into equal counts. */
+export class BrowserTestSequencer extends BaseSequencer {
+  override async shard(specifications: TestSpecification[]): Promise<TestSpecification[]> {
+    const shardConfiguration = this.ctx.config.shard;
+    if (!shardConfiguration) {
+      return specifications;
+    }
+
+    const weightedSpecifications = specifications
+      .map(specification => {
+        const testPath = relative(this.ctx.config.root, specification.moduleId).replaceAll(
+          '\\',
+          '/'
+        );
+        return {
+          path: testPath,
+          specification,
+          weight: SLOW_BROWSER_TEST_WEIGHTS[testPath] ?? DEFAULT_BROWSER_TEST_WEIGHT
+        } satisfies WeightedTestSpecification;
+      })
+      .sort((left, right) => right.weight - left.weight || left.path.localeCompare(right.path));
+    const shardBuckets: ShardBucket[] = Array.from(
+      {length: shardConfiguration.count},
+      (_, index) => ({index, specifications: [], totalWeight: 0})
+    );
+
+    for (const weightedSpecification of weightedSpecifications) {
+      const lightestBucket = shardBuckets.reduce((selectedBucket, candidateBucket) => {
+        if (candidateBucket.totalWeight !== selectedBucket.totalWeight) {
+          return candidateBucket.totalWeight < selectedBucket.totalWeight
+            ? candidateBucket
+            : selectedBucket;
+        }
+        if (candidateBucket.specifications.length !== selectedBucket.specifications.length) {
+          return candidateBucket.specifications.length < selectedBucket.specifications.length
+            ? candidateBucket
+            : selectedBucket;
+        }
+        return candidateBucket.index < selectedBucket.index ? candidateBucket : selectedBucket;
+      });
+      lightestBucket.specifications.push(weightedSpecification.specification);
+      lightestBucket.totalWeight += weightedSpecification.weight;
+    }
+
+    return shardBuckets[shardConfiguration.index - 1].specifications;
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -111,10 +111,10 @@ const nodeCoverageIncludePatterns = [
 const nodeCoverageNativePatterns = [
   'test/dev-modules/**/*.node.spec.{ts,js}',
   'modules/gltf/test/gltf/gltf-animated-crowd.node.spec.{ts,js}',
-  'modules/anari/test/{gltf-import,scene-export,scene-interchange}.node.spec.{ts,js}',
-  'modules/geoarrow/test/geoarrow/{geoarrow-dense-union,arrow-polygon-tessellation}.node.spec.{ts,js}',
+  'modules/scene/test/{gltf-import,scene-export,scene-interchange}.node.spec.{ts,js}',
+  'modules/math-geoarrow/test/geoarrow/{geoarrow-dense-union,arrow-polygon-tessellation}.node.spec.{ts,js}',
   'modules/splats/test/{splat-renderer,gpu-paged-splat-renderer,splat-residency,splat-hierarchy}.node.spec.{ts,js}',
-  'modules/experimental/test/gpu-core/gpu-command-graph-{history,passes,planning}.node.spec.{ts,js}',
+  'modules/gpgpu/test/gpu-core/gpu-command-graph-{history,passes,planning}.node.spec.{ts,js}',
   'modules/experimental/test/gpu-raster/{gpu-raster-tile-source,gpu-raster-tile-cache,gpu-raster-cross-tile-components}.node.spec.{ts,js}',
   'modules/experimental/test/gpu-sql/lu-sql.node.spec.{ts,js}'
 ];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import {getVitestConfig} from '@vis.gl/dev-tools';
+import {BrowserTestSequencer} from './test/utils/browser-test-sequencer';
 
 const excludePatterns = [
   '**/*.disabled.*',
@@ -17,9 +18,105 @@ const excludePatterns = [
   'test/perf/**',
   'test/render/**'
 ];
+// These specs exercise pure data transforms, layouts, shader assembly, and validation. Running
+// them in Node preserves the assertions while avoiding one isolated browser page per file.
+const nodeOnlyTestPatterns = [
+  'test/devtools/**/*.spec.{ts,js}',
+  'modules/effects/test/passes/image-adjust-filters/**/*.spec.{ts,js}',
+  'modules/effects/test/passes/image-blur-filters/{gaussianblur,zoomblur,tiltshift,triangleblur}.spec.{ts,js}',
+  'modules/effects/test/passes/image-warp-filters/**/*.spec.{ts,js}',
+  'modules/effects/test/passes/image-fun-filters/**/*.spec.{ts,js}',
+  'modules/effects/test/passes/screen-space/dof.spec.{ts,js}',
+  'modules/core/test/shadertypes/**/*.spec.{ts,js}',
+  'modules/core/test/adapter-utils/{buffer-layout-utils,format-compiler-log,get-attribute-from-layout}.spec.{ts,js}',
+  'modules/core/test/adapter/helpers/parse-shader-compiler-log.spec.{ts,js}',
+  'modules/core/test/portable/**/*.spec.{ts,js}',
+  'modules/core/test/utils/**/*.spec.{ts,js}',
+  'modules/engine/test/animation/**/*.spec.{ts,js}',
+  'modules/engine/test/application-utils/**/*.spec.{ts,js}',
+  'modules/engine/test/debug/**/*.spec.{ts,js}',
+  'modules/engine/test/geometry/{geometries,geometry,geometry-utils}.spec.{ts,js}',
+  'modules/engine/test/lib/picking-manager.spec.{ts,js}',
+  'modules/engine/test/scenegraph/scenegraph-node.spec.{ts,js}',
+  'modules/engine/test/utils/**/*.spec.{ts,js}',
+  'modules/engine/test/shader-inputs.spec.{ts,js}',
+  'modules/text/test/text-2d/{text-layout,arrow-text,text-utils,build-msdf-font-atlas,font-atlas-builders}.spec.{ts,js}',
+  'modules/text/test/text-3d/**/*.spec.{ts,js}',
+  'modules/tables/test/table/{gpu-table-model,generated-buffer-batches,table-buffer-planner}.spec.{ts,js}',
+  'modules/webgpu/test/adapter/helpers/get-vertex-buffer-layout.spec.{ts,js}',
+  'modules/webgpu/test/adapter/resources/webgpu-render-pass.spec.{ts,js}',
+  'modules/webgpu/test/wgsl/**/*.spec.{ts,js}',
+  'modules/webgl/test/adapter/helpers/{parse-shader-compiler-log,webgl-texture-table,webgl-topology-utils}.spec.{ts,js}',
+  'modules/webgl/test/adapter/device-helpers/webgl-device-info.spec.{ts,js}',
+  'modules/webgl/test/adapter/webgl-adapter.spec.{ts,js}',
+  'modules/webgl/test/context/state-tracker/deep-array-equal.spec.{ts,js}',
+  'modules/webgl/test/utils/**/*.spec.{ts,js}',
+  'modules/arrow/test/arrow/{arrow-column-info,arrow-shader-layout,arrow-input-schema,arrow-splats,arrow-matrix-gpu-vector,arrow-geometry,arrow-model,arrow-paths,arrow-polygon-renderer,arrow-polygon,plain-gpu-table,analyze-arrow-table,arrow-variable-length-attribute-gpu-vector,get-arrow-data,arrow-fixed-size-list}.spec.{ts,js}',
+  'modules/geoarrow/test/geoarrow/geoarrow-interleaving.spec.{ts,js}',
+  'modules/gltf/test/gltf/{lights,gltf-extension-support,gltf-animator}.spec.{ts,js}',
+  'modules/gltf/test/parsers/{parse-gltf-animations,parse-pbr-material,parse-pbr-compressed-texture}.spec.{ts,js}',
+  'modules/gltf/test/webgl-to-webgpu/**/*.spec.{ts,js}',
+  'modules/gpgpu/test/gpu-vector/gpu-data-evaluator-types.spec.{ts,js}',
+  'modules/gpgpu/test/operations/arithmetic-operation.spec.{ts,js}',
+  'modules/gpgpu/test/utils/{expression,webgpu-dispatch}.spec.{ts,js}',
+  'modules/splats/test/{splat-rad-hierarchy,splat-browser-coverage}.spec.{ts,js}',
+  'modules/test-utils/test/null-device/**/*.spec.{ts,js}',
+  'modules/experimental/test/geospatial/geospatial-types.spec.{ts,js}',
+  'modules/experimental/test/textures/packed-pixels.spec.{ts,js}',
+  'modules/experimental/test/webxr/webxr-animation-frame-provider.spec.{ts,js}',
+  'modules/shadertools/test/lib/preprocessor/**/*.spec.{ts,js}',
+  'modules/shadertools/test/lib/generator/**/*.spec.{ts,js}',
+  'modules/shadertools/test/lib/glsl-utils/**/*.spec.{ts,js}',
+  'modules/shadertools/test/lib/shader-assembly/assemble-wgsl-auto-bindings.spec.{ts,js}',
+  'modules/shadertools/test/lib/shader-module/{shader-module-dependencies,shader-module}.spec.{ts,js}',
+  'modules/shadertools/test/lib/{uniform-types,shader-plugin,shader-assembler}.spec.{ts,js}',
+  'modules/shadertools/test/modules/lighting/{lambert-material,lights,gouraud-material,water-material,phong-material,dirlight,pbr-scene}.spec.{ts,js}',
+  'modules/shadertools/test/modules/math/{fp16-utils,fp64-utils}.spec.{ts,js}',
+  'modules/shadertools/test/modules/utils/random.spec.{ts,js}',
+  'modules/shadertools/test/modules/modules.spec.{ts,js}'
+];
+const nodeIncludePatterns = [
+  'modules/**/*.node.spec.{ts,js}',
+  'test/**/*.node.spec.{ts,js}',
+  ...nodeOnlyTestPatterns
+];
+// These plain specs are imported by an existing .node.spec wrapper or register the same shared
+// suite as one. Exclude the plain entry point so the shared module graph registers each suite once.
+const nodeWrapperSourcePatterns = [
+  'modules/arrow/test/arrow/{arrow-polygon,arrow-polygon-renderer,arrow-splats}.spec.{ts,js}',
+  'modules/core/test/adapter/helpers/parse-shader-compiler-log.spec.{ts,js}',
+  'modules/core/test/adapter-utils/format-compiler-log.spec.{ts,js}',
+  'modules/core/test/shadertypes/data-type-utils.spec.{ts,js}',
+  'modules/core/test/shadertypes/textures/texture-layout.spec.{ts,js}',
+  'modules/engine/test/animation/{animation-mixer,key-frames,morph-targets,timeline}.spec.{ts,js}',
+  'modules/engine/test/geometry/geometries.spec.{ts,js}',
+  'modules/engine/test/utils/{deep-equal,split-uniforms-and-bindings}.spec.{ts,js}',
+  'modules/gltf/test/gltf/gltf-animator.spec.{ts,js}',
+  'modules/gltf/test/parsers/parse-gltf-animations.spec.{ts,js}',
+  'modules/gltf/test/webgl-to-webgpu/convert-webgl-sampler.spec.{ts,js}',
+  'modules/shadertools/test/lib/generator/{captialize,generate-shader}.spec.{ts,js}',
+  'modules/shadertools/test/lib/glsl-utils/shader-utils.spec.{ts,js}',
+  'modules/shadertools/test/lib/preprocessor/preprocessor.spec.{ts,js}',
+  'modules/shadertools/test/modules/lighting/{gouraud-material,lambert-material,lights,phong-material}.spec.{ts,js}',
+  'modules/splats/test/{splat-browser-coverage,splat-rad-hierarchy}.spec.{ts,js}',
+  'modules/tables/test/table/gpu-table-model.spec.{ts,js}',
+  'modules/webgl/test/adapter/helpers/{parse-shader-compiler-log,webgl-topology-utils}.spec.{ts,js}'
+];
+// Benchmarks answer performance questions but do not add stable correctness coverage. Keep them
+// out of every pull request's instrumented browser run and expose them through an opt-in project.
+const browserBenchmarkTestPatterns = [
+  'modules/experimental/test/gpu-core/gpu-spatial-query-benchmark.spec.ts',
+  'modules/experimental/test/gpu-core/gpu-workgroup-reduction-benchmark.spec.ts',
+  'modules/experimental/test/gpu-core/gpu-workgroup-scan-benchmark.spec.ts',
+  'modules/experimental/test/gpu-graph/gpu-graph-benchmark.spec.ts',
+  'modules/experimental/test/gpu-project/projection-benchmark.spec.ts'
+];
+const runBrowserBenchmarks = process.env.LUMA_TEST_BROWSER_BENCHMARKS === 'true';
 const browserExcludePatterns = [
   'modules/**/*.node.spec.{ts,js}',
   'test/**/*.node.spec.{ts,js}',
+  ...browserBenchmarkTestPatterns,
+  ...nodeOnlyTestPatterns,
   ...excludePatterns
 ];
 const launchArguments = [
@@ -28,7 +125,7 @@ const launchArguments = [
   ...(process.env.CI ? ['--use-angle=swiftshader', '--enable-unsafe-swiftshader'] : [])
 ];
 
-export default getVitestConfig({
+const vitestConfig = getVitestConfig({
   excludePatterns,
   launchOptions: {
     channel: 'chromium',
@@ -47,7 +144,9 @@ export default getVitestConfig({
         // Node tests restore the globals they replace, so workers can safely reuse their module
         // graph. This avoids rebuilding the full monorepo graph in a child process for every file.
         pool: 'threads',
-        isolate: false
+        isolate: false,
+        include: nodeIncludePatterns,
+        exclude: [...excludePatterns, ...nodeWrapperSourcePatterns]
       }
     },
     browser: {
@@ -58,8 +157,10 @@ export default getVitestConfig({
         isolate: true,
         fileParallelism: !process.env.CI,
         setupFiles: ['./test/utils/browser-process-shim.mjs'],
-        include: ['modules/**/*.spec.{ts,js}', 'test/**/*.spec.{ts,js}'],
-        exclude: browserExcludePatterns
+        include: runBrowserBenchmarks
+          ? browserBenchmarkTestPatterns
+          : ['modules/**/*.spec.{ts,js}', 'test/**/*.spec.{ts,js}'],
+        exclude: runBrowserBenchmarks ? excludePatterns : browserExcludePatterns
       }
     },
     headless: {
@@ -70,8 +171,10 @@ export default getVitestConfig({
         isolate: true,
         fileParallelism: !process.env.CI,
         setupFiles: ['./test/utils/browser-process-shim.mjs'],
-        include: ['modules/**/*.spec.{ts,js}', 'test/**/*.spec.{ts,js}'],
-        exclude: browserExcludePatterns
+        include: runBrowserBenchmarks
+          ? browserBenchmarkTestPatterns
+          : ['modules/**/*.spec.{ts,js}', 'test/**/*.spec.{ts,js}'],
+        exclude: runBrowserBenchmarks ? excludePatterns : browserExcludePatterns
       }
     }
   },
@@ -91,3 +194,12 @@ export default getVitestConfig({
     excludeAfterRemap: true
   }
 });
+
+// Vitest selects its sharding sequencer from the root test config before it groups files by
+// project. Project-level sequence settings only affect ordering after files have been sharded.
+vitestConfig.test = {
+  ...vitestConfig.test,
+  sequence: {...vitestConfig.test?.sequence, sequencer: BrowserTestSequencer}
+};
+
+export default vitestConfig;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -102,6 +102,26 @@ const nodeWrapperSourcePatterns = [
   'modules/tables/test/table/gpu-table-model.spec.{ts,js}',
   'modules/webgl/test/adapter/helpers/{parse-shader-compiler-log,webgl-topology-utils}.spec.{ts,js}'
 ];
+const nodeCoverageIncludePatterns = [
+  ...nodeOnlyTestPatterns,
+  ...nodeWrapperSourcePatterns.map(pattern => pattern.replace('.spec.', '.node.spec.'))
+];
+// These native Node suites exercise production branches that no browser-backed spec reaches. Keep
+// this list focused: Istanbul remapping for the complete Node graph takes several minutes.
+const nodeCoverageNativePatterns = [
+  'test/dev-modules/**/*.node.spec.{ts,js}',
+  'modules/gltf/test/gltf/gltf-animated-crowd.node.spec.{ts,js}',
+  'modules/anari/test/{gltf-import,scene-export,scene-interchange}.node.spec.{ts,js}',
+  'modules/geoarrow/test/geoarrow/{geoarrow-dense-union,arrow-polygon-tessellation}.node.spec.{ts,js}',
+  'modules/splats/test/{splat-renderer,gpu-paged-splat-renderer,splat-residency,splat-hierarchy}.node.spec.{ts,js}',
+  'modules/experimental/test/gpu-core/gpu-command-graph-{history,passes,planning}.node.spec.{ts,js}',
+  'modules/experimental/test/gpu-raster/{gpu-raster-tile-source,gpu-raster-tile-cache,gpu-raster-cross-tile-components}.node.spec.{ts,js}',
+  'modules/experimental/test/gpu-sql/lu-sql.node.spec.{ts,js}'
+];
+const nodeCoveragePatterns = [
+  ...nodeCoverageIncludePatterns,
+  ...nodeCoverageNativePatterns
+];
 // Benchmarks answer performance questions but do not add stable correctness coverage. Keep them
 // out of every pull request's instrumented browser run and expose them through an opt-in project.
 const browserBenchmarkTestPatterns = [
@@ -112,6 +132,7 @@ const browserBenchmarkTestPatterns = [
   'modules/experimental/test/gpu-project/projection-benchmark.spec.ts'
 ];
 const runBrowserBenchmarks = process.env.LUMA_TEST_BROWSER_BENCHMARKS === 'true';
+const runNodeCoverage = process.env.LUMA_TEST_NODE_COVERAGE === 'true';
 const browserExcludePatterns = [
   'modules/**/*.node.spec.{ts,js}',
   'test/**/*.node.spec.{ts,js}',
@@ -145,7 +166,10 @@ const vitestConfig = getVitestConfig({
         // graph. This avoids rebuilding the full monorepo graph in a child process for every file.
         pool: 'threads',
         isolate: false,
-        include: nodeIncludePatterns,
+        // Istanbul transforms use substantial memory. Bound the focused coverage pass so it is
+        // stable on GitHub's two-core runners without changing the fast default Node command.
+        ...(runNodeCoverage ? {maxWorkers: 2} : {}),
+        include: runNodeCoverage ? nodeCoveragePatterns : nodeIncludePatterns,
         exclude: [...excludePatterns, ...nodeWrapperSourcePatterns]
       }
     },
@@ -180,13 +204,17 @@ const vitestConfig = getVitestConfig({
   },
   coverage: {
     provider: 'istanbul',
-    include: ['modules/**/src/**/*.{js,ts,tsx}'],
+    // Browser coverage owns the all-files denominator. The focused Node pass only reports files
+    // loaded by its selected specs; remapping every source adds minutes of duplicate work.
+    ...(runNodeCoverage ? {} : {include: ['modules/**/src/**/*.{js,ts,tsx}']}),
     exclude: [
       '**/*.d.ts',
       '**/*.map',
       '**/*.{bundle,min}.{js,ts}',
       '**/{build,coverage,dist,node_modules,vendor,vendored}/**',
+      'dev-modules/**',
       'examples/**',
+      'scripts/**',
       'website/**',
       'test/**',
       'modules/**/test/**'


### PR DESCRIPTION
## Goals

Reduce luma.gl browser-test wall time without losing meaningful coverage. Keep the existing three browser shards, move CPU-only work out of Chromium, and keep CI's slowest path moving toward 4–5 minutes.

## Changes

- Route 127 audited CPU-only specs from isolated Chromium pages to the shared Node project while preserving their assertions.
- Remove 43 duplicate Node registrations where plain and `.node.spec` entry points register the same shared suite.
- Skip pathological raw-binary64 and integer-fp64 variants on software WebGPU only; full precision cases still run on hardware WebGPU.
- Keep five benchmark-only specs out of default instrumented coverage and expose them through `yarn test-browser-benchmarks`.
- Use a deterministic weighted sequencer to spread measured GPU outliers across the existing three browser shards.
- Run the complete Node suite uninstrumented in the parallel build/examples job.
- Add a focused, CPU-only **Node coverage** job using Istanbul. It covers the specs moved out of Chromium plus native Node coverage anchors, uploads LCOV, and runs in parallel with browser/build jobs.
- Merge the Node LCOV artifact with all three browser Istanbul artifacts before uploading to Coveralls.
- Rename the fan-in check to **Aggregate test coverage** and keep **Build, lint, Node tests, examples, and website** explicit.

## Coverage strategy

Browser coverage remains on Istanbul. V8 was evaluated and rejected:

- browser V8 exceeded eight minutes and was stopped;
- Node V8 took roughly two minutes in repeat runs;
- full-suite Node Istanbul also took several minutes.

The focused Istanbul pass is bounded to two workers for stable memory use and runs in its own parallel job, so it does not lengthen browser shards or the build/examples job.

Only production files under `modules/*/src` contribute to the Node artifact. Browser coverage continues to own the all-files denominator.

After rebasing, three package renames made eight coverage-anchor globs stale. The follow-up commit updates `anari→scene`, `geoarrow→math-geoarrow`, and `experimental/gpu-core→gpgpu/gpu-core`. Merging the corrected local Node LCOV with the exact three browser artifacts from the fresh CI run projects **77.527%**, above the **75.86%** base.

## Verification

Completed on the rebased branch:

- `nvm use`
- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn test-node-coverage`: 141 files passed, 1 skipped; 756 tests passed, 3 skipped
- commit hook / `yarn test-node`: 374 files passed, 1 skipped; 3,013 tests passed, 3 skipped
- `yarn website:build`
- `(cd website && yarn build)`
- workflow YAML parse
- exact four-report LCOV merge: 44,706 / 54,630 lines and 27,434 / 38,421 branches, 77.527% combined
- first rebased GitHub Actions run: every Actions job passed; its pre-fix Coveralls result was 75.285%

`yarn test` passed the Node phase. The local hardware-WebGPU phase reproduced six existing adapter-sensitive failures and one browser disconnect; the same rebased commit passed all three CI SwiftShader browser shards.

Earlier focused checks:

- CI-equivalent targeted SwiftShader run: 34 tests passed
- browser benchmarks: 5 files / 11 tests passed

Fresh CI and Coveralls on the latest path-fix commit are the final authority.