### PR TITLE
fix(website): optimize MRC glass showcase and info panels for phones

### DIFF
--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -10,7 +10,11 @@ import type {
   RenderPipelineParameters,
   TextureFormatColor
 } from '@luma.gl/core';
-import {bloomShaderPassPipeline, toneMapping} from '@luma.gl/effects';
+import {
+  bloomShaderPassPipeline,
+  createBloomShaderPassPipeline,
+  toneMapping
+} from '@luma.gl/effects';
 import type {AnimationProps, Geometry} from '@luma.gl/engine';
 import {
   AnimationLoopTemplate,
@@ -139,6 +143,7 @@ import {
   type Vector3
 } from './network';
 import {makeStudioEnvironmentMipLevels} from './optics';
+import {makeNetworkRenderProfile, type NetworkRenderProfile} from './render-profile';
 import {
   DEFAULT_NETWORK_HDR_HIGHLIGHT_BOOST,
   DEFAULT_NETWORK_OPTICS_LEVEL,
@@ -923,6 +928,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   }>({app: appShaderModule, picking: colorPicking});
   readonly settingsPanel: ExampleSettingsPanelManager;
   readonly panels: ExamplePanelManager;
+  readonly renderProfile: NetworkRenderProfile;
   readonly sceneColorFormat: TextureFormatColor;
   readonly sceneFramebuffer: Framebuffer;
   readonly glassBackfaceFramebuffer: Framebuffer;
@@ -1146,7 +1152,14 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.orbit = Math.max(0, Math.min(Number(requestedOrbit), 0.5));
     }
 
-    this.sceneColorFormat = getSceneColorFormat(device);
+    this.renderProfile = makeNetworkRenderProfile({
+      coarsePointer:
+        typeof window.matchMedia === 'function' && window.matchMedia('(pointer: coarse)').matches,
+      maxTouchPoints: navigator.maxTouchPoints ?? 0,
+      viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth
+    });
+    this.sceneColorFormat = getSceneColorFormat(device, this.renderProfile);
     this.dynamicRangeOptions = {
       deviceType: device.type,
       displaySupportsHighDynamicRange:
@@ -1160,8 +1173,10 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       highlightBoost: this.hdrHighlightBoost,
       visualIntensity: this.currentVisualIntensity
     });
-    const supportsABuffer = getABufferSupport(device).supported;
-    const supportsWeightedBlending = getWBOITSupport(device).supported;
+    const supportsABuffer =
+      this.renderProfile.orderIndependentTransparency && getABufferSupport(device).supported;
+    const supportsWeightedBlending =
+      this.renderProfile.orderIndependentTransparency && getWBOITSupport(device).supported;
     const preferredTransparencyMode = supportsABuffer
       ? 'a-buffer'
       : supportsWeightedBlending
@@ -1205,7 +1220,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     });
     this.environmentTexture = makeStudioEnvironmentTexture(device);
     this.postprocessingRenderer = new ShaderPassRenderer(device, {
-      shaderPasses: [makeBloomPipeline(this.sceneColorFormat), toneMapping],
+      shaderPasses: [makeBloomPipeline(this.sceneColorFormat, this.renderProfile), toneMapping],
       colorFormat: this.sceneColorFormat
     });
 
@@ -1508,6 +1523,9 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       canvas.dataset.packetSprayingDynamicRange = this.dynamicRangeProfile.displayMode;
       canvas.dataset.packetSprayingTransparencyMode = this.transparencyMode;
       canvas.dataset.packetSprayingLab = this.reflectionLab ? 'reflection' : '';
+      canvas.dataset.packetSprayingRenderProfile = this.renderProfile.handheld
+        ? 'handheld'
+        : 'desktop';
       canvas.dataset.packetSprayingSceneColorFormat = this.sceneColorFormat;
       canvas.dataset.packetSprayingEnvironmentMipLevels = String(this.environmentTexture.mipLevels);
       canvas.dataset.packetSprayingHighlightBoost =
@@ -4374,11 +4392,23 @@ function makeBalancedEmissionColor(color: Color, alpha: number): Color {
   ];
 }
 
