### PR TITLE
feat(gltf): normalize legacy primitive modes

### DIFF
--- a/dev-docs/roadmaps/effects-lighting-materials-roadmap.md
+++ b/dev-docs/roadmaps/effects-lighting-materials-roadmap.md
@@ -156,6 +156,10 @@ license/provenance tests, focused WebGPU/WebGL2 coverage, user documentation, an
 
 **Priority:** P0. **Owners:** upstream `@loaders.gl/gltf`, `@luma.gl/gltf`.
 
+**Status:** In progress. The first post-Animation-Studio slice normalizes WebGL-only `LINE_LOOP`
+and `TRIANGLE_FAN` modes into portable indexed list topologies without modifying source accessor
+data. Codec negotiation and the remaining official fixture matrix are still pending.
+
 - Implement actual `KHR_meshopt_compression` release-candidate decoding in the shared asset-loader
   boundary, including geometry/index buffers, animation tracks, morph targets, and instance data.
 - Keep the existing ratified `EXT_meshopt_compression` behavior; validate that the two extensions

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -49,6 +49,7 @@ Target Release Date: Q3, 2026
 - **Animated glTF properties** - `KHR_animation_pointer` channels drive supported node transforms, physical-material factors, and texture transforms through the shared engine animation mixer.
 - **[Lossless animated asset interchange](/docs/api-reference/gltf/gltf-interchange)** - Format-owned `.gltf` and `.glb` export preserves hierarchy, animation clips, material pointers, skins, inverse bind matrices, morph targets, RGBA colors, joint attributes, material variants, GPU instancing, cameras, and punctual lights.
 - **Punctual lights and source-faithful materials** - Source directional, point, and spot lights retain authored colors, intensity, and cones; generic export round-trips supported materials, all map slots, UV sets, texture transforms, and sampler settings.
+- **Portable legacy primitive modes** - glTF `LINE_LOOP` and `TRIANGLE_FAN` primitives are expanded into indexed line and triangle lists without mutating post-processed source accessors, so the same geometry runs on WebGPU and WebGL 2.
 
 **@luma.gl/scene (Experimental)**
 

--- a/modules/gltf/src/parsers/parse-gltf.ts
+++ b/modules/gltf/src/parsers/parse-gltf.ts
@@ -8,7 +8,7 @@ import {
   type GLTFNodePostprocessed,
   type GLTFPostprocessed
 } from '@loaders.gl/gltf';
