### PR TITLE
fix(gltf): gate compressed textures by device

### DIFF
--- a/dev-docs/roadmaps/effects-lighting-materials-roadmap.md
+++ b/dev-docs/roadmaps/effects-lighting-materials-roadmap.md
@@ -158,7 +158,10 @@ license/provenance tests, focused WebGPU/WebGL2 coverage, user documentation, an
 
 **Status:** In progress. The first post-Animation-Studio slice normalizes WebGL-only `LINE_LOOP`
 and `TRIANGLE_FAN` modes into portable indexed list topologies without modifying source accessor
-data. Codec negotiation and the remaining official fixture matrix are still pending.
+data. The next slice validates loaders.gl's selected BasisU/KTX2 GPU format against the active
+device, uses a deterministic fallback for optional unsupported textures, and rejects unsupported
+required BasisU textures in strict mode. Meshopt decoding, WebP/AVIF loader selection, and the
+remaining official fixture matrix are still pending.
 
 - Implement actual `KHR_meshopt_compression` release-candidate decoding in the shared asset-loader
   boundary, including geometry/index buffers, animation tracks, morph targets, and instance data.

--- a/docs/api-reference/gltf/gltf-extensions.mdx
+++ b/docs/api-reference/gltf/gltf-extensions.mdx
@@ -241,7 +241,9 @@ GLB container serialization. `postProcessGLTF()` must still be called explicitly
     </SupportRow>
     <SupportRow name="KHR_texture_basisu" support="✅ *️⃣">
       BasisU / KTX2 textures are passed through as compressed textures when supported
-      by the device.
+      by the device. The runtime checks the transcoded GPU format before upload; optional
+      unsupported formats use a 1×1 fallback, and required BasisU assets fail
+      <code>strictExtensions</code> instead of issuing an invalid backend texture operation.
     </SupportRow>
     <SupportRow name="EXT_texture_webp" support="✅ *️⃣">
       <code>@loaders.gl/gltf</code> resolves the texture source; runtime support still

