### PR TITLE
feat(examples): explain quantum showcase visuals

### DIFF
--- a/examples/showcase/quantum-state-studio/app.ts
+++ b/examples/showcase/quantum-state-studio/app.ts
@@ -15,6 +15,11 @@ import {
   type QuantumGate
 } from './quantum-circuit';
 import {QuantumStateEngine} from './quantum-engine';
+import {
+  getQuantumExplanation,
+  getQuantumGateExplanation,
+  type QuantumExplanation
+} from './quantum-explanations';
 import {getQuantumBackgroundMarkup, getQuantumImplementationMarkup} from './quantum-notes';
 import {QuantumStateRenderer} from './quantum-renderer';
 
@@ -47,6 +52,9 @@ export default class QuantumStateStudioAnimationLoopTemplate extends AnimationLo
   private targetSelect: HTMLSelectElement | null = null;
   private qubitSelect: HTMLSelectElement | null = null;
   private status: HTMLElement | null = null;
+  private tooltip: HTMLElement | null = null;
+  private explainedTarget: HTMLElement | null = null;
+  private tooltipHideTimer: ReturnType<typeof setTimeout> | undefined;
   private selectedStep = 0;
   private selectedQubit = 0;
   private playing = true;
@@ -81,6 +89,7 @@ export default class QuantumStateStudioAnimationLoopTemplate extends AnimationLo
     this.targetSelect = this.root.querySelector('[data-target-qubit]');
     this.qubitSelect = this.root.querySelector('[data-observed-qubit]');
     this.status = this.root.querySelector('[data-status]');
+    this.tooltip = this.root.querySelector('[data-tooltip]');
     this.installEvents();
     this.setActiveTab('explore');
     this.refreshInterface();
