### PR TITLE
feat(gltf): upload ordinary morph weights to GPU

### DIFF
--- a/modules/gltf/src/gltf/create-gltf-model.ts
+++ b/modules/gltf/src/gltf/create-gltf-model.ts
@@ -775,7 +775,7 @@ export function createGLTFModel(device: Device, options: CreateGLTFModelOptions)
       ...(morphTargetData
         ? {HAS_INSTANCED_MORPH: true, CROWD_MORPH_TARGET_COUNT: morphTargetCount}
         : {}),
-      ...(crowd ? {CROWD_ANIMATION_JOINT_COUNT: animationJointCount} : {})
+      ...(crowd || morphTargetData ? {CROWD_ANIMATION_JOINT_COUNT: animationJointCount} : {})
     },
     parameters: {...parameters, ...parsedPPBRMaterial.parameters, ...modelOptions.parameters}
   };

--- a/modules/gltf/src/gltf/create-gltf-model.ts
+++ b/modules/gltf/src/gltf/create-gltf-model.ts
@@ -750,7 +750,7 @@ export function createGLTFModel(device: Device, options: CreateGLTFModelOptions)
     geometry,
     topology: geometry.topology,
     vertexCount,
-    modules: [pbrMaterial, skin, ...(morphTargetData ? [gpuAnimation] : [])],
+    modules: [pbrMaterial, skin, ...(crowd || morphTargetData ? [gpuAnimation] : [])],
     ...modelOptions,
 
     ...(instanceMatrices || crowd

--- a/modules/gltf/src/gltf/create-gltf-model.ts
+++ b/modules/gltf/src/gltf/create-gltf-model.ts
@@ -58,6 +58,10 @@ struct VertexInputs {
   @location(11) instanceModelMatrixCol2: vec4f,
   @location(12) instanceModelMatrixCol3: vec4f,
   @builtin(instance_index) instanceIndex: u32,
+#else
+#ifdef HAS_INSTANCED_MORPH
+  @builtin(instance_index) instanceIndex: u32,
+#endif
 #endif
 #ifdef HAS_GPU_CROWD_ANIMATION
   @location(13) instanceAnimationFrames: vec4f,
@@ -659,12 +663,12 @@ export function createGLTFModel(device: Device, options: CreateGLTFModelOptions)
     managedResources.push(skinJointMatrices);
   }
 
-  const morphTargetCount = crowd ? morphTargets.length : 0;
+  const morphTargetCount = morphTargets.length;
   const morphVertexCount = Math.floor((geometry.attributes['POSITION']?.value.length || 0) / 3);
   let morphTargetData: Buffer | Texture | undefined;
   let morphWeights: Float32Array | undefined;
   let morphWeightData: Buffer | Texture | undefined;
-  if (crowd && morphTargetCount > 0 && morphVertexCount > 0) {
+  if (morphTargetCount > 0 && morphVertexCount > 0) {
     const targetValues = new Float32Array(morphTargetCount * 3 * morphVertexCount * 4);
     for (const [targetIndex, target] of morphTargets.entries()) {
       for (const [attributeIndex, attributeName] of ['POSITION', 'NORMAL', 'TANGENT'].entries()) {
@@ -696,13 +700,14 @@ export function createGLTFModel(device: Device, options: CreateGLTFModelOptions)
 
     if (!hasGPUAnimation) {
       const packedTargetCount = Math.ceil(morphTargetCount / 4);
-      morphWeights = new Float32Array(crowd.capacity * packedTargetCount * 4);
+      const morphInstanceCount = crowd?.capacity || 1;
+      morphWeights = new Float32Array(morphInstanceCount * packedTargetCount * 4);
       morphWeightData = createGPUAnimationResource(
         device,
         `${id || 'gltf'}-crowd-morph-weights`,
         morphWeights,
         packedTargetCount,
-        crowd.capacity
+        morphInstanceCount
       );
       managedResources.push(morphWeightData);
     }
@@ -745,7 +750,7 @@ export function createGLTFModel(device: Device, options: CreateGLTFModelOptions)
     geometry,
     topology: geometry.topology,
     vertexCount,
-    modules: [pbrMaterial, skin, ...(crowd ? [gpuAnimation] : [])],
+    modules: [pbrMaterial, skin, ...(morphTargetData ? [gpuAnimation] : [])],
     ...modelOptions,
 
     ...(instanceMatrices || crowd
@@ -816,6 +821,13 @@ export function createGLTFModel(device: Device, options: CreateGLTFModelOptions)
     instanceMatrices
   });
   modelNode.userData['gltfLargeSkinPalette'] = hasLargeSkinPalette;
+  if (morphWeights && morphWeightData && !crowd) {
+    modelNode.userData['gltfMorphWeights'] = {
+      values: morphWeights,
+      data: morphWeightData,
+      packedTargetCount: Math.ceil(morphTargetCount / 4)
+    };
+  }
   if (crowd) {
     modelNode.userData['gltfAnimatedCrowd'] = {
       transformBuffers,

--- a/modules/gltf/src/gltf/morph-targets.ts
+++ b/modules/gltf/src/gltf/morph-targets.ts
@@ -9,12 +9,20 @@ import {
   type MorphTargetAttributes,
   updateMorphTargetBuffers
 } from '@luma.gl/engine';
+import {Buffer, Texture} from '@luma.gl/core';
 
 /** Immutable primitive attributes and glTF morph deltas retained by its existing model node. */
 export type GLTFMorphTargetState = {
   geometry: Geometry;
   baseAttributes: MorphTargetAttributes;
   targets: readonly MorphTargetAttributes[];
+};
+
+/** GPU-owned morph weights for one ordinary glTF primitive. */
+export type GLTFMorphWeightState = {
+  values: Float32Array;
+  data: Buffer | Texture;
+  packedTargetCount: number;
 };
 
 /** Updates existing vertex buffers so morph animation works on both WebGL and WebGPU. */
@@ -32,8 +40,25 @@ export function setGLTFMorphWeights(node: GroupNode, weights: readonly number[])
         return;
       }
 
+      const gpuWeights = child.userData['gltfMorphWeights'] as GLTFMorphWeightState | undefined;
+      if (gpuWeights) {
+        updateGLTFMorphWeights(gpuWeights, weights);
+        child.userData['morphWeights'] = [...weights];
+        return;
+      }
+
       updateMorphTargetBuffers(child.model, state.geometry, state.targets, weights);
       child.userData['morphWeights'] = [...weights];
     });
+  }
+}
+
+function updateGLTFMorphWeights(state: GLTFMorphWeightState, weights: readonly number[]): void {
+  state.values.fill(0);
+  state.values.set(weights.slice(0, state.values.length));
+  if (state.data instanceof Buffer) {
+    state.data.write(state.values);
+  } else {
+    state.data.writeData(state.values, {width: state.packedTargetCount, height: 1});
   }
 }

--- a/modules/gltf/test/gltf/gltf-review-correctness.node.spec.ts
+++ b/modules/gltf/test/gltf/gltf-review-correctness.node.spec.ts
@@ -98,7 +98,7 @@ describe('reviewed glTF deformation edge cases', () => {
     }
   });
 