-import {Device, type PrimitiveTopology, type Texture} from '@luma.gl/core';
+import {Device, type Texture} from '@luma.gl/core';
 import {
   decodeMorphTargetAttribute,
   Geometry,
@@ -26,7 +26,10 @@ import {type GLTFGPUInstancing, getGLTFNodeInstancing} from '../gltf/gltf-instan
 import type {GLTFPrimitiveMaterialVariants} from '../gltf/gltf-material-variants';
 import {type GLTFMorphTargetState, setGLTFMorphWeights} from '../gltf/morph-targets';
 import {type PBREnvironment} from '../pbr/pbr-environment';
-import {convertGLDrawModeToTopology} from '../webgl-to-webgpu/convert-webgl-topology';
+import {
+  normalizeGLTFTopology,
+  type NormalizedGLTFTopology
+} from '../webgl-to-webgpu/convert-webgl-topology';
 
 import {parsePBRMaterial} from './parse-pbr-material';
 
@@ -313,12 +316,15 @@ function createNodeForGLTFPrimitive({
   instancing
 }: CreateNodeForGLTFPrimitiveOptions): ModelNode {
   const id = gltfPrimitive.name || `${gltfMesh.name || gltfMesh.id}-primitive-${primitiveIndex}`;
-  const topology = convertGLDrawModeToTopology(gltfPrimitive.mode ?? 4);
-  const vertexCount = gltfPrimitive.indices
-    ? gltfPrimitive.indices.count
-    : getVertexCount(gltfPrimitive.attributes);
+  const sourceVertexCount = getVertexCount(gltfPrimitive.attributes);
+  const normalizedTopology = normalizeGLTFTopology(
+    gltfPrimitive.mode ?? 4,
+    gltfPrimitive.indices?.value,
+    sourceVertexCount
+  );
 
-  const geometry = createGeometry(id, gltfPrimitive, topology);
+  const geometry = createGeometry(id, gltfPrimitive, normalizedTopology);
+  const vertexCount = geometry.vertexCount;
   const morphTargetState = createGLTFMorphTargetState(gltfPrimitive, gltf, geometry);
 
   const parsedPPBRMaterial = parseOwnedPBRMaterial(
@@ -451,7 +457,11 @@ function getVertexCount(attributes: any) {
 }
 
 /** Converts glTF primitive attributes and indices into a luma.gl `Geometry`. */
-function createGeometry(id: string, gltfPrimitive: any, topology: PrimitiveTopology): Geometry {
+function createGeometry(
+  id: string,
+  gltfPrimitive: any,
+  normalizedTopology: NormalizedGLTFTopology
+): Geometry {
   const attributes: Record<string, GeometryAttribute> = {};
   for (const [attributeName, attribute] of Object.entries(gltfPrimitive.attributes)) {
     const {components, size, value, normalized} = attribute as GeometryAttribute;
@@ -470,8 +480,8 @@ function createGeometry(id: string, gltfPrimitive: any, topology: PrimitiveTopol
 
   return new Geometry({
     id,
-    topology,
-    indices: gltfPrimitive.indices?.value,
+    topology: normalizedTopology.topology,
+    indices: normalizedTopology.indices ?? gltfPrimitive.indices?.value,
     attributes
   });
 }

--- a/modules/gltf/src/webgl-to-webgpu/convert-webgl-topology.ts
+++ b/modules/gltf/src/webgl-to-webgpu/convert-webgl-topology.ts
@@ -5,17 +5,23 @@
 import {PrimitiveTopology} from '@luma.gl/core';
 import {GLEnum} from './gltf-webgl-constants';
 
+type GLTFIndexArray = Uint8Array | Uint16Array | Uint32Array;
+type GLTFDrawMode =
+  | GLEnum.POINTS
+  | GLEnum.LINES
+  | GLEnum.LINE_STRIP
+  | GLEnum.LINE_LOOP
+  | GLEnum.TRIANGLES
+  | GLEnum.TRIANGLE_STRIP
+  | GLEnum.TRIANGLE_FAN;
+
+export type NormalizedGLTFTopology = {
+  topology: PrimitiveTopology;
+  indices?: Uint16Array | Uint32Array;
+};
+
 /** Converts a WebGL draw mode into a luma.gl primitive topology string. */
-export function convertGLDrawModeToTopology(
-  drawMode:
-    | GLEnum.POINTS
-    | GLEnum.LINES
-    | GLEnum.LINE_STRIP
-    | GLEnum.LINE_LOOP
-    | GLEnum.TRIANGLES
-    | GLEnum.TRIANGLE_STRIP
-    | GLEnum.TRIANGLE_FAN
-): PrimitiveTopology {
+export function convertGLDrawModeToTopology(drawMode: GLTFDrawMode): PrimitiveTopology {
   // biome-ignore format: preserve layout
   switch (drawMode) {
     case GLEnum.POINTS: return 'point-list';
@@ -25,4 +31,51 @@ export function convertGLDrawModeToTopology(
     case GLEnum.TRIANGLE_STRIP: return 'triangle-strip';
     default: throw new Error(String(drawMode));
   }
+}
+
+/**
+ * Converts WebGL-only glTF primitive modes to portable indexed list topologies.
+ *
+ * The returned indices are newly allocated so the post-processed source document remains
+ * unchanged. Uint8 source indices are widened because WebGPU does not support uint8 index buffers.
+ */
+export function normalizeGLTFTopology(
+  drawMode: GLTFDrawMode,
+  sourceIndices: GLTFIndexArray | undefined,
+  vertexCount: number
+): NormalizedGLTFTopology {
+  if (drawMode !== GLEnum.LINE_LOOP && drawMode !== GLEnum.TRIANGLE_FAN) {
+    return {topology: convertGLDrawModeToTopology(drawMode)};
+  }
+
+  const sourceVertexCount = sourceIndices?.length ?? vertexCount;
+  const indexCount =
+    drawMode === GLEnum.LINE_LOOP
+      ? sourceVertexCount >= 2
+        ? sourceVertexCount * 2
+        : 0
+      : sourceVertexCount >= 3
+        ? (sourceVertexCount - 2) * 3
+        : 0;
+  const IndexArray =
+    sourceIndices instanceof Uint32Array || (!sourceIndices && vertexCount > 65536)
+      ? Uint32Array
+      : Uint16Array;
+  const indices = new IndexArray(indexCount);
+  const getSourceIndex = (index: number): number => sourceIndices?.[index] ?? index;
+
+  if (drawMode === GLEnum.LINE_LOOP) {
+    for (let index = 0; index < sourceVertexCount; index++) {
+      indices[index * 2] = getSourceIndex(index);
+      indices[index * 2 + 1] = getSourceIndex((index + 1) % sourceVertexCount);
+    }
+    return {topology: 'line-list', indices};
+  }
+
+  for (let triangleIndex = 0; triangleIndex < sourceVertexCount - 2; triangleIndex++) {
+    indices[triangleIndex * 3] = getSourceIndex(0);
+    indices[triangleIndex * 3 + 1] = getSourceIndex(triangleIndex + 1);
+    indices[triangleIndex * 3 + 2] = getSourceIndex(triangleIndex + 2);
+  }
+  return {topology: 'triangle-list', indices};
 }

--- a/modules/gltf/test/webgl-to-webgpu/convert-webgl-topology.node.spec.ts
+++ b/modules/gltf/test/webgl-to-webgpu/convert-webgl-topology.node.spec.ts
@@ -1,0 +1,85 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {readFile} from 'node:fs/promises';
+import {parse} from '@loaders.gl/core';
+import {GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf';
+import {createScenegraphsFromGLTF} from '@luma.gl/gltf';
+import {ModelNode} from '@luma.gl/engine';
+import {NullDevice} from '@luma.gl/test-utils';
+import {describe, expect, test} from 'vitest';
+
+import {GLEnum} from '../../src/webgl-to-webgpu/gltf-webgl-constants';
+import {normalizeGLTFTopology} from '../../src/webgl-to-webgpu/convert-webgl-topology';
+
+describe('normalizeGLTFTopology', () => {
+  test('closes indexed LINE_LOOP primitives without changing source indices', () => {
+    const sourceIndices = new Uint8Array([4, 1, 7]);
+    const normalized = normalizeGLTFTopology(GLEnum.LINE_LOOP, sourceIndices, 8);
+
+    expect(normalized.topology).toBe('line-list');
+    expect(normalized.indices).toBeInstanceOf(Uint16Array);
+    expect([...normalized.indices!]).toEqual([4, 1, 1, 7, 7, 4]);
+    expect([...sourceIndices]).toEqual([4, 1, 7]);
+  });
+
+  test('expands non-indexed TRIANGLE_FAN primitives counter-clockwise', () => {
+    const normalized = normalizeGLTFTopology(GLEnum.TRIANGLE_FAN, undefined, 5);
+
+    expect(normalized.topology).toBe('triangle-list');
+    expect([...normalized.indices!]).toEqual([0, 1, 2, 0, 2, 3, 0, 3, 4]);
+  });
+
+  test('preserves uint32 indices and leaves portable modes non-indexed', () => {
+    const sourceIndices = new Uint32Array([70_000, 70_001, 70_002]);
+    const normalizedFan = normalizeGLTFTopology(GLEnum.TRIANGLE_FAN, sourceIndices, 70_003);
+    const normalizedTriangles = normalizeGLTFTopology(GLEnum.TRIANGLES, undefined, 3);
+
+    expect(normalizedFan.indices).toBeInstanceOf(Uint32Array);
+    expect([...normalizedFan.indices!]).toEqual([70_000, 70_001, 70_002]);
+    expect(normalizedTriangles).toEqual({topology: 'triangle-list'});
+  });
+
+  test('handles incomplete portable primitives without creating invalid indices', () => {
+    expect(normalizeGLTFTopology(GLEnum.LINE_LOOP, undefined, 1).indices).toHaveLength(0);
+    expect(normalizeGLTFTopology(GLEnum.TRIANGLE_FAN, undefined, 2).indices).toHaveLength(0);
+  });
+
+  test('uploads normalized indices and draw count through the glTF scenegraph', async () => {
+    const data = await readFile(new URL('../../../../test/data/box.glb', import.meta.url));
+    const source = postProcessGLTF(await parse(data, GLTFLoader, {gltf: {loadImages: false}}));
+    const primitive = source.meshes[0].primitives[0];
+    const sourceIndices = primitive.indices!.value as Uint16Array;
+    primitive.mode = GLEnum.LINE_LOOP;
+
+    const device = new NullDevice({});
+    const scenegraphs = createScenegraphsFromGLTF(device, source);
+    try {
+      let modelNode: ModelNode | undefined;
+      scenegraphs.scenes[0].traverse(node => {
+        if (node instanceof ModelNode) {
+          modelNode = node;
+        }
+      });
+
+      expect(modelNode?.model.topology).toBe('line-list');
+      expect(modelNode?.model.vertexCount).toBe(sourceIndices.length * 2);
+      const indexBuffer = modelNode?.model.indexBuffer;
+      expect(indexBuffer?.indexType).toBe('uint16');
+      const uploadedIndices = new Uint16Array(indexBuffer!.debugData);
+      expect([...uploadedIndices.slice(0, 4)]).toEqual([
+        sourceIndices[0],
+        sourceIndices[1],
+        sourceIndices[1],
+        sourceIndices[2]
+      ]);
+      expect(primitive.indices!.value).toBe(sourceIndices);
+    } finally {
+      for (const scene of scenegraphs.scenes) {
+        scene.destroy();
+      }
+      device.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Goals

Start Tranche 2 by closing the portable primitive-topology gap for glTF LINE_LOOP and TRIANGLE_FAN meshes.

## Changes

- Expand LINE_LOOP into an indexed line list, including the closing edge.
- Expand TRIANGLE_FAN into an indexed triangle list with preserved winding.
- Generate indices for non-indexed primitives and widen uint8 source indices for WebGPU.
- Keep post-processed source accessors unchanged.
- Use the normalized index count for the actual model draw.
- Add focused unit and scenegraph integration coverage.
- Mark Tranche 2 in progress and add the feature to the v10 release notes.

## Verification

- `yarn lint fix` — passed.
- `yarn build` — passed.
- Focused node topology suite — 5 passed.
- Focused headless Chromium glTF parser suite — 13 passed.
- `yarn test` node phase — 2,665 passed, 1 skipped.
- `yarn test` headless phase — unrelated existing GPU failures remained in splats, DGGS, ray tracing, raster math, and model pipeline timing; the focused glTF browser suite passes.

## Follow-up

Tranche 2 codec and compressed-texture capability negotiation remain separate follow-on slices. The pinned Khronos Sample Viewer capture and full evidence matrix remain explicit Tranche 0 work.