### PR TITLE
feat(core): display debug device creation errors

### DIFF
--- a/docs/api-reference/core/luma.md
+++ b/docs/api-reference/core/luma.md
@@ -144,6 +144,10 @@ Failed attempts are retained in `device.creationInfo` after successful fallback.
 fails, `createDevice()` rejects with `DeviceCreationError`, whose `attempts` identify the backend,
 feature level, software status, failure phase, and native cause.
 
+When `debug` is enabled in a browser, a final creation failure is also displayed beside the first
+HTML canvas found in the document. The alert can be styled or faded with CSS using
+`#luma-device-error`.
+
 Note: A specific device type is available and supported if both of the following are true:
 1. The backend module has been registered
 2. The browser supports that GPU API

--- a/modules/core/src/adapter/luma.ts
+++ b/modules/core/src/adapter/luma.ts
@@ -185,7 +185,11 @@ export class Luma {
     }
 
     const lastError = attempts[attempts.length - 1]?.error;
-    throw new DeviceCreationError(lastError?.message || ERROR_MESSAGE, attempts, lastError);
+    const error = new DeviceCreationError(lastError?.message || ERROR_MESSAGE, attempts, lastError);
+    if (props.debug) {
+      displayDeviceCreationError(error);
+    }
+    throw error;
   }
 
   /**
@@ -360,6 +364,19 @@ function replaceCanvasAfterFailedInitialization(props: Required<CreateDeviceProp
     canvas.replaceWith(replacement);
     contextProps.canvas = replacement;
   }
+}
+
+/** Display fatal device creation errors beside an available HTML canvas in debug builds. */
+function displayDeviceCreationError(error: DeviceCreationError): void {
+  const canvas = typeof document === 'undefined' ? null : document.querySelector('canvas');
+  if (!canvas) return;
+
+  const errorElement =
+    document.getElementById('luma-device-error') || document.createElement('div');
+  errorElement.id = 'luma-device-error';
+  errorElement.setAttribute('role', 'alert');
+  errorElement.textContent = error.message;
+  canvas.after(errorElement);
 }
 
 /**

--- a/modules/core/test/adapter/luma.spec.ts
+++ b/modules/core/test/adapter/luma.spec.ts
@@ -468,6 +468,77 @@ test('luma#createDevice records unavailable adapters without calling create', as
   t.end();
 });
 
+test('luma#createDevice displays final debug failures beside a page canvas', async t => {
+  const container = document.createElement('div');
+  const canvas = document.createElement('canvas');
+  container.appendChild(canvas);
+  document.body.prepend(container);
+  const webgpuAdapter = new RecordingAdapter('webgpu', async () => {
+    throw new Error('WebGPU unavailable');
+  });
+
+  try {
+    await luma.createDevice({
+      type: 'webgpu',
+      adapters: [webgpuAdapter],
+      createCanvasContext: {canvas},
+      debug: true,
+      waitForPageLoad: false
+    });
+  } catch {
+    // Expected device creation failure.
+  }
+
+  const errorElement = document.getElementById('luma-device-error');
+  t.equal(errorElement?.previousElementSibling, canvas, 'the error is displayed beside the canvas');
+  t.equal(errorElement?.getAttribute('role'), 'alert', 'the error is announced accessibly');
+  t.ok(errorElement?.textContent?.includes('WebGPU unavailable'), 'the native error is shown');
+  container.remove();
+  t.end();
+});
+
+test('luma#createDevice only changes the page when debug is enabled', async t => {
+  const canvas = document.createElement('canvas');
+  document.body.prepend(canvas);
+  const webgpuAdapter = new RecordingAdapter('webgpu', async () => {
+    throw new Error('WebGPU unavailable');
+  });
+
+  try {
+    await luma.createDevice({
+      type: 'webgpu',
+      adapters: [webgpuAdapter],
+      debug: false,
+      waitForPageLoad: false
+    });
+  } catch {
+    // Expected device creation failure.
+  }
+  t.notOk(
+    document.getElementById('luma-device-error'),
+    'production failures do not modify the DOM'
+  );
+
+  try {
+    await luma.createDevice({
+      type: 'webgpu',
+      adapters: [webgpuAdapter],
+      debug: true,
+      waitForPageLoad: false
+    });
+  } catch {
+    // Expected device creation failure.
+  }
+  t.equal(
+    document.getElementById('luma-device-error')?.parentElement,
+    document.body,
+    'core displays the error without engine integration'
+  );
+  document.getElementById('luma-device-error')?.remove();
+  canvas.remove();
+  t.end();
+});
+
 test('luma#registerAdapters', async t => {
   luma.registerAdapters([nullAdapter]);
   const device = await luma.createDevice({type: 'null'});


### PR DESCRIPTION
## Summary

- after all `luma.createDevice()` attempts fail, append the error beside the first HTML canvas when `debug` is enabled
- keep the behavior entirely in `@luma.gl/core`, so core-only consumers receive it
- expose the accessible alert as `#luma-device-error` for application-owned CSS, including optional fading
- avoid engine lifecycle changes, timers, listeners, and built-in animation or styling

## Dependency

Based on #3141 because both PRs change `modules/core/src/adapter/luma.ts`.

## Review focus

The production change is 21 added lines in `luma.ts`; there is no new public API or engine lifecycle machinery. The alert is only created after final failure, uses `textContent` and `role="alert"`, and can be styled by the application.

Bundle impact over #3141 is 284 B minified, 124 B gzip, and 76 B Brotli. Every bundle ceiling passes.

## Verification

- `nvm use`
- `yarn lint fix`
- `yarn build`
- `yarn test-node`: 3,103 passed; 3 skipped
- focused headless `luma.spec.ts`: 22 passed
- bundle-size suite: all fixtures pass
- full headless suite: 1,839 passed; six unrelated WebGPU environment failures (DGGS, splat sorting, raster math, and lighting)

Replaces the previous animation-loop implementation with the narrower core behavior requested in review.