-  test('decodes quantized AnimatedMorphCube bases before creating animated GPU geometry', async () => {
+  test('keeps AnimatedMorphCube vertices immutable while animation updates GPU morph weights', async () => {
     const source = await loadFixture('AnimatedMorphCube.glb');
     const primitive = source.meshes[0].primitives[0];
     const positionAccessor = primitive.attributes['POSITION'];
@@ -141,6 +141,15 @@ describe('reviewed glTF deformation edge cases', () => {
 
       const vertexBuffer = modelNode!.model._gpuGeometry!.attributes['geometry'];
       const previousBytes = new Uint8Array(await vertexBuffer.readAsync());
+      const morphWeights = modelNode!.userData['gltfMorphWeights'] as {
+        values: Float32Array;
+        data: unknown;
+        packedTargetCount: number;
+      };
+      expect(morphWeights).toBeDefined();
+      expect(morphWeights.data).toBeDefined();
+      expect(morphWeights.packedTargetCount).toBeGreaterThan(0);
+      const previousWeights = Array.from(morphWeights.values);
       const weightChannel = scenegraphs.animations[0].channels.find(
         channel => channel.type === 'node' && channel.path === 'weights'
       );
@@ -152,7 +161,9 @@ describe('reviewed glTF deformation edge cases', () => {
         );
         scenegraphs.animator.setTime(weightChannel.sampler.input[changedKeyframe] * 1000);
       }
-      expect(Array.from(await vertexBuffer.readAsync())).not.toEqual(Array.from(previousBytes));
+      expect(Array.from(await vertexBuffer.readAsync())).toEqual(Array.from(previousBytes));
+      expect(Array.from(morphWeights.values)).not.toEqual(previousWeights);
+      expect(modelNode!.model.shaderInputs.getUniformValues()['gpuAnimation']).toBeDefined();
       expect(positionAccessor.value).toBe(sourcePositions);
       expect(normalAccessor.value).toBe(sourceNormals);
       expect(tangentAccessor.value).toBe(sourceTangents);

--- a/modules/scene/test/gltf-deformation-import.node.spec.ts
+++ b/modules/scene/test/gltf-deformation-import.node.spec.ts
@@ -21,7 +21,7 @@ async function loadAnimatedMorphCube() {
   return postProcessGLTF(await parse(assetData, GLTFLoader, {gltf: {loadImages: false}}));
 }
 
-test('glTF AnimatedMorphCube changes existing packed geometry through the existing animator', async testContext => {
+test('glTF AnimatedMorphCube updates GPU weights through the existing animator', async testContext => {
   const source = await loadAnimatedMorphCube();
   const device = new NullDevice({});
   const scenegraphs = createScenegraphsFromGLTF(device, source);
@@ -47,6 +47,12 @@ test('glTF AnimatedMorphCube changes existing packed geometry through the existi
     const model = modelNode.model;
     const vertexBuffer = model._gpuGeometry!.attributes['geometry'];
     const initialBytes = new Uint8Array(await vertexBuffer.readAsync());
+    const morphWeights = modelNode.userData['gltfMorphWeights'] as {
+      values: Float32Array;
+      data: unknown;
+      packedTargetCount: number;
+    };
+    const initialGPUWeights = Array.from(morphWeights.values);
     const initialWeights = weightChannel.sampler.output[0];
     const changedKeyframe = weightChannel.sampler.output.findIndex(weights =>
       weights.some((weight, index) => weight !== initialWeights[index])
@@ -56,10 +62,20 @@ test('glTF AnimatedMorphCube changes existing packed geometry through the existi
     scenegraphs.animator.setTime(weightChannel.sampler.input[changedKeyframe] * 1000);
     const morphedBytes = await vertexBuffer.readAsync();
 
-    testContext.notDeepEqual(
+    testContext.deepEqual(
       Array.from(morphedBytes),
       Array.from(initialBytes),
-      'existing interleaved GPU vertices change without recreating the model'
+      'immutable source vertices are not rewritten for every animation frame'
+    );
+    testContext.notDeepEqual(
+      Array.from(morphWeights.values),
+      initialGPUWeights,
+      'the packed GPU morph weights carry the animated deformation state'
+    );
+    testContext.ok(morphWeights.data, 'the morph weight resource is retained by the model');
+    testContext.ok(
+      morphWeights.packedTargetCount > 0,
+      'morph weights remain packed in vec4 groups'
     );
     testContext.equal(modelNode.model, model, 'the authored model and vertex layout remain stable');
   }


### PR DESCRIPTION
Goals

Advance glTF Supremacy Tranche 5 by keeping ordinary glTF morph deformation GPU-resident.

Changes

- Upload immutable POSITION, NORMAL, and TANGENT morph target data for ordinary glTF primitives.
- Store ordinary node morph weights in a one-row GPU buffer or float texture.
- Update only packed weight data when the existing animator changes a node’s morph weights; source geometry is no longer rewritten every frame.
- Reuse the existing GPU crowd morph shader/resource path with instance index zero for ordinary models.
- Update deformation regression tests to enforce immutable geometry and changing GPU weights.

Verification

- nvm use
- yarn lint fix
- Focused glTF TypeScript check
- yarn test-node modules/gltf/test/gltf/gltf-review-correctness.node.spec.ts modules/scene/test/gltf-deformation-import.node.spec.ts: suite passed with 3,042 tests and 3 skips.

Follow-up

This covers one GPU weight row per ordinary model. Actor-indexed weight atlases and GPU-sampled clips remain the next steps for independently animated shared models.