### PR TITLE
feat(gltf): support large skin joint palettes

### DIFF
--- a/modules/gltf/src/gltf/create-gltf-model.ts
+++ b/modules/gltf/src/gltf/create-gltf-model.ts
@@ -429,6 +429,8 @@ export type CreateGLTFModelOptions = {
   bounds?: ScenegraphBounds;
   /** Source-authored local transforms for `EXT_mesh_gpu_instancing`. */
   instanceMatrices?: readonly NumericArray[];
+  /** Primitive joint indices exceed the portable uniform skin palette size. */
+  usesLargeSkinPalette?: boolean;
   /** Immutable source POSITION/NORMAL/TANGENT deltas for GPU crowd morph deformation. */
   morphTargets?: readonly MorphTargetAttributes[];
 };
@@ -500,6 +502,7 @@ export function createGLTFModel(device: Device, options: CreateGLTFModelOptions)
     vertexCount,
     modelOptions = {},
     instanceMatrices,
+    usesLargeSkinPalette = false,
     morphTargets = []
   } = options;
   const crowd = modelOptions.userData?.['gltfAnimatedCrowd'] as
@@ -580,6 +583,7 @@ export function createGLTFModel(device: Device, options: CreateGLTFModelOptions)
   }
 
   const hasSkin = Boolean(parsedPPBRMaterial.defines['HAS_SKIN']);
+  const hasLargeSkinPalette = Boolean(usesLargeSkinPalette && hasSkin && !crowd);
   const hasInstancedSkin = Boolean(crowd && hasSkin && !hasGPUAnimation);
   let skinJointMatrices: Buffer | Texture | undefined;
   let jointMatrices: Float32Array | undefined;
@@ -707,6 +711,7 @@ export function createGLTFModel(device: Device, options: CreateGLTFModelOptions)
       ...(hasInstancedSkin
         ? {HAS_INSTANCED_SKIN: true, CROWD_JOINTS_PER_INSTANCE: crowd!.jointsPerInstance}
         : {}),
+      ...(hasLargeSkinPalette ? {HAS_LARGE_SKIN: true} : {}),
       ...(hasGPUAnimation
         ? {HAS_GPU_CROWD_ANIMATION: true, CROWD_ANIMATION_FRAME_STRIDE: animationFrameStride}
         : {}),
@@ -758,6 +763,7 @@ export function createGLTFModel(device: Device, options: CreateGLTFModelOptions)
     bounds: options.bounds,
     instanceMatrices
   });
