### PR TITLE
fix(webgpu): report texture capabilities accurately

### DIFF
--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -307,6 +307,8 @@ export type WebGPUDeviceFeature =
   | 'bgra8unorm-storage' // Can the bgra8unorm texture format be used in storage buffers?
   | 'float32-filterable' // Is the float32 format filterable?
   | 'float32-blendable' // Is the float32 format blendable?
+  | 'texture-formats-tier1'
+  | 'texture-formats-tier2'
   | 'clip-distances'
   | 'dual-source-blending'
   | 'subgroups';

--- a/modules/core/src/shadertypes/texture-types/texture-format-decoder.ts
+++ b/modules/core/src/shadertypes/texture-types/texture-format-decoder.ts
@@ -18,6 +18,7 @@ import {getTextureFormatDefinition} from './texture-format-table';
 const RGB_FORMAT_REGEX = /^(r|rg|rgb|rgba|bgra)([0-9]*)([a-z]*)(-srgb)?(-webgl)?$/;
 const COLOR_FORMAT_PREFIXES = ['rgb', 'rgba', 'bgra'];
 const DEPTH_FORMAT_PREFIXES = ['depth', 'stencil'];
+const WEBGPU_CREATE_FILTER = 1 | 4;
 // biome-ignore format: preserve layout
 const COMPRESSED_TEXTURE_FORMAT_PREFIXES = [
   'bc1', 'bc2', 'bc3', 'bc4', 'bc5', 'bc6', 'bc7', 'etc1', 'etc2', 'eac', 'atc', 'astc', 'pvrtc'
@@ -64,6 +65,15 @@ export class TextureFormatDecoder {
   /**  "static" capabilities of a texture format. @note Needs to be adjusted against current device */
   getCapabilities(format: TextureFormat): TextureFormatCapabilities {
     return getTextureFormatCapabilities(format);
+  }
+
+  /** Returns the compact WebGPU capability mask stored in the canonical format table. */
+  getWebGPUCapabilities(format: TextureFormat): number {
+    const definition = getTextureFormatDefinition(format);
+    if (definition.webgpu !== undefined) {
+      return definition.webgpu;
+    }
+    return this.isCompressed(format) && !format.endsWith('-webgl') ? WEBGPU_CREATE_FILTER : 0;
   }
 
   /** Computes the memory layout for a texture, in particular including row byte alignment */
@@ -225,6 +235,7 @@ function getTextureFormatInfoUsingTable(format: TextureFormat): TextureFormatInf
   delete info.filter;
   delete info.blend;
   delete info.store;
+  delete info.webgpu;
 
   const formatInfo: TextureFormatInfo = {
     ...info,

--- a/modules/core/src/shadertypes/texture-types/texture-format-table.ts
+++ b/modules/core/src/shadertypes/texture-types/texture-format-table.ts
@@ -31,6 +31,30 @@ const snorm16_renderable: TextureFeature = 'snorm16-renderable-webgl';
 const float32_filterable: TextureFeature = 'float32-filterable';
 const float16_filterable: TextureFeature = 'float16-filterable-webgl';
 
+const WEBGPU_CREATE = 1;
+const WEBGPU_RENDER = 2;
+const WEBGPU_FILTER = 4;
+const WEBGPU_BLEND = 8;
+const WEBGPU_STORE = 16;
+const WEBGPU_TIER_1_SHIFT = 5;
+const WEBGPU_CORE_SHIFT = 10;
+
+const WEBGPU_CREATE_RENDER = WEBGPU_CREATE | WEBGPU_RENDER;
+const WEBGPU_CREATE_FILTER = WEBGPU_CREATE | WEBGPU_FILTER;
+const WEBGPU_CREATE_RENDER_FILTER_BLEND =
+  WEBGPU_CREATE | WEBGPU_RENDER | WEBGPU_FILTER | WEBGPU_BLEND;
+const WEBGPU_CREATE_RENDER_STORE = WEBGPU_CREATE | WEBGPU_RENDER | WEBGPU_STORE;
+const WEBGPU_CREATE_FILTER_STORE = WEBGPU_CREATE | WEBGPU_FILTER | WEBGPU_STORE;
+const WEBGPU_CREATE_RENDER_FILTER_BLEND_STORE = WEBGPU_CREATE_RENDER_FILTER_BLEND | WEBGPU_STORE;
+const WEBGPU_TIER_1_RENDER_BLEND_STORE =
+  (WEBGPU_RENDER | WEBGPU_BLEND | WEBGPU_STORE) << WEBGPU_TIER_1_SHIFT;
+const WEBGPU_TIER_1_RENDER_BLEND = (WEBGPU_RENDER | WEBGPU_BLEND) << WEBGPU_TIER_1_SHIFT;
+const WEBGPU_TIER_1_STORE = WEBGPU_STORE << WEBGPU_TIER_1_SHIFT;
+const WEBGPU_TIER_1_ALL = WEBGPU_CREATE_RENDER_FILTER_BLEND_STORE << WEBGPU_TIER_1_SHIFT;
+const WEBGPU_CORE_CREATE_RENDER_FILTER_BLEND =
+  WEBGPU_CREATE_RENDER_FILTER_BLEND << WEBGPU_CORE_SHIFT;
+const WEBGPU_CORE_STORE = WEBGPU_STORE << WEBGPU_CORE_SHIFT;
+
 /** https://www.w3.org/TR/webgpu/#texture-format-caps */
 
 /** Internal type representing texture capabilities */
@@ -52,8 +76,8 @@ type TextureFormatDefinition = Partial<TextureFormatInfo> & {
   /** packed */
   p?: number;
 
-  /** If not supported on WebGPU */
-  wgpu?: false;
+  /** Compact WebGPU capability mask: base bits, then tier-one and core additions. */
+  webgpu?: number;
 };
 
 export function getTextureFormatDefinition(format: TextureFormat): TextureFormatDefinition {
@@ -71,63 +95,63 @@ export function getTextureFormatTable(): Readonly<Record<TextureFormat, TextureF
 // biome-ignore format: preserve layout
 const TEXTURE_FORMAT_COLOR_DEPTH_TABLE: Readonly<Record<TextureFormatColorUncompressed | TextureFormatDepthStencil, TextureFormatDefinition>> = {
   // 8-bit formats
-  'r8unorm': {},
-  'rg8unorm': {},
+  'r8unorm': {webgpu: WEBGPU_CREATE_RENDER_FILTER_BLEND | WEBGPU_TIER_1_STORE},
+  'rg8unorm': {webgpu: WEBGPU_CREATE_RENDER_FILTER_BLEND | WEBGPU_TIER_1_STORE},
   'rgb8unorm-webgl': {},
-  'rgba8unorm': {},
-  'rgba8unorm-srgb': {},
+  'rgba8unorm': {webgpu: WEBGPU_CREATE_RENDER_FILTER_BLEND_STORE},
+  'rgba8unorm-srgb': {webgpu: WEBGPU_CREATE_RENDER_FILTER_BLEND},
 
-  'r8snorm': {render: snorm8_renderable},
-  'rg8snorm': {render: snorm8_renderable},
+  'r8snorm': {render: snorm8_renderable, webgpu: WEBGPU_CREATE_FILTER | WEBGPU_TIER_1_RENDER_BLEND_STORE},
+  'rg8snorm': {render: snorm8_renderable, webgpu: WEBGPU_CREATE_FILTER | WEBGPU_TIER_1_RENDER_BLEND_STORE},
   'rgb8snorm-webgl': {},
-  'rgba8snorm': {render: snorm8_renderable},
+  'rgba8snorm': {render: snorm8_renderable, webgpu: WEBGPU_CREATE_FILTER_STORE | WEBGPU_TIER_1_RENDER_BLEND},
 
-  'r8uint': {},
-  'rg8uint': {},
-  'rgba8uint': {},
+  'r8uint': {webgpu: WEBGPU_CREATE_RENDER | WEBGPU_TIER_1_STORE},
+  'rg8uint': {webgpu: WEBGPU_CREATE_RENDER | WEBGPU_TIER_1_STORE},
+  'rgba8uint': {webgpu: WEBGPU_CREATE_RENDER_STORE},
 
-  'r8sint': {},
-  'rg8sint': {},
-  'rgba8sint': {},
+  'r8sint': {webgpu: WEBGPU_CREATE_RENDER | WEBGPU_TIER_1_STORE},
+  'rg8sint': {webgpu: WEBGPU_CREATE_RENDER | WEBGPU_TIER_1_STORE},
+  'rgba8sint': {webgpu: WEBGPU_CREATE_RENDER_STORE},
 
-  'bgra8unorm': {},
-  'bgra8unorm-srgb': {},
+  'bgra8unorm': {webgpu: WEBGPU_CREATE_RENDER_FILTER_BLEND},
+  'bgra8unorm-srgb': {webgpu: WEBGPU_CORE_CREATE_RENDER_FILTER_BLEND},
 
 
-  'r16unorm': {f: norm16_webgl, render: norm16_renderable},
-  'rg16unorm': {f: norm16_webgl, render: norm16_renderable},
+  'r16unorm': {f: norm16_webgl, render: norm16_renderable, webgpu: WEBGPU_TIER_1_ALL},
+  'rg16unorm': {f: norm16_webgl, render: norm16_renderable, webgpu: WEBGPU_TIER_1_ALL},
   'rgb16unorm-webgl': {f: norm16_webgl, render: false}, // rgb not renderable
-  'rgba16unorm': {f: norm16_webgl, render: norm16_renderable},
+  'rgba16unorm': {f: norm16_webgl, render: norm16_renderable, webgpu: WEBGPU_TIER_1_ALL},
 
-  'r16snorm': {f: norm16_webgl, render: snorm16_renderable},
-  'rg16snorm': {f: norm16_webgl, render: snorm16_renderable},
+  'r16snorm': {f: norm16_webgl, render: snorm16_renderable, webgpu: WEBGPU_TIER_1_ALL},
+  'rg16snorm': {f: norm16_webgl, render: snorm16_renderable, webgpu: WEBGPU_TIER_1_ALL},
   'rgb16snorm-webgl': {f: norm16_webgl, render: false}, // rgb not renderable
-  'rgba16snorm': {f: norm16_webgl, render: snorm16_renderable},
+  'rgba16snorm': {f: norm16_webgl, render: snorm16_renderable, webgpu: WEBGPU_TIER_1_ALL},
 
-  'r16uint': {},
-  'rg16uint': {},
-  'rgba16uint': {},
+  'r16uint': {webgpu: WEBGPU_CREATE_RENDER | WEBGPU_TIER_1_STORE},
+  'rg16uint': {webgpu: WEBGPU_CREATE_RENDER | WEBGPU_TIER_1_STORE},
+  'rgba16uint': {webgpu: WEBGPU_CREATE_RENDER_STORE},
 
-  'r16sint': {},
-  'rg16sint': {},
-  'rgba16sint': {},
+  'r16sint': {webgpu: WEBGPU_CREATE_RENDER | WEBGPU_TIER_1_STORE},
+  'rg16sint': {webgpu: WEBGPU_CREATE_RENDER | WEBGPU_TIER_1_STORE},
+  'rgba16sint': {webgpu: WEBGPU_CREATE_RENDER_STORE},
 
-  'r16float': {render: float16_renderable, filter: 'float16-filterable-webgl'},
-  'rg16float': {render: float16_renderable, filter: float16_filterable},
-  'rgba16float': {render: float16_renderable, filter: float16_filterable},
+  'r16float': {render: float16_renderable, filter: 'float16-filterable-webgl', webgpu: WEBGPU_CREATE_RENDER_FILTER_BLEND | WEBGPU_TIER_1_STORE},
+  'rg16float': {render: float16_renderable, filter: float16_filterable, webgpu: WEBGPU_CREATE_RENDER_FILTER_BLEND | WEBGPU_TIER_1_STORE},
+  'rgba16float': {render: float16_renderable, filter: float16_filterable, webgpu: WEBGPU_CREATE_RENDER_FILTER_BLEND_STORE},
 
-  'r32uint': {},
-  'rg32uint': {},
-  'rgba32uint': {},
+  'r32uint': {webgpu: WEBGPU_CREATE_RENDER_STORE},
+  'rg32uint': {webgpu: WEBGPU_CREATE_RENDER | WEBGPU_CORE_STORE},
+  'rgba32uint': {webgpu: WEBGPU_CREATE_RENDER_STORE},
 
-  'r32sint': {},
-  'rg32sint': {},
-  'rgba32sint': {},
+  'r32sint': {webgpu: WEBGPU_CREATE_RENDER_STORE},
+  'rg32sint': {webgpu: WEBGPU_CREATE_RENDER | WEBGPU_CORE_STORE},
+  'rgba32sint': {webgpu: WEBGPU_CREATE_RENDER_STORE},
 
-  'r32float': {render: float32_renderable, filter: float32_filterable},
-  'rg32float': {render: false, filter: float32_filterable},
+  'r32float': {render: float32_renderable, filter: float32_filterable, webgpu: WEBGPU_CREATE_RENDER_STORE},
+  'rg32float': {render: false, filter: float32_filterable, webgpu: WEBGPU_CREATE_RENDER | WEBGPU_CORE_STORE},
   'rgb32float-webgl': {render: float32_renderable, filter: float32_filterable},
-  'rgba32float': {render: float32_renderable, filter: float32_filterable},
+  'rgba32float': {render: float32_renderable, filter: float32_filterable, webgpu: WEBGPU_CREATE_RENDER_STORE},
 
   // Packed 16-bit formats
   'rgba4unorm-webgl': {channels: 'rgba', bitsPerChannel: [4, 4, 4, 4], packed: true},
@@ -135,22 +159,22 @@ const TEXTURE_FORMAT_COLOR_DEPTH_TABLE: Readonly<Record<TextureFormatColorUncomp
   'rgb5a1unorm-webgl': {channels: 'rgba', bitsPerChannel: [5, 5, 5, 1], packed: true},
 
   // Packed 32 bit formats
-  'rgb9e5ufloat': {channels: 'rgb', packed: true, render: rgb9e5ufloat_renderable}, // , filter: true},
-  'rg11b10ufloat': {channels: 'rgb', bitsPerChannel: [11, 11, 10, 0], packed: true, p: 1,render: float32_renderable},
-  'rgb10a2unorm': {channels: 'rgba',  bitsPerChannel: [10, 10, 10, 2], packed: true, p: 1},
-  'rgb10a2uint': {channels: 'rgba',  bitsPerChannel: [10, 10, 10, 2], packed: true, p: 1},
+  'rgb9e5ufloat': {channels: 'rgb', packed: true, render: rgb9e5ufloat_renderable, webgpu: WEBGPU_CREATE_FILTER},
+  'rg11b10ufloat': {channels: 'rgb', bitsPerChannel: [11, 11, 10, 0], packed: true, p: 1,render: float32_renderable, webgpu: WEBGPU_CREATE_FILTER | WEBGPU_TIER_1_STORE},
+  'rgb10a2unorm': {channels: 'rgba',  bitsPerChannel: [10, 10, 10, 2], packed: true, p: 1, webgpu: WEBGPU_CREATE_RENDER_FILTER_BLEND | WEBGPU_TIER_1_STORE},
+  'rgb10a2uint': {channels: 'rgba',  bitsPerChannel: [10, 10, 10, 2], packed: true, p: 1, webgpu: WEBGPU_CREATE_RENDER | WEBGPU_TIER_1_STORE},
 
   // Depth/stencil Formats
   
   // Depth and stencil formats
-  stencil8: {attachment: 'stencil', bitsPerChannel: [8, 0, 0, 0], dataType: 'uint8'},
-  'depth16unorm': {attachment: 'depth',  bitsPerChannel: [16, 0, 0, 0], dataType: 'uint16'},
-  'depth24plus': {attachment: 'depth', bitsPerChannel: [24, 0, 0, 0], dataType: 'uint32'},
-  'depth32float': {attachment: 'depth', bitsPerChannel: [32, 0, 0, 0], dataType: 'float32'},
+  stencil8: {attachment: 'stencil', bitsPerChannel: [8, 0, 0, 0], dataType: 'uint8', webgpu: WEBGPU_CREATE_RENDER},
+  'depth16unorm': {attachment: 'depth',  bitsPerChannel: [16, 0, 0, 0], dataType: 'uint16', webgpu: WEBGPU_CREATE_RENDER},
+  'depth24plus': {attachment: 'depth', bitsPerChannel: [24, 0, 0, 0], dataType: 'uint32', webgpu: WEBGPU_CREATE_RENDER},
+  'depth32float': {attachment: 'depth', bitsPerChannel: [32, 0, 0, 0], dataType: 'float32', webgpu: WEBGPU_CREATE_RENDER},
   // The depth component of the "depth24plus" and "depth24plus-stencil8" formats may be implemented as either a 24-bit depth value or a "depth32float" value.
-  'depth24plus-stencil8': {attachment: 'depth-stencil', bitsPerChannel: [24, 8, 0, 0], packed: true},
+  'depth24plus-stencil8': {attachment: 'depth-stencil', bitsPerChannel: [24, 8, 0, 0], packed: true, webgpu: WEBGPU_CREATE_RENDER},
   // "depth32float-stencil8" feature
-  'depth32float-stencil8': {attachment: 'depth-stencil', bitsPerChannel: [32, 8, 0, 0], packed: true},
+  'depth32float-stencil8': {attachment: 'depth-stencil', bitsPerChannel: [32, 8, 0, 0], packed: true, f: 'depth32float-stencil8', webgpu: WEBGPU_CREATE_RENDER},
 };
 
 // biome-ignore format: preserve layout

--- a/modules/core/src/shadertypes/texture-types/texture-formats.ts
+++ b/modules/core/src/shadertypes/texture-types/texture-formats.ts
@@ -115,6 +115,7 @@ export type TextureFeature =
   | 'texture-compression-bc'
   | 'texture-compression-astc'
   | 'texture-compression-etc2'
+  | 'depth32float-stencil8'
   | 'texture-compression-etc1-webgl'
   | 'texture-compression-pvrtc-webgl'
   | 'texture-compression-atc-webgl'

--- a/modules/engine/src/passes/shader-pass-renderer.ts
+++ b/modules/engine/src/passes/shader-pass-renderer.ts
@@ -764,7 +764,8 @@ function isShaderPassPipeline(shaderPass: ShaderPassLike): shaderPass is ShaderP
   return 'steps' in shaderPass;
 }
 
-function supportsComputeOptimization(device: Device, pipeline: ShaderPassPipeline): boolean {
+/** @internal Returns whether a pipeline's optional compute path is valid for this device. */
+export function supportsComputeOptimization(device: Device, pipeline: ShaderPassPipeline): boolean {
   const optimization = pipeline.compute;
   if (!optimization || device.type !== 'webgpu') {
     return false;

--- a/modules/engine/test/passes/shader-pass-renderer.spec.ts
+++ b/modules/engine/test/passes/shader-pass-renderer.spec.ts
@@ -6,7 +6,8 @@ import test from 'test/utils/vitest-tape';
 import {getTestDevices, getWebGPUTestDevice} from '@luma.gl/test-utils';
 import {ShaderPassRenderer, DynamicTexture, ShaderInputs} from '@luma.gl/engine';
 import type {ShaderPass, ShaderPassPipeline} from '@luma.gl/shadertools';
-import {Buffer, CommandEncoder, Texture} from '@luma.gl/core';
+import {Buffer, CommandEncoder, Texture, type Device} from '@luma.gl/core';
+import {supportsComputeOptimization} from '../../src/passes/shader-pass-renderer';
 
 const invertPass: ShaderPass = {
   name: 'invert',
@@ -188,6 +189,58 @@ const stagedPipeline: ShaderPassPipeline<'extract' | 'blurred'> = {
     }
   ]
 };
+
+test('ShaderPassRenderer compute optimization requires storage-capable output formats', t => {
+  const pipeline: ShaderPassPipeline<'output'> = {
+    name: 'storage-capability-gate',
+    renderTargets: {output: {format: 'bgra8unorm', storage: true}},
+    steps: [],
+    compute: {
+      name: 'storage-capability-compute',
+      source: '',
+      uniformModule: 'storageCapability',
+      uniformBinding: 'storageCapabilityUniforms',
+      uniformNames: [],
+      uniforms: {},
+      input: 'original',
+      outputs: {outputTexture: 'output'},
+      replacedPasses: [],
+      workgroupSize: [8, 8]
+    }
+  };
+  let supportsStorage = false;
+  const device = {
+    type: 'webgpu',
+    preferredColorFormat: 'bgra8unorm',
+    limits: {
+      maxStorageTexturesPerShaderStage: 4,
+      maxComputeWorkgroupSizeX: 256,
+      maxComputeWorkgroupSizeY: 256,
+      maxComputeInvocationsPerWorkgroup: 256
+    },
+    getTextureFormatCapabilities: (format: 'bgra8unorm') => ({
+      format,
+      create: true,
+      render: true,
+      filter: true,
+      blend: true,
+      store: supportsStorage
+    })
+  } as unknown as Device;
+
+  t.equal(
+    supportsComputeOptimization(device, pipeline),
+    false,
+    'unsupported storage format selects the render-pass fallback'
+  );
+  supportsStorage = true;
+  t.equal(
+    supportsComputeOptimization(device, pipeline),
+    true,
+    'storage-capable format enables the compute optimization'
+  );
+  t.end();
+});
 
 const tintPipeline: ShaderPassPipeline<'scratch'> = {
   name: 'tintPipeline',

--- a/modules/webgpu/src/adapter/helpers/webgpu-texture-capabilities.ts
+++ b/modules/webgpu/src/adapter/helpers/webgpu-texture-capabilities.ts
@@ -1,0 +1,229 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {
+  DeviceFeatures,
+  DeviceTextureFormatCapabilities,
+  TextureFormat,
+  WebGPUDeviceFeatureLevel
+} from '@luma.gl/core';
+
+const TIER_1_FORMATS = new Set<TextureFormat>([
+  'r16unorm',
+  'r16snorm',
+  'rg16unorm',
+  'rg16snorm',
+  'rgba16unorm',
+  'rgba16snorm'
+]);
+
+const RENDERABLE_FORMATS = new Set<TextureFormat>([
+  'r8unorm',
+  'r8uint',
+  'r8sint',
+  'rg8unorm',
+  'rg8uint',
+  'rg8sint',
+  'rgba8unorm',
+  'rgba8unorm-srgb',
+  'rgba8uint',
+  'rgba8sint',
+  'bgra8unorm',
+  'bgra8unorm-srgb',
+  'r16unorm',
+  'r16snorm',
+  'r16uint',
+  'r16sint',
+  'r16float',
+  'rg16unorm',
+  'rg16snorm',
+  'rg16uint',
+  'rg16sint',
+  'rg16float',
+  'rgba16unorm',
+  'rgba16snorm',
+  'rgba16uint',
+  'rgba16sint',
+  'rgba16float',
+  'r32uint',
+  'r32sint',
+  'r32float',
+  'rg32uint',
+  'rg32sint',
+  'rg32float',
+  'rgba32uint',
+  'rgba32sint',
+  'rgba32float',
+  'rgb10a2uint',
+  'rgb10a2unorm',
+  'stencil8',
+  'depth16unorm',
+  'depth24plus',
+  'depth24plus-stencil8',
+  'depth32float',
+  'depth32float-stencil8'
+]);
+
+const TIER_1_RENDERABLE_FORMATS = new Set<TextureFormat>(['r8snorm', 'rg8snorm', 'rgba8snorm']);
+
+const FILTERABLE_FORMATS = new Set<TextureFormat>([
+  'r8unorm',
+  'r8snorm',
+  'rg8unorm',
+  'rg8snorm',
+  'rgba8unorm',
+  'rgba8unorm-srgb',
+  'rgba8snorm',
+  'bgra8unorm',
+  'bgra8unorm-srgb',
+  'r16float',
+  'rg16float',
+  'rgba16float',
+  'rgb9e5ufloat',
+  'rgb10a2unorm',
+  'rg11b10ufloat'
+]);
+
+const BLENDABLE_FORMATS = new Set<TextureFormat>([
+  'r8unorm',
+  'rg8unorm',
+  'rgba8unorm',
+  'rgba8unorm-srgb',
+  'bgra8unorm',
+  'bgra8unorm-srgb',
+  'r16unorm',
+  'r16snorm',
+  'r16float',
+  'rg16unorm',
+  'rg16snorm',
+  'rg16float',
+  'rgba16unorm',
+  'rgba16snorm',
+  'rgba16float',
+  'rgb10a2unorm'
+]);
+
+const TIER_1_BLENDABLE_FORMATS = new Set<TextureFormat>(['r8snorm', 'rg8snorm', 'rgba8snorm']);
+
+const STORAGE_FORMATS = new Set<TextureFormat>([
+  'rgba8unorm',
+  'rgba8snorm',
+  'rgba8uint',
+  'rgba8sint',
+  'rgba16unorm',
+  'rgba16snorm',
+  'rgba16uint',
+  'rgba16sint',
+  'rgba16float',
+  'r32uint',
+  'r32sint',
+  'r32float',
+  'rgba32uint',
+  'rgba32sint',
+  'rgba32float'
+]);
+
+const TIER_1_STORAGE_FORMATS = new Set<TextureFormat>([
+  'r8unorm',
+  'r8snorm',
+  'r8uint',
+  'r8sint',
+  'rg8unorm',
+  'rg8snorm',
+  'rg8uint',
+  'rg8sint',
+  'r16unorm',
+  'r16snorm',
+  'r16uint',
+  'r16sint',
+  'r16float',
+  'rg16unorm',
+  'rg16snorm',
+  'rg16uint',
+  'rg16sint',
+  'rg16float',
+  'rgb10a2uint',
+  'rgb10a2unorm',
+  'rg11b10ufloat'
+]);
+
+const CORE_STORAGE_FORMATS = new Set<TextureFormat>(['rg32uint', 'rg32sint', 'rg32float']);
+
+/** Returns spec-derived texture usages for the active WebGPU feature set. */
+export function getWebGPUTextureFormatCapabilities(
+  format: TextureFormat,
+  features: DeviceFeatures,
+  featureLevel: WebGPUDeviceFeatureLevel
+): DeviceTextureFormatCapabilities {
+  const tier1 = features.has('texture-formats-tier1');
+  const core = featureLevel !== 'compatibility' || features.has('core-features-and-limits');
+  const create = isWebGPUTextureFormatSupported(format, features, tier1, core);
+  const render =
+    create &&
+    (RENDERABLE_FORMATS.has(format) ||
+      (tier1 && TIER_1_RENDERABLE_FORMATS.has(format)) ||
+      (format === 'rg11b10ufloat' && features.has('rg11b10ufloat-renderable')));
+  const filter =
+    create &&
+    (FILTERABLE_FORMATS.has(format) ||
+      (isFloat32Format(format) && features.has('float32-filterable')) ||
+      isCompressedFormat(format));
+  const blend =
+    render &&
+    (BLENDABLE_FORMATS.has(format) ||
+      (tier1 && TIER_1_BLENDABLE_FORMATS.has(format)) ||
+      (isFloat32Format(format) && features.has('float32-blendable')) ||
+      (format === 'rg11b10ufloat' && features.has('rg11b10ufloat-renderable')));
+  const store =
+    create &&
+    (STORAGE_FORMATS.has(format) ||
+      (tier1 && TIER_1_STORAGE_FORMATS.has(format)) ||
+      (core && CORE_STORAGE_FORMATS.has(format)) ||
+      (format === 'bgra8unorm' && features.has('bgra8unorm-storage')));
+
+  return {format, create, render, filter, blend, store};
+}
+
+function isWebGPUTextureFormatSupported(
+  format: TextureFormat,
+  features: DeviceFeatures,
+  tier1: boolean,
+  core: boolean
+): boolean {
+  if (format.includes('webgl')) {
+    return false;
+  }
+  if (TIER_1_FORMATS.has(format) && !tier1) {
+    return false;
+  }
+  if (format === 'bgra8unorm-srgb' && !core) {
+    return false;
+  }
+  if (format === 'depth32float-stencil8') {
+    return features.has('depth32float-stencil8');
+  }
+  if (format.startsWith('bc')) {
+    return features.has('texture-compression-bc');
+  }
+  if (format.startsWith('etc2') || format.startsWith('eac')) {
+    return features.has('texture-compression-etc2');
+  }
+  if (format.startsWith('astc')) {
+    return features.has('texture-compression-astc');
+  }
+  return true;
+}
+
+function isFloat32Format(format: TextureFormat): boolean {
+  return format === 'r32float' || format === 'rg32float' || format === 'rgba32float';
+}
+
+function isCompressedFormat(format: TextureFormat): boolean {
+  return (
+    format.startsWith('bc') ||
+    format.startsWith('etc2') ||
+    format.startsWith('eac') ||
+    format.startsWith('astc')
+  );
+}

--- a/modules/webgpu/src/adapter/helpers/webgpu-texture-capabilities.ts
+++ b/modules/webgpu/src/adapter/helpers/webgpu-texture-capabilities.ts
@@ -2,153 +2,22 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import type {
-  DeviceFeatures,
-  DeviceTextureFormatCapabilities,
-  TextureFormat,
-  WebGPUDeviceFeatureLevel
+import {
+  textureFormatDecoder,
+  type DeviceFeatures,
+  type DeviceTextureFormatCapabilities,
+  type TextureFormat,
+  type WebGPUDeviceFeatureLevel
 } from '@luma.gl/core';
 
-const TIER_1_FORMATS = new Set<TextureFormat>([
-  'r16unorm',
-  'r16snorm',
-  'rg16unorm',
-  'rg16snorm',
-  'rgba16unorm',
-  'rgba16snorm'
-]);
-
-const RENDERABLE_FORMATS = new Set<TextureFormat>([
-  'r8unorm',
-  'r8uint',
-  'r8sint',
-  'rg8unorm',
-  'rg8uint',
-  'rg8sint',
-  'rgba8unorm',
-  'rgba8unorm-srgb',
-  'rgba8uint',
-  'rgba8sint',
-  'bgra8unorm',
-  'bgra8unorm-srgb',
-  'r16unorm',
-  'r16snorm',
-  'r16uint',
-  'r16sint',
-  'r16float',
-  'rg16unorm',
-  'rg16snorm',
-  'rg16uint',
-  'rg16sint',
-  'rg16float',
-  'rgba16unorm',
-  'rgba16snorm',
-  'rgba16uint',
-  'rgba16sint',
-  'rgba16float',
-  'r32uint',
-  'r32sint',
-  'r32float',
-  'rg32uint',
-  'rg32sint',
-  'rg32float',
-  'rgba32uint',
-  'rgba32sint',
-  'rgba32float',
-  'rgb10a2uint',
-  'rgb10a2unorm',
-  'stencil8',
-  'depth16unorm',
-  'depth24plus',
-  'depth24plus-stencil8',
-  'depth32float',
-  'depth32float-stencil8'
-]);
-
-const TIER_1_RENDERABLE_FORMATS = new Set<TextureFormat>(['r8snorm', 'rg8snorm', 'rgba8snorm']);
-
-const FILTERABLE_FORMATS = new Set<TextureFormat>([
-  'r8unorm',
-  'r8snorm',
-  'rg8unorm',
-  'rg8snorm',
-  'rgba8unorm',
-  'rgba8unorm-srgb',
-  'rgba8snorm',
-  'bgra8unorm',
-  'bgra8unorm-srgb',
-  'r16float',
-  'rg16float',
-  'rgba16float',
-  'rgb9e5ufloat',
-  'rgb10a2unorm',
-  'rg11b10ufloat'
-]);
-
-const BLENDABLE_FORMATS = new Set<TextureFormat>([
-  'r8unorm',
-  'rg8unorm',
-  'rgba8unorm',
-  'rgba8unorm-srgb',
-  'bgra8unorm',
-  'bgra8unorm-srgb',
-  'r16unorm',
-  'r16snorm',
-  'r16float',
-  'rg16unorm',
-  'rg16snorm',
-  'rg16float',
-  'rgba16unorm',
-  'rgba16snorm',
-  'rgba16float',
-  'rgb10a2unorm'
-]);
-
-const TIER_1_BLENDABLE_FORMATS = new Set<TextureFormat>(['r8snorm', 'rg8snorm', 'rgba8snorm']);
-
-const STORAGE_FORMATS = new Set<TextureFormat>([
-  'rgba8unorm',
-  'rgba8snorm',
-  'rgba8uint',
-  'rgba8sint',
-  'rgba16unorm',
-  'rgba16snorm',
-  'rgba16uint',
-  'rgba16sint',
-  'rgba16float',
-  'r32uint',
-  'r32sint',
-  'r32float',
-  'rgba32uint',
-  'rgba32sint',
-  'rgba32float'
-]);
-
-const TIER_1_STORAGE_FORMATS = new Set<TextureFormat>([
-  'r8unorm',
-  'r8snorm',
-  'r8uint',
-  'r8sint',
-  'rg8unorm',
-  'rg8snorm',
-  'rg8uint',
-  'rg8sint',
-  'r16unorm',
-  'r16snorm',
-  'r16uint',
-  'r16sint',
-  'r16float',
-  'rg16unorm',
-  'rg16snorm',
-  'rg16uint',
-  'rg16sint',
-  'rg16float',
-  'rgb10a2uint',
-  'rgb10a2unorm',
-  'rg11b10ufloat'
-]);
-
-const CORE_STORAGE_FORMATS = new Set<TextureFormat>(['rg32uint', 'rg32sint', 'rg32float']);
+const CREATE = 1;
+const RENDER = 2;
+const FILTER = 4;
+const BLEND = 8;
+const STORE = 16;
+const CAPABILITY_MASK = CREATE | RENDER | FILTER | BLEND | STORE;
+const TIER_1_SHIFT = 5;
+const CORE_SHIFT = 10;
 
 /** Returns spec-derived texture usages for the active WebGPU feature set. */
 export function getWebGPUTextureFormatCapabilities(
@@ -156,74 +25,47 @@ export function getWebGPUTextureFormatCapabilities(
   features: DeviceFeatures,
   featureLevel: WebGPUDeviceFeatureLevel
 ): DeviceTextureFormatCapabilities {
-  const tier1 = features.has('texture-formats-tier1');
-  const core = featureLevel !== 'compatibility' || features.has('core-features-and-limits');
-  const create = isWebGPUTextureFormatSupported(format, features, tier1, core);
-  const render =
-    create &&
-    (RENDERABLE_FORMATS.has(format) ||
-      (tier1 && TIER_1_RENDERABLE_FORMATS.has(format)) ||
-      (format === 'rg11b10ufloat' && features.has('rg11b10ufloat-renderable')));
-  const filter =
-    create &&
-    (FILTERABLE_FORMATS.has(format) ||
-      (isFloat32Format(format) && features.has('float32-filterable')) ||
-      isCompressedFormat(format));
-  const blend =
-    render &&
-    (BLENDABLE_FORMATS.has(format) ||
-      (tier1 && TIER_1_BLENDABLE_FORMATS.has(format)) ||
-      (isFloat32Format(format) && features.has('float32-blendable')) ||
-      (format === 'rg11b10ufloat' && features.has('rg11b10ufloat-renderable')));
-  const store =
-    create &&
-    (STORAGE_FORMATS.has(format) ||
-      (tier1 && TIER_1_STORAGE_FORMATS.has(format)) ||
-      (core && CORE_STORAGE_FORMATS.has(format)) ||
-      (format === 'bgra8unorm' && features.has('bgra8unorm-storage')));
+  const encodedCapabilities = textureFormatDecoder.getWebGPUCapabilities(format);
+  let capabilities = encodedCapabilities & CAPABILITY_MASK;
 
-  return {format, create, render, filter, blend, store};
-}
+  if (features.has('texture-formats-tier1')) {
+    capabilities |= (encodedCapabilities >> TIER_1_SHIFT) & CAPABILITY_MASK;
+  }
+  if (featureLevel !== 'compatibility' || features.has('core-features-and-limits')) {
+    capabilities |= (encodedCapabilities >> CORE_SHIFT) & CAPABILITY_MASK;
+  }
 
-function isWebGPUTextureFormatSupported(
-  format: TextureFormat,
-  features: DeviceFeatures,
-  tier1: boolean,
-  core: boolean
-): boolean {
-  if (format.includes('webgl')) {
-    return false;
+  const staticCapabilities = textureFormatDecoder.getCapabilities(format);
+  const requiredFeature =
+    typeof staticCapabilities.create === 'string' && !staticCapabilities.create.endsWith('-webgl')
+      ? staticCapabilities.create
+      : null;
+  if (requiredFeature && !features.has(requiredFeature)) {
+    capabilities = 0;
   }
-  if (TIER_1_FORMATS.has(format) && !tier1) {
-    return false;
-  }
-  if (format === 'bgra8unorm-srgb' && !core) {
-    return false;
-  }
-  if (format === 'depth32float-stencil8') {
-    return features.has('depth32float-stencil8');
-  }
-  if (format.startsWith('bc')) {
-    return features.has('texture-compression-bc');
-  }
-  if (format.startsWith('etc2') || format.startsWith('eac')) {
-    return features.has('texture-compression-etc2');
-  }
-  if (format.startsWith('astc')) {
-    return features.has('texture-compression-astc');
-  }
-  return true;
-}
 
-function isFloat32Format(format: TextureFormat): boolean {
-  return format === 'r32float' || format === 'rg32float' || format === 'rgba32float';
-}
+  if (format === 'bgra8unorm' && features.has('bgra8unorm-storage')) {
+    capabilities |= STORE;
+  }
+  if (format === 'rg11b10ufloat' && features.has('rg11b10ufloat-renderable')) {
+    capabilities |= RENDER | BLEND;
+  }
+  if (format === 'r32float' || format === 'rg32float' || format === 'rgba32float') {
+    if (features.has('float32-filterable')) {
+      capabilities |= FILTER;
+    }
+    if (features.has('float32-blendable')) {
+      capabilities |= BLEND;
+    }
+  }
 
-function isCompressedFormat(format: TextureFormat): boolean {
-  return (
-    format.startsWith('bc') ||
-    format.startsWith('etc2') ||
-    format.startsWith('eac') ||
-    format.startsWith('astc')
-  );
+  const create = Boolean(capabilities & CREATE);
+  return {
+    format,
+    create,
+    render: create && Boolean(capabilities & RENDER),
+    filter: create && Boolean(capabilities & FILTER),
+    blend: create && Boolean(capabilities & BLEND),
+    store: create && Boolean(capabilities & STORE)
+  };
 }

--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -58,6 +58,7 @@ import {WebGPUCommandBuffer} from './resources/webgpu-command-buffer';
 import {WebGPUQuerySet} from './resources/webgpu-query-set';
 import {WebGPUPipelineLayout} from './resources/webgpu-pipeline-layout';
 import {WebGPUFence} from './resources/webgpu-fence';
+import {getWebGPUTextureFormatCapabilities} from './helpers/webgpu-texture-capabilities';
 
 import {
   getShaderLayoutFromWGSL,
@@ -593,11 +594,11 @@ export class WebGPUDevice extends Device {
   override _getDeviceSpecificTextureFormatCapabilities(
     capabilities: DeviceTextureFormatCapabilities
   ): DeviceTextureFormatCapabilities {
-    const {format} = capabilities;
-    if (format.includes('webgl')) {
-      return {format, create: false, render: false, filter: false, blend: false, store: false};
-    }
-    return capabilities;
+    return getWebGPUTextureFormatCapabilities(
+      capabilities.format,
+      this.features,
+      getWebGPUDeviceFeatureLevel(this.props.featureLevel)
+    );
   }
 }
 

--- a/modules/webgpu/test/adapter/webgpu-texture-capabilities.node.spec.ts
+++ b/modules/webgpu/test/adapter/webgpu-texture-capabilities.node.spec.ts
@@ -1,0 +1,151 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {DeviceFeatures, _getTextureFormatTable, type TextureFormat} from '@luma.gl/core';
+import {getWebGPUTextureFormatCapabilities} from '../../src/adapter/helpers/webgpu-texture-capabilities';
+
+test('WebGPU texture capabilities require the matching optional features', t => {
+  const baselineFeatures = new DeviceFeatures([], {});
+  const optionalFeatures = new DeviceFeatures(
+    ['bgra8unorm-storage', 'rg11b10ufloat-renderable', 'float32-filterable', 'float32-blendable'],
+    {}
+  );
+
+  t.equal(
+    getWebGPUTextureFormatCapabilities('bgra8unorm', baselineFeatures, 'core').store,
+    false,
+    'bgra storage is not over-reported'
+  );
+  t.equal(
+    getWebGPUTextureFormatCapabilities('bgra8unorm', optionalFeatures, 'core').store,
+    true,
+    'bgra storage is enabled by its feature'
+  );
+  t.equal(
+    getWebGPUTextureFormatCapabilities('rg11b10ufloat', baselineFeatures, 'core').render,
+    false,
+    'rg11b10 renderability is not over-reported'
+  );
+  t.equal(
+    getWebGPUTextureFormatCapabilities('rg11b10ufloat', optionalFeatures, 'core').render,
+    true,
+    'rg11b10 renderability is enabled by its feature'
+  );
+  const baselineFloat32 = getWebGPUTextureFormatCapabilities(
+    'rgba32float',
+    baselineFeatures,
+    'core'
+  );
+  const optionalFloat32 = getWebGPUTextureFormatCapabilities(
+    'rgba32float',
+    optionalFeatures,
+    'core'
+  );
+  t.equal(baselineFloat32.filter, false, 'float32 filtering is not over-reported');
+  t.equal(baselineFloat32.blend, false, 'float32 blending is not over-reported');
+  t.equal(optionalFloat32.filter, true, 'float32 filtering follows its feature');
+  t.equal(optionalFloat32.blend, true, 'float32 blending follows its feature');
+  t.equal(
+    getWebGPUTextureFormatCapabilities('rgba16float', baselineFeatures, 'core').store,
+    true,
+    'baseline rgba16float storage remains available to effects'
+  );
+  t.end();
+});
+
+test('WebGPU texture capability table covers every luma texture format', t => {
+  const baselineFeatures = new DeviceFeatures([], {});
+  const formats = Object.keys(_getTextureFormatTable()) as TextureFormat[];
+
+  for (const format of formats) {
+    const capabilities = getWebGPUTextureFormatCapabilities(format, baselineFeatures, 'core');
+    t.equal(capabilities.format, format, `${format} preserves its format`);
+    for (const capability of ['create', 'render', 'filter', 'blend', 'store'] as const) {
+      t.equal(
+        typeof capabilities[capability],
+        'boolean',
+        `${format}.${capability} is explicitly classified`
+      );
+    }
+    if (format.includes('webgl')) {
+      t.deepEqual(
+        capabilities,
+        {format, create: false, render: false, filter: false, blend: false, store: false},
+        `${format} remains WebGL-only`
+      );
+    }
+  }
+  t.end();
+});
+
+test('WebGPU texture capabilities gate compressed, tier, and compatibility formats', t => {
+  const baselineFeatures = new DeviceFeatures([], {});
+  const optionalFeatures = new DeviceFeatures(
+    [
+      'core-features-and-limits',
+      'texture-compression-bc',
+      'texture-compression-etc2',
+      'texture-compression-astc',
+      'depth32float-stencil8',
+      'texture-formats-tier1',
+      'texture-formats-tier2'
+    ],
+    {}
+  );
+
+  for (const format of ['bc1-rgba-unorm', 'etc2-rgb8unorm', 'astc-4x4-unorm'] as const) {
+    t.equal(
+      getWebGPUTextureFormatCapabilities(format, baselineFeatures, 'core').create,
+      false,
+      `${format} requires its compression feature`
+    );
+    t.deepEqual(
+      getWebGPUTextureFormatCapabilities(format, optionalFeatures, 'core'),
+      {format, create: true, render: false, filter: true, blend: false, store: false},
+      `${format} is sampleable but not renderable or storage-capable`
+    );
+  }
+
+  t.equal(
+    getWebGPUTextureFormatCapabilities('depth32float-stencil8', baselineFeatures, 'core').create,
+    false,
+    'depth32float-stencil8 requires its optional feature'
+  );
+  t.equal(
+    getWebGPUTextureFormatCapabilities('depth32float-stencil8', optionalFeatures, 'core').render,
+    true,
+    'depth32float-stencil8 becomes renderable with its feature'
+  );
+  t.deepEqual(
+    getWebGPUTextureFormatCapabilities('r16unorm', baselineFeatures, 'core'),
+    {
+      format: 'r16unorm',
+      create: false,
+      render: false,
+      filter: false,
+      blend: false,
+      store: false
+    },
+    'tier-one normalized formats are unavailable without the feature'
+  );
+  t.deepEqual(
+    getWebGPUTextureFormatCapabilities('r16unorm', optionalFeatures, 'core'),
+    {
+      format: 'r16unorm',
+      create: true,
+      render: true,
+      filter: false,
+      blend: true,
+      store: true
+    },
+    'tier-one normalized formats expose only their specified capabilities'
+  );
+  t.equal(
+    getWebGPUTextureFormatCapabilities('bgra8unorm-srgb', baselineFeatures, 'compatibility').create,
+    false,
+    'compatibility profile does not over-report core-only sRGB BGRA creation'
+  );
+  t.end();
+});

--- a/modules/webgpu/test/adapter/webgpu-texture-capabilities.node.spec.ts
+++ b/modules/webgpu/test/adapter/webgpu-texture-capabilities.node.spec.ts
@@ -136,11 +136,11 @@ test('WebGPU texture capabilities gate compressed, tier, and compatibility forma
       format: 'r16unorm',
       create: true,
       render: true,
-      filter: false,
+      filter: true,
       blend: true,
       store: true
     },
-    'tier-one normalized formats expose only their specified capabilities'
+    'tier-one normalized formats expose their render, filter, blend, and storage capabilities'
   );
   t.equal(
     getWebGPUTextureFormatCapabilities('bgra8unorm-srgb', baselineFeatures, 'compatibility').create,


### PR DESCRIPTION
## Summary

- derive WebGPU texture create, render, filter, blend, and storage capabilities from the active feature set
- prevent shader passes from selecting compute paths when output formats are not storage-capable
- move the capability matrix into a focused Node suite so it can be reviewed independently of Android device creation

## Review focus

This PR is independent from the Android initialization and fallback changes. The main review surface is the spec-derived format matrix and the compute-path storage gate.

Extracted from #3129.

## Verification

- `nvm use`
- `yarn install`
- `yarn lint fix`
- focused texture capability tests: 3 passed
- focused shader-pass tests: 17 passed
- full Node pre-commit suite: 3,096 passed; 3 skipped
- integrated `yarn build`: passed
- integrated `yarn test`: Node passed; six unrelated headless failures reproduced on current `master`
- integrated `yarn website:build`: passed
- integrated `(cd website && yarn build)`: passed
