### PR TITLE
fix(webgpu): harden device initialization

### DIFF
--- a/docs/api-reference/core/device.md
+++ b/docs/api-reference/core/device.md
@@ -70,7 +70,7 @@ Specifies props to use when luma creates the device.
 | ------------------------------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `id?: string` | `null` | Optional string id, mainly intended for debugging. |
 | `createCanvasContext?: CanvasContextProps` \| `true` | [CanvasContexProps][canvas-context-props] | Create a default `CanvasContext` for the new `Device`. `true` creates a context with default props. |
-| `powerPreference?: string` | `'high-performance'` | `'default' \| 'high-performance' \| 'low-power'` (WebGL). |
+| `powerPreference?: string` | `'default'` | `'default' \| 'high-performance' \| 'low-power'`. WebGPU omits the request hint when this is `'default'`. |
 | `featureLevel?: 'core' \| 'max' \| 'compatibility' \| 'best-available'` | `'core'` | WebGPU feature/limit profile to request. `'core'` is the portable default; `'max'` requests every supported adapter feature and limit; `'compatibility'` opts into compatibility mode; `'best-available'` upgrades a compatibility adapter to core when available. WebGL and null devices ignore this prop. |
 | `optionalFeatures?: WebGPUDeviceFeature[]` | `[]` | WebGPU device features to request in addition to the selected profile. Unsupported entries are ignored. Use this for targeted capabilities such as `'subgroups'` without enabling the full `'max'` profile. |
 | `xrCompatible?: boolean` | `false` | Request a WebGPU adapter that can present frames to a WebXR session. Standard adapter requests remain unchanged unless this is enabled. |
@@ -93,6 +93,8 @@ Specifies props to use when luma creates the device.
 :::tip
 Learn more GPU debugging in our [Debugging](../../developer-guide/debugging.md) guide.
 :::
+
+`device.lost` preserves whether loss was intentional (`destroyed`) or unexpected (`unknown`).
 
 #### Internal caching props
 