--- a/docs/api-reference/gltf/gltf-native-extensions.md
+++ b/docs/api-reference/gltf/gltf-native-extensions.md
@@ -354,9 +354,11 @@ if (unsupportedRequired.length > 0) {
 }
 ```
 
-`createScenegraphsFromGLTF(device, gltf, {strictExtensions: true})` performs the same assertion
-**before** parsing GPU resources. The returned `scenegraphs.extensionSupport` is the same
-document-specific capability model.
+`createScenegraphsFromGLTF(device, gltf, {strictExtensions: true})` performs a device-aware version
+of the same assertion **before** parsing GPU resources. In particular, required
+`KHR_texture_basisu` fails when loaders.gl selected a compressed GPU format that the active device
+cannot create. The returned `scenegraphs.extensionSupport` uses the same device-specific capability
+model.
 
 | Support level | Meaning | Accepted when required? |
 | --- | --- | --- |

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -50,6 +50,7 @@ Target Release Date: Q3, 2026
 - **[Lossless animated asset interchange](/docs/api-reference/gltf/gltf-interchange)** - Format-owned `.gltf` and `.glb` export preserves hierarchy, animation clips, material pointers, skins, inverse bind matrices, morph targets, RGBA colors, joint attributes, material variants, GPU instancing, cameras, and punctual lights.
 - **Punctual lights and source-faithful materials** - Source directional, point, and spot lights retain authored colors, intensity, and cones; generic export round-trips supported materials, all map slots, UV sets, texture transforms, and sampler settings.
 - **Portable legacy primitive modes** - glTF `LINE_LOOP` and `TRIANGLE_FAN` primitives are expanded into indexed line and triangle lists without mutating post-processed source accessors, so the same geometry runs on WebGPU and WebGL 2.
+- **Device-checked BasisU textures** - Compressed KTX2/BasisU uploads validate the loaders.gl-selected GPU format against the active device. Optional unsupported formats receive a deterministic fallback instead of causing backend validation errors, while required `KHR_texture_basisu` assets fail strict extension checks.
 
 **@luma.gl/scene (Experimental)**
 

--- a/modules/gltf/src/gltf/create-scenegraph-from-gltf.ts
+++ b/modules/gltf/src/gltf/create-scenegraph-from-gltf.ts
@@ -79,7 +79,7 @@ export function createScenegraphsFromGLTF(
   options?: ParseGLTFOptions
 ): GLTFScenegraphs {
   if (options?.strictExtensions) {
-    assertSupportedGLTFExtensions(gltf);
+    assertSupportedGLTFExtensions(gltf, device);
   }
 
   const {
@@ -130,7 +130,7 @@ export function createScenegraphsFromGLTF(
     materials
   });
   const variants = new GLTFMaterialVariants(gltf, scenes);
-  const extensionSupport = getGLTFExtensionSupport(gltf);
+  const extensionSupport = getGLTFExtensionSupport(gltf, device);
   const sceneBounds = scenes.map(scene => getScenegraphBounds(scene.getBounds()));
   const modelBounds = getCombinedScenegraphBounds(sceneBounds);
   const skins = new GLTFSkinController({gltf, scenes, gltfNodeIndexToNodeMap});

--- a/modules/gltf/src/gltf/gltf-extension-support.ts
+++ b/modules/gltf/src/gltf/gltf-extension-support.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {GLTFPostprocessed} from '@loaders.gl/gltf';
+import type {Device, TextureFormat} from '@luma.gl/core';
 
 export type GLTFExtensionSupportLevel = 'built-in' | 'parsed-and-wired' | 'loader-only' | 'none';
 
@@ -285,7 +286,8 @@ export function getGLTFExtensionSupportSummary(): GLTFExtensionSupportSummary {
 }
 
 export function getGLTFExtensionSupport(
-  gltf: GLTFPostprocessed
+  gltf: GLTFPostprocessed,
+  device?: Device
 ): Map<string, GLTFExtensionSupport> {
   const extensionNames = Array.from(collectGLTFExtensionNames(gltf)).sort();
   const requiredExtensionNames = new Set(gltf.extensionsRequired || []);
@@ -293,16 +295,22 @@ export function getGLTFExtensionSupport(
     extensionName => {
       const extensionSupportDefinition =
         GLTF_EXTENSION_SUPPORT_REGISTRY[extensionName] || UNKNOWN_EXTENSION_SUPPORT;
+      const deviceSupport = getDeviceExtensionSupport(
+        extensionName,
+        extensionSupportDefinition,
+        gltf,
+        device
+      );
 
       return [
         extensionName,
         {
           extensionName,
           required: requiredExtensionNames.has(extensionName),
-          supported: isRuntimeSupported(extensionSupportDefinition.supportLevel),
-          supportLevel: extensionSupportDefinition.supportLevel,
+          supported: isRuntimeSupported(deviceSupport.supportLevel),
+          supportLevel: deviceSupport.supportLevel,
           standardStatus: extensionSupportDefinition.standardStatus,
-          comment: extensionSupportDefinition.comment
+          comment: deviceSupport.comment
         }
       ];
     }
@@ -313,16 +321,17 @@ export function getGLTFExtensionSupport(
 
 /** Returns required extensions that have no complete runtime implementation. */
 export function getUnsupportedRequiredGLTFExtensions(
-  gltf: GLTFPostprocessed
+  gltf: GLTFPostprocessed,
+  device?: Device
 ): GLTFExtensionSupport[] {
-  return Array.from(getGLTFExtensionSupport(gltf).values()).filter(
+  return Array.from(getGLTFExtensionSupport(gltf, device).values()).filter(
     extension => extension.required && !extension.supported
   );
 }
 
 /** Rejects documents whose required extensions cannot be honored by the runtime. */
-export function assertSupportedGLTFExtensions(gltf: GLTFPostprocessed): void {
-  const unsupportedExtensions = getUnsupportedRequiredGLTFExtensions(gltf);
+export function assertSupportedGLTFExtensions(gltf: GLTFPostprocessed, device?: Device): void {
+  const unsupportedExtensions = getUnsupportedRequiredGLTFExtensions(gltf, device);
   if (unsupportedExtensions.length) {
     throw new Error(
       `Unsupported required glTF extensions: ${unsupportedExtensions
@@ -330,6 +339,50 @@ export function assertSupportedGLTFExtensions(gltf: GLTFPostprocessed): void {
         .join(', ')}`
     );
   }
+}
+
+function getDeviceExtensionSupport(
+  extensionName: string,
+  definition: GLTFExtensionSupportDefinition,
+  gltf: GLTFPostprocessed,
+  device?: Device
+): Pick<GLTFExtensionSupportDefinition, 'supportLevel' | 'comment'> {
+  if (extensionName !== 'KHR_texture_basisu' || !device) {
+    return definition;
+  }
+
+  const compressedFormats = collectCompressedTextureFormats(gltf);
+  const unsupportedFormat = compressedFormats.find(
+    format => format === null || !device.isTextureFormatSupported(format)
+  );
+  if (unsupportedFormat === undefined) {
+    return definition;
+  }
+
+  return {
+    supportLevel: 'none',
+    comment:
+      unsupportedFormat === null
+        ? `The ${device.type} device cannot use a BasisU texture whose transcoded GPU format is missing.`
+        : `The ${device.type} device does not support the transcoded BasisU texture format '${unsupportedFormat}'.`
+  };
+}
+
+function collectCompressedTextureFormats(gltf: GLTFPostprocessed): Array<TextureFormat | null> {
+  const formats: Array<TextureFormat | null> = [];
+  for (const texture of gltf.textures || []) {
+    const image = (texture as any)?.source?.image;
+    if (!image?.compressed) {
+      continue;
+    }
+    const firstLevel = Array.isArray(image.data)
+      ? image.data[0]
+      : Array.isArray(image.mipmaps)
+        ? image.mipmaps[0]
+        : undefined;
+    formats.push((firstLevel?.textureFormat as TextureFormat | undefined) ?? null);
+  }
+  return formats;
 }
 
 export function getRegisteredGLTFExtensionSupport(

--- a/modules/gltf/src/parsers/parse-pbr-material.ts
+++ b/modules/gltf/src/parsers/parse-pbr-material.ts
@@ -1334,6 +1334,13 @@ export function createCompressedTexture(
     return createCompressedTextureFallback(device, baseOptions);
   }
 
+  if (!device.isTextureFormatSupported(format)) {
+    log.warn(
+      `createCompressedTexture: ${device.type} device does not support '${format}', creating fallback`
+    )();
+    return createCompressedTextureFallback(device, baseOptions);
+  }
+
   // Validate mip levels: truncate chain at first invalid level.
   // Levels must be contiguous, so we stop at the first level that has
   // a format mismatch, missing data, non-positive dimensions, or

--- a/modules/gltf/test/gltf/gltf-extension-support.spec.ts
+++ b/modules/gltf/test/gltf/gltf-extension-support.spec.ts
@@ -4,12 +4,22 @@
 
 import test from 'test/utils/vitest-tape';
 import type {GLTFPostprocessed} from '@loaders.gl/gltf';
+import type {TextureFormat} from '@luma.gl/core';
+import {NullDevice} from '@luma.gl/test-utils';
 
 import {
+  assertSupportedGLTFExtensions,
+  createScenegraphsFromGLTF,
   getGLTFExtensionSupport,
   getGLTFExtensionSupportSummary,
   getRegisteredGLTFExtensions
 } from '@luma.gl/gltf';
+
+class CompressedTextureNullDevice extends NullDevice {
+  override isTextureFormatSupported(_format: TextureFormat): boolean {
+    return true;
+  }
+}
 
 type GLTFPostprocessedWithRemovedExtensions = GLTFPostprocessed & {
   extensionsRemoved?: string[];
@@ -125,6 +135,60 @@ test('gltf#getGLTFExtensionSupport distinguishes actual loader implementations',
     'generic AVIF image decoding does not imply glTF extension source selection'
   );
 
+  t.end();
+});
+
+test('gltf#getGLTFExtensionSupport applies BasisU device format capabilities', t => {
+  const gltf = {
+    extensionsUsed: ['KHR_texture_basisu'],
+    extensionsRequired: ['KHR_texture_basisu'],
+    nodes: [],
+    materials: [],
+    textures: [
+      {
+        source: {
+          image: {
+            compressed: true,
+            data: [
+              {
+                data: new Uint8Array(16),
+                width: 4,
+                height: 4,
+                textureFormat: 'bc7-rgba-unorm'
+              }
+            ]
+          }
+        }
+      }
+    ]
+  } as unknown as GLTFPostprocessed;
+  const unsupportedDevice = new NullDevice({});
+  const supportedDevice = new CompressedTextureNullDevice({});
+
+  const unsupported = getGLTFExtensionSupport(gltf, unsupportedDevice).get('KHR_texture_basisu');
+  const supported = getGLTFExtensionSupport(gltf, supportedDevice).get('KHR_texture_basisu');
+
+  t.equal(unsupported?.supported, false, 'unsupported transcode format is reported truthfully');
+  t.equal(unsupported?.supportLevel, 'none', 'device gap fails strict extension support');
+  t.match(unsupported?.comment || '', /does not support.*bc7-rgba-unorm/);
+  t.equal(supported?.supported, true, 'supported transcode format retains built-in support');
+  t.throws(
+    () => assertSupportedGLTFExtensions(gltf, unsupportedDevice),
+    /KHR_texture_basisu/,
+    'required BasisU rejects an unsupported selected GPU format'
+  );
+  t.throws(
+    () => createScenegraphsFromGLTF(unsupportedDevice, gltf, {strictExtensions: true}),
+    /KHR_texture_basisu/,
+    'strict scenegraph creation checks the active device before allocating resources'
+  );
+  t.doesNotThrow(
+    () => assertSupportedGLTFExtensions(gltf, supportedDevice),
+    'required BasisU accepts a selected GPU format supported by the device'
+  );
+
+  unsupportedDevice.destroy();
+  supportedDevice.destroy();
   t.end();
 });
 

--- a/modules/gltf/test/parsers/parse-pbr-compressed-texture.spec.ts
+++ b/modules/gltf/test/parsers/parse-pbr-compressed-texture.spec.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
+import type {TextureFormat} from '@luma.gl/core';
 import {NullDevice} from '@luma.gl/test-utils';
 import {
   createCompressedTexture,
@@ -10,7 +11,13 @@ import {
   type CompressedImageMipmapArray
 } from '@luma.gl/gltf/parsers/parse-pbr-material';
 
-const device = new NullDevice({});
+class CompressedTextureNullDevice extends NullDevice {
+  override isTextureFormatSupported(_format: TextureFormat): boolean {
+    return true;
+  }
+}
+
+const device = new CompressedTextureNullDevice({});
 
 const BASE_OPTIONS = {
   id: 'test-texture',
@@ -267,6 +274,31 @@ test('gltf#createCompressedTexture - missing textureFormat returns fallback', t 
   t.equals(texture.format, 'rgba8unorm', 'fallback format');
 
   texture.destroy();
+  t.end();
+});
+
+test('gltf#createCompressedTexture - unsupported device format returns fallback', t => {
+  const unsupportedDevice = new NullDevice({});
+  const image: CompressedImageDataArray = {
+    compressed: true,
+    mipmaps: true,
+    data: [
+      {
+        data: new Uint8Array(64),
+        width: 256,
+        height: 256,
+        textureFormat: 'bc7-rgba-unorm'
+      }
+    ]
+  };
+
+  const texture = createCompressedTexture(unsupportedDevice, image, BASE_OPTIONS);
+
+  t.equals(texture.format, 'rgba8unorm', 'unsupported compressed format uses fallback');
+  t.equals(texture.width, 1, 'fallback has deterministic dimensions');
+
+  texture.destroy();
+  unsupportedDevice.destroy();
   t.end();
 });
 

--- a/modules/gltf/test/parsers/parse-pbr-material.spec.ts
+++ b/modules/gltf/test/parsers/parse-pbr-material.spec.ts
@@ -2,12 +2,18 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import {log} from '@luma.gl/core';
+import {log, type TextureFormat} from '@luma.gl/core';
 import {parsePBRMaterial} from '@luma.gl/gltf/parsers/parse-pbr-material';
 import {NullDevice} from '@luma.gl/test-utils';
 import test from 'test/utils/vitest-tape';
 
-const device = new NullDevice({});
+class CompressedTextureNullDevice extends NullDevice {
+  override isTextureFormatSupported(_format: TextureFormat): boolean {
+    return true;
+  }
+}
+
+const device = new CompressedTextureNullDevice({});
 
 function makeCompressedTextureInfo(id: string) {
   return {


### PR DESCRIPTION
## Goals

Continue Tranche 2 by making BasisU/KTX2 behavior truthful at the active WebGPU/WebGL2 device boundary.

## Changes

- Check the loaders.gl-selected compressed GPU format before texture creation.
- Use the existing deterministic 1x1 fallback for optional unsupported compressed textures instead of issuing an invalid backend operation.
- Make document extension evidence device-aware for `KHR_texture_basisu`.
- Reject required BasisU assets in `strictExtensions` mode when the selected transcode format is unavailable.
- Preserve registry-level support summaries when no device is supplied.
- Document the capability and remaining Meshopt/WebP/AVIF follow-ups.

## Verification

- `yarn lint fix` — passed.
- `yarn build` — passed.
- `yarn test-node` — 3,031 passed, 3 skipped.
- `yarn test` node phase — 3,031 passed, 3 skipped.
- `yarn test` headless phase — unrelated existing/flaky GPU failures remained in splat ordering, DGGS, raster math, ray tracing, and deck keyboard interaction; no glTF test failed.

## Follow-up

`KHR_meshopt_compression` still belongs first in loaders.gl. WebP/AVIF source selection remains loader/browser-owned and is intentionally not claimed by this PR.