### PR TITLE
fix: make WebGPU device creation resilient on Android

### DIFF
--- a/docs/api-guide/gpu/gpu-initialization.md
+++ b/docs/api-guide/gpu/gpu-initialization.md
@@ -78,9 +78,11 @@ const device = await luma.createDevice({
 console.log(device.type); // 'webgpu' or 'webgl'
 ```
 
-`best-available` prefers WebGPU when it is usable and otherwise selects WebGL 2. Registering a
-fallback does not make WGSL, compute, storage buffers, or other WebGPU-only code portable; the
-application must still provide a supported path for the selected device.
+`best-available` attempts WebGPU core, WebGPU compatibility, and then WebGL 2. Use
+`best-available-webgpu` when the application has no WebGL implementation: it attempts WebGPU core,
+WebGPU compatibility, and finally software WebGPU compatibility. Registering a fallback does not
+make WGSL, compute, storage buffers, or other WebGPU-only code portable; the application must still
+provide a supported path for the selected device.
 
 ## Select a capability-dependent path
 

--- a/docs/api-reference/core/device.md
+++ b/docs/api-reference/core/device.md
@@ -70,7 +70,7 @@ Specifies props to use when luma creates the device.
 | ------------------------------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `id?: string` | `null` | Optional string id, mainly intended for debugging. |
 | `createCanvasContext?: CanvasContextProps` \| `true` | [CanvasContexProps][canvas-context-props] | Create a default `CanvasContext` for the new `Device`. `true` creates a context with default props. |
-| `powerPreference?: string` | `'high-performance'` | `'default' \| 'high-performance' \| 'low-power'` (WebGL). |
+| `powerPreference?: string` | `'default'` | `'default' \| 'high-performance' \| 'low-power'`. WebGPU omits the request hint when this is `'default'`. |
 | `featureLevel?: 'core' \| 'max' \| 'compatibility' \| 'best-available'` | `'core'` | WebGPU feature/limit profile to request. `'core'` is the portable default; `'max'` requests every supported adapter feature and limit; `'compatibility'` opts into compatibility mode; `'best-available'` upgrades a compatibility adapter to core when available. WebGL and null devices ignore this prop. |
 | `optionalFeatures?: WebGPUDeviceFeature[]` | `[]` | WebGPU device features to request in addition to the selected profile. Unsupported entries are ignored. Use this for targeted capabilities such as `'subgroups'` without enabling the full `'max'` profile. |
 | `xrCompatible?: boolean` | `false` | Request a WebGPU adapter that can present frames to a WebXR session. Standard adapter requests remain unchanged unless this is enabled. |
@@ -93,6 +93,10 @@ Specifies props to use when luma creates the device.
 :::tip
 Learn more GPU debugging in our [Debugging](../../developer-guide/debugging.md) guide.
 :::
+
+`device.creationInfo` describes the selection policy and failed fallback attempts that preceded a
+successful device. `device.lost` preserves whether loss was intentional (`destroyed`) or unexpected
+(`unknown`).
 
 #### Internal caching props
 

--- a/docs/api-reference/core/luma.md
+++ b/docs/api-reference/core/luma.md
@@ -99,8 +99,8 @@ Properties for creating a new device. See [`DeviceProps`](./device.md#deviceprop
 
 ```ts
 type CreateDeviceProps = {
-  /** Selects the type of device. `best-available` uses webgpu if available, then webgl. */
-  type?: 'webgl' | 'webgpu' | 'unknown' | 'best-available';
+  /** Selects an exact backend or an ordered device creation policy. */
+  type?: 'webgl' | 'webgpu' | 'unknown' | 'best-available' | 'best-available-webgpu';
   /** List of device types. Will also search any pre-registered device backends */
   adapters?: Adapter[];
   /** Whether to wait for page to be loaded, which ensures that canvas contexts can refer to existing canvases by id (defaults to true) */
@@ -131,12 +131,18 @@ luma.createDevice({type, adapters, ...deviceProps}: CreateDeviceProps);
 
 To create a Device instance, the application calls `luma.createDevice()`.
 
-- `type`: `'webgl' \| 'webgpu' \| 'best-available'`
+- `type`: `'webgl' \| 'webgpu' \| 'best-available' \| 'best-available-webgpu'`
 - `adapters`: list of `Adapter` instances providing support for different GPU backends. Can be omitted if `luma.registerAdapters()` has been called.
 - `...deviceProps`: See [`DeviceProps`](./device.md#deviceprops) for device specific options.
 
-Unless a device `type` is specified a `Device` will be created using the `'best-available'` adapter.
-luma.gl favors WebGPU over WebGL adapters, whenever WebGPU is available.
+Unless a device `type` is specified, luma.gl uses the outcome-based `'best-available'` policy:
+WebGPU core, WebGPU compatibility, then WebGL 2. `'best-available-webgpu'` tries core and
+compatibility hardware adapters, then a software WebGPU compatibility adapter; it never returns
+WebGL. Exact `'webgpu'` and `'webgl'` requests do not change backends after failure.
+
+Failed attempts are retained in `device.creationInfo` after successful fallback. If every attempt
+fails, `createDevice()` rejects with `DeviceCreationError`, whose `attempts` identify the backend,
+feature level, software status, failure phase, and native cause.
 
 Note: A specific device type is available and supported if both of the following are true:
 1. The backend module has been registered

--- a/docs/api-reference/engine/animation-loop-template.md
+++ b/docs/api-reference/engine/animation-loop-template.md
@@ -42,15 +42,15 @@ await animationLoop.start();
 ### `MakeAnimationLoopProps`
 
 ```ts
-export type MakeAnimationLoopProps = Omit<
-  AnimationLoopProps,
-  'onCreateDevice' | 'onInitialize' | 'onRedraw' | 'onFinalize'
-> & {
-  adapters?: Adapter[];
-};
+`MakeAnimationLoopProps` accepts either a supplied `device`, or `adapters` plus `deviceProps` for
+automatic creation. The two forms are mutually exclusive. `deviceProps` forwards backend policy,
+feature level, power preference, optional features, canvas configuration, and callbacks to
+`luma.createDevice()`.
 ```
 
-If `device` is omitted, `makeAnimationLoop()` creates one with `luma.createDevice({adapters, createCanvasContext: true})`.
+If `device` is omitted, `makeAnimationLoop()` creates or resolves the HTML canvas before starting
+device creation. This lets the default `errorDisplay` report adapter, device, or canvas failures in
+the intended canvas area even on mobile devices without developer tools.
 
 ## Methods
 

--- a/docs/api-reference/engine/animation-loop.md
+++ b/docs/api-reference/engine/animation-loop.md
@@ -69,6 +69,7 @@ export type AnimationLoopProps = {
   onRender?: (animationProps: AnimationProps) => unknown;
   onFinalize?: (animationProps: AnimationProps) => void;
   onError?: (reason: Error) => void;
+  errorDisplay?: false | CanvasErrorDisplayProps;
   stats?: Stats;
   autoResizeViewport?: boolean;
   animationFrameProvider?: AnimationFrameProvider;
@@ -77,6 +78,17 @@ export type AnimationLoopProps = {
 
 - `device` is required and may be supplied lazily as a promise.
 - `autoResizeViewport` resizes the default canvas context drawing buffer before rendering.
+- `errorDisplay` defaults to an accessible overlay on the resolved HTML canvas. Set it to `false`
+  to keep errors callback/console-only, or provide a `target` canvas, container, or DOM id so device
+  promise failures are visible before a device exists.
+
+Device creation, initialization, rendering, and unexpected device loss flow through
+`reportError()`. Fatal errors stop frame scheduling, call the animation loop's `onError`, and remain
+visible on the canvas. Runtime errors reported by `device.reportError()` (including validation,
+resource, and uncaptured GPU errors) keep the loop running and briefly appear as red fading text.
+Supplying `DeviceProps.onError` gives the application control of those runtime errors and suppresses
+the transient canvas message. Intentional destruction and failed attempts followed by successful
+fallback do not show either display.
 
 ### `AnimationProps`
 

--- a/examples/showcase/billion-point-spatial-atlas/index.html
+++ b/examples/showcase/billion-point-spatial-atlas/index.html
@@ -58,6 +58,7 @@
         try {
           device = await luma.createDevice({
             id: 'billion-point-spatial-atlas',
+            type: softwareVisualSmoke ? 'webgpu' : 'best-available',
             adapters: [webgpuAdapter],
             createCanvasContext: supportsHighDynamicRange
               ? {
@@ -72,6 +73,7 @@
           if (!supportsHighDynamicRange) throw error;
           device = await luma.createDevice({
             id: 'billion-point-spatial-atlas-sdr-fallback',
+            type: softwareVisualSmoke ? 'webgpu' : 'best-available',
             adapters: [webgpuAdapter],
             createCanvasContext: standardCanvasContext
           });

--- a/modules/core/src/adapter/device-creation-error.ts
+++ b/modules/core/src/adapter/device-creation-error.ts
@@ -1,0 +1,63 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {WebGPUDeviceFeatureLevel, WebGPUFeatureLevel} from './device';
+
+/** Identifies the stage at which GPU device creation failed. */
+export type DeviceCreationPhase =
+  | 'adapter-selection'
+  | 'adapter-request'
+  | 'device-request'
+  | 'wrapper-initialization'
+  | 'canvas-initialization';
+
+/** One attempted backend/profile during device creation. */
+export type DeviceCreationAttempt = {
+  backend: 'webgpu' | 'webgl' | 'null' | 'unknown';
+  featureLevel?: WebGPUFeatureLevel;
+  software: boolean;
+  phase: DeviceCreationPhase;
+  error: Error;
+};
+
+/** Diagnostics retained on a successfully created device. */
+export type DeviceCreationInfo = {
+  requestedType: string;
+  selected: {
+    backend: DeviceCreationAttempt['backend'];
+    featureLevel?: WebGPUDeviceFeatureLevel;
+    software: boolean;
+  } | null;
+  attempts: readonly DeviceCreationAttempt[];
+};
+
+/** Error thrown after one or more device creation attempts fail. */
+export class DeviceCreationError extends Error {
+  readonly attempts: readonly DeviceCreationAttempt[];
+  readonly phase: DeviceCreationPhase;
+
+  constructor(
+    message: string,
+    attempts: readonly DeviceCreationAttempt[],
+    cause: unknown = attempts[attempts.length - 1]?.error
+  ) {
+    super(message, {cause});
+    this.name = 'DeviceCreationError';
+    this.attempts = attempts;
+    this.phase = attempts[attempts.length - 1]?.phase || 'wrapper-initialization';
+  }
+}
+
+/** Wraps an adapter-specific failure without losing an existing structured error. */
+export function wrapDeviceCreationError(
+  error: unknown,
+  attempt: Omit<DeviceCreationAttempt, 'error'>,
+  message: string
+): DeviceCreationError {
+  if (error instanceof DeviceCreationError) {
+    return error;
+  }
+  const cause = error instanceof Error ? error : new Error(String(error));
+  return new DeviceCreationError(message, [{...attempt, error: cause}], cause);
+}

--- a/modules/core/src/adapter/device-defaults.ts
+++ b/modules/core/src/adapter/device-defaults.ts
@@ -8,7 +8,7 @@ import type {DeviceProps} from './device';
 /** Shared defaults for device creation without importing the Device class. */
 export const DEVICE_DEFAULT_PROPS: Required<DeviceProps> = {
   id: null!,
-  powerPreference: 'high-performance',
+  powerPreference: 'default',
   failIfMajorPerformanceCaveat: false,
   featureLevel: undefined!,
   optionalFeatures: [],
@@ -49,6 +49,8 @@ export const DEVICE_DEFAULT_PROPS: Required<DeviceProps> = {
   _cachePipelines: true,
   _sharePipelines: true,
   _destroyPipelines: false,
+  _forceFallbackAdapter: false,
+  _canvasContextOwned: false,
   // TODO - Change these after confirming things work as expected
   _initializeFeatures: true,
   _disabledFeatures: {

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -463,7 +463,7 @@ export type DeviceProps = {
   _destroyPipelines?: boolean;
   /** Internal: request a software-backed WebGPU adapter. */
   _forceFallbackAdapter?: boolean;
-  /** Internal: the HTML canvas may be replaced if a failed backend locked its context type. */
+  /** Internal: the engine created this HTML canvas and may insert it into the document. */
   _canvasContextOwned?: boolean;
 
   /** @deprecated Internal, Do not use directly! Use `luma.attachDevice()` to attach to pre-created contexts/devices. */

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -40,6 +40,7 @@ import type {ExternalImage} from '../shadertypes/image-types/image-types';
 import {isExternalImage, getExternalImageSize} from '../shadertypes/image-types/image-types';
 import {getTextureFormatTable} from '../shadertypes/texture-types/texture-format-table';
 import {DEVICE_DEFAULT_PROPS} from './device-defaults';
+import type {DeviceCreationInfo} from './device-creation-error';
 
 export {_getDefaultDebugValue} from './device-defaults';
 
@@ -91,6 +92,12 @@ export type WebGPUFeatureLevel = 'core' | 'max' | 'compatibility' | 'best-availa
 
 /** Effective WebGPU feature level reported by a created WebGPU device. */
 export type WebGPUDeviceFeatureLevel = Exclude<WebGPUFeatureLevel, 'best-available'>;
+
+/** Information supplied when a device is lost. */
+export type DeviceLostInfo = {
+  reason: 'destroyed' | 'unknown';
+  message: string;
+};
 
 /** Limits for a device (max supported sizes of resources, max number of bindings etc) */
 export abstract class DeviceLimits {
@@ -307,6 +314,8 @@ export type WebGPUDeviceFeature =
   | 'bgra8unorm-storage' // Can the bgra8unorm texture format be used in storage buffers?
   | 'float32-filterable' // Is the float32 format filterable?
   | 'float32-blendable' // Is the float32 format blendable?
+  | 'texture-formats-tier1'
+  | 'texture-formats-tier2'
   | 'clip-distances'
   | 'dual-source-blending'
   | 'subgroups';
@@ -371,7 +380,7 @@ export type DeviceProps = {
   id?: string;
   /** Properties for creating a default canvas context */
   createCanvasContext?: CanvasContextProps | true;
-  /** Control which type of GPU is preferred on systems with both integrated and discrete GPU. Defaults to "high-performance" / discrete GPU. */
+  /** Control which type of GPU is preferred on systems with both integrated and discrete GPU. Defaults to `'default'`; WebGPU omits the adapter hint unless explicitly set. */
   powerPreference?: 'default' | 'high-performance' | 'low-power';
   /** Hints that device creation should fail if no hardware GPU is available (if the system performance is "low"). */
   failIfMajorPerformanceCaveat?: boolean;
@@ -452,6 +461,10 @@ export type DeviceProps = {
    * Enable this if the application creates very large numbers of distinct pipelines and needs cache eviction.
    */
   _destroyPipelines?: boolean;
+  /** Internal: request a software-backed WebGPU adapter. */
+  _forceFallbackAdapter?: boolean;
+  /** Internal: the HTML canvas may be replaced if a failed backend locked its context type. */
+  _canvasContextOwned?: boolean;
 
   /** @deprecated Internal, Do not use directly! Use `luma.attachDevice()` to attach to pre-created contexts/devices. */
   _handle?: unknown; // WebGL2RenderingContext | GPUDevice | null;
@@ -535,6 +548,12 @@ export abstract class Device {
   _reused: boolean = false;
   /** Used by other luma.gl modules to store data on the device */
   private _moduleData: Record<string, Record<string, unknown>> = {};
+  /** Device selection and fallback attempts used to create this device. */
+  creationInfo: DeviceCreationInfo = {
+    requestedType: 'unknown',
+    selected: null,
+    attempts: []
+  };
 
   // Capabilities
 
@@ -660,7 +679,7 @@ export abstract class Device {
   abstract get isLost(): boolean;
 
   /** Promise that resolves when device is lost */
-  abstract readonly lost: Promise<{reason: 'destroyed'; message: string}>;
+  abstract readonly lost: Promise<DeviceLostInfo>;
 
   /**
    * Trigger device loss.

--- a/modules/core/src/adapter/luma.ts
+++ b/modules/core/src/adapter/luma.ts
@@ -3,9 +3,14 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {Log} from '@probe.gl/log';
-import type {Device, DeviceProps} from './device';
+import type {Device, DeviceProps, WebGPUFeatureLevel} from './device';
 import {DEVICE_DEFAULT_PROPS} from './device-defaults';
 import {Adapter} from './adapter';
+import {
+  DeviceCreationError,
+  type DeviceCreationAttempt,
+  wrapDeviceCreationError
+} from './device-creation-error';
 import {StatsManager, lumaStats} from '../utils/stats-manager';
 import {log} from '../utils/log';
 
@@ -19,10 +24,17 @@ const STARTUP_MESSAGE = 'set luma.log.level=1 (or higher) to trace rendering';
 const ERROR_MESSAGE =
   'No matching device found. Ensure `@luma.gl/webgl` and/or `@luma.gl/webgpu` modules are imported.';
 
+type DeviceCreationCandidate = {
+  adapter?: Adapter;
+  backend: DeviceCreationAttempt['backend'];
+  featureLevel?: WebGPUFeatureLevel;
+  software?: boolean;
+};
+
 /** Properties for creating a new device */
 export type CreateDeviceProps = {
-  /** Selects the type of device. `best-available` uses webgpu if available, then webgl. */
-  type?: 'webgl' | 'webgpu' | 'null' | 'unknown' | 'best-available';
+  /** Selects an exact backend or an ordered device creation policy. */
+  type?: 'webgl' | 'webgpu' | 'null' | 'unknown' | 'best-available' | 'best-available-webgpu';
   /** List of adapters. Will also search any pre-registered adapters */
   adapters?: Adapter[];
   /**
@@ -92,18 +104,85 @@ export class Luma {
   /** Creates a device. Asynchronously. */
   async createDevice(props_: CreateDeviceProps = {}): Promise<Device> {
     const props: Required<CreateDeviceProps> = {...Luma.defaultProps, ...props_};
+    const candidates = this._getDeviceCreationCandidates(props);
+    const attempts: DeviceCreationAttempt[] = [];
 
-    const adapter = this.selectAdapter(props.type, props.adapters);
-    if (!adapter) {
-      throw new Error(ERROR_MESSAGE);
+    for (const candidate of candidates) {
+      const attempt = {
+        backend: candidate.backend,
+        featureLevel: candidate.featureLevel,
+        software: Boolean(candidate.software),
+        phase: 'adapter-selection' as const
+      };
+
+      if (!candidate.adapter?.isSupported?.()) {
+        const error = new Error(`No ${candidate.backend} adapter`);
+        attempts.push({...attempt, error});
+        continue;
+      }
+
+      try {
+        if (props.waitForPageLoad) {
+          try {
+            await candidate.adapter.pageLoaded;
+          } catch (error) {
+            throw wrapDeviceCreationError(
+              error,
+              {...attempt, phase: 'adapter-request'},
+              `Waiting for ${candidate.backend} failed`
+            );
+          }
+        }
+
+        const device = await candidate.adapter.create({
+          ...props,
+          featureLevel: candidate.featureLevel,
+          _forceFallbackAdapter: Boolean(candidate.software)
+        });
+        const selectedSoftware =
+          candidate.software || device.info.gpu === 'software' || Boolean(device.info.fallback);
+        if (
+          (props.type === 'best-available' || props.type === 'best-available-webgpu') &&
+          candidate.backend === 'webgpu' &&
+          !candidate.software &&
+          selectedSoftware
+        ) {
+          device.destroy();
+          attempts.push({
+            ...attempt,
+            phase: 'adapter-selection',
+            error: new Error('Software WebGPU rejected')
+          });
+          continue;
+        }
+        device.creationInfo = {
+          requestedType: props.type,
+          selected: {
+            backend: candidate.backend,
+            featureLevel: device.info.featureLevel,
+            software: selectedSoftware
+          },
+          attempts
+        };
+        if (attempts.length > 0) {
+          log.warn(`Recovered ${candidate.backend}; ${attempts.length} failed`, attempts)();
+        }
+        return device;
+      } catch (error) {
+        const structuredError = wrapDeviceCreationError(
+          error,
+          {...attempt, phase: 'wrapper-initialization'},
+          `Failed to create ${candidate.backend}`
+        );
+        attempts.push(...structuredError.attempts);
+        if (structuredError.phase === 'canvas-initialization') {
+          replaceOwnedCanvasAfterFailedInitialization(props);
+        }
+      }
     }
 
-    // Wait for page to load so that CanvasContext's can access the DOM.
-    if (props.waitForPageLoad) {
-      await adapter.pageLoaded;
-    }
-
-    return await adapter.create(props);
+    const lastError = attempts[attempts.length - 1]?.error;
+    throw new DeviceCreationError(lastError?.message || ERROR_MESSAGE, attempts, lastError);
   }
 
   /**
@@ -157,6 +236,8 @@ export class Luma {
     let selectedType: string | null = type;
     if (type === 'best-available') {
       selectedType = this.getBestAvailableAdapterType(adapters);
+    } else if (type === 'best-available-webgpu') {
+      selectedType = 'webgpu';
     }
 
     const adapterMap = this._getAdapterMap(adapters);
@@ -194,6 +275,52 @@ export class Luma {
     return map;
   }
 
+  protected _getDeviceCreationCandidates(
+    props: Required<CreateDeviceProps>
+  ): DeviceCreationCandidate[] {
+    const adapterMap = this._getAdapterMap(props.adapters);
+    if (props.type !== 'best-available' && props.type !== 'best-available-webgpu') {
+      const adapter = adapterMap.get(props.type);
+      return [
+        {
+          adapter,
+          backend: props.type as DeviceCreationCandidate['backend'],
+          featureLevel: props.type === 'webgpu' ? props.featureLevel : undefined,
+          software: Boolean(props.type === 'webgpu' && props._forceFallbackAdapter)
+        }
+      ];
+    }
+
+    const featureLevels: WebGPUFeatureLevel[] =
+      props.featureLevel === 'max'
+        ? ['max', 'core', 'compatibility']
+        : props.featureLevel === 'compatibility'
+          ? ['compatibility']
+          : ['core', 'compatibility'];
+    const webgpuAdapter = adapterMap.get('webgpu');
+    const candidates: DeviceCreationCandidate[] = featureLevels.map(featureLevel => ({
+      adapter: webgpuAdapter,
+      backend: 'webgpu',
+      featureLevel
+    }));
+
+    if (props.type === 'best-available') {
+      candidates.push({
+        adapter: adapterMap.get('webgl'),
+        backend: 'webgl'
+      });
+    } else if (!props.failIfMajorPerformanceCaveat) {
+      candidates.push({
+        adapter: webgpuAdapter,
+        backend: 'webgpu',
+        featureLevel: 'compatibility',
+        software: true
+      });
+    }
+
+    return candidates;
+  }
+
   /** Get type of a handle (for attachDevice) */
   protected _getTypeFromHandle(
     handle: unknown,
@@ -227,6 +354,21 @@ export class Luma {
     }
 
     return null;
+  }
+}
+
+function replaceOwnedCanvasAfterFailedInitialization(props: Required<CreateDeviceProps>): void {
+  const contextProps = props.createCanvasContext;
+  if (
+    props._canvasContextOwned &&
+    typeof HTMLCanvasElement !== 'undefined' &&
+    contextProps !== true &&
+    contextProps.canvas instanceof HTMLCanvasElement
+  ) {
+    const canvas = contextProps.canvas;
+    const replacement = canvas.cloneNode() as HTMLCanvasElement;
+    canvas.replaceWith(replacement);
+    contextProps.canvas = replacement;
   }
 }
 

--- a/modules/core/src/adapter/luma.ts
+++ b/modules/core/src/adapter/luma.ts
@@ -153,6 +153,7 @@ export class Luma {
             phase: 'adapter-selection',
             error: new Error('Software WebGPU rejected')
           });
+          replaceOwnedCanvasAfterFailedInitialization(props);
           continue;
         }
         device.creationInfo = {

--- a/modules/core/src/adapter/luma.ts
+++ b/modules/core/src/adapter/luma.ts
@@ -21,8 +21,7 @@ declare global {
 
 const STARTUP_MESSAGE = 'set luma.log.level=1 (or higher) to trace rendering';
 
-const ERROR_MESSAGE =
-  'No matching device found. Ensure `@luma.gl/webgl` and/or `@luma.gl/webgpu` modules are imported.';
+const ERROR_MESSAGE = 'No matching device found. Import `@luma.gl/webgl` and/or `@luma.gl/webgpu`.';
 
 type DeviceCreationCandidate = {
   adapter?: Adapter;
@@ -106,6 +105,7 @@ export class Luma {
     const props: Required<CreateDeviceProps> = {...Luma.defaultProps, ...props_};
     const candidates = this._getDeviceCreationCandidates(props);
     const attempts: DeviceCreationAttempt[] = [];
+    const isBestAvailablePolicy = props.type.startsWith('best');
 
     for (const candidate of candidates) {
       const attempt = {
@@ -137,12 +137,18 @@ export class Luma {
         const device = await candidate.adapter.create({
           ...props,
           featureLevel: candidate.featureLevel,
-          _forceFallbackAdapter: Boolean(candidate.software)
+          _forceFallbackAdapter: Boolean(candidate.software),
+          failIfMajorPerformanceCaveat:
+            props.failIfMajorPerformanceCaveat ||
+            (isBestAvailablePolicy && candidate.backend === 'webgpu' && !candidate.software)
         });
         const selectedSoftware =
-          candidate.software || device.info.gpu === 'software' || Boolean(device.info.fallback);
+          candidate.software ||
+          device.info.gpu === 'software' ||
+          device.info.gpuType === 'cpu' ||
+          Boolean(device.info.fallback);
         if (
-          (props.type === 'best-available' || props.type === 'best-available-webgpu') &&
+          isBestAvailablePolicy &&
           candidate.backend === 'webgpu' &&
           !candidate.software &&
           selectedSoftware
@@ -151,7 +157,7 @@ export class Luma {
           attempts.push({
             ...attempt,
             phase: 'adapter-selection',
-            error: new Error('Software WebGPU rejected')
+            error: new Error('Software rejected')
           });
           replaceOwnedCanvasAfterFailedInitialization(props);
           continue;
@@ -280,7 +286,7 @@ export class Luma {
     props: Required<CreateDeviceProps>
   ): DeviceCreationCandidate[] {
     const adapterMap = this._getAdapterMap(props.adapters);
-    if (props.type !== 'best-available' && props.type !== 'best-available-webgpu') {
+    if (!props.type.startsWith('best')) {
       const adapter = adapterMap.get(props.type);
       return [
         {
@@ -309,6 +315,10 @@ export class Luma {
       candidates.push({
         adapter: adapterMap.get('webgl'),
         backend: 'webgl'
+      });
+      candidates.push({
+        adapter: adapterMap.get('null'),
+        backend: 'null'
       });
     } else if (!props.failIfMajorPerformanceCaveat) {
       candidates.push({

--- a/modules/core/src/adapter/luma.ts
+++ b/modules/core/src/adapter/luma.ts
@@ -159,7 +159,7 @@ export class Luma {
             phase: 'adapter-selection',
             error: new Error('Software rejected')
           });
-          replaceOwnedCanvasAfterFailedInitialization(props);
+          replaceCanvasAfterFailedInitialization(props);
           continue;
         }
         device.creationInfo = {
@@ -183,7 +183,7 @@ export class Luma {
         );
         attempts.push(...structuredError.attempts);
         if (structuredError.phase === 'canvas-initialization') {
-          replaceOwnedCanvasAfterFailedInitialization(props);
+          replaceCanvasAfterFailedInitialization(props);
         }
       }
     }
@@ -368,10 +368,9 @@ export class Luma {
   }
 }
 
-function replaceOwnedCanvasAfterFailedInitialization(props: Required<CreateDeviceProps>): void {
+function replaceCanvasAfterFailedInitialization(props: Required<CreateDeviceProps>): void {
   const contextProps = props.createCanvasContext;
   if (
-    props._canvasContextOwned &&
     typeof HTMLCanvasElement !== 'undefined' &&
     contextProps !== true &&
     contextProps.canvas instanceof HTMLCanvasElement

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -5,6 +5,12 @@
 // MAIN API ACCESS POINT
 export type {AttachDeviceProps, CreateDeviceProps} from './adapter/luma';
 export {luma} from './adapter/luma';
+export type {
+  DeviceCreationPhase,
+  DeviceCreationAttempt,
+  DeviceCreationInfo
+} from './adapter/device-creation-error';
+export {DeviceCreationError} from './adapter/device-creation-error';
 
 // ADAPTER (DEVICE AND GPU RESOURCE INTERFACES)
 export {Adapter} from './adapter/adapter';
@@ -17,7 +23,8 @@ export type {
   BrowserDeviceFeature,
   DeviceTextureFormatCapabilities,
   WebGPUFeatureLevel,
-  WebGPUDeviceFeatureLevel
+  WebGPUDeviceFeatureLevel,
+  DeviceLostInfo
 } from './adapter/device';
 export {Device, DeviceFeatures, DeviceLimits, isHTMLInCanvasSupported} from './adapter/device';
 

--- a/modules/core/test/adapter/luma.spec.ts
+++ b/modules/core/test/adapter/luma.spec.ts
@@ -4,7 +4,42 @@
 
 import test from 'test/utils/vitest-tape';
 import {nullAdapter} from '@luma.gl/test-utils';
-import {luma} from '@luma.gl/core';
+import {Adapter, DeviceCreationError, luma, type Device, type DeviceProps} from '@luma.gl/core';
+
+class RecordingAdapter extends Adapter {
+  readonly calls: DeviceProps[] = [];
+  supported = true;
+
+  constructor(
+    readonly type: string,
+    private readonly createImplementation: (props: DeviceProps) => Promise<Device>
+  ) {
+    super();
+  }
+
+  isSupported(): boolean {
+    return this.supported;
+  }
+
+  isDeviceHandle(): boolean {
+    return false;
+  }
+
+  async create(props: DeviceProps): Promise<Device> {
+    this.calls.push(props);
+    return await this.createImplementation(props);
+  }
+
+  async attach(): Promise<Device> {
+    throw new Error('Not implemented');
+  }
+}
+
+async function createNullDevice(props: DeviceProps): Promise<Device> {
+  const device = await nullAdapter.create({...props, createCanvasContext: true});
+  device.info.gpu = 'unknown';
+  return device;
+}
 
 test('luma#attachDevice', async t => {
   const device = await luma.attachDevice(null, {adapters: [nullAdapter]});
@@ -28,6 +63,248 @@ test('luma#createDevice', async t => {
   t.equal(device.type, 'null', 'info.vendor ok');
   t.equal(device.info.vendor, 'no one', 'info.vendor ok');
   t.equal(device.info.renderer, 'none', 'info.renderer ok');
+  t.end();
+});
+
+test('luma#createDevice best-available retries actual creation before WebGL', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
+    throw new Error(`Rejected ${props.featureLevel}`);
+  });
+  const webglAdapter = new RecordingAdapter('webgl', createNullDevice);
+
+  const device = await luma.createDevice({
+    type: 'best-available',
+    adapters: [webgpuAdapter, webglAdapter],
+    waitForPageLoad: false
+  });
+
+  t.deepEqual(
+    webgpuAdapter.calls.map(call => call.featureLevel),
+    ['core', 'compatibility'],
+    'core and compatibility are attempted in order'
+  );
+  t.equal(webglAdapter.calls.length, 1, 'WebGL is attempted after hardware WebGPU');
+  t.equal(device.creationInfo.attempts.length, 2, 'failed attempts are retained on success');
+  t.equal(device.creationInfo.selected?.backend, 'webgl', 'selected backend is recorded');
+  device.destroy();
+  t.end();
+});
+
+test('luma#createDevice uses compatibility WebGPU after a core creation failure', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
+    if (props.featureLevel === 'core') {
+      throw new Error('Core device request failed');
+    }
+    return await createNullDevice(props);
+  });
+  const webglAdapter = new RecordingAdapter('webgl', createNullDevice);
+
+  const device = await luma.createDevice({
+    type: 'best-available',
+    adapters: [webgpuAdapter, webglAdapter],
+    waitForPageLoad: false
+  });
+
+  t.deepEqual(
+    webgpuAdapter.calls.map(call => call.featureLevel),
+    ['core', 'compatibility'],
+    'compatibility follows core'
+  );
+  t.equal(webglAdapter.calls.length, 0, 'successful compatibility does not attempt WebGL');
+  t.equal(device.creationInfo.attempts.length, 1, 'the recovered core failure is retained');
+  device.destroy();
+  t.end();
+});
+
+test('luma#createDevice best-available-webgpu uses software last and never WebGL', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
+    if (!props._forceFallbackAdapter) {
+      throw new Error(`Rejected ${props.featureLevel}`);
+    }
+    return await createNullDevice(props);
+  });
+  const webglAdapter = new RecordingAdapter('webgl', createNullDevice);
+
+  const device = await luma.createDevice({
+    type: 'best-available-webgpu',
+    adapters: [webgpuAdapter, webglAdapter],
+    waitForPageLoad: false
+  });
+
+  t.deepEqual(
+    webgpuAdapter.calls.map(call => [call.featureLevel, call._forceFallbackAdapter]),
+    [
+      ['core', false],
+      ['compatibility', false],
+      ['compatibility', true]
+    ],
+    'software compatibility WebGPU is the final attempt'
+  );
+  t.equal(webglAdapter.calls.length, 0, 'WebGL is never attempted');
+  t.equal(device.creationInfo.selected?.software, true, 'software selection is recorded');
+  device.destroy();
+  t.end();
+});
+
+test('luma#createDevice explicit backends stay strict', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', async () => {
+    throw new Error('Strict WebGPU failure');
+  });
+  const webglAdapter = new RecordingAdapter('webgl', createNullDevice);
+
+  let error: unknown;
+  try {
+    await luma.createDevice({
+      type: 'webgpu',
+      adapters: [webgpuAdapter, webglAdapter],
+      waitForPageLoad: false
+    });
+  } catch (caughtError) {
+    error = caughtError;
+  }
+
+  t.ok(error instanceof DeviceCreationError, 'strict failure is structured');
+  t.equal(webgpuAdapter.calls.length, 1, 'strict WebGPU is attempted once');
+  t.equal(webglAdapter.calls.length, 0, 'strict WebGPU does not fall back');
+  t.end();
+});
+
+test('luma#createDevice major performance caveat suppresses software WebGPU', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', async () => {
+    throw new Error('Hardware unavailable');
+  });
+
+  let error: DeviceCreationError | null = null;
+  try {
+    await luma.createDevice({
+      type: 'best-available-webgpu',
+      adapters: [webgpuAdapter],
+      failIfMajorPerformanceCaveat: true,
+      waitForPageLoad: false
+    });
+  } catch (caughtError) {
+    error = caughtError as DeviceCreationError;
+  }
+
+  t.ok(error instanceof DeviceCreationError, 'final failure is structured');
+  t.deepEqual(
+    webgpuAdapter.calls.map(call => call._forceFallbackAdapter),
+    [false, false],
+    'software request is suppressed'
+  );
+  t.equal(error?.attempts.length, 2, 'both hardware failures are retained');
+  t.end();
+});
+
+test('luma#createDevice honors max and compatibility policy starting points', async t => {
+  const maxAdapter = new RecordingAdapter('webgpu', async props => {
+    if (props.featureLevel !== 'compatibility') {
+      throw new Error(`${props.featureLevel} unavailable`);
+    }
+    return await createNullDevice(props);
+  });
+  const maxDevice = await luma.createDevice({
+    type: 'best-available-webgpu',
+    featureLevel: 'max',
+    adapters: [maxAdapter],
+    waitForPageLoad: false
+  });
+  t.deepEqual(
+    maxAdapter.calls.map(call => call.featureLevel),
+    ['max', 'core', 'compatibility'],
+    'max degrades through core to compatibility'
+  );
+  maxDevice.destroy();
+
+  const compatibilityAdapter = new RecordingAdapter('webgpu', createNullDevice);
+  const compatibilityDevice = await luma.createDevice({
+    type: 'best-available-webgpu',
+    featureLevel: 'compatibility',
+    adapters: [compatibilityAdapter],
+    waitForPageLoad: false
+  });
+  t.deepEqual(
+    compatibilityAdapter.calls.map(call => call.featureLevel),
+    ['compatibility'],
+    'compatibility starts and succeeds at compatibility'
+  );
+  compatibilityDevice.destroy();
+  t.end();
+});
+
+test('luma#createDevice does not select an incidental software adapter as hardware', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
+    const device = await createNullDevice(props);
+    (device.info as {fallback?: boolean}).fallback = true;
+    return device;
+  });
+  const webglAdapter = new RecordingAdapter('webgl', createNullDevice);
+
+  const device = await luma.createDevice({
+    type: 'best-available',
+    adapters: [webgpuAdapter, webglAdapter],
+    waitForPageLoad: false
+  });
+
+  t.equal(webgpuAdapter.calls.length, 2, 'both hardware profiles reject software devices');
+  t.equal(device.creationInfo.selected?.backend, 'webgl', 'broad fallback prefers WebGL');
+  t.equal(device.creationInfo.attempts.length, 2, 'software detections are diagnostic attempts');
+  device.destroy();
+  t.end();
+});
+
+test('luma#createDevice preserves native attempt phases and causes', async t => {
+  const nativeError = new Error('Native requestDevice rejection');
+  const webgpuAdapter = new RecordingAdapter('webgpu', async () => {
+    throw new DeviceCreationError(
+      'Native WebGPU failure',
+      [
+        {
+          backend: 'webgpu',
+          featureLevel: 'core',
+          software: false,
+          phase: 'device-request',
+          error: nativeError
+        }
+      ],
+      nativeError
+    );
+  });
+
+  let error: DeviceCreationError | null = null;
+  try {
+    await luma.createDevice({
+      type: 'webgpu',
+      adapters: [webgpuAdapter],
+      waitForPageLoad: false
+    });
+  } catch (caughtError) {
+    error = caughtError as DeviceCreationError;
+  }
+
+  t.equal(error?.phase, 'device-request', 'the adapter phase is retained');
+  t.equal(error?.attempts[0]?.error, nativeError, 'the native error is retained');
+  t.equal(error?.cause, nativeError, 'the final cause is the native error');
+  t.end();
+});
+
+test('luma#createDevice records unavailable adapters without calling create', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', createNullDevice);
+  webgpuAdapter.supported = false;
+
+  let error: DeviceCreationError | null = null;
+  try {
+    await luma.createDevice({
+      type: 'webgpu',
+      adapters: [webgpuAdapter],
+      waitForPageLoad: false
+    });
+  } catch (caughtError) {
+    error = caughtError as DeviceCreationError;
+  }
+
+  t.equal(webgpuAdapter.calls.length, 0, 'unsupported adapters are not invoked');
+  t.equal(error?.phase, 'adapter-selection', 'adapter unavailability has an exact phase');
   t.end();
 });
 

--- a/modules/core/test/adapter/luma.spec.ts
+++ b/modules/core/test/adapter/luma.spec.ts
@@ -233,23 +233,39 @@ test('luma#createDevice honors max and compatibility policy starting points', as
 });
 
 test('luma#createDevice does not select an incidental software adapter as hardware', async t => {
+  const container = document.createElement('div');
+  const canvas = document.createElement('canvas');
+  container.appendChild(canvas);
+  document.body.appendChild(container);
+  const requestedCanvases: HTMLCanvasElement[] = [];
   const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
+    requestedCanvases.push((props.createCanvasContext as {canvas: HTMLCanvasElement}).canvas);
     const device = await createNullDevice(props);
     (device.info as {fallback?: boolean}).fallback = true;
     return device;
   });
-  const webglAdapter = new RecordingAdapter('webgl', createNullDevice);
+  const webglAdapter = new RecordingAdapter('webgl', async props => {
+    requestedCanvases.push((props.createCanvasContext as {canvas: HTMLCanvasElement}).canvas);
+    return await createNullDevice(props);
+  });
 
   const device = await luma.createDevice({
     type: 'best-available',
     adapters: [webgpuAdapter, webglAdapter],
+    createCanvasContext: {canvas},
+    _canvasContextOwned: true,
     waitForPageLoad: false
   });
 
   t.equal(webgpuAdapter.calls.length, 2, 'both hardware profiles reject software devices');
+  const [firstCanvas, secondCanvas, webglCanvas] = requestedCanvases;
+  t.notEqual(firstCanvas, secondCanvas, 'core rejection replaces the owned canvas');
+  t.notEqual(secondCanvas, webglCanvas, 'compatibility rejection replaces the owned canvas');
+  t.equal(webglCanvas.parentElement, container, 'WebGL receives the visible replacement canvas');
   t.equal(device.creationInfo.selected?.backend, 'webgl', 'broad fallback prefers WebGL');
   t.equal(device.creationInfo.attempts.length, 2, 'software detections are diagnostic attempts');
   device.destroy();
+  container.remove();
   t.end();
 });
 

--- a/modules/core/test/adapter/luma.spec.ts
+++ b/modules/core/test/adapter/luma.spec.ts
@@ -332,6 +332,62 @@ test('luma#createDevice rejects software WebGPU before reusing a caller-owned ca
   t.end();
 });
 
+test('luma#createDevice replaces a caller-owned canvas after canvas initialization fails', async t => {
+  const container = document.createElement('div');
+  const canvas = document.createElement('canvas');
+  canvas.id = 'caller-canvas';
+  canvas.width = 640;
+  canvas.height = 480;
+  canvas.style.width = '320px';
+  container.appendChild(canvas);
+  document.body.appendChild(container);
+
+  const requestedCanvases: HTMLCanvasElement[] = [];
+  const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
+    requestedCanvases.push((props.createCanvasContext as {canvas: HTMLCanvasElement}).canvas);
+    const nativeError = new Error('Canvas context configuration failed');
+    throw new DeviceCreationError(
+      'WebGPU canvas initialization failed',
+      [
+        {
+          backend: 'webgpu',
+          featureLevel: props.featureLevel,
+          software: false,
+          phase: 'canvas-initialization',
+          error: nativeError
+        }
+      ],
+      nativeError
+    );
+  });
+  const webglAdapter = new RecordingAdapter('webgl', async props => {
+    requestedCanvases.push((props.createCanvasContext as {canvas: HTMLCanvasElement}).canvas);
+    return await createNullDevice(props);
+  });
+
+  const device = await luma.createDevice({
+    type: 'best-available',
+    adapters: [webgpuAdapter, webglAdapter],
+    createCanvasContext: {canvas},
+    waitForPageLoad: false
+  });
+
+  const [coreCanvas, compatibilityCanvas, webglCanvas] = requestedCanvases;
+  t.equal(coreCanvas, canvas, 'core WebGPU receives the caller canvas');
+  t.notEqual(compatibilityCanvas, coreCanvas, 'compatibility receives an unbound replacement');
+  t.notEqual(webglCanvas, compatibilityCanvas, 'WebGL receives a second unbound replacement');
+  t.equal(webglCanvas.parentElement, container, 'the final replacement remains visible');
+  t.equal(webglCanvas.id, canvas.id, 'the replacement preserves the canvas id');
+  t.equal(webglCanvas.width, canvas.width, 'the replacement preserves drawing-buffer width');
+  t.equal(webglCanvas.height, canvas.height, 'the replacement preserves drawing-buffer height');
+  t.equal(webglCanvas.style.width, canvas.style.width, 'the replacement preserves CSS dimensions');
+  t.equal(device.creationInfo.selected?.backend, 'webgl', 'WebGL fallback succeeds');
+
+  device.destroy();
+  container.remove();
+  t.end();
+});
+
 test('luma#createDevice classifies CPU WebGPU devices as software', async t => {
   const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
     const device = await createNullDevice(props);

--- a/modules/core/test/adapter/luma.spec.ts
+++ b/modules/core/test/adapter/luma.spec.ts
@@ -90,6 +90,25 @@ test('luma#createDevice best-available retries actual creation before WebGL', as
   t.end();
 });
 
+test('luma#createDevice best-available retains the null adapter as a final fallback', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', createNullDevice);
+  const webglAdapter = new RecordingAdapter('webgl', createNullDevice);
+  webgpuAdapter.supported = false;
+  webglAdapter.supported = false;
+
+  const device = await luma.createDevice({
+    type: 'best-available',
+    adapters: [webgpuAdapter, webglAdapter, nullAdapter],
+    waitForPageLoad: false
+  });
+
+  t.equal(device.type, 'null', 'null device is selected after unavailable GPU backends');
+  t.equal(device.creationInfo.selected?.backend, 'null', 'null selection is recorded');
+  t.equal(device.creationInfo.attempts.length, 3, 'failed WebGPU profiles and WebGL are retained');
+  device.destroy();
+  t.end();
+});
+
 test('luma#createDevice uses compatibility WebGPU after a core creation failure', async t => {
   const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
     if (props.featureLevel === 'core') {
@@ -266,6 +285,70 @@ test('luma#createDevice does not select an incidental software adapter as hardwa
   t.equal(device.creationInfo.attempts.length, 2, 'software detections are diagnostic attempts');
   device.destroy();
   container.remove();
+  t.end();
+});
+
+test('luma#createDevice rejects software WebGPU before reusing a caller-owned canvas', async t => {
+  const canvas = document.createElement('canvas');
+  const requestedCanvases: HTMLCanvasElement[] = [];
+  const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
+    requestedCanvases.push((props.createCanvasContext as {canvas: HTMLCanvasElement}).canvas);
+    if (props.failIfMajorPerformanceCaveat) {
+      throw new DeviceCreationError('Software adapter rejected before canvas initialization', [
+        {
+          backend: 'webgpu',
+          featureLevel: props.featureLevel,
+          software: true,
+          phase: 'adapter-selection',
+          error: new Error('Software WebGPU adapter rejected')
+        }
+      ]);
+    }
+    return await createNullDevice(props);
+  });
+  const webglAdapter = new RecordingAdapter('webgl', async props => {
+    requestedCanvases.push((props.createCanvasContext as {canvas: HTMLCanvasElement}).canvas);
+    return await createNullDevice(props);
+  });
+
+  const device = await luma.createDevice({
+    type: 'best-available',
+    adapters: [webgpuAdapter, webglAdapter],
+    createCanvasContext: {canvas},
+    waitForPageLoad: false
+  });
+
+  t.deepEqual(
+    webgpuAdapter.calls.map(call => call.failIfMajorPerformanceCaveat),
+    [true, true],
+    'hardware WebGPU candidates reject software before canvas initialization'
+  );
+  t.ok(
+    requestedCanvases.every(requestedCanvas => requestedCanvas === canvas),
+    'all candidates retain the untouched caller-owned canvas'
+  );
+  t.equal(device.creationInfo.selected?.backend, 'webgl', 'WebGL fallback succeeds');
+  device.destroy();
+  t.end();
+});
+
+test('luma#createDevice classifies CPU WebGPU devices as software', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
+    const device = await createNullDevice(props);
+    device.info.gpuType = 'cpu';
+    return device;
+  });
+  const webglAdapter = new RecordingAdapter('webgl', createNullDevice);
+
+  const device = await luma.createDevice({
+    type: 'best-available',
+    adapters: [webgpuAdapter, webglAdapter],
+    waitForPageLoad: false
+  });
+
+  t.equal(webgpuAdapter.calls.length, 2, 'CPU devices are rejected for both hardware profiles');
+  t.equal(device.creationInfo.selected?.backend, 'webgl', 'CPU WebGPU degrades to WebGL');
+  device.destroy();
   t.end();
 });
 

--- a/modules/engine/src/animation-loop/animation-loop.ts
+++ b/modules/engine/src/animation-loop/animation-loop.ts
@@ -214,6 +214,9 @@ export class AnimationLoop {
       if (!this._initialized) {
         // Create the WebGL context
         await this._initDevice();
+        if (!this._running) {
+          return null;
+        }
         this._initialize();
         if (!this._running) {
           return null;
@@ -526,6 +529,9 @@ export class AnimationLoop {
       this.canvas instanceof OffscreenCanvas
     ) {
       this.errorDisplay?.disable();
+    }
+    if (!this._running) {
+      return;
     }
     this._attachDeviceErrorHandler();
     if (this._observedLostDevice !== this.device) {

--- a/modules/engine/src/animation-loop/animation-loop.ts
+++ b/modules/engine/src/animation-loop/animation-loop.ts
@@ -106,11 +106,13 @@ export class AnimationLoop {
   _lastFrameTime: number = 0;
   private _restoreDeviceErrorHandler: (() => void) | null = null;
   private _observedLostDevice: Device | null = null;
+  private readonly _hasExplicitErrorDisplayTarget: boolean;
 
   /*
    * @param {HTMLCanvasElement} canvas - if provided, width and height will be passed to context
    */
   constructor(props: AnimationLoopProps) {
+    this._hasExplicitErrorDisplayTarget = Boolean(props.errorDisplay && props.errorDisplay.target);
     this.props = {...AnimationLoop.defaultAnimationLoopProps, ...props};
     props = this.props;
 
@@ -512,9 +514,17 @@ export class AnimationLoop {
       throw new Error('No device provided');
     }
     this.canvas = this.device.getDefaultCanvasContext().canvas || null;
-    if (typeof HTMLCanvasElement !== 'undefined' && this.canvas instanceof HTMLCanvasElement) {
+    if (
+      !this._hasExplicitErrorDisplayTarget &&
+      typeof HTMLCanvasElement !== 'undefined' &&
+      this.canvas instanceof HTMLCanvasElement
+    ) {
       this.errorDisplay?.setTarget(this.canvas);
-    } else if (typeof OffscreenCanvas !== 'undefined' && this.canvas instanceof OffscreenCanvas) {
+    } else if (
+      !this._hasExplicitErrorDisplayTarget &&
+      typeof OffscreenCanvas !== 'undefined' &&
+      this.canvas instanceof OffscreenCanvas
+    ) {
       this.errorDisplay?.disable();
     }
     this._attachDeviceErrorHandler();

--- a/modules/engine/src/animation-loop/animation-loop.ts
+++ b/modules/engine/src/animation-loop/animation-loop.ts
@@ -10,6 +10,7 @@ import {
 import {Timeline} from '../animation/timeline';
 import {AnimationProps} from './animation-props';
 import {Stats, Stat} from '@probe.gl/stats';
+import {CanvasErrorDisplay, type CanvasErrorDisplayProps} from './canvas-error-display';
 
 let statIdCounter = 0;
 const ANIMATION_LOOP_STATS = 'Animation Loop';
@@ -38,6 +39,8 @@ export type AnimationLoopProps = {
   onRender?: (animationProps: AnimationProps) => unknown;
   onFinalize?: (animationProps: AnimationProps) => void;
   onError?: (reason: Error) => void;
+  /** Browser canvas error overlay. Enabled by default; set to false to disable. */
+  errorDisplay?: false | CanvasErrorDisplayProps;
 
   stats?: Stats;
 
@@ -67,6 +70,7 @@ export class AnimationLoop {
       // biome-ignore lint/suspicious/noConsole: default fallback error reporting for app loops.
       console.error(error);
     },
+    errorDisplay: {},
 
     stats: undefined!,
 
@@ -88,6 +92,7 @@ export class AnimationLoop {
   frameRate: Stat;
 
   display: any;
+  readonly errorDisplay: CanvasErrorDisplay | null;
 
   private _needsRedraw: string | false = 'initialized';
 
@@ -99,6 +104,8 @@ export class AnimationLoop {
   _cpuStartTime: number = 0;
   _error: Error | null = null;
   _lastFrameTime: number = 0;
+  private _restoreDeviceErrorHandler: (() => void) | null = null;
+  private _observedLostDevice: Device | null = null;
 
   /*
    * @param {HTMLCanvasElement} canvas - if provided, width and height will be passed to context
@@ -110,6 +117,9 @@ export class AnimationLoop {
     if (!props.device) {
       throw new Error('No device provided');
     }
+
+    this.errorDisplay =
+      props.errorDisplay === false ? null : new CanvasErrorDisplay(props.errorDisplay);
 
     // state
     this.stats = props.stats || new Stats({id: `animation-loop-${statIdCounter++}`});
@@ -134,6 +144,7 @@ export class AnimationLoop {
 
   destroy(): void {
     this.stop();
+    this.errorDisplay?.destroy();
     this._setDisplay(null);
     this.device?._disableDebugGPUTime();
   }
@@ -144,8 +155,13 @@ export class AnimationLoop {
   }
 
   reportError(error: Error): void {
-    this.props.onError(error);
     this._error = error;
+    this.errorDisplay?.show(error);
+    try {
+      this.props.onError(error);
+    } finally {
+      this.stop();
+    }
   }
 
   /** Flags this animation loop as needing redraw */
@@ -187,11 +203,13 @@ export class AnimationLoop {
       return this;
     }
     this._running = true;
+    this._error = null;
+    this.errorDisplay?.clear();
+    this._attachDeviceErrorHandler();
 
     try {
       let appContext;
       if (!this._initialized) {
-        this._initialized = true;
         // Create the WebGL context
         await this._initDevice();
         this._initialize();
@@ -201,6 +219,7 @@ export class AnimationLoop {
 
         // Note: onIntialize can return a promise (e.g. in case app needs to load resources)
         await this.props.onInitialize(this._getAnimationProps());
+        this._initialized = true;
       }
 
       // check that we haven't been stopped
@@ -218,8 +237,9 @@ export class AnimationLoop {
       return this;
     } catch (err: unknown) {
       const error = err instanceof Error ? err : new Error('Unknown error');
-      this.props.onError(error);
-      // this._running = false; // TODO
+      if (this._error !== error) {
+        this.reportError(error);
+      }
       throw error;
     }
   }
@@ -240,6 +260,8 @@ export class AnimationLoop {
       this._running = false;
       this._lastFrameTime = 0;
     }
+    this._restoreDeviceErrorHandler?.();
+    this._restoreDeviceErrorHandler = null;
     return this;
   }
 
@@ -249,28 +271,33 @@ export class AnimationLoop {
       return this;
     }
 
-    this._beginFrameTimers(time);
+    try {
+      this._beginFrameTimers(time);
 
-    this._setupFrame();
-    if (this.animationProps) {
-      this.animationProps.animationFrame = animationFrame;
+      this._setupFrame();
+      if (this.animationProps) {
+        this.animationProps.animationFrame = animationFrame;
+      }
+      this._updateAnimationProps();
+
+      this._renderFrame(this._getAnimationProps());
+
+      // clear needsRedraw flag
+      this._clearNeedsRedraw();
+
+      if (this._resolveNextFrame) {
+        this._resolveNextFrame(this);
+        this._nextFramePromise = null;
+        this._resolveNextFrame = null;
+      }
+
+      this._endFrameTimers();
+      return this;
+    } catch (error) {
+      const renderError = error instanceof Error ? error : new Error(String(error));
+      this.reportError(renderError);
+      throw renderError;
     }
-    this._updateAnimationProps();
-
-    this._renderFrame(this._getAnimationProps());
-
-    // clear needsRedraw flag
-    this._clearNeedsRedraw();
-
-    if (this._resolveNextFrame) {
-      this._resolveNextFrame(this);
-      this._nextFramePromise = null;
-      this._resolveNextFrame = null;
-    }
-
-    this._endFrameTimers();
-
-    return this;
   }
 
   /** Add a timeline, it will be automatically updated by the animation loop. */
@@ -358,7 +385,11 @@ export class AnimationLoop {
     if (!this._running) {
       return;
     }
-    this.redraw(time, animationFrame ?? null);
+    try {
+      this.redraw(time, animationFrame ?? null);
+    } catch {
+      return;
+    }
     this._requestAnimationFrame();
   }
 
@@ -481,7 +512,50 @@ export class AnimationLoop {
       throw new Error('No device provided');
     }
     this.canvas = this.device.getDefaultCanvasContext().canvas || null;
+    if (typeof HTMLCanvasElement !== 'undefined' && this.canvas instanceof HTMLCanvasElement) {
+      this.errorDisplay?.setTarget(this.canvas);
+    } else if (typeof OffscreenCanvas !== 'undefined' && this.canvas instanceof OffscreenCanvas) {
+      this.errorDisplay?.disable();
+    }
+    this._attachDeviceErrorHandler();
+    if (this._observedLostDevice !== this.device) {
+      this._observedLostDevice = this.device;
+      void this.device.lost.then(loss => {
+        if (loss.reason !== 'destroyed' && this._running && !this._error) {
+          const error = new Error(loss.message || 'GPU device was lost') as Error & {
+            deviceLossInfo?: typeof loss;
+          };
+          error.deviceLossInfo = loss;
+          this.reportError(error);
+        }
+      });
+    }
     // this._createInfoDiv();
+  }
+
+  private _attachDeviceErrorHandler(): void {
+    if (
+      !this.device ||
+      this._restoreDeviceErrorHandler ||
+      this.device.props.onError !== Device.defaultProps.onError
+    ) {
+      return;
+    }
+
+    const device = this.device;
+    const originalOnError = device.props.onError;
+    const displayOnError = (error: Error, context?: unknown): unknown => {
+      if (this._running && !this._error) {
+        this.errorDisplay?.showMessage(error);
+      }
+      return originalOnError(error, context);
+    };
+    device.props.onError = displayOnError;
+    this._restoreDeviceErrorHandler = () => {
+      if (device.props.onError === displayOnError) {
+        device.props.onError = originalOnError;
+      }
+    };
   }
 
   _createInfoDiv(): void {

--- a/modules/engine/src/animation-loop/animation-loop.ts
+++ b/modules/engine/src/animation-loop/animation-loop.ts
@@ -255,7 +255,7 @@ export class AnimationLoop {
     if (this._running) {
       // call callback
       // If stop is called immediately, we can end up in a state where props haven't been initialized...
-      if (this.animationProps && !this._error) {
+      if (this.animationProps && this._initialized) {
         this.props.onFinalize(this.animationProps);
       }
 

--- a/modules/engine/src/animation-loop/animation-loop.ts
+++ b/modules/engine/src/animation-loop/animation-loop.ts
@@ -101,6 +101,7 @@ export class AnimationLoop {
   _animationFrameId: any = null;
   _nextFramePromise: Promise<AnimationLoop> | null = null;
   _resolveNextFrame: ((animationLoop: AnimationLoop) => void) | null = null;
+  _rejectNextFrame: ((error: Error) => void) | null = null;
   _cpuStartTime: number = 0;
   _error: Error | null = null;
   _lastFrameTime: number = 0;
@@ -158,6 +159,10 @@ export class AnimationLoop {
 
   reportError(error: Error): void {
     this._error = error;
+    this._rejectNextFrame?.(error);
+    this._nextFramePromise = null;
+    this._resolveNextFrame = null;
+    this._rejectNextFrame = null;
     this.errorDisplay?.show(error);
     try {
       this.props.onError(error);
@@ -262,6 +267,7 @@ export class AnimationLoop {
       this._cancelAnimationFrame();
       this._nextFramePromise = null;
       this._resolveNextFrame = null;
+      this._rejectNextFrame = null;
       this._running = false;
       this._lastFrameTime = 0;
     }
@@ -294,6 +300,7 @@ export class AnimationLoop {
         this._resolveNextFrame(this);
         this._nextFramePromise = null;
         this._resolveNextFrame = null;
+        this._rejectNextFrame = null;
       }
 
       this._endFrameTimers();
@@ -321,8 +328,9 @@ export class AnimationLoop {
     this.setNeedsRedraw('waitForRender');
 
     if (!this._nextFramePromise) {
-      this._nextFramePromise = new Promise(resolve => {
+      this._nextFramePromise = new Promise((resolve, reject) => {
         this._resolveNextFrame = resolve;
+        this._rejectNextFrame = reject;
       });
     }
     return this._nextFramePromise;

--- a/modules/engine/src/animation-loop/canvas-error-display.ts
+++ b/modules/engine/src/animation-loop/canvas-error-display.ts
@@ -1,0 +1,309 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {DeviceCreationError} from '@luma.gl/core';
+
+const positionedContainers = new WeakMap<HTMLElement, {count: number; previousPosition: string}>();
+
+export type CanvasErrorDisplayTarget = HTMLCanvasElement | HTMLElement | string;
+
+/** Options for the browser canvas error display used by AnimationLoop. */
+export type CanvasErrorDisplayProps = {
+  target?: CanvasErrorDisplayTarget;
+};
+
+/** Accessible, per-loop fatal and transient error display for browser canvases. */
+export class CanvasErrorDisplay {
+  private target?: CanvasErrorDisplayTarget;
+  private element: HTMLDivElement | null = null;
+  private messageElement: HTMLDivElement | null = null;
+  private positionedContainer: HTMLElement | null = null;
+  private fadeMessageTimer: ReturnType<typeof setTimeout> | null = null;
+  private removeMessageTimer: ReturnType<typeof setTimeout> | null = null;
+  private enabled = true;
+
+  constructor(props: CanvasErrorDisplayProps = {}) {
+    this.target = props.target;
+  }
+
+  setTarget(target: CanvasErrorDisplayTarget | null): void {
+    if (target) {
+      this.target = target;
+    }
+  }
+
+  disable(): void {
+    this.enabled = false;
+    this.clear();
+  }
+
+  show(error: Error): void {
+    if (!this.enabled || typeof document === 'undefined') {
+      return;
+    }
+    this.clear();
+
+    const target = resolveTarget(this.target);
+    const canvas = target instanceof HTMLCanvasElement ? target : null;
+    const container = canvas ? canvas.parentElement || document.body : target || document.body;
+    if (!container) {
+      return;
+    }
+
+    const element = document.createElement('div');
+    element.dataset['lumaErrorDisplay'] = 'true';
+    element.setAttribute('role', 'alert');
+    element.setAttribute('aria-live', 'assertive');
+    Object.assign(element.style, {
+      position: container === document.body ? 'fixed' : 'absolute',
+      inset: '0',
+      zIndex: '2147483647',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      alignItems: 'stretch',
+      gap: '12px',
+      boxSizing: 'border-box',
+      overflow: 'auto',
+      padding:
+        'max(20px, env(safe-area-inset-top)) max(20px, env(safe-area-inset-right)) max(20px, env(safe-area-inset-bottom)) max(20px, env(safe-area-inset-left))',
+      color: '#ffffff',
+      background: 'rgba(86, 8, 8, 0.96)',
+      font: '500 16px/1.45 system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
+      overflowWrap: 'anywhere',
+      touchAction: 'pan-y'
+    });
+    if (canvas?.isConnected && container === document.body) {
+      const bounds = canvas.getBoundingClientRect();
+      Object.assign(element.style, {
+        inset: 'auto',
+        left: `${bounds.left}px`,
+        top: `${bounds.top}px`,
+        width: `${bounds.width}px`,
+        height: `${bounds.height}px`
+      });
+    } else if (canvas?.isConnected) {
+      const bounds = canvas.getBoundingClientRect();
+      const containerBounds = container.getBoundingClientRect();
+      Object.assign(element.style, {
+        inset: 'auto',
+        left: `${bounds.left - containerBounds.left + container.scrollLeft}px`,
+        top: `${bounds.top - containerBounds.top + container.scrollTop}px`,
+        width: `${bounds.width}px`,
+        height: `${bounds.height}px`
+      });
+    }
+
+    const title = document.createElement('strong');
+    title.textContent = getErrorTitle(error);
+    title.style.fontSize = 'clamp(20px, 5vw, 30px)';
+    element.appendChild(title);
+
+    const message = document.createElement('div');
+    message.textContent = error.message || 'An unknown GPU error occurred.';
+    element.appendChild(message);
+
+    const technicalDetails = formatTechnicalDetails(error);
+    if (technicalDetails) {
+      const details = document.createElement('details');
+      const summary = document.createElement('summary');
+      summary.textContent = 'Technical details';
+      summary.style.cursor = 'pointer';
+      details.appendChild(summary);
+      const pre = document.createElement('pre');
+      pre.textContent = technicalDetails;
+      Object.assign(pre.style, {
+        margin: '10px 0 0',
+        padding: '12px',
+        overflow: 'auto',
+        whiteSpace: 'pre-wrap',
+        background: 'rgba(0, 0, 0, 0.3)',
+        font: '12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace'
+      });
+      details.appendChild(pre);
+      element.appendChild(details);
+    }
+
+    if (container !== document.body && acquirePositionedContainer(container)) {
+      this.positionedContainer = container;
+    }
+    container.appendChild(element);
+    this.element = element;
+  }
+
+  /** Show a brief nonfatal error message without obscuring or stopping the canvas. */
+  showMessage(error: Error): void {
+    if (!this.enabled || this.element || typeof document === 'undefined') {
+      return;
+    }
+    this.clearMessage();
+
+    const target = resolveTarget(this.target);
+    const canvas = target instanceof HTMLCanvasElement ? target : null;
+    const container = canvas ? canvas.parentElement || document.body : target || document.body;
+    if (!container) {
+      return;
+    }
+
+    const element = document.createElement('div');
+    element.dataset['lumaErrorMessage'] = 'true';
+    element.setAttribute('role', 'status');
+    element.setAttribute('aria-live', 'polite');
+    element.textContent = error.message || 'An unknown graphics error occurred.';
+    Object.assign(element.style, {
+      position: container === document.body ? 'fixed' : 'absolute',
+      zIndex: '2147483647',
+      left: '50%',
+      top: 'max(12px, env(safe-area-inset-top))',
+      maxWidth: 'min(calc(100% - 24px), 720px)',
+      boxSizing: 'border-box',
+      transform: 'translateX(-50%)',
+      padding: '8px 12px',
+      border: '1px solid rgba(255, 100, 100, 0.75)',
+      borderRadius: '4px',
+      color: '#ff8a8a',
+      background: 'rgba(45, 0, 0, 0.9)',
+      boxShadow: '0 2px 12px rgba(0, 0, 0, 0.45)',
+      font: '600 14px/1.4 system-ui, -apple-system, BlinkMacSystemFont, sans-serif',
+      overflowWrap: 'anywhere',
+      pointerEvents: 'none',
+      opacity: '1',
+      transition: 'opacity 900ms ease-out'
+    });
+    if (canvas?.isConnected && container === document.body) {
+      const bounds = canvas.getBoundingClientRect();
+      Object.assign(element.style, {
+        left: `${bounds.left + bounds.width / 2}px`,
+        top: `${bounds.top + 12}px`
+      });
+    } else if (canvas?.isConnected) {
+      const bounds = canvas.getBoundingClientRect();
+      const containerBounds = container.getBoundingClientRect();
+      Object.assign(element.style, {
+        left: `${bounds.left - containerBounds.left + container.scrollLeft + bounds.width / 2}px`,
+        top: `${bounds.top - containerBounds.top + container.scrollTop + 12}px`
+      });
+    }
+
+    if (container !== document.body && !this.positionedContainer) {
+      if (acquirePositionedContainer(container)) {
+        this.positionedContainer = container;
+      }
+    }
+    container.appendChild(element);
+    this.messageElement = element;
+    this.fadeMessageTimer = setTimeout(() => {
+      if (this.messageElement === element) {
+        element.style.opacity = '0';
+      }
+    }, 3000);
+    this.removeMessageTimer = setTimeout(() => {
+      if (this.messageElement === element) {
+        this.clearMessage();
+      }
+    }, 4000);
+  }
+
+  clear(): void {
+    this.element?.remove();
+    this.element = null;
+    this.clearMessage();
+    this.releasePositionedContainer();
+  }
+
+  clearMessage(): void {
+    if (this.fadeMessageTimer) {
+      clearTimeout(this.fadeMessageTimer);
+      this.fadeMessageTimer = null;
+    }
+    if (this.removeMessageTimer) {
+      clearTimeout(this.removeMessageTimer);
+      this.removeMessageTimer = null;
+    }
+    this.messageElement?.remove();
+    this.messageElement = null;
+    if (!this.element) {
+      this.releasePositionedContainer();
+    }
+  }
+
+  private releasePositionedContainer(): void {
+    if (this.positionedContainer) {
+      releasePositionedContainer(this.positionedContainer);
+      this.positionedContainer = null;
+    }
+  }
+
+  destroy(): void {
+    this.clear();
+  }
+}
+
+function acquirePositionedContainer(container: HTMLElement): boolean {
+  const existingState = positionedContainers.get(container);
+  if (existingState) {
+    existingState.count++;
+    return true;
+  }
+  if (getComputedStyle(container).position !== 'static') {
+    return false;
+  }
+  positionedContainers.set(container, {count: 1, previousPosition: container.style.position});
+  container.style.position = 'relative';
+  return true;
+}
+
+function releasePositionedContainer(container: HTMLElement): void {
+  const state = positionedContainers.get(container);
+  if (!state) {
+    return;
+  }
+  state.count--;
+  if (state.count === 0) {
+    container.style.position = state.previousPosition;
+    positionedContainers.delete(container);
+  }
+}
+
+function resolveTarget(target?: CanvasErrorDisplayTarget): HTMLElement | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  if (typeof target === 'string') {
+    return document.getElementById(target);
+  }
+  return target || null;
+}
+
+function getErrorTitle(error: Error): string {
+  if (error instanceof DeviceCreationError) {
+    return 'Unable to start graphics';
+  }
+  if (getDeviceLossInfo(error)) {
+    return 'Graphics device lost';
+  }
+  return 'Graphics error';
+}
+
+function formatTechnicalDetails(error: Error): string {
+  if (error instanceof DeviceCreationError) {
+    return error.attempts
+      .map((attempt, index) => {
+        const profile = attempt.featureLevel ? `/${attempt.featureLevel}` : '';
+        const software = attempt.software ? '/software' : '';
+        const message = attempt.error?.message || 'Unknown failure';
+        return `${index + 1}. ${attempt.backend}${profile}${software} [${attempt.phase}] ${message}`;
+      })
+      .join('\n');
+  }
+  const loss = getDeviceLossInfo(error);
+  if (loss) {
+    return `Device loss [${loss.reason}]\n${loss.message}`;
+  }
+  return error.stack || '';
+}
+
+function getDeviceLossInfo(error: Error): {reason: string; message: string} | undefined {
+  return (error as Error & {deviceLossInfo?: {reason: string; message: string}}).deviceLossInfo;
+}

--- a/modules/engine/src/animation-loop/make-animation-loop.ts
+++ b/modules/engine/src/animation-loop/make-animation-loop.ts
@@ -148,15 +148,13 @@ function prepareAutomaticDeviceProps(
   }
 
   const canvas = document.createElement('canvas');
+  const width = requestedCanvasProps.width ?? 800;
+  const height = requestedCanvasProps.height ?? 600;
   canvas.id = requestedCanvasProps.id || `luma-animation-loop-canvas-${automaticCanvasCounter++}`;
-  canvas.width = requestedCanvasProps.width || 800;
-  canvas.height = requestedCanvasProps.height || 600;
-  canvas.style.width = Number.isFinite(requestedCanvasProps.width)
-    ? `${requestedCanvasProps.width}px`
-    : '100%';
-  canvas.style.height = Number.isFinite(requestedCanvasProps.height)
-    ? `${requestedCanvasProps.height}px`
-    : '100%';
+  canvas.width = width;
+  canvas.height = height;
+  canvas.style.width = Number.isFinite(width) ? `${width}px` : '100%';
+  canvas.style.height = Number.isFinite(height) ? `${height}px` : '100%';
   if (requestedCanvasProps.visible === false) {
     canvas.style.visibility = 'hidden';
   }

--- a/modules/engine/src/animation-loop/make-animation-loop.ts
+++ b/modules/engine/src/animation-loop/make-animation-loop.ts
@@ -62,7 +62,7 @@ export function makeAnimationLoop(
     typeof OffscreenCanvas !== 'undefined' &&
     preparedDeviceProps.createCanvasContext?.canvas instanceof OffscreenCanvas;
   const errorDisplay =
-    props.errorDisplay === false || usesOffscreenCanvas
+    props.errorDisplay === false || (usesOffscreenCanvas && !props.errorDisplay?.target)
       ? false
       : {
           ...props.errorDisplay,

--- a/modules/engine/src/animation-loop/make-animation-loop.ts
+++ b/modules/engine/src/animation-loop/make-animation-loop.ts
@@ -71,13 +71,7 @@ export function makeAnimationLoop(
             (preparedDeviceProps ? getDeviceErrorTarget(preparedDeviceProps) : undefined)
         };
 
-  const device =
-    props.device ||
-    luma.createDevice({
-      ...preparedDeviceProps,
-      id: 'animation-loop',
-      adapters: props.adapters
-    });
+  const device = props.device || createAutomaticDevice(preparedDeviceProps!, props.adapters);
 
   const onAfterRender = props.onAfterRender;
 
@@ -126,6 +120,14 @@ export function makeAnimationLoop(
   };
 
   return templateAnimationLoop;
+}
+
+async function createAutomaticDevice(
+  deviceProps: Omit<CreateDeviceProps, 'adapters'>,
+  adapters?: Adapter[]
+): Promise<Device> {
+  await insertAutomaticCanvas(deviceProps);
+  return await luma.createDevice({...deviceProps, id: 'animation-loop', adapters});
 }
 
 function prepareAutomaticDeviceProps(
@@ -181,6 +183,39 @@ function getDeviceErrorTarget(
     return typeof canvas === 'string' || !canvas.id ? canvas : canvas.id;
   }
   return resolveContainer(canvasProps?.container) || undefined;
+}
+
+async function insertAutomaticCanvas(
+  deviceProps: Omit<CreateDeviceProps, 'adapters'>
+): Promise<void> {
+  const canvasProps = deviceProps.createCanvasContext;
+  if (
+    !deviceProps._canvasContextOwned ||
+    typeof document === 'undefined' ||
+    canvasProps === true ||
+    !(canvasProps?.canvas instanceof HTMLCanvasElement) ||
+    canvasProps.canvas.isConnected
+  ) {
+    return;
+  }
+  const canvas = canvasProps.canvas;
+
+  let container = resolveContainer(canvasProps?.container);
+  if (!container && document.readyState !== 'complete') {
+    await new Promise<void>(resolve => {
+      const target = document.readyState === 'loading' ? document : window;
+      target.addEventListener(
+        document.readyState === 'loading' ? 'DOMContentLoaded' : 'load',
+        () => resolve(),
+        {
+          once: true
+        }
+      );
+    });
+    container = resolveContainer(canvasProps?.container);
+  }
+  container ||= document.body || document.documentElement;
+  container.insertBefore(canvas, container.firstChild);
 }
 
 function resolveContainer(container?: HTMLElement | string | null): HTMLElement | null {

--- a/modules/engine/src/animation-loop/make-animation-loop.ts
+++ b/modules/engine/src/animation-loop/make-animation-loop.ts
@@ -127,7 +127,7 @@ async function createAutomaticDevice(
   adapters?: Adapter[]
 ): Promise<Device> {
   await insertAutomaticCanvas(deviceProps);
-  return await luma.createDevice({...deviceProps, id: 'animation-loop', adapters});
+  return await luma.createDevice({id: 'animation-loop', ...deviceProps, adapters});
 }
 
 function prepareAutomaticDeviceProps(

--- a/modules/engine/src/animation-loop/make-animation-loop.ts
+++ b/modules/engine/src/animation-loop/make-animation-loop.ts
@@ -2,24 +2,42 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import {luma, Adapter, Device} from '@luma.gl/core';
+import {luma, Adapter, Device, type CreateDeviceProps} from '@luma.gl/core';
 import {AnimationLoopTemplate} from './animation-loop-template';
 import {AnimationLoop, AnimationLoopProps} from './animation-loop';
 import type {AnimationProps} from './animation-props';
+import type {CanvasErrorDisplayTarget} from './canvas-error-display';
+
+let automaticCanvasCounter = 0;
 
 /** Props accepted while constructing an animation loop from a template. */
-export type MakeAnimationLoopProps = Omit<
+type MakeAnimationLoopBaseProps = Omit<
   AnimationLoopProps,
-  'onCreateDevice' | 'onInitialize' | 'onRedraw' | 'onFinalize'
+  'device' | 'onInitialize' | 'onRender' | 'onFinalize'
 > & {
-  /** List of adapters to use when creating the device */
-  adapters?: Adapter[];
   /** Runs after the template has encoded its frame and before the animation loop submits it. */
   onAfterRender?: (
     animationProps: AnimationProps,
     animationLoopTemplate: AnimationLoopTemplate | null
   ) => unknown;
 };
+
+type AutomaticAnimationLoopDeviceProps = {
+  device?: undefined;
+  /** List of adapters to use when creating the device. */
+  adapters?: Adapter[];
+  /** Device options used when makeAnimationLoop creates the device. */
+  deviceProps?: Omit<CreateDeviceProps, 'adapters'>;
+};
+
+type SuppliedAnimationLoopDeviceProps = {
+  device: Device | Promise<Device>;
+  adapters?: never;
+  deviceProps?: never;
+};
+
+export type MakeAnimationLoopProps = MakeAnimationLoopBaseProps &
+  (AutomaticAnimationLoopDeviceProps | SuppliedAnimationLoopDeviceProps);
 
 /** Animation loop created from a template, with access to the active template instance. */
 export type TemplateAnimationLoop = AnimationLoop & {
@@ -33,47 +51,59 @@ export type TemplateAnimationLoop = AnimationLoop & {
  */
 export function makeAnimationLoop(
   AnimationLoopTemplateCtor: typeof AnimationLoopTemplate,
-  props?: MakeAnimationLoopProps
+  props: MakeAnimationLoopProps = {}
 ): TemplateAnimationLoop {
   let renderLoop: AnimationLoopTemplate | null = null;
 
+  const preparedDeviceProps = props.device ? null : prepareAutomaticDeviceProps(props.deviceProps);
+  const usesOffscreenCanvas =
+    preparedDeviceProps &&
+    preparedDeviceProps.createCanvasContext !== true &&
+    typeof OffscreenCanvas !== 'undefined' &&
+    preparedDeviceProps.createCanvasContext?.canvas instanceof OffscreenCanvas;
+  const errorDisplay =
+    props.errorDisplay === false || usesOffscreenCanvas
+      ? false
+      : {
+          ...props.errorDisplay,
+          target:
+            props.errorDisplay?.target ||
+            (preparedDeviceProps ? getDeviceErrorTarget(preparedDeviceProps) : undefined)
+        };
+
   const device =
-    props?.device ||
+    props.device ||
     luma.createDevice({
+      ...preparedDeviceProps,
       id: 'animation-loop',
-      adapters: props?.adapters,
-      createCanvasContext: true
+      adapters: props.adapters
     });
+
+  const onAfterRender = props.onAfterRender;
 
   // Create an animation loop;
   const animationLoop = new AnimationLoop({
     ...props,
 
     device,
+    errorDisplay,
 
     async onInitialize(animationProps: AnimationProps): Promise<unknown> {
-      clearError(animationProps.animationLoop.device);
       try {
         // @ts-expect-error abstract to prevent instantiation
         renderLoop = new AnimationLoopTemplateCtor(animationProps);
         // Any async loading can be handled here
         return await renderLoop?.onInitialize(animationProps);
       } catch (error) {
-        // biome-ignore lint/suspicious/noConsole: fallback logging before rendering the in-canvas error banner.
-        console.error(error);
         renderLoop = null;
-        setError(animationProps.animationLoop.device, error as Error);
-        animationProps.animationLoop.stop();
-        return null;
+        throw error;
       }
     },
 
     onRender(animationProps: AnimationProps): unknown {
       const renderResult = renderLoop?.onRender(animationProps);
-      const afterRenderResult = props?.onAfterRender?.(animationProps, renderLoop);
-      return props?.onAfterRender
-        ? renderResult !== false || afterRenderResult !== false
-        : renderResult;
+      const afterRenderResult = onAfterRender?.(animationProps, renderLoop);
+      return onAfterRender ? renderResult !== false || afterRenderResult !== false : renderResult;
     },
 
     onFinalize(animationProps: AnimationProps): void {
@@ -98,36 +128,67 @@ export function makeAnimationLoop(
   return templateAnimationLoop;
 }
 
-function setError(device: Device | null, error: Error): void {
-  if (!device) {
-    return;
+function prepareAutomaticDeviceProps(
+  deviceProps: Omit<CreateDeviceProps, 'adapters'> = {}
+): Omit<CreateDeviceProps, 'adapters'> {
+  const requestedCanvasProps =
+    deviceProps.createCanvasContext === true || !deviceProps.createCanvasContext
+      ? {}
+      : deviceProps.createCanvasContext;
+
+  if (
+    typeof document === 'undefined' ||
+    (typeof OffscreenCanvas !== 'undefined' &&
+      requestedCanvasProps.canvas instanceof OffscreenCanvas) ||
+    requestedCanvasProps.canvas
+  ) {
+    return {...deviceProps, createCanvasContext: requestedCanvasProps};
   }
 
-  const canvas = device.getDefaultCanvasContext().canvas;
-  if (canvas instanceof HTMLCanvasElement) {
-    canvas.style.overflow = 'visible';
-    let errorDiv = document.getElementById('animation-loop-error');
-    errorDiv?.remove();
-    errorDiv = document.createElement('h1');
-    errorDiv.id = 'animation-loop-error';
-    errorDiv.innerHTML = error.message;
-    errorDiv.style.position = 'absolute';
-    errorDiv.style.top = '10px'; // left: 50%; transform: translate(-50%, -50%);';
-    errorDiv.style.left = '10px';
-    errorDiv.style.color = 'black';
-    errorDiv.style.backgroundColor = 'red';
-    canvas.parentElement?.appendChild(errorDiv);
-    // canvas.style.position = 'absolute';
+  const canvas = document.createElement('canvas');
+  canvas.id = requestedCanvasProps.id || `luma-animation-loop-canvas-${automaticCanvasCounter++}`;
+  canvas.width = requestedCanvasProps.width || 800;
+  canvas.height = requestedCanvasProps.height || 600;
+  canvas.style.width = Number.isFinite(requestedCanvasProps.width)
+    ? `${requestedCanvasProps.width}px`
+    : '100%';
+  canvas.style.height = Number.isFinite(requestedCanvasProps.height)
+    ? `${requestedCanvasProps.height}px`
+    : '100%';
+  if (requestedCanvasProps.visible === false) {
+    canvas.style.visibility = 'hidden';
   }
+
+  const container = resolveContainer(requestedCanvasProps.container);
+  container?.insertBefore(canvas, container.firstChild);
+  return {
+    ...deviceProps,
+    _canvasContextOwned: true,
+    createCanvasContext: {...requestedCanvasProps, canvas}
+  };
 }
 
-function clearError(device: Device | null): void {
-  if (!device) {
-    return;
+function getDeviceErrorTarget(
+  deviceProps: Omit<CreateDeviceProps, 'adapters'>
+): CanvasErrorDisplayTarget | undefined {
+  const canvasProps =
+    deviceProps.createCanvasContext === true ? {} : deviceProps.createCanvasContext;
+  const canvas = canvasProps?.canvas;
+  if (
+    typeof canvas === 'string' ||
+    (typeof HTMLCanvasElement !== 'undefined' && canvas instanceof HTMLCanvasElement)
+  ) {
+    return typeof canvas === 'string' || !canvas.id ? canvas : canvas.id;
   }
+  return resolveContainer(canvasProps?.container) || undefined;
+}
 
-  const errorDiv = document.getElementById('animation-loop-error');
-  if (errorDiv) {
-    errorDiv.remove();
+function resolveContainer(container?: HTMLElement | string | null): HTMLElement | null {
+  if (typeof document === 'undefined') {
+    return null;
   }
+  if (typeof container === 'string') {
+    return document.getElementById(container);
+  }
+  return container || document.body;
 }

--- a/modules/engine/src/index.ts
+++ b/modules/engine/src/index.ts
@@ -39,6 +39,11 @@ export type {
   AnimationLoopProps
 } from './animation-loop/animation-loop';
 export {AnimationLoop} from './animation-loop/animation-loop';
+export type {
+  CanvasErrorDisplayProps,
+  CanvasErrorDisplayTarget
+} from './animation-loop/canvas-error-display';
+export {CanvasErrorDisplay} from './animation-loop/canvas-error-display';
 
 export type {MakeAnimationLoopProps} from './animation-loop/make-animation-loop';
 export type {TemplateAnimationLoop} from './animation-loop/make-animation-loop';

--- a/modules/engine/src/passes/shader-pass-renderer.ts
+++ b/modules/engine/src/passes/shader-pass-renderer.ts
@@ -764,7 +764,8 @@ function isShaderPassPipeline(shaderPass: ShaderPassLike): shaderPass is ShaderP
   return 'steps' in shaderPass;
 }
 
-function supportsComputeOptimization(device: Device, pipeline: ShaderPassPipeline): boolean {
+/** @internal Returns whether a pipeline's optional compute path is valid for this device. */
+export function supportsComputeOptimization(device: Device, pipeline: ShaderPassPipeline): boolean {
   const optimization = pipeline.compute;
   if (!optimization || device.type !== 'webgpu') {
     return false;

--- a/modules/engine/test/lib/animation-loop.spec.ts
+++ b/modules/engine/test/lib/animation-loop.spec.ts
@@ -239,6 +239,7 @@ test('engine#AnimationLoop does not attach device handlers after stopping during
 test('engine#makeAnimationLoop stops after template initialization failure', async t => {
   const device = await getWebGLTestDevice();
   let renderCalled = 0;
+  let finalizeCalled = 0;
 
   class FailingAnimationLoopTemplate extends AnimationLoopTemplate {
     override async onInitialize(): Promise<unknown> {
@@ -249,7 +250,9 @@ test('engine#makeAnimationLoop stops after template initialization failure', asy
       renderCalled++;
     }
 
-    override onFinalize(): void {}
+    override onFinalize(): void {
+      finalizeCalled++;
+    }
   }
 
   const reportedErrors: Error[] = [];
@@ -267,6 +270,7 @@ test('engine#makeAnimationLoop stops after template initialization failure', asy
   t.equal(startError?.message, 'Expected initialization failure', 'start preserves the error');
   t.equal(reportedErrors.length, 1, 'initialization failure is reported once');
   t.is(renderCalled, 0, 'onRender is not called after template initialization failure');
+  t.is(finalizeCalled, 0, 'incomplete initialization is not finalized');
   if (typeof document !== 'undefined') {
     const errorDisplay = document.querySelector('[data-luma-error-display="true"]');
     t.ok(errorDisplay, 'fatal error is visible over the canvas');
@@ -283,6 +287,39 @@ test('engine#makeAnimationLoop stops after template initialization failure', asy
     );
   }
 
+  t.end();
+});
+
+test('engine#AnimationLoop finalizes after a fatal render error', async t => {
+  const device = new NullDevice({createCanvasContext: true});
+  const expectedError = new Error('Expected render failure');
+  const reportedErrors: Error[] = [];
+  let finalizeCalled = 0;
+  const animationLoop = new AnimationLoop({
+    device,
+    animationFrameProvider: {
+      requestAnimationFrame: () => 1,
+      cancelAnimationFrame: () => {}
+    },
+    onRender: () => {
+      throw expectedError;
+    },
+    onFinalize: () => {
+      finalizeCalled++;
+    },
+    onError: error => reportedErrors.push(error)
+  });
+
+  await animationLoop.start();
+  t.throws(() => animationLoop.redraw(), 'fatal render failure is preserved');
+
+  t.deepEqual(reportedErrors, [expectedError], 'fatal render failure is reported once');
+  t.is(finalizeCalled, 1, 'initialized loop is finalized after the fatal error');
+  t.equal(animationLoop._running, false, 'fatal render failure stops the loop');
+
+  animationLoop.destroy();
+  t.is(finalizeCalled, 1, 'destroy does not finalize the stopped loop twice');
+  device.destroy();
   t.end();
 });
 
@@ -571,6 +608,7 @@ test('engine#makeAnimationLoop preserves default automatic canvas dimensions', a
   const animationLoop = makeAnimationLoop(DefaultCanvasAnimationLoopTemplate, {
     adapters: [nullAdapter],
     deviceProps: {
+      id: 'custom-animation-loop-device',
       type: 'null',
       waitForPageLoad: false,
       createCanvasContext: {container}
@@ -585,6 +623,7 @@ test('engine#makeAnimationLoop preserves default automatic canvas dimensions', a
   t.is(canvas?.style.height, '600px', 'default CSS height is preserved');
 
   await animationLoop.start();
+  t.is(animationLoop.device?.id, 'custom-animation-loop-device', 'caller device id is preserved');
   animationLoop.destroy();
   container.remove();
   t.end();

--- a/modules/engine/test/lib/animation-loop.spec.ts
+++ b/modules/engine/test/lib/animation-loop.spec.ts
@@ -311,9 +311,15 @@ test('engine#AnimationLoop finalizes after a fatal render error', async t => {
   });
 
   await animationLoop.start();
+  let renderWaitError: Error | null = null;
+  const renderWaitPromise = animationLoop.waitForRender().catch(error => {
+    renderWaitError = error as Error;
+  });
   t.throws(() => animationLoop.redraw(), 'fatal render failure is preserved');
+  await renderWaitPromise;
 
   t.deepEqual(reportedErrors, [expectedError], 'fatal render failure is reported once');
+  t.equal(renderWaitError, expectedError, 'pending render wait rejects with the fatal error');
   t.is(finalizeCalled, 1, 'initialized loop is finalized after the fatal error');
   t.equal(animationLoop._running, false, 'fatal render failure stops the loop');
 

--- a/modules/engine/test/lib/animation-loop.spec.ts
+++ b/modules/engine/test/lib/animation-loop.spec.ts
@@ -3,7 +3,12 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
-import {getWebGLTestDevice, getWebGPUTestDevice, NullDevice} from '@luma.gl/test-utils';
+import {
+  getWebGLTestDevice,
+  getWebGPUTestDevice,
+  nullAdapter,
+  NullDevice
+} from '@luma.gl/test-utils';
 import {luma} from '@luma.gl/core';
 import {webgpuAdapter, type WebGPUDevice} from '@luma.gl/webgpu';
 
@@ -390,6 +395,51 @@ test('engine#makeAnimationLoop exposes the active template instance', async t =>
   );
   animationLoop.destroy();
   t.is(animationLoop.getAnimationLoopTemplate(), null, 'finalized template is no longer exposed');
+  t.end();
+});
+
+test('engine#makeAnimationLoop inserts its automatic canvas after the DOM is ready', async t => {
+  if (typeof document === 'undefined') {
+    t.comment('DOM is unavailable');
+    t.end();
+    return;
+  }
+
+  const readyStateDescriptor = Object.getOwnPropertyDescriptor(document, 'readyState');
+  Object.defineProperty(document, 'readyState', {configurable: true, value: 'loading'});
+  const containerId = 'late-animation-loop-container';
+
+  class DeferredCanvasAnimationLoopTemplate extends AnimationLoopTemplate {
+    override onRender(): void {}
+    override onFinalize(): void {}
+  }
+
+  const animationLoop = makeAnimationLoop(DeferredCanvasAnimationLoopTemplate, {
+    adapters: [nullAdapter],
+    deviceProps: {
+      type: 'null',
+      waitForPageLoad: false,
+      createCanvasContext: {container: containerId}
+    }
+  });
+
+  const container = document.createElement('div');
+  container.id = containerId;
+  document.body.appendChild(container);
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+
+  try {
+    await animationLoop.start();
+    t.ok(container.querySelector('canvas'), 'automatic canvas is inserted into the late container');
+  } finally {
+    animationLoop.destroy();
+    container.remove();
+    if (readyStateDescriptor) {
+      Object.defineProperty(document, 'readyState', readyStateDescriptor);
+    } else {
+      delete (document as Document & {readyState?: string}).readyState;
+    }
+  }
   t.end();
 });
 

--- a/modules/engine/test/lib/animation-loop.spec.ts
+++ b/modules/engine/test/lib/animation-loop.spec.ts
@@ -292,6 +292,88 @@ test('engine#AnimationLoop reports device promise rejection to an explicit targe
   t.end();
 });
 
+test('engine#AnimationLoop preserves an explicit target after an HTML device resolves', async t => {
+  if (typeof document === 'undefined') {
+    t.comment('DOM is unavailable');
+    t.end();
+    return;
+  }
+
+  const canvasContainer = document.createElement('div');
+  const errorContainer = document.createElement('div');
+  const canvas = document.createElement('canvas');
+  canvasContainer.appendChild(canvas);
+  document.body.append(canvasContainer, errorContainer);
+  const device = new NullDevice({createCanvasContext: {canvas}});
+  const animationLoop = new AnimationLoop({
+    device,
+    errorDisplay: {target: errorContainer},
+    onError: () => {}
+  });
+  await animationLoop.start();
+
+  animationLoop.reportError(new Error('Explicit target failure'));
+
+  t.ok(
+    errorContainer.querySelector('[data-luma-error-display="true"]'),
+    'fatal error remains in the explicit target'
+  );
+  t.notOk(
+    canvasContainer.querySelector('[data-luma-error-display="true"]'),
+    'resolved canvas does not replace the explicit target'
+  );
+
+  animationLoop.destroy();
+  canvasContainer.remove();
+  errorContainer.remove();
+  device.destroy();
+  t.end();
+});
+
+test('engine#makeAnimationLoop preserves an explicit target for an offscreen device', async t => {
+  if (typeof document === 'undefined' || typeof OffscreenCanvas === 'undefined') {
+    t.comment('Offscreen DOM execution is unavailable');
+    t.end();
+    return;
+  }
+
+  class FailingOffscreenAnimationLoopTemplate extends AnimationLoopTemplate {
+    override onInitialize(): never {
+      throw new Error('Offscreen initialization failure');
+    }
+    override onRender(): void {}
+    override onFinalize(): void {}
+  }
+
+  const errorContainer = document.createElement('div');
+  document.body.appendChild(errorContainer);
+  const animationLoop = makeAnimationLoop(FailingOffscreenAnimationLoopTemplate, {
+    adapters: [nullAdapter],
+    deviceProps: {
+      type: 'null',
+      waitForPageLoad: false,
+      createCanvasContext: {canvas: new OffscreenCanvas(16, 16)}
+    },
+    errorDisplay: {target: errorContainer},
+    onError: () => {}
+  });
+
+  try {
+    await animationLoop.start();
+  } catch {
+    // Expected initialization failure.
+  }
+
+  t.ok(
+    errorContainer.querySelector('[data-luma-error-display="true"]'),
+    'offscreen fatal error is shown in the explicit DOM target'
+  );
+
+  animationLoop.destroy();
+  errorContainer.remove();
+  t.end();
+});
+
 test('engine#AnimationLoop briefly displays asynchronous device errors without stopping', async t => {
   if (typeof document === 'undefined') {
     t.comment('DOM is unavailable');

--- a/modules/engine/test/lib/animation-loop.spec.ts
+++ b/modules/engine/test/lib/animation-loop.spec.ts
@@ -207,6 +207,35 @@ test('engine#AnimationLoop start followed immediately by stop() should stop', as
   t.end();
 });
 
+test('engine#AnimationLoop does not attach device handlers after stopping during creation', async t => {
+  let resolveDevice!: (device: NullDevice) => void;
+  const devicePromise = new Promise<NullDevice>(resolve => {
+    resolveDevice = resolve;
+  });
+  const device = new NullDevice({});
+  const originalOnError = device.props.onError;
+  let initializeCalled = 0;
+  const animationLoop = new AnimationLoop({
+    device: devicePromise,
+    onInitialize: () => {
+      initializeCalled++;
+    }
+  });
+
+  const startPromise = animationLoop.start();
+  animationLoop.stop();
+  resolveDevice(device);
+  const startResult = await startPromise;
+
+  t.is(startResult, null, 'late device resolution leaves the loop stopped');
+  t.is(initializeCalled, 0, 'late device resolution does not initialize the loop');
+  t.is(device.props.onError, originalOnError, 'late device resolution does not retain the loop');
+
+  animationLoop.destroy();
+  device.destroy();
+  t.end();
+});
+
 test('engine#makeAnimationLoop stops after template initialization failure', async t => {
   const device = await getWebGLTestDevice();
   let renderCalled = 0;
@@ -522,6 +551,42 @@ test('engine#makeAnimationLoop inserts its automatic canvas after the DOM is rea
       delete (document as Document & {readyState?: string}).readyState;
     }
   }
+  t.end();
+});
+
+test('engine#makeAnimationLoop preserves default automatic canvas dimensions', async t => {
+  if (typeof document === 'undefined') {
+    t.comment('DOM is unavailable');
+    t.end();
+    return;
+  }
+
+  class DefaultCanvasAnimationLoopTemplate extends AnimationLoopTemplate {
+    override onRender(): void {}
+    override onFinalize(): void {}
+  }
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const animationLoop = makeAnimationLoop(DefaultCanvasAnimationLoopTemplate, {
+    adapters: [nullAdapter],
+    deviceProps: {
+      type: 'null',
+      waitForPageLoad: false,
+      createCanvasContext: {container}
+    }
+  });
+  const canvas = container.querySelector('canvas');
+
+  t.ok(canvas, 'automatic canvas is created synchronously for an available container');
+  t.is(canvas?.width, 800, 'default drawing-buffer width is preserved');
+  t.is(canvas?.height, 600, 'default drawing-buffer height is preserved');
+  t.is(canvas?.style.width, '800px', 'default CSS width is preserved');
+  t.is(canvas?.style.height, '600px', 'default CSS height is preserved');
+
+  await animationLoop.start();
+  animationLoop.destroy();
+  container.remove();
   t.end();
 });
 

--- a/modules/engine/test/lib/animation-loop.spec.ts
+++ b/modules/engine/test/lib/animation-loop.spec.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
-import {getWebGLTestDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
+import {getWebGLTestDevice, getWebGPUTestDevice, NullDevice} from '@luma.gl/test-utils';
 import {luma} from '@luma.gl/core';
 import {webgpuAdapter, type WebGPUDevice} from '@luma.gl/webgpu';
 
@@ -218,26 +218,156 @@ test('engine#makeAnimationLoop stops after template initialization failure', asy
     override onFinalize(): void {}
   }
 
-  // biome-ignore lint/suspicious/noConsole: test suppresses expected initialization failure logging.
-  const originalConsoleError = console.error;
-  // biome-ignore lint/suspicious/noConsole: test suppresses expected initialization failure logging.
-  console.error = () => {};
+  const reportedErrors: Error[] = [];
+  const animationLoop = makeAnimationLoop(FailingAnimationLoopTemplate, {
+    device,
+    onError: error => reportedErrors.push(error)
+  });
+  let startError: Error | null = null;
   try {
-    const animationLoop = makeAnimationLoop(FailingAnimationLoopTemplate, {
-      device
-    });
-    const startResult = await animationLoop.start();
-    t.is(startResult, null, 'Animation loop stops after template initialization failure');
-    t.is(renderCalled, 0, 'onRender is not called after template initialization failure');
-    animationLoop.destroy();
-  } finally {
-    // biome-ignore lint/suspicious/noConsole: test restores console state after suppressing expected logging.
-    console.error = originalConsoleError;
-    if (typeof document !== 'undefined') {
-      document.getElementById('animation-loop-error')?.remove();
-    }
+    await animationLoop.start();
+  } catch (error) {
+    startError = error as Error;
   }
 
+  t.equal(startError?.message, 'Expected initialization failure', 'start preserves the error');
+  t.equal(reportedErrors.length, 1, 'initialization failure is reported once');
+  t.is(renderCalled, 0, 'onRender is not called after template initialization failure');
+  if (typeof document !== 'undefined') {
+    const errorDisplay = document.querySelector('[data-luma-error-display="true"]');
+    t.ok(errorDisplay, 'fatal error is visible over the canvas');
+    t.ok(
+      errorDisplay?.textContent?.includes('Expected initialization failure'),
+      'error display includes the failure message'
+    );
+  }
+  animationLoop.destroy();
+  if (typeof document !== 'undefined') {
+    t.notOk(
+      document.querySelector('[data-luma-error-display="true"]'),
+      'destroy removes the error display'
+    );
+  }
+
+  t.end();
+});
+
+test('engine#AnimationLoop reports device promise rejection to an explicit target', async t => {
+  if (typeof document === 'undefined') {
+    t.comment('DOM is unavailable');
+    t.end();
+    return;
+  }
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const expectedError = new Error('<device creation failed>');
+  const animationLoop = new AnimationLoop({
+    device: Promise.reject(expectedError),
+    errorDisplay: {target: container},
+    onError: () => {}
+  });
+
+  try {
+    await animationLoop.start();
+  } catch {
+    // Expected failure.
+  }
+
+  const errorDisplay = container.querySelector('[data-luma-error-display="true"]');
+  t.ok(errorDisplay, 'device creation failure is visible without a resolved device');
+  t.ok(
+    errorDisplay?.textContent?.includes('<device creation failed>'),
+    'error is inserted as text rather than HTML'
+  );
+  t.notOk(errorDisplay?.querySelector('device'), 'error text did not create markup');
+
+  animationLoop.destroy();
+  container.remove();
+  t.end();
+});
+
+test('engine#AnimationLoop briefly displays asynchronous device errors without stopping', async t => {
+  if (typeof document === 'undefined') {
+    t.comment('DOM is unavailable');
+    t.end();
+    return;
+  }
+
+  const container = document.createElement('div');
+  const canvas = document.createElement('canvas');
+  container.appendChild(canvas);
+  document.body.appendChild(container);
+  const device = new NullDevice({createCanvasContext: {canvas}});
+  const animationLoop = new AnimationLoop({device});
+  await animationLoop.start();
+
+  device.reportError(new Error('<expected asynchronous GPU error>'), device)();
+
+  const errorMessage = container.querySelector('[data-luma-error-message="true"]');
+  t.equal(animationLoop._running, true, 'runtime device error does not stop the animation loop');
+  t.ok(errorMessage, 'runtime device error is briefly visible over the canvas');
+  t.equal(errorMessage?.getAttribute('role'), 'status', 'message has an accessible status role');
+  t.equal(
+    errorMessage?.textContent,
+    '<expected asynchronous GPU error>',
+    'message is inserted as text rather than HTML'
+  );
+  t.equal(errorMessage?.querySelector('expected'), null, 'message text did not create markup');
+  t.ok(
+    (errorMessage as HTMLElement | null)?.style.transition.includes('opacity'),
+    'message is configured to fade out'
+  );
+  t.notOk(
+    container.querySelector('[data-luma-error-display="true"]'),
+    'nonfatal error does not create the fatal overlay'
+  );
+
+  animationLoop.destroy();
+  t.notOk(
+    container.querySelector('[data-luma-error-message="true"]'),
+    'destroy removes the transient message'
+  );
+  container.remove();
+  device.destroy();
+  t.end();
+});
+
+test('engine#AnimationLoop defers runtime device errors to DeviceProps.onError', async t => {
+  if (typeof document === 'undefined') {
+    t.comment('DOM is unavailable');
+    t.end();
+    return;
+  }
+
+  const container = document.createElement('div');
+  const canvas = document.createElement('canvas');
+  container.appendChild(canvas);
+  document.body.appendChild(container);
+  const reportedErrors: Error[] = [];
+  const device = new NullDevice({
+    createCanvasContext: {canvas},
+    onError: error => {
+      reportedErrors.push(error);
+      return true;
+    }
+  });
+  const animationLoop = new AnimationLoop({device});
+  await animationLoop.start();
+
+  const expectedError = new Error('Application-owned device error');
+  device.reportError(expectedError, device)();
+
+  t.deepEqual(reportedErrors, [expectedError], 'application device error handler is called');
+  t.equal(animationLoop._running, true, 'handled device error keeps rendering');
+  t.notOk(
+    container.querySelector('[data-luma-error-message="true"]'),
+    'application device error handler suppresses the default canvas message'
+  );
+
+  animationLoop.destroy();
+  container.remove();
+  device.destroy();
   t.end();
 });
 

--- a/modules/engine/test/passes/shader-pass-renderer.spec.ts
+++ b/modules/engine/test/passes/shader-pass-renderer.spec.ts
@@ -6,7 +6,8 @@ import test from 'test/utils/vitest-tape';
 import {getTestDevices, getWebGPUTestDevice} from '@luma.gl/test-utils';
 import {ShaderPassRenderer, DynamicTexture, ShaderInputs} from '@luma.gl/engine';
 import type {ShaderPass, ShaderPassPipeline} from '@luma.gl/shadertools';
-import {Buffer, CommandEncoder, Texture} from '@luma.gl/core';
+import {Buffer, CommandEncoder, Texture, type Device} from '@luma.gl/core';
+import {supportsComputeOptimization} from '../../src/passes/shader-pass-renderer';
 
 const invertPass: ShaderPass = {
   name: 'invert',
@@ -188,6 +189,58 @@ const stagedPipeline: ShaderPassPipeline<'extract' | 'blurred'> = {
     }
   ]
 };
+
+test('ShaderPassRenderer compute optimization requires storage-capable output formats', t => {
+  const pipeline: ShaderPassPipeline<'output'> = {
+    name: 'storage-capability-gate',
+    renderTargets: {output: {format: 'bgra8unorm', storage: true}},
+    steps: [],
+    compute: {
+      name: 'storage-capability-compute',
+      source: '',
+      uniformModule: 'storageCapability',
+      uniformBinding: 'storageCapabilityUniforms',
+      uniformNames: [],
+      uniforms: {},
+      input: 'original',
+      outputs: {outputTexture: 'output'},
+      replacedPasses: [],
+      workgroupSize: [8, 8]
+    }
+  };
+  let supportsStorage = false;
+  const device = {
+    type: 'webgpu',
+    preferredColorFormat: 'bgra8unorm',
+    limits: {
+      maxStorageTexturesPerShaderStage: 4,
+      maxComputeWorkgroupSizeX: 256,
+      maxComputeWorkgroupSizeY: 256,
+      maxComputeInvocationsPerWorkgroup: 256
+    },
+    getTextureFormatCapabilities: (format: 'bgra8unorm') => ({
+      format,
+      create: true,
+      render: true,
+      filter: true,
+      blend: true,
+      store: supportsStorage
+    })
+  } as unknown as Device;
+
+  t.equal(
+    supportsComputeOptimization(device, pipeline),
+    false,
+    'unsupported storage format selects the render-pass fallback'
+  );
+  supportsStorage = true;
+  t.equal(
+    supportsComputeOptimization(device, pipeline),
+    true,
+    'storage-capable format enables the compute optimization'
+  );
+  t.end();
+});
 
 const tintPipeline: ShaderPassPipeline<'scratch'> = {
   name: 'tintPipeline',

--- a/modules/test-utils/src/null-device/null-device.ts
+++ b/modules/test-utils/src/null-device/null-device.ts
@@ -23,7 +23,8 @@ import type {
   CommandEncoder,
   CommandEncoderProps,
   TransformFeedbackProps,
-  QuerySetProps
+  QuerySetProps,
+  DeviceLostInfo
 } from '@luma.gl/core';
 import {Device, DeviceFeatures} from '@luma.gl/core';
 import type {NullCommandBuffer} from './resources/null-command-buffer';
@@ -57,12 +58,12 @@ export class NullDevice extends Device {
 
   features: DeviceFeatures = new DeviceFeatures([], this.props._disabledFeatures);
   limits: NullDeviceLimits = new NullDeviceLimits();
-  readonly info = NullDeviceInfo;
+  readonly info = {...NullDeviceInfo};
 
   readonly canvasContext: NullCanvasContext;
   override commandEncoder: NullCommandEncoder;
 
-  readonly lost: Promise<{reason: 'destroyed'; message: string}>;
+  readonly lost: Promise<DeviceLostInfo>;
 
   constructor(props: DeviceProps) {
     super({...props, id: props.id || 'null-device'});

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -33,7 +33,8 @@ import type {
   TransformFeedbackProps,
   QuerySetProps,
   Resource,
-  VertexFormat
+  VertexFormat,
+  DeviceLostInfo
 } from '@luma.gl/core';
 import {Device, CanvasContext, log} from '@luma.gl/core';
 import type {GLExtensions} from '@luma.gl/webgl/constants';
@@ -103,9 +104,10 @@ export class WebGLDevice extends Device {
 
   commandEncoder!: WEBGLCommandEncoder;
 
-  readonly lost: Promise<{reason: 'destroyed'; message: string}>;
+  readonly lost: Promise<DeviceLostInfo>;
 
-  private _resolveContextLost?: (value: {reason: 'destroyed'; message: string}) => void;
+  private _resolveContextLost?: (value: DeviceLostInfo) => void;
+  private _lossWasRequested = false;
 
   /** WebGL2 context. */
   readonly gl!: WebGL2RenderingContext;
@@ -165,7 +167,7 @@ export class WebGLDevice extends Device {
     // Create and instrument context
     this.canvasContext = new WebGLCanvasContext(this, canvasContextProps);
 
-    this.lost = new Promise<{reason: 'destroyed'; message: string}>(resolve => {
+    this.lost = new Promise<DeviceLostInfo>(resolve => {
       this._resolveContextLost = resolve;
     });
 
@@ -189,11 +191,15 @@ export class WebGLDevice extends Device {
       createBrowserContext(
         this.canvasContext.canvas,
         {
-          onContextLost: (event: Event) =>
-            this._resolveContextLost?.({
-              reason: 'destroyed',
-              message: 'Entered sleep mode, or too many apps or browser tabs are using the GPU.'
-            }),
+          onContextLost: (_event: Event) => {
+            const loss: DeviceLostInfo = {
+              reason: this._lossWasRequested ? 'destroyed' : 'unknown',
+              message: this._lossWasRequested
+                ? 'Application triggered context loss'
+                : 'Entered sleep mode, or too many apps or browser tabs are using the GPU.'
+            };
+            this._resolveContextLost?.(loss);
+          },
           onContextRestored: (_event: Event) => {
             // biome-ignore lint/suspicious/noConsole: debug-only context restore notification.
             console.log('WebGL context restored');
@@ -502,6 +508,7 @@ export class WebGLDevice extends Device {
    * @note primarily intended for testing how application reacts to device loss
    */
   override loseDevice(): boolean {
+    this._lossWasRequested = true;
     let deviceLossTriggered = false;
     const extensions = this.getExtension('WEBGL_lose_context');
     const ext = extensions.WEBGL_lose_context;

--- a/modules/webgpu/src/adapter/helpers/webgpu-texture-capabilities.ts
+++ b/modules/webgpu/src/adapter/helpers/webgpu-texture-capabilities.ts
@@ -1,0 +1,229 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {
+  DeviceFeatures,
+  DeviceTextureFormatCapabilities,
+  TextureFormat,
+  WebGPUDeviceFeatureLevel
+} from '@luma.gl/core';
+
+const TIER_1_FORMATS = new Set<TextureFormat>([
+  'r16unorm',
+  'r16snorm',
+  'rg16unorm',
+  'rg16snorm',
+  'rgba16unorm',
+  'rgba16snorm'
+]);
+
+const RENDERABLE_FORMATS = new Set<TextureFormat>([
+  'r8unorm',
+  'r8uint',
+  'r8sint',
+  'rg8unorm',
+  'rg8uint',
+  'rg8sint',
+  'rgba8unorm',
+  'rgba8unorm-srgb',
+  'rgba8uint',
+  'rgba8sint',
+  'bgra8unorm',
+  'bgra8unorm-srgb',
+  'r16unorm',
+  'r16snorm',
+  'r16uint',
+  'r16sint',
+  'r16float',
+  'rg16unorm',
+  'rg16snorm',
+  'rg16uint',
+  'rg16sint',
+  'rg16float',
+  'rgba16unorm',
+  'rgba16snorm',
+  'rgba16uint',
+  'rgba16sint',
+  'rgba16float',
+  'r32uint',
+  'r32sint',
+  'r32float',
+  'rg32uint',
+  'rg32sint',
+  'rg32float',
+  'rgba32uint',
+  'rgba32sint',
+  'rgba32float',
+  'rgb10a2uint',
+  'rgb10a2unorm',
+  'stencil8',
+  'depth16unorm',
+  'depth24plus',
+  'depth24plus-stencil8',
+  'depth32float',
+  'depth32float-stencil8'
+]);
+
+const TIER_1_RENDERABLE_FORMATS = new Set<TextureFormat>(['r8snorm', 'rg8snorm', 'rgba8snorm']);
+
+const FILTERABLE_FORMATS = new Set<TextureFormat>([
+  'r8unorm',
+  'r8snorm',
+  'rg8unorm',
+  'rg8snorm',
+  'rgba8unorm',
+  'rgba8unorm-srgb',
+  'rgba8snorm',
+  'bgra8unorm',
+  'bgra8unorm-srgb',
+  'r16float',
+  'rg16float',
+  'rgba16float',
+  'rgb9e5ufloat',
+  'rgb10a2unorm',
+  'rg11b10ufloat'
+]);
+
+const BLENDABLE_FORMATS = new Set<TextureFormat>([
+  'r8unorm',
+  'rg8unorm',
+  'rgba8unorm',
+  'rgba8unorm-srgb',
+  'bgra8unorm',
+  'bgra8unorm-srgb',
+  'r16unorm',
+  'r16snorm',
+  'r16float',
+  'rg16unorm',
+  'rg16snorm',
+  'rg16float',
+  'rgba16unorm',
+  'rgba16snorm',
+  'rgba16float',
+  'rgb10a2unorm'
+]);
+
+const TIER_1_BLENDABLE_FORMATS = new Set<TextureFormat>(['r8snorm', 'rg8snorm', 'rgba8snorm']);
+
+const STORAGE_FORMATS = new Set<TextureFormat>([
+  'rgba8unorm',
+  'rgba8snorm',
+  'rgba8uint',
+  'rgba8sint',
+  'rgba16unorm',
+  'rgba16snorm',
+  'rgba16uint',
+  'rgba16sint',
+  'rgba16float',
+  'r32uint',
+  'r32sint',
+  'r32float',
+  'rgba32uint',
+  'rgba32sint',
+  'rgba32float'
+]);
+
+const TIER_1_STORAGE_FORMATS = new Set<TextureFormat>([
+  'r8unorm',
+  'r8snorm',
+  'r8uint',
+  'r8sint',
+  'rg8unorm',
+  'rg8snorm',
+  'rg8uint',
+  'rg8sint',
+  'r16unorm',
+  'r16snorm',
+  'r16uint',
+  'r16sint',
+  'r16float',
+  'rg16unorm',
+  'rg16snorm',
+  'rg16uint',
+  'rg16sint',
+  'rg16float',
+  'rgb10a2uint',
+  'rgb10a2unorm',
+  'rg11b10ufloat'
+]);
+
+const CORE_STORAGE_FORMATS = new Set<TextureFormat>(['rg32uint', 'rg32sint', 'rg32float']);
+
+/** Returns spec-derived texture usages for the active WebGPU feature set. */
+export function getWebGPUTextureFormatCapabilities(
+  format: TextureFormat,
+  features: DeviceFeatures,
+  featureLevel: WebGPUDeviceFeatureLevel
+): DeviceTextureFormatCapabilities {
+  const tier1 = features.has('texture-formats-tier1');
+  const core = featureLevel !== 'compatibility' || features.has('core-features-and-limits');
+  const create = isWebGPUTextureFormatSupported(format, features, tier1, core);
+  const render =
+    create &&
+    (RENDERABLE_FORMATS.has(format) ||
+      (tier1 && TIER_1_RENDERABLE_FORMATS.has(format)) ||
+      (format === 'rg11b10ufloat' && features.has('rg11b10ufloat-renderable')));
+  const filter =
+    create &&
+    (FILTERABLE_FORMATS.has(format) ||
+      (isFloat32Format(format) && features.has('float32-filterable')) ||
+      isCompressedFormat(format));
+  const blend =
+    render &&
+    (BLENDABLE_FORMATS.has(format) ||
+      (tier1 && TIER_1_BLENDABLE_FORMATS.has(format)) ||
+      (isFloat32Format(format) && features.has('float32-blendable')) ||
+      (format === 'rg11b10ufloat' && features.has('rg11b10ufloat-renderable')));
+  const store =
+    create &&
+    (STORAGE_FORMATS.has(format) ||
+      (tier1 && TIER_1_STORAGE_FORMATS.has(format)) ||
+      (core && CORE_STORAGE_FORMATS.has(format)) ||
+      (format === 'bgra8unorm' && features.has('bgra8unorm-storage')));
+
+  return {format, create, render, filter, blend, store};
+}
+
+function isWebGPUTextureFormatSupported(
+  format: TextureFormat,
+  features: DeviceFeatures,
+  tier1: boolean,
+  core: boolean
+): boolean {
+  if (format.includes('webgl')) {
+    return false;
+  }
+  if (TIER_1_FORMATS.has(format) && !tier1) {
+    return false;
+  }
+  if (format === 'bgra8unorm-srgb' && !core) {
+    return false;
+  }
+  if (format === 'depth32float-stencil8') {
+    return features.has('depth32float-stencil8');
+  }
+  if (format.startsWith('bc')) {
+    return features.has('texture-compression-bc');
+  }
+  if (format.startsWith('etc2') || format.startsWith('eac')) {
+    return features.has('texture-compression-etc2');
+  }
+  if (format.startsWith('astc')) {
+    return features.has('texture-compression-astc');
+  }
+  return true;
+}
+
+function isFloat32Format(format: TextureFormat): boolean {
+  return format === 'r32float' || format === 'rg32float' || format === 'rgba32float';
+}
+
+function isCompressedFormat(format: TextureFormat): boolean {
+  return (
+    format.startsWith('bc') ||
+    format.startsWith('etc2') ||
+    format.startsWith('eac') ||
+    format.startsWith('astc')
+  );
+}

--- a/modules/webgpu/src/adapter/webgpu-adapter.ts
+++ b/modules/webgpu/src/adapter/webgpu-adapter.ts
@@ -230,6 +230,14 @@ export class WebGPUAdapter extends Adapter {
     }
 
     const adapterInfo = await getWebGPUAdapterInfo(adapter);
+    if (props.failIfMajorPerformanceCaveat && isSoftwareWebGPUAdapter(adapter, adapterInfo)) {
+      throw makeWebGPUCreationError(
+        new Error('Software WebGPU adapter rejected'),
+        requestedFeatureLevel,
+        true,
+        'adapter-selection'
+      );
+    }
     // log.probe(2, 'Adapter available', adapterInfo)();
 
     const deviceDescriptor: GPUDeviceDescriptor = {};
@@ -340,6 +348,26 @@ export async function getWebGPUAdapterInfo(adapter: GPUAdapter): Promise<GPUAdap
     log.warn('WebGPU adapter metadata is unavailable', error)();
     return {} as GPUAdapterInfo;
   }
+}
+
+/** Identifies software adapters before native device or canvas creation. */
+export function isSoftwareWebGPUAdapter(adapter: GPUAdapter, adapterInfo: GPUAdapterInfo): boolean {
+  const fallback = Boolean(
+    (adapterInfo as GPUAdapterInfo & {isFallbackAdapter?: boolean}).isFallbackAdapter ??
+      (adapter as GPUAdapter & {isFallbackAdapter?: boolean}).isFallbackAdapter
+  );
+  const extendedAdapterInfo = adapterInfo as GPUAdapterInfo & {
+    driver?: string;
+    gpuType?: string;
+    type?: string;
+  };
+  const adapterType = String(extendedAdapterInfo.type || extendedAdapterInfo.gpuType || '')
+    .split(' ')[0]
+    .toLowerCase();
+  const description = `${adapterInfo.vendor || ''} ${extendedAdapterInfo.driver || ''} ${
+    adapterInfo.architecture || ''
+  }`;
+  return fallback || adapterType === 'cpu' || /SwiftShader|llvmpipe|lavapipe/i.test(description);
 }
 
 function makeWebGPUCreationError(

--- a/modules/webgpu/src/adapter/webgpu-adapter.ts
+++ b/modules/webgpu/src/adapter/webgpu-adapter.ts
@@ -7,6 +7,7 @@
 
 import {
   Adapter,
+  DeviceCreationError,
   type DeviceInfo,
   type DeviceProps,
   type WebGPUDeviceFeature,
@@ -110,6 +111,10 @@ export function getWebGPURequestAdapterOptions(props: DeviceProps): GPURequestAd
     options.xrCompatible = true;
   }
 
+  if (props._forceFallbackAdapter) {
+    options.forceFallbackAdapter = true;
+  }
+
   return options;
 }
 
@@ -189,23 +194,42 @@ export class WebGPUAdapter extends Adapter {
   }
 
   async create(props: DeviceProps): Promise<WebGPUDevice> {
+    return await this._create(props, true);
+  }
+
+  private async _create(
+    props: DeviceProps,
+    allowImmediateLossRetry: boolean
+  ): Promise<WebGPUDevice> {
+    const requestedFeatureLevel = getWebGPUFeatureLevel(props);
+    const software = Boolean(props._forceFallbackAdapter);
     if (!navigator.gpu) {
-      throw new Error('WebGPU not available. Recent Chrome browsers should work.');
+      throw makeWebGPUCreationError(
+        new Error('WebGPU is not available'),
+        requestedFeatureLevel,
+        software,
+        'adapter-selection'
+      );
     }
 
-    const requestedFeatureLevel = getWebGPUFeatureLevel(props);
     const requestAdapterOptions = getWebGPURequestAdapterOptions(props);
-    const adapter = await this.requestGPUAdapter(requestAdapterOptions);
+    let adapter: GPUAdapter | null;
+    try {
+      adapter = await this.requestGPUAdapter(requestAdapterOptions);
+    } catch (error) {
+      throw makeWebGPUCreationError(error, requestedFeatureLevel, software, 'adapter-request');
+    }
 
     if (!adapter) {
-      throw new Error('Failed to request WebGPU adapter');
+      throw makeWebGPUCreationError(
+        new Error('Failed to request WebGPU adapter'),
+        requestedFeatureLevel,
+        software,
+        'adapter-request'
+      );
     }
 
-    //  Note: adapter.requestAdapterInfo() has been replaced with adapter.info. Fall back in case adapter.info is not available
-    const adapterInfo =
-      adapter.info ||
-      // @ts-ignore
-      (await adapter.requestAdapterInfo?.());
+    const adapterInfo = await getWebGPUAdapterInfo(adapter);
     // log.probe(2, 'Adapter available', adapterInfo)();
 
     const deviceDescriptor: GPUDeviceDescriptor = {};
@@ -223,7 +247,27 @@ export class WebGPUAdapter extends Adapter {
       deviceDescriptor.requiredLimits = getRequiredWebGPULimits(adapter.limits);
     }
 
-    const gpuDevice = await adapter.requestDevice(deviceDescriptor);
+    let gpuDevice: GPUDevice;
+    try {
+      gpuDevice = await adapter.requestDevice(deviceDescriptor);
+    } catch (error) {
+      throw makeWebGPUCreationError(error, requestedFeatureLevel, software, 'device-request');
+    }
+
+    const immediateLoss = await getImmediateDeviceLoss(gpuDevice);
+    if (immediateLoss) {
+      gpuDevice.destroy();
+      if (allowImmediateLossRetry && immediateLoss.reason !== 'destroyed') {
+        log.warn('WebGPU device was returned already lost; retrying with a fresh adapter')();
+        return await this._create(props, false);
+      }
+      throw makeWebGPUCreationError(
+        new Error(immediateLoss.message || 'WebGPU device was returned already lost'),
+        requestedFeatureLevel,
+        software,
+        'device-request'
+      );
+    }
 
     // log.probe(1, 'GPUDevice available')();
 
@@ -233,7 +277,33 @@ export class WebGPUAdapter extends Adapter {
 
     log.groupCollapsed(1, 'WebGPUDevice created')();
     try {
-      const device = new WebGPUDevice(deviceProps, gpuDevice, adapter, adapterInfo);
+      let device: WebGPUDevice;
+      try {
+        device = new WebGPUDevice(deviceProps, gpuDevice, adapter, adapterInfo);
+      } catch (error) {
+        gpuDevice.destroy();
+        throw makeWebGPUCreationError(
+          error,
+          requestedFeatureLevel,
+          software,
+          'wrapper-initialization'
+        );
+      }
+
+      const canvasContextProps = WebGPUDevice.getCanvasContextProps(deviceProps);
+      if (canvasContextProps) {
+        try {
+          device.initializeCanvasContext(canvasContextProps);
+        } catch (error) {
+          device.destroy();
+          throw makeWebGPUCreationError(
+            error,
+            requestedFeatureLevel,
+            software,
+            'canvas-initialization'
+          );
+        }
+      }
       log.probe(
         1,
         'Device created. For more info, set chrome://flags/#enable-webgpu-developer-features'
@@ -255,6 +325,45 @@ export class WebGPUAdapter extends Adapter {
   ): Promise<GPUAdapter | null> {
     return navigator.gpu.requestAdapter(requestAdapterOptions);
   }
+}
+
+/** Reads adapter metadata across current and legacy browsers without making it creation-critical. */
+export async function getWebGPUAdapterInfo(adapter: GPUAdapter): Promise<GPUAdapterInfo> {
+  try {
+    return (
+      adapter.info ||
+      // @ts-ignore Legacy Chromium API.
+      (await adapter.requestAdapterInfo?.()) ||
+      ({} as GPUAdapterInfo)
+    );
+  } catch (error) {
+    log.warn('WebGPU adapter metadata is unavailable', error)();
+    return {} as GPUAdapterInfo;
+  }
+}
+
+function makeWebGPUCreationError(
+  error: unknown,
+  featureLevel: RequestedWebGPUFeatureLevel,
+  software: boolean,
+  phase: import('@luma.gl/core').DeviceCreationPhase
+): DeviceCreationError {
+  if (error instanceof DeviceCreationError) {
+    return error;
+  }
+  const cause = error instanceof Error ? error : new Error(String(error));
+  return new DeviceCreationError(
+    `WebGPU ${phase} failed: ${cause.message}`,
+    [{backend: 'webgpu', featureLevel, software, phase, error: cause}],
+    cause
+  );
+}
+
+async function getImmediateDeviceLoss(device: GPUDevice): Promise<GPUDeviceLostInfo | null> {
+  return await Promise.race([
+    device.lost,
+    new Promise<null>(resolve => globalThis.setTimeout(() => resolve(null), 0))
+  ]);
 }
 
 export const webgpuAdapter = new WebGPUAdapter();

--- a/modules/webgpu/src/adapter/webgpu-canvas-context.ts
+++ b/modules/webgpu/src/adapter/webgpu-canvas-context.ts
@@ -75,7 +75,25 @@ export class WebGPUCanvasContext extends CanvasContext {
       this.depthStencilAttachment = null;
     }
 
-    const requestedColorFormat = this.colorFormat || this.device.preferredColorFormat;
+    let requestedColorFormat = this.colorFormat || this.device.preferredColorFormat;
+    let requestedToneMapping = this.toneMapping || this.props.toneMapping;
+    const getConfiguration =
+      typeof this.handle.getConfiguration === 'function'
+        ? () => this.handle.getConfiguration()
+        : null;
+    const requestedHighDynamicRange =
+      requestedColorFormat === 'rgba16float' || requestedToneMapping === 'extended';
+
+    // Older Chromium-derived browsers expose WebGPU without getConfiguration(). They cannot
+    // verify HDR acceptance, so preserve device creation and use a portable SDR canvas.
+    if (requestedHighDynamicRange && !getConfiguration) {
+      log.warn('HDR canvas verification is unavailable; using standard presentation')();
+      requestedColorFormat = navigator.gpu.getPreferredCanvasFormat() as
+        | 'rgba8unorm'
+        | 'bgra8unorm';
+      requestedToneMapping = 'standard';
+    }
+
     const requestedConfiguration: GPUCanvasConfiguration = {
       device: this.device.handle,
       format: requestedColorFormat,
@@ -83,40 +101,62 @@ export class WebGPUCanvasContext extends CanvasContext {
       // viewFormats: [...]
       colorSpace: this.colorSpace || this.props.colorSpace,
       alphaMode: this.props.alphaMode,
-      toneMapping: {mode: this.toneMapping || this.props.toneMapping},
+      ...(requestedToneMapping === 'extended' ? {toneMapping: {mode: requestedToneMapping}} : {}),
       usage:
         requestedColorFormat === 'rgba16float'
           ? Texture.RENDER_ATTACHMENT | Texture.COPY_SRC
           : Texture.RENDER_ATTACHMENT
     };
 
-    // Reconfigure the canvas size.
-    this.handle.configure(requestedConfiguration);
-
     let configuredConfiguration = requestedConfiguration;
-    let acceptedConfiguration = this.handle.getConfiguration();
+    let acceptedConfiguration: GPUCanvasConfigurationOut | null = null;
+    const standardConfiguration: GPUCanvasConfiguration = {
+      device: this.device.handle,
+      format: navigator.gpu.getPreferredCanvasFormat(),
+      colorSpace: 'srgb',
+      alphaMode: this.props.alphaMode,
+      usage: Texture.RENDER_ATTACHMENT
+    };
+
+    try {
+      this.handle.configure(requestedConfiguration);
+      if (requestedConfiguration.toneMapping?.mode === 'extended') {
+        try {
+          acceptedConfiguration = getConfiguration?.() || null;
+        } catch (error) {
+          log.warn(
+            'Unable to verify HDR canvas configuration; using standard presentation',
+            error
+          )();
+        }
+      }
+    } catch (error) {
+      if (requestedConfiguration.toneMapping?.mode !== 'extended') {
+        throw error;
+      }
+      log.warn('HDR canvas configuration was rejected; using standard presentation', error)();
+      configuredConfiguration = standardConfiguration;
+      this.handle.configure(standardConfiguration);
+    }
+
     if (
       requestedConfiguration.toneMapping?.mode === 'extended' &&
-      !isHighDynamicRangeCanvasConfiguration(acceptedConfiguration)
+      !isHighDynamicRangeCanvasConfiguration(acceptedConfiguration) &&
+      configuredConfiguration !== standardConfiguration
     ) {
-      const standardConfiguration: GPUCanvasConfiguration = {
-        device: this.device.handle,
-        format: navigator.gpu.getPreferredCanvasFormat(),
-        colorSpace: 'srgb',
-        alphaMode: this.props.alphaMode,
-        toneMapping: {mode: 'standard'},
-        usage: Texture.RENDER_ATTACHMENT
-      };
+      log.warn('HDR canvas configuration was not accepted; using standard presentation')();
       this.handle.configure(standardConfiguration);
       configuredConfiguration = standardConfiguration;
-      acceptedConfiguration = this.handle.getConfiguration();
+      acceptedConfiguration = null;
     }
 
     this.colorFormat = (acceptedConfiguration?.format ||
       configuredConfiguration.format) as typeof this.colorFormat;
     this.colorSpace = acceptedConfiguration?.colorSpace || configuredConfiguration.colorSpace;
     this.toneMapping =
-      acceptedConfiguration?.toneMapping?.mode || configuredConfiguration.toneMapping?.mode;
+      acceptedConfiguration?.toneMapping?.mode ||
+      configuredConfiguration.toneMapping?.mode ||
+      'standard';
 
     this._createDepthStencilAttachment(this.device.preferredDepthFormat);
   }

--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -32,6 +32,7 @@ import type {
   QuerySet,
   QuerySetProps,
   DeviceProps,
+  DeviceLostInfo,
   CommandEncoderProps,
   CommandEncoder,
   PipelineLayoutProps,
@@ -58,6 +59,7 @@ import {WebGPUCommandBuffer} from './resources/webgpu-command-buffer';
 import {WebGPUQuerySet} from './resources/webgpu-query-set';
 import {WebGPUPipelineLayout} from './resources/webgpu-pipeline-layout';
 import {WebGPUFence} from './resources/webgpu-fence';
+import {getWebGPUTextureFormatCapabilities} from './helpers/webgpu-texture-capabilities';
 
 import {
   getShaderLayoutFromWGSL,
@@ -83,7 +85,7 @@ export class WebGPUDevice extends Device {
   /** type of this device */
   readonly type = 'webgpu';
 
-  readonly preferredColorFormat: 'rgba8unorm' | 'bgra8unorm' | 'rgba16float';
+  preferredColorFormat: 'rgba8unorm' | 'bgra8unorm' | 'rgba16float';
   readonly preferredDepthFormat = 'depth24plus';
 
   readonly features: DeviceFeatures;
@@ -91,7 +93,7 @@ export class WebGPUDevice extends Device {
   readonly info: DeviceInfo;
   readonly limits: DeviceLimits;
 
-  readonly lost: Promise<{reason: 'destroyed'; message: string}>;
+  readonly lost: Promise<DeviceLostInfo>;
 
   override canvasContext: WebGPUCanvasContext | null = null;
 
@@ -141,16 +143,25 @@ export class WebGPUDevice extends Device {
     // "Context" loss handling
     this.lost = this.handle.lost.then(lostInfo => {
       this._isLost = true;
-      return {reason: 'destroyed', message: lostInfo.message};
+      const loss: DeviceLostInfo = {
+        reason: lostInfo.reason === 'destroyed' ? 'destroyed' : 'unknown',
+        message: lostInfo.message
+      };
+      return loss;
     });
 
-    // Note: WebGPU devices can be created without a canvas, for compute shader purposes
-    if (canvasContextProps) {
-      this.canvasContext = new WebGPUCanvasContext(this, this.adapter, canvasContextProps);
-      this.preferredColorFormat = this.canvasContext.colorFormat || this.preferredColorFormat;
-    }
-
     this.commandEncoder = this.createCommandEncoder({});
+  }
+
+  /** @internal Returns normalized canvas props before a device wrapper exists. */
+  static getCanvasContextProps(props: DeviceProps): CanvasContextProps | undefined {
+    return Device._getCanvasContextProps(props);
+  }
+
+  /** @internal Initializes the default canvas as a separately diagnosable creation stage. */
+  initializeCanvasContext(props: CanvasContextProps): void {
+    this.canvasContext = new WebGPUCanvasContext(this, this.adapter, props);
+    this.preferredColorFormat = this.canvasContext.colorFormat || this.preferredColorFormat;
   }
 
   // TODO
@@ -592,11 +603,11 @@ export class WebGPUDevice extends Device {
   override _getDeviceSpecificTextureFormatCapabilities(
     capabilities: DeviceTextureFormatCapabilities
   ): DeviceTextureFormatCapabilities {
-    const {format} = capabilities;
-    if (format.includes('webgl')) {
-      return {format, create: false, render: false, filter: false, blend: false, store: false};
-    }
-    return capabilities;
+    return getWebGPUTextureFormatCapabilities(
+      capabilities.format,
+      this.features,
+      getWebGPUDeviceFeatureLevel(this.props.featureLevel)
+    );
   }
 }
 

--- a/modules/webgpu/test/adapter/webgpu-device-lifecycle.node.spec.ts
+++ b/modules/webgpu/test/adapter/webgpu-device-lifecycle.node.spec.ts
@@ -1,0 +1,156 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {DeviceCreationError, type DeviceProps} from '@luma.gl/core';
+import {getWebGPUAdapterInfo, WebGPUAdapter} from '../../src/adapter/webgpu-adapter';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+class MockWebGPUAdapter extends WebGPUAdapter {
+  readonly requests: GPURequestAdapterOptions[] = [];
+
+  constructor(private readonly adapters: GPUAdapter[]) {
+    super();
+  }
+
+  protected override async requestGPUAdapter(
+    options: GPURequestAdapterOptions
+  ): Promise<GPUAdapter | null> {
+    this.requests.push(options);
+    return this.adapters.shift() || null;
+  }
+}
+
+function makeDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolver => {
+    resolve = resolver;
+  });
+  return {promise, resolve};
+}
+
+function makeNativeDevice(lost: Promise<GPUDeviceLostInfo>) {
+  const commandEncoder = {label: ''};
+  return {
+    device: {
+      features: new Set(),
+      limits: {},
+      lost,
+      queue: {},
+      addEventListener: vi.fn(),
+      createCommandEncoder: vi.fn(() => commandEncoder),
+      destroy: vi.fn()
+    } as unknown as GPUDevice,
+    commandEncoder
+  };
+}
+
+function makeNativeAdapter(device: GPUDevice, info: GPUAdapterInfo = {} as GPUAdapterInfo) {
+  const requestDevice = vi.fn(async (_descriptor: GPUDeviceDescriptor) => device);
+  return {
+    adapter: {
+      features: new Set(),
+      limits: {},
+      info,
+      requestDevice
+    } as unknown as GPUAdapter,
+    requestDevice
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal('navigator', {
+    gpu: {
+      getPreferredCanvasFormat: () => 'bgra8unorm',
+      requestAdapter: vi.fn()
+    }
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('WebGPU device creation lifecycle', () => {
+  test('uses an empty descriptor for the safe core profile', async () => {
+    const pendingLoss = makeDeferred<GPUDeviceLostInfo>();
+    const nativeDevice = makeNativeDevice(pendingLoss.promise);
+    const nativeAdapter = makeNativeAdapter(nativeDevice.device);
+    const adapter = new MockWebGPUAdapter([nativeAdapter.adapter]);
+
+    const device = await adapter.create({} as DeviceProps);
+
+    expect(nativeAdapter.requestDevice).toHaveBeenCalledWith({});
+    device.destroy();
+  });
+
+  test('retries one immediately lost device with a fresh adapter', async () => {
+    const firstDevice = makeNativeDevice(
+      Promise.resolve({reason: 'unknown', message: 'Transient driver loss'} as GPUDeviceLostInfo)
+    );
+    const pendingLoss = makeDeferred<GPUDeviceLostInfo>();
+    const secondDevice = makeNativeDevice(pendingLoss.promise);
+    const firstAdapter = makeNativeAdapter(firstDevice.device);
+    const secondAdapter = makeNativeAdapter(secondDevice.device);
+    const adapter = new MockWebGPUAdapter([firstAdapter.adapter, secondAdapter.adapter]);
+
+    const device = await adapter.create({} as DeviceProps);
+
+    expect(adapter.requests).toHaveLength(2);
+    expect(firstDevice.device.destroy).toHaveBeenCalledTimes(1);
+    expect(firstAdapter.requestDevice).toHaveBeenCalledWith({});
+    expect(secondAdapter.requestDevice).toHaveBeenCalledWith({});
+    device.destroy();
+  });
+
+  test('cleans up native devices after wrapper and canvas initialization failures', async () => {
+    const pendingWrapperLoss = makeDeferred<GPUDeviceLostInfo>();
+    const wrapperDevice = makeNativeDevice(pendingWrapperLoss.promise);
+    vi.mocked(wrapperDevice.device.createCommandEncoder).mockImplementation(() => {
+      throw new Error('Command encoder construction failed');
+    });
+    const wrapperAdapter = makeNativeAdapter(wrapperDevice.device);
+
+    await expect(
+      new MockWebGPUAdapter([wrapperAdapter.adapter]).create({} as DeviceProps)
+    ).rejects.toMatchObject<DeviceCreationError>({phase: 'wrapper-initialization'});
+    expect(wrapperDevice.device.destroy).toHaveBeenCalledTimes(1);
+
+    const pendingCanvasLoss = makeDeferred<GPUDeviceLostInfo>();
+    const canvasDevice = makeNativeDevice(pendingCanvasLoss.promise);
+    const canvasAdapter = makeNativeAdapter(canvasDevice.device);
+    await expect(
+      new MockWebGPUAdapter([canvasAdapter.adapter]).create({
+        createCanvasContext: true
+      } as DeviceProps)
+    ).rejects.toMatchObject<DeviceCreationError>({phase: 'canvas-initialization'});
+    expect(canvasDevice.device.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves native loss reasons', async () => {
+    const unexpectedLoss = makeDeferred<GPUDeviceLostInfo>();
+    const nativeDevice = makeNativeDevice(unexpectedLoss.promise);
+    const nativeAdapter = makeNativeAdapter(nativeDevice.device);
+    const device = await new MockWebGPUAdapter([nativeAdapter.adapter]).create({} as DeviceProps);
+    unexpectedLoss.resolve({reason: 'unknown', message: 'Driver reset'} as GPUDeviceLostInfo);
+
+    await expect(device.lost).resolves.toEqual({reason: 'unknown', message: 'Driver reset'});
+  });
+
+  test('tolerates missing and rejected adapter metadata', async () => {
+    await expect(getWebGPUAdapterInfo({} as GPUAdapter)).resolves.toEqual({});
+
+    const adapter = {} as GPUAdapter;
+    Object.defineProperty(adapter, 'info', {
+      get() {
+        throw new Error('Metadata blocked');
+      }
+    });
+    await expect(getWebGPUAdapterInfo(adapter)).resolves.toEqual({});
+  });
+});

--- a/modules/webgpu/test/adapter/webgpu-device-lifecycle.node.spec.ts
+++ b/modules/webgpu/test/adapter/webgpu-device-lifecycle.node.spec.ts
@@ -89,6 +89,25 @@ describe('WebGPU device creation lifecycle', () => {
     device.destroy();
   });
 
+  test('rejects software adapters before requesting a device or initializing a canvas', async () => {
+    const pendingLoss = makeDeferred<GPUDeviceLostInfo>();
+    const nativeDevice = makeNativeDevice(pendingLoss.promise);
+    const nativeAdapter = makeNativeAdapter(nativeDevice.device, {
+      type: 'CPU',
+      vendor: 'Software Adapter'
+    } as GPUAdapterInfo);
+    const adapter = new MockWebGPUAdapter([nativeAdapter.adapter]);
+
+    await expect(
+      adapter.create({
+        failIfMajorPerformanceCaveat: true,
+        createCanvasContext: {canvas: {} as HTMLCanvasElement}
+      } as DeviceProps)
+    ).rejects.toMatchObject<DeviceCreationError>({phase: 'adapter-selection'});
+
+    expect(nativeAdapter.requestDevice).not.toHaveBeenCalled();
+  });
+
   test('retries one immediately lost device with a fresh adapter', async () => {
     const firstDevice = makeNativeDevice(
       Promise.resolve({reason: 'unknown', message: 'Transient driver loss'} as GPUDeviceLostInfo)

--- a/modules/webgpu/test/adapter/webgpu-xr-adapter.node.spec.ts
+++ b/modules/webgpu/test/adapter/webgpu-xr-adapter.node.spec.ts
@@ -19,6 +19,7 @@ afterEach(() => {
 describe('XR-compatible WebGPU adapter requests', () => {
   test('preserves ordinary adapter requests unless XR compatibility is enabled', () => {
     expect(Device.defaultProps.xrCompatible).toBe(false);
+    expect(Device.defaultProps.powerPreference).toBe('default');
     expect(getWebGPURequestAdapterOptions({})).toEqual({featureLevel: 'core'});
     expect(getWebGPURequestAdapterOptions({xrCompatible: false})).toEqual({
       featureLevel: 'core'

--- a/modules/webgpu/test/webgpu/adapter/webgpu-adapter.spec.ts
+++ b/modules/webgpu/test/webgpu/adapter/webgpu-adapter.spec.ts
@@ -11,6 +11,9 @@ import {
   getWebGPURequestAdapterOptions
 } from '../../../src/adapter/webgpu-adapter';
 import {isHighDynamicRangeCanvasConfiguration} from '../../../src/adapter/webgpu-canvas-context';
+import {WebGPUCanvasContext} from '../../../src/adapter/webgpu-canvas-context';
+import {DeviceFeatures, _getTextureFormatTable, type TextureFormat} from '@luma.gl/core';
+import {getWebGPUTextureFormatCapabilities} from '../../../src/adapter/helpers/webgpu-texture-capabilities';
 
 test('WebGPUAdapter imports from the ESM package entry without circular init errors', async t => {
   t.plan(2);
@@ -75,6 +78,14 @@ test('WebGPUAdapter feature level helpers map luma props to WebGPU requests', t 
     getWebGPURequestAdapterOptions({featureLevel: 'best-available'}),
     {featureLevel: 'compatibility'},
     'best available starts from a compatibility adapter'
+  );
+  t.deepEqual(
+    getWebGPURequestAdapterOptions({
+      featureLevel: 'compatibility',
+      _forceFallbackAdapter: true
+    }),
+    {featureLevel: 'compatibility', forceFallbackAdapter: true},
+    'software fallback is explicitly requested'
   );
 
   t.end();
@@ -170,6 +181,244 @@ test('isHighDynamicRangeCanvasConfiguration verifies accepted HDR presentation',
     isHighDynamicRangeCanvasConfiguration(null),
     false,
     'an unavailable configuration cannot verify HDR support'
+  );
+  t.end();
+});
+
+test('WebGPUCanvasContext configures SDR without getConfiguration', t => {
+  const configurations: GPUCanvasConfiguration[] = [];
+  const context = makeMockCanvasContext({
+    preferredColorFormat: navigator.gpu.getPreferredCanvasFormat(),
+    toneMapping: 'standard',
+    handle: {
+      configure: configuration => configurations.push(configuration)
+    }
+  });
+
+  context._configureDevice();
+
+  t.equal(configurations.length, 1, 'standard canvas configures without introspection');
+  t.equal(
+    configurations[0]?.format,
+    navigator.gpu.getPreferredCanvasFormat(),
+    'standard canvas uses the browser preferred format'
+  );
+  t.equal(context.toneMapping, 'standard', 'standard tone mapping is recorded');
+  t.end();
+});
+
+test('WebGPUCanvasContext falls back from unverifiable or rejected HDR to SDR', t => {
+  const missingIntrospectionConfigurations: GPUCanvasConfiguration[] = [];
+  const missingIntrospectionContext = makeMockCanvasContext({
+    preferredColorFormat: 'rgba16float',
+    toneMapping: 'extended',
+    handle: {
+      configure: configuration => missingIntrospectionConfigurations.push(configuration)
+    }
+  });
+  missingIntrospectionContext._configureDevice();
+
+  t.equal(
+    missingIntrospectionConfigurations.length,
+    1,
+    'missing getConfiguration skips an unverifiable HDR request'
+  );
+  t.equal(
+    missingIntrospectionConfigurations[0]?.format,
+    navigator.gpu.getPreferredCanvasFormat(),
+    'missing getConfiguration uses the SDR format'
+  );
+  t.equal(
+    missingIntrospectionContext.toneMapping,
+    'standard',
+    'missing getConfiguration records the SDR fallback'
+  );
+
+  const rejectedConfigurations: GPUCanvasConfiguration[] = [];
+  const rejectedContext = makeMockCanvasContext({
+    preferredColorFormat: 'rgba16float',
+    toneMapping: 'extended',
+    handle: {
+      configure: configuration => {
+        rejectedConfigurations.push(configuration);
+        if (configuration.toneMapping?.mode === 'extended') {
+          throw new Error('HDR is unsupported');
+        }
+      },
+      getConfiguration: () => null
+    }
+  });
+  rejectedContext._configureDevice();
+
+  t.equal(rejectedConfigurations.length, 2, 'rejected HDR is followed by an SDR configuration');
+  t.equal(
+    rejectedConfigurations[1]?.format,
+    navigator.gpu.getPreferredCanvasFormat(),
+    'rejected HDR uses the SDR format'
+  );
+  t.equal(rejectedContext.toneMapping, 'standard', 'rejected HDR records the SDR fallback');
+  t.end();
+});
+
+test('WebGPU texture capabilities require the matching optional features', t => {
+  const baselineFeatures = new DeviceFeatures([], {});
+  const optionalFeatures = new DeviceFeatures(
+    ['bgra8unorm-storage', 'rg11b10ufloat-renderable', 'float32-filterable', 'float32-blendable'],
+    {}
+  );
+
+  t.equal(
+    getWebGPUTextureFormatCapabilities('bgra8unorm', baselineFeatures, 'core').store,
+    false,
+    'bgra storage is not over-reported'
+  );
+  t.equal(
+    getWebGPUTextureFormatCapabilities('bgra8unorm', optionalFeatures, 'core').store,
+    true,
+    'bgra storage is enabled by its feature'
+  );
+  t.equal(
+    getWebGPUTextureFormatCapabilities('rg11b10ufloat', baselineFeatures, 'core').render,
+    false,
+    'rg11b10 renderability is not over-reported'
+  );
+  t.equal(
+    getWebGPUTextureFormatCapabilities('rg11b10ufloat', optionalFeatures, 'core').render,
+    true,
+    'rg11b10 renderability is enabled by its feature'
+  );
+  const baselineFloat32 = getWebGPUTextureFormatCapabilities(
+    'rgba32float',
+    baselineFeatures,
+    'core'
+  );
+  const optionalFloat32 = getWebGPUTextureFormatCapabilities(
+    'rgba32float',
+    optionalFeatures,
+    'core'
+  );
+  t.equal(baselineFloat32.filter, false, 'float32 filtering is not over-reported');
+  t.equal(baselineFloat32.blend, false, 'float32 blending is not over-reported');
+  t.equal(optionalFloat32.filter, true, 'float32 filtering follows its feature');
+  t.equal(optionalFloat32.blend, true, 'float32 blending follows its feature');
+  t.equal(
+    getWebGPUTextureFormatCapabilities('rgba16float', baselineFeatures, 'core').store,
+    true,
+    'baseline rgba16float storage remains available to effects'
+  );
+  t.end();
+});
+
+function makeMockCanvasContext(options: {
+  preferredColorFormat: 'rgba8unorm' | 'bgra8unorm' | 'rgba16float';
+  toneMapping: 'standard' | 'extended';
+  handle: Pick<GPUCanvasContext, 'configure'> & Partial<Pick<GPUCanvasContext, 'getConfiguration'>>;
+}): WebGPUCanvasContext {
+  const context = Object.create(WebGPUCanvasContext.prototype) as WebGPUCanvasContext;
+  Object.assign(context, {
+    device: {
+      preferredColorFormat: options.preferredColorFormat,
+      preferredDepthFormat: 'depth24plus',
+      handle: {}
+    },
+    handle: options.handle,
+    props: {toneMapping: options.toneMapping, colorSpace: 'srgb', alphaMode: 'opaque'},
+    _createDepthStencilAttachment: () => {}
+  });
+  return context;
+}
+
+test('WebGPU texture capability table covers every luma texture format', t => {
+  const baselineFeatures = new DeviceFeatures([], {});
+  const formats = Object.keys(_getTextureFormatTable()) as TextureFormat[];
+
+  for (const format of formats) {
+    const capabilities = getWebGPUTextureFormatCapabilities(format, baselineFeatures, 'core');
+    t.equal(capabilities.format, format, `${format} preserves its format`);
+    for (const capability of ['create', 'render', 'filter', 'blend', 'store'] as const) {
+      t.equal(
+        typeof capabilities[capability],
+        'boolean',
+        `${format}.${capability} is explicitly classified`
+      );
+    }
+    if (format.includes('webgl')) {
+      t.deepEqual(
+        capabilities,
+        {format, create: false, render: false, filter: false, blend: false, store: false},
+        `${format} remains WebGL-only`
+      );
+    }
+  }
+  t.end();
+});
+
+test('WebGPU texture capabilities gate compressed, tier, and compatibility formats', t => {
+  const baselineFeatures = new DeviceFeatures([], {});
+  const optionalFeatures = new DeviceFeatures(
+    [
+      'core-features-and-limits',
+      'texture-compression-bc',
+      'texture-compression-etc2',
+      'texture-compression-astc',
+      'depth32float-stencil8',
+      'texture-formats-tier1',
+      'texture-formats-tier2'
+    ],
+    {}
+  );
+
+  for (const format of ['bc1-rgba-unorm', 'etc2-rgb8unorm', 'astc-4x4-unorm'] as const) {
+    t.equal(
+      getWebGPUTextureFormatCapabilities(format, baselineFeatures, 'core').create,
+      false,
+      `${format} requires its compression feature`
+    );
+    t.deepEqual(
+      getWebGPUTextureFormatCapabilities(format, optionalFeatures, 'core'),
+      {format, create: true, render: false, filter: true, blend: false, store: false},
+      `${format} is sampleable but not renderable or storage-capable`
+    );
+  }
+
+  t.equal(
+    getWebGPUTextureFormatCapabilities('depth32float-stencil8', baselineFeatures, 'core').create,
+    false,
+    'depth32float-stencil8 requires its optional feature'
+  );
+  t.equal(
+    getWebGPUTextureFormatCapabilities('depth32float-stencil8', optionalFeatures, 'core').render,
+    true,
+    'depth32float-stencil8 becomes renderable with its feature'
+  );
+  t.deepEqual(
+    getWebGPUTextureFormatCapabilities('r16unorm', baselineFeatures, 'core'),
+    {
+      format: 'r16unorm',
+      create: false,
+      render: false,
+      filter: false,
+      blend: false,
+      store: false
+    },
+    'tier-one normalized formats are unavailable without the feature'
+  );
+  t.deepEqual(
+    getWebGPUTextureFormatCapabilities('r16unorm', optionalFeatures, 'core'),
+    {
+      format: 'r16unorm',
+      create: true,
+      render: true,
+      filter: false,
+      blend: true,
+      store: true
+    },
+    'tier-one normalized formats expose only their specified capabilities'
+  );
+  t.equal(
+    getWebGPUTextureFormatCapabilities('bgra8unorm-srgb', baselineFeatures, 'compatibility').create,
+    false,
+    'compatibility profile does not over-report core-only sRGB BGRA creation'
   );
   t.end();
 });


### PR DESCRIPTION
#### Background

Recent Samsung Galaxy S23 reports show that exposing `navigator.gpu` does not guarantee successful device or canvas initialization. Device selection should be based on completed creation attempts, optional WebGPU capabilities should only be requested when needed, and fatal errors must remain visible on mobile devices without developer tools.

#### Change List

- Add outcome-based `best-available` and `best-available-webgpu` creation policies with structured, phase-specific diagnostics and bounded WebGPU retry/cleanup.
- Preserve native device-loss information, tolerate incomplete adapter metadata, and make SDR/HDR canvas initialization resilient across Chromium versions.
- Add an accessible per-animation-loop canvas error display: persistent diagnostics for fatal failures and brief red messages for the default `device.onError`; application-supplied handlers remain authoritative.
- Correct WebGPU texture capability reporting and prevent unsupported storage formats from selecting compute-effect paths.
- Forward complete automatic-device options through `makeAnimationLoop` and use mobile-safe power defaults.
- Add deterministic selection, lifecycle, overlay, and texture-capability tests plus API documentation.

#### Verification

- `nvm use` — passed
- `yarn install` — passed (peer dependency warnings only)
- `yarn lint fix` — passed
- `yarn build` — passed
- `yarn test` — Node: 3,064 passed; headless browser run exposed 18 failures, including two new mock issues that were fixed and rerun successfully. The remaining observed failures are unrelated existing real-WebGPU output, timeout, and benchmark failures.
- `yarn test-browser` — 1,827 passed; 4 unrelated real-WebGPU output/parity failures remain.
- `yarn test-headless` — exercised through `yarn test`; focused selection, lifecycle, overlay, and capability suites pass.
- `yarn website:build` — passed with existing documentation/chunk warnings.
- `(cd website && yarn build)` — passed with existing warnings.

#### Follow-up

- Validate both policies and the visible fatal-error path on a physical Galaxy S23 using current Chrome and Samsung Internet; record Android, One UI, browser, and adapter versions.