-function makeBloomPipeline(colorFormat: TextureFormatColor): ShaderPassPipeline {
+function makeBloomPipeline(
+  colorFormat: TextureFormatColor,
+  renderProfile: NetworkRenderProfile
+): ShaderPassPipeline {
+  const bloomPipeline = renderProfile.handheld
+    ? createBloomShaderPassPipeline({
+        blurAlgorithm: 'dual-kawase',
+        colorFormat,
+        quality: renderProfile.bloomQuality,
+        resolutionScale: renderProfile.bloomResolutionScale
+      })
+    : bloomShaderPassPipeline;
+
   return {
-    ...bloomShaderPassPipeline,
+    ...bloomPipeline,
     renderTargets: Object.fromEntries(
-      Object.entries(bloomShaderPassPipeline.renderTargets).map(([targetName, renderTarget]) => [
+      Object.entries(bloomPipeline.renderTargets ?? {}).map(([targetName, renderTarget]) => [
         targetName,
         {...renderTarget, format: colorFormat}
       ])
@@ -4386,7 +4416,14 @@ function makeBloomPipeline(colorFormat: TextureFormatColor): ShaderPassPipeline 
   };
 }
 
-function getSceneColorFormat(device: Device): TextureFormatColor {
+function getSceneColorFormat(
+  device: Device,
+  renderProfile: NetworkRenderProfile
+): TextureFormatColor {
+  if (!renderProfile.preferFloatingPointColor) {
+    return 'rgba8unorm';
+  }
+
   const floatingPointCapabilities = device.getTextureFormatCapabilities('rgba16float');
   if (floatingPointCapabilities.render && floatingPointCapabilities.filter) {
     return 'rgba16float';

--- a/examples/showcase/packet-spraying/render-profile.ts
+++ b/examples/showcase/packet-spraying/render-profile.ts
@@ -1,0 +1,46 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export type NetworkRenderEnvironment = {
+  coarsePointer: boolean;
+  maxTouchPoints: number;
+  viewportHeight: number;
+  viewportWidth: number;
+};
+
+export type NetworkRenderProfile = {
+  bloomQuality: 'low' | 'high';
+  bloomResolutionScale: number;
+  handheld: boolean;
+  orderIndependentTransparency: boolean;
+  preferFloatingPointColor: boolean;
+};
+
+/** Preserves desktop optics while keeping handheld render targets within mobile GPU budgets. */
+export function makeNetworkRenderProfile({
+  coarsePointer,
+  maxTouchPoints,
+  viewportHeight,
+  viewportWidth
+}: NetworkRenderEnvironment): NetworkRenderProfile {
+  const shortestViewportEdge = Math.min(viewportWidth, viewportHeight);
+  const handheld =
+    coarsePointer && maxTouchPoints > 0 && shortestViewportEdge > 0 && shortestViewportEdge <= 700;
+
+  return handheld
+    ? {
+        bloomQuality: 'low',
+        bloomResolutionScale: 0.75,
+        handheld: true,
+        orderIndependentTransparency: false,
+        preferFloatingPointColor: false
+      }
+    : {
+        bloomQuality: 'high',
+        bloomResolutionScale: 1,
+        handheld: false,
+        orderIndependentTransparency: true,
+        preferFloatingPointColor: true
+      };
+}

--- a/test/examples/example-device-tabs.node.spec.ts
+++ b/test/examples/example-device-tabs.node.spec.ts
@@ -8,7 +8,10 @@ import {buildSync} from 'esbuild';
 import React from 'react';
 import {renderToStaticMarkup} from 'react-dom/server';
 import {describe, expect, test} from 'vitest';
-import {getMobileExamplePixelRatio} from '../../website/src/react-luma/utils/mobile-example-pixel-ratio';
+import {
+  getMobileExamplePixelRatio,
+  isMobileExampleViewport
+} from '../../website/src/react-luma/utils/mobile-example-pixel-ratio';
 
 describe('example graphics backend tab semantics', () => {
   test('renders native, labeled tabs with backend capability badges', () => {
@@ -66,6 +69,24 @@ describe('compact example graphics backend selection', () => {
 });
 
 describe('high-density mobile example rendering', () => {
+  test('recognizes responsive mobile examples consistently across their shared controls', () => {
+    const matchedQueries: string[] = [];
+    const viewport = {
+      matchMedia: (query: string) => {
+        matchedQueries.push(query);
+        return {matches: true} as MediaQueryList;
+      }
+    };
+
+    expect(isMobileExampleViewport(viewport)).toBe(true);
+    expect(matchedQueries).toEqual([
+      '(max-width: 700px), (max-height: 500px) and (pointer: coarse)'
+    ]);
+    expect(isMobileExampleViewport({matchMedia: () => ({matches: false}) as MediaQueryList})).toBe(
+      false
+    );
+  });
+
   test('keeps desktop and ordinary-density phones at exact native resolution', () => {
     expect(
       getMobileExamplePixelRatio({

--- a/test/examples/packet-spraying-story.node.spec.ts
+++ b/test/examples/packet-spraying-story.node.spec.ts
@@ -8,6 +8,7 @@ import {
   SWITCH_PROBE_DURATION
 } from '../../examples/showcase/packet-spraying/animation';
 import {SWITCH_POSITIONS} from '../../examples/showcase/packet-spraying/network';
+import {makeNetworkRenderProfile} from '../../examples/showcase/packet-spraying/render-profile';
 import {
   DEFAULT_NETWORK_HDR_HIGHLIGHT_BOOST,
   DEFAULT_NETWORK_OPTICS_LEVEL,
@@ -28,6 +29,54 @@ import {
   NETWORK_STORY_CHAPTERS,
   shouldAdvanceNetworkAutorotationScenario
 } from '../../examples/showcase/packet-spraying/story';
+
+test('packet-spraying handheld rendering preserves glass with a bounded mobile GPU budget', testCase => {
+  const handheld = makeNetworkRenderProfile({
+    coarsePointer: true,
+    maxTouchPoints: 5,
+    viewportHeight: 844,
+    viewportWidth: 390
+  });
+
+  testCase.equal(handheld.handheld, true, 'touchscreen phone viewports use the mobile profile');
+  testCase.equal(handheld.bloomQuality, 'low', 'phone bloom uses a smaller two-level pyramid');
+  testCase.equal(handheld.bloomResolutionScale, 0.75, 'phone bloom targets are downsampled');
+  testCase.equal(
+    handheld.orderIndependentTransparency,
+    false,
+    'phone glass uses the existing depth-sorted transparency path'
+  );
+  testCase.equal(
+    handheld.preferFloatingPointColor,
+    false,
+    'phone scene and refraction textures use portable 8-bit formats'
+  );
+  testCase.end();
+});
+
+test('packet-spraying retains complete desktop optics in narrow non-touch viewports', testCase => {
+  const desktop = makeNetworkRenderProfile({
+    coarsePointer: false,
+    maxTouchPoints: 0,
+    viewportHeight: 844,
+    viewportWidth: 390
+  });
+  const tablet = makeNetworkRenderProfile({
+    coarsePointer: true,
+    maxTouchPoints: 5,
+    viewportHeight: 1024,
+    viewportWidth: 768
+  });
+
+  for (const profile of [desktop, tablet]) {
+    testCase.equal(profile.handheld, false);
+    testCase.equal(profile.bloomQuality, 'high');
+    testCase.equal(profile.bloomResolutionScale, 1);
+    testCase.equal(profile.orderIndependentTransparency, true);
+    testCase.equal(profile.preferFloatingPointColor, true);
+  }
+  testCase.end();
+});
 
 test('packet-spraying guided tour tells the complete MRC recovery story', testCase => {
   testCase.deepEqual(

--- a/website/src/react-luma/components/info-box.tsx
+++ b/website/src/react-luma/components/info-box.tsx
@@ -9,6 +9,7 @@ import {
   type ExamplePanelAppearance
 } from '../../../../examples/example-panels';
 import {applyExampleTheme, EXAMPLE_THEME_TOKENS} from '../../../../examples/example-theme';
+import {isMobileExampleViewport} from '../utils/mobile-example-pixel-ratio';
 
 const GITHUB_TREE = 'https://github.com/visgl/luma.gl/tree/master';
 const INFO_BOX_DEFAULT_WIDTH = 420;
@@ -202,7 +203,11 @@ function InfoBoxView(props: InfoBoxViewProps) {
   );
   const sourcePathsKey = sourcePaths.join('|');
   const title = getExampleTitle(props.id, props.title);
-  const [isCollapsed, setIsCollapsed] = useState(() => isInfoBoxCollapsedByDefault);
+  const [isCollapsed, setIsCollapsed] = useState(
+    () =>
+      isInfoBoxCollapsedByDefault ||
+      (typeof window !== 'undefined' && isMobileExampleViewport(window))
+  );
   const [activeTab, setActiveTab] = useState<'info' | 'source'>('info');
   const [activeSourcePath, setActiveSourcePath] = useState('');
   const [infoBoxSize, setInfoBoxSize] = useState<InfoBoxSize | null>(null);

--- a/website/src/react-luma/components/luma-example.tsx
+++ b/website/src/react-luma/components/luma-example.tsx
@@ -20,7 +20,10 @@ import {
   HDRCanvasCaptureController,
   type HDRScreenshotCapture
 } from '../utils/hdr-screenshot-capture';
-import {getMobileExamplePixelRatio} from '../utils/mobile-example-pixel-ratio';
+import {
+  getMobileExamplePixelRatio,
+  isMobileExampleViewport
+} from '../utils/mobile-example-pixel-ratio';
 // import {VRDisplay} from '@luma.gl/experimental';
 import {
   createDevice,
@@ -475,9 +478,7 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
       const mobilePixelRatio = getMobileExamplePixelRatio({
         devicePixelRatio: window.devicePixelRatio || 1,
         height: canvasContainer.clientHeight || window.innerHeight,
-        mobile: window.matchMedia(
-          '(max-width: 700px), (max-height: 500px) and (pointer: coarse)'
-        ).matches,
+        mobile: isMobileExampleViewport(window),
         width: canvasContainer.clientWidth || window.innerWidth
       });
       defaultCanvasContext.setProps({useDevicePixels: mobilePixelRatio});

--- a/website/src/react-luma/utils/mobile-example-pixel-ratio.ts
+++ b/website/src/react-luma/utils/mobile-example-pixel-ratio.ts
@@ -4,6 +4,8 @@
 
 const MAX_HIGH_DENSITY_MOBILE_PIXEL_RATIO = 2;
 const MAX_HIGH_DENSITY_MOBILE_PIXEL_COUNT = 1_500_000;
+const MOBILE_EXAMPLE_MEDIA_QUERY =
+  '(max-width: 700px), (max-height: 500px) and (pointer: coarse)';
 
 type MobileExamplePixelRatioOptions = {
   devicePixelRatio: number;
@@ -11,6 +13,13 @@ type MobileExamplePixelRatioOptions = {
   mobile: boolean;
   width: number;
 };
+
+/** Uses the same responsive breakpoint for example controls and drawing-buffer selection. */
+export function isMobileExampleViewport(viewport: Pick<Window, 'matchMedia'>): boolean {
+  return (
+    typeof viewport.matchMedia === 'function' && viewport.matchMedia(MOBILE_EXAMPLE_MEDIA_QUERY).matches
+  );
+}
 
 /** Limits only oversized 3x mobile canvases; ordinary devices keep exact native resolution. */
 export function getMobileExamplePixelRatio({


### PR DESCRIPTION
## Goals

- Carry the portable mobile improvements from the 9.4 release backport #3127 back to `master`.
- Keep the MRC glass showcase reliable and readable on iPhones without reducing desktop visual quality.

## Changes

- Detect actual handheld touchscreen viewports separately from narrow desktop windows and tablets.
- Use existing depth-sorted glass instead of allocating order-independent transparency buffers on phones.
- Keep phone scene, refraction, and glass-backface targets in portable 8-bit color formats.
- Replace the desktop four-level bloom pyramid with a smaller two-level dual-Kawase bloom pipeline on phones.
- Preserve native phone drawing-buffer resolution and the complete desktop HDR, bloom, and transparency pipeline.
- Centralize the shared mobile example breakpoint.
- Start each newly opened mobile example with its information panel collapsed, including after navigating away from an expanded example.
- Add focused coverage for handheld profiles, narrow desktop/tablet behavior, and shared mobile viewport detection.

## Verification

- `corepack yarn lint fix`
- `corepack yarn build`
- `corepack yarn test-node` — **3,062 passed, 3 skipped**
- `corepack yarn examples:typecheck` — **50 example workspaces passed**
- `corepack yarn website:build`
- Focused Chromium controls, panels, and navigation tests — **62 passed**
- Interactive iPhone-sized website verification: after expanding MRC information and navigating to another example, the next example starts collapsed with no unformatted content.

## Related

- Release backport: #3127