@@ -95,6 +104,7 @@ export default class QuantumStateStudioAnimationLoopTemplate extends AnimationLo
   }
 
   override onFinalize(): void {
+    clearTimeout(this.tooltipHideTimer);
     this.root?.remove();
     this.root = null;
     this.renderer.destroy();
@@ -102,6 +112,38 @@ export default class QuantumStateStudioAnimationLoopTemplate extends AnimationLo
   }
 
   private installEvents(): void {
+    this.root?.addEventListener('pointerover', event => {
+      const target = (event.target as HTMLElement).closest<HTMLElement>('[data-explain]');
+      if (target) this.showExplanation(target, event);
+    });
+    this.root?.addEventListener('pointerdown', event => {
+      if (event.pointerType !== 'touch') return;
+      const target = (event.target as HTMLElement).closest<HTMLElement>('[data-explain]');
+      if (!target) return;
+      this.showExplanation(target, event);
+      clearTimeout(this.tooltipHideTimer);
+      this.tooltipHideTimer = setTimeout(() => this.hideExplanation(), 4200);
+    });
+    this.root?.addEventListener('pointermove', event => {
+      if (this.explainedTarget && event.pointerType !== 'touch') {
+        this.showExplanation(this.explainedTarget, event);
+      }
+    });
+    this.root?.addEventListener('pointerout', event => {
+      if (event.pointerType === 'touch') return;
+      const target = (event.target as HTMLElement).closest<HTMLElement>('[data-explain]');
+      const relatedTarget = event.relatedTarget as Node | null;
+      if (target && (!relatedTarget || !target.contains(relatedTarget))) this.hideExplanation();
+    });
+    this.root?.addEventListener('focusin', event => {
+      const target = (event.target as HTMLElement).closest<HTMLElement>('[data-explain]');
+      if (target) this.showExplanation(target);
+    });
+    this.root?.addEventListener('focusout', event => {
+      const target = (event.target as HTMLElement).closest<HTMLElement>('[data-explain]');
+      const relatedTarget = event.relatedTarget as Node | null;
+      if (target && (!relatedTarget || !target.contains(relatedTarget))) this.hideExplanation();
+    });
     this.root?.querySelector('[data-tabs]')?.addEventListener('click', event => {
       const button = (event.target as HTMLElement).closest<HTMLButtonElement>('[data-tab]');
       const tab = button?.dataset.tab;
@@ -242,10 +284,10 @@ export default class QuantumStateStudioAnimationLoopTemplate extends AnimationLo
     }
     if (this.circuitTrack) {
       this.circuitTrack.innerHTML = [
-        '<button class="quantum-gate active initial" data-gate-step="0" title="Initial |0…0⟩ state">|0⟩</button>',
+        '<button class="quantum-gate active initial" data-gate-step="0" data-explain="gate">|0⟩</button>',
         ...this.circuit.gates.map(
           (gate, index) =>
-            `<button class="quantum-gate" data-gate-step="${index + 1}" title="${getGateTitle(gate)}"><span>${gate.label}</span><small>${gate.control === undefined ? '' : `q${gate.control}→`}q${gate.target}</small></button>`
+            `<button class="quantum-gate" data-gate-step="${index + 1}" data-explain="gate" aria-label="${getGateTitle(gate)}"><span>${gate.label}</span><small>${gate.control === undefined ? '' : `q${gate.control}→`}q${gate.target}</small></button>`
         )
       ].join('');
     }
@@ -264,6 +306,123 @@ export default class QuantumStateStudioAnimationLoopTemplate extends AnimationLo
   private setNoteText(selector: string, text: string): void {
     const element = this.root?.querySelector(selector);
     if (element) element.textContent = text;
+  }
+
+  private showExplanation(target: HTMLElement, pointerEvent?: PointerEvent): void {
+    if (!this.tooltip) return;
+    const explanation = this.getContextualExplanation(target, pointerEvent);
+    if (!explanation) return;
+    this.explainedTarget?.removeAttribute('aria-describedby');
+    this.explainedTarget = target;
+    target.setAttribute('aria-describedby', 'quantum-context-tooltip');
+    this.setTooltipText('[data-tooltip-eyebrow]', explanation.eyebrow);
+    this.setTooltipText('[data-tooltip-title]', explanation.title);
+    this.setTooltipText('[data-tooltip-body]', explanation.body);
+    this.setTooltipText('[data-tooltip-detail]', explanation.detail ?? '');
+    const detail = this.tooltip.querySelector<HTMLElement>('[data-tooltip-detail]');
+    if (detail) detail.hidden = !explanation.detail;
+    this.tooltip.hidden = false;
+    this.positionTooltip(target, pointerEvent);
+  }
+
+  private hideExplanation(): void {
+    clearTimeout(this.tooltipHideTimer);
+    if (this.tooltip) this.tooltip.hidden = true;
+    this.explainedTarget?.removeAttribute('aria-describedby');
+    this.explainedTarget = null;
+  }
+
+  private setTooltipText(selector: string, value: string): void {
+    const element = this.tooltip?.querySelector(selector);
+    if (element) element.textContent = value;
+  }
+
+  private getContextualExplanation(
+    target: HTMLElement,
+    pointerEvent?: PointerEvent
+  ): (QuantumExplanation & {detail?: string}) | undefined {
+    const identifier = target.dataset.explain;
+    if (!identifier) return undefined;
+    if (identifier === 'gate') {
+      const step = Number(target.dataset.gateStep ?? 0);
+      if (step === 0) {
+        return {
+          eyebrow: 'Initial state · slice 0',
+          title: '|0…0⟩ initialization',
+          body: 'Every qubit begins in |0⟩, so basis state zero has amplitude 1 + 0i and every other amplitude is zero. This is the only full-state CPU upload.'
+        };
+      }
+      const gate = this.circuit.gates[step - 1];
+      return gate ? getQuantumGateExplanation(gate, step) : undefined;
+    }
+    const explanation = getQuantumExplanation(identifier);
+    if (!explanation) return undefined;
+    const detail = this.getPointerDetail(identifier, target, pointerEvent);
+    return {...explanation, detail};
+  }
+
+  private getPointerDetail(
+    identifier: string,
+    target: HTMLElement,
+    pointerEvent?: PointerEvent
+  ): string | undefined {
+    if (identifier === 'bloch-sphere') {
+      return `Currently reducing q${this.selectedQubit} at snapshot ${this.selectedStep}.`;
+    }
+    if (identifier === 'scrubber' || identifier === 'circuit-track') {
+      return `Selected snapshot ${this.selectedStep} of ${this.circuit.gates.length}.`;
+    }
+    if (!pointerEvent) return undefined;
+    const bounds = target.getBoundingClientRect();
+    const horizontal = Math.max(
+      0,
+      Math.min(0.999999, (pointerEvent.clientX - bounds.left) / bounds.width)
+    );
+    const vertical = Math.max(
+      0,
+      Math.min(0.999999, (pointerEvent.clientY - bounds.top) / bounds.height)
+    );
+    if (identifier === 'probability-landscape' || identifier === 'interference-history') {
+      const basisIndex = Math.floor(horizontal * this.engine.stateCount);
+      const ket = basisIndex.toString(2).padStart(this.circuit.qubitCount, '0');
+      if (identifier === 'interference-history') {
+        const step = Math.min(
+          this.circuit.gates.length,
+          Math.floor((1 - vertical) * this.engine.snapshotCount)
+        );
+        return `Pointer: |${ket}⟩ (basis ${basisIndex}), near snapshot ${step}.`;
+      }
+      return `Pointer: |${ket}⟩ (basis index ${basisIndex}) at snapshot ${this.selectedStep}.`;
+    }
+    if (identifier === 'correlations') {
+      const column = Math.min(
+        this.circuit.qubitCount - 1,
+        Math.floor(horizontal * this.circuit.qubitCount)
+      );
+      const row = Math.min(
+        this.circuit.qubitCount - 1,
+        Math.floor(vertical * this.circuit.qubitCount)
+      );
+      return `Pointer: correlation cell q${row} × q${column} at snapshot ${this.selectedStep}.`;
+    }
+    return undefined;
+  }
+
+  private positionTooltip(target: HTMLElement, pointerEvent?: PointerEvent): void {
+    if (!this.tooltip) return;
+    const targetBounds = target.getBoundingClientRect();
+    const tooltipBounds = this.tooltip.getBoundingClientRect();
+    const padding = 12;
+    let left = pointerEvent ? pointerEvent.clientX + 18 : targetBounds.right + 14;
+    let top = pointerEvent ? pointerEvent.clientY + 18 : targetBounds.top;
+    if (left + tooltipBounds.width > window.innerWidth - padding) {
+      left = (pointerEvent ? pointerEvent.clientX : targetBounds.left) - tooltipBounds.width - 18;
+    }
+    if (top + tooltipBounds.height > window.innerHeight - padding) {
+      top = window.innerHeight - tooltipBounds.height - padding;
+    }
+    this.tooltip.style.left = `${Math.max(padding, left)}px`;
+    this.tooltip.style.top = `${Math.max(padding, top)}px`;
   }
 }
 
@@ -296,20 +455,28 @@ function getInterfaceMarkup(): string {
       ${getQuantumImplementationMarkup()}
     </section>
     <nav class="quantum-presets explore-only" data-presets aria-label="Circuit presets">
-      ${PRESET_IDENTIFIERS.map(identifier => `<button data-preset="${identifier}">${identifier === 'qft' ? 'QFT' : identifier[0]!.toUpperCase() + identifier.slice(1)}</button>`).join('')}
+      ${PRESET_IDENTIFIERS.map(identifier => `<button data-preset="${identifier}" data-explain="preset-${identifier}">${identifier === 'qft' ? 'QFT' : identifier[0]!.toUpperCase() + identifier.slice(1)}</button>`).join('')}
     </nav>
-    <section class="quantum-copy explore-only">
+    <section class="quantum-copy explore-only" data-explain="active-circuit" tabindex="0">
       <p class="eyebrow">Active circuit</p><h2 data-circuit-name></h2><p data-circuit-description></p>
     </section>
+    <div class="explain-region landscape-region explore-only" data-explain="probability-landscape" tabindex="0" aria-label="Explain the probability landscape"></div>
+    <div class="explain-region bloch-region explore-only" data-explain="bloch-sphere" tabindex="0" aria-label="Explain the reduced-qubit Bloch sphere"></div>
+    <div class="explain-region correlation-region explore-only" data-explain="correlations" tabindex="0" aria-label="Explain the connected correlation matrix"></div>
+    <div class="explain-region history-region explore-only" data-explain="interference-history" tabindex="0" aria-label="Explain the interference history"></div>
     <section class="visual-label landscape-label explore-only"><span>Probability landscape</span><small>height = probability · hue = complex phase</small></section>
     <section class="visual-label bloch-label explore-only"><span>Reduced qubit</span><small>Bloch vector · radius = purity</small></section>
     <section class="visual-label correlation-label explore-only"><span>Connected correlations</span><small>⟨Zi Zj⟩ − ⟨Zi⟩⟨Zj⟩</small></section>
     <section class="visual-label history-label explore-only"><span>Interference history</span><small>basis state → · circuit step ↑</small></section>
     <section class="quantum-controls explore-only">
-      <div class="scrubber"><button data-play>Pause</button><input data-step type="range" min="0" value="0" aria-label="Circuit step"><output data-step-value>0 / 0</output></div>
-      <div class="editor" data-gates><span>Add on</span><select data-target-qubit aria-label="Target qubit"></select>${['H', 'X', 'Y', 'Z', 'P', 'Rx', 'CX'].map(gate => `<button data-add-gate="${gate}">${gate}</button>`).join('')}<button data-undo>Undo</button></div>
-      <label class="observe">Observe <select data-observed-qubit aria-label="Observed qubit"></select></label>
+      <div class="scrubber" data-explain="scrubber"><button data-play data-explain="play">Pause</button><input data-step data-explain="scrubber" type="range" min="0" value="0" aria-label="Circuit step"><output data-step-value>0 / 0</output></div>
+      <div class="editor" data-gates data-explain="gate-editor"><span>Add on</span><select data-target-qubit data-explain="target-qubit" aria-label="Target qubit"></select>${['H', 'X', 'Y', 'Z', 'P', 'Rx', 'CX'].map(gate => `<button data-add-gate="${gate}" data-explain="gate-editor">${gate}</button>`).join('')}<button data-undo data-explain="gate-editor">Undo</button></div>
+      <label class="observe" data-explain="observed-qubit">Observe <select data-observed-qubit data-explain="observed-qubit" aria-label="Observed qubit"></select></label>
     </section>
-    <div class="quantum-circuit-scroll explore-only"><div class="quantum-circuit" data-circuit-track></div></div>
-    <footer><span data-status></span><span>State remains on GPU from gate application through rendering</span></footer>`;
+    <div class="quantum-circuit-scroll explore-only" data-explain="circuit-track"><div class="quantum-circuit" data-circuit-track></div></div>
+    <footer><span data-status data-explain="status"></span><span class="explanation-hint">Hover or focus glowing regions for an explanation</span></footer>
+    <aside id="quantum-context-tooltip" class="quantum-tooltip" data-tooltip role="tooltip" aria-live="polite" hidden>
+      <p class="eyebrow" data-tooltip-eyebrow></p><strong data-tooltip-title></strong>
+      <p data-tooltip-body></p><code data-tooltip-detail hidden></code>
+    </aside>`;
 }

--- a/examples/showcase/quantum-state-studio/quantum-explanations.ts
+++ b/examples/showcase/quantum-state-studio/quantum-explanations.ts
@@ -1,0 +1,182 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {QuantumGate} from './quantum-circuit';
+
+export type QuantumExplanation = {
+  eyebrow: string;
+  title: string;
+  body: string;
+};
+
+const QUANTUM_EXPLANATIONS: Record<string, QuantumExplanation> = {
+  'probability-landscape': {
+    eyebrow: 'Computational basis',
+    title: 'Probability landscape',
+    body: 'Every horizontal position is one basis state |x⟩. Column height is |αₓ|² after the selected gate; hue is the complex phase arg(αₓ). Phase can change while probability stays fixed.'
+  },
+  'bloch-sphere': {
+    eyebrow: 'One-qubit reduced state',
+    title: 'Bloch sphere',
+    body: 'The arrow is the selected qubit’s reduced Bloch vector. Direction describes its local state; length describes purity. A short vector often means this qubit is entangled with the rest of the globally pure state.'
+  },
+  correlations: {
+    eyebrow: 'Two-qubit structure',
+    title: 'Connected Z correlations',
+    body: 'Each cell is ⟨ZiZj⟩ − ⟨Zi⟩⟨Zj⟩. Cyan and magenta encode the sign; brightness encodes strength. Connected correlation removes what the two individual qubit averages already explain.'
+  },
+  'interference-history': {
+    eyebrow: 'Circuit evolution',
+    title: 'Interference history',
+    body: 'Each horizontal band is a GPU-resident state snapshot after one gate. Read upward through circuit time and across basis states to see phase become constructive or destructive probability.'
+  },
+  'active-circuit': {
+    eyebrow: 'Current experiment',
+    title: 'Active circuit',
+    body: 'A circuit is an ordered list of unitary gates. The simulator stores the initial state plus one full state-vector snapshot after every gate, enabling instant scrubbing without replay.'
+  },
+  'preset-qft': {
+    eyebrow: 'Preset',
+    title: 'Quantum Fourier transform',
+    body: 'Hadamards and controlled phase rotations convert a basis-domain pattern into phase/frequency structure. Watch the phase hues organize before the final bit-reversal swaps.'
+  },
+  'preset-bell': {
+    eyebrow: 'Preset',
+    title: 'Bell pair',
+    body: 'A Hadamard creates two branches and CX correlates them. The result has two probability peaks, maximally mixed local qubits, and a strong off-diagonal correlation.'
+  },
+  'preset-ghz': {
+    eyebrow: 'Preset',
+    title: 'GHZ entanglement',
+    body: 'One Hadamard followed by a CX chain creates a coherent superposition of all-zero and all-one states. Local Bloch vectors contract while correlations spread across many qubits.'
+  },
+  'preset-interference': {
+    eyebrow: 'Preset',
+    title: 'Interference echo',
+    body: 'Two paths receive a relative phase and are recombined by a Hadamard. This makes the distinction between invisible phase rotation and visible probability redistribution especially clear.'
+  },
+  'preset-grover': {
+    eyebrow: 'Preset',
+    title: 'Grover amplitude amplification',
+    body: 'An oracle flips the marked state’s phase, then diffusion reflects amplitudes around their mean. The marked basis state grows through interference—not through parallel quantum hardware here.'
+  },
+  play: {
+    eyebrow: 'Timeline control',
+    title: 'Animate gate boundaries',
+    body: 'Play advances through already-computed GPU-resident snapshots. It does not rerun the simulation each frame; it changes the selected state-history offset used by analysis and rendering.'
+  },
+  scrubber: {
+    eyebrow: 'Timeline control',
+    title: 'Scrub gate by gate',
+    body: 'Select the initial state or the state immediately after any gate. The probability landscape and history select a new buffer slice; the compact analysis graph recomputes Bloch and correlation observables.'
+  },
+  'target-qubit': {
+    eyebrow: 'Circuit editor',
+    title: 'Choose a gate target',
+    body: 'The target bit selects which pairs of basis amplitudes a 2×2 complex matrix mixes. q0 is the least-significant bit in this showcase’s computational-basis indexing.'
+  },
+  'gate-editor': {
+    eyebrow: 'Circuit editor',
+    title: 'Append a reusable gate',
+    body: 'These controls add descriptors over one general GPU kernel: a complex 2×2 matrix, target-bit mask, and optional control-bit mask. The engine then recompiles the circuit graph and its retained history.'
+  },
+  'observed-qubit': {
+    eyebrow: 'Analysis selection',
+    title: 'Choose the reduced qubit',
+    body: 'This changes which single-qubit density reduction feeds the Bloch sphere. It does not change the circuit or global state—only the compact selected-observables graph.'
+  },
+  'circuit-track': {
+    eyebrow: 'GPU-resident history',
+    title: 'Circuit snapshots',
+    body: 'Each tile selects the state immediately after that gate. The highlighted tile is the slice currently bound to the linked views.'
+  },
+  status: {
+    eyebrow: 'Resource footprint',
+    title: 'Current simulation scale',
+    body: 'State count grows as 2^qubits. Retaining every gate boundary multiplies that cost by the snapshot count; complex f32 amplitudes use eight bytes per basis state per snapshot.'
+  },
+  'metric-qubits': {
+    eyebrow: 'Live graph metric',
+    title: 'Qubit count',
+    body: 'The logical width of the simulated circuit. Adding one qubit doubles the state-vector length and the work performed by each full-state gate pass.'
+  },
+  'metric-states': {
+    eyebrow: 'Live graph metric',
+    title: 'Basis-state count',
+    body: 'Exactly 2^qubits complex amplitudes describe this ideal pure state. These amplitudes remain in GPU storage buffers through analysis and rendering.'
+  },
+  'metric-snapshots': {
+    eyebrow: 'Live graph metric',
+    title: 'Retained snapshots',
+    body: 'One initial slice plus one slice per gate. Retention makes scrubbing immediate but makes circuit depth a direct GPU-memory cost.'
+  },
+  'metric-nodes': {
+    eyebrow: 'Live graph metric',
+    title: 'Simulation graph nodes',
+    body: 'Gate passes plus probability/phase derivation and normalization reduction. GPUCommandGraph derives execution order from declared buffer usage.'
+  },
+  'metric-memory': {
+    eyebrow: 'Live graph metric',
+    title: 'Resident GPU memory',
+    body: 'The approximate byte footprint of state history, gate descriptors, derived probability/phase data, reductions, analysis outputs, and small control buffers.'
+  },
+  'graph-initial': {
+    eyebrow: 'GPUCommandGraph node',
+    title: 'Initial-state upload',
+    body: 'The CPU initializes |0…0⟩ once. Every later state transformation, observable derivation, and rendered view consumes GPU-resident buffers.'
+  },
+  'graph-gates': {
+    eyebrow: 'GPUCommandGraph nodes',
+    title: 'Dependency-ordered gate passes',
+    body: 'Each gate reads snapshot n and writes snapshot n+1. Declared storage usage lets the graph order hazards and compile reusable luma.gl Computations.'
+  },
+  'graph-probability': {
+    eyebrow: 'GPUCommandGraph node',
+    title: 'Probability and phase derivation',
+    body: 'A parallel pass converts every complex amplitude (real, imaginary) into (probability, phase) for every retained snapshot. Rendering consumes this buffer directly.'
+  },
+  'graph-normalization': {
+    eyebrow: 'GPUCommandGraph publication',
+    title: 'Normalization reduction',
+    body: 'A workgroup reduction measures Σ|αₓ|² for every snapshot and publishes complete-state-history. The value is visualized honestly rather than silently renormalizing the state.'
+  },
+  'graph-render': {
+    eyebrow: 'luma.gl render node',
+    title: 'Direct linked-view rendering',
+    body: 'One fullscreen luma.gl Model binds probability, phase, normalization, Bloch, and correlation storage buffers. Only tiny control values cross from JavaScript.'
+  },
+  'graph-analysis': {
+    eyebrow: 'Selected-observables graph',
+    title: 'Scrub-triggered analysis branch',
+    body: 'Changing the step or observed qubit runs only Bloch and connected-correlation reductions, then publishes selected-observables. The main circuit history is not replayed.'
+  }
+};
+
+/** Returns stable educational copy for one interactive showcase element. */
+export function getQuantumExplanation(identifier: string): QuantumExplanation | undefined {
+  return QUANTUM_EXPLANATIONS[identifier];
+}
+
+/** Describes a concrete circuit gate rather than only its short circuit-diagram label. */
+export function getQuantumGateExplanation(gate: QuantumGate, step: number): QuantumExplanation {
+  const controlled =
+    gate.control === undefined ? '' : ` q${gate.control} controls q${gate.target}.`;
+  const gateBodies: Record<string, string> = {
+    H: 'Hadamard mixes |0⟩ and |1⟩ with equal magnitude. It creates superposition or recombines branches so their relative phase becomes constructive or destructive probability.',
+    X: 'Pauli X swaps the target bit’s |0⟩ and |1⟩ amplitudes—the quantum analogue of a NOT operation.',
+    Y: 'Pauli Y swaps |0⟩ and |1⟩ while adding opposite imaginary phases.',
+    Z: 'Pauli Z leaves |0⟩ unchanged and flips the sign of |1⟩, changing phase without directly changing probability.',
+    S: 'The S gate rotates the |1⟩ amplitude by π/2 in complex phase.',
+    T: 'The T gate rotates the |1⟩ amplitude by π/4, a finer phase step used by universal gate decompositions.',
+    P: 'A phase gate rotates the target’s |1⟩ branch by the circuit-specified angle while preserving magnitude.',
+    CP: 'Controlled phase rotates a target branch only when the control bit is set, creating conditional phase structure and often entanglement.',
+    Rx: 'Rx rotates the target qubit around the Bloch sphere’s X axis, mixing real and imaginary components of its basis amplitudes.',
+    CX: 'Controlled X flips the target only when the control is |1⟩. Acting on a superposed control can create entanglement.'
+  };
+  return {
+    eyebrow: `Gate ${step} · state slice ${step}`,
+    title: `${gate.label} on q${gate.target}`,
+    body: `${gateBodies[gate.label] ?? 'A complex 2×2 unitary matrix transforms paired target-bit amplitudes.'}${controlled} The resulting full state is retained as GPU snapshot ${step}.`
+  };
+}

--- a/examples/showcase/quantum-state-studio/quantum-notes.ts
+++ b/examples/showcase/quantum-state-studio/quantum-notes.ts
@@ -64,26 +64,26 @@ export function getQuantumImplementationMarkup(): string {
       It does not claim quantum acceleration and intentionally keeps quantum-domain APIs out of core.</p>
     </div>
     <div class="implementation-metrics" aria-label="Current circuit GPU statistics">
-      <div><strong data-note-qubits>–</strong><span>qubits</span></div>
-      <div><strong data-note-states>–</strong><span>basis states</span></div>
-      <div><strong data-note-snapshots>–</strong><span>resident snapshots</span></div>
-      <div><strong data-note-nodes>–</strong><span>simulation graph nodes</span></div>
-      <div><strong data-note-memory>–</strong><span>resident GPU memory</span></div>
+      <div data-explain="metric-qubits" tabindex="0"><strong data-note-qubits>–</strong><span>qubits</span></div>
+      <div data-explain="metric-states" tabindex="0"><strong data-note-states>–</strong><span>basis states</span></div>
+      <div data-explain="metric-snapshots" tabindex="0"><strong data-note-snapshots>–</strong><span>resident snapshots</span></div>
+      <div data-explain="metric-nodes" tabindex="0"><strong data-note-nodes>–</strong><span>simulation graph nodes</span></div>
+      <div data-explain="metric-memory" tabindex="0"><strong data-note-memory>–</strong><span>resident GPU memory</span></div>
     </div>
     <section class="graph-notes">
       <div class="graph-title"><p class="eyebrow">Compiled GPUCommandGraph</p><h3>Circuit evolution graph</h3></div>
       <div class="graph-flow" role="img" aria-label="Initial state flows through gate nodes, probability and phase derivation, normalization reduction, and direct rendering">
-        <div class="graph-node source"><small>upload once</small><strong>|0…0⟩</strong><span>slice 0</span></div>
+        <div class="graph-node source" data-explain="graph-initial" tabindex="0"><small>upload once</small><strong>|0…0⟩</strong><span>slice 0</span></div>
         <b>→</b>
-        <div class="graph-node repeated"><small>compute × gate count</small><strong>Gate nodes</strong><span>slice n → n+1</span></div>
+        <div class="graph-node repeated" data-explain="graph-gates" tabindex="0"><small>compute × gate count</small><strong>Gate nodes</strong><span>slice n → n+1</span></div>
         <b>→</b>
-        <div class="graph-node"><small>compute</small><strong>Probability + phase</strong><span>all snapshots</span></div>
+        <div class="graph-node" data-explain="graph-probability" tabindex="0"><small>compute</small><strong>Probability + phase</strong><span>all snapshots</span></div>
         <b>→</b>
-        <div class="graph-node publication"><small>reduction + publication</small><strong>Normalization</strong><span>complete history</span></div>
+        <div class="graph-node publication" data-explain="graph-normalization" tabindex="0"><small>reduction + publication</small><strong>Normalization</strong><span>complete history</span></div>
         <b>→</b>
-        <div class="graph-node render"><small>luma.gl Model</small><strong>Linked views</strong><span>zero amplitude readback</span></div>
+        <div class="graph-node render" data-explain="graph-render" tabindex="0"><small>luma.gl Model</small><strong>Linked views</strong><span>zero amplitude readback</span></div>
       </div>
-      <div class="analysis-branch"><span>On scrub / observed-qubit change</span><b>Selected history slice</b><i>→</i><b>Bloch reduction</b><i>+</i><b>Connected Z correlations</b></div>
+      <div class="analysis-branch" data-explain="graph-analysis" tabindex="0"><span>On scrub / observed-qubit change</span><b>Selected history slice</b><i>→</i><b>Bloch reduction</b><i>+</i><b>Connected Z correlations</b></div>
     </section>
     <div class="implementation-grid">
       <article><p class="eyebrow">Storage layout</p><h3>Complex f32 pairs</h3>

--- a/examples/showcase/quantum-state-studio/quantum-styles.css
+++ b/examples/showcase/quantum-state-studio/quantum-styles.css
@@ -73,6 +73,22 @@
 .quantum-gate.active { border-color: #72e4ff; background: rgb(28 92 133 / 86%); box-shadow: 0 0 22px rgb(74 218 255 / 22%), inset 0 0 14px rgb(109 224 255 / 12%); }
 .quantum-gate.initial { color: #f0b3ff; }
 footer { position: absolute; left: 34px; right: 34px; bottom: 15px; display: flex; justify-content: space-between; color: #526981; font: 9px ui-monospace, SFMono-Regular, monospace; letter-spacing: .03em; }
+.explain-region { position: absolute; z-index: 1; border: 1px solid transparent; border-radius: 18px; outline: none; pointer-events: auto; transition: border-color 160ms ease, background 160ms ease, box-shadow 160ms ease; }
+.explain-region::after { position: absolute; top: 9px; right: 10px; display: grid; width: 18px; height: 18px; place-items: center; border: 1px solid rgb(110 220 255 / 25%); border-radius: 50%; background: rgb(5 17 38 / 64%); color: rgb(139 229 255 / 62%); content: 'i'; font: 700 9px ui-serif, Georgia, serif; opacity: .58; box-shadow: 0 0 16px rgb(72 216 255 / 8%); transition: opacity 160ms ease, box-shadow 160ms ease; }
+.explain-region:hover, .explain-region:focus-visible { border-color: rgb(98 223 255 / 26%); background: rgb(50 178 224 / 2.5%); box-shadow: inset 0 0 48px rgb(67 205 255 / 4%); }
+.explain-region:hover::after, .explain-region:focus-visible::after { opacity: 1; box-shadow: 0 0 18px rgb(72 216 255 / 28%); }
+.landscape-region { top: 15%; right: 2%; bottom: 31%; left: 27%; }
+.bloch-region { top: 20%; bottom: 50%; left: 2%; width: 24%; }
+.correlation-region { top: 54%; bottom: 31%; left: 2%; width: 24%; }
+.history-region { right: 2%; bottom: 16%; left: 27%; height: 13%; }
+.quantum-tooltip { position: fixed; z-index: 40; width: min(340px, calc(100vw - 24px)); padding: 16px 18px; border: 1px solid rgb(104 220 255 / 34%); border-radius: 14px; background: linear-gradient(145deg, rgb(6 20 42 / 96%), rgb(13 18 45 / 96%)); color: #dcefff; box-shadow: 0 20px 70px rgb(0 0 0 / 56%), 0 0 34px rgb(72 216 255 / 9%), inset 0 1px rgb(255 255 255 / 5%); backdrop-filter: blur(22px) saturate(125%); pointer-events: none; }
+.quantum-tooltip[hidden] { display: none; }
+.quantum-tooltip strong { display: block; color: #effcff; font-size: 14px; font-weight: 650; letter-spacing: -.015em; }
+.quantum-tooltip > p:not(.eyebrow) { margin: 8px 0 0; color: #9eb2c9; font-size: 11px; line-height: 1.58; }
+.quantum-tooltip code { display: block; margin-top: 10px; padding-top: 9px; border-top: 1px solid rgb(102 189 227 / 14%); color: #72dff5; font: 9px/1.45 ui-monospace, SFMono-Regular, monospace; white-space: normal; }
+.explanation-hint::before { margin-right: 6px; color: #66d9f2; content: 'ⓘ'; }
+[data-explain]:focus-visible:not(.explain-region) { outline: 1px solid rgb(104 224 255 / 70%); outline-offset: 3px; }
+.implementation-metrics [data-explain], .graph-notes [data-explain] { cursor: help; }
 @media (max-width: 900px) { .disclaimer { display: none; }.quantum-tabs { right: 18px; }.quantum-tabs button span { display: none; }.editor span { display: none; }.quantum-controls { grid-template-columns: 1fr auto; }.editor { position: absolute; right: 0; bottom: 42px; }.quantum-copy { display: none; }.visual-label small { display: none; }.notes-hero, .preset-field-guide { grid-template-columns: 1fr; gap: 18px; }.concept-grid, .implementation-grid { grid-template-columns: 1fr; }.implementation-metrics { grid-template-columns: repeat(3, 1fr); }.graph-flow { display: flex; overflow-x: auto; }.graph-node { min-width: 140px; } }
 @media (max-width: 700px) {
   .quantum-header { top: 14px; left: 14px; right: 14px; }
@@ -89,6 +105,11 @@ footer { position: absolute; left: 34px; right: 34px; bottom: 15px; display: fle
   .bloch-label { top: 57%; left: 5%; }
   .correlation-label { top: 57%; right: 5%; left: auto; text-align: right; }
   .history-label { top: 71%; bottom: auto; left: 5%; }
+  .landscape-region { top: 20%; right: 3%; bottom: auto; left: 3%; width: auto; height: 34%; }
+  .bloch-region { top: 54%; bottom: auto; left: 3%; width: 51%; height: 17%; }
+  .correlation-region { top: 54%; right: 3%; bottom: auto; left: auto; width: 42%; height: 17%; }
+  .history-region { top: 71%; right: 3%; bottom: auto; left: 3%; height: 10%; }
+  .explain-region::after { top: 6px; right: 7px; }
   .quantum-circuit-scroll { right: 10px; bottom: 101px; left: 10px; padding-bottom: 5px; }
   .quantum-controls { right: 10px; bottom: 10px; left: 10px; grid-template-columns: minmax(0, 1fr) auto; gap: 6px 8px; }
   .scrubber { grid-column: 1 / -1; grid-template-columns: auto minmax(0, 1fr) 48px; }

--- a/test/examples/quantum-state-studio.node.spec.ts
+++ b/test/examples/quantum-state-studio.node.spec.ts
@@ -16,6 +16,10 @@ import {
   getQuantumBackgroundMarkup,
   getQuantumImplementationMarkup
 } from '../../examples/showcase/quantum-state-studio/quantum-notes';
+import {
+  getQuantumExplanation,
+  getQuantumGateExplanation
+} from '../../examples/showcase/quantum-state-studio/quantum-explanations';
 
 describe('Quantum State Studio state-vector indexing', () => {
   test('treats q0 as the least-significant computational-basis bit', () => {
@@ -99,5 +103,15 @@ describe('Quantum State Studio explanatory tabs', () => {
     expect(implementation).toContain('GPUCommandGraph');
     expect(implementation).toContain('complete-state-history');
     expect(implementation).toContain('selected-observables');
+  });
+
+  test('provides contextual explanations for GPU views, graph nodes, and concrete gates', () => {
+    expect(getQuantumExplanation('probability-landscape')?.body).toContain('complex phase');
+    expect(getQuantumExplanation('graph-normalization')?.body).toContain('Σ|αₓ|²');
+    expect(getQuantumGateExplanation(makeCommonGate('H', 2), 4)).toMatchObject({
+      eyebrow: 'Gate 4 · state slice 4',
+      title: 'H on q2'
+    });
+    expect(getQuantumImplementationMarkup()).toContain('data-explain="graph-analysis"');
   });
 });


### PR DESCRIPTION
## Goals

Make Quantum State Studio much more self-explanatory without obscuring its GPU-rendered hero views.

## Changes

- Add one reusable, accessible contextual explanation inspector for hover, keyboard focus, and touch.
- Explain the probability/phase landscape, reduced-qubit Bloch sphere, connected correlations, interference history, circuit controls, presets, individual gates, and live resource metrics.
- Add pointer-aware basis-state, snapshot, and qubit-pair readouts without reading amplitude data back from the GPU.
- Annotate the implementation tab’s GPUCommandGraph nodes and selected-observables branch.
- Add responsive view hit regions and restrained info glows that preserve the showcase’s visual hierarchy.
- Add focused tests for explanation copy and gate-specific metadata.

## Verification

- `nvm use`
- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn test` — 280 files passed, 1 skipped; 2650 tests passed, 1 skipped
- `yarn workspace luma.gl-examples-showcase-quantum-state-studio build`
- `npx vitest run --project node test/examples/quantum-state-studio.node.spec.ts` — 13 tests passed
- Browser QA at desktop and 390×844 mobile viewport, including hover/focus inspector positioning, gate and compute-graph explanations, circuit preset reload, and console logs

## Notes

This remains a classical GPU state-vector simulator and makes no quantum-speedup claim. The inspector derives spatial labels from pointer position and existing state metadata; amplitudes remain GPU-resident.