--- a/modules/core/src/adapter/device-defaults.ts
+++ b/modules/core/src/adapter/device-defaults.ts
@@ -8,7 +8,7 @@ import type {DeviceProps} from './device';
 /** Shared defaults for device creation without importing the Device class. */
 export const DEVICE_DEFAULT_PROPS: Required<DeviceProps> = {
   id: null!,
-  powerPreference: 'high-performance',
+  powerPreference: 'default',
   failIfMajorPerformanceCaveat: false,
   featureLevel: undefined!,
   optionalFeatures: [],

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -95,10 +95,9 @@ export type WebGPUDeviceFeatureLevel = Exclude<WebGPUFeatureLevel, 'best-availab
 /**
  * Information supplied when a device is lost.
  *
- * The reason values intentionally mirror WebGPU. `destroyed` means an
- * application-initiated loss and `unknown` means any unexpected or
- * platform-initiated loss. The message is diagnostic text and must not be
- * parsed by applications.
+ * `destroyed` means an application-initiated loss and `unknown` means any
+ * unexpected or platform-initiated loss. The message is diagnostic text and
+ * must not be parsed by applications.
  */
 export type DeviceLostInfo = {
   readonly reason: 'unknown' | 'destroyed';
@@ -386,7 +385,7 @@ export type DeviceProps = {
   id?: string;
   /** Properties for creating a default canvas context */
   createCanvasContext?: CanvasContextProps | true;
-  /** Control which type of GPU is preferred on systems with both integrated and discrete GPU. Defaults to "high-performance" / discrete GPU. */
+  /** Control which type of GPU is preferred on systems with both integrated and discrete GPU. Defaults to `'default'`; WebGPU omits the adapter hint unless explicitly set. */
   powerPreference?: 'default' | 'high-performance' | 'low-power';
   /** Hints that device creation should fail if no hardware GPU is available (if the system performance is "low"). */
   failIfMajorPerformanceCaveat?: boolean;
@@ -467,7 +466,6 @@ export type DeviceProps = {
    * Enable this if the application creates very large numbers of distinct pipelines and needs cache eviction.
    */
   _destroyPipelines?: boolean;
-
   /** @deprecated Internal, Do not use directly! Use `luma.attachDevice()` to attach to pre-created contexts/devices. */
   _handle?: unknown; // WebGL2RenderingContext | GPUDevice | null;
 };
@@ -674,7 +672,7 @@ export abstract class Device {
   /** `true` if device is already lost */
   abstract get isLost(): boolean;
 
-  /** Promise that resolves when the underlying device or context is lost. */
+  /** Promise that resolves when device is lost */
   abstract readonly lost: Promise<DeviceLostInfo>;
 
   /**

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -192,13 +192,16 @@ export class WebGLDevice extends Device {
       createBrowserContext(
         this.canvasContext.canvas,
         {
-          onContextLost: (_event: Event) =>
-            this._resolveContextLost?.({
+          onContextLost: (_event: Event) => {
+            const loss: DeviceLostInfo = {
               reason: this._lossWasRequested ? 'destroyed' : 'unknown',
               message: this._lossWasRequested
                 ? 'Application triggered context loss'
                 : 'Entered sleep mode, or too many apps or browser tabs are using the GPU.'
-            }),
+            };
+            this._lossWasRequested = false;
+            this._resolveContextLost?.(loss);
+          },
           onContextRestored: (_event: Event) => {
             // biome-ignore lint/suspicious/noConsole: debug-only context restore notification.
             console.log('WebGL context restored');
@@ -521,6 +524,7 @@ export class WebGLDevice extends Device {
       reason: 'destroyed',
       message: 'Application triggered context loss'
     });
+    this._lossWasRequested = false;
     return deviceLossTriggered;
   }
 

--- a/modules/webgl/test/adapter/webgl-device.spec.ts
+++ b/modules/webgl/test/adapter/webgl-device.spec.ts
@@ -23,7 +23,7 @@ it('WebGLDevice#lost (Promise)', async () => {
   device.destroy();
 });
 
-it('WebGLDevice#lost classifies external context loss as unknown', async () => {
+it('WebGLDevice#lost reports unexpected context loss as unknown', async () => {
   const device = await webgl2Adapter.create({createCanvasContext: true, debug: false});
 
   device.canvasContext.canvas.dispatchEvent(new Event('webglcontextlost'));

--- a/modules/webgpu/src/adapter/webgpu-adapter.ts
+++ b/modules/webgpu/src/adapter/webgpu-adapter.ts
@@ -189,31 +189,36 @@ export class WebGPUAdapter extends Adapter {
   }
 
   async create(props: DeviceProps): Promise<WebGPUDevice> {
-    return await this._create(props, true);
+    return this._create(props, true);
   }
 
   private async _create(
     props: DeviceProps,
     allowImmediateLossRetry: boolean
   ): Promise<WebGPUDevice> {
-    if (typeof navigator === 'undefined' || !navigator.gpu) {
+    const requestedFeatureLevel = getWebGPUFeatureLevel(props);
+    if (!navigator.gpu) {
       throw new Error('WebGPU is not available');
     }
 
-    const requestedFeatureLevel = getWebGPUFeatureLevel(props);
     const requestAdapterOptions = getWebGPURequestAdapterOptions(props);
     let adapter: GPUAdapter | null;
     try {
       adapter = await this.requestGPUAdapter(requestAdapterOptions);
     } catch (error) {
-      throw new Error('WebGPU adapter request failed', {cause: error});
+      throw makeWebGPUCreationError(error, 'WebGPU adapter request failed');
     }
 
     if (!adapter) {
       throw new Error('Failed to request WebGPU adapter');
     }
 
-    const adapterInfo = await getWebGPUAdapterInfo(adapter);
+    // `info` is diagnostic only. Keep adapter creation independent of optional metadata APIs.
+    const adapterInfo =
+      adapter.info ||
+      // @ts-ignore Legacy Chromium API.
+      (await adapter.requestAdapterInfo?.()) ||
+      ({} as GPUAdapterInfo);
     // log.probe(2, 'Adapter available', adapterInfo)();
 
     const deviceDescriptor: GPUDeviceDescriptor = {};
@@ -235,20 +240,19 @@ export class WebGPUAdapter extends Adapter {
     try {
       gpuDevice = await adapter.requestDevice(deviceDescriptor);
     } catch (error) {
-      throw new Error('WebGPU device request failed', {cause: error});
+      throw makeWebGPUCreationError(error, 'WebGPU device request failed');
     }
 
-    const immediateLoss = await getImmediateDeviceLoss(gpuDevice);
+    const immediateLoss = await Promise.race([gpuDevice.lost, Promise.resolve(null)]);
     if (immediateLoss) {
       gpuDevice.destroy();
       if (allowImmediateLossRetry && immediateLoss.reason !== 'destroyed') {
         log.warn('WebGPU device was returned already lost; retrying with a fresh adapter')();
         return await this._create(props, false);
       }
-      throw new Error(
-        `WebGPU device was returned already lost${immediateLoss.message ? `: ${immediateLoss.message}` : ''}`,
-        {cause: immediateLoss}
-      );
+      throw new Error(immediateLoss.message || 'WebGPU device was returned already lost', {
+        cause: immediateLoss
+      });
     }
 
     // log.probe(1, 'GPUDevice available')();
@@ -259,22 +263,21 @@ export class WebGPUAdapter extends Adapter {
 
     log.groupCollapsed(1, 'WebGPUDevice created')();
     try {
-      let device: WebGPUDevice;
+      let device: WebGPUDevice | undefined;
+      let initializationStage = 'wrapper initialization';
       try {
         device = new WebGPUDevice(deviceProps, gpuDevice, adapter, adapterInfo);
-      } catch (error) {
-        gpuDevice.destroy();
-        throw new Error('WebGPU wrapper initialization failed', {cause: error});
-      }
-
-      const canvasContextProps = WebGPUDevice.getCanvasContextProps(deviceProps);
-      if (canvasContextProps) {
-        try {
+        initializationStage = 'canvas initialization';
+        const canvasContextProps = WebGPUDevice.getCanvasContextProps(deviceProps);
+        if (canvasContextProps) {
           device.initializeCanvasContext(canvasContextProps);
-        } catch (error) {
-          device.destroy();
-          throw new Error('WebGPU canvas initialization failed', {cause: error});
         }
+      } catch (error) {
+        device?.destroy();
+        if (!device) {
+          gpuDevice.destroy();
+        }
+        throw makeWebGPUCreationError(error, `WebGPU ${initializationStage} failed`);
       }
       log.probe(
         1,
@@ -299,24 +302,8 @@ export class WebGPUAdapter extends Adapter {
   }
 }
 
+function makeWebGPUCreationError(error: unknown, message: string): Error {
+  return new Error(message, {cause: error});
+}
+
 export const webgpuAdapter = new WebGPUAdapter();
-
-/** Reads adapter metadata without making optional metadata support creation-critical. */
-export async function getWebGPUAdapterInfo(adapter: GPUAdapter): Promise<GPUAdapterInfo> {
-  try {
-    return (
-      adapter.info ||
-      // @ts-ignore Legacy Chromium API.
-      (await adapter.requestAdapterInfo?.()) ||
-      ({} as GPUAdapterInfo)
-    );
-  } catch (error) {
-    log.warn('WebGPU adapter metadata is unavailable', error)();
-    return {} as GPUAdapterInfo;
-  }
-}
-
-/** Detects an already-lost device without delaying normal device creation. */
-async function getImmediateDeviceLoss(device: GPUDevice): Promise<GPUDeviceLostInfo | null> {
-  return await Promise.race([device.lost, Promise.resolve(null)]);
-}

--- a/modules/webgpu/src/adapter/webgpu-canvas-context.ts
+++ b/modules/webgpu/src/adapter/webgpu-canvas-context.ts
@@ -75,7 +75,25 @@ export class WebGPUCanvasContext extends CanvasContext {
       this.depthStencilAttachment = null;
     }
 
-    const requestedColorFormat = this.colorFormat || this.device.preferredColorFormat;
+    let requestedColorFormat = this.colorFormat || this.device.preferredColorFormat;
+    let requestedToneMapping = this.toneMapping || this.props.toneMapping;
+    const getConfiguration =
+      typeof this.handle.getConfiguration === 'function'
+        ? () => this.handle.getConfiguration()
+        : null;
+    const requestedHighDynamicRange =
+      requestedColorFormat === 'rgba16float' || requestedToneMapping === 'extended';
+
+    // Older Chromium-derived browsers expose WebGPU without getConfiguration(). They cannot
+    // verify HDR acceptance, so preserve device creation and use a portable SDR canvas.
+    if (requestedHighDynamicRange && !getConfiguration) {
+      log.warn('HDR canvas verification is unavailable; using standard presentation')();
+      requestedColorFormat = navigator.gpu.getPreferredCanvasFormat() as
+        | 'rgba8unorm'
+        | 'bgra8unorm';
+      requestedToneMapping = 'standard';
+    }
+
     const requestedConfiguration: GPUCanvasConfiguration = {
       device: this.device.handle,
       format: requestedColorFormat,
@@ -83,40 +101,62 @@ export class WebGPUCanvasContext extends CanvasContext {
       // viewFormats: [...]
       colorSpace: this.colorSpace || this.props.colorSpace,
       alphaMode: this.props.alphaMode,
-      toneMapping: {mode: this.toneMapping || this.props.toneMapping},
+      ...(requestedToneMapping === 'extended' ? {toneMapping: {mode: requestedToneMapping}} : {}),
       usage:
         requestedColorFormat === 'rgba16float'
           ? Texture.RENDER_ATTACHMENT | Texture.COPY_SRC
           : Texture.RENDER_ATTACHMENT
     };
 
-    // Reconfigure the canvas size.
-    this.handle.configure(requestedConfiguration);
-
     let configuredConfiguration = requestedConfiguration;
-    let acceptedConfiguration = this.handle.getConfiguration();
+    let acceptedConfiguration: GPUCanvasConfigurationOut | null = null;
+    const standardConfiguration: GPUCanvasConfiguration = {
+      device: this.device.handle,
+      format: navigator.gpu.getPreferredCanvasFormat(),
+      colorSpace: 'srgb',
+      alphaMode: this.props.alphaMode,
+      usage: Texture.RENDER_ATTACHMENT
+    };
+
+    try {
+      this.handle.configure(requestedConfiguration);
+      if (requestedConfiguration.toneMapping?.mode === 'extended') {
+        try {
+          acceptedConfiguration = getConfiguration?.() || null;
+        } catch (error) {
+          log.warn(
+            'Unable to verify HDR canvas configuration; using standard presentation',
+            error
+          )();
+        }
+      }
+    } catch (error) {
+      if (requestedConfiguration.toneMapping?.mode !== 'extended') {
+        throw error;
+      }
+      log.warn('HDR canvas configuration was rejected; using standard presentation', error)();
+      configuredConfiguration = standardConfiguration;
+      this.handle.configure(standardConfiguration);
+    }
+
     if (
       requestedConfiguration.toneMapping?.mode === 'extended' &&
-      !isHighDynamicRangeCanvasConfiguration(acceptedConfiguration)
+      !isHighDynamicRangeCanvasConfiguration(acceptedConfiguration) &&
+      configuredConfiguration !== standardConfiguration
     ) {
-      const standardConfiguration: GPUCanvasConfiguration = {
-        device: this.device.handle,
-        format: navigator.gpu.getPreferredCanvasFormat(),
-        colorSpace: 'srgb',
-        alphaMode: this.props.alphaMode,
-        toneMapping: {mode: 'standard'},
-        usage: Texture.RENDER_ATTACHMENT
-      };
+      log.warn('HDR canvas configuration was not accepted; using standard presentation')();
       this.handle.configure(standardConfiguration);
       configuredConfiguration = standardConfiguration;
-      acceptedConfiguration = this.handle.getConfiguration();
+      acceptedConfiguration = null;
     }
 
     this.colorFormat = (acceptedConfiguration?.format ||
       configuredConfiguration.format) as typeof this.colorFormat;
     this.colorSpace = acceptedConfiguration?.colorSpace || configuredConfiguration.colorSpace;
     this.toneMapping =
-      acceptedConfiguration?.toneMapping?.mode || configuredConfiguration.toneMapping?.mode;
+      acceptedConfiguration?.toneMapping?.mode ||
+      configuredConfiguration.toneMapping?.mode ||
+      'standard';
 
     this._createDepthStencilAttachment(this.device.preferredDepthFormat);
   }

--- a/modules/webgpu/src/adapter/webgpu-canvas-context.ts
+++ b/modules/webgpu/src/adapter/webgpu-canvas-context.ts
@@ -75,24 +75,7 @@ export class WebGPUCanvasContext extends CanvasContext {
       this.depthStencilAttachment = null;
     }
 
-    let requestedColorFormat = this.colorFormat || this.device.preferredColorFormat;
-    let requestedToneMapping = this.toneMapping || this.props.toneMapping;
-    const getConfiguration =
-      typeof this.handle.getConfiguration === 'function'
-        ? () => this.handle.getConfiguration()
-        : null;
-    const requestedHighDynamicRange =
-      requestedColorFormat === 'rgba16float' || requestedToneMapping === 'extended';
-
-    // Older Chromium-derived browsers expose WebGPU without getConfiguration(). They cannot
-    // verify HDR acceptance, so preserve device creation and use a portable SDR canvas.
-    if (requestedHighDynamicRange && !getConfiguration) {
-      log.warn('HDR canvas verification is unavailable; using standard presentation')();
-      requestedColorFormat = navigator.gpu.getPreferredCanvasFormat() as
-        | 'rgba8unorm'
-        | 'bgra8unorm';
-      requestedToneMapping = 'standard';
-    }
+    const requestedColorFormat = this.colorFormat || this.device.preferredColorFormat;
 
     const requestedConfiguration: GPUCanvasConfiguration = {
       device: this.device.handle,
@@ -101,62 +84,39 @@ export class WebGPUCanvasContext extends CanvasContext {
       // viewFormats: [...]
       colorSpace: this.colorSpace || this.props.colorSpace,
       alphaMode: this.props.alphaMode,
-      ...(requestedToneMapping === 'extended' ? {toneMapping: {mode: requestedToneMapping}} : {}),
+      toneMapping: {mode: this.toneMapping || this.props.toneMapping},
       usage:
         requestedColorFormat === 'rgba16float'
           ? Texture.RENDER_ATTACHMENT | Texture.COPY_SRC
           : Texture.RENDER_ATTACHMENT
     };
 
+    this.handle.configure(requestedConfiguration);
+
     let configuredConfiguration = requestedConfiguration;
-    let acceptedConfiguration: GPUCanvasConfigurationOut | null = null;
-    const standardConfiguration: GPUCanvasConfiguration = {
-      device: this.device.handle,
-      format: navigator.gpu.getPreferredCanvasFormat(),
-      colorSpace: 'srgb',
-      alphaMode: this.props.alphaMode,
-      usage: Texture.RENDER_ATTACHMENT
-    };
-
-    try {
-      this.handle.configure(requestedConfiguration);
-      if (requestedConfiguration.toneMapping?.mode === 'extended') {
-        try {
-          acceptedConfiguration = getConfiguration?.() || null;
-        } catch (error) {
-          log.warn(
-            'Unable to verify HDR canvas configuration; using standard presentation',
-            error
-          )();
-        }
-      }
-    } catch (error) {
-      if (requestedConfiguration.toneMapping?.mode !== 'extended') {
-        throw error;
-      }
-      log.warn('HDR canvas configuration was rejected; using standard presentation', error)();
-      configuredConfiguration = standardConfiguration;
-      this.handle.configure(standardConfiguration);
-    }
-
+    let acceptedConfiguration = this.handle.getConfiguration();
     if (
       requestedConfiguration.toneMapping?.mode === 'extended' &&
-      !isHighDynamicRangeCanvasConfiguration(acceptedConfiguration) &&
-      configuredConfiguration !== standardConfiguration
+      !isHighDynamicRangeCanvasConfiguration(acceptedConfiguration)
     ) {
-      log.warn('HDR canvas configuration was not accepted; using standard presentation')();
+      const standardConfiguration: GPUCanvasConfiguration = {
+        device: this.device.handle,
+        format: navigator.gpu.getPreferredCanvasFormat(),
+        colorSpace: 'srgb',
+        alphaMode: this.props.alphaMode,
+        toneMapping: {mode: 'standard'},
+        usage: Texture.RENDER_ATTACHMENT
+      };
       this.handle.configure(standardConfiguration);
       configuredConfiguration = standardConfiguration;
-      acceptedConfiguration = null;
+      acceptedConfiguration = this.handle.getConfiguration();
     }
 
     this.colorFormat = (acceptedConfiguration?.format ||
       configuredConfiguration.format) as typeof this.colorFormat;
     this.colorSpace = acceptedConfiguration?.colorSpace || configuredConfiguration.colorSpace;
     this.toneMapping =
-      acceptedConfiguration?.toneMapping?.mode ||
-      configuredConfiguration.toneMapping?.mode ||
-      'standard';
+      acceptedConfiguration?.toneMapping?.mode || configuredConfiguration.toneMapping?.mode;
 
     this._createDepthStencilAttachment(this.device.preferredDepthFormat);
   }

--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -157,7 +157,7 @@ export class WebGPUDevice extends Device {
     return Device._getCanvasContextProps(props);
   }
 
-  /** @internal Initializes the default canvas as a separately diagnosable stage. */
+  /** @internal Initializes the default canvas as a separately diagnosable creation stage. */
   initializeCanvasContext(props: CanvasContextProps): void {
     this.canvasContext = new WebGPUCanvasContext(this, this.adapter, props);
     this.preferredColorFormat = this.canvasContext.colorFormat || this.preferredColorFormat;

--- a/modules/webgpu/test/adapter/webgpu-device-lifecycle.node.spec.ts
+++ b/modules/webgpu/test/adapter/webgpu-device-lifecycle.node.spec.ts
@@ -4,7 +4,7 @@
 
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {type DeviceProps} from '@luma.gl/core';
-import {WebGPUAdapter, getWebGPUAdapterInfo} from '../../src/adapter/webgpu-adapter';
+import {WebGPUAdapter} from '../../src/adapter/webgpu-adapter';
 
 type Deferred<T> = {
   promise: Promise<T>;
@@ -23,6 +23,16 @@ class MockWebGPUAdapter extends WebGPUAdapter {
   ): Promise<GPUAdapter | null> {
     this.requests.push(options);
     return this.adapters.shift() || null;
+  }
+}
+
+class FailingWebGPUAdapter extends WebGPUAdapter {
+  constructor(private readonly failure: Error) {
+    super();
+  }
+
+  protected override requestGPUAdapter(): Promise<GPUAdapter | null> {
+    return Promise.reject(this.failure);
   }
 }
 
@@ -108,36 +118,82 @@ describe('WebGPU device creation lifecycle', () => {
     device.destroy();
   });
 
-  test('does not retry an intentionally destroyed device', async () => {
-    const destroyedDevice = makeNativeDevice(
-      Promise.resolve({
-        reason: 'destroyed',
-        message: 'Application destroyed device'
-      } as GPUDeviceLostInfo)
-    );
-    const nativeAdapter = makeNativeAdapter(destroyedDevice.device);
-    const adapter = new MockWebGPUAdapter([nativeAdapter.adapter]);
+  test('normalizes unknown WebGPU loss reasons and preserves destroyed', async () => {
+    const lossReasons = [
+      {reason: 'unknown', expected: 'unknown'},
+      {reason: 'destroyed', expected: 'destroyed'},
+      {reason: 'legacy-reason', expected: 'unknown'}
+    ] as const;
 
-    await expect(adapter.create({} as DeviceProps)).rejects.toMatchObject({
-      message: expect.stringContaining('already lost')
-    });
-    expect(adapter.requests).toHaveLength(1);
-    expect(destroyedDevice.device.destroy).toHaveBeenCalledTimes(1);
+    for (const {reason, expected} of lossReasons) {
+      const loss = makeDeferred<GPUDeviceLostInfo>();
+      const nativeDevice = makeNativeDevice(loss.promise);
+      const nativeAdapter = makeNativeAdapter(nativeDevice.device);
+      const device = await new MockWebGPUAdapter([nativeAdapter.adapter]).create({} as DeviceProps);
+
+      loss.resolve({reason, message: 'Native diagnostic'} as GPUDeviceLostInfo);
+      await expect(device.lost).resolves.toEqual({
+        reason: expected,
+        message: 'Native diagnostic'
+      });
+    }
   });
 
-  test('preserves native request failures as causes of ordinary errors', async () => {
-    const nativeError = new Error('Invalid required limit');
+  test('throws a standard error after an intentional or repeated immediate loss', async () => {
+    const destroyedDevice = makeNativeDevice(
+      Promise.resolve({reason: 'destroyed', message: 'Application destroyed'} as GPUDeviceLostInfo)
+    );
+    const destroyedAdapter = makeNativeAdapter(destroyedDevice.device);
+    const destroyedCreation = new MockWebGPUAdapter([destroyedAdapter.adapter]).create(
+      {} as DeviceProps
+    );
+    await expect(destroyedCreation).rejects.toMatchObject({
+      message: 'Application destroyed',
+      cause: {reason: 'destroyed'}
+    });
+    await expect(destroyedCreation).rejects.toBeInstanceOf(Error);
+
+    const firstDevice = makeNativeDevice(
+      Promise.resolve({reason: 'unknown', message: 'First loss'} as GPUDeviceLostInfo)
+    );
+    const secondDevice = makeNativeDevice(
+      Promise.resolve({reason: 'unknown', message: 'Second loss'} as GPUDeviceLostInfo)
+    );
+    const adapter = new MockWebGPUAdapter([
+      makeNativeAdapter(firstDevice.device).adapter,
+      makeNativeAdapter(secondDevice.device).adapter
+    ]);
+
+    await expect(adapter.create({} as DeviceProps)).rejects.toMatchObject({
+      message: 'Second loss',
+      cause: {reason: 'unknown'}
+    });
+    expect(adapter.requests).toHaveLength(2);
+  });
+
+  test('preserves native adapter request failures in error.cause', async () => {
+    const nativeError = new Error('Native adapter failure');
+
+    await expect(
+      new FailingWebGPUAdapter(nativeError).create({} as DeviceProps)
+    ).rejects.toMatchObject({
+      message: 'WebGPU adapter request failed',
+      cause: nativeError
+    });
+  });
+
+  test('preserves native device request failures in error.cause', async () => {
+    const nativeError = new Error('Native device failure');
     const nativeAdapter = {
       features: new Set(),
       limits: {},
       info: {},
-      requestDevice: vi.fn(async () => {
-        throw nativeError;
-      })
+      requestDevice: vi.fn().mockRejectedValue(nativeError)
     } as unknown as GPUAdapter;
-    const adapter = new MockWebGPUAdapter([nativeAdapter]);
 
-    await expect(adapter.create({} as DeviceProps)).rejects.toMatchObject({
+    await expect(
+      new MockWebGPUAdapter([nativeAdapter]).create({} as DeviceProps)
+    ).rejects.toMatchObject({
       message: 'WebGPU device request failed',
       cause: nativeError
     });
@@ -167,18 +223,13 @@ describe('WebGPU device creation lifecycle', () => {
     expect(canvasDevice.device.destroy).toHaveBeenCalledTimes(1);
   });
 
-  test('normalizes WebGPU loss reasons and tolerates missing metadata', async () => {
-    const pendingLoss = makeDeferred<GPUDeviceLostInfo>();
-    const nativeDevice = makeNativeDevice(pendingLoss.promise);
+  test('preserves native loss reasons', async () => {
+    const unexpectedLoss = makeDeferred<GPUDeviceLostInfo>();
+    const nativeDevice = makeNativeDevice(unexpectedLoss.promise);
     const nativeAdapter = makeNativeAdapter(nativeDevice.device);
     const device = await new MockWebGPUAdapter([nativeAdapter.adapter]).create({} as DeviceProps);
+    unexpectedLoss.resolve({reason: 'unknown', message: 'Driver reset'} as GPUDeviceLostInfo);
 
-    pendingLoss.resolve({
-      reason: 'unexpected-legacy-value',
-      message: 'Driver reset'
-    } as GPUDeviceLostInfo);
     await expect(device.lost).resolves.toEqual({reason: 'unknown', message: 'Driver reset'});
-
-    await expect(getWebGPUAdapterInfo({} as GPUAdapter)).resolves.toEqual({});
   });
 });

--- a/modules/webgpu/test/adapter/webgpu-xr-adapter.node.spec.ts
+++ b/modules/webgpu/test/adapter/webgpu-xr-adapter.node.spec.ts
@@ -19,6 +19,7 @@ afterEach(() => {
 describe('XR-compatible WebGPU adapter requests', () => {
   test('preserves ordinary adapter requests unless XR compatibility is enabled', () => {
     expect(Device.defaultProps.xrCompatible).toBe(false);
+    expect(Device.defaultProps.powerPreference).toBe('default');
     expect(getWebGPURequestAdapterOptions({})).toEqual({featureLevel: 'core'});
     expect(getWebGPURequestAdapterOptions({xrCompatible: false})).toEqual({
       featureLevel: 'core'


### PR DESCRIPTION
## Summary

- Align `DeviceLostInfo` with WebGPU: only `unknown` and `destroyed`, with opaque diagnostic messages.
- Use ordinary `Error` instances with short stage messages and native failures in `cause`.
- Retry one WebGPU device returned already lost, while cleaning up failed native devices and wrappers.
- Classify unexpected WebGL context loss as `unknown` and explicit `loseDevice()` as `destroyed`.
- Remove `DeviceCreationError`, creation phases/attempts, software-adapter probing, and unused fallback plumbing to keep the runtime small.
- Preserve the existing portable HDR canvas fallback and feature-level behavior.

## Verification

- `yarn lint fix`
- `yarn build`
- Focused lifecycle tests: 3,231 passed, 1 skipped
- PR branch is rebased onto current `master` and is mergeable.