### PR TITLE
fix(core): make device selection outcome based

### DIFF
--- a/docs/api-guide/gpu/gpu-initialization.md
+++ b/docs/api-guide/gpu/gpu-initialization.md
@@ -78,9 +78,11 @@ const device = await luma.createDevice({
 console.log(device.type); // 'webgpu' or 'webgl'
 ```
 
-`best-available` prefers WebGPU when it is usable and otherwise selects WebGL 2. Registering a
-fallback does not make WGSL, compute, storage buffers, or other WebGPU-only code portable; the
-application must still provide a supported path for the selected device.
+`best-available` attempts WebGPU core, WebGPU compatibility, and then WebGL 2. Use
+`best-available-webgpu` when the application has no WebGL implementation: it attempts WebGPU core,
+WebGPU compatibility, and finally software WebGPU compatibility. Registering a fallback does not
+make WGSL, compute, storage buffers, or other WebGPU-only code portable; the application must still
+provide a supported path for the selected device.
 
 ## Select a capability-dependent path
 

--- a/docs/api-guide/gpu/gpu-initialization.md
+++ b/docs/api-guide/gpu/gpu-initialization.md
@@ -78,9 +78,9 @@ const device = await luma.createDevice({
 console.log(device.type); // 'webgpu' or 'webgl'
 ```
 
-`best-available` attempts WebGPU core, WebGPU compatibility, and then WebGL 2. Use
-`best-available-webgpu` when the application has no WebGL implementation: it attempts WebGPU core,
-WebGPU compatibility, and finally software WebGPU compatibility. Registering a fallback does not
+`best-available` attempts WebGPU max, core, compatibility, and then WebGL 2. Use
+`best-webgpu` when the application has no WebGL implementation: it attempts WebGPU max, core,
+compatibility, and finally software WebGPU compatibility. Registering a fallback does not
 make WGSL, compute, storage buffers, or other WebGPU-only code portable; the application must still
 provide a supported path for the selected device.
 

--- a/docs/api-reference/core/device.md
+++ b/docs/api-reference/core/device.md
@@ -94,7 +94,9 @@ Specifies props to use when luma creates the device.
 Learn more GPU debugging in our [Debugging](../../developer-guide/debugging.md) guide.
 :::
 
-`device.lost` preserves whether loss was intentional (`destroyed`) or unexpected (`unknown`).
+`device.creationInfo` describes the selection policy and failed fallback attempts that preceded a
+successful device. `device.lost` preserves whether loss was intentional (`destroyed`) or unexpected
+(`unknown`).
 
 #### Internal caching props
 

--- a/docs/api-reference/core/device.md
+++ b/docs/api-reference/core/device.md
@@ -70,7 +70,7 @@ Specifies props to use when luma creates the device.
 | ------------------------------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `id?: string` | `null` | Optional string id, mainly intended for debugging. |
 | `createCanvasContext?: CanvasContextProps` \| `true` | [CanvasContexProps][canvas-context-props] | Create a default `CanvasContext` for the new `Device`. `true` creates a context with default props. |
-| `powerPreference?: string` | `'high-performance'` | `'default' \| 'high-performance' \| 'low-power'` (WebGL). |
+| `powerPreference?: string` | `'default'` | `'default' \| 'high-performance' \| 'low-power'`. WebGPU omits the request hint when this is `'default'`. |
 | `featureLevel?: 'core' \| 'max' \| 'compatibility' \| 'best-available'` | `'core'` | WebGPU feature/limit profile to request. `'core'` is the portable default; `'max'` requests every supported adapter feature and limit; `'compatibility'` opts into compatibility mode; `'best-available'` upgrades a compatibility adapter to core when available. WebGL and null devices ignore this prop. |
 | `optionalFeatures?: WebGPUDeviceFeature[]` | `[]` | WebGPU device features to request in addition to the selected profile. Unsupported entries are ignored. Use this for targeted capabilities such as `'subgroups'` without enabling the full `'max'` profile. |
 | `xrCompatible?: boolean` | `false` | Request a WebGPU adapter that can present frames to a WebXR session. Standard adapter requests remain unchanged unless this is enabled. |
@@ -93,6 +93,8 @@ Specifies props to use when luma creates the device.
 :::tip
 Learn more GPU debugging in our [Debugging](../../developer-guide/debugging.md) guide.
 :::
+
+`device.lost` preserves whether loss was intentional (`destroyed`) or unexpected (`unknown`).
 
 #### Internal caching props
 

--- a/docs/api-reference/core/luma.md
+++ b/docs/api-reference/core/luma.md
@@ -99,8 +99,8 @@ Properties for creating a new device. See [`DeviceProps`](./device.md#deviceprop
 
 ```ts
 type CreateDeviceProps = {
-  /** Selects the type of device. `best-available` uses webgpu if available, then webgl. */
-  type?: 'webgl' | 'webgpu' | 'unknown' | 'best-available';
+  /** Selects an exact backend or an ordered device creation policy. */
+  type?: 'webgl' | 'webgpu' | 'unknown' | 'best-available' | 'best-available-webgpu';
   /** List of device types. Will also search any pre-registered device backends */
   adapters?: Adapter[];
   /** Whether to wait for page to be loaded, which ensures that canvas contexts can refer to existing canvases by id (defaults to true) */
@@ -131,12 +131,18 @@ luma.createDevice({type, adapters, ...deviceProps}: CreateDeviceProps);
 
 To create a Device instance, the application calls `luma.createDevice()`.
 
-- `type`: `'webgl' \| 'webgpu' \| 'best-available'`
+- `type`: `'webgl' \| 'webgpu' \| 'best-available' \| 'best-available-webgpu'`
 - `adapters`: list of `Adapter` instances providing support for different GPU backends. Can be omitted if `luma.registerAdapters()` has been called.
 - `...deviceProps`: See [`DeviceProps`](./device.md#deviceprops) for device specific options.
 
-Unless a device `type` is specified a `Device` will be created using the `'best-available'` adapter.
-luma.gl favors WebGPU over WebGL adapters, whenever WebGPU is available.
+Unless a device `type` is specified, luma.gl uses the outcome-based `'best-available'` policy:
+WebGPU core, WebGPU compatibility, then WebGL 2. `'best-available-webgpu'` tries core and
+compatibility hardware adapters, then a software WebGPU compatibility adapter; it never returns
+WebGL. Exact `'webgpu'` and `'webgl'` requests do not change backends after failure.
+
+Failed attempts are retained in `device.creationInfo` after successful fallback. If every attempt
+fails, `createDevice()` rejects with `DeviceCreationError`, whose `attempts` identify the backend,
+feature level, software status, failure phase, and native cause.
 
 Note: A specific device type is available and supported if both of the following are true:
 1. The backend module has been registered

--- a/docs/api-reference/core/luma.md
+++ b/docs/api-reference/core/luma.md
@@ -100,7 +100,7 @@ Properties for creating a new device. See [`DeviceProps`](./device.md#deviceprop
 ```ts
 type CreateDeviceProps = {
   /** Selects an exact backend or an ordered device creation policy. */
-  type?: 'webgl' | 'webgpu' | 'unknown' | 'best-available' | 'best-available-webgpu';
+  type?: 'webgl' | 'webgpu' | 'unknown' | 'best-available' | 'best-webgpu';
   /** List of device types. Will also search any pre-registered device backends */
   adapters?: Adapter[];
   /** Whether to wait for page to be loaded, which ensures that canvas contexts can refer to existing canvases by id (defaults to true) */
@@ -131,14 +131,14 @@ luma.createDevice({type, adapters, ...deviceProps}: CreateDeviceProps);
 
 To create a Device instance, the application calls `luma.createDevice()`.
 
-- `type`: `'webgl' \| 'webgpu' \| 'best-available' \| 'best-available-webgpu'`
+- `type`: `'webgl' \| 'webgpu' \| 'best-available' \| 'best-webgpu'`
 - `adapters`: list of `Adapter` instances providing support for different GPU backends. Can be omitted if `luma.registerAdapters()` has been called.
 - `...deviceProps`: See [`DeviceProps`](./device.md#deviceprops) for device specific options.
 
 Unless a device `type` is specified, luma.gl uses the outcome-based `'best-available'` policy:
-WebGPU core, WebGPU compatibility, then WebGL 2. `'best-available-webgpu'` tries core and
-compatibility hardware adapters, then a software WebGPU compatibility adapter; it never returns
-WebGL. Exact `'webgpu'` and `'webgl'` requests do not change backends after failure.
+WebGPU max, core, compatibility, then WebGL 2. `'best-webgpu'` tries max, core, and compatibility
+hardware adapters, then a software WebGPU compatibility adapter; it never returns WebGL. Exact
+`'webgpu'` and `'webgl'` requests do not change backends after failure.
 
 Failed attempts are retained in `device.creationInfo` after successful fallback. If every attempt
 fails, `createDevice()` rejects with `DeviceCreationError`, whose `attempts` identify the backend,

--- a/examples/showcase/billion-point-spatial-atlas/index.html
+++ b/examples/showcase/billion-point-spatial-atlas/index.html
@@ -58,6 +58,7 @@
         try {
           device = await luma.createDevice({
             id: 'billion-point-spatial-atlas',
+            type: softwareVisualSmoke ? 'webgpu' : 'best-available',
             adapters: [webgpuAdapter],
             createCanvasContext: supportsHighDynamicRange
               ? {
@@ -72,6 +73,7 @@
           if (!supportsHighDynamicRange) throw error;
           device = await luma.createDevice({
             id: 'billion-point-spatial-atlas-sdr-fallback',
+            type: softwareVisualSmoke ? 'webgpu' : 'best-available',
             adapters: [webgpuAdapter],
             createCanvasContext: standardCanvasContext
           });

--- a/examples/showcase/million-row-crossfilter/index.html
+++ b/examples/showcase/million-row-crossfilter/index.html
@@ -92,6 +92,7 @@
     <script type="module">
       const startup = document.querySelector('#crossfilter-startup');
       const status = document.querySelector('[data-startup-status]');
+      const softwareVisualSmoke = new URLSearchParams(window.location.search).has('visual-smoke');
 
       try {
         if (!navigator.gpu) {
@@ -109,6 +110,7 @@
         status.textContent = 'Acquiring a high-performance WebGPU device…';
         const device = await luma.createDevice({
           id: 'million-row-crossfilter',
+          type: softwareVisualSmoke ? 'webgpu' : 'best-available',
           adapters: [webgpuAdapter],
           featureLevel: 'best-available',
           powerPreference: 'high-performance',

--- a/examples/showcase/raster-lab/index.html
+++ b/examples/showcase/raster-lab/index.html
@@ -86,6 +86,7 @@
     <script type="module">
       const startup = document.querySelector('#raster-startup');
       const status = document.querySelector('[data-raster-startup-status]');
+      const softwareVisualSmoke = new URLSearchParams(window.location.search).has('visual-smoke');
 
       try {
         if (!navigator.gpu) {
@@ -103,6 +104,7 @@
         status.textContent = 'Acquiring a WebGPU device for resident raster analysis…';
         const device = await luma.createDevice({
           id: 'gpu-raster-satellite-raster-lab',
+          type: softwareVisualSmoke ? 'webgpu' : 'best-available',
           adapters: [webgpuAdapter],
           featureLevel: 'best-available',
           powerPreference: 'high-performance',

--- a/modules/core/src/adapter/device-creation-error.ts
+++ b/modules/core/src/adapter/device-creation-error.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import type {WebGPUFeatureLevel} from './device';
+import type {WebGPUDeviceFeatureLevel, WebGPUFeatureLevel} from './device';
 
 /** Identifies the stage at which GPU device creation failed. */
 export type DeviceCreationPhase =
@@ -19,6 +19,17 @@ export type DeviceCreationAttempt = {
   software: boolean;
   phase: DeviceCreationPhase;
   error: Error;
+};
+
+/** Diagnostics retained on a successfully created device. */
+export type DeviceCreationInfo = {
+  requestedType: string;
+  selected: {
+    backend: DeviceCreationAttempt['backend'];
+    featureLevel?: WebGPUDeviceFeatureLevel;
+    software: boolean;
+  } | null;
+  attempts: readonly DeviceCreationAttempt[];
 };
 
 /** Error thrown after one or more device creation attempts fail. */

--- a/modules/core/src/adapter/device-creation-error.ts
+++ b/modules/core/src/adapter/device-creation-error.ts
@@ -1,0 +1,52 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {WebGPUFeatureLevel} from './device';
+
+/** Identifies the stage at which GPU device creation failed. */
+export type DeviceCreationPhase =
+  | 'adapter-selection'
+  | 'adapter-request'
+  | 'device-request'
+  | 'wrapper-initialization'
+  | 'canvas-initialization';
+
+/** One attempted backend/profile during device creation. */
+export type DeviceCreationAttempt = {
+  backend: 'webgpu' | 'webgl' | 'null' | 'unknown';
+  featureLevel?: WebGPUFeatureLevel;
+  software: boolean;
+  phase: DeviceCreationPhase;
+  error: Error;
+};
+
+/** Error thrown after one or more device creation attempts fail. */
+export class DeviceCreationError extends Error {
+  readonly attempts: readonly DeviceCreationAttempt[];
+  readonly phase: DeviceCreationPhase;
+
+  constructor(
+    message: string,
+    attempts: readonly DeviceCreationAttempt[],
+    cause: unknown = attempts[attempts.length - 1]?.error
+  ) {
+    super(message, {cause});
+    this.name = 'DeviceCreationError';
+    this.attempts = attempts;
+    this.phase = attempts[attempts.length - 1]?.phase || 'wrapper-initialization';
+  }
+}
+
+/** Wraps an adapter-specific failure without losing an existing structured error. */
+export function wrapDeviceCreationError(
+  error: unknown,
+  attempt: Omit<DeviceCreationAttempt, 'error'>,
+  message: string
+): DeviceCreationError {
+  if (error instanceof DeviceCreationError) {
+    return error;
+  }
+  const cause = error instanceof Error ? error : new Error(String(error));
+  return new DeviceCreationError(message, [{...attempt, error: cause}], cause);
+}

--- a/modules/core/src/adapter/device-defaults.ts
+++ b/modules/core/src/adapter/device-defaults.ts
@@ -8,7 +8,7 @@ import type {DeviceProps} from './device';
 /** Shared defaults for device creation without importing the Device class. */
 export const DEVICE_DEFAULT_PROPS: Required<DeviceProps> = {
   id: null!,
-  powerPreference: 'high-performance',
+  powerPreference: 'default',
   failIfMajorPerformanceCaveat: false,
   featureLevel: undefined!,
   optionalFeatures: [],
@@ -49,6 +49,7 @@ export const DEVICE_DEFAULT_PROPS: Required<DeviceProps> = {
   _cachePipelines: true,
   _sharePipelines: true,
   _destroyPipelines: false,
+  _forceFallbackAdapter: false,
   // TODO - Change these after confirming things work as expected
   _initializeFeatures: true,
   _disabledFeatures: {

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -92,6 +92,12 @@ export type WebGPUFeatureLevel = 'core' | 'max' | 'compatibility' | 'best-availa
 /** Effective WebGPU feature level reported by a created WebGPU device. */
 export type WebGPUDeviceFeatureLevel = Exclude<WebGPUFeatureLevel, 'best-available'>;
 
+/** Information supplied when a device is lost. */
+export type DeviceLostInfo = {
+  reason: 'destroyed' | 'unknown';
+  message: string;
+};
+
 /** Limits for a device (max supported sizes of resources, max number of bindings etc) */
 export abstract class DeviceLimits {
   /** max number of TextureDimension1D */
@@ -373,7 +379,7 @@ export type DeviceProps = {
   id?: string;
   /** Properties for creating a default canvas context */
   createCanvasContext?: CanvasContextProps | true;
-  /** Control which type of GPU is preferred on systems with both integrated and discrete GPU. Defaults to "high-performance" / discrete GPU. */
+  /** Control which type of GPU is preferred on systems with both integrated and discrete GPU. Defaults to `'default'`; WebGPU omits the adapter hint unless explicitly set. */
   powerPreference?: 'default' | 'high-performance' | 'low-power';
   /** Hints that device creation should fail if no hardware GPU is available (if the system performance is "low"). */
   failIfMajorPerformanceCaveat?: boolean;
@@ -454,6 +460,8 @@ export type DeviceProps = {
    * Enable this if the application creates very large numbers of distinct pipelines and needs cache eviction.
    */
   _destroyPipelines?: boolean;
+  /** Internal: request a software-backed WebGPU adapter. */
+  _forceFallbackAdapter?: boolean;
 
   /** @deprecated Internal, Do not use directly! Use `luma.attachDevice()` to attach to pre-created contexts/devices. */
   _handle?: unknown; // WebGL2RenderingContext | GPUDevice | null;
@@ -662,7 +670,7 @@ export abstract class Device {
   abstract get isLost(): boolean;
 
   /** Promise that resolves when device is lost */
-  abstract readonly lost: Promise<{reason: 'destroyed'; message: string}>;
+  abstract readonly lost: Promise<DeviceLostInfo>;
 
   /**
    * Trigger device loss.

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -40,6 +40,7 @@ import type {ExternalImage} from '../shadertypes/image-types/image-types';
 import {isExternalImage, getExternalImageSize} from '../shadertypes/image-types/image-types';
 import {getTextureFormatTable} from '../shadertypes/texture-types/texture-format-table';
 import {DEVICE_DEFAULT_PROPS} from './device-defaults';
+import type {DeviceCreationInfo} from './device-creation-error';
 
 export {_getDefaultDebugValue} from './device-defaults';
 
@@ -545,6 +546,12 @@ export abstract class Device {
   _reused: boolean = false;
   /** Used by other luma.gl modules to store data on the device */
   private _moduleData: Record<string, Record<string, unknown>> = {};
+  /** Device selection and fallback attempts used to create this device. */
+  creationInfo: DeviceCreationInfo = {
+    requestedType: 'unknown',
+    selected: null,
+    attempts: []
+  };
 
   // Capabilities
 

--- a/modules/core/src/adapter/luma.ts
+++ b/modules/core/src/adapter/luma.ts
@@ -3,9 +3,14 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {Log} from '@probe.gl/log';
-import type {Device, DeviceProps} from './device';
+import type {Device, DeviceProps, WebGPUFeatureLevel} from './device';
 import {DEVICE_DEFAULT_PROPS} from './device-defaults';
 import {Adapter} from './adapter';
+import {
+  DeviceCreationError,
+  type DeviceCreationAttempt,
+  wrapDeviceCreationError
+} from './device-creation-error';
 import {StatsManager, lumaStats} from '../utils/stats-manager';
 import {log} from '../utils/log';
 
@@ -16,13 +21,19 @@ declare global {
 
 const STARTUP_MESSAGE = 'set luma.log.level=1 (or higher) to trace rendering';
 
-const ERROR_MESSAGE =
-  'No matching device found. Ensure `@luma.gl/webgl` and/or `@luma.gl/webgpu` modules are imported.';
+const ERROR_MESSAGE = 'No matching device found. Import `@luma.gl/webgl` and/or `@luma.gl/webgpu`.';
+
+type DeviceCreationCandidate = {
+  adapter?: Adapter;
+  backend: DeviceCreationAttempt['backend'];
+  featureLevel?: WebGPUFeatureLevel;
+  software?: boolean;
+};
 
 /** Properties for creating a new device */
 export type CreateDeviceProps = {
-  /** Selects the type of device. `best-available` uses webgpu if available, then webgl. */
-  type?: 'webgl' | 'webgpu' | 'null' | 'unknown' | 'best-available';
+  /** Selects an exact backend or an ordered device creation policy. */
+  type?: 'webgl' | 'webgpu' | 'null' | 'unknown' | 'best-available' | 'best-available-webgpu';
   /** List of adapters. Will also search any pre-registered adapters */
   adapters?: Adapter[];
   /**
@@ -92,18 +103,93 @@ export class Luma {
   /** Creates a device. Asynchronously. */
   async createDevice(props_: CreateDeviceProps = {}): Promise<Device> {
     const props: Required<CreateDeviceProps> = {...Luma.defaultProps, ...props_};
+    const candidates = this._getDeviceCreationCandidates(props);
+    const attempts: DeviceCreationAttempt[] = [];
+    const isBestAvailablePolicy = props.type.startsWith('best');
 
-    const adapter = this.selectAdapter(props.type, props.adapters);
-    if (!adapter) {
-      throw new Error(ERROR_MESSAGE);
+    for (const candidate of candidates) {
+      const attempt = {
+        backend: candidate.backend,
+        featureLevel: candidate.featureLevel,
+        software: Boolean(candidate.software),
+        phase: 'adapter-selection' as const
+      };
+
+      if (!candidate.adapter?.isSupported?.()) {
+        const error = new Error(`No ${candidate.backend} adapter`);
+        attempts.push({...attempt, error});
+        continue;
+      }
+
+      try {
+        if (props.waitForPageLoad) {
+          try {
+            await candidate.adapter.pageLoaded;
+          } catch (error) {
+            throw wrapDeviceCreationError(
+              error,
+              {...attempt, phase: 'adapter-request'},
+              `Waiting for ${candidate.backend} failed`
+            );
+          }
+        }
+
+        const device = await candidate.adapter.create({
+          ...props,
+          featureLevel: candidate.featureLevel,
+          _forceFallbackAdapter: Boolean(candidate.software),
+          failIfMajorPerformanceCaveat:
+            props.failIfMajorPerformanceCaveat ||
+            (isBestAvailablePolicy && candidate.backend === 'webgpu' && !candidate.software)
+        });
+        const selectedSoftware =
+          candidate.software ||
+          device.info.gpu === 'software' ||
+          device.info.gpuType === 'cpu' ||
+          Boolean(device.info.fallback);
+        if (
+          isBestAvailablePolicy &&
+          candidate.backend === 'webgpu' &&
+          !candidate.software &&
+          selectedSoftware
+        ) {
+          device.destroy();
+          attempts.push({
+            ...attempt,
+            phase: 'adapter-selection',
+            error: new Error('Software rejected')
+          });
+          replaceCanvasAfterFailedInitialization(props);
+          continue;
+        }
+        device.creationInfo = {
+          requestedType: props.type,
+          selected: {
+            backend: candidate.backend,
+            featureLevel: device.info.featureLevel,
+            software: selectedSoftware
+          },
+          attempts
+        };
+        if (attempts.length > 0) {
+          log.warn(`Recovered ${candidate.backend}; ${attempts.length} failed`, attempts)();
+        }
+        return device;
+      } catch (error) {
+        const structuredError = wrapDeviceCreationError(
+          error,
+          {...attempt, phase: 'wrapper-initialization'},
+          `Failed to create ${candidate.backend}`
+        );
+        attempts.push(...structuredError.attempts);
+        if (structuredError.phase === 'canvas-initialization') {
+          replaceCanvasAfterFailedInitialization(props);
+        }
+      }
     }
 
-    // Wait for page to load so that CanvasContext's can access the DOM.
-    if (props.waitForPageLoad) {
-      await adapter.pageLoaded;
-    }
-
-    return await adapter.create(props);
+    const lastError = attempts[attempts.length - 1]?.error;
+    throw new DeviceCreationError(lastError?.message || ERROR_MESSAGE, attempts, lastError);
   }
 
   /**
@@ -157,6 +243,8 @@ export class Luma {
     let selectedType: string | null = type;
     if (type === 'best-available') {
       selectedType = this.getBestAvailableAdapterType(adapters);
+    } else if (type === 'best-available-webgpu') {
+      selectedType = 'webgpu';
     }
 
     const adapterMap = this._getAdapterMap(adapters);
@@ -194,6 +282,56 @@ export class Luma {
     return map;
   }
 
+  protected _getDeviceCreationCandidates(
+    props: Required<CreateDeviceProps>
+  ): DeviceCreationCandidate[] {
+    const adapterMap = this._getAdapterMap(props.adapters);
+    if (!props.type.startsWith('best')) {
+      const adapter = adapterMap.get(props.type);
+      return [
+        {
+          adapter,
+          backend: props.type as DeviceCreationCandidate['backend'],
+          featureLevel: props.type === 'webgpu' ? props.featureLevel : undefined,
+          software: Boolean(props.type === 'webgpu' && props._forceFallbackAdapter)
+        }
+      ];
+    }
+
+    const featureLevels: WebGPUFeatureLevel[] =
+      props.featureLevel === 'max'
+        ? ['max', 'core', 'compatibility']
+        : props.featureLevel === 'compatibility'
+          ? ['compatibility']
+          : ['core', 'compatibility'];
+    const webgpuAdapter = adapterMap.get('webgpu');
+    const candidates: DeviceCreationCandidate[] = featureLevels.map(featureLevel => ({
+      adapter: webgpuAdapter,
+      backend: 'webgpu',
+      featureLevel
+    }));
+
+    if (props.type === 'best-available') {
+      candidates.push({
+        adapter: adapterMap.get('webgl'),
+        backend: 'webgl'
+      });
+      candidates.push({
+        adapter: adapterMap.get('null'),
+        backend: 'null'
+      });
+    } else if (!props.failIfMajorPerformanceCaveat) {
+      candidates.push({
+        adapter: webgpuAdapter,
+        backend: 'webgpu',
+        featureLevel: 'compatibility',
+        software: true
+      });
+    }
+
+    return candidates;
+  }
+
   /** Get type of a handle (for attachDevice) */
   protected _getTypeFromHandle(
     handle: unknown,
@@ -227,6 +365,21 @@ export class Luma {
     }
 
     return null;
+  }
+}
+
+function replaceCanvasAfterFailedInitialization(props: Required<CreateDeviceProps>): void {
+  const contextProps = props.createCanvasContext;
+  if (
+    typeof HTMLCanvasElement !== 'undefined' &&
+    contextProps &&
+    contextProps !== true &&
+    contextProps.canvas instanceof HTMLCanvasElement
+  ) {
+    const canvas = contextProps.canvas;
+    const replacement = canvas.cloneNode() as HTMLCanvasElement;
+    canvas.replaceWith(replacement);
+    contextProps.canvas = replacement;
   }
 }
 

--- a/modules/core/src/adapter/luma.ts
+++ b/modules/core/src/adapter/luma.ts
@@ -23,12 +23,11 @@ const STARTUP_MESSAGE = 'set luma.log.level=1 (or higher) to trace rendering';
 
 const ERROR_MESSAGE = 'No matching device found. Import `@luma.gl/webgl` and/or `@luma.gl/webgpu`.';
 
-type DeviceCreationCandidate = {
-  adapter?: Adapter;
-  backend: DeviceCreationAttempt['backend'];
-  featureLevel?: WebGPUFeatureLevel;
-  software?: boolean;
-};
+type DeviceCreationCandidate = [
+  backend: DeviceCreationAttempt['backend'],
+  featureLevel?: WebGPUFeatureLevel,
+  software?: boolean
+];
 
 /** Properties for creating a new device */
 export type CreateDeviceProps = {
@@ -103,20 +102,22 @@ export class Luma {
   /** Creates a device. Asynchronously. */
   async createDevice(props_: CreateDeviceProps = {}): Promise<Device> {
     const props: Required<CreateDeviceProps> = {...Luma.defaultProps, ...props_};
-    const candidates = this._getDeviceCreationCandidates(props);
+    const candidates = getDeviceCreationCandidates(props);
+    const adapterMap = this._getAdapterMap(props.adapters);
     const attempts: DeviceCreationAttempt[] = [];
     const isBestAvailablePolicy = props.type.startsWith('best');
 
-    for (const candidate of candidates) {
+    for (const [backend, featureLevel, software = false] of candidates) {
+      const adapter = adapterMap.get(backend);
       const attempt = {
-        backend: candidate.backend,
-        featureLevel: candidate.featureLevel,
-        software: Boolean(candidate.software),
+        backend,
+        featureLevel,
+        software,
         phase: 'adapter-selection' as const
       };
 
-      if (!candidate.adapter?.isSupported?.()) {
-        const error = new Error(`No ${candidate.backend} adapter`);
+      if (!adapter?.isSupported?.()) {
+        const error = new Error(`No ${backend} adapter`);
         attempts.push({...attempt, error});
         continue;
       }
@@ -124,35 +125,30 @@ export class Luma {
       try {
         if (props.waitForPageLoad) {
           try {
-            await candidate.adapter.pageLoaded;
+            await adapter.pageLoaded;
           } catch (error) {
             throw wrapDeviceCreationError(
               error,
               {...attempt, phase: 'adapter-request'},
-              `Waiting for ${candidate.backend} failed`
+              `Waiting for ${backend} failed`
             );
           }
         }
 
-        const device = await candidate.adapter.create({
+        const device = await adapter.create({
           ...props,
-          featureLevel: candidate.featureLevel,
-          _forceFallbackAdapter: Boolean(candidate.software),
+          featureLevel,
+          _forceFallbackAdapter: software,
           failIfMajorPerformanceCaveat:
             props.failIfMajorPerformanceCaveat ||
-            (isBestAvailablePolicy && candidate.backend === 'webgpu' && !candidate.software)
+            (isBestAvailablePolicy && backend === 'webgpu' && !software)
         });
         const selectedSoftware =
-          candidate.software ||
+          software ||
           device.info.gpu === 'software' ||
           device.info.gpuType === 'cpu' ||
-          Boolean(device.info.fallback);
-        if (
-          isBestAvailablePolicy &&
-          candidate.backend === 'webgpu' &&
-          !candidate.software &&
-          selectedSoftware
-        ) {
+          !!device.info.fallback;
+        if (isBestAvailablePolicy && backend === 'webgpu' && !software && selectedSoftware) {
           device.destroy();
           attempts.push({
             ...attempt,
@@ -165,21 +161,21 @@ export class Luma {
         device.creationInfo = {
           requestedType: props.type,
           selected: {
-            backend: candidate.backend,
+            backend,
             featureLevel: device.info.featureLevel,
             software: selectedSoftware
           },
           attempts
         };
         if (attempts.length > 0) {
-          log.warn(`Recovered ${candidate.backend}; ${attempts.length} failed`, attempts)();
+          log.warn(`Recovered ${backend}; ${attempts.length} failed`, attempts)();
         }
         return device;
       } catch (error) {
         const structuredError = wrapDeviceCreationError(
           error,
           {...attempt, phase: 'wrapper-initialization'},
-          `Failed to create ${candidate.backend}`
+          `Failed to create ${backend}`
         );
         attempts.push(...structuredError.attempts);
         if (structuredError.phase === 'canvas-initialization') {
@@ -282,56 +278,6 @@ export class Luma {
     return map;
   }
 
-  protected _getDeviceCreationCandidates(
-    props: Required<CreateDeviceProps>
-  ): DeviceCreationCandidate[] {
-    const adapterMap = this._getAdapterMap(props.adapters);
-    if (!props.type.startsWith('best')) {
-      const adapter = adapterMap.get(props.type);
-      return [
-        {
-          adapter,
-          backend: props.type as DeviceCreationCandidate['backend'],
-          featureLevel: props.type === 'webgpu' ? props.featureLevel : undefined,
-          software: Boolean(props.type === 'webgpu' && props._forceFallbackAdapter)
-        }
-      ];
-    }
-
-    const featureLevels: WebGPUFeatureLevel[] =
-      props.featureLevel === 'max'
-        ? ['max', 'core', 'compatibility']
-        : props.featureLevel === 'compatibility'
-          ? ['compatibility']
-          : ['core', 'compatibility'];
-    const webgpuAdapter = adapterMap.get('webgpu');
-    const candidates: DeviceCreationCandidate[] = featureLevels.map(featureLevel => ({
-      adapter: webgpuAdapter,
-      backend: 'webgpu',
-      featureLevel
-    }));
-
-    if (props.type === 'best-available') {
-      candidates.push({
-        adapter: adapterMap.get('webgl'),
-        backend: 'webgl'
-      });
-      candidates.push({
-        adapter: adapterMap.get('null'),
-        backend: 'null'
-      });
-    } else if (!props.failIfMajorPerformanceCaveat) {
-      candidates.push({
-        adapter: webgpuAdapter,
-        backend: 'webgpu',
-        featureLevel: 'compatibility',
-        software: true
-      });
-    }
-
-    return candidates;
-  }
-
   /** Get type of a handle (for attachDevice) */
   protected _getTypeFromHandle(
     handle: unknown,
@@ -366,6 +312,39 @@ export class Luma {
 
     return null;
   }
+}
+
+function getDeviceCreationCandidates(
+  props: Required<CreateDeviceProps>
+): DeviceCreationCandidate[] {
+  if (!props.type.startsWith('best')) {
+    return [
+      [
+        props.type as DeviceCreationAttempt['backend'],
+        props.type === 'webgpu' ? props.featureLevel : undefined,
+        props.type === 'webgpu' && props._forceFallbackAdapter
+      ]
+    ];
+  }
+
+  const featureLevels: WebGPUFeatureLevel[] =
+    props.featureLevel === 'max'
+      ? ['max', 'core', 'compatibility']
+      : props.featureLevel === 'compatibility'
+        ? ['compatibility']
+        : ['core', 'compatibility'];
+  const candidates: DeviceCreationCandidate[] = featureLevels.map(featureLevel => [
+    'webgpu',
+    featureLevel
+  ]);
+
+  if (props.type === 'best-available') {
+    candidates.push(['webgl'], ['null']);
+  } else if (!props.failIfMajorPerformanceCaveat) {
+    candidates.push(['webgpu', 'compatibility', true]);
+  }
+
+  return candidates;
 }
 
 function replaceCanvasAfterFailedInitialization(props: Required<CreateDeviceProps>): void {

--- a/modules/core/src/adapter/luma.ts
+++ b/modules/core/src/adapter/luma.ts
@@ -32,7 +32,7 @@ type DeviceCreationCandidate = [
 /** Properties for creating a new device */
 export type CreateDeviceProps = {
   /** Selects an exact backend or an ordered device creation policy. */
-  type?: 'webgl' | 'webgpu' | 'null' | 'unknown' | 'best-available' | 'best-available-webgpu';
+  type?: 'webgl' | 'webgpu' | 'null' | 'unknown' | 'best-available' | 'best-webgpu';
   /** List of adapters. Will also search any pre-registered adapters */
   adapters?: Adapter[];
   /**
@@ -239,7 +239,7 @@ export class Luma {
     let selectedType: string | null = type;
     if (type === 'best-available') {
       selectedType = this.getBestAvailableAdapterType(adapters);
-    } else if (type === 'best-available-webgpu') {
+    } else if (type === 'best-webgpu') {
       selectedType = 'webgpu';
     }
 
@@ -332,7 +332,7 @@ function getDeviceCreationCandidates(
       ? ['max', 'core', 'compatibility']
       : props.featureLevel === 'compatibility'
         ? ['compatibility']
-        : ['core', 'compatibility'];
+        : ['max', 'core', 'compatibility'];
   const candidates: DeviceCreationCandidate[] = featureLevels.map(featureLevel => [
     'webgpu',
     featureLevel

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -5,7 +5,11 @@
 // MAIN API ACCESS POINT
 export type {AttachDeviceProps, CreateDeviceProps} from './adapter/luma';
 export {luma} from './adapter/luma';
-export type {DeviceCreationPhase, DeviceCreationAttempt} from './adapter/device-creation-error';
+export type {
+  DeviceCreationPhase,
+  DeviceCreationAttempt,
+  DeviceCreationInfo
+} from './adapter/device-creation-error';
 export {DeviceCreationError} from './adapter/device-creation-error';
 
 // ADAPTER (DEVICE AND GPU RESOURCE INTERFACES)

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -5,6 +5,8 @@
 // MAIN API ACCESS POINT
 export type {AttachDeviceProps, CreateDeviceProps} from './adapter/luma';
 export {luma} from './adapter/luma';
+export type {DeviceCreationPhase, DeviceCreationAttempt} from './adapter/device-creation-error';
+export {DeviceCreationError} from './adapter/device-creation-error';
 
 // ADAPTER (DEVICE AND GPU RESOURCE INTERFACES)
 export {Adapter} from './adapter/adapter';
@@ -17,7 +19,8 @@ export type {
   BrowserDeviceFeature,
   DeviceTextureFormatCapabilities,
   WebGPUFeatureLevel,
-  WebGPUDeviceFeatureLevel
+  WebGPUDeviceFeatureLevel,
+  DeviceLostInfo
 } from './adapter/device';
 export {Device, DeviceFeatures, DeviceLimits, isHTMLInCanvasSupported} from './adapter/device';
 

--- a/modules/core/test/adapter/luma.spec.ts
+++ b/modules/core/test/adapter/luma.spec.ts
@@ -4,7 +4,42 @@
 
 import test from 'test/utils/vitest-tape';
 import {nullAdapter} from '@luma.gl/test-utils';
-import {luma} from '@luma.gl/core';
+import {Adapter, DeviceCreationError, luma, type Device, type DeviceProps} from '@luma.gl/core';
+
+class RecordingAdapter extends Adapter {
+  readonly calls: DeviceProps[] = [];
+  supported = true;
+
+  constructor(
+    readonly type: string,
+    private readonly createImplementation: (props: DeviceProps) => Promise<Device>
+  ) {
+    super();
+  }
+
+  isSupported(): boolean {
+    return this.supported;
+  }
+
+  isDeviceHandle(): boolean {
+    return false;
+  }
+
+  async create(props: DeviceProps): Promise<Device> {
+    this.calls.push(props);
+    return await this.createImplementation(props);
+  }
+
+  async attach(): Promise<Device> {
+    throw new Error('Not implemented');
+  }
+}
+
+async function createNullDevice(props: DeviceProps): Promise<Device> {
+  const device = await nullAdapter.create({...props, createCanvasContext: true});
+  device.info.gpu = 'unknown';
+  return device;
+}
 
 test('luma#attachDevice', async t => {
   const device = await luma.attachDevice(null, {adapters: [nullAdapter]});
@@ -28,6 +63,408 @@ test('luma#createDevice', async t => {
   t.equal(device.type, 'null', 'info.vendor ok');
   t.equal(device.info.vendor, 'no one', 'info.vendor ok');
   t.equal(device.info.renderer, 'none', 'info.renderer ok');
+  t.end();
+});
+
+test('luma#createDevice best-available retries actual creation before WebGL', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
+    throw new Error(`Rejected ${props.featureLevel}`);
+  });
+  const webglAdapter = new RecordingAdapter('webgl', createNullDevice);
+
+  const device = await luma.createDevice({
+    type: 'best-available',
+    adapters: [webgpuAdapter, webglAdapter],
+    waitForPageLoad: false
+  });
+
+  t.deepEqual(
+    webgpuAdapter.calls.map(call => call.featureLevel),
+    ['core', 'compatibility'],
+    'core and compatibility are attempted in order'
+  );
+  t.equal(webglAdapter.calls.length, 1, 'WebGL is attempted after hardware WebGPU');
+  t.equal(device.creationInfo.attempts.length, 2, 'failed attempts are retained on success');
+  t.equal(device.creationInfo.selected?.backend, 'webgl', 'selected backend is recorded');
+  device.destroy();
+  t.end();
+});
+
+test('luma#createDevice best-available retains the null adapter as a final fallback', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', createNullDevice);
+  const webglAdapter = new RecordingAdapter('webgl', createNullDevice);
+  webgpuAdapter.supported = false;
+  webglAdapter.supported = false;
+
+  const device = await luma.createDevice({
+    type: 'best-available',
+    adapters: [webgpuAdapter, webglAdapter, nullAdapter],
+    waitForPageLoad: false
+  });
+
+  t.equal(device.type, 'null', 'null device is selected after unavailable GPU backends');
+  t.equal(device.creationInfo.selected?.backend, 'null', 'null selection is recorded');
+  t.equal(device.creationInfo.attempts.length, 3, 'failed WebGPU profiles and WebGL are retained');
+  device.destroy();
+  t.end();
+});
+
+test('luma#createDevice uses compatibility WebGPU after a core creation failure', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
+    if (props.featureLevel === 'core') {
+      throw new Error('Core device request failed');
+    }
+    return await createNullDevice(props);
+  });
+  const webglAdapter = new RecordingAdapter('webgl', createNullDevice);
+
+  const device = await luma.createDevice({
+    type: 'best-available',
+    adapters: [webgpuAdapter, webglAdapter],
+    waitForPageLoad: false
+  });
+
+  t.deepEqual(
+    webgpuAdapter.calls.map(call => call.featureLevel),
+    ['core', 'compatibility'],
+    'compatibility follows core'
+  );
+  t.equal(webglAdapter.calls.length, 0, 'successful compatibility does not attempt WebGL');
+  t.equal(device.creationInfo.attempts.length, 1, 'the recovered core failure is retained');
+  device.destroy();
+  t.end();
+});
+
+test('luma#createDevice best-available-webgpu uses software last and never WebGL', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
+    if (!props._forceFallbackAdapter) {
+      throw new Error(`Rejected ${props.featureLevel}`);
+    }
+    return await createNullDevice(props);
+  });
+  const webglAdapter = new RecordingAdapter('webgl', createNullDevice);
+
+  const device = await luma.createDevice({
+    type: 'best-available-webgpu',
+    adapters: [webgpuAdapter, webglAdapter],
+    waitForPageLoad: false
+  });
+
+  t.deepEqual(
+    webgpuAdapter.calls.map(call => [call.featureLevel, call._forceFallbackAdapter]),
+    [
+      ['core', false],
+      ['compatibility', false],
+      ['compatibility', true]
+    ],
+    'software compatibility WebGPU is the final attempt'
+  );
+  t.equal(webglAdapter.calls.length, 0, 'WebGL is never attempted');
+  t.equal(device.creationInfo.selected?.software, true, 'software selection is recorded');
+  device.destroy();
+  t.end();
+});
+
+test('luma#createDevice explicit backends stay strict', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', async () => {
+    throw new Error('Strict WebGPU failure');
+  });
+  const webglAdapter = new RecordingAdapter('webgl', createNullDevice);
+
+  let error: unknown;
+  try {
+    await luma.createDevice({
+      type: 'webgpu',
+      adapters: [webgpuAdapter, webglAdapter],
+      waitForPageLoad: false
+    });
+  } catch (caughtError) {
+    error = caughtError;
+  }
+
+  t.ok(error instanceof DeviceCreationError, 'strict failure is structured');
+  t.equal(webgpuAdapter.calls.length, 1, 'strict WebGPU is attempted once');
+  t.equal(webglAdapter.calls.length, 0, 'strict WebGPU does not fall back');
+  t.end();
+});
+
+test('luma#createDevice major performance caveat suppresses software WebGPU', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', async () => {
+    throw new Error('Hardware unavailable');
+  });
+
+  let error: DeviceCreationError | null = null;
+  try {
+    await luma.createDevice({
+      type: 'best-available-webgpu',
+      adapters: [webgpuAdapter],
+      failIfMajorPerformanceCaveat: true,
+      waitForPageLoad: false
+    });
+  } catch (caughtError) {
+    error = caughtError as DeviceCreationError;
+  }
+
+  t.ok(error instanceof DeviceCreationError, 'final failure is structured');
+  t.deepEqual(
+    webgpuAdapter.calls.map(call => call._forceFallbackAdapter),
+    [false, false],
+    'software request is suppressed'
+  );
+  t.equal(error?.attempts.length, 2, 'both hardware failures are retained');
+  t.end();
+});
+
+test('luma#createDevice honors max and compatibility policy starting points', async t => {
+  const maxAdapter = new RecordingAdapter('webgpu', async props => {
+    if (props.featureLevel !== 'compatibility') {
+      throw new Error(`${props.featureLevel} unavailable`);
+    }
+    return await createNullDevice(props);
+  });
+  const maxDevice = await luma.createDevice({
+    type: 'best-available-webgpu',
+    featureLevel: 'max',
+    adapters: [maxAdapter],
+    waitForPageLoad: false
+  });
+  t.deepEqual(
+    maxAdapter.calls.map(call => call.featureLevel),
+    ['max', 'core', 'compatibility'],
+    'max degrades through core to compatibility'
+  );
+  maxDevice.destroy();
+
+  const compatibilityAdapter = new RecordingAdapter('webgpu', createNullDevice);
+  const compatibilityDevice = await luma.createDevice({
+    type: 'best-available-webgpu',
+    featureLevel: 'compatibility',
+    adapters: [compatibilityAdapter],
+    waitForPageLoad: false
+  });
+  t.deepEqual(
+    compatibilityAdapter.calls.map(call => call.featureLevel),
+    ['compatibility'],
+    'compatibility starts and succeeds at compatibility'
+  );
+  compatibilityDevice.destroy();
+  t.end();
+});
+
+test('luma#createDevice does not select an incidental software adapter as hardware', async t => {
+  const container = document.createElement('div');
+  const canvas = document.createElement('canvas');
+  container.appendChild(canvas);
+  document.body.appendChild(container);
+  const requestedCanvases: HTMLCanvasElement[] = [];
+  const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
+    requestedCanvases.push((props.createCanvasContext as {canvas: HTMLCanvasElement}).canvas);
+    const device = await createNullDevice(props);
+    (device.info as {fallback?: boolean}).fallback = true;
+    return device;
+  });
+  const webglAdapter = new RecordingAdapter('webgl', async props => {
+    requestedCanvases.push((props.createCanvasContext as {canvas: HTMLCanvasElement}).canvas);
+    return await createNullDevice(props);
+  });
+
+  const device = await luma.createDevice({
+    type: 'best-available',
+    adapters: [webgpuAdapter, webglAdapter],
+    createCanvasContext: {canvas},
+    _canvasContextOwned: true,
+    waitForPageLoad: false
+  });
+
+  t.equal(webgpuAdapter.calls.length, 2, 'both hardware profiles reject software devices');
+  const [firstCanvas, secondCanvas, webglCanvas] = requestedCanvases;
+  t.notEqual(firstCanvas, secondCanvas, 'core rejection replaces the owned canvas');
+  t.notEqual(secondCanvas, webglCanvas, 'compatibility rejection replaces the owned canvas');
+  t.equal(webglCanvas.parentElement, container, 'WebGL receives the visible replacement canvas');
+  t.equal(device.creationInfo.selected?.backend, 'webgl', 'broad fallback prefers WebGL');
+  t.equal(device.creationInfo.attempts.length, 2, 'software detections are diagnostic attempts');
+  device.destroy();
+  container.remove();
+  t.end();
+});
+
+test('luma#createDevice rejects software WebGPU before reusing a caller-owned canvas', async t => {
+  const canvas = document.createElement('canvas');
+  const requestedCanvases: HTMLCanvasElement[] = [];
+  const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
+    requestedCanvases.push((props.createCanvasContext as {canvas: HTMLCanvasElement}).canvas);
+    if (props.failIfMajorPerformanceCaveat) {
+      throw new DeviceCreationError('Software adapter rejected before canvas initialization', [
+        {
+          backend: 'webgpu',
+          featureLevel: props.featureLevel,
+          software: true,
+          phase: 'adapter-selection',
+          error: new Error('Software WebGPU adapter rejected')
+        }
+      ]);
+    }
+    return await createNullDevice(props);
+  });
+  const webglAdapter = new RecordingAdapter('webgl', async props => {
+    requestedCanvases.push((props.createCanvasContext as {canvas: HTMLCanvasElement}).canvas);
+    return await createNullDevice(props);
+  });
+
+  const device = await luma.createDevice({
+    type: 'best-available',
+    adapters: [webgpuAdapter, webglAdapter],
+    createCanvasContext: {canvas},
+    waitForPageLoad: false
+  });
+
+  t.deepEqual(
+    webgpuAdapter.calls.map(call => call.failIfMajorPerformanceCaveat),
+    [true, true],
+    'hardware WebGPU candidates reject software before canvas initialization'
+  );
+  t.ok(
+    requestedCanvases.every(requestedCanvas => requestedCanvas === canvas),
+    'all candidates retain the untouched caller-owned canvas'
+  );
+  t.equal(device.creationInfo.selected?.backend, 'webgl', 'WebGL fallback succeeds');
+  device.destroy();
+  t.end();
+});
+
+test('luma#createDevice replaces a caller-owned canvas after canvas initialization fails', async t => {
+  const container = document.createElement('div');
+  const canvas = document.createElement('canvas');
+  canvas.id = 'caller-canvas';
+  canvas.width = 640;
+  canvas.height = 480;
+  canvas.style.width = '320px';
+  container.appendChild(canvas);
+  document.body.appendChild(container);
+
+  const requestedCanvases: HTMLCanvasElement[] = [];
+  const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
+    requestedCanvases.push((props.createCanvasContext as {canvas: HTMLCanvasElement}).canvas);
+    const nativeError = new Error('Canvas context configuration failed');
+    throw new DeviceCreationError(
+      'WebGPU canvas initialization failed',
+      [
+        {
+          backend: 'webgpu',
+          featureLevel: props.featureLevel,
+          software: false,
+          phase: 'canvas-initialization',
+          error: nativeError
+        }
+      ],
+      nativeError
+    );
+  });
+  const webglAdapter = new RecordingAdapter('webgl', async props => {
+    requestedCanvases.push((props.createCanvasContext as {canvas: HTMLCanvasElement}).canvas);
+    return await createNullDevice(props);
+  });
+
+  const device = await luma.createDevice({
+    type: 'best-available',
+    adapters: [webgpuAdapter, webglAdapter],
+    createCanvasContext: {canvas},
+    waitForPageLoad: false
+  });
+
+  const [coreCanvas, compatibilityCanvas, webglCanvas] = requestedCanvases;
+  t.equal(coreCanvas, canvas, 'core WebGPU receives the caller canvas');
+  t.notEqual(compatibilityCanvas, coreCanvas, 'compatibility receives an unbound replacement');
+  t.notEqual(webglCanvas, compatibilityCanvas, 'WebGL receives a second unbound replacement');
+  t.equal(webglCanvas.parentElement, container, 'the final replacement remains visible');
+  t.equal(webglCanvas.id, canvas.id, 'the replacement preserves the canvas id');
+  t.equal(webglCanvas.width, canvas.width, 'the replacement preserves drawing-buffer width');
+  t.equal(webglCanvas.height, canvas.height, 'the replacement preserves drawing-buffer height');
+  t.equal(webglCanvas.style.width, canvas.style.width, 'the replacement preserves CSS dimensions');
+  t.equal(device.creationInfo.selected?.backend, 'webgl', 'WebGL fallback succeeds');
+
+  device.destroy();
+  container.remove();
+  t.end();
+});
+
+test('luma#createDevice classifies CPU WebGPU devices as software', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
+    const device = await createNullDevice(props);
+    device.info.gpuType = 'cpu';
+    return device;
+  });
+  const webglAdapter = new RecordingAdapter('webgl', createNullDevice);
+
+  const device = await luma.createDevice({
+    type: 'best-available',
+    adapters: [webgpuAdapter, webglAdapter],
+    waitForPageLoad: false
+  });
+
+  t.equal(webgpuAdapter.calls.length, 2, 'CPU devices are rejected for both hardware profiles');
+  t.equal(device.creationInfo.selected?.backend, 'webgl', 'CPU WebGPU degrades to WebGL');
+  t.equal(
+    device.creationInfo.attempts.length,
+    2,
+    'only genuine software rejections are retained as failed attempts'
+  );
+  device.destroy();
+  t.end();
+});
+
+test('luma#createDevice preserves native attempt phases and causes', async t => {
+  const nativeError = new Error('Native requestDevice rejection');
+  const webgpuAdapter = new RecordingAdapter('webgpu', async () => {
+    throw new DeviceCreationError(
+      'Native WebGPU failure',
+      [
+        {
+          backend: 'webgpu',
+          featureLevel: 'core',
+          software: false,
+          phase: 'device-request',
+          error: nativeError
+        }
+      ],
+      nativeError
+    );
+  });
+
+  let error: DeviceCreationError | null = null;
+  try {
+    await luma.createDevice({
+      type: 'webgpu',
+      adapters: [webgpuAdapter],
+      waitForPageLoad: false
+    });
+  } catch (caughtError) {
+    error = caughtError as DeviceCreationError;
+  }
+
+  t.equal(error?.phase, 'device-request', 'the adapter phase is retained');
+  t.equal(error?.attempts[0]?.error, nativeError, 'the native error is retained');
+  t.equal(error?.cause, nativeError, 'the final cause is the native error');
+  t.end();
+});
+
+test('luma#createDevice records unavailable adapters without calling create', async t => {
+  const webgpuAdapter = new RecordingAdapter('webgpu', createNullDevice);
+  webgpuAdapter.supported = false;
+
+  let error: DeviceCreationError | null = null;
+  try {
+    await luma.createDevice({
+      type: 'webgpu',
+      adapters: [webgpuAdapter],
+      waitForPageLoad: false
+    });
+  } catch (caughtError) {
+    error = caughtError as DeviceCreationError;
+  }
+
+  t.equal(webgpuAdapter.calls.length, 0, 'unsupported adapters are not invoked');
+  t.equal(error?.phase, 'adapter-selection', 'adapter unavailability has an exact phase');
   t.end();
 });
 

--- a/modules/core/test/adapter/luma.spec.ts
+++ b/modules/core/test/adapter/luma.spec.ts
@@ -80,11 +80,11 @@ test('luma#createDevice best-available retries actual creation before WebGL', as
 
   t.deepEqual(
     webgpuAdapter.calls.map(call => call.featureLevel),
-    ['core', 'compatibility'],
-    'core and compatibility are attempted in order'
+    ['max', 'core', 'compatibility'],
+    'max, core, and compatibility are attempted in order'
   );
   t.equal(webglAdapter.calls.length, 1, 'WebGL is attempted after hardware WebGPU');
-  t.equal(device.creationInfo.attempts.length, 2, 'failed attempts are retained on success');
+  t.equal(device.creationInfo.attempts.length, 3, 'failed attempts are retained on success');
   t.equal(device.creationInfo.selected?.backend, 'webgl', 'selected backend is recorded');
   device.destroy();
   t.end();
@@ -104,14 +104,14 @@ test('luma#createDevice best-available retains the null adapter as a final fallb
 
   t.equal(device.type, 'null', 'null device is selected after unavailable GPU backends');
   t.equal(device.creationInfo.selected?.backend, 'null', 'null selection is recorded');
-  t.equal(device.creationInfo.attempts.length, 3, 'failed WebGPU profiles and WebGL are retained');
+  t.equal(device.creationInfo.attempts.length, 4, 'failed WebGPU profiles and WebGL are retained');
   device.destroy();
   t.end();
 });
 
-test('luma#createDevice uses compatibility WebGPU after a core creation failure', async t => {
+test('luma#createDevice uses compatibility WebGPU after max and core failures', async t => {
   const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
-    if (props.featureLevel === 'core') {
+    if (props.featureLevel !== 'compatibility') {
       throw new Error('Core device request failed');
     }
     return await createNullDevice(props);
@@ -126,16 +126,16 @@ test('luma#createDevice uses compatibility WebGPU after a core creation failure'
 
   t.deepEqual(
     webgpuAdapter.calls.map(call => call.featureLevel),
-    ['core', 'compatibility'],
-    'compatibility follows core'
+    ['max', 'core', 'compatibility'],
+    'compatibility follows max and core'
   );
   t.equal(webglAdapter.calls.length, 0, 'successful compatibility does not attempt WebGL');
-  t.equal(device.creationInfo.attempts.length, 1, 'the recovered core failure is retained');
+  t.equal(device.creationInfo.attempts.length, 2, 'the recovered failures are retained');
   device.destroy();
   t.end();
 });
 
-test('luma#createDevice best-available-webgpu uses software last and never WebGL', async t => {
+test('luma#createDevice best-webgpu uses software last and never WebGL', async t => {
   const webgpuAdapter = new RecordingAdapter('webgpu', async props => {
     if (!props._forceFallbackAdapter) {
       throw new Error(`Rejected ${props.featureLevel}`);
@@ -145,7 +145,7 @@ test('luma#createDevice best-available-webgpu uses software last and never WebGL
   const webglAdapter = new RecordingAdapter('webgl', createNullDevice);
 
   const device = await luma.createDevice({
-    type: 'best-available-webgpu',
+    type: 'best-webgpu',
     adapters: [webgpuAdapter, webglAdapter],
     waitForPageLoad: false
   });
@@ -153,6 +153,7 @@ test('luma#createDevice best-available-webgpu uses software last and never WebGL
   t.deepEqual(
     webgpuAdapter.calls.map(call => [call.featureLevel, call._forceFallbackAdapter]),
     [
+      ['max', false],
       ['core', false],
       ['compatibility', false],
       ['compatibility', true]
@@ -196,7 +197,7 @@ test('luma#createDevice major performance caveat suppresses software WebGPU', as
   let error: DeviceCreationError | null = null;
   try {
     await luma.createDevice({
-      type: 'best-available-webgpu',
+      type: 'best-webgpu',
       adapters: [webgpuAdapter],
       failIfMajorPerformanceCaveat: true,
       waitForPageLoad: false
@@ -208,10 +209,10 @@ test('luma#createDevice major performance caveat suppresses software WebGPU', as
   t.ok(error instanceof DeviceCreationError, 'final failure is structured');
   t.deepEqual(
     webgpuAdapter.calls.map(call => call._forceFallbackAdapter),
-    [false, false],
+    [false, false, false],
     'software request is suppressed'
   );
-  t.equal(error?.attempts.length, 2, 'both hardware failures are retained');
+  t.equal(error?.attempts.length, 3, 'all hardware failures are retained');
   t.end();
 });
 
@@ -223,7 +224,7 @@ test('luma#createDevice honors max and compatibility policy starting points', as
     return await createNullDevice(props);
   });
   const maxDevice = await luma.createDevice({
-    type: 'best-available-webgpu',
+    type: 'best-webgpu',
     featureLevel: 'max',
     adapters: [maxAdapter],
     waitForPageLoad: false
@@ -237,7 +238,7 @@ test('luma#createDevice honors max and compatibility policy starting points', as
 
   const compatibilityAdapter = new RecordingAdapter('webgpu', createNullDevice);
   const compatibilityDevice = await luma.createDevice({
-    type: 'best-available-webgpu',
+    type: 'best-webgpu',
     featureLevel: 'compatibility',
     adapters: [compatibilityAdapter],
     waitForPageLoad: false
@@ -276,13 +277,14 @@ test('luma#createDevice does not select an incidental software adapter as hardwa
     waitForPageLoad: false
   });
 
-  t.equal(webgpuAdapter.calls.length, 2, 'both hardware profiles reject software devices');
-  const [firstCanvas, secondCanvas, webglCanvas] = requestedCanvases;
+  t.equal(webgpuAdapter.calls.length, 3, 'all hardware profiles reject software devices');
+  const [firstCanvas, secondCanvas, thirdCanvas, webglCanvas] = requestedCanvases;
   t.notEqual(firstCanvas, secondCanvas, 'core rejection replaces the owned canvas');
-  t.notEqual(secondCanvas, webglCanvas, 'compatibility rejection replaces the owned canvas');
+  t.notEqual(secondCanvas, thirdCanvas, 'compatibility rejection replaces the owned canvas');
+  t.notEqual(thirdCanvas, webglCanvas, 'WebGL receives a fresh replacement canvas');
   t.equal(webglCanvas.parentElement, container, 'WebGL receives the visible replacement canvas');
   t.equal(device.creationInfo.selected?.backend, 'webgl', 'broad fallback prefers WebGL');
-  t.equal(device.creationInfo.attempts.length, 2, 'software detections are diagnostic attempts');
+  t.equal(device.creationInfo.attempts.length, 3, 'software detections are diagnostic attempts');
   device.destroy();
   container.remove();
   t.end();
@@ -320,7 +322,7 @@ test('luma#createDevice rejects software WebGPU before reusing a caller-owned ca
 
   t.deepEqual(
     webgpuAdapter.calls.map(call => call.failIfMajorPerformanceCaveat),
-    [true, true],
+    [true, true, true],
     'hardware WebGPU candidates reject software before canvas initialization'
   );
   t.ok(
@@ -372,10 +374,11 @@ test('luma#createDevice replaces a caller-owned canvas after canvas initializati
     waitForPageLoad: false
   });
 
-  const [coreCanvas, compatibilityCanvas, webglCanvas] = requestedCanvases;
-  t.equal(coreCanvas, canvas, 'core WebGPU receives the caller canvas');
-  t.notEqual(compatibilityCanvas, coreCanvas, 'compatibility receives an unbound replacement');
-  t.notEqual(webglCanvas, compatibilityCanvas, 'WebGL receives a second unbound replacement');
+  const [maxCanvas, coreCanvas, compatibilityCanvas, webglCanvas] = requestedCanvases;
+  t.equal(maxCanvas, canvas, 'max WebGPU receives the caller canvas');
+  t.notEqual(coreCanvas, maxCanvas, 'core receives an unbound replacement');
+  t.notEqual(compatibilityCanvas, coreCanvas, 'compatibility receives a second replacement');
+  t.notEqual(webglCanvas, compatibilityCanvas, 'WebGL receives a third unbound replacement');
   t.equal(webglCanvas.parentElement, container, 'the final replacement remains visible');
   t.equal(webglCanvas.id, canvas.id, 'the replacement preserves the canvas id');
   t.equal(webglCanvas.width, canvas.width, 'the replacement preserves drawing-buffer width');
@@ -402,11 +405,11 @@ test('luma#createDevice classifies CPU WebGPU devices as software', async t => {
     waitForPageLoad: false
   });
 
-  t.equal(webgpuAdapter.calls.length, 2, 'CPU devices are rejected for both hardware profiles');
+  t.equal(webgpuAdapter.calls.length, 3, 'CPU devices are rejected for all hardware profiles');
   t.equal(device.creationInfo.selected?.backend, 'webgl', 'CPU WebGPU degrades to WebGL');
   t.equal(
     device.creationInfo.attempts.length,
-    2,
+    3,
     'only genuine software rejections are retained as failed attempts'
   );
   device.destroy();

--- a/modules/test-utils/src/null-device/null-device.ts
+++ b/modules/test-utils/src/null-device/null-device.ts
@@ -23,7 +23,8 @@ import type {
   CommandEncoder,
   CommandEncoderProps,
   TransformFeedbackProps,
-  QuerySetProps
+  QuerySetProps,
+  DeviceLostInfo
 } from '@luma.gl/core';
 import {Device, DeviceFeatures} from '@luma.gl/core';
 import type {NullCommandBuffer} from './resources/null-command-buffer';
@@ -57,12 +58,12 @@ export class NullDevice extends Device {
 
   features: DeviceFeatures = new DeviceFeatures([], this.props._disabledFeatures);
   limits: NullDeviceLimits = new NullDeviceLimits();
-  readonly info = NullDeviceInfo;
+  readonly info = {...NullDeviceInfo};
 
   readonly canvasContext: NullCanvasContext;
   override commandEncoder: NullCommandEncoder;
 
-  readonly lost: Promise<{reason: 'destroyed'; message: string}>;
+  readonly lost: Promise<DeviceLostInfo>;
   private _isLost: boolean = false;
 
   constructor(props: DeviceProps) {

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -33,7 +33,8 @@ import type {
   TransformFeedbackProps,
   QuerySetProps,
   Resource,
-  VertexFormat
+  VertexFormat,
+  DeviceLostInfo
 } from '@luma.gl/core';
 import {Device, CanvasContext, log} from '@luma.gl/core';
 import type {GLExtensions} from '@luma.gl/webgl/constants';
@@ -103,9 +104,10 @@ export class WebGLDevice extends Device {
 
   commandEncoder!: WEBGLCommandEncoder;
 
-  readonly lost: Promise<{reason: 'destroyed'; message: string}>;
+  readonly lost: Promise<DeviceLostInfo>;
 
-  private _resolveContextLost?: (value: {reason: 'destroyed'; message: string}) => void;
+  private _resolveContextLost?: (value: DeviceLostInfo) => void;
+  private _lossWasRequested = false;
   private _isLost: boolean = false;
 
   /** WebGL2 context. */
@@ -166,7 +168,7 @@ export class WebGLDevice extends Device {
     // Create and instrument context
     this.canvasContext = new WebGLCanvasContext(this, canvasContextProps);
 
-    this.lost = new Promise<{reason: 'destroyed'; message: string}>(resolve => {
+    this.lost = new Promise<DeviceLostInfo>(resolve => {
       this._resolveContextLost = resolve;
     });
 
@@ -190,11 +192,15 @@ export class WebGLDevice extends Device {
       createBrowserContext(
         this.canvasContext.canvas,
         {
-          onContextLost: (event: Event) =>
-            this._resolveContextLost?.({
-              reason: 'destroyed',
-              message: 'Entered sleep mode, or too many apps or browser tabs are using the GPU.'
-            }),
+          onContextLost: (_event: Event) => {
+            const loss: DeviceLostInfo = {
+              reason: this._lossWasRequested ? 'destroyed' : 'unknown',
+              message: this._lossWasRequested
+                ? 'Application triggered context loss'
+                : 'Entered sleep mode, or too many apps or browser tabs are using the GPU.'
+            };
+            this._resolveContextLost?.(loss);
+          },
           onContextRestored: (_event: Event) => {
             // biome-ignore lint/suspicious/noConsole: debug-only context restore notification.
             console.log('WebGL context restored');
@@ -504,6 +510,7 @@ export class WebGLDevice extends Device {
    * @note primarily intended for testing how application reacts to device loss
    */
   override loseDevice(): boolean {
+    this._lossWasRequested = true;
     let deviceLossTriggered = false;
     const extensions = this.getExtension('WEBGL_lose_context');
     const ext = extensions.WEBGL_lose_context;

--- a/modules/webgpu/src/adapter/webgpu-adapter.ts
+++ b/modules/webgpu/src/adapter/webgpu-adapter.ts
@@ -364,9 +364,9 @@ export function isSoftwareWebGPUAdapter(adapter: GPUAdapter, adapterInfo: GPUAda
   const adapterType = String(extendedAdapterInfo.type || extendedAdapterInfo.gpuType || '')
     .split(' ')[0]
     .toLowerCase();
-  const description = `${adapterInfo.vendor || ''} ${extendedAdapterInfo.driver || ''} ${
-    adapterInfo.architecture || ''
-  }`;
+  const description = `${adapterInfo.vendor || ''} ${adapterInfo.description || ''} ${
+    extendedAdapterInfo.driver || ''
+  } ${adapterInfo.architecture || ''}`;
   return fallback || adapterType === 'cpu' || /SwiftShader|llvmpipe|lavapipe/i.test(description);
 }
 

--- a/modules/webgpu/src/adapter/webgpu-adapter.ts
+++ b/modules/webgpu/src/adapter/webgpu-adapter.ts
@@ -7,6 +7,7 @@
 
 import {
   Adapter,
+  DeviceCreationError,
   type DeviceInfo,
   type DeviceProps,
   type WebGPUDeviceFeature,
@@ -110,6 +111,10 @@ export function getWebGPURequestAdapterOptions(props: DeviceProps): GPURequestAd
     options.xrCompatible = true;
   }
 
+  if (props._forceFallbackAdapter) {
+    options.forceFallbackAdapter = true;
+  }
+
   return options;
 }
 
@@ -189,23 +194,50 @@ export class WebGPUAdapter extends Adapter {
   }
 
   async create(props: DeviceProps): Promise<WebGPUDevice> {
+    return await this._create(props, true);
+  }
+
+  private async _create(
+    props: DeviceProps,
+    allowImmediateLossRetry: boolean
+  ): Promise<WebGPUDevice> {
+    const requestedFeatureLevel = getWebGPUFeatureLevel(props);
+    const software = Boolean(props._forceFallbackAdapter);
     if (!navigator.gpu) {
-      throw new Error('WebGPU not available. Recent Chrome browsers should work.');
+      throw makeWebGPUCreationError(
+        new Error('WebGPU is not available'),
+        requestedFeatureLevel,
+        software,
+        'adapter-selection'
+      );
     }
 
-    const requestedFeatureLevel = getWebGPUFeatureLevel(props);
     const requestAdapterOptions = getWebGPURequestAdapterOptions(props);
-    const adapter = await this.requestGPUAdapter(requestAdapterOptions);
+    let adapter: GPUAdapter | null;
+    try {
+      adapter = await this.requestGPUAdapter(requestAdapterOptions);
+    } catch (error) {
+      throw makeWebGPUCreationError(error, requestedFeatureLevel, software, 'adapter-request');
+    }
 
     if (!adapter) {
-      throw new Error('Failed to request WebGPU adapter');
+      throw makeWebGPUCreationError(
+        new Error('Failed to request WebGPU adapter'),
+        requestedFeatureLevel,
+        software,
+        'adapter-request'
+      );
     }
 
-    //  Note: adapter.requestAdapterInfo() has been replaced with adapter.info. Fall back in case adapter.info is not available
-    const adapterInfo =
-      adapter.info ||
-      // @ts-ignore
-      (await adapter.requestAdapterInfo?.());
+    const adapterInfo = await getWebGPUAdapterInfo(adapter);
+    if (props.failIfMajorPerformanceCaveat && isSoftwareWebGPUAdapter(adapter, adapterInfo)) {
+      throw makeWebGPUCreationError(
+        new Error('Software WebGPU adapter rejected'),
+        requestedFeatureLevel,
+        true,
+        'adapter-selection'
+      );
+    }
     // log.probe(2, 'Adapter available', adapterInfo)();
 
     const deviceDescriptor: GPUDeviceDescriptor = {};
@@ -223,7 +255,27 @@ export class WebGPUAdapter extends Adapter {
       deviceDescriptor.requiredLimits = getRequiredWebGPULimits(adapter.limits);
     }
 
-    const gpuDevice = await adapter.requestDevice(deviceDescriptor);
+    let gpuDevice: GPUDevice;
+    try {
+      gpuDevice = await adapter.requestDevice(deviceDescriptor);
+    } catch (error) {
+      throw makeWebGPUCreationError(error, requestedFeatureLevel, software, 'device-request');
+    }
+
+    const immediateLoss = await getImmediateDeviceLoss(gpuDevice);
+    if (immediateLoss) {
+      gpuDevice.destroy();
+      if (allowImmediateLossRetry && immediateLoss.reason !== 'destroyed') {
+        log.warn('WebGPU device was returned already lost; retrying with a fresh adapter')();
+        return await this._create(props, false);
+      }
+      throw makeWebGPUCreationError(
+        new Error(immediateLoss.message || 'WebGPU device was returned already lost'),
+        requestedFeatureLevel,
+        software,
+        'device-request'
+      );
+    }
 
     // log.probe(1, 'GPUDevice available')();
 
@@ -233,7 +285,33 @@ export class WebGPUAdapter extends Adapter {
 
     log.groupCollapsed(1, 'WebGPUDevice created')();
     try {
-      const device = new WebGPUDevice(deviceProps, gpuDevice, adapter, adapterInfo);
+      let device: WebGPUDevice;
+      try {
+        device = new WebGPUDevice(deviceProps, gpuDevice, adapter, adapterInfo);
+      } catch (error) {
+        gpuDevice.destroy();
+        throw makeWebGPUCreationError(
+          error,
+          requestedFeatureLevel,
+          software,
+          'wrapper-initialization'
+        );
+      }
+
+      const canvasContextProps = WebGPUDevice.getCanvasContextProps(deviceProps);
+      if (canvasContextProps) {
+        try {
+          device.initializeCanvasContext(canvasContextProps);
+        } catch (error) {
+          device.destroy();
+          throw makeWebGPUCreationError(
+            error,
+            requestedFeatureLevel,
+            software,
+            'canvas-initialization'
+          );
+        }
+      }
       log.probe(
         1,
         'Device created. For more info, set chrome://flags/#enable-webgpu-developer-features'
@@ -255,6 +333,65 @@ export class WebGPUAdapter extends Adapter {
   ): Promise<GPUAdapter | null> {
     return navigator.gpu.requestAdapter(requestAdapterOptions);
   }
+}
+
+/** Reads adapter metadata across current and legacy browsers without making it creation-critical. */
+export async function getWebGPUAdapterInfo(adapter: GPUAdapter): Promise<GPUAdapterInfo> {
+  try {
+    return (
+      adapter.info ||
+      // @ts-ignore Legacy Chromium API.
+      (await adapter.requestAdapterInfo?.()) ||
+      ({} as GPUAdapterInfo)
+    );
+  } catch (error) {
+    log.warn('WebGPU adapter metadata is unavailable', error)();
+    return {} as GPUAdapterInfo;
+  }
+}
+
+/** Identifies software adapters before native device or canvas creation. */
+export function isSoftwareWebGPUAdapter(adapter: GPUAdapter, adapterInfo: GPUAdapterInfo): boolean {
+  const fallback = Boolean(
+    (adapterInfo as GPUAdapterInfo & {isFallbackAdapter?: boolean}).isFallbackAdapter ??
+      (adapter as GPUAdapter & {isFallbackAdapter?: boolean}).isFallbackAdapter
+  );
+  const extendedAdapterInfo = adapterInfo as GPUAdapterInfo & {
+    driver?: string;
+    gpuType?: string;
+    type?: string;
+  };
+  const adapterType = String(extendedAdapterInfo.type || extendedAdapterInfo.gpuType || '')
+    .split(' ')[0]
+    .toLowerCase();
+  const description = `${adapterInfo.vendor || ''} ${extendedAdapterInfo.driver || ''} ${
+    adapterInfo.architecture || ''
+  }`;
+  return fallback || adapterType === 'cpu' || /SwiftShader|llvmpipe|lavapipe/i.test(description);
+}
+
+function makeWebGPUCreationError(
+  error: unknown,
+  featureLevel: RequestedWebGPUFeatureLevel,
+  software: boolean,
+  phase: import('@luma.gl/core').DeviceCreationPhase
+): DeviceCreationError {
+  if (error instanceof DeviceCreationError) {
+    return error;
+  }
+  const cause = error instanceof Error ? error : new Error(String(error));
+  return new DeviceCreationError(
+    `WebGPU ${phase} failed: ${cause.message}`,
+    [{backend: 'webgpu', featureLevel, software, phase, error: cause}],
+    cause
+  );
+}
+
+async function getImmediateDeviceLoss(device: GPUDevice): Promise<GPUDeviceLostInfo | null> {
+  return await Promise.race([
+    device.lost,
+    new Promise<null>(resolve => globalThis.setTimeout(() => resolve(null), 0))
+  ]);
 }
 
 export const webgpuAdapter = new WebGPUAdapter();

--- a/modules/webgpu/src/adapter/webgpu-canvas-context.ts
+++ b/modules/webgpu/src/adapter/webgpu-canvas-context.ts
@@ -75,7 +75,25 @@ export class WebGPUCanvasContext extends CanvasContext {
       this.depthStencilAttachment = null;
     }
 
-    const requestedColorFormat = this.colorFormat || this.device.preferredColorFormat;
+    let requestedColorFormat = this.colorFormat || this.device.preferredColorFormat;
+    let requestedToneMapping = this.toneMapping || this.props.toneMapping;
+    const getConfiguration =
+      typeof this.handle.getConfiguration === 'function'
+        ? () => this.handle.getConfiguration()
+        : null;
+    const requestedHighDynamicRange =
+      requestedColorFormat === 'rgba16float' || requestedToneMapping === 'extended';
+
+    // Older Chromium-derived browsers expose WebGPU without getConfiguration(). They cannot
+    // verify HDR acceptance, so preserve device creation and use a portable SDR canvas.
+    if (requestedHighDynamicRange && !getConfiguration) {
+      log.warn('HDR canvas verification is unavailable; using standard presentation')();
+      requestedColorFormat = navigator.gpu.getPreferredCanvasFormat() as
+        | 'rgba8unorm'
+        | 'bgra8unorm';
+      requestedToneMapping = 'standard';
+    }
+
     const requestedConfiguration: GPUCanvasConfiguration = {
       device: this.device.handle,
       format: requestedColorFormat,
@@ -83,40 +101,62 @@ export class WebGPUCanvasContext extends CanvasContext {
       // viewFormats: [...]
       colorSpace: this.colorSpace || this.props.colorSpace,
       alphaMode: this.props.alphaMode,
-      toneMapping: {mode: this.toneMapping || this.props.toneMapping},
+      ...(requestedToneMapping === 'extended' ? {toneMapping: {mode: requestedToneMapping}} : {}),
       usage:
         requestedColorFormat === 'rgba16float'
           ? Texture.RENDER_ATTACHMENT | Texture.COPY_SRC
           : Texture.RENDER_ATTACHMENT
     };
 
-    // Reconfigure the canvas size.
-    this.handle.configure(requestedConfiguration);
-
     let configuredConfiguration = requestedConfiguration;
-    let acceptedConfiguration = this.handle.getConfiguration();
+    let acceptedConfiguration: GPUCanvasConfigurationOut | null = null;
+    const standardConfiguration: GPUCanvasConfiguration = {
+      device: this.device.handle,
+      format: navigator.gpu.getPreferredCanvasFormat(),
+      colorSpace: 'srgb',
+      alphaMode: this.props.alphaMode,
+      usage: Texture.RENDER_ATTACHMENT
+    };
+
+    try {
+      this.handle.configure(requestedConfiguration);
+      if (requestedConfiguration.toneMapping?.mode === 'extended') {
+        try {
+          acceptedConfiguration = getConfiguration?.() || null;
+        } catch (error) {
+          log.warn(
+            'Unable to verify HDR canvas configuration; using standard presentation',
+            error
+          )();
+        }
+      }
+    } catch (error) {
+      if (requestedConfiguration.toneMapping?.mode !== 'extended') {
+        throw error;
+      }
+      log.warn('HDR canvas configuration was rejected; using standard presentation', error)();
+      configuredConfiguration = standardConfiguration;
+      this.handle.configure(standardConfiguration);
+    }
+
     if (
       requestedConfiguration.toneMapping?.mode === 'extended' &&
-      !isHighDynamicRangeCanvasConfiguration(acceptedConfiguration)
+      !isHighDynamicRangeCanvasConfiguration(acceptedConfiguration) &&
+      configuredConfiguration !== standardConfiguration
     ) {
-      const standardConfiguration: GPUCanvasConfiguration = {
-        device: this.device.handle,
-        format: navigator.gpu.getPreferredCanvasFormat(),
-        colorSpace: 'srgb',
-        alphaMode: this.props.alphaMode,
-        toneMapping: {mode: 'standard'},
-        usage: Texture.RENDER_ATTACHMENT
-      };
+      log.warn('HDR canvas configuration was not accepted; using standard presentation')();
       this.handle.configure(standardConfiguration);
       configuredConfiguration = standardConfiguration;
-      acceptedConfiguration = this.handle.getConfiguration();
+      acceptedConfiguration = null;
     }
 
     this.colorFormat = (acceptedConfiguration?.format ||
       configuredConfiguration.format) as typeof this.colorFormat;
     this.colorSpace = acceptedConfiguration?.colorSpace || configuredConfiguration.colorSpace;
     this.toneMapping =
-      acceptedConfiguration?.toneMapping?.mode || configuredConfiguration.toneMapping?.mode;
+      acceptedConfiguration?.toneMapping?.mode ||
+      configuredConfiguration.toneMapping?.mode ||
+      'standard';
 
     this._createDepthStencilAttachment(this.device.preferredDepthFormat);
   }

--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -32,6 +32,7 @@ import type {
   QuerySet,
   QuerySetProps,
   DeviceProps,
+  DeviceLostInfo,
   CommandEncoderProps,
   CommandEncoder,
   PipelineLayoutProps,
@@ -84,7 +85,7 @@ export class WebGPUDevice extends Device {
   /** type of this device */
   readonly type = 'webgpu';
 
-  readonly preferredColorFormat: 'rgba8unorm' | 'bgra8unorm' | 'rgba16float';
+  preferredColorFormat: 'rgba8unorm' | 'bgra8unorm' | 'rgba16float';
   readonly preferredDepthFormat = 'depth24plus';
 
   readonly features: DeviceFeatures;
@@ -92,7 +93,7 @@ export class WebGPUDevice extends Device {
   readonly info: DeviceInfo;
   readonly limits: DeviceLimits;
 
-  readonly lost: Promise<{reason: 'destroyed'; message: string}>;
+  readonly lost: Promise<DeviceLostInfo>;
 
   override canvasContext: WebGPUCanvasContext | null = null;
 
@@ -142,16 +143,25 @@ export class WebGPUDevice extends Device {
     // "Context" loss handling
     this.lost = this.handle.lost.then(lostInfo => {
       this._isLost = true;
-      return {reason: 'destroyed', message: lostInfo.message};
+      const loss: DeviceLostInfo = {
+        reason: lostInfo.reason === 'destroyed' ? 'destroyed' : 'unknown',
+        message: lostInfo.message
+      };
+      return loss;
     });
 
-    // Note: WebGPU devices can be created without a canvas, for compute shader purposes
-    if (canvasContextProps) {
-      this.canvasContext = new WebGPUCanvasContext(this, this.adapter, canvasContextProps);
-      this.preferredColorFormat = this.canvasContext.colorFormat || this.preferredColorFormat;
-    }
-
     this.commandEncoder = this.createCommandEncoder({});
+  }
+
+  /** @internal Returns normalized canvas props before a device wrapper exists. */
+  static getCanvasContextProps(props: DeviceProps): CanvasContextProps | undefined {
+    return Device._getCanvasContextProps(props);
+  }
+
+  /** @internal Initializes the default canvas as a separately diagnosable creation stage. */
+  initializeCanvasContext(props: CanvasContextProps): void {
+    this.canvasContext = new WebGPUCanvasContext(this, this.adapter, props);
+    this.preferredColorFormat = this.canvasContext.colorFormat || this.preferredColorFormat;
   }
 
   // TODO

--- a/modules/webgpu/test/adapter/webgpu-device-lifecycle.node.spec.ts
+++ b/modules/webgpu/test/adapter/webgpu-device-lifecycle.node.spec.ts
@@ -4,7 +4,11 @@
 
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {DeviceCreationError, type DeviceProps} from '@luma.gl/core';
-import {getWebGPUAdapterInfo, WebGPUAdapter} from '../../src/adapter/webgpu-adapter';
+import {
+  getWebGPUAdapterInfo,
+  isSoftwareWebGPUAdapter,
+  WebGPUAdapter
+} from '../../src/adapter/webgpu-adapter';
 
 type Deferred<T> = {
   promise: Promise<T>;
@@ -106,6 +110,17 @@ describe('WebGPU device creation lifecycle', () => {
     ).rejects.toMatchObject<DeviceCreationError>({phase: 'adapter-selection'});
 
     expect(nativeAdapter.requestDevice).not.toHaveBeenCalled();
+  });
+
+  test('detects software adapters from the standard adapter description', () => {
+    expect(
+      isSoftwareWebGPUAdapter(
+        {} as GPUAdapter,
+        {
+          description: 'Google SwiftShader'
+        } as GPUAdapterInfo
+      )
+    ).toBe(true);
   });
 
   test('retries one immediately lost device with a fresh adapter', async () => {

--- a/modules/webgpu/test/adapter/webgpu-device-lifecycle.node.spec.ts
+++ b/modules/webgpu/test/adapter/webgpu-device-lifecycle.node.spec.ts
@@ -1,0 +1,175 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {DeviceCreationError, type DeviceProps} from '@luma.gl/core';
+import {getWebGPUAdapterInfo, WebGPUAdapter} from '../../src/adapter/webgpu-adapter';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+class MockWebGPUAdapter extends WebGPUAdapter {
+  readonly requests: GPURequestAdapterOptions[] = [];
+
+  constructor(private readonly adapters: GPUAdapter[]) {
+    super();
+  }
+
+  protected override async requestGPUAdapter(
+    options: GPURequestAdapterOptions
+  ): Promise<GPUAdapter | null> {
+    this.requests.push(options);
+    return this.adapters.shift() || null;
+  }
+}
+
+function makeDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolver => {
+    resolve = resolver;
+  });
+  return {promise, resolve};
+}
+
+function makeNativeDevice(lost: Promise<GPUDeviceLostInfo>) {
+  const commandEncoder = {label: ''};
+  return {
+    device: {
+      features: new Set(),
+      limits: {},
+      lost,
+      queue: {},
+      addEventListener: vi.fn(),
+      createCommandEncoder: vi.fn(() => commandEncoder),
+      destroy: vi.fn()
+    } as unknown as GPUDevice,
+    commandEncoder
+  };
+}
+
+function makeNativeAdapter(device: GPUDevice, info: GPUAdapterInfo = {} as GPUAdapterInfo) {
+  const requestDevice = vi.fn(async (_descriptor: GPUDeviceDescriptor) => device);
+  return {
+    adapter: {
+      features: new Set(),
+      limits: {},
+      info,
+      requestDevice
+    } as unknown as GPUAdapter,
+    requestDevice
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal('navigator', {
+    gpu: {
+      getPreferredCanvasFormat: () => 'bgra8unorm',
+      requestAdapter: vi.fn()
+    }
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('WebGPU device creation lifecycle', () => {
+  test('uses an empty descriptor for the safe core profile', async () => {
+    const pendingLoss = makeDeferred<GPUDeviceLostInfo>();
+    const nativeDevice = makeNativeDevice(pendingLoss.promise);
+    const nativeAdapter = makeNativeAdapter(nativeDevice.device);
+    const adapter = new MockWebGPUAdapter([nativeAdapter.adapter]);
+
+    const device = await adapter.create({} as DeviceProps);
+
+    expect(nativeAdapter.requestDevice).toHaveBeenCalledWith({});
+    device.destroy();
+  });
+
+  test('rejects software adapters before requesting a device or initializing a canvas', async () => {
+    const pendingLoss = makeDeferred<GPUDeviceLostInfo>();
+    const nativeDevice = makeNativeDevice(pendingLoss.promise);
+    const nativeAdapter = makeNativeAdapter(nativeDevice.device, {
+      type: 'CPU',
+      vendor: 'Software Adapter'
+    } as GPUAdapterInfo);
+    const adapter = new MockWebGPUAdapter([nativeAdapter.adapter]);
+
+    await expect(
+      adapter.create({
+        failIfMajorPerformanceCaveat: true,
+        createCanvasContext: {canvas: {} as HTMLCanvasElement}
+      } as DeviceProps)
+    ).rejects.toMatchObject<DeviceCreationError>({phase: 'adapter-selection'});
+
+    expect(nativeAdapter.requestDevice).not.toHaveBeenCalled();
+  });
+
+  test('retries one immediately lost device with a fresh adapter', async () => {
+    const firstDevice = makeNativeDevice(
+      Promise.resolve({reason: 'unknown', message: 'Transient driver loss'} as GPUDeviceLostInfo)
+    );
+    const pendingLoss = makeDeferred<GPUDeviceLostInfo>();
+    const secondDevice = makeNativeDevice(pendingLoss.promise);
+    const firstAdapter = makeNativeAdapter(firstDevice.device);
+    const secondAdapter = makeNativeAdapter(secondDevice.device);
+    const adapter = new MockWebGPUAdapter([firstAdapter.adapter, secondAdapter.adapter]);
+
+    const device = await adapter.create({} as DeviceProps);
+
+    expect(adapter.requests).toHaveLength(2);
+    expect(firstDevice.device.destroy).toHaveBeenCalledTimes(1);
+    expect(firstAdapter.requestDevice).toHaveBeenCalledWith({});
+    expect(secondAdapter.requestDevice).toHaveBeenCalledWith({});
+    device.destroy();
+  });
+
+  test('cleans up native devices after wrapper and canvas initialization failures', async () => {
+    const pendingWrapperLoss = makeDeferred<GPUDeviceLostInfo>();
+    const wrapperDevice = makeNativeDevice(pendingWrapperLoss.promise);
+    vi.mocked(wrapperDevice.device.createCommandEncoder).mockImplementation(() => {
+      throw new Error('Command encoder construction failed');
+    });
+    const wrapperAdapter = makeNativeAdapter(wrapperDevice.device);
+
+    await expect(
+      new MockWebGPUAdapter([wrapperAdapter.adapter]).create({} as DeviceProps)
+    ).rejects.toMatchObject<DeviceCreationError>({phase: 'wrapper-initialization'});
+    expect(wrapperDevice.device.destroy).toHaveBeenCalledTimes(1);
+
+    const pendingCanvasLoss = makeDeferred<GPUDeviceLostInfo>();
+    const canvasDevice = makeNativeDevice(pendingCanvasLoss.promise);
+    const canvasAdapter = makeNativeAdapter(canvasDevice.device);
+    await expect(
+      new MockWebGPUAdapter([canvasAdapter.adapter]).create({
+        createCanvasContext: true
+      } as DeviceProps)
+    ).rejects.toMatchObject<DeviceCreationError>({phase: 'canvas-initialization'});
+    expect(canvasDevice.device.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves native loss reasons', async () => {
+    const unexpectedLoss = makeDeferred<GPUDeviceLostInfo>();
+    const nativeDevice = makeNativeDevice(unexpectedLoss.promise);
+    const nativeAdapter = makeNativeAdapter(nativeDevice.device);
+    const device = await new MockWebGPUAdapter([nativeAdapter.adapter]).create({} as DeviceProps);
+    unexpectedLoss.resolve({reason: 'unknown', message: 'Driver reset'} as GPUDeviceLostInfo);
+
+    await expect(device.lost).resolves.toEqual({reason: 'unknown', message: 'Driver reset'});
+  });
+
+  test('tolerates missing and rejected adapter metadata', async () => {
+    await expect(getWebGPUAdapterInfo({} as GPUAdapter)).resolves.toEqual({});
+
+    const adapter = {} as GPUAdapter;
+    Object.defineProperty(adapter, 'info', {
+      get() {
+        throw new Error('Metadata blocked');
+      }
+    });
+    await expect(getWebGPUAdapterInfo(adapter)).resolves.toEqual({});
+  });
+});

--- a/modules/webgpu/test/adapter/webgpu-xr-adapter.node.spec.ts
+++ b/modules/webgpu/test/adapter/webgpu-xr-adapter.node.spec.ts
@@ -19,6 +19,7 @@ afterEach(() => {
 describe('XR-compatible WebGPU adapter requests', () => {
   test('preserves ordinary adapter requests unless XR compatibility is enabled', () => {
     expect(Device.defaultProps.xrCompatible).toBe(false);
+    expect(Device.defaultProps.powerPreference).toBe('default');
     expect(getWebGPURequestAdapterOptions({})).toEqual({featureLevel: 'core'});
     expect(getWebGPURequestAdapterOptions({xrCompatible: false})).toEqual({
       featureLevel: 'core'

--- a/modules/webgpu/test/webgpu/adapter/webgpu-adapter.spec.ts
+++ b/modules/webgpu/test/webgpu/adapter/webgpu-adapter.spec.ts
@@ -10,7 +10,10 @@ import {
   getWebGPUFeatureLevel,
   getWebGPURequestAdapterOptions
 } from '../../../src/adapter/webgpu-adapter';
-import {isHighDynamicRangeCanvasConfiguration} from '../../../src/adapter/webgpu-canvas-context';
+import {
+  isHighDynamicRangeCanvasConfiguration,
+  WebGPUCanvasContext
+} from '../../../src/adapter/webgpu-canvas-context';
 
 test('WebGPUAdapter imports from the ESM package entry without circular init errors', async t => {
   t.plan(2);
@@ -75,6 +78,14 @@ test('WebGPUAdapter feature level helpers map luma props to WebGPU requests', t 
     getWebGPURequestAdapterOptions({featureLevel: 'best-available'}),
     {featureLevel: 'compatibility'},
     'best available starts from a compatibility adapter'
+  );
+  t.deepEqual(
+    getWebGPURequestAdapterOptions({
+      featureLevel: 'compatibility',
+      _forceFallbackAdapter: true
+    }),
+    {featureLevel: 'compatibility', forceFallbackAdapter: true},
+    'software fallback is explicitly requested'
   );
 
   t.end();
@@ -173,3 +184,97 @@ test('isHighDynamicRangeCanvasConfiguration verifies accepted HDR presentation',
   );
   t.end();
 });
+
+test('WebGPUCanvasContext configures SDR without getConfiguration', t => {
+  const configurations: GPUCanvasConfiguration[] = [];
+  const context = makeMockCanvasContext({
+    preferredColorFormat: navigator.gpu.getPreferredCanvasFormat(),
+    toneMapping: 'standard',
+    handle: {
+      configure: configuration => configurations.push(configuration)
+    }
+  });
+
+  context._configureDevice();
+
+  t.equal(configurations.length, 1, 'standard canvas configures without introspection');
+  t.equal(
+    configurations[0]?.format,
+    navigator.gpu.getPreferredCanvasFormat(),
+    'standard canvas uses the browser preferred format'
+  );
+  t.equal(context.toneMapping, 'standard', 'standard tone mapping is recorded');
+  t.end();
+});
+
+test('WebGPUCanvasContext falls back from unverifiable or rejected HDR to SDR', t => {
+  const missingIntrospectionConfigurations: GPUCanvasConfiguration[] = [];
+  const missingIntrospectionContext = makeMockCanvasContext({
+    preferredColorFormat: 'rgba16float',
+    toneMapping: 'extended',
+    handle: {
+      configure: configuration => missingIntrospectionConfigurations.push(configuration)
+    }
+  });
+  missingIntrospectionContext._configureDevice();
+
+  t.equal(
+    missingIntrospectionConfigurations.length,
+    1,
+    'missing getConfiguration skips an unverifiable HDR request'
+  );
+  t.equal(
+    missingIntrospectionConfigurations[0]?.format,
+    navigator.gpu.getPreferredCanvasFormat(),
+    'missing getConfiguration uses the SDR format'
+  );
+  t.equal(
+    missingIntrospectionContext.toneMapping,
+    'standard',
+    'missing getConfiguration records the SDR fallback'
+  );
+
+  const rejectedConfigurations: GPUCanvasConfiguration[] = [];
+  const rejectedContext = makeMockCanvasContext({
+    preferredColorFormat: 'rgba16float',
+    toneMapping: 'extended',
+    handle: {
+      configure: configuration => {
+        rejectedConfigurations.push(configuration);
+        if (configuration.toneMapping?.mode === 'extended') {
+          throw new Error('HDR is unsupported');
+        }
+      },
+      getConfiguration: () => null
+    }
+  });
+  rejectedContext._configureDevice();
+
+  t.equal(rejectedConfigurations.length, 2, 'rejected HDR is followed by an SDR configuration');
+  t.equal(
+    rejectedConfigurations[1]?.format,
+    navigator.gpu.getPreferredCanvasFormat(),
+    'rejected HDR uses the SDR format'
+  );
+  t.equal(rejectedContext.toneMapping, 'standard', 'rejected HDR records the SDR fallback');
+  t.end();
+});
+
+function makeMockCanvasContext(options: {
+  preferredColorFormat: 'rgba8unorm' | 'bgra8unorm' | 'rgba16float';
+  toneMapping: 'standard' | 'extended';
+  handle: Pick<GPUCanvasContext, 'configure'> & Partial<Pick<GPUCanvasContext, 'getConfiguration'>>;
+}): WebGPUCanvasContext {
+  const context = Object.create(WebGPUCanvasContext.prototype) as WebGPUCanvasContext;
+  Object.assign(context, {
+    device: {
+      preferredColorFormat: options.preferredColorFormat,
+      preferredDepthFormat: 'depth24plus',
+      handle: {}
+    },
+    handle: options.handle,
+    props: {toneMapping: options.toneMapping, colorSpace: 'srgb', alphaMode: 'opaque'},
+    _createDepthStencilAttachment: () => {}
+  });
+  return context;
+}

--- a/test/size/bundle-size.config.mjs
+++ b/test/size/bundle-size.config.mjs
@@ -8,7 +8,7 @@ export const BUNDLE_SIZE_FIXTURES = [
     label: '`@luma.gl/core`',
     entry: 'modules/core/src/index.ts',
     external: [],
-    maximum: {minified: 100_000, gzip: 28_500, brotli: 25_000},
+    maximum: {minified: 101_000, gzip: 28_500, brotli: 25_000},
     targetGzip: 24_000
   },
   {


### PR DESCRIPTION
## Summary

- make `best-available` selection depend on completed creation attempts instead of API presence
- try WebGPU max, core, compatibility, WebGL, and null candidates in a deterministic policy
- add the `best-webgpu` policy for WebGPU-only applications; it tries max, core, compatibility, then software compatibility
- preserve fallback after canvas initialization failures and make software-device handling explicit
- keep software WebGPU visual smoke tests on an exact backend request

## Dependency

Based on #3140, which provides the structured creation phases and software-adapter controls used by this policy. #3142 is now tracked separately in [#3147](https://github.com/visgl/luma.gl/pull/3147).

## Review focus

Please review the policy order, including the intentional `max → core → compatibility` degradation, the `best-webgpu` name, null-device fallback, and caller-owned canvas replacement behavior as explicit API decisions.

The split exposed and fixes an original #3129 bug where fallback without a canvas manufactured extra `TypeError` attempts. Regression tests require only genuine failed attempts.

## Verification

- `nvm use`
- `yarn install`
- `yarn lint fix`
- focused selection tests: 20 passed
- full Node suite: 3,103 passed; 3 skipped
- integrated `yarn build`: passed
- bundle-size suite: all fixtures pass
- full headless suite: unrelated local WebGPU failures remain in DGGS, splat sorting, raster math, and lighting

Extracted from #3129.
