### PR TITLE
feat(gltf): support eight skin influences

### DIFF
--- a/modules/gltf/src/gltf/create-gltf-model.ts
+++ b/modules/gltf/src/gltf/create-gltf-model.ts
@@ -48,16 +48,20 @@ struct VertexInputs {
   @location(5) JOINTS_0: vec4u,
   @location(6) WEIGHTS_0: vec4f,
 #endif
+#ifdef HAS_SKIN_1
+  @location(7) JOINTS_1: vec4u,
+  @location(8) WEIGHTS_1: vec4f,
+#endif
 #ifdef HAS_GLTF_INSTANCING
-  @location(8) instanceModelMatrixCol0: vec4f,
-  @location(9) instanceModelMatrixCol1: vec4f,
-  @location(10) instanceModelMatrixCol2: vec4f,
-  @location(11) instanceModelMatrixCol3: vec4f,
+  @location(9) instanceModelMatrixCol0: vec4f,
+  @location(10) instanceModelMatrixCol1: vec4f,
+  @location(11) instanceModelMatrixCol2: vec4f,
+  @location(12) instanceModelMatrixCol3: vec4f,
   @builtin(instance_index) instanceIndex: u32,
 #endif
 #ifdef HAS_GPU_CROWD_ANIMATION
-  @location(12) instanceAnimationFrames: vec4f,
-  @location(13) instanceAnimationBlend: vec4f,
+  @location(13) instanceAnimationFrames: vec4f,
+  @location(14) instanceAnimationBlend: vec4f,
 #endif
 #ifdef HAS_INSTANCED_MORPH
   @builtin(vertex_index) vertexIndex: u32,
@@ -160,7 +164,7 @@ fn vertexMain(inputs: VertexInputs) -> FragmentInputs {
 
 #ifdef HAS_SKIN
 #ifdef HAS_GPU_CROWD_ANIMATION
-  let skinMatrix = getGPUAnimatedSkinMatrix(
+  var skinMatrix = getGPUAnimatedSkinMatrix(
     inputs.WEIGHTS_0,
     inputs.JOINTS_0,
     inputs.instanceAnimationFrames,
@@ -169,14 +173,36 @@ fn vertexMain(inputs: VertexInputs) -> FragmentInputs {
   );
 #else
 #ifdef HAS_INSTANCED_SKIN
-  let skinMatrix = getInstancedSkinMatrix(
+  var skinMatrix = getInstancedSkinMatrix(
     inputs.WEIGHTS_0,
     inputs.JOINTS_0,
     inputs.instanceIndex,
     u32(CROWD_JOINTS_PER_INSTANCE)
   );
 #else
-  let skinMatrix = getSkinMatrix(inputs.WEIGHTS_0, inputs.JOINTS_0);
+  var skinMatrix = getSkinMatrix(inputs.WEIGHTS_0, inputs.JOINTS_0);
+#endif
+#endif
+#ifdef HAS_SKIN_1
+#ifdef HAS_GPU_CROWD_ANIMATION
+  skinMatrix += getGPUAnimatedSkinMatrix(
+    inputs.WEIGHTS_1,
+    inputs.JOINTS_1,
+    inputs.instanceAnimationFrames,
+    inputs.instanceAnimationBlend,
+    u32(CROWD_ANIMATION_FRAME_STRIDE)
+  );
+#else
+#ifdef HAS_INSTANCED_SKIN
+  skinMatrix += getInstancedSkinMatrix(
+    inputs.WEIGHTS_1,
+    inputs.JOINTS_1,
+    inputs.instanceIndex,
+    u32(CROWD_JOINTS_PER_INSTANCE)
+  );
+#else
+  skinMatrix += getSkinMatrix(inputs.WEIGHTS_1, inputs.JOINTS_1);
+#endif
 #endif
 #endif
   position = skinMatrix * position;
@@ -276,6 +302,11 @@ const vs = /* glsl */ `\
     in vec4 WEIGHTS_0;
   #endif
 
+  #ifdef HAS_SKIN_1
+    in uvec4 JOINTS_1;
+    in vec4 WEIGHTS_1;
+  #endif
+
   #ifdef HAS_GLTF_INSTANCING
     in vec4 instanceModelMatrixCol0;
     in vec4 instanceModelMatrixCol1;
@@ -371,6 +402,27 @@ const vs = /* glsl */ `\
       #else
       mat4 skinMat = getSkinMatrix(WEIGHTS_0, JOINTS_0);
       #endif
+      #endif
+      #ifdef HAS_SKIN_1
+        #ifdef HAS_GPU_CROWD_ANIMATION
+          skinMat += getGPUAnimatedSkinMatrix(
+            WEIGHTS_1,
+            JOINTS_1,
+            instanceAnimationFrames,
+            instanceAnimationBlend
+          );
+        #else
+        #ifdef HAS_INSTANCED_SKIN
+          skinMat += getInstancedSkinMatrix(
+            WEIGHTS_1,
+            JOINTS_1,
+            uint(gl_InstanceID),
+            uint(CROWD_JOINTS_PER_INSTANCE)
+          );
+        #else
+          skinMat += getSkinMatrix(WEIGHTS_1, JOINTS_1);
+        #endif
+        #endif
       #endif
       pos = skinMat * pos;
       _NORMAL = skinMat * _NORMAL;

--- a/modules/gltf/src/gltf/gltf-lod.ts
+++ b/modules/gltf/src/gltf/gltf-lod.ts
@@ -242,7 +242,15 @@ function simplifyGLTFMesh(
     }
 
     const attributes: MeshSimplificationAttribute[] = [];
-    for (const semantic of ['NORMAL', 'TEXCOORD_0', 'TEXCOORD_1', 'JOINTS_0', 'WEIGHTS_0']) {
+    for (const semantic of [
+      'NORMAL',
+      'TEXCOORD_0',
+      'TEXCOORD_1',
+      'JOINTS_0',
+      'WEIGHTS_0',
+      'JOINTS_1',
+      'WEIGHTS_1'
+    ]) {
       const attribute = primitive.attributes[semantic];
       if (attribute) {
         attributes.push({values: attribute.value, size: attribute.components});

--- a/modules/gltf/src/parsers/parse-gltf.ts
+++ b/modules/gltf/src/parsers/parse-gltf.ts
@@ -345,7 +345,10 @@ function createNodeForGLTFPrimitive({
     vertexCount,
     bounds: [gltfPrimitive.attributes.POSITION.min, gltfPrimitive.attributes.POSITION.max],
     instanceMatrices: instancing?.matrices,
-    usesLargeSkinPalette: usesLargeSkinPalette(gltfPrimitive.attributes.JOINTS_0),
+    usesLargeSkinPalette: usesLargeSkinPalette(
+      gltfPrimitive.attributes.JOINTS_0,
+      gltfPrimitive.attributes.JOINTS_1
+    ),
     morphTargets: morphTargetState?.targets
   });
 
@@ -404,17 +407,19 @@ function createNodeForGLTFPrimitive({
 
 /** Selects a GPU palette only when this primitive can index past the uniform palette. */
 function usesLargeSkinPalette(
-  joints: {max?: readonly number[]; value?: ArrayLike<number>} | undefined
+  ...jointSets: ({max?: readonly number[]; value?: ArrayLike<number>} | undefined)[]
 ): boolean {
-  if (!joints) {
-    return false;
-  }
-  if (joints.max?.some(jointIndex => jointIndex >= SKIN_MAX_JOINTS)) {
-    return true;
-  }
-  for (let jointIndex = 0; jointIndex < (joints.value?.length || 0); jointIndex++) {
-    if (joints.value![jointIndex] >= SKIN_MAX_JOINTS) {
+  for (const joints of jointSets) {
+    if (!joints) {
+      continue;
+    }
+    if (joints.max?.some(jointIndex => jointIndex >= SKIN_MAX_JOINTS)) {
       return true;
+    }
+    for (let jointIndex = 0; jointIndex < (joints.value?.length || 0); jointIndex++) {
+      if (joints.value![jointIndex] >= SKIN_MAX_JOINTS) {
+        return true;
+      }
     }
   }
   return false;

--- a/modules/gltf/src/parsers/parse-pbr-material.ts
+++ b/modules/gltf/src/parsers/parse-pbr-material.ts
@@ -193,6 +193,8 @@ type GLTFAttributeName =
   | 'TEXCOORD_1'
   | 'JOINTS_0'
   | 'WEIGHTS_0'
+  | 'JOINTS_1'
+  | 'WEIGHTS_1'
   | 'COLOR_0';
 
 const GLTF_ATTRIBUTE_ALIASES: Record<GLTFAttributeName, string[]> = {
@@ -202,6 +204,8 @@ const GLTF_ATTRIBUTE_ALIASES: Record<GLTFAttributeName, string[]> = {
   TEXCOORD_1: ['TEXCOORD_1', 'texCoords1'],
   JOINTS_0: ['JOINTS_0'],
   WEIGHTS_0: ['WEIGHTS_0'],
+  JOINTS_1: ['JOINTS_1'],
+  WEIGHTS_1: ['WEIGHTS_1'],
   COLOR_0: ['COLOR_0', 'colors']
 };
 
@@ -275,6 +279,13 @@ export function parsePBRMaterial(
   if (hasGLTFAttribute(attributes, 'TEXCOORD_1')) parsedMaterial.defines['HAS_UV_1'] = true;
   if (hasGLTFAttribute(attributes, 'JOINTS_0') && hasGLTFAttribute(attributes, 'WEIGHTS_0')) {
     parsedMaterial.defines['HAS_SKIN'] = true;
+  }
+  if (
+    parsedMaterial.defines['HAS_SKIN'] &&
+    hasGLTFAttribute(attributes, 'JOINTS_1') &&
+    hasGLTFAttribute(attributes, 'WEIGHTS_1')
+  ) {
+    parsedMaterial.defines['HAS_SKIN_1'] = true;
   }
   if (hasGLTFAttribute(attributes, 'COLOR_0')) parsedMaterial.defines['HAS_COLORS'] = true;
 

--- a/modules/gltf/test/parsers/parse-pbr-material.spec.ts
+++ b/modules/gltf/test/parsers/parse-pbr-material.spec.ts
@@ -163,6 +163,24 @@ test('gltf#parsePBRMaterial accepts normalized geometry attribute names', t => {
   t.end();
 });
 
+test('gltf#parsePBRMaterial enables the optional second skin influence set', t => {
+  const parsedMaterial = parsePBRMaterial(
+    device,
+    {},
+    {JOINTS_0: {}, WEIGHTS_0: {}, JOINTS_1: {}, WEIGHTS_1: {}},
+    {}
+  );
+
+  t.equal(parsedMaterial.defines['HAS_SKIN'], true, 'first joint influence set enables skinning');
+  t.equal(
+    parsedMaterial.defines['HAS_SKIN_1'],
+    true,
+    'second joint influence set enables eight-influence skinning'
+  );
+  destroyParsedTextures(parsedMaterial);
+  t.end();
+});
+
 test('gltf#parsePBRMaterial parses KHR_materials extensions', t => {
   const parsedMaterial = parsePBRMaterial(
     device,


### PR DESCRIPTION
Goals

Advance Tranche 4 after the large-palette foundation by supporting glTF primitives with JOINTS_1 and WEIGHTS_1.

Changes

- Add the second joint and weight semantic pair to PBR feature detection.
- Accumulate the second four influences in WebGPU and WebGL shaders.
- Cover ordinary, instanced, and GPU crowd-animation skinning paths.
- Preserve second influence data during generated LOD simplification.
- Include JOINTS_1 when deciding whether a primitive needs the large palette transport.

Verification

- nvm use
- yarn lint fix
- Focused glTF TypeScript check
- yarn test-node modules/gltf/test/parsers/parse-pbr-material.spec.ts: suite passed with 3,042 tests and 3 skips.

Stack

Base: #3118. This PR should merge after its large-skeleton palette transport is merged.