### PR TITLE
feat(examples): add WebGPU algebraic varieties showcase

### DIFF
--- a/.ocularrc.js
+++ b/.ocularrc.js
@@ -34,6 +34,7 @@ const config = {
       // Repo-owned shorthand aliases for website examples.
       examples: {
         animation: '/examples/api/animation',
+        'algebraic-varieties': '/examples/showcase/algebraic-varieties',
         scenes: '/examples/showcase/scene',
         'arrow-points': '/examples/arrow/arrow-points',
         'arrow-filtering': '/examples/arrow/arrow-filtering',

--- a/examples/showcase/algebraic-varieties/README.md
+++ b/examples/showcase/algebraic-varieties/README.md
@@ -1,0 +1,42 @@
+# Algebraic varieties
+
+This WebGPU-only showcase renders real implicit polynomial surfaces directly in a fullscreen
+fragment shader. It does not build a CPU mesh and does not assume that the polynomial value is a
+signed distance.
+
+The frame is declared as a reusable `GPUCommandGraph` render node. The application updates only its
+small camera, variety, coefficient, and lighting uniform block before encoding the compiled graph
+into the caller-owned command encoder. The per-pixel work remains a fragment render operation; a
+compute-to-storage-texture stage would add bandwidth without helping this single-pass MVP.
+
+Each camera ray is clipped to a conservative bounding sphere and sampled at fixed intervals. Sign
+changes are refined with guarded secant steps and bisection. Because even-multiplicity and tangent
+roots do not change sign, local minima of `abs(f) / max(length(grad f), epsilon)` also seed clamped
+Newton refinement using `grad f · d`. The nearest accepted root is shaded with an analytic
+gradient. Pixels whose gradient magnitude is small can be highlighted as candidate singular
+regions.
+
+The catalog includes an affine chart of the Clebsch diagonal cubic, Cayley's nodal cubic,
+Steiner's Roman quartic, a Kummer quartic, a Chmutov quintic, the Barth sextic, an algebraic heart
+sextic, a torus quartic, a tanglecube quartic, and the Whitney umbrella. The bounding sphere clips
+unbounded affine charts. The coefficient slider adds a low-order radial term; zero restores the
+named surface. Lighting is evaluated in a high dynamic range linear space and compressed for
+display with an ACES-like filmic curve.
+
+The showcase advances to the next surface after 15 seconds without input. Orbit, zoom, keyboard,
+preset, deformation, exposure, tab, and singularity-control interactions restart the idle
+countdown; a variety is never changed while a pointer interaction remains active. Each surface has
+an authored starting deformation, and slider changes are remembered independently while browsing
+the catalog. The reset button (or `R`) restores the active surface's authored coefficient, default
+exposure, camera, and default-on singularity overlay without changing the other saved coefficients.
+
+## Limitations
+
+- Fixed sampling is predictable but can miss roots closer together than a sampling interval.
+- Near-tangent roots and singular points are numerically ill-conditioned; the local-minimum path is
+  a practical heuristic rather than certified root isolation.
+- `f / length(grad f)` is used only as a local residual, never as a sphere-tracing distance.
+- The singular overlay shows small gradients near the rendered real locus, not a symbolic solution
+  of `f = grad f = 0`.
+
+Run with `yarn workspace luma.gl-example-algebraic-varieties start` in a WebGPU browser.

--- a/examples/showcase/algebraic-varieties/algebraic-varieties.ts
+++ b/examples/showcase/algebraic-varieties/algebraic-varieties.ts
@@ -1,0 +1,329 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+/** Algebraic fields included in the implicit-surface showcase. */
+export type AlgebraicVarietyPreset = {
+  id:
+    | 'clebsch'
+    | 'cayley'
+    | 'roman'
+    | 'kummer'
+    | 'chmutov'
+    | 'barth'
+    | 'heart'
+    | 'torus'
+    | 'tanglecube'
+    | 'whitney';
+  name: string;
+  degree: number;
+  shaderIndex: number;
+  boundingRadius: number;
+  cameraDistance: number;
+  defaultDeformation: number;
+  equation: string;
+  equationDefinitions?: string;
+  description: string;
+};
+
+export const ALGEBRAIC_VARIETY_PRESETS: readonly AlgebraicVarietyPreset[] = Object.freeze([
+  {
+    id: 'clebsch',
+    name: 'Clebsch diagonal cubic',
+    degree: 3,
+    shaderIndex: 0,
+    boundingRadius: 2.15,
+    cameraDistance: 5.2,
+    defaultDeformation: -0.12,
+    equation: 'x³ + y³ + z³ + 1 − (x + y + z + 1)³ = 0',
+    description: 'An affine chart of the projective cubic; its unbounded sheets are clipped.'
+  },
+  {
+    id: 'cayley',
+    name: 'Cayley nodal cubic',
+    degree: 3,
+    shaderIndex: 1,
+    boundingRadius: 1.8,
+    cameraDistance: 4.3,
+    defaultDeformation: 0.08,
+    equation: 'x² + y² + z² + 2xyz − 1 = 0',
+    description: 'A symmetric cubic whose real affine locus reveals four conical nodes.'
+  },
+  {
+    id: 'roman',
+    name: 'Steiner Roman surface',
+    degree: 4,
+    shaderIndex: 2,
+    boundingRadius: 1.55,
+    cameraDistance: 3.8,
+    defaultDeformation: -0.06,
+    equation: 'x²y² + y²z² + z²x² − (47/20)xyz = 0',
+    description: 'A quartic immersion of the projective plane with a triple point and double lines.'
+  },
+  {
+    id: 'kummer',
+    name: 'Kummer quartic',
+    degree: 4,
+    shaderIndex: 3,
+    boundingRadius: 1.8,
+    cameraDistance: 4.2,
+    defaultDeformation: 0,
+    equation: '(x² + y² + z² − μ²)² − λ((z−μ)² − 2x²)((z+μ)² − 2y²) = 0',
+    equationDefinitions: 'μ² = (3 − √3)/2,   λ = 3 − √3',
+    description: 'A classical quartic with sixteen ordinary double points in projective space.'
+  },
+  {
+    id: 'chmutov',
+    name: 'Chmutov quintic',
+    degree: 5,
+    shaderIndex: 4,
+    boundingRadius: 1.52,
+    cameraDistance: 3.8,
+    defaultDeformation: 0.06,
+    equation: 'T₅(x) + T₅(y) + T₅(z) = 0',
+    equationDefinitions: 'T₅(u) = 16u⁵ − 20u³ + 5u',
+    description: 'A Chebyshev construction packed with regularly arranged real nodal structure.'
+  },
+  {
+    id: 'barth',
+    name: 'Barth sextic',
+    degree: 6,
+    shaderIndex: 5,
+    boundingRadius: 1.55,
+    cameraDistance: 3.8,
+    defaultDeformation: 0,
+    equation: '4(φ²x²−y²)(φ²y²−z²)(φ²z²−x²) − (1+2φ)(x²+y²+z²−1)² = 0',
+    equationDefinitions: 'φ = (1 + √5)/2',
+    description: 'An icosahedrally symmetric sextic with the maximum 65 nodes.'
+  },
+  {
+    id: 'heart',
+    name: 'Algebraic heart',
+    degree: 6,
+    shaderIndex: 6,
+    boundingRadius: 1.65,
+    cameraDistance: 4,
+    defaultDeformation: 0,
+    equation: '(x² + 9y²/4 + z² − 1)³ − (x² + 9y²/80)z³ = 0',
+    description: 'A degree-six real algebraic surface with a familiar singular silhouette.'
+  },
+  {
+    id: 'torus',
+    name: 'Torus quartic',
+    degree: 4,
+    shaderIndex: 7,
+    boundingRadius: 1.55,
+    cameraDistance: 4,
+    defaultDeformation: 0,
+    equation: '(x² + y² + z² + R² − r²)² − 4R²(x² + z²) = 0',
+    equationDefinitions: 'R = 1,   r = 0.42',
+    description: 'A ring torus written as one quartic polynomial rather than a parametric mesh.'
+  },
+  {
+    id: 'tanglecube',
+    name: 'Tanglecube quartic',
+    degree: 4,
+    shaderIndex: 8,
+    boundingRadius: 2.55,
+    cameraDistance: 5.8,
+    defaultDeformation: 0,
+    equation: 'x⁴ − 5x² + y⁴ − 5y² + z⁴ − 5z² + 11.8 = 0',
+    description: 'A compact nodal quartic whose lobes weave into a cube-like sculptural form.'
+  },
+  {
+    id: 'whitney',
+    name: 'Whitney umbrella',
+    degree: 3,
+    shaderIndex: 9,
+    boundingRadius: 1.9,
+    cameraDistance: 4.5,
+    defaultDeformation: 0,
+    equation: 'x² − y²z = 0',
+    description: 'A singular cubic pinch surface; its unbounded sheet is clipped by the ray bounds.'
+  }
+]);
+
+/** WGSL field contract consumed by the generic implicit-surface renderer. */
+export const ALGEBRAIC_VARIETIES_WGSL = /* wgsl */ `\
+struct ImplicitSurfaceUniforms {
+  inverseViewProjectionMatrix: mat4x4f,
+  cameraPosition: vec4f,
+  variety: vec4f,
+  lighting: vec4f,
+};
+@group(0) @binding(auto) var<uniform> implicitSurface: ImplicitSurfaceUniforms;
+
+const GOLDEN_RATIO: f32 = 1.61803398875;
+
+fn evaluateClebsch(point: vec3f) -> vec4f {
+  let fifthCoordinate = -(point.x + point.y + point.z + 1.0);
+  let value = point.x * point.x * point.x + point.y * point.y * point.y +
+    point.z * point.z * point.z + 1.0 +
+    fifthCoordinate * fifthCoordinate * fifthCoordinate;
+  let fifthDerivative = -3.0 * fifthCoordinate * fifthCoordinate;
+  let gradient = vec3f(
+    3.0 * point.x * point.x + fifthDerivative,
+    3.0 * point.y * point.y + fifthDerivative,
+    3.0 * point.z * point.z + fifthDerivative
+  );
+  return vec4f(gradient, value);
+}
+
+fn evaluateCayley(point: vec3f) -> vec4f {
+  let value = dot(point, point) + 2.0 * point.x * point.y * point.z - 1.0;
+  let gradient = 2.0 * vec3f(
+    point.x + point.y * point.z,
+    point.y + point.x * point.z,
+    point.z + point.x * point.y
+  );
+  return vec4f(gradient, value);
+}
+
+fn evaluateRoman(point: vec3f) -> vec4f {
+  let scale = 2.35;
+  let value =
+    point.x * point.x * point.y * point.y +
+    point.y * point.y * point.z * point.z +
+    point.z * point.z * point.x * point.x -
+    scale * point.x * point.y * point.z;
+  let gradient = vec3f(
+    2.0 * point.x * (point.y * point.y + point.z * point.z) - scale * point.y * point.z,
+    2.0 * point.y * (point.x * point.x + point.z * point.z) - scale * point.x * point.z,
+    2.0 * point.z * (point.x * point.x + point.y * point.y) - scale * point.x * point.y
+  );
+  return vec4f(gradient, value);
+}
+
+fn evaluateKummer(point: vec3f) -> vec4f {
+  let squareRootThree = sqrt(3.0);
+  let mu = sqrt((3.0 - squareRootThree) * 0.5);
+  let lambda = 3.0 - squareRootThree;
+  let radial = dot(point, point) - mu * mu;
+  let negativeFactor = (point.z - mu) * (point.z - mu) - 2.0 * point.x * point.x;
+  let positiveFactor = (point.z + mu) * (point.z + mu) - 2.0 * point.y * point.y;
+  let value = radial * radial - lambda * negativeFactor * positiveFactor;
+  let gradient = vec3f(
+    4.0 * point.x * radial + 4.0 * lambda * point.x * positiveFactor,
+    4.0 * point.y * radial + 4.0 * lambda * point.y * negativeFactor,
+    4.0 * point.z * radial - lambda * (
+      2.0 * (point.z - mu) * positiveFactor +
+      2.0 * (point.z + mu) * negativeFactor
+    )
+  );
+  return vec4f(gradient, value);
+}
+
+fn evaluateChmutov(point: vec3f) -> vec4f {
+  let pointSquared = point * point;
+  let pointCubed = pointSquared * point;
+  let pointFifth = pointCubed * pointSquared;
+  let chebyshev = 16.0 * pointFifth - 20.0 * pointCubed + 5.0 * point;
+  let gradient = 80.0 * pointSquared * pointSquared - 60.0 * pointSquared + vec3f(5.0);
+  return vec4f(gradient, chebyshev.x + chebyshev.y + chebyshev.z);
+}
+
+fn evaluateBarth(point: vec3f) -> vec4f {
+  let goldenRatioSquared = GOLDEN_RATIO * GOLDEN_RATIO;
+  let firstFactor = goldenRatioSquared * point.x * point.x - point.y * point.y;
+  let secondFactor = goldenRatioSquared * point.y * point.y - point.z * point.z;
+  let thirdFactor = goldenRatioSquared * point.z * point.z - point.x * point.x;
+  let radial = dot(point, point) - 1.0;
+  let radialCoefficient = 1.0 + 2.0 * GOLDEN_RATIO;
+  let value = 4.0 * firstFactor * secondFactor * thirdFactor -
+    radialCoefficient * radial * radial;
+  let gradient = vec3f(
+    4.0 * (
+      2.0 * goldenRatioSquared * point.x * secondFactor * thirdFactor -
+      2.0 * point.x * firstFactor * secondFactor
+    ) - 4.0 * radialCoefficient * point.x * radial,
+    4.0 * (
+      -2.0 * point.y * secondFactor * thirdFactor +
+      2.0 * goldenRatioSquared * point.y * firstFactor * thirdFactor
+    ) - 4.0 * radialCoefficient * point.y * radial,
+    4.0 * (
+      -2.0 * point.z * firstFactor * thirdFactor +
+      2.0 * goldenRatioSquared * point.z * firstFactor * secondFactor
+    ) - 4.0 * radialCoefficient * point.z * radial
+  );
+  return vec4f(gradient, value);
+}
+
+fn evaluateHeart(point: vec3f) -> vec4f {
+  let radial = point.x * point.x + 2.25 * point.y * point.y + point.z * point.z - 1.0;
+  let zCubed = point.z * point.z * point.z;
+  let weightedPlanar = point.x * point.x + 0.1125 * point.y * point.y;
+  let value = radial * radial * radial - weightedPlanar * zCubed;
+  let gradient = vec3f(
+    6.0 * point.x * radial * radial - 2.0 * point.x * zCubed,
+    13.5 * point.y * radial * radial - 0.225 * point.y * zCubed,
+    6.0 * point.z * radial * radial - 3.0 * weightedPlanar * point.z * point.z
+  );
+  return vec4f(gradient, value);
+}
+
+fn evaluateTorus(point: vec3f) -> vec4f {
+  let majorRadius = 1.0;
+  let minorRadius = 0.42;
+  let radial = dot(point, point) + majorRadius * majorRadius - minorRadius * minorRadius;
+  let ringRadiusSquared = point.x * point.x + point.z * point.z;
+  let value = radial * radial - 4.0 * majorRadius * majorRadius * ringRadiusSquared;
+  let gradient = vec3f(
+    4.0 * point.x * radial - 8.0 * majorRadius * majorRadius * point.x,
+    4.0 * point.y * radial,
+    4.0 * point.z * radial - 8.0 * majorRadius * majorRadius * point.z
+  );
+  return vec4f(gradient, value);
+}
+
+fn evaluateTanglecube(point: vec3f) -> vec4f {
+  let pointSquared = point * point;
+  let value = dot(pointSquared, pointSquared) - 5.0 * dot(point, point) + 11.8;
+  let gradient = 4.0 * point * pointSquared - 10.0 * point;
+  return vec4f(gradient, value);
+}
+
+fn evaluateWhitneyUmbrella(point: vec3f) -> vec4f {
+  let value = point.x * point.x - point.y * point.y * point.z;
+  let gradient = vec3f(2.0 * point.x, -2.0 * point.y * point.z, -point.y * point.y);
+  return vec4f(gradient, value);
+}
+
+fn evaluateImplicitField(point: vec3f) -> vec4f {
+  var field: vec4f;
+  let varietyIndex = implicitSurface.variety.x;
+  if (varietyIndex < 0.5) {
+    field = evaluateClebsch(point);
+  } else if (varietyIndex < 1.5) {
+    field = evaluateCayley(point);
+  } else if (varietyIndex < 2.5) {
+    field = evaluateRoman(point);
+  } else if (varietyIndex < 3.5) {
+    field = evaluateKummer(point);
+  } else if (varietyIndex < 4.5) {
+    field = evaluateChmutov(point);
+  } else if (varietyIndex < 5.5) {
+    field = evaluateBarth(point);
+  } else if (varietyIndex < 6.5) {
+    field = evaluateHeart(point);
+  } else if (varietyIndex < 7.5) {
+    field = evaluateTorus(point);
+  } else if (varietyIndex < 8.5) {
+    field = evaluateTanglecube(point);
+  } else {
+    field = evaluateWhitneyUmbrella(point);
+  }
+
+  let deformation = implicitSurface.variety.y;
+  let deformationField = dot(point, point) - 0.72;
+  return vec4f(
+    field.xyz + deformation * 2.0 * point,
+    field.w + deformation * deformationField
+  );
+}
+`;
+
+export function getAlgebraicVarietyPreset(id: string): AlgebraicVarietyPreset {
+  return (
+    ALGEBRAIC_VARIETY_PRESETS.find(preset => preset.id === id) ?? ALGEBRAIC_VARIETY_PRESETS[1]!
+  );
+}

--- a/examples/showcase/algebraic-varieties/app.ts
+++ b/examples/showcase/algebraic-varieties/app.ts
@@ -1,0 +1,349 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Device} from '@luma.gl/core';
+import {
+  AnimationLoopTemplate,
+  ClipSpace,
+  OrbitControls,
+  ShaderInputs,
+  type AnimationProps
+} from '@luma.gl/engine';
+import {GPUCommandGraph, type CompiledGPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
+import type {ShaderModule} from '@luma.gl/shadertools';
+import {Matrix4, radians} from '@math.gl/core';
+import {
+  ALGEBRAIC_VARIETIES_WGSL,
+  ALGEBRAIC_VARIETY_PRESETS,
+  getAlgebraicVarietyPreset,
+  type AlgebraicVarietyPreset
+} from './algebraic-varieties';
+import {buildImplicitSurfaceShader} from './implicit-surface-shader';
+
+type ImplicitSurfaceUniforms = {
+  inverseViewProjectionMatrix: Matrix4;
+  cameraPosition: [number, number, number, number];
+  variety: [number, number, number, number];
+  lighting: [number, number, number, number];
+};
+
+const implicitSurface: ShaderModule<ImplicitSurfaceUniforms> = {
+  name: 'implicitSurface',
+  uniformTypes: {
+    inverseViewProjectionMatrix: 'mat4x4<f32>',
+    cameraPosition: 'vec4<f32>',
+    variety: 'vec4<f32>',
+    lighting: 'vec4<f32>'
+  }
+};
+
+const INFO_HTML = `\
+<section class="variety-info">
+  <p>Real algebraic surfaces are evaluated and intersected directly in WGSL—there is no mesh and the polynomial is not treated as an SDF.</p>
+  <p>Drag to orbit · wheel to zoom · <strong>1–9, 0</strong> presets · <strong>S</strong> singularities · <strong>R</strong> reset</p>
+  <div class="variety-badges"><span>WebGPU</span><span>analytic gradients</span><span>HDR lighting</span><span>hybrid root refinement</span></div>
+</section>`;
+const IDLE_PRESET_INTERVAL_MILLISECONDS = 15_000;
+
+/** WebGPU showcase for ray-intersected real algebraic surfaces. */
+export default class AlgebraicVarietiesAnimationLoopTemplate extends AnimationLoopTemplate {
+  static info = INFO_HTML;
+
+  readonly device: Device;
+  readonly model: ClipSpace;
+  readonly commandGraph: CompiledGPUCommandGraph<void>;
+  readonly shaderInputs = new ShaderInputs({implicitSurface});
+  orbitControls: OrbitControls | null = null;
+
+  private preset: AlgebraicVarietyPreset = ALGEBRAIC_VARIETY_PRESETS[3]!;
+  private readonly deformationByPreset = new Map(
+    ALGEBRAIC_VARIETY_PRESETS.map(preset => [preset.id, preset.defaultDeformation])
+  );
+  private deformation = this.preset.defaultDeformation;
+  private exposure = 1.15;
+  private showSingularities = true;
+  private currentTimeMilliseconds = 0;
+  private nextAutomaticPresetTimeMilliseconds = IDLE_PRESET_INTERVAL_MILLISECONDS;
+  private isUserInteracting = false;
+  private presetSelect: HTMLSelectElement | null = null;
+  private deformationInput: HTMLInputElement | null = null;
+  private exposureInput: HTMLInputElement | null = null;
+  private singularitiesInput: HTMLInputElement | null = null;
+  private resetButton: HTMLButtonElement | null = null;
+  private equationElement: HTMLElement | null = null;
+  private descriptionElement: HTMLElement | null = null;
+  private tabButtons: HTMLButtonElement[] = [];
+  private tabPanels: HTMLElement[] = [];
+
+  constructor({device}: AnimationProps) {
+    super();
+    if (device.type !== 'webgpu') {
+      throw new Error('Algebraic varieties require WebGPU.');
+    }
+    this.device = device;
+    this.model = new ClipSpace(device, {
+      id: 'algebraic-varieties-raycaster',
+      source: buildImplicitSurfaceShader(ALGEBRAIC_VARIETIES_WGSL),
+      shaderInputs: this.shaderInputs,
+      parameters: {cullMode: 'none'}
+    });
+    const commandGraph = new GPUCommandGraph<void>(device, {
+      id: 'algebraic-varieties-frame-graph'
+    });
+    commandGraph.addRenderPass({
+      id: 'ray-intersect-and-shade-variety',
+      workload: {operation: 'implicit-surface-raycasting', commandCount: 1},
+      compile: () => ({
+        getRenderPassProps: () => ({clearColor: [0.004, 0.006, 0.014, 1]}),
+        encode: ({renderPass}) => this.model.draw(renderPass)
+      })
+    });
+    this.commandGraph = commandGraph.compile();
+  }
+
+  override async onInitialize({canvas}: AnimationProps): Promise<void> {
+    if (!(canvas instanceof HTMLCanvasElement)) {
+      return;
+    }
+    this.orbitControls = new OrbitControls(canvas, {
+      target: [0, 0, 0],
+      distance: this.preset.cameraDistance,
+      minDistance: 2.2,
+      maxDistance: 9,
+      yaw: 0.55,
+      pitch: 0.18,
+      autoRotate: true,
+      autoRotateSpeed: 0.12,
+      onInteractionStart: this.noteInteraction
+    });
+    globalThis.addEventListener('keydown', this.handleKeyDown);
+    globalThis.addEventListener('pointerdown', this.handleInteractionStart);
+    globalThis.addEventListener('pointerup', this.handleInteractionEnd);
+    globalThis.addEventListener('pointercancel', this.handleInteractionEnd);
+    globalThis.addEventListener('wheel', this.noteInteraction);
+    this.connectControls();
+  }
+
+  onRender({device, aspect, time}: AnimationProps): void {
+    this.currentTimeMilliseconds = time;
+    if (!this.isUserInteracting && time >= this.nextAutomaticPresetTimeMilliseconds) {
+      const presetIndex = ALGEBRAIC_VARIETY_PRESETS.indexOf(this.preset);
+      const nextPreset =
+        ALGEBRAIC_VARIETY_PRESETS[(presetIndex + 1) % ALGEBRAIC_VARIETY_PRESETS.length]!;
+      this.setPreset(nextPreset.id, true);
+      this.nextAutomaticPresetTimeMilliseconds = time + IDLE_PRESET_INTERVAL_MILLISECONDS;
+    }
+    this.orbitControls?.update(time);
+    const cameraPosition = this.orbitControls?.getEyePosition() ?? [0, 0, 4.2];
+    const projectionMatrix = new Matrix4().perspective({
+      fovy: radians(44),
+      aspect,
+      near: 0.05,
+      far: 30
+    });
+    const viewMatrix = new Matrix4().lookAt({
+      eye: cameraPosition,
+      center: [0, 0, 0],
+      up: [0, 1, 0]
+    });
+    const inverseViewProjectionMatrix = new Matrix4(projectionMatrix)
+      .multiplyRight(viewMatrix)
+      .invert();
+    this.shaderInputs.setProps({
+      implicitSurface: {
+        inverseViewProjectionMatrix,
+        cameraPosition: [...cameraPosition, 0],
+        variety: [
+          this.preset.shaderIndex,
+          this.deformation,
+          this.preset.boundingRadius,
+          this.showSingularities ? 1 : 0
+        ],
+        lighting: [this.exposure, 0, 0, 0]
+      }
+    });
+    this.commandGraph.encode(device.commandEncoder, {parameters: undefined});
+  }
+
+  onFinalize(): void {
+    globalThis.removeEventListener('keydown', this.handleKeyDown);
+    globalThis.removeEventListener('pointerdown', this.handleInteractionStart);
+    globalThis.removeEventListener('pointerup', this.handleInteractionEnd);
+    globalThis.removeEventListener('pointercancel', this.handleInteractionEnd);
+    globalThis.removeEventListener('wheel', this.noteInteraction);
+    this.presetSelect?.removeEventListener('change', this.handlePresetChange);
+    this.deformationInput?.removeEventListener('input', this.handleDeformationChange);
+    this.exposureInput?.removeEventListener('input', this.handleExposureChange);
+    this.singularitiesInput?.removeEventListener('change', this.handleSingularitiesChange);
+    this.resetButton?.removeEventListener('click', this.handleReset);
+    for (const tabButton of this.tabButtons) {
+      tabButton.removeEventListener('click', this.handleTabChange);
+    }
+    this.orbitControls?.destroy();
+    this.orbitControls = null;
+    this.commandGraph.destroy();
+    this.model.destroy();
+    this.shaderInputs.destroy();
+  }
+
+  private connectControls(): void {
+    this.presetSelect = globalThis.document?.querySelector('[data-variety-preset]') ?? null;
+    this.deformationInput =
+      globalThis.document?.querySelector('[data-variety-deformation]') ?? null;
+    this.exposureInput = globalThis.document?.querySelector('[data-variety-exposure]') ?? null;
+    this.singularitiesInput =
+      globalThis.document?.querySelector('[data-variety-singularities]') ?? null;
+    this.resetButton = globalThis.document?.querySelector('[data-variety-reset]') ?? null;
+    this.equationElement = globalThis.document?.querySelector('[data-variety-equation]') ?? null;
+    this.descriptionElement =
+      globalThis.document?.querySelector('[data-variety-description]') ?? null;
+    this.tabButtons = Array.from(
+      globalThis.document?.querySelectorAll<HTMLButtonElement>('[data-variety-tab]') ?? []
+    );
+    this.tabPanels = Array.from(
+      globalThis.document?.querySelectorAll<HTMLElement>('[data-variety-panel]') ?? []
+    );
+    if (this.presetSelect) {
+      this.presetSelect.innerHTML = ALGEBRAIC_VARIETY_PRESETS.map(
+        preset => `<option value="${preset.id}">${preset.name} · degree ${preset.degree}</option>`
+      ).join('');
+      this.presetSelect.value = this.preset.id;
+      this.presetSelect.addEventListener('change', this.handlePresetChange);
+    }
+    if (this.deformationInput) {
+      this.deformationInput.value = String(this.deformation);
+    }
+    this.deformationInput?.addEventListener('input', this.handleDeformationChange);
+    this.exposureInput?.addEventListener('input', this.handleExposureChange);
+    this.singularitiesInput?.addEventListener('change', this.handleSingularitiesChange);
+    this.resetButton?.addEventListener('click', this.handleReset);
+    for (const tabButton of this.tabButtons) {
+      tabButton.addEventListener('click', this.handleTabChange);
+    }
+    this.updateControlPresentation();
+  }
+
+  private readonly handlePresetChange = (): void => {
+    if (this.presetSelect) {
+      this.setPreset(this.presetSelect.value);
+    }
+  };
+
+  private readonly handleDeformationChange = (): void => {
+    this.noteInteraction();
+    this.deformation = Number(this.deformationInput?.value ?? 0);
+    this.deformationByPreset.set(this.preset.id, this.deformation);
+    this.updateControlPresentation();
+  };
+
+  private readonly handleExposureChange = (): void => {
+    this.noteInteraction();
+    this.exposure = Number(this.exposureInput?.value ?? 1.15);
+    this.updateControlPresentation();
+  };
+
+  private readonly handleSingularitiesChange = (): void => {
+    this.noteInteraction();
+    this.showSingularities = this.singularitiesInput?.checked ?? true;
+    this.updateControlPresentation();
+  };
+
+  private readonly handleKeyDown = (event: KeyboardEvent): void => {
+    this.noteInteraction();
+    if (event.key >= '1' && event.key <= '9') {
+      this.setPreset(ALGEBRAIC_VARIETY_PRESETS[Number(event.key) - 1]!.id);
+    } else if (event.key === '0') {
+      this.setPreset(ALGEBRAIC_VARIETY_PRESETS[9]!.id);
+    } else if (event.key.toLowerCase() === 's') {
+      this.showSingularities = !this.showSingularities;
+      if (this.singularitiesInput) {
+        this.singularitiesInput.checked = this.showSingularities;
+      }
+      this.updateControlPresentation();
+    } else if (event.key.toLowerCase() === 'r') {
+      this.resetCurrentPreset();
+    }
+  };
+
+  private setPreset(id: string, automatic = false): void {
+    if (!automatic) {
+      this.noteInteraction();
+    }
+    this.preset = getAlgebraicVarietyPreset(id);
+    this.deformation =
+      this.deformationByPreset.get(this.preset.id) ?? this.preset.defaultDeformation;
+    this.orbitControls?.setProps({distance: this.preset.cameraDistance});
+    if (this.presetSelect) {
+      this.presetSelect.value = this.preset.id;
+    }
+    if (this.deformationInput) {
+      this.deformationInput.value = String(this.deformation);
+    }
+    this.updateControlPresentation();
+  }
+
+  private readonly handleReset = (): void => {
+    this.noteInteraction();
+    this.resetCurrentPreset();
+  };
+
+  private readonly handleTabChange = (event: Event): void => {
+    this.noteInteraction();
+    const selectedTab = (event.currentTarget as HTMLButtonElement).dataset['varietyTab'];
+    for (const tabButton of this.tabButtons) {
+      tabButton.setAttribute(
+        'aria-selected',
+        String(tabButton.dataset['varietyTab'] === selectedTab)
+      );
+    }
+    for (const tabPanel of this.tabPanels) {
+      tabPanel.hidden = tabPanel.dataset['varietyPanel'] !== selectedTab;
+    }
+  };
+
+  private resetCurrentPreset(): void {
+    this.deformation = this.preset.defaultDeformation;
+    this.deformationByPreset.set(this.preset.id, this.deformation);
+    this.exposure = 1.15;
+    this.showSingularities = true;
+    if (this.deformationInput) {
+      this.deformationInput.value = String(this.deformation);
+    }
+    if (this.exposureInput) {
+      this.exposureInput.value = '1.15';
+    }
+    if (this.singularitiesInput) {
+      this.singularitiesInput.checked = true;
+    }
+    this.orbitControls?.reset();
+    this.updateControlPresentation();
+  }
+
+  private readonly noteInteraction = (): void => {
+    this.nextAutomaticPresetTimeMilliseconds =
+      this.currentTimeMilliseconds + IDLE_PRESET_INTERVAL_MILLISECONDS;
+  };
+
+  private readonly handleInteractionStart = (): void => {
+    this.isUserInteracting = true;
+    this.noteInteraction();
+  };
+
+  private readonly handleInteractionEnd = (): void => {
+    this.isUserInteracting = false;
+    this.noteInteraction();
+  };
+
+  private updateControlPresentation(): void {
+    if (this.equationElement) {
+      const definitions = this.preset.equationDefinitions
+        ? `\n${this.preset.equationDefinitions}`
+        : '';
+      this.equationElement.textContent = `f₀:  ${this.preset.equation}${definitions}\n\nrendered:  f₀ + (${this.deformation.toFixed(3)})(x² + y² + z² − 0.72) = 0`;
+    }
+    if (this.descriptionElement) {
+      this.descriptionElement.textContent = `${this.preset.description} Deformation ${this.deformation.toFixed(2)} · exposure ${this.exposure.toFixed(2)} · singular overlay ${this.showSingularities ? 'on' : 'off'}.`;
+    }
+  }
+}

--- a/examples/showcase/algebraic-varieties/implicit-surface-shader.ts
+++ b/examples/showcase/algebraic-varieties/implicit-surface-shader.ts
@@ -1,0 +1,217 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+const IMPLICIT_SURFACE_RENDERER_WGSL = /* wgsl */ `\
+const IMPLICIT_SAMPLE_COUNT: u32 = 112u;
+const ROOT_REFINEMENT_COUNT: u32 = 12u;
+const NEWTON_REFINEMENT_COUNT: u32 = 7u;
+const NO_HIT: f32 = 1e20;
+
+fn intersectBoundingSphere(origin: vec3f, direction: vec3f, radius: f32) -> vec2f {
+  let originProjection = dot(origin, direction);
+  let discriminant = originProjection * originProjection - dot(origin, origin) + radius * radius;
+  if (discriminant < 0.0) {
+    return vec2f(NO_HIT, -NO_HIT);
+  }
+  let root = sqrt(discriminant);
+  return vec2f(max(0.0, -originProjection - root), -originProjection + root);
+}
+
+fn normalizedResidual(field: vec4f) -> f32 {
+  return abs(field.w) / max(length(field.xyz), 1e-5);
+}
+
+fn refineSignChange(
+  origin: vec3f,
+  direction: vec3f,
+  nearDistance: f32,
+  farDistance: f32
+) -> f32 {
+  var lowerDistance = nearDistance;
+  var upperDistance = farDistance;
+  var lowerValue = evaluateImplicitField(origin + direction * lowerDistance).w;
+  var upperValue = evaluateImplicitField(origin + direction * upperDistance).w;
+
+  for (var iteration = 0u; iteration < ROOT_REFINEMENT_COUNT; iteration++) {
+    let width = upperDistance - lowerDistance;
+    let midpoint = 0.5 * (lowerDistance + upperDistance);
+    let denominator = upperValue - lowerValue;
+    var candidate = midpoint;
+    if (abs(denominator) > 1e-8) {
+      candidate = lowerDistance - lowerValue * width / denominator;
+    }
+    candidate = clamp(candidate, lowerDistance + 0.1 * width, upperDistance - 0.1 * width);
+    let candidateValue = evaluateImplicitField(origin + direction * candidate).w;
+    if ((lowerValue <= 0.0 && candidateValue >= 0.0) ||
+        (lowerValue >= 0.0 && candidateValue <= 0.0)) {
+      upperDistance = candidate;
+      upperValue = candidateValue;
+    } else {
+      lowerDistance = candidate;
+      lowerValue = candidateValue;
+    }
+  }
+  return 0.5 * (lowerDistance + upperDistance);
+}
+
+fn refineNearRoot(
+  origin: vec3f,
+  direction: vec3f,
+  initialDistance: f32,
+  nearDistance: f32,
+  farDistance: f32
+) -> vec2f {
+  var distance = initialDistance;
+  let maximumStep = max((farDistance - nearDistance) * 0.08, 1e-4);
+  for (var iteration = 0u; iteration < NEWTON_REFINEMENT_COUNT; iteration++) {
+    let field = evaluateImplicitField(origin + direction * distance);
+    let rayDerivative = dot(field.xyz, direction);
+    if (abs(rayDerivative) < 1e-7) {
+      break;
+    }
+    let step = clamp(field.w / rayDerivative, -maximumStep, maximumStep);
+    distance = clamp(distance - step, nearDistance, farDistance);
+  }
+  let field = evaluateImplicitField(origin + direction * distance);
+  return vec2f(distance, normalizedResidual(field));
+}
+
+fn intersectImplicitSurface(origin: vec3f, direction: vec3f, radius: f32) -> f32 {
+  let interval = intersectBoundingSphere(origin, direction, radius);
+  if (interval.y <= interval.x) {
+    return NO_HIT;
+  }
+
+  let sampleStep = (interval.y - interval.x) / f32(IMPLICIT_SAMPLE_COUNT);
+  var bestDistance = NO_HIT;
+  var previousPreviousResidual = NO_HIT;
+  var previousResidual = NO_HIT;
+  var previousDistance = interval.x;
+  var previousField = evaluateImplicitField(origin + direction * previousDistance);
+
+  for (var sampleIndex = 1u; sampleIndex <= IMPLICIT_SAMPLE_COUNT; sampleIndex++) {
+    let distance = interval.x + f32(sampleIndex) * sampleStep;
+    let field = evaluateImplicitField(origin + direction * distance);
+    let residual = normalizedResidual(field);
+
+    if ((previousField.w <= 0.0 && field.w >= 0.0) ||
+        (previousField.w >= 0.0 && field.w <= 0.0)) {
+      let refinedDistance = refineSignChange(
+        origin,
+        direction,
+        previousDistance,
+        distance
+      );
+      if (refinedDistance < bestDistance) {
+        bestDistance = refinedDistance;
+      }
+    }
+
+    if (previousResidual < previousPreviousResidual &&
+        previousResidual <= residual &&
+        previousResidual < sampleStep * 0.35) {
+      let refined = refineNearRoot(
+        origin,
+        direction,
+        previousDistance,
+        max(interval.x, previousDistance - sampleStep),
+        min(interval.y, previousDistance + sampleStep)
+      );
+      if (refined.y < max(2e-4, sampleStep * 0.012) && refined.x < bestDistance) {
+        bestDistance = refined.x;
+      }
+    }
+
+    previousPreviousResidual = previousResidual;
+    previousResidual = residual;
+    previousDistance = distance;
+    previousField = field;
+  }
+  return bestDistance;
+}
+
+fn materialColor(index: f32, point: vec3f) -> vec3f {
+  let shimmer = 0.08 * sin(vec3f(2.1, 2.7, 3.2) * dot(point, vec3f(1.1, 0.8, 1.3)));
+  if (index < 1.5) {
+    return vec3f(0.18, 0.55, 1.15) + shimmer;
+  } else if (index < 3.5) {
+    return vec3f(0.85, 0.2, 0.72) + shimmer;
+  } else if (index < 5.5) {
+    return vec3f(0.15, 0.85, 0.68) + shimmer;
+  } else if (index < 7.5) {
+    return vec3f(1.05, 0.24, 0.34) + shimmer;
+  }
+  return vec3f(0.68, 0.34, 1.12) + shimmer;
+}
+
+fn acesFilm(color: vec3f) -> vec3f {
+  let a = 2.51;
+  let b = 0.03;
+  let c = 2.43;
+  let d = 0.59;
+  let e = 0.14;
+  return clamp((color * (a * color + b)) / (color * (c * color + d) + e), vec3f(0.0), vec3f(1.0));
+}
+
+fn shadeSurface(point: vec3f, rayDirection: vec3f, field: vec4f) -> vec3f {
+  var normal = normalize(field.xyz);
+  if (dot(normal, rayDirection) > 0.0) {
+    normal = -normal;
+  }
+  let viewDirection = -rayDirection;
+  let keyDirection = normalize(vec3f(-0.55, 0.72, 0.42));
+  let rimDirection = normalize(vec3f(0.72, 0.2, -0.65));
+  let halfDirection = normalize(keyDirection + viewDirection);
+  let diffuse = max(dot(normal, keyDirection), 0.0);
+  let fill = 0.22 + 0.22 * max(dot(normal, rimDirection), 0.0);
+  let fresnel = pow(1.0 - max(dot(normal, viewDirection), 0.0), 4.0);
+  let specular = pow(max(dot(normal, halfDirection), 0.0), 96.0) * 7.5;
+  let broadSpecular = pow(max(dot(normal, halfDirection), 0.0), 18.0) * 0.9;
+  let baseColor = materialColor(implicitSurface.variety.x, point);
+  var color = baseColor * (fill + 1.2 * diffuse);
+  color += vec3f(1.0, 0.9, 1.15) * specular;
+  color += vec3f(0.35, 0.65, 1.2) * (broadSpecular + 0.75 * fresnel);
+
+  if (implicitSurface.variety.w > 0.5) {
+    let gradientMagnitude = length(field.xyz);
+    let singularity = 1.0 - smoothstep(0.025, 0.12, gradientMagnitude);
+    color = mix(color, vec3f(5.0, 0.03, 0.08), singularity * 0.9);
+  }
+  return color * implicitSurface.lighting.x;
+}
+
+fn backgroundColor(direction: vec3f) -> vec3f {
+  let horizon = pow(max(0.0, 1.0 - abs(direction.y)), 3.0);
+  let glow = pow(max(dot(direction, normalize(vec3f(-0.4, 0.45, -0.8))), 0.0), 24.0);
+  return vec3f(0.002, 0.004, 0.012) + horizon * vec3f(0.012, 0.025, 0.06) +
+    glow * vec3f(0.12, 0.06, 0.18);
+}
+
+@fragment
+fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4f {
+  let farPosition = implicitSurface.inverseViewProjectionMatrix * vec4f(inputs.position, 1.0, 1.0);
+  let farWorld = farPosition.xyz / farPosition.w;
+  let origin = implicitSurface.cameraPosition.xyz;
+  let direction = normalize(farWorld - origin);
+  let distance = intersectImplicitSurface(origin, direction, implicitSurface.variety.z);
+
+  var linearColor = backgroundColor(direction);
+  if (distance < NO_HIT * 0.5) {
+    let point = origin + direction * distance;
+    let field = evaluateImplicitField(point);
+    linearColor = shadeSurface(point, direction, field);
+  }
+  let displayColor = pow(acesFilm(linearColor), vec3f(1.0 / 2.2));
+  return vec4f(displayColor, 1.0);
+}
+`;
+
+/**
+ * Assembles a generic implicit-surface raycaster with a caller-supplied WGSL field function.
+ *
+ * The supplied source must define evaluateImplicitField(point), returning gradient.xyz and f in w.
+ */
+export function buildImplicitSurfaceShader(fieldSource: string): string {
+  return `${fieldSource}\n${IMPLICIT_SURFACE_RENDERER_WGSL}`;
+}

--- a/examples/showcase/algebraic-varieties/implicit-surface.ts
+++ b/examples/showcase/algebraic-varieties/implicit-surface.ts
@@ -1,0 +1,178 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export type Vector3 = [number, number, number];
+
+export type Ray3 = {
+  origin: Vector3;
+  direction: Vector3;
+};
+
+export type RayInterval = {
+  near: number;
+  far: number;
+};
+
+export type ImplicitIntersectionOptions = {
+  boundingRadius: number;
+  sampleCount?: number;
+  refinementCount?: number;
+  residualTolerance?: number;
+};
+
+function evaluatePointOnRay(ray: Ray3, distance: number): Vector3 {
+  return [
+    ray.origin[0] + ray.direction[0] * distance,
+    ray.origin[1] + ray.direction[1] * distance,
+    ray.origin[2] + ray.direction[2] * distance
+  ];
+}
+
+/** Returns the forward interval where a ray lies inside a sphere centered at the origin. */
+export function intersectRayWithBoundingSphere(ray: Ray3, radius: number): RayInterval | null {
+  const directionLengthSquared =
+    ray.direction[0] ** 2 + ray.direction[1] ** 2 + ray.direction[2] ** 2;
+  const originDirection =
+    ray.origin[0] * ray.direction[0] +
+    ray.origin[1] * ray.direction[1] +
+    ray.origin[2] * ray.direction[2];
+  const originLengthSquared = ray.origin[0] ** 2 + ray.origin[1] ** 2 + ray.origin[2] ** 2;
+  const discriminant =
+    originDirection ** 2 - directionLengthSquared * (originLengthSquared - radius * radius);
+  if (discriminant < 0 || directionLengthSquared === 0) {
+    return null;
+  }
+  const root = Math.sqrt(discriminant);
+  const near = Math.max(0, (-originDirection - root) / directionLengthSquared);
+  const far = (-originDirection + root) / directionLengthSquared;
+  return far > near ? {near, far} : null;
+}
+
+function refineBracketedRoot(
+  ray: Ray3,
+  evaluateField: (point: Vector3) => number,
+  near: number,
+  far: number,
+  refinementCount: number
+): number {
+  let lowerDistance = near;
+  let upperDistance = far;
+  let lowerValue = evaluateField(evaluatePointOnRay(ray, lowerDistance));
+  let upperValue = evaluateField(evaluatePointOnRay(ray, upperDistance));
+  for (let iteration = 0; iteration < refinementCount; iteration++) {
+    const width = upperDistance - lowerDistance;
+    const denominator = upperValue - lowerValue;
+    const secantDistance =
+      Math.abs(denominator) > Number.EPSILON
+        ? lowerDistance - (lowerValue * width) / denominator
+        : (lowerDistance + upperDistance) / 2;
+    const candidateDistance = Math.min(
+      upperDistance - width * 0.1,
+      Math.max(lowerDistance + width * 0.1, secantDistance)
+    );
+    const candidateValue = evaluateField(evaluatePointOnRay(ray, candidateDistance));
+    if ((lowerValue <= 0 && candidateValue >= 0) || (lowerValue >= 0 && candidateValue <= 0)) {
+      upperDistance = candidateDistance;
+      upperValue = candidateValue;
+    } else {
+      lowerDistance = candidateDistance;
+      lowerValue = candidateValue;
+    }
+  }
+  return (lowerDistance + upperDistance) / 2;
+}
+
+function refineResidualMinimum(
+  ray: Ray3,
+  evaluateField: (point: Vector3) => number,
+  near: number,
+  center: number,
+  far: number,
+  refinementCount: number
+): {distance: number; residual: number} {
+  let lowerDistance = near;
+  let upperDistance = far;
+  let bestDistance = center;
+  let bestResidual = Math.abs(evaluateField(evaluatePointOnRay(ray, center)));
+  for (let iteration = 0; iteration < refinementCount; iteration++) {
+    const leftDistance = (2 * lowerDistance + upperDistance) / 3;
+    const rightDistance = (lowerDistance + 2 * upperDistance) / 3;
+    const leftResidual = Math.abs(evaluateField(evaluatePointOnRay(ray, leftDistance)));
+    const rightResidual = Math.abs(evaluateField(evaluatePointOnRay(ray, rightDistance)));
+    if (leftResidual < bestResidual) {
+      bestDistance = leftDistance;
+      bestResidual = leftResidual;
+    }
+    if (rightResidual < bestResidual) {
+      bestDistance = rightDistance;
+      bestResidual = rightResidual;
+    }
+    if (leftResidual <= rightResidual) {
+      upperDistance = rightDistance;
+    } else {
+      lowerDistance = leftDistance;
+    }
+  }
+  return {distance: bestDistance, residual: bestResidual};
+}
+
+/**
+ * CPU reference for the showcase's fixed-sample implicit intersection strategy.
+ *
+ * This is intentionally a numerical root finder, not sphere tracing: field values are never used
+ * as safe travel distances.
+ */
+export function intersectImplicitRay(
+  ray: Ray3,
+  evaluateField: (point: Vector3) => number,
+  options: ImplicitIntersectionOptions
+): number | null {
+  const interval = intersectRayWithBoundingSphere(ray, options.boundingRadius);
+  if (!interval) {
+    return null;
+  }
+  const sampleCount = options.sampleCount ?? 96;
+  const refinementCount = options.refinementCount ?? 14;
+  const residualTolerance = options.residualTolerance ?? 1e-6;
+  const sampleStep = (interval.far - interval.near) / sampleCount;
+  let previousPreviousResidual = Number.POSITIVE_INFINITY;
+  let previousDistance = interval.near;
+  let previousValue = evaluateField(evaluatePointOnRay(ray, previousDistance));
+  let previousResidual = Math.abs(previousValue);
+  let nearestDistance = Number.POSITIVE_INFINITY;
+
+  for (let sampleIndex = 1; sampleIndex <= sampleCount; sampleIndex++) {
+    const distance = interval.near + sampleIndex * sampleStep;
+    const value = evaluateField(evaluatePointOnRay(ray, distance));
+    const residual = Math.abs(value);
+    if ((previousValue <= 0 && value >= 0) || (previousValue >= 0 && value <= 0)) {
+      nearestDistance = Math.min(
+        nearestDistance,
+        refineBracketedRoot(ray, evaluateField, previousDistance, distance, refinementCount)
+      );
+    }
+    if (
+      previousResidual <= previousPreviousResidual &&
+      previousResidual <= residual &&
+      previousResidual < sampleStep
+    ) {
+      const refined = refineResidualMinimum(
+        ray,
+        evaluateField,
+        Math.max(interval.near, previousDistance - sampleStep),
+        previousDistance,
+        Math.min(interval.far, previousDistance + sampleStep),
+        refinementCount
+      );
+      if (refined.residual <= residualTolerance) {
+        nearestDistance = Math.min(nearestDistance, refined.distance);
+      }
+    }
+    previousPreviousResidual = previousResidual;
+    previousDistance = distance;
+    previousValue = value;
+    previousResidual = residual;
+  }
+  return Number.isFinite(nearestDistance) ? nearestDistance : null;
+}

--- a/examples/showcase/algebraic-varieties/index.html
+++ b/examples/showcase/algebraic-varieties/index.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Algebraic Varieties · luma.gl</title>
+    <style>
+      html, body { margin: 0; width: 100%; height: 100%; overflow: hidden; background: #02030a; color: #dce8ff; font: 14px/1.4 system-ui, sans-serif; }
+      canvas { display: block; width: 100%; height: 100%; }
+      .controls { position: fixed; right: 18px; top: 18px; width: min(360px, calc(100vw - 36px)); max-height: calc(100vh - 36px); overflow: auto; padding: 16px; box-sizing: border-box; border: 1px solid #5875a866; border-radius: 12px; background: #07101dea; backdrop-filter: blur(12px); box-shadow: 0 15px 50px #0009; }
+      h1 { margin: 0 0 12px; font-size: 18px; letter-spacing: .02em; }
+      .tabs { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; margin-bottom: 12px; }
+      .tab-button { margin: 0; padding: 7px 3px; background: #111d30; }
+      .tab-button[aria-selected="true"] { border-color: #ed5cb1; background: #34213f; color: #fff; }
+      [data-variety-panel][hidden] { display: none; }
+      label { display: block; margin-top: 10px; color: #9fb6db; font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
+      select, input { width: 100%; margin-top: 5px; accent-color: #ee4eae; }
+      .toggle { display: flex; align-items: center; gap: 8px; }
+      .toggle input { width: auto; margin: 0; }
+      select { padding: 8px; color: #edf4ff; border: 1px solid #4c6488; border-radius: 7px; background: #0a1728; }
+      button { width: 100%; margin-top: 13px; padding: 8px; color: #dce8ff; border: 1px solid #5875a8; border-radius: 7px; background: #1a2942; cursor: pointer; }
+      button:hover { background: #263b5e; }
+      .background-copy { color: #bdd0ec; }
+      .background-copy p { margin: 0 0 10px; }
+      .equation { padding: 8px 10px; border-left: 2px solid #ed5cb1; background: #0b1728; color: #f2d8ec; font-family: ui-monospace, monospace; }
+      .surface-equation { margin-top: 12px; padding: 10px; border: 1px solid #634b78; border-radius: 8px; background: #100d1c; color: #f5d9ed; font: 12px/1.55 ui-monospace, monospace; white-space: pre-wrap; overflow-wrap: anywhere; }
+      [data-variety-description] { min-height: 58px; margin: 13px 0 0; color: #bdd0ec; }
+      .variety-info { max-width: 620px; }
+      .variety-badges { display: flex; flex-wrap: wrap; gap: 6px; }
+      .variety-badges span { padding: 3px 7px; border-radius: 999px; background: #40578366; color: #cfe1ff; font-size: 11px; }
+      code { color: #f5d9ed; }
+      @media (max-width: 650px) { .controls { top: auto; bottom: 12px; right: 12px; left: 12px; width: auto; max-height: 58vh; } }
+    </style>
+  </head>
+  <body>
+    <aside class="controls">
+      <h1>Algebraic Varieties</h1>
+      <div class="tabs" role="tablist" aria-label="Variety information">
+        <button class="tab-button" data-variety-tab="surface" role="tab" aria-selected="true" type="button">Surface</button>
+        <button class="tab-button" data-variety-tab="background" role="tab" aria-selected="false" type="button">Background</button>
+        <button class="tab-button" data-variety-tab="rendering" role="tab" aria-selected="false" type="button">Rendering</button>
+      </div>
+      <section data-variety-panel="surface" role="tabpanel">
+        <label>Surface <select data-variety-preset></select></label>
+        <label>Coefficient deformation <input data-variety-deformation type="range" min="-0.35" max="0.35" step="0.005" value="0" /></label>
+        <label>HDR exposure <input data-variety-exposure type="range" min="0.55" max="2.2" step="0.025" value="1.15" /></label>
+        <label class="toggle"><input data-variety-singularities type="checkbox" checked /> Highlight singular regions</label>
+        <button data-variety-reset type="button">Reset current surface</button>
+        <div class="surface-equation" data-variety-equation aria-label="Defining equation"></div>
+        <p data-variety-description></p>
+      </section>
+      <section class="background-copy" data-variety-panel="background" role="tabpanel" hidden>
+        <p>An <strong>algebraic variety</strong> is the set of points where one or more polynomial equations vanish.</p>
+        <p class="equation">V = {x | f₁(x) = ··· = fₖ(x) = 0}</p>
+        <p>This gallery shows the <strong>real points</strong> of hypersurfaces <em>f(x,y,z)=0</em>. Algebraic geometers often study the richer complex and projective varieties; an affine view may therefore clip sheets that continue through infinity.</p>
+        <p>Where ∇f is nonzero it is perpendicular to the surface and supplies the shading normal. Points with both <em>f=0</em> and <em>∇f=0</em> are singular, optionally highlighted here in red.</p>
+        <p>Substituting a camera ray <em>o+td</em> into <em>f</em> produces a one-variable polynomial in <em>t</em>. The GPU samples and refines its nearest positive real root—without pretending that <em>f</em> is a distance field.</p>
+      </section>
+      <section class="background-copy" data-variety-panel="rendering" role="tabpanel" hidden>
+        <p>Each camera ray first intersects a conservative bounding sphere, producing a finite interval in which the surface can occur. WGSL then evaluates the polynomial along <em>o+td</em> at fixed samples and keeps the nearest sign change.</p>
+        <p>The bracket is refined with guarded secant steps and bisection. To recover tangent and even-multiplicity roots that never change sign, local minima of <em>|f| / max(|∇f|, ε)</em> seed clamped Newton steps using the ray derivative <em>∇f · d</em>.</p>
+        <p>Analytic gradients provide normals and reveal candidate singularities where <em>|∇f|</em> is small. Linear HDR lighting and specular highlights are compressed by an ACES-like display transform.</p>
+        <p>A reusable <code>GPUCommandGraph</code> render node encodes the fullscreen implicit-surface pass. The polynomial catalog supplies only field and gradient functions; intersection and shading remain geometry-agnostic.</p>
+        <p>This is numerical root finding, not a proof: fixed sampling can miss tightly clustered roots, and singular or grazing intersections are ill-conditioned. The polynomial value is never treated as a signed-distance field.</p>
+      </section>
+    </aside>
+    <script type="module">
+      import {makeAnimationLoop} from '@luma.gl/engine';
+      import {webgpuAdapter} from '@luma.gl/webgpu';
+      import AlgebraicVarietiesAnimationLoopTemplate from './app.ts';
+      makeAnimationLoop(AlgebraicVarietiesAnimationLoopTemplate, {adapters: [webgpuAdapter]}).start();
+    </script>
+  </body>
+</html>

--- a/examples/showcase/algebraic-varieties/package.json
+++ b/examples/showcase/algebraic-varieties/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "luma.gl-example-algebraic-varieties",
+  "version": "9.4.0-alpha.4",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "vite",
+    "build": "tsc && vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "@luma.gl/core": "9.4.0-alpha.4",
+    "@luma.gl/engine": "9.4.0-alpha.4",
+    "@luma.gl/gpgpu": "9.4.0-alpha.4",
+    "@luma.gl/shadertools": "9.4.0-alpha.4",
+    "@luma.gl/webgpu": "9.4.0-alpha.4",
+    "@math.gl/core": "^4.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vite": "^8.0.0"
+  }
+}

--- a/examples/showcase/algebraic-varieties/tsconfig.json
+++ b/examples/showcase/algebraic-varieties/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["."]
+}

--- a/examples/showcase/algebraic-varieties/vite.config.ts
+++ b/examples/showcase/algebraic-varieties/vite.config.ts
@@ -1,0 +1,18 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {defineConfig} from 'vite';
+
+const alias = {
+  '@luma.gl/core': `${__dirname}/../../../modules/core/src`,
+  '@luma.gl/engine': `${__dirname}/../../../modules/engine/src`,
+  '@luma.gl/gpgpu': `${__dirname}/../../../modules/gpgpu/src`,
+  '@luma.gl/shadertools': `${__dirname}/../../../modules/shadertools/src`,
+  '@luma.gl/webgpu': `${__dirname}/../../../modules/webgpu/src`
+};
+
+export default defineConfig({
+  resolve: {alias},
+  server: {open: true}
+});

--- a/scripts/examples-typecheck.mjs
+++ b/scripts/examples-typecheck.mjs
@@ -36,6 +36,7 @@ const SUPPORTED_EXAMPLE_WORKSPACES = new Set([
   'experimental/webxr-kaleidoscope',
   'integrations/hello-react',
   'experimental/antialiasing',
+  'showcase/algebraic-varieties',
   'showcase/scene',
   'showcase/dof',
   'showcase/gaussian-splats',

--- a/test/examples/algebraic-varieties.node.spec.ts
+++ b/test/examples/algebraic-varieties.node.spec.ts
@@ -1,0 +1,56 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {
+  ALGEBRAIC_VARIETIES_WGSL,
+  ALGEBRAIC_VARIETY_PRESETS,
+  getAlgebraicVarietyPreset
+} from '../../examples/showcase/algebraic-varieties/algebraic-varieties';
+import {buildImplicitSurfaceShader} from '../../examples/showcase/algebraic-varieties/implicit-surface-shader';
+import {
+  intersectImplicitRay,
+  intersectRayWithBoundingSphere
+} from '../../examples/showcase/algebraic-varieties/implicit-surface';
+
+describe('algebraic variety implicit intersection', () => {
+  test('clips rays to a forward bounding-sphere interval', () => {
+    expect(intersectRayWithBoundingSphere({origin: [0, 0, 3], direction: [0, 0, -1]}, 1)).toEqual({
+      near: 2,
+      far: 4
+    });
+    expect(intersectRayWithBoundingSphere({origin: [0, 0, 3], direction: [0, 1, 0]}, 1)).toBeNull();
+  });
+
+  test('returns the nearest positive bracketed root without treating f as an SDF', () => {
+    const distance = intersectImplicitRay(
+      {origin: [0, 0, 3], direction: [0, 0, -1]},
+      ([x, y, z]) => x * x + y * y + z * z - 1,
+      {boundingRadius: 1.2, sampleCount: 24}
+    );
+    expect(distance).toBeCloseTo(2, 5);
+  });
+
+  test('keeps presets and generic shader assembly independently reusable', () => {
+    expect(ALGEBRAIC_VARIETY_PRESETS.map(preset => preset.degree)).toEqual([
+      3, 3, 4, 4, 5, 6, 6, 4, 4, 3
+    ]);
+    expect(ALGEBRAIC_VARIETY_PRESETS.map(preset => preset.defaultDeformation)).toEqual([
+      -0.12, 0.08, -0.06, 0, 0.06, 0, 0, 0, 0, 0
+    ]);
+    expect(getAlgebraicVarietyPreset('barth').shaderIndex).toBe(5);
+    expect(getAlgebraicVarietyPreset('whitney').shaderIndex).toBe(9);
+    const shader = buildImplicitSurfaceShader(ALGEBRAIC_VARIETIES_WGSL);
+    expect(shader).toContain('fn evaluateImplicitField(point: vec3f) -> vec4f');
+    expect(shader).toContain('fn evaluateTorus(point: vec3f) -> vec4f');
+    expect(shader).toContain('fn evaluateTanglecube(point: vec3f) -> vec4f');
+    expect(shader).toContain('fn evaluateWhitneyUmbrella(point: vec3f) -> vec4f');
+    expect(shader).toContain('fn refineSignChange(');
+    expect(shader).toContain('fn refineNearRoot(');
+    expect(shader).toContain('fn acesFilm(');
+    expect(shader).toContain('@fragment');
+    expect(shader).toContain('fn fragmentMain');
+    expect(shader).not.toContain('sphereTrace');
+  });
+});

--- a/test/examples/algebraic-varieties.spec.ts
+++ b/test/examples/algebraic-varieties.spec.ts
@@ -1,0 +1,126 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {AnimationProps} from '@luma.gl/engine';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import {describe, expect, test} from 'vitest';
+import AlgebraicVarietiesAnimationLoopTemplate from '../../examples/showcase/algebraic-varieties/app';
+
+describe('Algebraic varieties WebGPU showcase', () => {
+  test('compiles, draws, and connects the implicit polynomial showcase', async () => {
+    const device = await getWebGPUTestDevice('core');
+    if (!device) {
+      return;
+    }
+    const width = 96;
+    const height = 64;
+    const host = document.createElement('div');
+    host.innerHTML = `
+      <select data-variety-preset></select>
+      <input data-variety-deformation>
+      <input data-variety-exposure value="1.15">
+      <input data-variety-singularities type="checkbox" checked>
+      <button data-variety-reset></button>
+      <div data-variety-equation></div>
+      <p data-variety-description></p>
+      <button data-variety-tab="surface" aria-selected="true"></button>
+      <button data-variety-tab="background" aria-selected="false"></button>
+      <button data-variety-tab="rendering" aria-selected="false"></button>
+      <section data-variety-panel="surface"></section>
+      <section data-variety-panel="background" hidden></section>
+      <section data-variety-panel="rendering" hidden>
+        guarded secant and bisection · ∇f · d · never treated as a signed-distance field
+      </section>`;
+    document.body.append(host);
+    const canvas = document.createElement('canvas');
+    document.body.append(canvas);
+    let viewer: AlgebraicVarietiesAnimationLoopTemplate | null = null;
+    try {
+      viewer = new AlgebraicVarietiesAnimationLoopTemplate(
+        makeAnimationProps(device, width, height, 0)
+      );
+      await viewer.onInitialize({
+        ...makeAnimationProps(device, width, height, 0),
+        canvas
+      } as AnimationProps);
+      viewer.onRender(makeAnimationProps(device, width, height, 1000));
+      device.submit();
+      expect(viewer.commandGraph.stats.nodeOrder).toEqual(['ray-intersect-and-shade-variety']);
+      expect(viewer.model.source).toContain('evaluateBarth');
+      expect(viewer.model.source).toContain('intersectImplicitSurface');
+
+      const presetSelect = host.querySelector<HTMLSelectElement>('[data-variety-preset]')!;
+      const deformationInput = host.querySelector<HTMLInputElement>('[data-variety-deformation]')!;
+      const singularitiesInput = host.querySelector<HTMLInputElement>(
+        '[data-variety-singularities]'
+      )!;
+      expect(presetSelect.options).toHaveLength(10);
+      expect(singularitiesInput.checked).toBe(true);
+      singularitiesInput.click();
+      expect(singularitiesInput.checked).toBe(false);
+
+      presetSelect.value = 'heart';
+      presetSelect.dispatchEvent(new Event('change'));
+      expect(deformationInput.value).toBe('0');
+      expect(host.querySelector('[data-variety-equation]')!.textContent).toContain(
+        '(x² + 9y²/4 + z² − 1)³'
+      );
+      deformationInput.value = '0.2';
+      deformationInput.dispatchEvent(new Event('input'));
+      presetSelect.value = 'barth';
+      presetSelect.dispatchEvent(new Event('change'));
+      presetSelect.value = 'heart';
+      presetSelect.dispatchEvent(new Event('change'));
+      expect(deformationInput.value).toBe('0.2');
+      host.querySelector<HTMLButtonElement>('[data-variety-reset]')!.click();
+      expect(deformationInput.value).toBe('0');
+      expect(singularitiesInput.checked).toBe(true);
+
+      host.querySelector<HTMLButtonElement>('[data-variety-tab="background"]')!.click();
+      expect(host.querySelector<HTMLElement>('[data-variety-panel="surface"]')!.hidden).toBe(true);
+      expect(host.querySelector<HTMLElement>('[data-variety-panel="background"]')!.hidden).toBe(
+        false
+      );
+      host.querySelector<HTMLButtonElement>('[data-variety-tab="rendering"]')!.click();
+      expect(host.querySelector<HTMLElement>('[data-variety-panel="background"]')!.hidden).toBe(
+        true
+      );
+      const renderingPanel = host.querySelector<HTMLElement>('[data-variety-panel="rendering"]')!;
+      expect(renderingPanel.hidden).toBe(false);
+      expect(renderingPanel.textContent).toContain('∇f · d');
+      expect(renderingPanel.textContent).toContain('never treated as a signed-distance field');
+
+      presetSelect.value = 'kummer';
+      presetSelect.dispatchEvent(new Event('change'));
+      globalThis.dispatchEvent(new Event('pointerdown'));
+      viewer.onRender(makeAnimationProps(device, width, height, 20_000));
+      expect(presetSelect.value).toBe('kummer');
+      globalThis.dispatchEvent(new Event('pointerup'));
+      viewer.onRender(makeAnimationProps(device, width, height, 34_000));
+      expect(presetSelect.value).toBe('kummer');
+      viewer.onRender(makeAnimationProps(device, width, height, 36_000));
+      expect(presetSelect.value).toBe('chmutov');
+    } finally {
+      viewer?.onFinalize();
+      canvas.remove();
+      host.remove();
+    }
+  });
+});
+
+function makeAnimationProps(
+  device: AnimationProps['device'],
+  width: number,
+  height: number,
+  time: number
+): AnimationProps {
+  return {
+    device,
+    tick: Math.floor((time / 1000) * 60),
+    time,
+    width,
+    height,
+    aspect: width / height
+  } as AnimationProps;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14621,6 +14621,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"luma.gl-example-algebraic-varieties@workspace:examples/showcase/algebraic-varieties":
+  version: 0.0.0-use.local
+  resolution: "luma.gl-example-algebraic-varieties@workspace:examples/showcase/algebraic-varieties"
+  dependencies:
+    "@luma.gl/core": "npm:9.4.0-alpha.4"
+    "@luma.gl/engine": "npm:9.4.0-alpha.4"
+    "@luma.gl/gpgpu": "npm:9.4.0-alpha.4"
+    "@luma.gl/shadertools": "npm:9.4.0-alpha.4"
+    "@luma.gl/webgpu": "npm:9.4.0-alpha.4"
+    "@math.gl/core": "npm:^4.1.0"
+    typescript: "npm:^6.0.3"
+    vite: "npm:^8.0.0"
+  languageName: unknown
+  linkType: soft
+
 "luma.gl-examples-animation@workspace:examples/api/animation":
   version: 0.0.0-use.local
   resolution: "luma.gl-examples-animation@workspace:examples/api/animation"


### PR DESCRIPTION
## Goals

Add a visually rich WebGPU showcase for rendering real algebraic varieties directly from their defining polynomial equations—without CPU meshing and without treating the polynomial as a signed-distance field.

## Changes

- Adds an algebraic-varieties showcase with ten presets:
  - Clebsch cubic
  - Cayley nodal cubic
  - Steiner Roman surface
  - Kummer quartic
  - Chmutov quintic
  - Barth sextic
  - algebraic heart
  - torus quartic
  - tanglecube quartic
  - Whitney umbrella
- Displays each defining equation and provides per-variety deformation controls whose values are preserved while switching presets.
- Adds reset behavior that restores the authored coefficients, camera, exposure, and singular-region overlay; the heart deformation starts at zero.
- Adds an idle presentation mode that advances every 15 seconds, but postpones switching whenever the user interacts.
- Adds optional singular-region highlighting, enabled by default.
- Adds higher-contrast HDR lighting, specular highlights, and an ACES-like display transform.
- Adds Surface, Background, and Rendering information tabs covering the mathematics and implementation.
- Encodes rendering through a `GPUCommandGraph` render node.

## Architecture

Reusable intersection utilities and WGSL assembly are kept separate from the algebraic preset catalog. The example adds no public luma.gl API and does not modify deck.gl.

The renderer:

1. clips each camera ray to a bounding sphere;
2. evaluates the selected polynomial along `o + td`;
3. samples the bounded interval and selects the nearest sign-changing bracket;
4. refines it with guarded secant/bisection steps;
5. also detects residual minima for tangent and even-multiplicity roots;
6. applies clamped Newton refinement using `∇f · d`;
7. computes normals from analytic gradients and highlights regions where `|∇f|` is small.

## Interaction and documentation

The infobox explains varieties as polynomial solution sets, distinguishes the displayed real affine locus from complex/projective viewpoints, presents the equations prominently, and documents the complete numerical rendering technique and its limitations.

## Verification

Passed:

- `nvm use` (Node 22.22.1)
- `yarn install`
- `yarn lint fix`
- focused polynomial-helper and shader-generation node tests
- focused Chromium/WebGPU UI smoke test, including tab switching and Rendering content
- algebraic-varieties production build
- `yarn examples:typecheck`
- `yarn build`
- all node tests: 280 files, 2,639 passed, 1 skipped
- `yarn website:build`

The requested `(cd website && yarn build)` check is covered by `yarn website:build`: in this repository the root command delegates directly to the website workspace's same `build` script.

The full `yarn test` completed its node suite successfully, then reported six existing headless WebGPU failures reproducible on a clean `origin/master` checkout (GPU splat ordering, two A5 DGGS assertions, lighting parity, and raster band math). One additional graph-slider assertion occurred only in the feature full-suite run and passed both its focused showcase run and the clean-master reproduction, so it appears transient. The new showcase headless test passes independently.

## Numerical limitations

This is a robust interactive prototype, not certified algebraic root isolation. Fixed sampling can still miss very close roots, high-frequency features, or roots whose residual minimum falls between samples. Bounding radii are preset-specific, and singular points necessarily make gradient-derived normals ill-conditioned. The polynomial is never used as an SDF.

## Follow-ups

- certified or adaptive GPU root isolation
- complex-variety slices and projective views
- Hessians, curvature, and higher-order singularity diagnostics
- temporal accumulation and improved antialiasing
- integration with gradient/divergence/curl visualization primitives