### PR TITLE
feat(experimental): plan GPU dataframes with loaders.gl SQL

### DIFF
--- a/.yarn/patches/@loaders.gl-schema-utils-npm-5.0.0-alpha.5-b7b149a264.patch
+++ b/.yarn/patches/@loaders.gl-schema-utils-npm-5.0.0-alpha.5-b7b149a264.patch
@@ -1,0 +1,69 @@
+diff --git a/dist/lib/schema/convert-arrow-schema.js b/dist/lib/schema/convert-arrow-schema.js
+index d30b6a68072b37ae36d3da5200bb3ce365cf052b..c3e83598a375d49b247e01008140fc5bade5edc7 100644
+--- a/dist/lib/schema/convert-arrow-schema.js
++++ b/dist/lib/schema/convert-arrow-schema.js
+@@ -2,6 +2,8 @@
+ // SPDX-License-Identifier: MIT
+ // Copyright (c) vis.gl contributors
+ import * as arrow from 'apache-arrow';
++// Apache Arrow does not export LargeList in all supported runtime builds.
++const ArrowLargeList = arrow['Large' + 'List'];
+ /** Returns the variable-width view types exported by the installed Apache Arrow runtime. */
+ export function getArrowViewTypeSupport() {
+     const constructors = getArrowViewConstructors();
+@@ -198,7 +200,7 @@ export function serializeArrowType(arrowType) {
+                 type: 'list',
+                 children: [serializeArrowField(listField)]
+             };
+-        case arrow.LargeList:
++        case ArrowLargeList:
+             const largeListType = arrowType;
+             return {
+                 type: 'large-list',
+@@ -259,7 +261,10 @@ export function deserializeArrowType(dataType, options) {
+             }
+             case 'large-list': {
+                 const field = deserializeArrowField(dataType.children[0], options);
+-                return new arrow.LargeList(field);
++                if (!ArrowLargeList) {
++                    throw new Error('Apache Arrow LargeList is not available in this runtime');
++                }
++                return new ArrowLargeList(field);
+             }
+             case 'fixed-size-list': {
+                 const child = deserializeArrowField(dataType.children[0], options);
+diff --git a/src/lib/schema/convert-arrow-schema.ts b/src/lib/schema/convert-arrow-schema.ts
+index 830905133356d0754ca9f73bbb3fc9ad8efac866..51f8bf41ed743a86a005df3f89ecf9f703ed405c 100644
+--- a/src/lib/schema/convert-arrow-schema.ts
++++ b/src/lib/schema/convert-arrow-schema.ts
+@@ -5,6 +5,9 @@
+ import type {DataType, Field, KeyType, Schema, SchemaMetadata} from '@loaders.gl/schema';
+ import * as arrow from 'apache-arrow';
+ 
++// Apache Arrow does not export LargeList in all supported runtime builds.
++const ArrowLargeList = (arrow as typeof arrow & {LargeList?: typeof arrow.List}).LargeList;
++
+ type ArrowDictionaryKeyType =
+   | arrow.Int8
+   | arrow.Int16
+@@ -263,7 +266,7 @@ export function serializeArrowType(arrowType: arrow.DataType): DataType {
+         type: 'list',
+         children: [serializeArrowField(listField)]
+       };
+-    case arrow.LargeList:
++    case ArrowLargeList:
+       const largeListType = arrowType as arrow.LargeList;
+       return {
+         type: 'large-list',
+@@ -330,7 +333,10 @@ export function deserializeArrowType(
+       }
+       case 'large-list': {
+         const field = deserializeArrowField(dataType.children[0], options);
+-        return new arrow.LargeList(field);
++        if (!ArrowLargeList) {
++          throw new Error('Apache Arrow LargeList is not available in this runtime');
++        }
++        return new ArrowLargeList(field);
+       }
+       case 'fixed-size-list': {
+         const child = deserializeArrowField(dataType.children[0], options);

--- a/docs/api-reference/experimental/gpu-sql.md
+++ b/docs/api-reference/experimental/gpu-sql.md
@@ -11,18 +11,50 @@ import {ExperimentalDocsTabs} from '@site/src/components/docs/experimental-docs-
 existing GPU dataframes by name and lowers supported statements into the same immutable GPU
 dataframe planner. Planning does not upload, submit, allocate query output, or read GPU buffers.
 
+The same subpath also adapts the portable predicate and table-query syntax introduced by
+`@loaders.gl/sql` 5.0. `planGPUDataFrameQuery()` consumes the loaders.gl plan directly; luma.gl does
+not maintain a copied query planner or a second predicate syntax for this integration.
+
 ## When to use it
 
 Use GPU SQL when an application already has GPU dataframe inputs and a constrained SQL surface is
 more convenient than manually composing expressions, filters, aggregations, ordering, and joins.
 Use GPU Dataframe directly when an application needs behavior outside the supported grammar.
 
+Use the loaders.gl adapter when a query originates in a loader, catalog, or application component
+that already emits `TableQueryOptions` and `SQLPredicate` values:
+
+```ts
+import {parseSQLPredicate} from '@loaders.gl/sql';
+import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
+import {planGPUDataFrameQuery} from '@luma.gl/experimental/gpu-sql';
+
+const predicate = parseSQLPredicate('fare >= :minimum AND category IN (0, 1)', {
+  preserveParameters: true
+});
+const query = planGPUDataFrameQuery(frame, {
+  predicate,
+  columns: ['fare', 'category'],
+  parameters: {minimum: 8}
+});
+const compiled = query.compile(new GPUCommandGraph(device));
+
+const commandEncoder = device.createCommandEncoder();
+compiled.encode(commandEncoder, {minimum: 10});
+device.submit(commandEncoder.finish());
+```
+
+The compiled result stays GPU-resident as `table`, `validity`, `dictionaries`, `rowIndices`, and
+`selectedCounts`. Rendering or another command graph can consume those resources directly. Arrow
+readback remains an explicit adapter operation rather than the query's required result type.
+
 ## Execution boundary
 
-The execution boundary is explicit: Arrow input → GPU dataframe execution → Arrow output. Use
-`makeGPUAnalyticsTableFromArrowTable()` to upload input, construct a `GPUDataFrame`, register it
-with `LuSQLContext`, compile the query into a caller-owned `GPUCommandGraph`, encode and submit
-the graph, then call `makeArrowTableFromGPUAnalyticsTable()` for explicit result readback.
+The execution boundary is explicit: Arrow input → GPU dataframe execution → GPU consumers.
+Use `makeGPUAnalyticsTableFromArrowTable()` to upload input, construct a `GPUDataFrame`, compile
+the query into a caller-owned `GPUCommandGraph`, then encode and submit the graph. Downstream
+rendering and compute can use the compiled GPU resources directly. Call
+`makeArrowTableFromGPUAnalyticsTable()` only when the application explicitly needs CPU readback.
 
 ## Supported grammar
 
@@ -37,6 +69,11 @@ the graph, then call `makeArrowTableFromGPUAnalyticsTable()` for explicit result
 Unsupported statements, unknown columns, unregistered tables, unsupported strings, ambiguous
 expressions, multiple sort/group keys, and `LIMIT` without ordering fail during CPU-only planning.
 Applications still own command submission, synchronization, result readback, and cleanup.
+
+The loaders.gl adapter currently supports predicate pushdown and output projection. It accepts
+finite numeric, Boolean, and null predicate values, including reusable named parameters. Portable
+source-order `limit`, streaming, in-flight cancellation, string/binary/date values, and relational
+extensions are reported or rejected as unsupported instead of silently falling back to CPU work.
 
 ## Related modules
 

--- a/examples/api/texture-tester/package.json
+++ b/examples/api/texture-tester/package.json
@@ -8,9 +8,9 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "@loaders.gl/core": "~5.0.0-alpha.4",
-    "@loaders.gl/images": "~5.0.0-alpha.4",
-    "@loaders.gl/textures": "~5.0.0-alpha.4",
+    "@loaders.gl/core": "~5.0.0-alpha.5",
+    "@loaders.gl/images": "~5.0.0-alpha.5",
+    "@loaders.gl/textures": "~5.0.0-alpha.5",
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",
     "@luma.gl/shadertools": "9.4.0-alpha.4",

--- a/examples/experimental/gpu-data-analysis/package.json
+++ b/examples/experimental/gpu-data-analysis/package.json
@@ -9,8 +9,8 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "@loaders.gl/core": "~5.0.0-alpha.3",
-    "@loaders.gl/sql": "~5.0.0-alpha.3",
+    "@loaders.gl/core": "~5.0.0-alpha.5",
+    "@loaders.gl/sql": "~5.0.0-alpha.5",
     "@luma.gl/arrow": "9.4.0-alpha.4",
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",

--- a/examples/experimental/gpu-data-analysis/package.json
+++ b/examples/experimental/gpu-data-analysis/package.json
@@ -9,6 +9,8 @@
     "serve": "vite preview"
   },
   "dependencies": {
+    "@loaders.gl/core": "~5.0.0-alpha.3",
+    "@loaders.gl/sql": "~5.0.0-alpha.3",
     "@luma.gl/arrow": "9.4.0-alpha.4",
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",

--- a/examples/experimental/gpu-data-analysis/src/app-shell.ts
+++ b/examples/experimental/gpu-data-analysis/src/app-shell.ts
@@ -68,12 +68,12 @@ export const GPU_DATA_ANALYSIS_TEMPLATE = `
       <article><span>GPU / CPU VALIDATION</span><strong data-validation>—</strong></article>
     </section>
 
-    <section class="dataframe-lab" aria-label="Interactive luDF derived-column lab">
+    <section class="dataframe-lab" aria-label="Interactive loaders.gl SQL GPU dataframe lab">
       <div class="lab-heading">
         <div>
-          <p class="eyebrow">GPU DATAFRAME / DERIVED COLUMN LAB</p>
-          <h2>Run an expression and watch your data move.</h2>
-          <p>Transform and filter the exact GPU buffers already driving the charts above.</p>
+          <p class="eyebrow">LOADERS.GL SQL / GPU DATAFRAME LAB</p>
+          <h2>Plan on the CPU. Filter on the GPU.</h2>
+          <p>Use the loaders.gl 5.0 query syntax against the GPU buffers driving the charts above.</p>
         </div>
         <span class="lab-badge">ZERO ROW COPIES</span>
       </div>
@@ -81,39 +81,28 @@ export const GPU_DATA_ANALYSIS_TEMPLATE = `
       <div class="expression-editor">
         <div class="editor-titlebar">
           <span class="editor-dots"><i></i><i></i><i></i></span>
-          <span>derived-query.ts</span>
+          <span>loaders-sql-query.ts</span>
           <span>GPU-RESIDENT</span>
         </div>
         <div class="expression-code">
-          <p><span>01</span> <i>const</i> query = frame</p>
-          <p><span>02</span>   .<b>withColumn</b>(<em>'adjustedValue'</em>, expression)</p>
-          <p><span>03</span>   .<b>filter</b>(adjustedValue.greaterThan(threshold));</p>
+          <p><span>01</span> <i>const</i> predicate = <b>parseSQLPredicate</b>(<em>'value &gt; :threshold'</em>, {preserveParameters: true});</p>
+          <p><span>02</span> <i>const</i> query = <b>planGPUDataFrameQuery</b>(frame, {</p>
+          <p><span>03</span>   predicate, columns: [<em>'category'</em>, <em>'value'</em>] });</p>
         </div>
         <div class="live-expression">
           <span>LIVE EXPRESSION</span>
-          <strong data-gpu-dataframe-expression>value × 2 + 1 > 1</strong>
+          <strong data-gpu-dataframe-expression>value &gt; :threshold · threshold = 1</strong>
         </div>
       </div>
 
       <div class="expression-controls">
-        <label>Multiplier
-          <select data-gpu-dataframe-multiplier>
-            <option value="0.5">0.5×</option>
-            <option value="1">1×</option>
-            <option value="2" selected>2×</option>
-            <option value="4">4×</option>
-          </select>
-        </label>
-        <label>Adjustment
-          <input data-gpu-dataframe-adjustment type="number" value="1" step="0.25">
-        </label>
-        <label>Threshold
+        <label>SQL parameter :threshold
           <input data-gpu-dataframe-threshold type="number" value="1" step="0.25">
         </label>
-        <button class="query-button" data-gpu-dataframe-run>Execute GPU query <span>→</span></button>
+        <button class="query-button" data-gpu-dataframe-run>Execute loaders.gl query <span>→</span></button>
       </div>
 
-      <div class="query-metrics" aria-label="Derived-query results">
+      <div class="query-metrics" aria-label="Loaders SQL GPU query results">
         <article><span>SELECTED ROWS</span><strong data-gpu-dataframe-selected>—</strong></article>
         <article><span>SELECTION RATE</span><strong data-gpu-dataframe-rate>—</strong></article>
         <article><span>QUERY + READBACK</span><strong data-gpu-dataframe-execution>—</strong></article>
@@ -121,7 +110,7 @@ export const GPU_DATA_ANALYSIS_TEMPLATE = `
       </div>
 
       <p class="query-status" data-gpu-dataframe-result role="status" aria-live="polite">
-        Derive and filter existing Arrow-backed GPU columns without copying rows.
+        Parse a portable loaders.gl predicate and filter Arrow-backed GPU columns without copying rows.
       </p>
     </section>
 

--- a/examples/experimental/gpu-data-analysis/src/app.ts
+++ b/examples/experimental/gpu-data-analysis/src/app.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {makeArrowFixedSizeListVector, makeGPUVectorFromArrow} from '@luma.gl/arrow';
+import {parseSQLPredicate} from '@loaders.gl/sql';
 import {Buffer, luma, type Device} from '@luma.gl/core';
 import {
   GPUCommandGraph,
@@ -15,12 +16,11 @@ import {
   type CompiledGPUCommandGraph
 } from '@luma.gl/gpgpu/gpu-core';
 import {
-  column,
   GPUDataFrame,
-  parameter,
   type CompiledGPUDataFrameQuery,
   type GPUDataFrameQueryParameters
 } from '@luma.gl/experimental/gpu-dataframe';
+import {planGPUDataFrameQuery} from '@luma.gl/experimental/gpu-sql';
 import {type GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {GPURecordBatch, GPUTable} from '@luma.gl/experimental/gpu-tables';
 import {webgpuAdapter} from '@luma.gl/webgpu';
@@ -56,10 +56,8 @@ type ExampleElements = {
   groups: HTMLElement;
   heatmap: HTMLElement;
   histogram: HTMLElement;
-  gpuDataFrameAdjustment: HTMLInputElement;
   gpuDataFrameExecution: HTMLElement;
   gpuDataFrameExpression: HTMLElement;
-  gpuDataFrameMultiplier: HTMLSelectElement;
   gpuDataFramePreview: HTMLElement;
   gpuDataFrameRate: HTMLElement;
   gpuDataFrameResult: HTMLElement;
@@ -619,7 +617,7 @@ class GPUDataAnalysisExample {
     this.resources = null;
   }
 
-  /** Runs an opt-in dataframe derivation directly over the existing Arrow-uploaded GPU columns. */
+  /** Runs a loaders.gl SQL predicate directly over the existing Arrow-uploaded GPU columns. */
   private async runGPUDataFrameDemo(): Promise<void> {
     const device = this.device;
     const resources = this.resources;
@@ -628,23 +626,19 @@ class GPUDataAnalysisExample {
       return;
     }
 
-    const adjustment = Number(this.elements.gpuDataFrameAdjustment.value);
-    const multiplier = Number(this.elements.gpuDataFrameMultiplier.value);
     const threshold = Number(this.elements.gpuDataFrameThreshold.value);
-    if (![adjustment, multiplier, threshold].every(Number.isFinite)) {
-      this.elements.gpuDataFrameResult.textContent = 'Every expression parameter must be finite.';
+    if (!Number.isFinite(threshold)) {
+      this.elements.gpuDataFrameResult.textContent = 'The SQL threshold must be finite.';
       return;
     }
 
     this.hasRunGPUDataFrameDemo = true;
     this.elements.gpuDataFrameRun.disabled = true;
-    this.elements.gpuDataFrameResult.textContent = 'Compiling GPU-resident derived columns...';
+    this.elements.gpuDataFrameResult.textContent = 'Planning loaders.gl SQL for GPU execution...';
     this.elements.gpuDataFrameResult.dataset.state = 'running';
     const executionStarted = performance.now();
     let frame: GPUDataFrame<{value: 'float32'; category: 'uint32'}> | undefined;
-    let compiled:
-      | CompiledGPUDataFrameQuery<{category: 'uint32'; adjustedValue: 'float32'}>
-      | undefined;
+    let compiled: CompiledGPUDataFrameQuery<{category: 'uint32'; value: 'float32'}> | undefined;
 
     try {
       const batches = resources.values.data.map(
@@ -654,41 +648,35 @@ class GPUDataAnalysisExample {
           })
       );
       frame = new GPUDataFrame({table: new GPUTable({batches})});
-      const query = frame
-        .withColumn(
-          'adjustedValue',
-          column('value')
-            .multiply(parameter('multiplier', multiplier))
-            .add(parameter('adjustment', adjustment))
-        )
-        .filter(column('adjustedValue').greaterThan(parameter('threshold', threshold)))
-        .select(['category', 'adjustedValue']);
+      const predicate = parseSQLPredicate('value > :threshold', {preserveParameters: true});
+      const query = planGPUDataFrameQuery(frame, {
+        predicate,
+        columns: ['category', 'value'],
+        parameters: {threshold}
+      });
       const graph = new GPUCommandGraph<GPUDataFrameQueryParameters>(device, {
         id: 'gpu-data-analysis-gpu-dataframe-derived-demo'
       });
       compiled = query.compile(graph);
 
       const commandEncoder = device.createCommandEncoder({id: 'gpu-dataframe-derived-demo'});
-      compiled.encode(commandEncoder, {adjustment, multiplier, threshold});
+      compiled.encode(commandEncoder, {threshold});
       device.submit(commandEncoder.finish());
 
       const countData = compiled.selectedCounts.data[0];
-      const derivedData = compiled.table.gpuVectors.adjustedValue.data[0];
+      const valueData = compiled.table.gpuVectors.value.data[0];
       const countBuffer =
         countData.buffer instanceof Buffer ? countData.buffer : countData.buffer.buffer;
-      const derivedBuffer =
-        derivedData.buffer instanceof Buffer ? derivedData.buffer : derivedData.buffer.buffer;
-      const sampleLength = Math.min(derivedData.length, 4);
+      const valueBuffer =
+        valueData.buffer instanceof Buffer ? valueData.buffer : valueData.buffer.buffer;
+      const sampleLength = Math.min(valueData.length, 4);
       const [countBytes, sampleBytes] = await Promise.all([
         countBuffer.readAsync(countData.byteOffset, Uint32Array.BYTES_PER_ELEMENT),
-        derivedBuffer.readAsync(
-          derivedData.byteOffset,
-          sampleLength * Float32Array.BYTES_PER_ELEMENT
-        )
+        valueBuffer.readAsync(valueData.byteOffset, sampleLength * Float32Array.BYTES_PER_ELEMENT)
       ]);
       const selectedCount = new Uint32Array(countBytes.buffer, countBytes.byteOffset, 1)[0];
       const expectedCount = resources.sourceValues.reduce(
-        (count, value) => count + Number(value * multiplier + adjustment > threshold),
+        (count, value) => count + Number(value > threshold),
         0
       );
       const sample = Array.from(
@@ -708,8 +696,8 @@ class GPUDataAnalysisExample {
         this.elements.gpuDataFrameResult.dataset.state =
           selectedCount === expectedCount ? 'verified' : 'error';
         this.elements.gpuDataFrameResult.textContent =
-          `${selectedCount.toLocaleString()} selected rows · adjusted = value × ${multiplier} + ${adjustment} · ` +
-          `first GPU values [${sample.join(', ')}] · ${validation}`;
+          `${selectedCount.toLocaleString()} selected rows · loaders.gl WHERE value > :threshold · ` +
+          `threshold ${threshold} · first GPU values [${sample.join(', ')}] · ${validation}`;
       }
     } catch (error) {
       if (!this.destroyed) {
@@ -723,20 +711,14 @@ class GPUDataAnalysisExample {
     }
   }
 
-  /** Keeps the visible expression synchronized without allocating or dispatching GPU work. */
+  /** Keeps the visible loaders.gl predicate synchronized without allocating or dispatching work. */
   private updateGPUDataFrameExpression(): void {
-    this.elements.gpuDataFrameExpression.textContent =
-      `value × ${this.elements.gpuDataFrameMultiplier.value} + ` +
-      `${this.elements.gpuDataFrameAdjustment.value} > ${this.elements.gpuDataFrameThreshold.value}`;
+    this.elements.gpuDataFrameExpression.textContent = `value > :threshold  ·  threshold = ${this.elements.gpuDataFrameThreshold.value}`;
   }
 
-  /** Returns the three lightweight controls that parameterize the reusable dataframe plan. */
-  private getGPUDataFrameControls(): (HTMLInputElement | HTMLSelectElement)[] {
-    return [
-      this.elements.gpuDataFrameMultiplier,
-      this.elements.gpuDataFrameAdjustment,
-      this.elements.gpuDataFrameThreshold
-    ];
+  /** Returns the lightweight control that parameterizes the reusable dataframe plan. */
+  private getGPUDataFrameControls(): HTMLInputElement[] {
+    return [this.elements.gpuDataFrameThreshold];
   }
 
   private setStatus(message: string, error = false): void {
@@ -1052,10 +1034,8 @@ function getElements(root: HTMLElement): ExampleElements {
     groups: get('[data-groups]'),
     heatmap: get('[data-heatmap]'),
     histogram: get('[data-histogram]'),
-    gpuDataFrameAdjustment: get('[data-gpu-dataframe-adjustment]'),
     gpuDataFrameExecution: get('[data-gpu-dataframe-execution]'),
     gpuDataFrameExpression: get('[data-gpu-dataframe-expression]'),
-    gpuDataFrameMultiplier: get('[data-gpu-dataframe-multiplier]'),
     gpuDataFramePreview: get('[data-gpu-dataframe-preview]'),
     gpuDataFrameRate: get('[data-gpu-dataframe-rate]'),
     gpuDataFrameResult: get('[data-gpu-dataframe-result]'),

--- a/examples/showcase/billion-point-spatial-atlas/package.json
+++ b/examples/showcase/billion-point-spatial-atlas/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e",
-    "@loaders.gl/core": "~5.0.0-alpha.4",
-    "@loaders.gl/las": "~5.0.0-alpha.4",
+    "@loaders.gl/core": "~5.0.0-alpha.5",
+    "@loaders.gl/las": "~5.0.0-alpha.5",
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/effects": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",

--- a/examples/showcase/gltf/package.json
+++ b/examples/showcase/gltf/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e",
-    "@loaders.gl/core": "~5.0.0-alpha.4",
-    "@loaders.gl/gltf": "~5.0.0-alpha.4",
+    "@loaders.gl/core": "~5.0.0-alpha.5",
+    "@loaders.gl/gltf": "~5.0.0-alpha.5",
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",
     "@luma.gl/gltf": "9.4.0-alpha.4",

--- a/examples/showcase/postprocessing/package.json
+++ b/examples/showcase/postprocessing/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e",
-    "@loaders.gl/core": "~5.0.0-alpha.4",
-    "@loaders.gl/gltf": "~5.0.0-alpha.4",
+    "@loaders.gl/core": "~5.0.0-alpha.5",
+    "@loaders.gl/gltf": "~5.0.0-alpha.5",
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/effects": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",

--- a/examples/showcase/scene/package.json
+++ b/examples/showcase/scene/package.json
@@ -9,8 +9,8 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "@loaders.gl/core": "~5.0.0-alpha.4",
-    "@loaders.gl/gltf": "~5.0.0-alpha.4",
+    "@loaders.gl/core": "~5.0.0-alpha.5",
+    "@loaders.gl/gltf": "~5.0.0-alpha.5",
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/effects": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",

--- a/examples/tutorials/hello-gltf/package.json
+++ b/examples/tutorials/hello-gltf/package.json
@@ -8,8 +8,8 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "@loaders.gl/core": "~5.0.0-alpha.4",
-    "@loaders.gl/gltf": "~5.0.0-alpha.4",
+    "@loaders.gl/core": "~5.0.0-alpha.5",
+    "@loaders.gl/gltf": "~5.0.0-alpha.5",
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",
     "@luma.gl/gltf": "9.4.0-alpha.4",

--- a/modules/experimental/package.json
+++ b/modules/experimental/package.json
@@ -101,8 +101,8 @@
     "@luma.gl/shadertools": "~9.4.0-alpha.1"
   },
   "dependencies": {
-    "@loaders.gl/core": "~5.0.0-alpha.3",
-    "@loaders.gl/sql": "~5.0.0-alpha.3",
+    "@loaders.gl/core": "~5.0.0-alpha.5",
+    "@loaders.gl/sql": "~5.0.0-alpha.5",
     "@luma.gl/gpgpu": "9.4.0-alpha.4",
     "@math.gl/core": "^4.1.0",
     "@math.gl/types": "^4.1.0"

--- a/modules/experimental/package.json
+++ b/modules/experimental/package.json
@@ -101,6 +101,8 @@
     "@luma.gl/shadertools": "~9.4.0-alpha.1"
   },
   "dependencies": {
+    "@loaders.gl/core": "~5.0.0-alpha.3",
+    "@loaders.gl/sql": "~5.0.0-alpha.3",
     "@luma.gl/gpgpu": "9.4.0-alpha.4",
     "@math.gl/core": "^4.1.0",
     "@math.gl/types": "^4.1.0"

--- a/modules/experimental/src/gpu-dataframe/gpu-query-compiler.ts
+++ b/modules/experimental/src/gpu-dataframe/gpu-query-compiler.ts
@@ -222,7 +222,7 @@ export function compileGPUDataFrameQuery<
       predicates,
       derivedColumns,
       selectedColumns,
-      extension?.allowEmptyPredicates === true
+      predicates.length === 0 || extension?.allowEmptyPredicates === true
     );
     validateGPUQueryBatchCapacity(retainedSource, graph);
     validateGPUQueryBindingCapacity(plan, graph);

--- a/modules/experimental/src/gpu-sql/index.ts
+++ b/modules/experimental/src/gpu-sql/index.ts
@@ -4,3 +4,9 @@
 
 export {LuSQLContext, LuSQLQuery} from './lu-sql';
 export type {LuSQLQueryOptions, LuSQLTables} from './lu-sql';
+export {
+  GPU_DATAFRAME_TABLE_QUERY_CAPABILITIES,
+  makeGPUExpressionFromSQLPredicate,
+  planGPUDataFrameQuery
+} from './loaders-sql-query';
+export type {GPUDataFrameTableQueryOptions} from './loaders-sql-query';

--- a/modules/experimental/src/gpu-sql/loaders-sql-query.ts
+++ b/modules/experimental/src/gpu-sql/loaders-sql-query.ts
@@ -1,0 +1,218 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  isSQLPredicateParameter,
+  planTableQuery,
+  type SQLPredicate,
+  type SQLPredicateValue,
+  type TableQueryOptions
+} from '@loaders.gl/sql';
+import type {GPUTypeMap} from '@luma.gl/experimental/gpu-tables';
+import {GPUDataFrame} from '../gpu-dataframe/gpu-data-frame';
+import {GPUDataFrameQuery} from '../gpu-dataframe/gpu-data-frame-query';
+import {
+  GPUExpression,
+  type GPUExpressionBinaryOperator,
+  type GPUExpressionNode,
+  type GPUExpressionValue
+} from '../gpu-dataframe/gpu-expression';
+import type {GPUDataFrameQueryParameters} from '../gpu-dataframe/gpu-query-compiler';
+
+/** loaders.gl table-query operators currently lowered into GPU dataframe command graphs. */
+export const GPU_DATAFRAME_TABLE_QUERY_CAPABILITIES = Object.freeze({
+  projection: 'pushdown',
+  predicate: 'pushdown',
+  limit: 'unsupported',
+  streaming: false,
+  cancellation: false
+} as const);
+
+/** loaders.gl query syntax plus reusable default values for preserved SQL parameters. */
+export type GPUDataFrameTableQueryOptions<ColumnName extends string = string> = Omit<
+  TableQueryOptions,
+  'columns'
+> &
+  Readonly<{
+    /** Output GPU dataframe columns in caller-specified order. */
+    columns?: readonly ColumnName[];
+    /** Defaults for named predicate parameters retained in a reusable compiled GPU graph. */
+    parameters?: GPUDataFrameQueryParameters;
+  }>;
+
+/**
+ * Lowers a validated loaders.gl table query into an immutable GPU dataframe query plan.
+ *
+ * Planning remains CPU-only. It neither allocates GPU buffers nor submits commands, and predicate
+ * parameters remain graph inputs that callers can override each time the compiled query is encoded.
+ */
+export function planGPUDataFrameQuery<
+  T extends GPUTypeMap,
+  SelectedColumns extends keyof T & string = keyof T & string
+>(
+  frame: GPUDataFrame<T>,
+  options: GPUDataFrameTableQueryOptions<SelectedColumns> = {}
+): GPUDataFrameQuery<T, SelectedColumns, T> {
+  if (options.signal?.aborted) {
+    throw new Error('GPU dataframe query planning was cancelled');
+  }
+  if (options.limit !== undefined) {
+    throw new Error('GPU dataframe loaders.gl queries do not yet support source-ordered limits');
+  }
+
+  const {parameters = {}, ...tableQueryOptions} = options;
+  const plan = planTableQuery(frame.columnNames, tableQueryOptions);
+  const filterStep = plan.find(step => step.kind === 'filter');
+  const projectStep = plan.find(step => step.kind === 'project');
+  if (!projectStep || projectStep.kind !== 'project') {
+    throw new Error('GPU dataframe loaders.gl query plan is missing its projection');
+  }
+
+  const firstColumn = frame.columnNames[0];
+  if (!firstColumn) {
+    throw new Error('GPU dataframe loaders.gl queries require at least one source column');
+  }
+  const predicates = filterStep
+    ? [makeGPUExpressionFromSQLPredicate(filterStep.predicate, parameters)]
+    : [makeGPUDataFrameTautology(firstColumn)];
+
+  // loaders.gl validated every runtime column name against the source schema above.
+  return new GPUDataFrameQuery<T, SelectedColumns, T>(
+    frame,
+    predicates,
+    projectStep.columns as readonly SelectedColumns[]
+  );
+}
+
+/** Converts one portable loaders.gl SQL predicate into luma.gl's closed GPU expression tree. */
+export function makeGPUExpressionFromSQLPredicate(
+  predicate: SQLPredicate,
+  parameters: GPUDataFrameQueryParameters = {}
+): GPUExpression<boolean, string> {
+  return new GPUExpression<boolean, string>(makeGPUExpressionNode(predicate, parameters));
+}
+
+function makeGPUExpressionNode(
+  predicate: SQLPredicate,
+  parameters: GPUDataFrameQueryParameters
+): GPUExpressionNode {
+  switch (predicate.op) {
+    case '=':
+    case '<>':
+    case '<':
+    case '<=':
+    case '>':
+    case '>=':
+      return {
+        kind: 'binary',
+        operator: getGPUComparisonOperator(predicate.op),
+        left: makeGPUColumnNode(predicate.args[0].property),
+        right: makeGPUValueNode(predicate.args[1], parameters)
+      };
+    case 'in': {
+      const property = predicate.args[0].property;
+      const comparisons = predicate.args[1].map(
+        value =>
+          ({
+            kind: 'binary',
+            operator: 'equal',
+            left: makeGPUColumnNode(property),
+            right: makeGPUValueNode(value, parameters)
+          }) as const
+      );
+      return combineGPUExpressionNodes('or', comparisons);
+    }
+    case 'isNull':
+      return {
+        kind: 'unary',
+        operator: 'is-null',
+        operand: makeGPUColumnNode(predicate.args[0].property)
+      };
+    case 'and':
+    case 'or':
+      return combineGPUExpressionNodes(
+        predicate.op,
+        predicate.args.map(child => makeGPUExpressionNode(child, parameters))
+      );
+    case 'not':
+      return {
+        kind: 'unary',
+        operator: 'not',
+        operand: makeGPUExpressionNode(predicate.args[0], parameters)
+      };
+  }
+}
+
+function getGPUComparisonOperator(
+  operator: '=' | '<>' | '<' | '<=' | '>' | '>='
+): GPUExpressionBinaryOperator {
+  switch (operator) {
+    case '=':
+      return 'equal';
+    case '<>':
+      return 'not-equal';
+    case '<':
+      return 'less-than';
+    case '<=':
+      return 'less-than-or-equal';
+    case '>':
+      return 'greater-than';
+    case '>=':
+      return 'greater-than-or-equal';
+  }
+}
+
+function makeGPUColumnNode(name: string): GPUExpressionNode {
+  return {kind: 'column', name};
+}
+
+function makeGPUValueNode(
+  value: SQLPredicateValue,
+  parameters: GPUDataFrameQueryParameters
+): GPUExpressionNode {
+  if (isSQLPredicateParameter(value)) {
+    if (!Object.hasOwn(parameters, value.parameter)) {
+      throw new Error(`GPU dataframe SQL parameter ":${value.parameter}" requires a default value`);
+    }
+    return {
+      kind: 'parameter',
+      name: value.parameter,
+      value: getGPUExpressionValue(parameters[value.parameter], `parameter ":${value.parameter}"`)
+    };
+  }
+  return {kind: 'literal', value: getGPUExpressionValue(value, 'predicate literal')};
+}
+
+function getGPUExpressionValue(value: unknown, label: string): GPUExpressionValue {
+  if (value === null || typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  throw new Error(`GPU dataframe ${label} must be a finite number, boolean, or null`);
+}
+
+function combineGPUExpressionNodes(
+  operator: 'and' | 'or',
+  nodes: readonly GPUExpressionNode[]
+): GPUExpressionNode {
+  const first = nodes[0];
+  if (!first) {
+    throw new Error(`GPU dataframe SQL ${operator.toUpperCase()} requires an expression`);
+  }
+  return nodes
+    .slice(1)
+    .reduce<GPUExpressionNode>((left, right) => ({kind: 'binary', operator, left, right}), first);
+}
+
+function makeGPUDataFrameTautology(columnName: string): GPUExpression<boolean, string> {
+  const source = makeGPUColumnNode(columnName);
+  return new GPUExpression({
+    kind: 'binary',
+    operator: 'or',
+    left: {kind: 'unary', operator: 'is-valid', operand: source},
+    right: {kind: 'unary', operator: 'is-null', operand: source}
+  });
+}

--- a/modules/experimental/src/gpu-sql/loaders-sql-query.ts
+++ b/modules/experimental/src/gpu-sql/loaders-sql-query.ts
@@ -69,13 +69,9 @@ export function planGPUDataFrameQuery<
     throw new Error('GPU dataframe loaders.gl query plan is missing its projection');
   }
 
-  const firstColumn = frame.columnNames[0];
-  if (!firstColumn) {
-    throw new Error('GPU dataframe loaders.gl queries require at least one source column');
-  }
   const predicates = filterStep
     ? [makeGPUExpressionFromSQLPredicate(filterStep.predicate, parameters)]
-    : [makeGPUDataFrameTautology(firstColumn)];
+    : [];
 
   // loaders.gl validated every runtime column name against the source schema above.
   return new GPUDataFrameQuery<T, SelectedColumns, T>(
@@ -205,14 +201,4 @@ function combineGPUExpressionNodes(
   return nodes
     .slice(1)
     .reduce<GPUExpressionNode>((left, right) => ({kind: 'binary', operator, left, right}), first);
-}
-
-function makeGPUDataFrameTautology(columnName: string): GPUExpression<boolean, string> {
-  const source = makeGPUColumnNode(columnName);
-  return new GPUExpression({
-    kind: 'binary',
-    operator: 'or',
-    left: {kind: 'unary', operator: 'is-valid', operand: source},
-    right: {kind: 'unary', operator: 'is-null', operand: source}
-  });
 }

--- a/modules/experimental/test/gpu-sql/lu-sql.node.spec.ts
+++ b/modules/experimental/test/gpu-sql/lu-sql.node.spec.ts
@@ -4,12 +4,18 @@
 
 import {readFileSync} from 'node:fs';
 
+import {parseSQLPredicate} from '@loaders.gl/sql';
 import {Buffer} from '@luma.gl/core';
 import * as experimentalModule from '@luma.gl/experimental';
 import * as luDataFrameModule from '@luma.gl/experimental/gpu-dataframe';
 import {GPUDataFrame as LuDataFrame} from '@luma.gl/experimental/gpu-dataframe';
 import * as sqlModule from '@luma.gl/experimental/gpu-sql';
-import {LuSQLContext, LuSQLQuery} from '@luma.gl/experimental/gpu-sql';
+import {
+  LuSQLContext,
+  LuSQLQuery,
+  makeGPUExpressionFromSQLPredicate,
+  planGPUDataFrameQuery
+} from '@luma.gl/experimental/gpu-sql';
 import {GPUData} from '@luma.gl/gpgpu/gpu-data';
 import {GPURecordBatch, GPUTable} from '@luma.gl/experimental/gpu-tables';
 import {NullDevice} from '@luma.gl/test-utils';
@@ -18,7 +24,7 @@ import {describe, expect, test, vi} from 'vitest';
 type LuSQLFixtureColumns = {fare: 'float32'; category: 'uint32'; identifier: 'uint32'};
 
 describe('LuSQL immutable GPU dataframe planning', () => {
-  test('publishes SQL exclusively through its optional Arrow-free package subpath', () => {
+  test('publishes SQL and the loaders.gl planner adapter through its optional package subpath', () => {
     const packageJson = JSON.parse(
       readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
     ) as {
@@ -33,10 +39,42 @@ describe('LuSQL immutable GPU dataframe planning', () => {
       require: './dist/gpu-sql/index.cjs'
     });
     expect(packageJson.sideEffects).toBe(false);
+    expect(packageJson.dependencies?.['@loaders.gl/sql']).toBe('~5.0.0-alpha.3');
     expect(packageJson.dependencies?.['apache-arrow']).toBeUndefined();
     expect(sqlModule.LuSQLContext).toBe(LuSQLContext);
     expect('LuSQLContext' in experimentalModule).toBe(false);
     expect('LuSQLContext' in luDataFrameModule).toBe(false);
+  });
+
+  test('lowers loaders.gl predicate syntax, projection, and reusable parameters without GPU work', () => {
+    const {device, frame} = createLuSQLNodeFixture();
+    const createBuffer = vi.spyOn(device, 'createBuffer');
+    const submit = vi.spyOn(device, 'submit');
+    const predicate = parseSQLPredicate('fare >= :minimum AND category IN (0, 1)', {
+      preserveParameters: true
+    });
+    const query = planGPUDataFrameQuery(frame, {
+      predicate,
+      columns: ['category'],
+      parameters: {minimum: 5}
+    });
+
+    expect(query.selectedColumns).toEqual(['category']);
+    expect(query.predicates).toHaveLength(1);
+    expect(query.predicates[0].node).toEqual(
+      makeGPUExpressionFromSQLPredicate(predicate, {minimum: 5}).node
+    );
+    expect(createBuffer).not.toHaveBeenCalled();
+    expect(submit).not.toHaveBeenCalled();
+    expect(() => planGPUDataFrameQuery(frame, {predicate})).toThrow(/parameter/i);
+    expect(() =>
+      planGPUDataFrameQuery(frame, {predicate: parseSQLPredicate("fare = 'premium'")})
+    ).toThrow(/finite number, boolean, or null/i);
+    expect(() => planGPUDataFrameQuery(frame, {limit: 1})).toThrow(/source-ordered limits/i);
+
+    createBuffer.mockRestore();
+    submit.mockRestore();
+    frame.destroy();
   });
 
   test('plans projections, named parameters, arithmetic, global ordering, and limits without GPU work', () => {

--- a/modules/experimental/test/gpu-sql/lu-sql.node.spec.ts
+++ b/modules/experimental/test/gpu-sql/lu-sql.node.spec.ts
@@ -77,6 +77,40 @@ describe('LuSQL immutable GPU dataframe planning', () => {
     frame.destroy();
   });
 
+  test('compiles projection-only plans without binding an arbitrary source column', () => {
+    const device = new NullDevice({id: 'loaders-sql-projection-only-node'});
+    const batch = new GPURecordBatch<{
+      position: 'float32x3';
+      category: 'uint32';
+    }>({
+      gpuData: {
+        position: new GPUData({
+          buffer: device.createBuffer({
+            data: Float32Array.of(0, 1, 2, 3, 4, 5),
+            usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+          }),
+          format: 'float32x3',
+          length: 2,
+          ownsBuffer: true
+        }),
+        category: createLuSQLNodeData(device, Uint32Array.of(0, 1), 'uint32')
+      },
+      fields: [
+        {name: 'position', format: 'float32x3', nullable: false},
+        {name: 'category', format: 'uint32', nullable: false}
+      ]
+    });
+    const frame = new LuDataFrame({
+      table: new GPUTable({batches: [batch]}),
+      ownership: 'owned'
+    });
+    const query = planGPUDataFrameQuery(frame, {columns: ['category']});
+
+    expect(query.predicates).toEqual([]);
+    expect(query.selectedColumns).toEqual(['category']);
+    frame.destroy();
+  });
+
   test('plans projections, named parameters, arithmetic, global ordering, and limits without GPU work', () => {
     const {device, frame} = createLuSQLNodeFixture();
     const createBuffer = vi.spyOn(device, 'createBuffer');

--- a/modules/experimental/test/gpu-sql/lu-sql.node.spec.ts
+++ b/modules/experimental/test/gpu-sql/lu-sql.node.spec.ts
@@ -39,7 +39,7 @@ describe('LuSQL immutable GPU dataframe planning', () => {
       require: './dist/gpu-sql/index.cjs'
     });
     expect(packageJson.sideEffects).toBe(false);
-    expect(packageJson.dependencies?.['@loaders.gl/sql']).toBe('~5.0.0-alpha.3');
+    expect(packageJson.dependencies?.['@loaders.gl/sql']).toBe('~5.0.0-alpha.5');
     expect(packageJson.dependencies?.['apache-arrow']).toBeUndefined();
     expect(sqlModule.LuSQLContext).toBe(LuSQLContext);
     expect('LuSQLContext' in experimentalModule).toBe(false);

--- a/modules/experimental/test/gpu-sql/lu-sql.spec.ts
+++ b/modules/experimental/test/gpu-sql/lu-sql.spec.ts
@@ -7,7 +7,9 @@ import {
   makeGPUAnalyticsTableFromArrowTable
 } from '@luma.gl/arrow';
 import {parseSQLPredicate} from '@loaders.gl/sql';
+import {Buffer} from '@luma.gl/core';
 import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
+import {GPUData} from '@luma.gl/gpgpu/gpu-data';
 import {
   CompiledGPUDataFrameAggregation as CompiledLuDataFrameAggregation,
   CompiledGPUDataFrameGlobalSort as CompiledLuDataFrameGlobalSort,
@@ -16,6 +18,7 @@ import {
   GPUDataFrame as LuDataFrame
 } from '@luma.gl/experimental/gpu-dataframe';
 import {LuSQLContext, planGPUDataFrameQuery} from '@luma.gl/experimental/gpu-sql';
+import {GPURecordBatch, GPUTable} from '@luma.gl/experimental/gpu-tables';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import * as arrow from 'apache-arrow';
 import test from 'test/utils/vitest-tape';
@@ -132,6 +135,72 @@ test('loaders.gl SQL predicates compile into reusable GPU-resident dataframe res
     });
     testContext.deepEqual(Array.from(result.getChild('fare') ?? []), [10, 11]);
     testContext.deepEqual(Array.from(result.getChild('category') ?? []), ['premium', 'economy']);
+  } finally {
+    compiled.destroy();
+    frame.destroy();
+  }
+
+  testContext.end();
+});
+
+test('loaders.gl projection-only plans do not bind arbitrary source columns', async testContext => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testContext.comment('WebGPU is not available');
+    testContext.end();
+    return;
+  }
+
+  const batch = new GPURecordBatch<{
+    position: 'float32x3';
+    category: 'uint32';
+  }>({
+    gpuData: {
+      position: new GPUData({
+        buffer: device.createBuffer({
+          data: Float32Array.of(0, 1, 2, 3, 4, 5),
+          usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+        }),
+        format: 'float32x3',
+        length: 2,
+        ownsBuffer: true
+      }),
+      category: new GPUData({
+        buffer: device.createBuffer({
+          data: Uint32Array.of(7, 9),
+          usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+        }),
+        format: 'uint32',
+        length: 2,
+        ownsBuffer: true
+      })
+    },
+    fields: [
+      {name: 'position', format: 'float32x3', nullable: false},
+      {name: 'category', format: 'uint32', nullable: false}
+    ]
+  });
+  const frame = new LuDataFrame({
+    table: new GPUTable({batches: [batch]}),
+    ownership: 'owned'
+  });
+  const compiled = planGPUDataFrameQuery(frame, {columns: ['category']}).compile(
+    new GPUCommandGraph(device, {id: 'loaders-sql-projection-only'})
+  );
+
+  try {
+    const encoder = device.createCommandEncoder({id: 'loaders-sql-projection-only'});
+    compiled.encode(encoder);
+    device.submit(encoder.finish());
+
+    const result = await makeArrowTableFromGPUAnalyticsTable({
+      table: compiled.table,
+      validity: compiled.validity,
+      dictionaries: compiled.dictionaries,
+      rowIndices: compiled.rowIndices,
+      selectedCounts: compiled.selectedCounts
+    });
+    testContext.deepEqual(Array.from(result.getChild('category') ?? []), [7, 9]);
   } finally {
     compiled.destroy();
     frame.destroy();

--- a/modules/experimental/test/gpu-sql/lu-sql.spec.ts
+++ b/modules/experimental/test/gpu-sql/lu-sql.spec.ts
@@ -6,6 +6,7 @@ import {
   makeArrowTableFromGPUAnalyticsTable,
   makeGPUAnalyticsTableFromArrowTable
 } from '@luma.gl/arrow';
+import {parseSQLPredicate} from '@loaders.gl/sql';
 import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
 import {
   CompiledGPUDataFrameAggregation as CompiledLuDataFrameAggregation,
@@ -14,7 +15,7 @@ import {
   CompiledGPUDataFrameJoin as CompiledLuDataFrameJoin,
   GPUDataFrame as LuDataFrame
 } from '@luma.gl/experimental/gpu-dataframe';
-import {LuSQLContext} from '@luma.gl/experimental/gpu-sql';
+import {LuSQLContext, planGPUDataFrameQuery} from '@luma.gl/experimental/gpu-sql';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import * as arrow from 'apache-arrow';
 import test from 'test/utils/vitest-tape';
@@ -90,6 +91,49 @@ test('LuSQL executes Arrow filters, derived columns, global ordering, and select
   } finally {
     filtered.destroy();
     ordered.destroy();
+    frame.destroy();
+  }
+
+  testContext.end();
+});
+
+test('loaders.gl SQL predicates compile into reusable GPU-resident dataframe results', async testContext => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testContext.comment('WebGPU is not available');
+    testContext.end();
+    return;
+  }
+
+  const frame = new LuDataFrame({
+    ...makeGPUAnalyticsTableFromArrowTable(device, createLuSQLArrowTable()),
+    ownership: 'owned'
+  });
+  const predicate = parseSQLPredicate('fare >= :minimum AND category IN (0, 1)', {
+    preserveParameters: true
+  });
+  const compiled = planGPUDataFrameQuery(frame, {
+    predicate,
+    columns: ['fare', 'category'],
+    parameters: {minimum: 8}
+  }).compile(new GPUCommandGraph(device, {id: 'loaders-sql-gpu-dataframe'}));
+
+  try {
+    const encoder = device.createCommandEncoder({id: 'loaders-sql-gpu-dataframe'});
+    compiled.encode(encoder, {minimum: 9});
+    device.submit(encoder.finish());
+
+    const result = await makeArrowTableFromGPUAnalyticsTable({
+      table: compiled.table,
+      validity: compiled.validity,
+      dictionaries: compiled.dictionaries,
+      rowIndices: compiled.rowIndices,
+      selectedCounts: compiled.selectedCounts
+    });
+    testContext.deepEqual(Array.from(result.getChild('fare') ?? []), [10, 11]);
+    testContext.deepEqual(Array.from(result.getChild('category') ?? []), ['premium', 'economy']);
+  } finally {
+    compiled.destroy();
     frame.destroy();
   }
 

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -48,9 +48,9 @@
     "@luma.gl/shadertools": "~9.4.0-alpha.1"
   },
   "dependencies": {
-    "@loaders.gl/core": "~5.0.0-alpha.4",
-    "@loaders.gl/gltf": "~5.0.0-alpha.4",
-    "@loaders.gl/textures": "~5.0.0-alpha.4",
+    "@loaders.gl/core": "~5.0.0-alpha.5",
+    "@loaders.gl/gltf": "~5.0.0-alpha.5",
+    "@loaders.gl/textures": "~5.0.0-alpha.5",
     "@math.gl/core": "^4.1.0"
   },
   "gitHead": "c636c34b8f1581eed163e94543a8eb1f4382ba8e"

--- a/modules/gpgpu/test/gpu-parse/parquet/parquet-encoded-page-batch.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/parquet-encoded-page-batch.node.spec.ts
@@ -8,8 +8,8 @@ import {ParquetSourceLoader} from '@loaders.gl/parquet/parquet-source-loader';
 import {planGPUParquetEncodedPageBatch} from '@luma.gl/gpgpu/gpu-parse';
 import test from 'test/utils/vitest-tape';
 
-test('loaders.gl alpha.4 V1 and V2 pages produce mixed GPU batch plans', async testCase => {
-  testCase.equal(ParquetJSWriter.version, '5.0.0-alpha.4', 'uses the requested loaders.gl release');
+test('loaders.gl alpha.5 V1 and V2 pages produce mixed GPU batch plans', async testCase => {
+  testCase.equal(ParquetJSWriter.version, '5.0.0-alpha.5', 'uses the requested loaders.gl release');
 
   for (const useDataPageV2 of [false, true]) {
     const batch = await makeEncodedPageBatch(useDataPageV2);

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "@luma.gl/core": "workspace:*",
     "@luma.gl/engine": "workspace:*",
     "@luma.gl/shadertools": "workspace:*",
-    "@luma.gl/webgl": "workspace:*"
+    "@luma.gl/webgl": "workspace:*",
+    "@loaders.gl/schema-utils@npm:5.0.0-alpha.5": "patch:@loaders.gl/schema-utils@npm%3A5.0.0-alpha.5#~/.yarn/patches/@loaders.gl-schema-utils-npm-5.0.0-alpha.5-b7b149a264.patch"
   },
   "packageExtensions": {
     "@loaders.gl/gltf@~5.0.0-alpha.5": {

--- a/package.json
+++ b/package.json
@@ -54,11 +54,11 @@
   "devDependencies": {
     "@babel/core": "^7.28.3",
     "@babel/preset-env": "^7.28.3",
-    "@loaders.gl/core": "~5.0.0-alpha.4",
-    "@loaders.gl/gltf": "~5.0.0-alpha.4",
-    "@loaders.gl/las": "~5.0.0-alpha.4",
-    "@loaders.gl/parquet": "~5.0.0-alpha.4",
-    "@loaders.gl/polyfills": "~5.0.0-alpha.4",
+    "@loaders.gl/core": "~5.0.0-alpha.5",
+    "@loaders.gl/gltf": "~5.0.0-alpha.5",
+    "@loaders.gl/las": "~5.0.0-alpha.5",
+    "@loaders.gl/parquet": "~5.0.0-alpha.5",
+    "@loaders.gl/polyfills": "~5.0.0-alpha.5",
     "@math.gl/dggs-geohash": "^4.1.0",
     "@math.gl/dggs-quadkey": "^4.1.0",
     "@math.gl/dggs-s2": "^4.1.0",
@@ -93,14 +93,14 @@
     "@luma.gl/webgl": "workspace:*"
   },
   "packageExtensions": {
-    "@loaders.gl/gltf@~5.0.0-alpha.4": {
+    "@loaders.gl/gltf@~5.0.0-alpha.5": {
       "peerDependencies": {
-        "@loaders.gl/core": "~5.0.0-alpha.4"
+        "@loaders.gl/core": "~5.0.0-alpha.5"
       }
     },
-    "@loaders.gl/images@~5.0.0-alpha.4": {
+    "@loaders.gl/images@~5.0.0-alpha.5": {
       "peerDependencies": {
-        "@loaders.gl/core": "~5.0.0-alpha.4"
+        "@loaders.gl/core": "~5.0.0-alpha.5"
       }
     }
   },

--- a/test/examples/gpu-dataframe-derived-columns.node.spec.ts
+++ b/test/examples/gpu-dataframe-derived-columns.node.spec.ts
@@ -18,11 +18,9 @@ const EXAMPLE_SHELL = readFileSync(
   'utf8'
 );
 
-describe('GPU data-analysis luDF derived-column demo', () => {
-  test('offers an explicit interactive derived-column action without changing automatic startup', () => {
-    expect(EXAMPLE_SHELL).toContain('GPU DATAFRAME / DERIVED COLUMN LAB');
-    expect(EXAMPLE_SHELL).toContain('data-gpu-dataframe-adjustment');
-    expect(EXAMPLE_SHELL).toContain('data-gpu-dataframe-multiplier');
+describe('GPU data-analysis loaders.gl SQL demo', () => {
+  test('offers an explicit interactive loaders.gl query action without changing automatic startup', () => {
+    expect(EXAMPLE_SHELL).toContain('LOADERS.GL SQL / GPU DATAFRAME LAB');
     expect(EXAMPLE_SHELL).toContain('data-gpu-dataframe-threshold');
     expect(EXAMPLE_SHELL).toContain('data-gpu-dataframe-run');
     expect(EXAMPLE_SHELL).toContain('data-gpu-dataframe-result');
@@ -34,18 +32,18 @@ describe('GPU data-analysis luDF derived-column demo', () => {
     expect(EXAMPLE_SOURCE).not.toContain('await this.runGPUDataFrameDemo()');
   });
 
-  test('reuses Arrow-uploaded GPU columns and validates parameterized derivation and filtering', () => {
+  test('reuses Arrow-uploaded GPU columns and validates parameterized loaders.gl filtering', () => {
     expect(EXAMPLE_SOURCE).toContain("from '@luma.gl/experimental/gpu-dataframe'");
+    expect(EXAMPLE_SOURCE).toContain("from '@loaders.gl/sql'");
+    expect(EXAMPLE_SOURCE).toContain("from '@luma.gl/experimental/gpu-sql'");
     expect(EXAMPLE_SOURCE).toContain('resources.values.data.map(');
     expect(EXAMPLE_SOURCE).toContain(
       'gpuData: {value: valueData, category: resources.groupKeys.data[batchIndex]}'
     );
-    expect(EXAMPLE_SOURCE).toContain('.withColumn(');
-    expect(EXAMPLE_SOURCE).toContain("parameter('adjustment', adjustment)");
-    expect(EXAMPLE_SOURCE).toContain("parameter('multiplier', multiplier)");
-    expect(EXAMPLE_SOURCE).toContain("parameter('threshold', threshold)");
-    expect(EXAMPLE_SOURCE).toContain(".filter(column('adjustedValue').greaterThan(");
-    expect(EXAMPLE_SOURCE).toContain(".select(['category', 'adjustedValue'])");
+    expect(EXAMPLE_SOURCE).toContain("parseSQLPredicate('value > :threshold'");
+    expect(EXAMPLE_SOURCE).toContain('planGPUDataFrameQuery(frame, {');
+    expect(EXAMPLE_SOURCE).toContain("columns: ['category', 'value']");
+    expect(EXAMPLE_SOURCE).toContain('parameters: {threshold}');
     expect(EXAMPLE_SOURCE).toContain('compiled.selectedCounts');
     expect(EXAMPLE_SOURCE).toContain('CPU verified');
     expect(EXAMPLE_SOURCE).toContain('compiled?.destroy()');

--- a/test/examples/gpu-dataframe-derived-columns.spec.ts
+++ b/test/examples/gpu-dataframe-derived-columns.spec.ts
@@ -5,15 +5,14 @@
 import {describe, expect, test, vi} from 'vitest';
 import {initializeGPUDataAnalysisExample} from '../../examples/experimental/gpu-data-analysis/src/app';
 
-describe('GPU data-analysis luDF derived-column example', () => {
-  test('executes an opt-in derived-column filter over existing Arrow-backed GPU buffers', async () => {
+describe('GPU data-analysis loaders.gl SQL example', () => {
+  test('executes an opt-in loaders.gl predicate over existing Arrow-backed GPU buffers', async () => {
     const container = document.createElement('main');
     container.id = 'gpu-data-analysis-app';
     document.body.append(container);
     const example = initializeGPUDataAnalysisExample();
     const dataset = container.querySelector<HTMLSelectElement>('[data-dataset]');
     const button = container.querySelector<HTMLButtonElement>('[data-gpu-dataframe-run]');
-    const adjustment = container.querySelector<HTMLInputElement>('[data-gpu-dataframe-adjustment]');
     const expression = container.querySelector<HTMLElement>('[data-gpu-dataframe-expression]');
     const selected = container.querySelector<HTMLElement>('[data-gpu-dataframe-selected]');
     const rate = container.querySelector<HTMLElement>('[data-gpu-dataframe-rate]');
@@ -25,7 +24,6 @@ describe('GPU data-analysis luDF derived-column example', () => {
     try {
       expect(dataset).not.toBeNull();
       expect(button).not.toBeNull();
-      expect(adjustment).not.toBeNull();
       expect(expression).not.toBeNull();
       expect(selected).not.toBeNull();
       expect(rate).not.toBeNull();
@@ -36,7 +34,6 @@ describe('GPU data-analysis luDF derived-column example', () => {
       if (
         !dataset ||
         !button ||
-        !adjustment ||
         !expression ||
         !selected ||
         !rate ||
@@ -59,16 +56,13 @@ describe('GPU data-analysis luDF derived-column example', () => {
       );
 
       expect(result.textContent).toContain('without copying rows');
-      expect(expression.textContent).toContain('value × 2 + 1 > 1');
-      adjustment.value = '1.25';
-      adjustment.dispatchEvent(new Event('input', {bubbles: true}));
-      expect(expression.textContent).toContain('value × 2 + 1.25 > 1');
+      expect(expression.textContent).toContain('value > :threshold');
       button.click();
 
       await vi.waitFor(
         () => {
           expect(result.textContent).toContain('selected rows');
-          expect(result.textContent).toContain('value × 2 + 1.25');
+          expect(result.textContent).toContain('loaders.gl WHERE value > :threshold');
           expect(result.textContent).toContain('first GPU values');
           expect(result.textContent).toContain('CPU verified');
           expect(selected.textContent).toMatch(/[\d,]+/);
@@ -86,7 +80,7 @@ describe('GPU data-analysis luDF derived-column example', () => {
 
       await vi.waitFor(
         () => {
-          expect(expression.textContent).toContain('> 0.75');
+          expect(expression.textContent).toContain('threshold = 0.75');
           expect(selected.textContent).not.toBe(previousSelection);
           expect(result.textContent).toContain('CPU verified');
         },

--- a/test/utils/texture-compressor-shim.ts
+++ b/test/utils/texture-compressor-shim.ts
@@ -1,0 +1,8 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+/** Test-only stand-in for the optional loaders.gl DDS writer peer. */
+export async function pack(): Promise<never> {
+  throw new Error('texture-compressor is not installed in the luma.gl test workspace');
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,10 @@
+import {fileURLToPath} from 'node:url';
 import {getVitestConfig} from '@vis.gl/dev-tools';
 import {BrowserTestSequencer} from './test/utils/browser-test-sequencer';
+
+const optionalTextureCompressorShim = fileURLToPath(
+  new URL('./test/utils/texture-compressor-shim.ts', import.meta.url)
+);
 
 const excludePatterns = [
   '**/*.disabled.*',
@@ -155,7 +160,9 @@ const vitestConfig = getVitestConfig({
   overrides: {
     // Keep deck.gl in Vite's source graph so it shares this repository's luma.gl runtime.
     ssr: {noExternal: ['@deck.gl/core']},
-    optimizeDeps: {exclude: ['@deck.gl/core']}
+    // loaders.gl's optional writer peer must remain importable without installing its 33 MB CLI.
+    // Disabling discovery keeps Vite from restarting a CI shard when it first encounters zod.
+    optimizeDeps: {exclude: ['@deck.gl/core'], noDiscovery: true}
   },
   projects: {
     node: {
@@ -222,6 +229,17 @@ const vitestConfig = getVitestConfig({
     excludeAfterRemap: true
   }
 });
+
+// getVitestConfig installs the repository's TypeScript path aliases before applying overrides.
+// Append the optional peer alias here so those source aliases remain available to browser tests.
+const configuredAliases = vitestConfig.resolve?.alias;
+vitestConfig.resolve = {
+  ...vitestConfig.resolve,
+  alias: [
+    ...(Array.isArray(configuredAliases) ? configuredAliases : []),
+    {find: 'texture-compressor', replacement: optionalTextureCompressorShim}
+  ]
+};
 
 // Vitest selects its sharding sequencer from the root test config before it groups files by
 // project. Project-level sequence settings only affect ordering after files have been sharded.

--- a/wip/examples-wip/notready/gltf/package.json
+++ b/wip/examples-wip/notready/gltf/package.json
@@ -12,9 +12,9 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "@loaders.gl/core": "~5.0.0-alpha.4",
-    "@loaders.gl/gltf": "~5.0.0-alpha.4",
-    "@loaders.gl/polyfills": "~5.0.0-alpha.4",
+    "@loaders.gl/core": "~5.0.0-alpha.5",
+    "@loaders.gl/gltf": "~5.0.0-alpha.5",
+    "@loaders.gl/polyfills": "~5.0.0-alpha.5",
     "@luma.gl/engine": "~9.3.0",
     "@luma.gl/experimental": "~9.3.0",
     "@luma.gl/webgl": "~9.3.0",

--- a/wip/experimental/package.json
+++ b/wip/experimental/package.json
@@ -49,8 +49,8 @@
     "@luma.gl/test-utils": "~9.3.0"
   },
   "peerDependencies": {
-    "@loaders.gl/gltf": "~5.0.0-alpha.4",
-    "@loaders.gl/images": "~5.0.0-alpha.4"
+    "@loaders.gl/gltf": "~5.0.0-alpha.5",
+    "@loaders.gl/images": "~5.0.0-alpha.5"
   },
   "gitHead": "c636c34b8f1581eed163e94543a8eb1f4382ba8e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4787,6 +4787,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@loaders.gl/schema-utils@patch:@loaders.gl/schema-utils@npm%3A5.0.0-alpha.5#~/.yarn/patches/@loaders.gl-schema-utils-npm-5.0.0-alpha.5-b7b149a264.patch":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/schema-utils@patch:@loaders.gl/schema-utils@npm%3A5.0.0-alpha.5#~/.yarn/patches/@loaders.gl-schema-utils-npm-5.0.0-alpha.5-b7b149a264.patch::version=5.0.0-alpha.5&hash=2747dc"
+  dependencies:
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
+    "@math.gl/types": "npm:5.0.0-alpha.4"
+    "@types/geojson": "npm:^7946.0.7"
+    apache-arrow: "npm:>= 17.0.0"
+  peerDependencies:
+    "@loaders.gl/core": ~5.0.0-alpha.0
+  checksum: 10c0/7edddf4a543edb561d9f0b56b606ecc27c1bf3794746b0bb7254c7aadbf7bc28d04409cfbe4589d325203c1d8f6e96ac03b8808c123ed92ba4934fc5ad5d7983
+  languageName: node
+  linkType: hard
+
 "@loaders.gl/schema@npm:4.4.3":
   version: 4.4.3
   resolution: "@loaders.gl/schema@npm:4.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4466,58 +4466,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@loaders.gl/arrow@npm:5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/arrow@npm:5.0.0-alpha.4"
+"@loaders.gl/arrow@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/arrow@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/compression": "npm:5.0.0-alpha.4"
-    "@loaders.gl/gis": "npm:5.0.0-alpha.4"
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/wkt": "npm:5.0.0-alpha.4"
-    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.4"
-    "@math.gl/polygon": "npm:4.2.0-alpha.6"
+    "@loaders.gl/compression": "npm:5.0.0-alpha.5"
+    "@loaders.gl/gis": "npm:5.0.0-alpha.5"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/wkt": "npm:5.0.0-alpha.5"
+    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.5"
+    "@math.gl/polygon": "npm:5.0.0-alpha.4"
     apache-arrow: "npm:>= 17.0.0"
     lz4js: "npm:^0.2.0"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/c64558de1ad0f5ad98c8b02df8c526800ee4df0f6e1eb2154aba96a2f053b546d47d52c5055e0ba3477bb602f25d5517ed9ef551ed4f1a60e7bc0c26cb0180b0
+  checksum: 10c0/9aa9cdbef6f42c9fe7c76e2c5d73ec996d2480cc5b4965dbeac552d249d758d7f8be7515099baf005eccc28e722abdb68e1c73ab3373eaf0f0bc056f5aa3554d
   languageName: node
   linkType: hard
 
-"@loaders.gl/avro@npm:5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/avro@npm:5.0.0-alpha.4"
+"@loaders.gl/avro@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/avro@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/compression": "npm:5.0.0-alpha.4"
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    "@loaders.gl/compression": "npm:5.0.0-alpha.5"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
     apache-arrow: "npm:>= 17.0.0"
-  checksum: 10c0/02f51df4f43765e479b33cd5ba759773f4dcbcdd54589f8452e4104fd562db9e972c52c22d54364724c41fd62d97a1a018d9498cab6a9006e6010a73b31ed60b
+  checksum: 10c0/2f043cb4a76fc73376da8ccaa6fe81b7c48d3848138b3da28e4b8fd3627f95a6b622defdbcd9345cf9195b856d6707803aff37624b82e98da122cacd58293b01
   languageName: node
   linkType: hard
 
-"@loaders.gl/bson@npm:5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/bson@npm:5.0.0-alpha.4"
+"@loaders.gl/bson@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/bson@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/gis": "npm:5.0.0-alpha.4"
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    "@loaders.gl/gis": "npm:5.0.0-alpha.5"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
     bson: "npm:4.2.0"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/14398e4bf14dc20b3beac05be55ab94501cc881f357d986121e8669da8ccf0e71beceaea4bb8a7e7dd782a659d1ef4afa724bf1a6ed5c0a67d1776a599a5ca35
+  checksum: 10c0/5e2d87cfc770301e638e6c94d8db8cfa549c6d10e225383c92059afcc229b0f8ea2bd69ef919b04f790d6802daef21d8dc5b5f78bf6cd07e10125d09fa03d69b
   languageName: node
   linkType: hard
 
-"@loaders.gl/compression@npm:5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/compression@npm:5.0.0-alpha.4"
+"@loaders.gl/compression@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/compression@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.5"
     fflate: "npm:0.7.4"
     fzstd: "npm:0.1.1"
     hysnappy: "npm:^1.1.1"
@@ -4537,7 +4537,7 @@ __metadata:
       optional: true
     zstd-codec:
       optional: true
-  checksum: 10c0/7cf2ef227ea01be363cb099cb6a27d7c8dd291f38f1875fad42281e77bfd7464c0b49d4a74a12fa066bb629155c70d5187982c285223e4f3eb4aafa9b0445869
+  checksum: 10c0/2744357e40072464e42e355639ee36074e2c093a5ff028e85a5961ae1ed051fd1f09052ca3c4ca3141a6dd3233626d417f2b743bce3bf7b737f53076d1b048ba
   languageName: node
   linkType: hard
 
@@ -4554,110 +4554,113 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@loaders.gl/core@npm:~5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/core@npm:5.0.0-alpha.4"
+"@loaders.gl/core@npm:~5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/core@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.5"
     "@probe.gl/log": "npm:^4.1.1"
-  checksum: 10c0/230b48c1b4b2475a679912d6415c5b3c5bdd45b7e80583552665b2af8bdcf7da8e542e081118c90947f22ccda4962b647d6554da695a90df2e45c13445042f67
+  checksum: 10c0/fc16f85817b16b8cd1a4fbe73c2ee946583008c3bc3ed81b8be08fe9dbc2444e58c0cbf52357f0dae63a3b93f9b9fc5acee439fdde16d94628d979b584040b76
   languageName: node
   linkType: hard
 
-"@loaders.gl/crypto@npm:5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/crypto@npm:5.0.0-alpha.4"
+"@loaders.gl/crypto@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/crypto@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.5"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/c3bc05606af262c29109992945076d89423a976c54459b788161c57549973766cf2504244cb78a989361231c0fcdf4f36a895fafbaa618954bc5b1ee4a139ddb
+  checksum: 10c0/e42a0ddb3f01c1b11dec9a20d667c2b3a1d70aa7bee2379de046a158acf6e9e3598fbc5687b64477c920b540d07c60d1e3a1016adf5aa34b56ab365c3cb96c1b
   languageName: node
   linkType: hard
 
-"@loaders.gl/draco@npm:5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/draco@npm:5.0.0-alpha.4"
+"@loaders.gl/draco@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/draco@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.5"
     draco3d: "npm:1.5.7"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/145b04e17ee286810ba068439a7876f41da973ee8456b125082a84637d665ebffbc39ffce6a4a78370e9654a1fd779b1c179593cc4e8e8595c79406210898d5c
+  checksum: 10c0/9d353ffdc98d8678c6a7cda880f863c756db6bf2bbafb5c8a661edfade92a34cffa9de45f455636456d6a0ac1c2dc6a6603595dfa1f9d5975535389e0bda1794
   languageName: node
   linkType: hard
 
-"@loaders.gl/geoarrow@npm:5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/geoarrow@npm:5.0.0-alpha.4"
+"@loaders.gl/geoarrow@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/geoarrow@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/gis": "npm:5.0.0-alpha.4"
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
-    "@math.gl/polygon": "npm:4.2.0-alpha.6"
+    "@loaders.gl/gis": "npm:5.0.0-alpha.5"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.5"
+    "@math.gl/geoarrow": "npm:5.0.0-alpha.4"
+    "@math.gl/polygon": "npm:5.0.0-alpha.4"
+    "@math.gl/wkb": "npm:5.0.0-alpha.4"
     apache-arrow: "npm:>= 17.0.0"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/4e0a52f6287745fbbc54c2d8185ef67f5290c194498840b3f5233c49f9ae3e78ca6141e1cbf333707e4bbcf02e11293ae530a1724768c607e86195f6b4f3afc7
+  checksum: 10c0/81945d1cbaae079e8b49bc6e45273138dc03bc2bdae5e3a42d2fd7eed883ef180902b9c3853f0d2c9e409383dfaab598fadd29972fd3411a8fe8ade2b26cc6c3
   languageName: node
   linkType: hard
 
-"@loaders.gl/gis@npm:5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/gis@npm:5.0.0-alpha.4"
+"@loaders.gl/gis@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/gis@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.5"
     "@mapbox/vector-tile": "npm:^1.3.1"
-    "@math.gl/crs": "npm:^4.2.0-alpha.6"
-    "@math.gl/geometry-utils": "npm:4.2.0-alpha.6"
-    "@math.gl/polygon": "npm:4.2.0-alpha.6"
+    "@math.gl/crs": "npm:5.0.0-alpha.4"
+    "@math.gl/geometry-utils": "npm:5.0.0-alpha.4"
+    "@math.gl/polygon": "npm:5.0.0-alpha.4"
+    "@math.gl/wkb": "npm:5.0.0-alpha.4"
     apache-arrow: "npm:>= 17.0.0"
     pbf: "npm:^3.2.1"
     zod: "npm:^4.1.12"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/a61a5067e702f5065bc2fa2c75e059a675312431de31d9ca07e31739dd65be4251d907542954b5fd6f936ec51c03288c5733e52facd7ffc91a07cecf78b8dc7e
+  checksum: 10c0/0a81ee4f3db9815283f89cb72c2653de2b8f88cfd0c493368802d919cbeee4322896255e5ea2701ce77197fd2e9c92979cdb08019bd02c0a75bffe7d9fe3bc7c
   languageName: node
   linkType: hard
 
-"@loaders.gl/gltf@npm:~5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/gltf@npm:5.0.0-alpha.4"
+"@loaders.gl/gltf@npm:~5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/gltf@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/draco": "npm:5.0.0-alpha.4"
-    "@loaders.gl/images": "npm:5.0.0-alpha.4"
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/textures": "npm:5.0.0-alpha.4"
-    "@math.gl/core": "npm:4.2.0-alpha.6"
-    "@math.gl/culling": "npm:^4.2.0-alpha.6"
+    "@loaders.gl/draco": "npm:5.0.0-alpha.5"
+    "@loaders.gl/images": "npm:5.0.0-alpha.5"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/textures": "npm:5.0.0-alpha.5"
+    "@math.gl/core": "npm:5.0.0-alpha.4"
+    "@math.gl/culling": "npm:5.0.0-alpha.4"
     meshoptimizer: "npm:^1.2.0"
     zod: "npm:^4.1.12"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/8945dae82272347a3580a3429f34b16ca156e42ea23f37ce059f0bf0ac76137e56878ab6245ba4377c280faf5a8cb6e36d0206f31a4ad034a0393c57be227f0a
+  checksum: 10c0/52b93eff4c98dcc77625b74e49cd5798992059b26e81793dd6e809247fea2470c769fb59a26db255a95d9591f083f589aac80f3d4238479d7dc9ee62299046a0
   languageName: node
   linkType: hard
 
-"@loaders.gl/images@npm:5.0.0-alpha.4, @loaders.gl/images@npm:~5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/images@npm:5.0.0-alpha.4"
+"@loaders.gl/images@npm:5.0.0-alpha.5, @loaders.gl/images@npm:~5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/images@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/383e81cd42f25ddb37e474bd362def4cf7e23e92e178976cefd665cc9b0ca1b0e7504278743f78fd1b3e4e44ecd0c021df5fc61c5a8a8a3194fc08f9f71f9c00
+  checksum: 10c0/39187e6d0098a8e3d237cb3766b07042ca61b71a7be66e8d6b71c37055538b3688a3d6b8f7bb131ea8c6cd0111bf3e7af5f071f3f476ebced863ee7730c6560b
   languageName: node
   linkType: hard
 
@@ -4672,19 +4675,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@loaders.gl/las@npm:~5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/las@npm:5.0.0-alpha.4"
+"@loaders.gl/las@npm:~5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/las@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
-    "@math.gl/crs": "npm:^4.2.0-alpha.6"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.5"
+    "@math.gl/crs": "npm:5.0.0-alpha.4"
     copc: "npm:0.0.8"
     laz-perf: "npm:^0.0.7"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/6c9c738333ead85e2fe934d087e9a72bf1a11555310cc0a1f1e7f8ef77d4e09c0987ae921dcd6aa49fb521c5894e901aa7289763e6d7346ad3d29dd51da748c6
+  checksum: 10c0/8cec84cbfa570e543af70932ef375c6b6734c09981793783023d88d02ae7781b806fd4feae5d14484315bb6cf09974b789759b5c2e84cdbbf02b850807fdec92
   languageName: node
   linkType: hard
 
@@ -4700,33 +4703,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@loaders.gl/loader-utils@npm:5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/loader-utils@npm:5.0.0-alpha.4"
+"@loaders.gl/loader-utils@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/loader-utils@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
-    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.4"
-    "@math.gl/crs": "npm:^4.2.0-alpha.6"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
+    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.5"
+    "@math.gl/crs": "npm:5.0.0-alpha.4"
     "@probe.gl/log": "npm:^4.1.1"
     "@probe.gl/stats": "npm:^4.1.1"
-  checksum: 10c0/c3a832c91f405413381823dab5a9208dccc88ec19639de297de725de10d951352173fb03b92269a21a0a910f1b879c28220959315f76d9930727bd0701f665e0
+  checksum: 10c0/40420e6f470f3f4ed082ed2c4bb7cdd3c706fc6e77e4f1fbeba6b1bf75b96912d5d5a3c91083f4dd2190400c01fd75ede613678b5f77ea55949fd3bb1ff8455f
   languageName: node
   linkType: hard
 
-"@loaders.gl/parquet@npm:~5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/parquet@npm:5.0.0-alpha.4"
+"@loaders.gl/parquet@npm:~5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/parquet@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/arrow": "npm:5.0.0-alpha.4"
-    "@loaders.gl/avro": "npm:5.0.0-alpha.4"
-    "@loaders.gl/bson": "npm:5.0.0-alpha.4"
-    "@loaders.gl/compression": "npm:5.0.0-alpha.4"
-    "@loaders.gl/geoarrow": "npm:5.0.0-alpha.4"
-    "@loaders.gl/gis": "npm:5.0.0-alpha.4"
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/wkt": "npm:5.0.0-alpha.4"
+    "@loaders.gl/arrow": "npm:5.0.0-alpha.5"
+    "@loaders.gl/avro": "npm:5.0.0-alpha.5"
+    "@loaders.gl/bson": "npm:5.0.0-alpha.5"
+    "@loaders.gl/compression": "npm:5.0.0-alpha.5"
+    "@loaders.gl/geoarrow": "npm:5.0.0-alpha.5"
+    "@loaders.gl/gis": "npm:5.0.0-alpha.5"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/wkt": "npm:5.0.0-alpha.5"
     "@probe.gl/log": "npm:^4.1.1"
     async-mutex: "npm:^0.2.2"
     isomorphic-ws: "npm:^5.0.0"
@@ -4736,16 +4739,16 @@ __metadata:
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
     apache-arrow: ">= 17.0.0"
-  checksum: 10c0/04c0475b2c57827f986c059346743ddc860d4df9da645b0f45d36b0d98685f4eb428a9a46e760b6896a367369908e8ae2f9878b99347e77731513204e1cef855
+  checksum: 10c0/b6a6b50a4f334fd051e717e0deb8139701880f272e70a6a59773540e381ce4000287371693bd7dad79656d1f1de627bad66b2c4b5dd03d161bac697529d8dd1b
   languageName: node
   linkType: hard
 
-"@loaders.gl/polyfills@npm:~5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/polyfills@npm:5.0.0-alpha.4"
+"@loaders.gl/polyfills@npm:~5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/polyfills@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/crypto": "npm:5.0.0-alpha.4"
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/crypto": "npm:5.0.0-alpha.5"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
     buffer: "npm:^6.0.3"
     get-pixels: "npm:^3.3.3"
     ndarray: "npm:^1.0.19"
@@ -4753,7 +4756,7 @@ __metadata:
     web-streams-polyfill: "npm:^4.0.0"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/02004729427a3bf782372e258f19826e2567aa2f038e1495070870459cdbfcd9a24e3e796fb8817f03a986556a699f9e52eb45e231afe885048f589ada6a9575
+  checksum: 10c0/f0349837c9f8280f7e437f5c60a57f002206b09dc4d9eab07ab8b70872ba9794e06d514ee5996e3c2d3f00728c7d82596df590efe636ae95710de556ef873480
   languageName: node
   linkType: hard
 
@@ -4770,17 +4773,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@loaders.gl/schema-utils@npm:5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/schema-utils@npm:5.0.0-alpha.4"
+"@loaders.gl/schema-utils@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/schema-utils@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
-    "@math.gl/types": "npm:4.2.0-alpha.6"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
+    "@math.gl/types": "npm:5.0.0-alpha.4"
     "@types/geojson": "npm:^7946.0.7"
     apache-arrow: "npm:>= 17.0.0"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/ac4e70041ddb80c0a5adeac7e22e7e4dd851aa03c6bc03cf170151f3a91cfa4b8d4fb3f3fcfa060064fdf3e872d3dced7724ede25c290b479296bd049da37328
+  checksum: 10c0/62ee9141bc787ec1cfbef3d10326aa4c7ce749a419170e00df0c394cab86dae1f15ec3eed40720fcfb1a6e1582ad8b5a879026622738d629d8555ee8bd3e6b3a
   languageName: node
   linkType: hard
 
@@ -4794,25 +4797,49 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@loaders.gl/schema@npm:5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/schema@npm:5.0.0-alpha.4"
+"@loaders.gl/schema@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/schema@npm:5.0.0-alpha.5"
   dependencies:
     "@types/geojson": "npm:^7946.0.7"
     apache-arrow: "npm:>= 17.0.0"
-  checksum: 10c0/bfd9ca3185337e736bf6a34e0b598f559b1a132060863a3f994266244ac10d09abe73b16c8d905ee645079a2ce0defffbdbd68191acae09715ba99356dda9600
+  checksum: 10c0/3c73a9a320afca1a436be7603b429c52b8f9f10bb0839738d95b335c4af8624b682ca0f78e2bed7b6b74f6f030cd564c9e52ec059c1de20e88ca497213f5244f
   languageName: node
   linkType: hard
 
-"@loaders.gl/textures@npm:5.0.0-alpha.4, @loaders.gl/textures@npm:~5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/textures@npm:5.0.0-alpha.4"
+"@loaders.gl/sql@npm:~5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/sql@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/images": "npm:5.0.0-alpha.4"
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
-    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.4"
-    "@math.gl/types": "npm:4.2.0-alpha.6"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.5"
+    apache-arrow: "npm:>= 17.0.0"
+  peerDependencies:
+    "@duckdb/duckdb-wasm": ^1.33.1-dev45.0
+    "@duckdb/node-api": ^1.5.2-r.1
+    "@loaders.gl/core": ~5.0.0-alpha.0
+    zod: ^4.1.12
+  peerDependenciesMeta:
+    "@duckdb/duckdb-wasm":
+      optional: true
+    "@duckdb/node-api":
+      optional: true
+    zod:
+      optional: true
+  checksum: 10c0/6c191cc21d75733d1821aef2f0a71a6d412a6660ffdfa7f8621eab4545ede3f9a6f5a7370131dc88e71ff0a803a8a7f699262837a1bb790c8ebf288b99644fa7
+  languageName: node
+  linkType: hard
+
+"@loaders.gl/textures@npm:5.0.0-alpha.5, @loaders.gl/textures@npm:~5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/textures@npm:5.0.0-alpha.5"
+  dependencies:
+    "@loaders.gl/images": "npm:5.0.0-alpha.5"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
+    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.5"
+    "@math.gl/types": "npm:5.0.0-alpha.4"
     zod: "npm:^4.1.12"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
@@ -4820,21 +4847,21 @@ __metadata:
   peerDependenciesMeta:
     texture-compressor:
       optional: true
-  checksum: 10c0/97ff486197ca1b14b2ea93f411958276781476417c2ccde3ecfa7de7bb716065d7d16e0161b13347aee5209a7300ea188cfbcc6a30c41a2fa7ec1a5795d3ad4e
+  checksum: 10c0/fa567a1cda4a677cbae6d51be71bb1ae04ad0cb5aa70c32adae02f5acf54dcfc2882f3c342ea19973e8aaec93ac7ea853feded6134d25bde8cd9c60626465dc5
   languageName: node
   linkType: hard
 
-"@loaders.gl/wkt@npm:5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/wkt@npm:5.0.0-alpha.4"
+"@loaders.gl/wkt@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/wkt@npm:5.0.0-alpha.5"
   dependencies:
-    "@loaders.gl/gis": "npm:5.0.0-alpha.4"
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
-    "@math.gl/crs": "npm:^4.2.0-alpha.6"
+    "@loaders.gl/gis": "npm:5.0.0-alpha.5"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.5"
+    "@math.gl/crs": "npm:5.0.0-alpha.4"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/62c8f6d21f9c9b0c2872e0c3f1b72e0deb927668e6979379a104afb29a99d29190f8ccb3d3e4bde3d38317cfc6d12445a3739c7f7f07df9f0994c36a12a9451c
+  checksum: 10c0/a7b3250f2dee23abed3cdd924e8aa157f480b598a2d755126b8b8e521e18f205b8f77215bca8683e652ee5b5e23c1c0cd8571f0540160c847f4093ad001b6f94
   languageName: node
   linkType: hard
 
@@ -4847,12 +4874,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@loaders.gl/worker-utils@npm:5.0.0-alpha.4":
-  version: 5.0.0-alpha.4
-  resolution: "@loaders.gl/worker-utils@npm:5.0.0-alpha.4"
+"@loaders.gl/worker-utils@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@loaders.gl/worker-utils@npm:5.0.0-alpha.5"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/b5003cd0c3cec00c45047d20ec88d7a52ce8c592d54a338ab22d51e293fb7803b31269fa0ba330cb3b558cd8c844c09b72602574c2d83f65e9e1a9ee4de685d3
+  checksum: 10c0/e2e636a92fbb2f6d950c9262fd6e1c04de2a98ed96974ec35f94522da028c91f769e015c213c74a96dcffd4301732697aa321cd82ba83eec050dddfb0d3309ef
   languageName: node
   linkType: hard
 
@@ -4929,6 +4956,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@luma.gl/experimental@workspace:modules/experimental"
   dependencies:
+    "@loaders.gl/core": "npm:~5.0.0-alpha.5"
+    "@loaders.gl/sql": "npm:~5.0.0-alpha.5"
     "@luma.gl/gpgpu": "npm:9.4.0-alpha.4"
     "@math.gl/core": "npm:^4.1.0"
     "@math.gl/types": "npm:^4.1.0"
@@ -4943,9 +4972,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@luma.gl/gltf@workspace:modules/gltf"
   dependencies:
-    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
-    "@loaders.gl/gltf": "npm:~5.0.0-alpha.4"
-    "@loaders.gl/textures": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.5"
+    "@loaders.gl/gltf": "npm:~5.0.0-alpha.5"
+    "@loaders.gl/textures": "npm:~5.0.0-alpha.5"
     "@math.gl/core": "npm:^4.1.0"
   peerDependencies:
     "@luma.gl/core": ~9.4.0-alpha.1
@@ -5213,15 +5242,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@math.gl/core@npm:4.2.0-alpha.6":
-  version: 4.2.0-alpha.6
-  resolution: "@math.gl/core@npm:4.2.0-alpha.6"
-  dependencies:
-    "@math.gl/types": "npm:4.2.0-alpha.6"
-  checksum: 10c0/3d88f1de4eb58a62fdebf8500e3b34ea74368333e138790e1b3a1f9b1e38a80163c742de056497e90e98faa588b60e8ae3f641a9aea43a41031f1dc8da5d0b18
-  languageName: node
-  linkType: hard
-
 "@math.gl/core@npm:5.0.0-alpha.4":
   version: 5.0.0-alpha.4
   resolution: "@math.gl/core@npm:5.0.0-alpha.4"
@@ -5238,20 +5258,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@math.gl/crs@npm:^4.2.0-alpha.6":
-  version: 4.2.0-alpha.6
-  resolution: "@math.gl/crs@npm:4.2.0-alpha.6"
-  checksum: 10c0/7cfca2183cec0a59dc5561db47457fa6d603368c06e3b71805e53f2de2ceead6073c5c60168b3fd8f86eb865ffcb56bd6ca87d3ada14eac3278a09bbb38aef5d
-  languageName: node
-  linkType: hard
-
-"@math.gl/culling@npm:^4.2.0-alpha.6":
-  version: 4.2.0-alpha.6
-  resolution: "@math.gl/culling@npm:4.2.0-alpha.6"
+"@math.gl/culling@npm:5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@math.gl/culling@npm:5.0.0-alpha.4"
   dependencies:
-    "@math.gl/core": "npm:4.2.0-alpha.6"
-    "@math.gl/types": "npm:4.2.0-alpha.6"
-  checksum: 10c0/f1fb56d8510a5ac3f77cfe331630478ba539c81d24817f587a3fd28867cc832b807cc80008e5efee56bdf325bd4e981c6c326cbffc36685554569d59b1c8927d
+    "@math.gl/core": "npm:5.0.0-alpha.4"
+    "@math.gl/types": "npm:5.0.0-alpha.4"
+  checksum: 10c0/f9c5aaec0feab7848b13289ddef2bf023ddfd3fcdb0ebe7516cd0f54e1e8be39aad7bc43370050ee7a4ebe94ca5ee97f019462754f70b0a13ca78f8bf1a6617a
   languageName: node
   linkType: hard
 
@@ -5288,22 +5301,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@math.gl/geometry-utils@npm:4.2.0-alpha.6":
-  version: 4.2.0-alpha.6
-  resolution: "@math.gl/geometry-utils@npm:4.2.0-alpha.6"
+"@math.gl/geometry-utils@npm:5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@math.gl/geometry-utils@npm:5.0.0-alpha.4"
   dependencies:
-    "@math.gl/core": "npm:4.2.0-alpha.6"
-    "@math.gl/types": "npm:4.2.0-alpha.6"
-  checksum: 10c0/4f8edaa5ffc8bc86c58bdbf8b1415585d6aee96f8a38ec9294b3f6eb8e5a4ddf06424d7981753d4c0dc9392ef65ed599e430c651f99f20562899e268aadff009
-  languageName: node
-  linkType: hard
-
-"@math.gl/polygon@npm:4.2.0-alpha.6":
-  version: 4.2.0-alpha.6
-  resolution: "@math.gl/polygon@npm:4.2.0-alpha.6"
-  dependencies:
-    "@math.gl/core": "npm:4.2.0-alpha.6"
-  checksum: 10c0/fc38e1f4dbafaa9980616e4b23ece06e77f155d2a619735a7205429ed37cd72ab4cfa8d26fec42da36bcb2a75c2c0153717988dbfb606d801032ef6793509633
+    "@math.gl/core": "npm:5.0.0-alpha.4"
+    "@math.gl/types": "npm:5.0.0-alpha.4"
+  checksum: 10c0/7be199944eabcf1f8c1fc2c6a131672461d1d3728d21da0ca3f12b9ac02e6a2b1786f3bee761499aa6f38ac07c85e5172ecd6409ba1efaf6715ffca9fdf9c11b
   languageName: node
   linkType: hard
 
@@ -5336,13 +5340,6 @@ __metadata:
   version: 4.1.0
   resolution: "@math.gl/types@npm:4.1.0"
   checksum: 10c0/3c4dfa5ac5c9e2cef24d31f56b89c1dde785a5d70fd1a7030386346cb7dd4fa2cce5ba983b89842c1971492e30870dd22a078d64893f9c66887e38367bf992fa
-  languageName: node
-  linkType: hard
-
-"@math.gl/types@npm:4.2.0-alpha.6":
-  version: 4.2.0-alpha.6
-  resolution: "@math.gl/types@npm:4.2.0-alpha.6"
-  checksum: 10c0/fd7e3e3782b3a6834b3aa0f5bb75867743baf390ce63ad8f28de2aa633606c0eeddc4b999d8913d8416463e93b37cb3dac458a5bc0fdf57a265c329d23c56b75
   languageName: node
   linkType: hard
 
@@ -15496,6 +15493,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "luma.gl-examples-experimental-gpu-data-analysis@workspace:examples/experimental/gpu-data-analysis"
   dependencies:
+    "@loaders.gl/core": "npm:~5.0.0-alpha.5"
+    "@loaders.gl/sql": "npm:~5.0.0-alpha.5"
     "@luma.gl/arrow": "npm:9.4.0-alpha.4"
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
@@ -15697,8 +15696,8 @@ __metadata:
   resolution: "luma.gl-examples-gltf-showcase@workspace:examples/showcase/gltf"
   dependencies:
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e"
-    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
-    "@loaders.gl/gltf": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.5"
+    "@loaders.gl/gltf": "npm:~5.0.0-alpha.5"
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
     "@luma.gl/gltf": "npm:9.4.0-alpha.4"
@@ -15742,8 +15741,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "luma.gl-examples-hello-gltf@workspace:examples/tutorials/hello-gltf"
   dependencies:
-    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
-    "@loaders.gl/gltf": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.5"
+    "@loaders.gl/gltf": "npm:~5.0.0-alpha.5"
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
     "@luma.gl/gltf": "npm:9.4.0-alpha.4"
@@ -15872,8 +15871,8 @@ __metadata:
   resolution: "luma.gl-examples-postprocessing@workspace:examples/showcase/postprocessing"
   dependencies:
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e"
-    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
-    "@loaders.gl/gltf": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.5"
+    "@loaders.gl/gltf": "npm:~5.0.0-alpha.5"
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/effects": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
@@ -15949,8 +15948,8 @@ __metadata:
   resolution: "luma.gl-examples-showcase-billion-point-spatial-atlas@workspace:examples/showcase/billion-point-spatial-atlas"
   dependencies:
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e"
-    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
-    "@loaders.gl/las": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.5"
+    "@loaders.gl/las": "npm:~5.0.0-alpha.5"
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/effects": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
@@ -16100,8 +16099,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "luma.gl-examples-showcase-scene@workspace:examples/showcase/scene"
   dependencies:
-    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
-    "@loaders.gl/gltf": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.5"
+    "@loaders.gl/gltf": "npm:~5.0.0-alpha.5"
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/effects": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
@@ -16222,9 +16221,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "luma.gl-examples-texture-tester@workspace:examples/api/texture-tester"
   dependencies:
-    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
-    "@loaders.gl/images": "npm:~5.0.0-alpha.4"
-    "@loaders.gl/textures": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.5"
+    "@loaders.gl/images": "npm:~5.0.0-alpha.5"
+    "@loaders.gl/textures": "npm:~5.0.0-alpha.5"
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
     "@luma.gl/shadertools": "npm:9.4.0-alpha.4"
@@ -16341,11 +16340,11 @@ __metadata:
     "@babel/core": "npm:^7.28.3"
     "@babel/preset-env": "npm:^7.28.3"
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e"
-    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
-    "@loaders.gl/gltf": "npm:~5.0.0-alpha.4"
-    "@loaders.gl/las": "npm:~5.0.0-alpha.4"
-    "@loaders.gl/parquet": "npm:~5.0.0-alpha.4"
-    "@loaders.gl/polyfills": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.5"
+    "@loaders.gl/gltf": "npm:~5.0.0-alpha.5"
+    "@loaders.gl/las": "npm:~5.0.0-alpha.5"
+    "@loaders.gl/parquet": "npm:~5.0.0-alpha.5"
+    "@loaders.gl/polyfills": "npm:~5.0.0-alpha.5"
     "@math.gl/dggs-geohash": "npm:^4.1.0"
     "@math.gl/dggs-quadkey": "npm:^4.1.0"
     "@math.gl/dggs-s2": "npm:^4.1.0"


### PR DESCRIPTION
## Goals

- Consume the reusable loaders.gl 5.0 SQL/table-query planner instead of maintaining a copied planner.
- Keep query results GPU-resident for downstream rendering and compute.
- Demonstrate the integration in the GPU data-analysis example.

## Changes

- Upgrade loaders.gl dependencies to `5.0.0-alpha.3` and adapt to its glTF writer/accessor API changes.
- Add `planGPUDataFrameQuery()` and lower portable `SQLPredicate` values into reusable GPU dataframe command graphs.
- Advertise explicit backend capabilities and reject unsupported fallback paths.
- Update the interactive GPU data-analysis example, API docs, and node/headless WebGPU tests.

The loaders.gl adapter reuses `planTableQuery()` directly. The compiled result already exposes luma.gl's GPU-resident `table`, `validity`, `dictionaries`, `rowIndices`, and `selectedCounts`, so no new GPU result abstraction is needed.

## Verification

- `nvm use` — unavailable in this shell (`nvm: command not found`).
- `yarn install` — passed with existing peer-dependency warnings.
- `yarn lint fix` — passed.
- `yarn build` — passed.
- `yarn examples:typecheck` — passed across all 50 example workspaces.
- `yarn test-node` — passed (381 files, 3,067 tests; 1 file and 3 tests skipped).
- Focused SQL/example headless WebGPU tests — passed (2 files, 6 tests).
- Alpha.3 browser-import regression group — passed (9 files, 66 tests).
- GPU data-analysis production build — passed.
- `yarn website:build` — passed.
- `(cd website && yarn build)` — passed.
- GitHub Actions — all build, node, glTF reference, browser coverage, and aggregate coverage checks passed.
- An earlier full local `yarn test` run passed node and exposed the alpha.3 optional-peer/import-reload failures now covered by the focused browser regression group; unrelated local WebGPU conformance/rendering failures remained environment-specific.

## Current limits

- Source-order `limit`, streaming, in-flight cancellation, string/date/binary predicate values, and relational extensions are not lowered yet.
- Arrow result readback remains explicit and optional; compiled output remains GPU-resident.