+  modelNode.userData['gltfLargeSkinPalette'] = hasLargeSkinPalette;
   if (crowd) {
     modelNode.userData['gltfAnimatedCrowd'] = {
       transformBuffers,

--- a/modules/gltf/src/gltf/create-scenegraph-from-gltf.ts
+++ b/modules/gltf/src/gltf/create-scenegraph-from-gltf.ts
@@ -133,7 +133,7 @@ export function createScenegraphsFromGLTF(
   const extensionSupport = getGLTFExtensionSupport(gltf, device);
   const sceneBounds = scenes.map(scene => getScenegraphBounds(scene.getBounds()));
   const modelBounds = getCombinedScenegraphBounds(sceneBounds);
-  const skins = new GLTFSkinController({gltf, scenes, gltfNodeIndexToNodeMap});
+  const skins = new GLTFSkinController({device, gltf, scenes, gltfNodeIndexToNodeMap});
   animator.setUpdateHandler(() => skins.update());
 
   let destroyed = false;
@@ -142,6 +142,7 @@ export function createScenegraphsFromGLTF(
       return;
     }
     destroyed = true;
+    skins.destroy();
 
     const groups = new Set<GroupNode>([
       ...scenes,

--- a/modules/gltf/src/gltf/gltf-animated-crowd.ts
+++ b/modules/gltf/src/gltf/gltf-animated-crowd.ts
@@ -188,6 +188,7 @@ export class GLTFCrowdActor {
     this.isPlaying = options.playing ?? true;
 
     this.skins = new GLTFSkinController({
+      device: crowd.device,
       gltf: crowd.gltf,
       scenes: hierarchy.scenes,
       gltfNodeIndexToNodeMap: this.nodesByIndex
@@ -374,6 +375,7 @@ export class GLTFCrowdActor {
     }
     this.isDestroyed = true;
     this.isPlaying = false;
+    this.skins.destroy();
     this.crowd.removeActor(this.id);
     this.root.destroy();
   }

--- a/modules/gltf/src/gltf/gltf-skin.ts
+++ b/modules/gltf/src/gltf/gltf-skin.ts
@@ -3,7 +3,9 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {GLTFPostprocessed} from '@loaders.gl/gltf';
+import {Buffer, type Device, Texture} from '@luma.gl/core';
 import {GroupNode, ModelNode, updateSkinJointMatrices} from '@luma.gl/engine';
+import {SKIN_MAX_JOINTS} from '@luma.gl/shadertools';
 import {Matrix4} from '@math.gl/core';
 
 /** One glTF mesh node and the existing models driven by its source skin. */
@@ -20,12 +22,15 @@ export type GLTFSkinBinding = {
   inverseBindMatrices?: Float32Array;
   /** Reused, mesh-local joint palette supplied to the existing skin shader. */
   jointMatrices: Float32Array;
+  /** WebGPU storage buffer or WebGL float texture for a palette that exceeds uniform limits. */
+  skinJointMatrices?: Buffer | Texture;
   /** Existing primitive models that share this skin binding. */
   models: readonly ModelNode[];
 };
 
 /** Inputs already produced by the canonical glTF scenegraph parser. */
 export type GLTFSkinControllerProps = {
+  device: Device;
   gltf: GLTFPostprocessed;
   scenes: readonly GroupNode[];
   gltfNodeIndexToNodeMap: ReadonlyMap<number, GroupNode>;
@@ -66,8 +71,22 @@ export class GLTFSkinController {
         inverseBindMatrices: binding.inverseBindMatrices,
         target: binding.jointMatrices
       });
+      if (binding.skinJointMatrices) {
+        if (binding.skinJointMatrices instanceof Buffer) {
+          binding.skinJointMatrices.write(binding.jointMatrices);
+        } else {
+          binding.skinJointMatrices.writeData(binding.jointMatrices, {
+            width: binding.joints.length * 4,
+            height: 1
+          });
+        }
+      }
       for (const modelNode of binding.models) {
-        modelNode.model.shaderInputs.setProps({skin: {jointMatrices: binding.jointMatrices}});
+        modelNode.model.shaderInputs.setProps({
+          skin: binding.skinJointMatrices
+            ? {jointMatrices: [], skinJointMatrices: binding.skinJointMatrices}
+            : {jointMatrices: binding.jointMatrices}
+        });
       }
     }
   }
@@ -77,6 +96,13 @@ export class GLTFSkinController {
     return this.bindings.find(binding =>
       typeof node === 'number' ? binding.nodeIndex === node : binding.node === node
     );
+  }
+
+  /** Releases GPU palette transports owned by this controller. */
+  destroy(): void {
+    for (const binding of this.bindings) {
+      binding.skinJointMatrices?.destroy();
+    }
   }
 }
 
@@ -128,18 +154,54 @@ function makeSkinBindings(props: GLTFSkinControllerProps): GLTFSkinBinding[] {
 
     const models = meshNode.children.flatMap(child => (child instanceof ModelNode ? [child] : []));
     const inverseBindMatrices = sourceSkin.inverseBindMatrices?.value;
+    const jointMatrices = new Float32Array(joints.length * 16);
+    const usesLargeSkinPalette =
+      joints.length > SKIN_MAX_JOINTS &&
+      models.some(modelNode => modelNode.userData['gltfLargeSkinPalette'] === true);
+    let skinJointMatrices: Buffer | Texture | undefined;
+    if (usesLargeSkinPalette) {
+      skinJointMatrices = createSkinJointPaletteResource(props.device, node.id, jointMatrices);
+    }
     bindings.push({
       nodeIndex,
       skinIndex,
       node,
       joints,
       ...(inverseBindMatrices instanceof Float32Array ? {inverseBindMatrices} : {}),
-      jointMatrices: new Float32Array(joints.length * 16),
+      jointMatrices,
+      ...(skinJointMatrices ? {skinJointMatrices} : {}),
       models
     });
   }
 
   return bindings;
+}
+
+function createSkinJointPaletteResource(
+  device: Device,
+  id: string,
+  jointMatrices: Float32Array
+): Buffer | Texture {
+  if (device.type === 'webgpu') {
+    return device.createBuffer({
+      id: `${id}-skin-joint-matrices`,
+      byteLength: jointMatrices.byteLength,
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+  }
+
+  const width = jointMatrices.length / 4;
+  if (width > device.limits.maxTextureDimension2D) {
+    throw new Error('glTF skin palette exceeds the device texture width limit');
+  }
+  return device.createTexture({
+    id: `${id}-skin-joint-matrices`,
+    format: 'rgba32float',
+    width,
+    height: 1,
+    usage: Texture.SAMPLE | Texture.COPY_DST,
+    sampler: {minFilter: 'nearest', magFilter: 'nearest', mipmapFilter: 'nearest'}
+  });
 }
 
 /** Resolves both numeric and loaders.gl-postprocessed source skin references. */

--- a/modules/gltf/src/parsers/parse-gltf.ts
+++ b/modules/gltf/src/parsers/parse-gltf.ts
@@ -20,7 +20,7 @@ import {
   type ModelProps,
   type MorphTargetAttributes
 } from '@luma.gl/engine';
-import {pbrMaterial} from '@luma.gl/shadertools';
+import {pbrMaterial, SKIN_MAX_JOINTS} from '@luma.gl/shadertools';
 import {createGLTFMaterial, createGLTFModel} from '../gltf/create-gltf-model';
 import {type GLTFGPUInstancing, getGLTFNodeInstancing} from '../gltf/gltf-instancing';
 import type {GLTFPrimitiveMaterialVariants} from '../gltf/gltf-material-variants';
@@ -345,6 +345,7 @@ function createNodeForGLTFPrimitive({
     vertexCount,
     bounds: [gltfPrimitive.attributes.POSITION.min, gltfPrimitive.attributes.POSITION.max],
     instanceMatrices: instancing?.matrices,
+    usesLargeSkinPalette: usesLargeSkinPalette(gltfPrimitive.attributes.JOINTS_0),
     morphTargets: morphTargetState?.targets
   });
 
@@ -399,6 +400,24 @@ function createNodeForGLTFPrimitive({
   // modelNode.material =  gltfPrimitive.material;
 
   return modelNode;
+}
+
+/** Selects a GPU palette only when this primitive can index past the uniform palette. */
+function usesLargeSkinPalette(
+  joints: {max?: readonly number[]; value?: ArrayLike<number>} | undefined
+): boolean {
+  if (!joints) {
+    return false;
+  }
+  if (joints.max?.some(jointIndex => jointIndex >= SKIN_MAX_JOINTS)) {
+    return true;
+  }
+  for (let jointIndex = 0; jointIndex < (joints.value?.length || 0); jointIndex++) {
+    if (joints.value![jointIndex] >= SKIN_MAX_JOINTS) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function createGLTFMorphTargetState(

--- a/modules/shadertools/src/modules/engine/skin/skin.ts
+++ b/modules/shadertools/src/modules/engine/skin/skin.ts
@@ -32,13 +32,24 @@ fn getInstancedSkinMatrix(
        + (weights.z * skinJointMatrices[firstJoint + joints.z])
        + (weights.w * skinJointMatrices[firstJoint + joints.w]);
 }
+#else
+#ifdef HAS_LARGE_SKIN
+@group(0) @binding(auto) var<storage, read> skinJointMatrices: array<mat4x4<f32>>;
+#endif
 #endif
 
 fn getSkinMatrix(weights: vec4f, joints: vec4u) -> mat4x4<f32> {
+#ifdef HAS_LARGE_SKIN
+  return (weights.x * skinJointMatrices[joints.x])
+       + (weights.y * skinJointMatrices[joints.y])
+       + (weights.z * skinJointMatrices[joints.z])
+       + (weights.w * skinJointMatrices[joints.w]);
+#else
   return (weights.x * skin.jointMatrix[joints.x])
        + (weights.y * skin.jointMatrix[joints.y])
        + (weights.z * skin.jointMatrix[joints.z])
        + (weights.w * skin.jointMatrix[joints.w]);
+#endif
 }
 `;
 
@@ -73,13 +84,34 @@ mat4 getInstancedSkinMatrix(
        + (weights.z * getInstancedJointMatrix(joints.z, instanceIndex))
        + (weights.w * getInstancedJointMatrix(joints.w, instanceIndex));
 }
+#else
+#ifdef HAS_LARGE_SKIN
+uniform highp sampler2D skinJointMatrices;
+
+mat4 getSkinJointMatrix(uint jointIndex) {
+  int firstColumn = int(jointIndex * 4u);
+  return mat4(
+    texelFetch(skinJointMatrices, ivec2(firstColumn, 0), 0),
+    texelFetch(skinJointMatrices, ivec2(firstColumn + 1, 0), 0),
+    texelFetch(skinJointMatrices, ivec2(firstColumn + 2, 0), 0),
+    texelFetch(skinJointMatrices, ivec2(firstColumn + 3, 0), 0)
+  );
+}
+#endif
 #endif
 
 mat4 getSkinMatrix(vec4 weights, uvec4 joints) {
+#ifdef HAS_LARGE_SKIN
+  return (weights.x * getSkinJointMatrix(joints.x))
+       + (weights.y * getSkinJointMatrix(joints.y))
+       + (weights.z * getSkinJointMatrix(joints.z))
+       + (weights.w * getSkinJointMatrix(joints.w));
+#else
   return (weights.x * skin.jointMatrix[joints.x])
        + (weights.y * skin.jointMatrix[joints.y])
        + (weights.z * skin.jointMatrix[joints.z])
        + (weights.w * skin.jointMatrix[joints.w]);
+#endif
 }
 
 `;

--- a/modules/shadertools/test/modules/engine/skin.spec.ts
+++ b/modules/shadertools/test/modules/engine/skin.spec.ts
@@ -226,6 +226,32 @@ fn vertexMain(@builtin(instance_index) instanceIndex: u32) -> @builtin(position)
   t.end();
 });
 
+test('shadertools#skin selects indexed storage palettes for large WebGPU skins', t => {
+  const shaderAssembler = new WGSLShaderAssembler();
+  const assembledShader = shaderAssembler.assembleWGSLShader({
+    platformInfo: WGSL_PLATFORM_INFO,
+    source: /* wgsl */ `
+@vertex
+fn vertexMain() -> @builtin(position) vec4f {
+  return getSkinMatrix(vec4f(1.0, 0.0, 0.0, 0.0), vec4u(64u)) * vec4f(0.0, 0.0, 0.0, 1.0);
+}`,
+    modules: [skin],
+    defines: {HAS_LARGE_SKIN: true}
+  });
+
+  t.ok(
+    assembledShader.bindingTable.some(
+      binding => binding.name === 'skinJointMatrices' && binding.kind === 'read-only-storage'
+    ),
+    'large WebGPU skins use an indexed storage palette'
+  );
+  t.ok(
+    assembledShader.source.includes('skinJointMatrices[joints.x]'),
+    'large skinning indexes the palette directly without an instance offset'
+  );
+  t.end();
+});
+
 test('shadertools#skin assembles portable float-texture instance palettes for WebGL', async t => {
   const assembledShader = assembleGLSLShaderPair({
     platformInfo: GLSL_PLATFORM_INFO,


### PR DESCRIPTION
Goals

Advance glTF Supremacy Tranche 4 by removing the 64-joint uniform-palette ceiling for ordinary skinned primitives while preserving the compact path for small rigs.

Changes

- Select a large skin palette only when a primitive indexes a joint at or above 64.
- Use a WebGPU read-only storage buffer or WebGL2 rgba32float texture as the palette transport.
- Upload and bind the full palette from GLTFSkinController; release controller-owned resources on scenegraph and actor teardown.
- Cover the WebGPU large-palette shader specialization.

Verification

- nvm use
- yarn install
- yarn lint fix
- yarn test-node modules/shadertools/test/modules/engine/skin.spec.ts: suite passed with 3,041 tests and 3 skips.
- Focused TypeScript checks for modules/gltf and modules/shadertools.
- yarn build reached modules/gltf, but this fresh checkout fails earlier in modules/webgpu packaging because generated dist imports such as webgpu-buffer.js are absent.

Follow-up

This is the palette transport foundation. Tranche 4 still needs JOINTS_1 and WEIGHTS_1 eight-influence support plus 64/128/256-joint fixtures. Tranches 5 and 6 can reuse this resource boundary for GPU morph weights and sampled clip atlases.