### PR TITLE
feat(gpgpu): buffer pool improvements

### DIFF
--- a/modules/gpgpu/src/operation/gpu-data-evaluator.ts
+++ b/modules/gpgpu/src/operation/gpu-data-evaluator.ts
@@ -107,6 +107,20 @@ export type GPUDataEvaluatorProps = {
  * be applied independently across every `GPUData` chunk in a `GPUVector`.
  */
 export class GPUDataEvaluator {
+  /** Maximum number of inactive evaluator buffers cached per device. */
+  static get bufferPoolSize(): number {
+    return bufferPool.poolSize;
+  }
+
+  static set bufferPoolSize(poolSize: number) {
+    if (!Number.isSafeInteger(poolSize) || poolSize < 0) {
+      throw new Error('GPUDataEvaluator.bufferPoolSize must be a non-negative safe integer');
+    }
+    bufferPool.poolSize = poolSize;
+    // Lowering the limit must release buffers that are already cached.
+    bufferPool.purge();
+  }
+
   /** Scalar element type for each stored value. */
   readonly type: SignedDataType;
   /** Number of scalar elements in each logical row. */

--- a/modules/gpgpu/src/utils/buffer-pool.ts
+++ b/modules/gpgpu/src/utils/buffer-pool.ts
@@ -5,7 +5,7 @@
 import {Device, Buffer} from '@luma.gl/core';
 
 class BufferPool {
-  poolSize: number = 100;
+  poolSize: number = 20;
 
   private bufferPools: Map<Device, Buffer[]>;
 
@@ -45,9 +45,20 @@ class BufferPool {
     } else {
       pool.splice(i, 0, buffer);
     }
-    while (this.poolSize && pool.length > this.poolSize) {
-      // Drop the smallest one
-      pool.shift()!.destroy();
+    // Bound every pool and discard entries for devices that became unusable since the last recycle.
+    this.purge();
+  }
+
+  /** Destroys the smallest cached buffers until every device pool satisfies `poolSize`. */
+  purge(): void {
+    for (const [device, pool] of this.bufferPools) {
+      const targetSize = device.isLost ? 0 : this.poolSize;
+      while (pool.length > targetSize) {
+        pool.shift()!.destroy();
+      }
+      if (pool.length === 0) {
+        this.bufferPools.delete(device);
+      }
     }
   }
 }

--- a/modules/gpgpu/test/gpu-vector/gpu-data-evaluator.node.spec.ts
+++ b/modules/gpgpu/test/gpu-vector/gpu-data-evaluator.node.spec.ts
@@ -57,6 +57,61 @@ test('GPUDataEvaluator buffer pool allocates exact sizes and validates device li
   device.destroy();
 });
 
+test('GPUDataEvaluator.bufferPoolSize purges cached buffers', async () => {
+  const originalPoolSize = GPUDataEvaluator.bufferPoolSize;
+  const device = new NullDevice({});
+  const evaluator = GPUDataEvaluator.fromArray(new Uint8Array(8), {type: 'uint8', size: 1});
+
+  try {
+    GPUDataEvaluator.bufferPoolSize = 1;
+    await evaluator.evaluate(device);
+    const buffer = evaluator.buffer;
+    const destroy = vi.spyOn(buffer, 'destroy');
+
+    evaluator.destroy();
+    expect(destroy).not.toHaveBeenCalled();
+
+    GPUDataEvaluator.bufferPoolSize = 0;
+    expect(destroy).toHaveBeenCalledOnce();
+  } finally {
+    GPUDataEvaluator.bufferPoolSize = originalPoolSize;
+    device.destroy();
+  }
+});
+
+test('GPUDataEvaluator buffer pool purges lost devices during recycle', async () => {
+  const originalPoolSize = GPUDataEvaluator.bufferPoolSize;
+  const device = new NullDevice({});
+  const activeDevice = new NullDevice({id: 'active-null-device'});
+  let isLost = false;
+  Object.defineProperty(device, 'isLost', {get: () => isLost});
+  const evaluator = GPUDataEvaluator.fromArray(new Uint8Array(8), {type: 'uint8', size: 1});
+  const activeEvaluator = GPUDataEvaluator.fromArray(new Uint8Array(8), {
+    type: 'uint8',
+    size: 1
+  });
+
+  try {
+    GPUDataEvaluator.bufferPoolSize = 1;
+    await evaluator.evaluate(device);
+    const buffer = evaluator.buffer;
+    const destroy = vi.spyOn(buffer, 'destroy');
+
+    evaluator.destroy();
+    expect(destroy).not.toHaveBeenCalled();
+
+    isLost = true;
+    await activeEvaluator.evaluate(activeDevice);
+    activeEvaluator.destroy();
+    expect(destroy).toHaveBeenCalledOnce();
+  } finally {
+    GPUDataEvaluator.bufferPoolSize = 0;
+    GPUDataEvaluator.bufferPoolSize = originalPoolSize;
+    device.destroy();
+    activeDevice.destroy();
+  }
+});
+
 test('GPUDataEvaluator.fromGPUData accepts packed Float16 chunks', () => {
   const device = new NullDevice({});
   const vector2 = makeUint16Vector(device, 'colors16x2', [0x3c00, 0x3800], 2, {


### PR DESCRIPTION
Needs https://github.com/visgl/luma.gl/pull/3125

#### Change List
- Smaller default poolSize
- Track reusable buffers by device
- Purge cache when device is lost
- Allow poolSize to be controlled via `GPUDataEvaluator.bufferPoolSize` - this is needed during testing because recycled buffers are technically resource leak
