### PR TITLE
feat(gpgpu): Reassign GPUDataEvaluator external buffer post construction

### DIFF
--- a/docs/api-reference/gpgpu/gpu-data-evaluator.md
+++ b/docs/api-reference/gpgpu/gpu-data-evaluator.md
@@ -63,8 +63,31 @@ const packedOutput = await translatedPositions.evaluate(device);
 ```
 
 Input views retain their offset and stride, so multiple attributes may borrow
-the same interleaved buffer. Operation results remain newly materialized packed
-outputs; evaluating into an interleaved destination is not implicit.
+the same interleaved buffer. Operation results use newly materialized packed
+outputs by default. Call `setTargetBuffer()` before evaluation to direct an
+operation result into an existing buffer range.
+
+### Evaluate into an existing buffer
+
+```ts
+import {cleanEvaluate, fround, GPUDataEvaluator} from '@luma.gl/gpgpu';
+
+const source = GPUDataEvaluator.fromArray(new Float64Array(values), {size: 3});
+const splitPositions = fround(source);
+
+splitPositions.setTargetBuffer({
+  buffer: attributeBuffer,
+  byteOffset: destinationByteOffset
+});
+
+await cleanEvaluate(device, splitPositions);
+```
+
+The target is borrowed. Evaluation writes directly into `attributeBuffer` and
+does not allocate or copy through a separate output buffer. `cleanEvaluate()`
+recycles unreferenced owned dependency buffers, but preserves the borrowed root
+target. Calling `splitPositions.destroy()` is not required to release the target
+and never destroys `attributeBuffer`.
 
 ## `GPUDataEvaluator`
 
@@ -122,6 +145,27 @@ the stored scalar component width.
 
 ### Methods
 
+#### `setTargetBuffer(target: GPUDataEvaluatorTargetBuffer): void`
+
+Assigns borrowed storage for the next evaluation of a deferred operation
+output. This method is only valid before evaluation and on an evaluator whose
+source is an `Operation`.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `buffer` | `Buffer` | Borrowed buffer that receives the operation output. |
+| `byteOffset?` | `number` | Byte offset of the first output row. Defaults to `0`. |
+| `byteStride?` | `number` | Byte distance between adjacent output rows. Defaults to the operation output's current packed stride. Backend layout restrictions still apply. |
+
+`setTargetBuffer()` records the target without changing the evaluator's logical
+layout. When evaluation begins, the target replaces the normal pooled output
+allocation and `offset`, `stride`, and `byteLength` are updated to describe the
+physical target layout. The target buffer must belong to the evaluation device
+and be large enough for the resulting range.
+
+The evaluator borrows the assigned buffer. Evaluating or destroying the
+evaluator never transfers ownership of or destroys that buffer.
+
 #### `evaluate(device: Device, options?): Promise<GPUVector>`
 
 Materializes one single-chunk `GPUVector` on the provided device. Lazy
@@ -146,7 +190,8 @@ inspection and may be slower than staying on the GPU.
 #### `destroy(): void`
 
 Releases cached GPU storage owned by this evaluator and prevents future
-evaluation.
+evaluation. Borrowed buffers supplied through the constructor,
+`fromGPUData()`, `fromGPUDataView()`, or `setTargetBuffer()` are not destroyed.
 
 ## `GPUVectorEvaluator`
 
@@ -193,9 +238,12 @@ Releases cached GPU resources owned through child `GPUDataEvaluator` instances.
 - Leaf operations accept `GPUDataEvaluator`, `GPUData`, or `GPUDataView`, not `GPUVector`.
 - Use `GPUVectorEvaluator.fromGPUVector(vector).mapGPUData(...)` for vector-wide
   transforms that should preserve streaming chunks.
-- `GPUDataEvaluator` operation outputs own their materialized single-chunk
-  `GPUVector` backing resource.
+- `GPUDataEvaluator` operation outputs own their automatically allocated
+  backing resource. Outputs configured with `setTargetBuffer()` borrow their
+  backing resource instead.
 - Borrowed `GPUData` chunks are not destroyed by `GPUDataEvaluator.destroy()`.
 - Borrowed `GPUDataView` buffers are not destroyed by `GPUDataEvaluator.destroy()`.
+- Target buffers assigned with `GPUDataEvaluator.setTargetBuffer()` are not
+  destroyed or recycled by the evaluator.
 - Synchronous evaluation is intended for already-prepared graphs where backend
   registration and any required CPU values are available up front.

--- a/modules/gpgpu/src/index.ts
+++ b/modules/gpgpu/src/index.ts
@@ -9,7 +9,8 @@ export type {
   GPUDataEvaluatorFromGPUDataOptions,
   GPUDataEvaluatorFromGPUDataViewOptions,
   GPUDataEvaluatorInput,
-  GPUDataEvaluatorProps
+  GPUDataEvaluatorProps,
+  GPUDataEvaluatorTargetBuffer
 } from './operation/gpu-data-evaluator';
 export {getGPUVectorEvaluator, GPUVectorEvaluator} from './operation/gpu-vector-evaluator';
 export type {

--- a/modules/gpgpu/src/operation/gpu-data-evaluator.ts
+++ b/modules/gpgpu/src/operation/gpu-data-evaluator.ts
@@ -26,6 +26,16 @@ import type {Operation} from './operation';
 
 type GPUDataEvaluatorBufferOwnership = 'owned' | 'borrowed';
 
+/** Borrowed GPU buffer and row layout assigned to one deferred operation output. */
+export type GPUDataEvaluatorTargetBuffer = {
+  /** Buffer that receives the evaluated output. */
+  buffer: Buffer;
+  /** Number of bytes to skip before writing the first output row. */
+  byteOffset?: number;
+  /** Number of bytes between the starts of adjacent output rows. */
+  byteStride?: number;
+};
+
 /** Options for materializing one {@link GPUDataEvaluator}. */
 export type GPUDataEvaluatorEvaluateOptions = {
   /** Name assigned to the materialized single-chunk `GPUVector`. */
@@ -88,7 +98,7 @@ export type GPUDataEvaluatorProps = {
 };
 
 /**
- * Device-agnostic, immutable 2D numeric evaluator used by lazy GPGPU operations.
+ * Device-agnostic 2D numeric evaluator used by lazy GPGPU operations.
  *
  * @remarks
  * A `GPUDataEvaluator` describes exactly one logical `GPUData` chunk, a CPU value source, or a
@@ -102,9 +112,13 @@ export class GPUDataEvaluator {
   /** Number of scalar elements in each logical row. */
   readonly size: number;
   /** Number of bytes to skip before reading the first element. */
-  readonly offset: number;
+  get offset(): number {
+    return this._offset;
+  }
   /** Number of bytes between the starts of adjacent rows. */
-  readonly stride: number;
+  get stride(): number {
+    return this._stride;
+  }
   /** Whether integer values should be normalized when read as float vertex attributes. */
   readonly normalized: boolean;
   /** Whether all rows share the same value. */
@@ -112,7 +126,9 @@ export class GPUDataEvaluator {
   /** Number of logical rows. */
   readonly length: number;
   /** Total bytes needed for the table storage. */
-  readonly byteLength: number;
+  get byteLength(): number {
+    return this._byteLength;
+  }
   /** TypedArray constructor for CPU representation, derived from {@link GPUDataEvaluator.type}. */
   readonly ValueType: TypedArrayConstructor;
   /** Operation or evaluator whose output initializes this evaluator. */
@@ -127,10 +143,18 @@ export class GPUDataEvaluator {
 
   /** CPU buffer, either provided by the user or read back from the GPU. */
   protected _value?: TypedArray;
+  /** Physical byte offset of the first row in the current buffer. */
+  private _offset: number;
+  /** Physical byte stride between rows in the current buffer. */
+  private _stride: number;
+  /** Number of bytes occupied by the current row layout, excluding its initial offset. */
+  private _byteLength: number;
   /** Materialized GPU resource backing this evaluator. */
   private _gpuVector?: GPUVector;
   /** Whether this evaluator owns its backing GPU buffer or only borrows another resource's buffer. */
   private _bufferOwnership: GPUDataEvaluatorBufferOwnership = 'owned';
+  /** Borrowed output storage applied when a deferred operation is next evaluated. */
+  private _targetBuffer?: Required<GPUDataEvaluatorTargetBuffer>;
 
   /**
    * Constructs one evaluator from a CPU array.
@@ -165,7 +189,7 @@ export class GPUDataEvaluator {
       size *= 2;
       offset *= 2;
       stride *= 2;
-      typedValue = new Uint32Array(value.buffer);
+      typedValue = new Uint32Array(value.buffer, value.byteOffset, value.byteLength / 4);
     } else {
       resolvedType = resolvedType || getDataTypeFromTypedArray(value);
       typedValue = value;
@@ -288,8 +312,8 @@ export class GPUDataEvaluator {
     this.type = type;
     this.size = size;
     this.ValueType = getTypedArrayFromDataType(this.type);
-    this.offset = offset;
-    this.stride = stride || this.ValueType.BYTES_PER_ELEMENT * size;
+    this._offset = offset;
+    this._stride = stride || this.ValueType.BYTES_PER_ELEMENT * size;
     this.normalized = normalized;
     this.source = source;
     this.format = format;
@@ -306,7 +330,7 @@ export class GPUDataEvaluator {
     this.isConstant = isConstant;
     this.length = length;
     const rowByteLength = this.ValueType.BYTES_PER_ELEMENT * this.size;
-    this.byteLength = length === 0 ? 0 : (length - 1) * this.stride + rowByteLength;
+    this._byteLength = length === 0 ? 0 : (length - 1) * this.stride + rowByteLength;
     this._value = value;
     this._bufferOwnership =
       source instanceof GPUDataEvaluator || buffer || gpuData ? 'borrowed' : 'owned';
@@ -358,6 +382,29 @@ export class GPUDataEvaluator {
   }
 
   /**
+   * Assigns borrowed output storage for the next evaluation of a deferred operation.
+   *
+   * The evaluator keeps its logical output layout until evaluation starts. Evaluation then updates
+   * `offset`, `stride`, and `byteLength` to describe the target buffer location.
+   */
+  setTargetBuffer({
+    buffer,
+    byteOffset = 0,
+    byteStride = this.stride
+  }: GPUDataEvaluatorTargetBuffer): void {
+    if (this._destroyed) {
+      throw new Error(`GPUDataEvaluator ${this} already destroyed`);
+    }
+    if (this._gpuVector) {
+      throw new Error(`GPUDataEvaluator ${this} already evaluated`);
+    }
+    if (!this.source || this.source instanceof GPUDataEvaluator) {
+      throw new Error('GPUDataEvaluator target buffers require a deferred operation source');
+    }
+    this._targetBuffer = {buffer, byteOffset, byteStride};
+  }
+
+  /**
    * Materializes this evaluator on a device and returns the requested output format.
    *
    * If the evaluator is operation-backed, dependencies are evaluated first and then the backend
@@ -388,7 +435,7 @@ export class GPUDataEvaluator {
       return this._gpuVector;
     }
 
-    buffer = bufferPool.createOrReuse(device, this.byteLength);
+    buffer = this._getEvaluationBuffer(device);
     if (this._value) {
       buffer.write(this._value);
     } else {
@@ -423,7 +470,7 @@ export class GPUDataEvaluator {
       return this._gpuVector;
     }
 
-    buffer = bufferPool.createOrReuse(device, this.byteLength);
+    buffer = this._getEvaluationBuffer(device);
     if (this._value) {
       buffer.write(this._value);
     } else {
@@ -477,6 +524,32 @@ export class GPUDataEvaluator {
       rowByteLength: this.ValueType.BYTES_PER_ELEMENT * this.size,
       ownsBuffer: false
     });
+  }
+
+  /** Selects assigned output storage or allocates owned storage for one evaluation. */
+  private _getEvaluationBuffer(device: Device): Buffer {
+    const target = this._targetBuffer;
+    if (!target) {
+      return bufferPool.createOrReuse(device, this.byteLength);
+    }
+
+    if (target.buffer.device !== device) {
+      throw new Error('GPUDataEvaluator target buffer belongs to a different device');
+    }
+
+    const rowByteLength = this.ValueType.BYTES_PER_ELEMENT * this.size;
+    const targetByteLength =
+      this.length === 0 ? 0 : (this.length - 1) * target.byteStride + rowByteLength;
+    if (target.byteOffset + targetByteLength > target.buffer.byteLength) {
+      throw new Error('GPUDataEvaluator target buffer is too small for the output layout');
+    }
+
+    this._offset = target.byteOffset;
+    this._stride = target.byteStride;
+    this._byteLength = targetByteLength;
+    this._bufferOwnership = 'borrowed';
+    this._targetBuffer = undefined;
+    return target.buffer;
   }
 
   /**
@@ -571,6 +644,7 @@ export class GPUDataEvaluator {
       }
       this._gpuVector = undefined;
     }
+    this._targetBuffer = undefined;
     this._destroyed = true;
   }
 }

--- a/modules/gpgpu/src/operations/cpu/common.ts
+++ b/modules/gpgpu/src/operations/cpu/common.ts
@@ -57,10 +57,29 @@ export function runCPUTransform({
       );
     }
   }
-  outputBuffer.write(target);
+
+  const elementByteLength = output.ValueType.BYTES_PER_ELEMENT;
+  const outputOffset = output.offset / elementByteLength;
+  const outputStride = output.stride / elementByteLength;
+  const packedStride = outputSize;
+  let outputValue: TypedArray = target;
+  if (outputOffset !== 0 || outputStride !== packedStride) {
+    outputValue = new output.ValueType(
+      outputOffset + output.byteLength / elementByteLength
+    ) as TypedArray;
+    for (let rowIndex = 0; rowIndex < vertexCount; rowIndex++) {
+      const sourceOffset = rowIndex * packedStride;
+      const destinationOffset = outputOffset + rowIndex * outputStride;
+      const row = target.subarray(sourceOffset, sourceOffset + outputSize);
+      outputValue.set(row, destinationOffset);
+      outputBuffer.write(row, destinationOffset * elementByteLength);
+    }
+  } else {
+    outputBuffer.write(target);
+  }
   return {
     success: true,
-    value: target
+    value: outputValue
   };
 }
 

--- a/modules/gpgpu/src/operations/webgl/common/row-transform.ts
+++ b/modules/gpgpu/src/operations/webgl/common/row-transform.ts
@@ -117,7 +117,12 @@ set_result(result);
   device.statsManager.getStats(GPGPU_OPERATION_STATS).get(TRANSFORM_RUNS).incrementCount();
   transform.run({
     inputBuffers: inputBuffers,
-    outputBuffers: {[outputModule.varyings[0]]: outputBuffer}
+    outputBuffers: {
+      [outputModule.varyings[0]]:
+        output.offset === 0
+          ? outputBuffer
+          : {buffer: outputBuffer, byteOffset: output.offset, byteLength: output.byteLength}
+    }
   });
   if (placeholderBuffer) {
     bufferPool.recycle(placeholderBuffer);

--- a/modules/gpgpu/test/gpu-vector/gpu-data-evaluator.node.spec.ts
+++ b/modules/gpgpu/test/gpu-vector/gpu-data-evaluator.node.spec.ts
@@ -8,6 +8,20 @@ import {GPUVector, type GPUVectorFormat} from '@luma.gl/gpgpu/gpu-data';
 import {NullDevice} from '@luma.gl/test-utils';
 import {expect, test, vi} from 'vitest';
 
+test('GPUDataEvaluator.fromArray preserves Float64Array view bounds', () => {
+  const source = new Float64Array([10, 20, 30, 40]);
+  const evaluator = GPUDataEvaluator.fromArray(source.subarray(1, 3), {size: 1});
+  const value = evaluator.value!;
+  const float64Value = new Float64Array(
+    value.buffer,
+    value.byteOffset,
+    value.byteLength / Float64Array.BYTES_PER_ELEMENT
+  );
+
+  expect(evaluator.length).toBe(2);
+  expect(Array.from(float64Value)).toEqual([20, 30]);
+});
+
 test('GPUDataEvaluator buffer pool allocates exact sizes and validates device limits', async () => {
   const device = new NullDevice({});
   Object.defineProperty(device.limits, 'maxBufferSize', {value: 16});

--- a/modules/gpgpu/test/operations/fround.spec.ts
+++ b/modules/gpgpu/test/operations/fround.spec.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {test, expect, describe, beforeEach} from 'vitest';
-import type {Device} from '@luma.gl/core';
+import {Buffer, type Device} from '@luma.gl/core';
 import {cleanEvaluate, fround, GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice, verifyTableValue} from './fixtures';
 
@@ -28,6 +28,44 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
 
     beforeEach(async () => {
       device = await getTestDevice(deviceType);
+    });
+
+    test('writes into an assigned target buffer range', async t => {
+      if (!device) {
+        t.skip(`${deviceType} not available`);
+        return;
+      }
+
+      const values = [Math.PI, -Math.E, 0.1, -1 / 3];
+      const output = fround(GPUDataEvaluator.fromArray(new Float64Array(values), {size: 2}));
+      const byteOffset = 16;
+      const targetBuffer = device.createBuffer({
+        usage: Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC,
+        data: new Float32Array(16).fill(-1)
+      });
+
+      output.setTargetBuffer({buffer: targetBuffer, byteOffset});
+      expect(output.offset).toBe(0);
+
+      await cleanEvaluate(device, output);
+
+      expect(output.buffer).toBe(targetBuffer);
+      expect(output.offset).toBe(byteOffset);
+      expect(output.stride).toBe(16);
+      expect(await verifyTableValue(output, {value: splitFloatsCPU(values, 2), size: 4})).toBe(
+        null
+      );
+
+      const targetBytes = await targetBuffer.readAsync();
+      const targetValues = new Float32Array(
+        targetBytes.buffer,
+        targetBytes.byteOffset,
+        targetBytes.byteLength / Float32Array.BYTES_PER_ELEMENT
+      );
+      expect(Array.from(targetValues.subarray(0, byteOffset / 4))).toEqual([-1, -1, -1, -1]);
+
+      // The evaluated output borrows this buffer, so no output.destroy() is required.
+      targetBuffer.destroy();
     });
 
     const TEST_CASES: {


### PR DESCRIPTION
When using device-agnostic operation functions, output GPUDataEvaluator are constructed internally without any user control. This feature allows consumers (deck.gl Attribute/Transition) to force a GPUDataEvaluator to write into a pre-allocated buffer instead of creating its own.

#### Change List
- Add GPUDataEvaluator.setTargetBuffer
- Docs
- Tests
