### PR TITLE
feat(gpu-parse): integrate loaders.gl deferred Parquet pages

### DIFF
--- a/examples/api/texture-tester/package.json
+++ b/examples/api/texture-tester/package.json
@@ -8,9 +8,9 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "@loaders.gl/core": "~5.0.0-alpha.1",
-    "@loaders.gl/images": "~5.0.0-alpha.1",
-    "@loaders.gl/textures": "~5.0.0-alpha.1",
+    "@loaders.gl/core": "~5.0.0-alpha.4",
+    "@loaders.gl/images": "~5.0.0-alpha.4",
+    "@loaders.gl/textures": "~5.0.0-alpha.4",
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",
     "@luma.gl/shadertools": "9.4.0-alpha.4",

--- a/examples/showcase/billion-point-spatial-atlas/package.json
+++ b/examples/showcase/billion-point-spatial-atlas/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e",
-    "@loaders.gl/core": "~5.0.0-alpha.1",
-    "@loaders.gl/las": "~5.0.0-alpha.1",
+    "@loaders.gl/core": "~5.0.0-alpha.4",
+    "@loaders.gl/las": "~5.0.0-alpha.4",
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/effects": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",

--- a/examples/showcase/gltf/package.json
+++ b/examples/showcase/gltf/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e",
-    "@loaders.gl/core": "~5.0.0-alpha.1",
-    "@loaders.gl/gltf": "~5.0.0-alpha.1",
+    "@loaders.gl/core": "~5.0.0-alpha.4",
+    "@loaders.gl/gltf": "~5.0.0-alpha.4",
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",
     "@luma.gl/gltf": "9.4.0-alpha.4",

--- a/examples/showcase/postprocessing/package.json
+++ b/examples/showcase/postprocessing/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e",
-    "@loaders.gl/core": "~5.0.0-alpha.1",
-    "@loaders.gl/gltf": "~5.0.0-alpha.1",
+    "@loaders.gl/core": "~5.0.0-alpha.4",
+    "@loaders.gl/gltf": "~5.0.0-alpha.4",
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/effects": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",

--- a/examples/showcase/scene/gltf-to-anari.ts
+++ b/examples/showcase/scene/gltf-to-anari.ts
@@ -262,15 +262,12 @@ function translateNode(
       }
 
       const positionAccessor = primitive.attributes['POSITION'];
-      for (
-        let positionIndex = 0;
-        positionIndex < positionAccessor.value.length;
-        positionIndex += 3
-      ) {
+      const positionValues = getNumericAccessorValues(positionAccessor);
+      for (let positionIndex = 0; positionIndex < positionValues.length; positionIndex += 3) {
         const position = transform.transformAsPoint([
-          positionAccessor.value[positionIndex],
-          positionAccessor.value[positionIndex + 1],
-          positionAccessor.value[positionIndex + 2]
+          positionValues[positionIndex],
+          positionValues[positionIndex + 1],
+          positionValues[positionIndex + 2]
         ]);
         extendBounds(state.bounds, position);
       }
@@ -313,36 +310,37 @@ function getSurfaceIdentifier(
   surfaceIdentifier = createIdentifier(meshIdentifier, `primitive-${primitiveIndex}`, state);
   const geometry: JSONGeometryDeclaration = {
     '@@type': 'triangle',
-    'vertex.position': Array.from(positionAccessor.value)
+    'vertex.position': Array.from(getNumericAccessorValues(positionAccessor))
   };
   const normalAccessor = primitive.attributes['NORMAL'];
   if (normalAccessor) {
-    geometry['vertex.normal'] = Array.from(normalAccessor.value);
+    geometry['vertex.normal'] = Array.from(getNumericAccessorValues(normalAccessor));
   }
   const tangentAccessor = primitive.attributes['TANGENT'];
   if (tangentAccessor) {
-    geometry['vertex.tangent'] = Array.from(tangentAccessor.value);
+    geometry['vertex.tangent'] = Array.from(getNumericAccessorValues(tangentAccessor));
   }
   const jointAccessor = primitive.attributes['JOINTS_0'];
   if (jointAccessor) {
-    geometry['vertex.joint'] = Array.from(jointAccessor.value);
+    geometry['vertex.joint'] = Array.from(getNumericAccessorValues(jointAccessor));
   }
   const jointWeightAccessor = primitive.attributes['WEIGHTS_0'];
   if (jointWeightAccessor) {
+    const jointWeightValues = getNumericAccessorValues(jointWeightAccessor);
     const maximumJointWeight = jointWeightAccessor.normalized
-      ? jointWeightAccessor.value instanceof Uint8Array
+      ? jointWeightValues instanceof Uint8Array
         ? 255
-        : jointWeightAccessor.value instanceof Uint16Array
+        : jointWeightValues instanceof Uint16Array
           ? 65535
           : 1
       : 1;
     geometry['vertex.weight'] = Array.from(
-      jointWeightAccessor.value,
+      jointWeightValues,
       weight => weight / maximumJointWeight
     );
   }
   if (primitive.indices) {
-    geometry['primitive.index'] = Array.from(primitive.indices.value);
+    geometry['primitive.index'] = Array.from(getNumericAccessorValues(primitive.indices));
   }
 
   const vertexColors = getVertexColors(primitive, positionAccessor.count);
@@ -351,11 +349,13 @@ function getSurfaceIdentifier(
   }
   const textureCoordinates = primitive.attributes['TEXCOORD_0'];
   if (textureCoordinates) {
-    geometry['vertex.attribute1'] = Array.from(textureCoordinates.value);
+    geometry['vertex.attribute1'] = Array.from(getNumericAccessorValues(textureCoordinates));
   }
   const additionalTextureCoordinates = primitive.attributes['TEXCOORD_1'];
   if (additionalTextureCoordinates) {
-    geometry['vertex.attribute2'] = Array.from(additionalTextureCoordinates.value);
+    geometry['vertex.attribute2'] = Array.from(
+      getNumericAccessorValues(additionalTextureCoordinates)
+    );
   }
   if (primitive.targets?.length) {
     geometry.morphTargets = primitive.targets.map(target => {
@@ -367,7 +367,7 @@ function getSurfaceIdentifier(
             ? state.gltf.accessors[accessorReference]
             : accessorReference;
         if (accessor) {
-          attributes[attributeName] = Array.from(accessor.value);
+          attributes[attributeName] = Array.from(getNumericAccessorValues(accessor));
         }
       }
       return attributes;
@@ -387,7 +387,11 @@ function getSurfaceIdentifier(
         node: node.id,
         joints: sourceSkin.joints.map(jointIndex => state.gltf.nodes[jointIndex].id),
         ...(sourceSkin.inverseBindMatrices?.value
-          ? {inverseBindMatrices: Array.from(sourceSkin.inverseBindMatrices.value)}
+          ? {
+              inverseBindMatrices: Array.from(
+                getNumericAccessorValues(sourceSkin.inverseBindMatrices)
+              )
+            }
           : {})
       }
     : undefined;
@@ -532,6 +536,7 @@ function getVertexColors(
   }
 
   const colorSize = colorAccessor.components === 4 ? 4 : 3;
+  const colorValues = getNumericAccessorValues(colorAccessor);
   const colors = new Array<number>(vertexCount * colorSize);
   for (let vertexIndex = 0; vertexIndex < vertexCount; vertexIndex++) {
     const sourceColor = getAccessorColor(colorAccessor, vertexIndex);
@@ -540,7 +545,7 @@ function getVertexColors(
     colors[offset + 1] = sourceColor[1];
     colors[offset + 2] = sourceColor[2];
     if (colorSize === 4) {
-      const sourceAlpha = colorAccessor.value[vertexIndex * colorAccessor.components + 3];
+      const sourceAlpha = colorValues[vertexIndex * colorAccessor.components + 3];
       const divisor = colorAccessor.normalized
         ? colorAccessor.componentType === 5121
           ? 255
@@ -562,6 +567,7 @@ function getAccessorColor(
     return [1, 1, 1];
   }
   const offset = vertexIndex * accessor.components;
+  const values = getNumericAccessorValues(accessor);
   const divisor = accessor.normalized
     ? accessor.componentType === 5121
       ? 255
@@ -569,11 +575,17 @@ function getAccessorColor(
         ? 65535
         : 1
     : 1;
-  return [
-    accessor.value[offset] / divisor,
-    accessor.value[offset + 1] / divisor,
-    accessor.value[offset + 2] / divisor
-  ];
+  return [values[offset] / divisor, values[offset + 1] / divisor, values[offset + 2] / divisor];
+}
+
+/** glTF component types are numeric even though loaders.gl's shared table type also includes BigInt. */
+function getNumericAccessorValues(
+  accessor: GLTFAccessorPostprocessed
+): Exclude<GLTFAccessorPostprocessed['value'], BigInt64Array | BigUint64Array> {
+  if (accessor.value instanceof BigInt64Array || accessor.value instanceof BigUint64Array) {
+    throw new Error('glTF accessors cannot use BigInt component arrays');
+  }
+  return accessor.value;
 }
 
 function addMaterialTexture(

--- a/examples/showcase/scene/package.json
+++ b/examples/showcase/scene/package.json
@@ -9,8 +9,8 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "@loaders.gl/core": "~5.0.0-alpha.1",
-    "@loaders.gl/gltf": "~5.0.0-alpha.1",
+    "@loaders.gl/core": "~5.0.0-alpha.4",
+    "@loaders.gl/gltf": "~5.0.0-alpha.4",
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/effects": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",

--- a/examples/tutorials/hello-gltf/package.json
+++ b/examples/tutorials/hello-gltf/package.json
@@ -8,8 +8,8 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "@loaders.gl/core": "~5.0.0-alpha.1",
-    "@loaders.gl/gltf": "~5.0.0-alpha.1",
+    "@loaders.gl/core": "~5.0.0-alpha.4",
+    "@loaders.gl/gltf": "~5.0.0-alpha.4",
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",
     "@luma.gl/gltf": "9.4.0-alpha.4",

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -48,9 +48,9 @@
     "@luma.gl/shadertools": "~9.4.0-alpha.1"
   },
   "dependencies": {
-    "@loaders.gl/core": "~5.0.0-alpha.1",
-    "@loaders.gl/gltf": "~5.0.0-alpha.1",
-    "@loaders.gl/textures": "~5.0.0-alpha.1",
+    "@loaders.gl/core": "~5.0.0-alpha.4",
+    "@loaders.gl/gltf": "~5.0.0-alpha.4",
+    "@loaders.gl/textures": "~5.0.0-alpha.4",
     "@math.gl/core": "^4.1.0"
   },
   "gitHead": "c636c34b8f1581eed163e94543a8eb1f4382ba8e"

--- a/modules/gltf/src/export/gltf-exporter.ts
+++ b/modules/gltf/src/export/gltf-exporter.ts
@@ -258,7 +258,15 @@ class GLTFExportWriter {
       ? GLBWriter.encodeSync(
           {
             json: document,
-            ...(binary.byteLength > 0 ? {binary} : {})
+            // loaders.gl alpha.4's GLB parser expects the legacy v2 BIN chunk to exist even when
+            // the JSON has no buffer definition. An empty chunk preserves the JSON contract.
+            buffers: [
+              {
+                arrayBuffer: binary.buffer as ArrayBuffer,
+                byteOffset: binary.byteOffset,
+                byteLength: binary.byteLength
+              }
+            ]
           },
           {}
         )

--- a/modules/gltf/src/gltf/gltf-lod.ts
+++ b/modules/gltf/src/gltf/gltf-lod.ts
@@ -253,12 +253,12 @@ function simplifyGLTFMesh(
     ]) {
       const attribute = primitive.attributes[semantic];
       if (attribute) {
-        attributes.push({values: attribute.value, size: attribute.components});
+        attributes.push({values: getNumericAccessorValues(attribute), size: attribute.components});
       }
     }
 
     const simplified = simplifyMesh({
-      positions: positions.value,
+      positions: getNumericAccessorValues(positions),
       indices: sourceIndices,
       targetRatio,
       attributes,
@@ -302,6 +302,16 @@ function simplifyGLTFMesh(
     primitives,
     extras: {...sourceMesh.extras, geometricError}
   };
+}
+
+/** glTF component types are numeric even though loaders.gl's shared table type also includes BigInt. */
+function getNumericAccessorValues(
+  accessor: GLTFAccessorPostprocessed
+): Exclude<GLTFAccessorPostprocessed['value'], BigInt64Array | BigUint64Array> {
+  if (accessor.value instanceof BigInt64Array || accessor.value instanceof BigUint64Array) {
+    throw new Error('glTF mesh accessors cannot use BigInt component arrays');
+  }
+  return accessor.value;
 }
 
 function getPrimitiveIndices(

--- a/modules/gltf/src/parsers/parse-gltf-animations.ts
+++ b/modules/gltf/src/parsers/parse-gltf-animations.ts
@@ -757,10 +757,15 @@ function accessorToJsArray2D(
 }
 
 /** Preserve manually appended float accessors without duplicating loaders.gl postprocessing. */
-function resolveAnimationAccessor(
-  accessor: GLTFAccessorPostprocessed
-): Pick<GLTFAccessorPostprocessed, 'value' | 'components'> {
+function resolveAnimationAccessor(accessor: GLTFAccessorPostprocessed): {
+  value: Exclude<GLTFAccessorPostprocessed['value'], BigInt64Array | BigUint64Array>;
+  components: number;
+} {
   if (accessor.value) {
+    assert(
+      !(accessor.value instanceof BigInt64Array) && !(accessor.value instanceof BigUint64Array),
+      'glTF animation accessors cannot use BigInt component arrays'
+    );
     return {value: accessor.value, components: accessor.components};
   }
 

--- a/modules/gltf/test/export/gltf-exporter.node.spec.ts
+++ b/modules/gltf/test/export/gltf-exporter.node.spec.ts
@@ -115,7 +115,13 @@ describe('source-faithful glTF asset export', () => {
       expect(encodeGLB).toHaveBeenCalledOnce();
       expect(encodeGLB.mock.calls[0][0]).toMatchObject({
         json: {asset: {version: '2.0'}},
-        binary: expect.any(Uint8Array)
+        buffers: [
+          {
+            arrayBuffer: expect.any(ArrayBuffer),
+            byteOffset: expect.any(Number),
+            byteLength: expect.any(Number)
+          }
+        ]
       });
       expect(binary).toBeInstanceOf(ArrayBuffer);
     } finally {

--- a/modules/gpgpu/src/gpu-parse/README.md
+++ b/modules/gpgpu/src/gpu-parse/README.md
@@ -61,6 +61,7 @@ public class matrix for every scalar type. Object-oriented operations such as `G
 | `parseParquetDeltaByteArrayPlan` | BYTE_ARRAY uses prefix compression | prefix/suffix plans and suffix boundary |
 | `parseLZ4RawDecompressionPlan` | a page uses LZ4_RAW | sequence descriptors and exact output size |
 | `parseSnappyDecompressionPlan` | a page uses raw Snappy | generic literal/backreference descriptors and declared output size |
+| `planGPUParquetEncodedPageBatch` | loaders.gl returned deferred encoded pages | validated mixed GPU/CPU decisions and one aligned upload containing pages, dictionaries, and descriptors |
 
 Plans retain offsets into the original input. Pass that same packed input view to the GPU operation
 unless a function explicitly documents an isolated slice.
@@ -85,6 +86,7 @@ unless a function explicitly documents an isolated slice.
 | `GPUParquetLevelLayout` | decoded levels must become null/value and repeated-row layout | physical validity/value offsets, logical element offsets, row indices, list offsets, and counts |
 | `GPULZ4RawDecompressor` | a page body uses LZ4_RAW | semantic wrapper over `GPULZByteDecompressor` |
 | `GPUSnappyDecompressor` | a Parquet page body uses raw Snappy | semantic wrapper over `GPULZByteDecompressor` |
+| `addGPUParquetEncodedPageBatchToGraph` | a loaders.gl page-batch plan should become executable GPU work | decompression, level decoding, value decoding, dictionary reuse, and result graph views |
 
 ## Common recipes
 
@@ -139,48 +141,91 @@ Use the codec-specific GPU wrapper when operation names and metrics should retai
 use `GPULZByteDecompressor` directly when another byte-oriented LZ format can produce the same
 descriptor contract.
 
-## Proposed loaders.gl integration
+## loaders.gl integration
 
-A Parquet loader option such as `parquet.deferPageDecoding: 'gpu'` should parse the file and page
-metadata while preserving GPU-tractable page work. The returned object should be a transport-neutral
-description rather than a luma.gl command graph:
+loaders.gl 5.0.0-alpha.4 implements the transport-neutral boundary through
+`ParquetSource.readPages()`. It retains file I/O, Thrift metadata, schema traversal, page indexes,
+checksums, encryption, and range requests while returning `ParquetEncodedPageBatch` objects. The
+loader contract contains no luma.gl device or graph types.
 
-```ts
-type DeferredParquetPage = {
-  encoding: string;
-  compression: string;
-  physicalType: string;
-  valueCount: number;
-  nonNullValueCount: number;
-  typeLength?: number;
-  maxDefinitionLevel: number;
-  maxRepetitionLevel: number;
-  pageVersion: 1 | 2;
-  pageBytes: Uint8Array;
-  repetitionLevels?: {byteOffset: number; byteLength: number};
-  definitionLevels?: {byteOffset: number; byteLength: number};
-  values: {byteOffset: number; byteLength: number};
-  dictionaryPageId?: number;
-};
+Install loaders.gl explicitly when using this optional adapter:
+
+```sh
+yarn add @loaders.gl/parquet@5.0.0-alpha.4
 ```
 
-Recommended behavior:
+Request encoded pages and preserve only codecs that `gpu-parse` can decompress:
 
-- The loader still handles file I/O, Thrift metadata, schema traversal, page boundaries, checksums,
-  encryption, and unsupported codec fallback.
-- `pageBytes` keeps compressed bytes only when the codec is GPU-supported; otherwise the loader
-  decompresses but preserves the encoded value representation.
-- Data Page V1/V2 level ranges are normalized explicitly so the GPU adapter never guesses framing.
-- Dictionary pages remain associated with data pages by a stable page ID and share ownership with
-  the returned batch.
-- CPU decoding remains the default. Deferred mode is opt-in and may return a mixed batch where only
-  supported pages are deferred.
-- The loader owns byte buffers until the consumer releases the batch. The GPU adapter may upload,
-  cache, or stream pages without loaders.gl depending on WebGPU.
+```ts
+import {ParquetSourceLoader} from '@loaders.gl/parquet/parquet-source-loader';
+import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
+import {
+  addGPUParquetEncodedPageBatchToGraph,
+  createGPUParquetEncodedPageBatchInputBuffer,
+  planGPUParquetEncodedPageBatch
+} from '@luma.gl/gpgpu/gpu-parse';
 
-An adapter in luma.gl can map this object to the appropriate `parse...Plan` and `GPU...` operations.
-Keeping the contract free of `Device`, `Buffer`, and `GPUCommandGraph` types lets loaders.gl expose
-the option to other GPU runtimes too.
+const source = ParquetSourceLoader.createDataSource(parquetBlob, {});
+
+for await (const encodedBatch of source.readPages({
+  columns: ['position', 'category'],
+  preserveCompression: ['SNAPPY', 'LZ4_RAW']
+})) {
+  const plan = planGPUParquetEncodedPageBatch(encodedBatch, {
+    minimumGPUByteLength: 64 * 1024
+  });
+  const inputBuffer = createGPUParquetEncodedPageBatchInputBuffer(device, plan);
+  const graph = new GPUCommandGraph(device);
+  const decodedBatch = addGPUParquetEncodedPageBatchToGraph(graph, plan, inputBuffer);
+
+  // Add table, filtering, rendering, or readback operations that consume decodedBatch.pages.
+  const compiled = graph.compile();
+  // Encode and submit the compiled graph, then destroy compiled and inputBuffer when finished.
+}
+```
+
+### What the adapter does
+
+- Validates page counts, ordinals, compression metadata, and every advertised section range before
+  uploading data.
+- Copies page sections and CPU-parsed descriptors into one four-byte-aligned upload instead of
+  creating one GPU buffer per page.
+- Reuses one immutable dictionary plan and graph resource across every dictionary data page in the
+  column chunk.
+- Composes Snappy or LZ4_RAW decompression, V1/V2 level decoding, and supported value decoders in
+  one command graph.
+- Returns packed-byte, uint32, split-uint64, or byte-array result views for downstream graph work.
+- Keeps unsupported pages in source order as `CPUParquetPageFallbackPlan`; no page is silently
+  omitted.
+
+`minimumGPUByteLength` is an application policy rather than a fixed library heuristic. Use zero
+after explicitly choosing GPU deferral, or set a measured crossover size when CPU decoding is
+available. `requireGPU: true` converts every fallback into an exception and is useful for tests and
+controlled pipelines.
+
+### Deliberate automatic-fallback cases
+
+- Compression codecs other than Snappy and LZ4_RAW.
+- Compressed V1 pages containing levels. V1 compresses the entire body, so level/value boundaries
+  are unknowable until decompression. V2 leaves level sections addressable and is fully composable.
+- Encodings whose serial control headers remain hidden inside a compressed value payload. The
+  loader may CPU-decompress these pages while still deferring their value decoding.
+- Encodings with no bounded automatic output allocation. Lower-level operations remain available
+  when an application supplies an explicit output capacity.
+
+CPU decoding remains the loaders.gl default. `readPages()` is the explicit opt-in, and mixed
+CPU/GPU execution remains caller-owned because loaders.gl should not depend on luma.gl.
+
+## Conformance and hardening
+
+The adapter tests real V1 and V2 pages emitted by loaders.gl's Parquet writer, including nullable,
+all-null, fixed-width, and variable-width values. Additional fixtures cover dictionary reuse,
+malformed section rejection, page thresholds, raw Snappy decompression, BYTE_STREAM_SPLIT, and
+definition-level decoding. Every lower-level decoder also retains focused truncation and boundary
+tests.
+
+Malformed framing and contradictory metadata throw during planning. Only recognized capability or
+policy boundaries become CPU fallbacks; corrupt data is never relabeled as an unsupported page.
 
 ## Support matrix
 

--- a/modules/gpgpu/src/gpu-parse/README.md
+++ b/modules/gpgpu/src/gpu-parse/README.md
@@ -245,6 +245,34 @@ policy boundaries become CPU fallbacks; corrupt data is never relabeled as an un
 | Gzip, Brotli, Zstandard | Not supported | better supplied by dedicated implementations |
 | legacy LZ4 | Not supported | deprecated framing distinct from LZ4_RAW |
 
+## Follow-up roadmap
+
+Tranches 1 and 2 are complete: the package has composable low-level operations, and loaders.gl
+encoded-page batches can now be validated, uploaded once, and executed as mixed GPU/CPU command
+graphs. Further work should remain incremental. Each tranche below has a useful stopping point and
+does not require turning `gpu-parse` into a complete Parquet parser.
+
+| Tranche | Priority | Scope | Completion bar |
+| --- | --- | --- | --- |
+| 3. Close inexpensive adapter gaps | Recommended next | Let a loader choose preserve-compressed, CPU-decompress-but-keep-encoded, or CPU-decode per page; automatically use `DELTA_BYTE_ARRAY` when an exact output capacity is available; accept variable dictionaries and V1 level framing after loader-side decompression | Common supported encodings stop falling back merely because compression hides their serial control headers; no GPU metadata parser is introduced |
+| 4. Extract generic materialization primitives | High value | Generalize validity expansion, segmented offsets, compaction, scatter, and byte-range assembly from the Parquet level and byte-array paths | The same operations can materialize another columnar format without importing Parquet-specific classes |
+| 5. Assemble nested GPU columns | Selective | Compose multiple definition/repetition depths into validity, row, and list offsets; expose chunk-preserving `GPUData`/`GPUVector` results without adding Arrow to `@luma.gl/gpgpu` | Common required, optional, list, and nested-list columns can remain GPU-resident through their consumer boundary |
+| 6. Streaming and throughput | Measure first | Reuse compiled graph templates, pool upload/output buffers, batch compatible pages and columns, add backpressure, and benchmark CPU/GPU crossover thresholds | Sustained row-group streaming has bounded memory and published evidence for when GPU deferral pays off |
+| 7. Conformance and hardening | Ongoing | Add files from multiple Parquet writers, differential CPU/GPU decoding, planner fuzzing, malformed/truncated inputs, empty/all-null pages, large offsets, and maximum-width stress cases | Every automatic path is covered by independent writer fixtures and corruption tests; fallbacks remain distinguishable from malformed data |
+| 8. Demand-driven format additions | Optional | Evaluate ALP and focused logical conversions such as DECIMAL or legacy INT96 only when real datasets justify them | A new operation has a bounded layout, a reusable primitive where possible, fixtures, benchmarks, and a documented CPU fallback |
+
+The intended order is 3, 4, and then whichever of 5–7 is justified by an actual consumer. Tranche 8
+is not a completeness checklist.
+
+### Roadmap stop line
+
+The roadmap does not include GPU Thrift/schema parsing, file I/O, page indexes, encryption,
+checksums, or a second Arrow/table implementation. Those remain loader or adapter responsibilities.
+It also does not currently include Zstandard, Gzip, Brotli, deprecated framed LZ4, or a general GPU
+parser for serial encoding headers. These are substantial independent projects and should only be
+reconsidered with workload profiles showing that CPU or WebAssembly decompression is the dominant
+bottleneck after GPU value decoding is enabled.
+
 ## Boundaries
 
 The package does not parse Thrift metadata, decrypt pages, evaluate logical type annotations, build

--- a/modules/gpgpu/src/gpu-parse/index.ts
+++ b/modules/gpgpu/src/gpu-parse/index.ts
@@ -12,6 +12,31 @@ export {
   type ParquetPhysicalType
 } from './parquet/parquet-column-decode-plan';
 export {
+  planGPUParquetEncodedPageBatch,
+  type LoadersGLParquetEncodedColumnChunk,
+  type LoadersGLParquetEncodedPage,
+  type LoadersGLParquetEncodedPageBatch,
+  type LoadersGLParquetEncodedPageSection,
+  type CPUParquetPageFallbackPlan,
+  type GPUParquetCompressionPlan,
+  type GPUParquetDecodedPagePlan,
+  type GPUParquetDictionaryPlan,
+  type GPUParquetEncodedPageBatchPlan,
+  type GPUParquetEncodedPageBatchPlanOptions,
+  type GPUParquetLevelPlan,
+  type GPUParquetUploadSection,
+  type GPUParquetValuePlan
+} from './parquet/parquet-encoded-page-batch';
+export {
+  addGPUParquetEncodedPageBatchToGraph,
+  createGPUParquetEncodedPageBatchInputBuffer,
+  type GPUParquetByteArrayPageValues,
+  type GPUParquetDecodedPage,
+  type GPUParquetEncodedPageBatch,
+  type GPUParquetFixedPageValues,
+  type GPUParquetInt64PageValues
+} from './parquet/gpu-parquet-encoded-page-batch';
+export {
   GPUParquetByteStreamSplitDecoder,
   GPU_PARQUET_BYTE_STREAM_SPLIT_WORKGROUP_SIZE,
   getGPUParquetByteStreamSplitShaderSource,

--- a/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-encoded-page-batch.ts
+++ b/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-encoded-page-batch.ts
@@ -1,0 +1,517 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {
+  GPUCommandGraph,
+  createTransientView,
+  type GraphBufferHandle,
+  type GraphDataView
+} from '@luma.gl/gpgpu/gpu-core';
+import {GPULZ4RawDecompressor} from '../compression/gpu-lz4-raw-decompressor';
+import {GPUSnappyDecompressor} from '../compression/gpu-snappy-decompressor';
+import {GPUParquetBitPackedDecoder} from './gpu-parquet-bit-packed-decoder';
+import {GPUParquetByteArrayDictionaryDecoder} from './gpu-parquet-byte-array-dictionary-decoder';
+import {GPUParquetByteStreamSplitDecoder} from './gpu-parquet-byte-stream-split-decoder';
+import {GPUParquetDeltaBinaryPackedDecoder} from './gpu-parquet-delta-binary-packed-decoder';
+import {GPUParquetDeltaBinaryPackedInt64Decoder} from './gpu-parquet-delta-binary-packed-int64-decoder';
+import {GPUParquetDeltaLengthByteArrayDecoder} from './gpu-parquet-delta-length-byte-array-decoder';
+import {GPUParquetPlainBooleanDecoder} from './gpu-parquet-plain-boolean-decoder';
+import {GPUParquetPlainByteArrayDecoder} from './gpu-parquet-plain-byte-array-decoder';
+import {GPUParquetRleBitPackedDecoder} from './gpu-parquet-rle-bit-packed-decoder';
+import {GPUParquetRleDictionaryDecoder} from './gpu-parquet-rle-dictionary-decoder';
+import type {
+  CPUParquetPageFallbackPlan,
+  GPUParquetCompressionPlan,
+  GPUParquetDecodedPagePlan,
+  GPUParquetDictionaryPlan,
+  GPUParquetEncodedPageBatchPlan,
+  GPUParquetLevelPlan,
+  GPUParquetUploadSection,
+  GPUParquetValuePlan
+} from './parquet-encoded-page-batch';
+
+/** Decoded fixed-width or boolean values for one GPU page. */
+export type GPUParquetFixedPageValues = Readonly<{
+  layout: 'packed-bytes' | 'uint32';
+  values: GraphDataView<'uint32'>;
+  valueCount: number;
+  byteLength: number;
+}>;
+
+/** Split-word INT64 values produced by the portable uint64 decoder. */
+export type GPUParquetInt64PageValues = Readonly<{
+  layout: 'split-uint64';
+  low: GraphDataView<'uint32'>;
+  high: GraphDataView<'uint32'>;
+  valueCount: number;
+  byteLength: number;
+}>;
+
+/** Packed bytes plus row metadata for one variable-width page. */
+export type GPUParquetByteArrayPageValues = Readonly<{
+  layout: 'byte-array';
+  values: GraphDataView<'uint32'>;
+  lengths: GraphDataView<'uint32'>;
+  offsets: GraphDataView<'uint32'>;
+  valueCount: number;
+  byteLength: number;
+}>;
+
+/** Graph views produced for one automatically decoded page. */
+export type GPUParquetDecodedPage = Readonly<{
+  mode: 'gpu';
+  plan: GPUParquetDecodedPagePlan;
+  values: GPUParquetFixedPageValues | GPUParquetInt64PageValues | GPUParquetByteArrayPageValues;
+  repetitionLevels?: GraphDataView<'uint32'>;
+  definitionLevels?: GraphDataView<'uint32'>;
+}>;
+
+/** Mixed graph result preserving explicit CPU fallback pages in source order. */
+export type GPUParquetEncodedPageBatch = Readonly<{
+  inputBuffer: Buffer;
+  pages: readonly (GPUParquetDecodedPage | CPUParquetPageFallbackPlan)[];
+}>;
+
+type GPUParquetGraphDictionary = Readonly<{
+  plan: GPUParquetDictionaryPlan;
+  values: GraphDataView<'uint32'>;
+  lengths?: GraphDataView<'uint32'>;
+  offsets?: GraphDataView<'uint32'>;
+}>;
+
+/** Uploads the aligned bytes and descriptor arrays owned by one page-batch plan. */
+export function createGPUParquetEncodedPageBatchInputBuffer(
+  device: Device,
+  plan: GPUParquetEncodedPageBatchPlan
+): Buffer {
+  const data = plan.uploadData.byteLength > 0 ? plan.uploadData : new Uint32Array(1);
+  return device.createBuffer({
+    id: 'gpu-parquet-page-batch-input',
+    data,
+    usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC
+  });
+}
+
+/**
+ * Adds every accepted page in a loaders.gl batch to one command graph.
+ *
+ * The caller owns `inputBuffer` and may reuse the immutable upload across compiled executions.
+ * Returned transient views are intended for downstream graph operations; pages that require CPU
+ * handling remain in the result unchanged so mixed batches cannot silently drop data.
+ */
+export function addGPUParquetEncodedPageBatchToGraph<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  plan: GPUParquetEncodedPageBatchPlan,
+  inputBuffer: Buffer
+): GPUParquetEncodedPageBatch {
+  const inputHandle = graph.importBuffer(
+    {
+      id: `${graph.id}-parquet-page-batch-input`,
+      byteLength: Math.max(plan.uploadData.byteLength, 4),
+      usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC
+    },
+    inputBuffer
+  );
+  const dictionaries = new Map<GPUParquetDictionaryPlan, GPUParquetGraphDictionary>();
+  for (let columnIndex = 0; columnIndex < plan.dictionaries.length; columnIndex++) {
+    const dictionaryPlan = plan.dictionaries[columnIndex];
+    if (dictionaryPlan) {
+      dictionaries.set(
+        dictionaryPlan,
+        addDictionaryToGraph(graph, inputHandle, dictionaryPlan, columnIndex)
+      );
+    }
+  }
+  const pages = plan.pages.map(page =>
+    page.mode === 'cpu-fallback' ? page : addPageToGraph(graph, inputHandle, page, dictionaries)
+  );
+  return Object.freeze({inputBuffer, pages: Object.freeze(pages)});
+}
+
+function addPageToGraph<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  inputHandle: GraphBufferHandle,
+  plan: GPUParquetDecodedPagePlan,
+  dictionaries: ReadonlyMap<GPUParquetDictionaryPlan, GPUParquetGraphDictionary>
+): GPUParquetDecodedPage {
+  const id = `parquet-${plan.columnIndex}-${plan.pageOrdinal}`;
+  const encodedValues = createUploadView(graph, inputHandle, plan.encodedValues);
+  const valueInput = plan.compression
+    ? addDecompressionToGraph(graph, inputHandle, plan.compression, id)
+    : encodedValues;
+  const repetitionLevels = plan.repetitionLevels
+    ? addLevelToGraph(graph, inputHandle, plan.repetitionLevels, `${id}-repetition`)
+    : undefined;
+  const definitionLevels = plan.definitionLevels
+    ? addLevelToGraph(graph, inputHandle, plan.definitionLevels, `${id}-definition`)
+    : undefined;
+  const values = addValuesToGraph(graph, inputHandle, valueInput, plan.values, id, dictionaries);
+  return Object.freeze({mode: 'gpu' as const, plan, values, repetitionLevels, definitionLevels});
+}
+
+function addDictionaryToGraph<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  inputHandle: GraphBufferHandle,
+  plan: GPUParquetDictionaryPlan,
+  columnIndex: number
+): GPUParquetGraphDictionary {
+  const id = `parquet-${columnIndex}-dictionary`;
+  const encodedValues = createUploadView(graph, inputHandle, plan.encodedValues);
+  const input =
+    plan.kind === 'fixed' && plan.compression
+      ? addDecompressionToGraph(graph, inputHandle, plan.compression, id)
+      : encodedValues;
+  if (plan.kind === 'fixed') {
+    return Object.freeze({plan, values: input});
+  }
+  const values = createTransientPackedBytes(graph, `${id}-values`, plan.decodedByteLength);
+  const lengths = createUploadView(graph, inputHandle, plan.valueLengths);
+  const offsets = createUploadView(graph, inputHandle, plan.valueOffsets);
+  new GPUParquetPlainByteArrayDecoder({
+    id,
+    input,
+    sourceOffsets: createUploadView(graph, inputHandle, plan.sourceOffsets),
+    valueLengths: lengths,
+    valueOffsets: offsets,
+    output: values,
+    encodedByteLength: plan.encodedValues.byteLength,
+    outputByteLength: plan.decodedByteLength
+  }).addToGraph(graph);
+  return Object.freeze({plan, values, lengths, offsets});
+}
+
+function addDecompressionToGraph<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  inputHandle: GraphBufferHandle,
+  plan: GPUParquetCompressionPlan,
+  id: string
+): GraphDataView<'uint32'> {
+  const input = createUploadView(graph, inputHandle, plan.input);
+  const descriptors = createUploadView(graph, inputHandle, plan.descriptors);
+  const output = createTransientPackedBytes(
+    graph,
+    `${id}-${plan.codec.toLowerCase()}-output`,
+    plan.outputByteLength
+  );
+  if (plan.codec === 'SNAPPY') {
+    new GPUSnappyDecompressor({
+      id: `${id}-snappy`,
+      input,
+      descriptors,
+      output,
+      compressedByteLength: plan.input.byteLength,
+      outputByteLength: plan.outputByteLength,
+      descriptorCount: plan.descriptorCount
+    }).addToGraph(graph);
+  } else {
+    new GPULZ4RawDecompressor({
+      id: `${id}-lz4-raw`,
+      input,
+      descriptors,
+      output,
+      compressedByteLength: plan.input.byteLength,
+      outputByteLength: plan.outputByteLength,
+      descriptorCount: plan.descriptorCount
+    }).addToGraph(graph);
+  }
+  return output;
+}
+
+function addLevelToGraph<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  inputHandle: GraphBufferHandle,
+  plan: GPUParquetLevelPlan,
+  id: string
+): GraphDataView<'uint32'> {
+  const input = createUploadView(graph, inputHandle, plan.input);
+  const output = createTransientResultView(graph, `${id}-output`, plan.valueCount);
+  if (plan.encoding === 'RLE') {
+    const descriptors = createUploadView(graph, inputHandle, plan.runDescriptors!);
+    new GPUParquetRleBitPackedDecoder({
+      id,
+      input,
+      runDescriptors: descriptors,
+      output,
+      encodedByteLength: plan.input.byteLength,
+      valueCount: plan.valueCount,
+      runCount: plan.runPlan!.runCount,
+      bitWidth: plan.bitWidth
+    }).addToGraph(graph);
+  } else {
+    new GPUParquetBitPackedDecoder({
+      id,
+      input,
+      output,
+      encodedByteLength: plan.input.byteLength,
+      valueCount: plan.valueCount,
+      bitWidth: plan.bitWidth
+    }).addToGraph(graph);
+  }
+  return output;
+}
+
+function addValuesToGraph<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  inputHandle: GraphBufferHandle,
+  input: GraphDataView<'uint32'>,
+  plan: GPUParquetValuePlan,
+  id: string,
+  dictionaries: ReadonlyMap<GPUParquetDictionaryPlan, GPUParquetGraphDictionary>
+): GPUParquetFixedPageValues | GPUParquetInt64PageValues | GPUParquetByteArrayPageValues {
+  switch (plan.kind) {
+    case 'plain-fixed':
+      return Object.freeze({
+        layout: 'packed-bytes' as const,
+        values: input,
+        valueCount: plan.valueCount,
+        byteLength: plan.decodedByteLength
+      });
+    case 'byte-stream-split': {
+      const values = createTransientPackedBytes(
+        graph,
+        `${id}-values`,
+        plan.decodedByteLength,
+        Buffer.STORAGE | Buffer.COPY_SRC
+      );
+      new GPUParquetByteStreamSplitDecoder({
+        id: `${id}-byte-stream-split`,
+        input,
+        output: values,
+        valueCount: plan.valueCount,
+        byteWidth: plan.byteWidth
+      }).addToGraph(graph);
+      return Object.freeze({
+        layout: 'packed-bytes' as const,
+        values,
+        valueCount: plan.valueCount,
+        byteLength: plan.decodedByteLength
+      });
+    }
+    case 'plain-boolean': {
+      const values = createTransientResultView(graph, `${id}-values`, plan.valueCount);
+      new GPUParquetPlainBooleanDecoder({
+        id: `${id}-plain-boolean`,
+        input,
+        output: values,
+        valueCount: plan.valueCount
+      }).addToGraph(graph);
+      return Object.freeze({
+        layout: 'uint32' as const,
+        values,
+        valueCount: plan.valueCount,
+        byteLength: plan.decodedByteLength
+      });
+    }
+    case 'plain-byte-array': {
+      const values = createTransientPackedBytes(
+        graph,
+        `${id}-values`,
+        plan.decodedByteLength,
+        Buffer.STORAGE | Buffer.COPY_SRC
+      );
+      const lengths = createUploadView(graph, inputHandle, plan.valueLengths);
+      const offsets = createUploadView(graph, inputHandle, plan.valueOffsets);
+      new GPUParquetPlainByteArrayDecoder({
+        id: `${id}-plain-byte-array`,
+        input,
+        sourceOffsets: createUploadView(graph, inputHandle, plan.sourceOffsets),
+        valueLengths: lengths,
+        valueOffsets: offsets,
+        output: values,
+        encodedByteLength: input.length * 4,
+        outputByteLength: plan.decodedByteLength
+      }).addToGraph(graph);
+      return Object.freeze({
+        layout: 'byte-array' as const,
+        values,
+        lengths,
+        offsets,
+        valueCount: plan.valueCount,
+        byteLength: plan.decodedByteLength
+      });
+    }
+    case 'delta-binary-packed-int32': {
+      const values = createTransientResultView(graph, `${id}-values`, plan.valueCount);
+      new GPUParquetDeltaBinaryPackedDecoder({
+        id: `${id}-delta-int32`,
+        input,
+        miniBlockDescriptors: createUploadView(graph, inputHandle, plan.miniBlockDescriptors),
+        output: values,
+        encodedByteLength: input.length * 4,
+        valueCount: plan.valueCount,
+        descriptorCount: plan.deltaPlan.descriptorCount,
+        firstValue: plan.deltaPlan.firstValue
+      }).addToGraph(graph);
+      return Object.freeze({
+        layout: 'uint32' as const,
+        values,
+        valueCount: plan.valueCount,
+        byteLength: plan.decodedByteLength
+      });
+    }
+    case 'delta-binary-packed-int64': {
+      const low = createTransientResultView(graph, `${id}-values-low`, plan.valueCount);
+      const high = createTransientResultView(graph, `${id}-values-high`, plan.valueCount);
+      new GPUParquetDeltaBinaryPackedInt64Decoder({
+        id: `${id}-delta-int64`,
+        input,
+        miniBlockDescriptors: createUploadView(graph, inputHandle, plan.miniBlockDescriptors),
+        outputLow: low,
+        outputHigh: high,
+        encodedByteLength: input.length * 4,
+        valueCount: plan.valueCount,
+        descriptorCount: plan.deltaPlan.descriptorCount,
+        firstValueLow: plan.deltaPlan.firstValueLow,
+        firstValueHigh: plan.deltaPlan.firstValueHigh
+      }).addToGraph(graph);
+      return Object.freeze({
+        layout: 'split-uint64' as const,
+        low,
+        high,
+        valueCount: plan.valueCount,
+        byteLength: plan.decodedByteLength
+      });
+    }
+    case 'delta-length-byte-array': {
+      const lengths = createTransientResultView(graph, `${id}-lengths`, plan.valueCount);
+      const offsets = createTransientResultView(graph, `${id}-offsets`, plan.valueCount);
+      new GPUParquetDeltaLengthByteArrayDecoder({
+        id: `${id}-delta-length-byte-array`,
+        input,
+        miniBlockDescriptors: createUploadView(graph, inputHandle, plan.miniBlockDescriptors),
+        lengths,
+        offsets,
+        encodedByteLength: input.length * 4,
+        valueCount: plan.valueCount,
+        descriptorCount: plan.deltaPlan.lengthPlan.descriptorCount,
+        firstValue: plan.deltaPlan.lengthPlan.firstValue
+      }).addToGraph(graph);
+      return Object.freeze({
+        layout: 'byte-array' as const,
+        values: createUploadView(graph, inputHandle, plan.payload),
+        lengths,
+        offsets,
+        valueCount: plan.valueCount,
+        byteLength: plan.decodedByteLength
+      });
+    }
+    case 'dictionary-fixed': {
+      const dictionary = dictionaries.get(plan.dictionary);
+      if (!dictionary || dictionary.plan.kind !== 'fixed') {
+        throw new Error(`${id} fixed dictionary graph resource is missing`);
+      }
+      const values = createTransientPackedBytes(
+        graph,
+        `${id}-values`,
+        plan.decodedByteLength,
+        Buffer.STORAGE | Buffer.COPY_SRC
+      );
+      new GPUParquetRleDictionaryDecoder({
+        id: `${id}-dictionary`,
+        input,
+        runDescriptors: createUploadView(graph, inputHandle, plan.runDescriptors),
+        dictionary: dictionary.values,
+        output: values,
+        encodedByteLength: input.length * 4,
+        valueCount: plan.valueCount,
+        runCount: plan.indicesPlan.runPlan.runCount,
+        bitWidth: plan.indicesPlan.bitWidth,
+        dictionaryValueCount: dictionary.plan.valueCount,
+        byteWidth: dictionary.plan.byteWidth
+      }).addToGraph(graph);
+      return Object.freeze({
+        layout: 'packed-bytes' as const,
+        values,
+        valueCount: plan.valueCount,
+        byteLength: plan.decodedByteLength
+      });
+    }
+    case 'dictionary-byte-array': {
+      const dictionary = dictionaries.get(plan.dictionary);
+      if (
+        !dictionary ||
+        dictionary.plan.kind !== 'byte-array' ||
+        !dictionary.lengths ||
+        !dictionary.offsets
+      ) {
+        throw new Error(`${id} byte-array dictionary graph resource is missing`);
+      }
+      const indices = createTransientView(graph, `${id}-indices`, 'uint32', plan.valueCount);
+      new GPUParquetRleBitPackedDecoder({
+        id: `${id}-dictionary-indices`,
+        input,
+        runDescriptors: createUploadView(graph, inputHandle, plan.runDescriptors),
+        output: indices,
+        encodedByteLength: input.length * 4,
+        valueCount: plan.valueCount,
+        runCount: plan.indicesPlan.runPlan.runCount,
+        bitWidth: plan.indicesPlan.bitWidth
+      }).addToGraph(graph);
+      const values = createTransientPackedBytes(
+        graph,
+        `${id}-values`,
+        plan.decodedByteLength,
+        Buffer.STORAGE | Buffer.COPY_SRC
+      );
+      const lengths = createTransientResultView(graph, `${id}-lengths`, plan.valueCount);
+      const offsets = createTransientResultView(graph, `${id}-offsets`, plan.valueCount);
+      new GPUParquetByteArrayDictionaryDecoder({
+        id: `${id}-dictionary`,
+        dictionary: dictionary.values,
+        dictionaryLengths: dictionary.lengths,
+        dictionaryOffsets: dictionary.offsets,
+        indices,
+        outputLengths: lengths,
+        outputOffsets: offsets,
+        output: values,
+        dictionaryByteLength: dictionary.plan.decodedByteLength,
+        outputByteCapacity: plan.decodedByteLength
+      }).addToGraph(graph);
+      return Object.freeze({
+        layout: 'byte-array' as const,
+        values,
+        lengths,
+        offsets,
+        valueCount: plan.valueCount,
+        byteLength: plan.decodedByteLength
+      });
+    }
+  }
+}
+
+function createUploadView<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  inputHandle: GraphBufferHandle,
+  section: GPUParquetUploadSection
+): GraphDataView<'uint32'> {
+  return graph.createDataView(inputHandle, {
+    format: 'uint32',
+    length: Math.ceil(section.byteLength / Uint32Array.BYTES_PER_ELEMENT),
+    byteOffset: section.byteOffset
+  });
+}
+
+function createTransientPackedBytes<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  id: string,
+  byteLength: number,
+  usage = Buffer.STORAGE
+): GraphDataView<'uint32'> {
+  return createTransientView(
+    graph,
+    id,
+    'uint32',
+    Math.ceil(byteLength / Uint32Array.BYTES_PER_ELEMENT),
+    usage
+  );
+}
+
+function createTransientResultView<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  id: string,
+  length: number
+): GraphDataView<'uint32'> {
+  return createTransientView(graph, id, 'uint32', length, Buffer.STORAGE | Buffer.COPY_SRC);
+}

--- a/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-encoded-page-batch.ts
+++ b/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-encoded-page-batch.ts
@@ -193,7 +193,8 @@ function addDecompressionToGraph<Parameters>(
   const output = createTransientPackedBytes(
     graph,
     `${id}-${plan.codec.toLowerCase()}-output`,
-    plan.outputByteLength
+    plan.outputByteLength,
+    Buffer.STORAGE | Buffer.COPY_SRC
   );
   if (plan.codec === 'SNAPPY') {
     new GPUSnappyDecompressor({

--- a/modules/gpgpu/src/gpu-parse/parquet/parquet-encoded-page-batch.ts
+++ b/modules/gpgpu/src/gpu-parse/parquet/parquet-encoded-page-batch.ts
@@ -1,0 +1,1134 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {parseLZ4RawDecompressionPlan} from '../compression/lz4-raw-plan';
+import {parseSnappyDecompressionPlan} from '../compression/snappy-plan';
+import {
+  getParquetPhysicalTypeByteWidth,
+  type ParquetPhysicalType
+} from './parquet-column-decode-plan';
+import {
+  parseParquetDeltaBinaryPackedPlan,
+  type ParquetDeltaBinaryPackedPlan
+} from './parquet-delta-binary-packed';
+import {
+  parseParquetDeltaBinaryPackedInt64Plan,
+  type ParquetDeltaBinaryPackedInt64Plan
+} from './parquet-delta-binary-packed-int64';
+import {
+  parseParquetDeltaLengthByteArrayPlan,
+  type ParquetDeltaLengthByteArrayPlan
+} from './parquet-delta-length-byte-array';
+import {
+  parseParquetPlainByteArrayPlan,
+  type ParquetPlainByteArrayPlan
+} from './parquet-plain-byte-array';
+import {
+  parseParquetBitPackedRunPlan,
+  parseParquetDictionaryIndicesPlan,
+  type ParquetBitPackedPlan,
+  type ParquetDictionaryIndicesPlan
+} from './parquet-rle-framing';
+import {
+  parseParquetRleBitPackedRunPlan,
+  type ParquetRleBitPackedRunPlan
+} from './parquet-rle-bit-packed';
+
+/** Structural view of loaders.gl's `ParquetEncodedPageSection` alpha.4 contract. */
+export type LoadersGLParquetEncodedPageSection = Readonly<{
+  byteOffset: number;
+  byteLength: number;
+}>;
+
+/** Structural view of one loaders.gl deferred Parquet page. */
+export type LoadersGLParquetEncodedPage = Readonly<{
+  type: 'dictionary' | 'data-v1' | 'data-v2';
+  pageOrdinal: number;
+  encoding: string;
+  repetitionLevelEncoding?: string;
+  definitionLevelEncoding?: string;
+  compression: string;
+  compressionState: 'compressed' | 'decompressed';
+  valueCount: number;
+  nonNullValueCount?: number;
+  data: Uint8Array;
+  repetitionLevels?: LoadersGLParquetEncodedPageSection;
+  definitionLevels?: LoadersGLParquetEncodedPageSection;
+  values?: LoadersGLParquetEncodedPageSection;
+  compressedByteLength: number;
+  uncompressedByteLength: number;
+}>;
+
+/** Structural view of one loaders.gl deferred Parquet column chunk. */
+export type LoadersGLParquetEncodedColumnChunk = Readonly<{
+  path: readonly string[];
+  physicalType: string;
+  typeLength?: number;
+  maxRepetitionLevel: number;
+  maxDefinitionLevel: number;
+  compression: string;
+  valueCount: number;
+  dictionary?: LoadersGLParquetEncodedPage;
+  pages: readonly LoadersGLParquetEncodedPage[];
+}>;
+
+/**
+ * Dependency-free structural input accepted from loaders.gl 5.0.0-alpha.4 `readPages()`.
+ *
+ * Keeping this interface local prevents users of unrelated gpu-parse operations from needing to
+ * install loaders.gl. Type-level conformance tests pass the official loaders.gl type directly.
+ */
+export type LoadersGLParquetEncodedPageBatch = Readonly<{
+  shape: 'parquet-encoded-pages';
+  rowGroup: unknown;
+  projectedColumns: readonly string[];
+  filterColumns: readonly string[];
+  columns: readonly LoadersGLParquetEncodedColumnChunk[];
+  residualFilter?: unknown;
+}>;
+
+type ParquetEncodedPageSection = LoadersGLParquetEncodedPageSection;
+type ParquetEncodedPage = LoadersGLParquetEncodedPage;
+type ParquetEncodedColumnChunk = LoadersGLParquetEncodedColumnChunk;
+type ParquetEncodedPageBatch = LoadersGLParquetEncodedPageBatch;
+
+/** Four-byte-aligned byte range in one batched GPU upload. */
+export type GPUParquetUploadSection = Readonly<{
+  byteOffset: number;
+  byteLength: number;
+}>;
+
+/** Compression work that can be performed before value decoding without a readback. */
+export type GPUParquetCompressionPlan = Readonly<{
+  codec: 'SNAPPY' | 'LZ4_RAW';
+  input: GPUParquetUploadSection;
+  descriptors: GPUParquetUploadSection;
+  descriptorCount: number;
+  outputByteLength: number;
+}>;
+
+/** RLE or legacy BIT_PACKED work for one definition- or repetition-level stream. */
+export type GPUParquetLevelPlan = Readonly<{
+  encoding: 'RLE' | 'BIT_PACKED';
+  bitWidth: number;
+  valueCount: number;
+  input: GPUParquetUploadSection;
+  runPlan?: ParquetRleBitPackedRunPlan;
+  runDescriptors?: GPUParquetUploadSection;
+  bitPackedPlan?: ParquetBitPackedPlan;
+}>;
+
+/** One column-chunk dictionary planned once and reused by all dictionary data pages. */
+export type GPUParquetDictionaryPlan =
+  | Readonly<{
+      kind: 'fixed';
+      valueCount: number;
+      byteWidth: number;
+      decodedByteLength: number;
+      encodedValues: GPUParquetUploadSection;
+      compression?: GPUParquetCompressionPlan;
+    }>
+  | Readonly<{
+      kind: 'byte-array';
+      valueCount: number;
+      decodedByteLength: number;
+      encodedValues: GPUParquetUploadSection;
+      plainPlan: ParquetPlainByteArrayPlan;
+      sourceOffsets: GPUParquetUploadSection;
+      valueLengths: GPUParquetUploadSection;
+      valueOffsets: GPUParquetUploadSection;
+    }>;
+
+/** Value work whose output size and control descriptors are known before GPU execution. */
+export type GPUParquetValuePlan =
+  | Readonly<{
+      kind: 'plain-fixed' | 'byte-stream-split';
+      valueCount: number;
+      byteWidth: number;
+      decodedByteLength: number;
+    }>
+  | Readonly<{
+      kind: 'plain-boolean';
+      valueCount: number;
+      decodedByteLength: number;
+    }>
+  | Readonly<{
+      kind: 'plain-byte-array';
+      valueCount: number;
+      decodedByteLength: number;
+      plainPlan: ParquetPlainByteArrayPlan;
+      sourceOffsets: GPUParquetUploadSection;
+      valueLengths: GPUParquetUploadSection;
+      valueOffsets: GPUParquetUploadSection;
+    }>
+  | Readonly<{
+      kind: 'delta-binary-packed-int32';
+      valueCount: number;
+      decodedByteLength: number;
+      deltaPlan: ParquetDeltaBinaryPackedPlan;
+      miniBlockDescriptors: GPUParquetUploadSection;
+    }>
+  | Readonly<{
+      kind: 'delta-binary-packed-int64';
+      valueCount: number;
+      decodedByteLength: number;
+      deltaPlan: ParquetDeltaBinaryPackedInt64Plan;
+      miniBlockDescriptors: GPUParquetUploadSection;
+    }>
+  | Readonly<{
+      kind: 'delta-length-byte-array';
+      valueCount: number;
+      decodedByteLength: number;
+      deltaPlan: ParquetDeltaLengthByteArrayPlan;
+      miniBlockDescriptors: GPUParquetUploadSection;
+      payload: GPUParquetUploadSection;
+    }>
+  | Readonly<{
+      kind: 'dictionary-fixed' | 'dictionary-byte-array';
+      valueCount: number;
+      decodedByteLength: number;
+      dictionary: GPUParquetDictionaryPlan;
+      indicesPlan: ParquetDictionaryIndicesPlan;
+      runDescriptors: GPUParquetUploadSection;
+    }>;
+
+/** One page accepted by the automatic GPU adapter. */
+export type GPUParquetDecodedPagePlan = Readonly<{
+  mode: 'gpu';
+  columnIndex: number;
+  pageIndex: number;
+  path: readonly string[];
+  pageType: 'data-v1' | 'data-v2';
+  pageOrdinal: number;
+  physicalType: ParquetPhysicalType;
+  valueCount: number;
+  physicalValueCount: number;
+  compression?: GPUParquetCompressionPlan;
+  encodedValues: GPUParquetUploadSection;
+  values: GPUParquetValuePlan;
+  repetitionLevels?: GPUParquetLevelPlan;
+  definitionLevels?: GPUParquetLevelPlan;
+}>;
+
+/** One page deliberately retained for a CPU decoder. */
+export type CPUParquetPageFallbackPlan = Readonly<{
+  mode: 'cpu-fallback';
+  columnIndex: number;
+  pageIndex: number;
+  path: readonly string[];
+  pageOrdinal: number;
+  reason:
+    | 'below-gpu-threshold'
+    | 'unsupported-compression'
+    | 'compressed-v1-level-framing'
+    | 'compressed-control-stream'
+    | 'unsupported-encoding'
+    | 'unsupported-physical-type'
+    | 'missing-dictionary'
+    | 'variable-dictionary-output';
+  detail: string;
+  page: ParquetEncodedPage;
+}>;
+
+/** Mixed GPU/CPU plan for one loaders.gl encoded-page batch. */
+export type GPUParquetEncodedPageBatchPlan = Readonly<{
+  shape: 'gpu-parquet-page-batch-plan';
+  source: ParquetEncodedPageBatch;
+  uploadData: Uint8Array;
+  dictionaries: readonly (GPUParquetDictionaryPlan | undefined)[];
+  pages: readonly (GPUParquetDecodedPagePlan | CPUParquetPageFallbackPlan)[];
+  gpuPageCount: number;
+  cpuFallbackPageCount: number;
+}>;
+
+/** Policy for mapping loaders.gl deferred pages to GPU work. */
+export type GPUParquetEncodedPageBatchPlanOptions = Readonly<{
+  /** Minimum encoded value bytes for GPU execution. Defaults to zero after explicit deferral. */
+  minimumGPUByteLength?: number;
+  /** Compression codecs retained by loaders.gl and accepted by this adapter. */
+  compressionCodecs?: readonly ('SNAPPY' | 'LZ4_RAW')[];
+  /** Throws instead of returning a mixed plan when any page needs CPU work. */
+  requireGPU?: boolean;
+}>;
+
+/**
+ * Validates and batches a loaders.gl `ParquetSource.readPages()` result.
+ *
+ * Page and descriptor slices are copied into one four-byte-aligned upload so that every operation
+ * can bind packed `uint32` views without creating a GPU buffer per page. Unsupported pages remain
+ * in the returned plan as explicit CPU fallbacks. This makes mixed row groups safe and observable.
+ */
+export function planGPUParquetEncodedPageBatch(
+  batch: ParquetEncodedPageBatch,
+  options: GPUParquetEncodedPageBatchPlanOptions = {}
+): GPUParquetEncodedPageBatchPlan {
+  if (batch.shape !== 'parquet-encoded-pages') {
+    throw new Error('Expected a loaders.gl parquet-encoded-pages batch');
+  }
+  const minimumGPUByteLength = options.minimumGPUByteLength ?? 0;
+  validateUint32(minimumGPUByteLength, 'minimumGPUByteLength');
+  const compressionCodecs = new Set(options.compressionCodecs ?? ['SNAPPY', 'LZ4_RAW']);
+  const upload = new GPUParquetUploadBuilder();
+  const pages: (GPUParquetDecodedPagePlan | CPUParquetPageFallbackPlan)[] = [];
+  const dictionaries: (GPUParquetDictionaryPlan | undefined)[] = [];
+  const dictionaryErrors: (PlannerError | undefined)[] = [];
+
+  for (let columnIndex = 0; columnIndex < batch.columns.length; columnIndex++) {
+    const column = batch.columns[columnIndex];
+    validateColumn(column);
+    dictionaries[columnIndex] = undefined;
+    dictionaryErrors[columnIndex] = undefined;
+    if (column.dictionary) {
+      try {
+        dictionaries[columnIndex] = planDictionary(
+          column,
+          column.dictionary,
+          compressionCodecs,
+          upload
+        );
+      } catch (error) {
+        const plannerError = error as PlannerError;
+        if (!plannerError.reason) throw error;
+        dictionaryErrors[columnIndex] = plannerError;
+      }
+    }
+    for (let pageIndex = 0; pageIndex < column.pages.length; pageIndex++) {
+      const page = column.pages[pageIndex];
+      validatePage(column, page, pageIndex);
+      let plan: GPUParquetDecodedPagePlan | CPUParquetPageFallbackPlan;
+      try {
+        plan = planPage(
+          column,
+          page,
+          columnIndex,
+          pageIndex,
+          minimumGPUByteLength,
+          compressionCodecs,
+          upload,
+          dictionaries[columnIndex],
+          dictionaryErrors[columnIndex]
+        );
+      } catch (error) {
+        const reason = (error as PlannerError)?.reason;
+        if (options.requireGPU || !reason) throw error;
+        plan = makeFallback(
+          column,
+          page,
+          columnIndex,
+          pageIndex,
+          reason,
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+      if (options.requireGPU && plan.mode === 'cpu-fallback') {
+        throw new Error(plan.detail);
+      }
+      pages.push(plan);
+    }
+  }
+
+  const gpuPageCount = pages.filter(page => page.mode === 'gpu').length;
+  return Object.freeze({
+    shape: 'gpu-parquet-page-batch-plan' as const,
+    source: batch,
+    uploadData: upload.finish(),
+    dictionaries: Object.freeze(dictionaries),
+    pages: Object.freeze(pages),
+    gpuPageCount,
+    cpuFallbackPageCount: pages.length - gpuPageCount
+  });
+}
+
+function planDictionary(
+  column: ParquetEncodedColumnChunk,
+  page: ParquetEncodedPage,
+  compressionCodecs: ReadonlySet<string>,
+  upload: GPUParquetUploadBuilder
+): GPUParquetDictionaryPlan {
+  if (page.encoding !== 'PLAIN') {
+    throw makePlannerError(
+      'unsupported-encoding',
+      `Parquet dictionary encoding ${page.encoding} is not supported`
+    );
+  }
+  const physicalType = parsePhysicalType(column.physicalType);
+  const encoded =
+    page.compressionState === 'compressed'
+      ? page.data
+      : (getSectionBytes(page, page.values) ?? page.data);
+  const encodedValues = upload.add(encoded, 'dictionary values');
+  const compression = planCompression(
+    column,
+    page,
+    encoded,
+    encodedValues,
+    page.uncompressedByteLength,
+    compressionCodecs,
+    upload
+  );
+  if (physicalType === 'BYTE_ARRAY') {
+    if (compression) {
+      throw makePlannerError(
+        'compressed-control-stream',
+        'Compressed PLAIN BYTE_ARRAY dictionary lengths require CPU decompression before GPU planning'
+      );
+    }
+    const plainPlan = parseParquetPlainByteArrayPlan(encoded, page.valueCount);
+    return Object.freeze({
+      kind: 'byte-array' as const,
+      valueCount: page.valueCount,
+      decodedByteLength: plainPlan.outputByteLength,
+      encodedValues,
+      plainPlan,
+      sourceOffsets: upload.add(plainPlan.sourceOffsets, 'dictionary source offsets'),
+      valueLengths: upload.add(plainPlan.valueLengths, 'dictionary value lengths'),
+      valueOffsets: upload.add(plainPlan.valueOffsets, 'dictionary value offsets')
+    });
+  }
+  const byteWidth = getParquetPhysicalTypeByteWidth(physicalType, column.typeLength);
+  if (byteWidth === null) {
+    throw makePlannerError(
+      'unsupported-physical-type',
+      `Parquet ${physicalType} dictionary has no fixed-width GPU layout`
+    );
+  }
+  const decodedByteLength = multiplyUint32(
+    page.valueCount,
+    byteWidth,
+    'dictionary decoded byte length'
+  );
+  if (!compression && encoded.byteLength !== decodedByteLength) {
+    throw new Error(
+      `PLAIN dictionary has ${encoded.byteLength} bytes; expected ${decodedByteLength}`
+    );
+  }
+  if (compression && compression.outputByteLength !== decodedByteLength) {
+    throw new Error(
+      `Compressed dictionary declares ${compression.outputByteLength} decoded bytes; expected ${decodedByteLength}`
+    );
+  }
+  return Object.freeze({
+    kind: 'fixed' as const,
+    valueCount: page.valueCount,
+    byteWidth,
+    decodedByteLength,
+    encodedValues,
+    compression
+  });
+}
+
+function planPage(
+  column: ParquetEncodedColumnChunk,
+  page: ParquetEncodedPage,
+  columnIndex: number,
+  pageIndex: number,
+  minimumGPUByteLength: number,
+  compressionCodecs: ReadonlySet<string>,
+  upload: GPUParquetUploadBuilder,
+  dictionary: GPUParquetDictionaryPlan | undefined,
+  dictionaryError: PlannerError | undefined
+): GPUParquetDecodedPagePlan | CPUParquetPageFallbackPlan {
+  const physicalType = parsePhysicalType(column.physicalType);
+  const sections = getPageSections(column, page);
+  if (sections.encodedValues.byteLength < minimumGPUByteLength) {
+    return makeFallback(
+      column,
+      page,
+      columnIndex,
+      pageIndex,
+      'below-gpu-threshold',
+      `Parquet page has ${sections.encodedValues.byteLength} encoded value bytes below the ${minimumGPUByteLength} byte GPU threshold`
+    );
+  }
+
+  const repetitionLevels = planLevel(
+    page,
+    sections.repetitionLevels,
+    page.repetitionLevelEncoding,
+    column.maxRepetitionLevel,
+    upload,
+    `${column.path.join('.')}-${page.pageOrdinal}-repetition`
+  );
+  const definitionLevels = planLevel(
+    page,
+    sections.definitionLevels,
+    page.definitionLevelEncoding,
+    column.maxDefinitionLevel,
+    upload,
+    `${column.path.join('.')}-${page.pageOrdinal}-definition`
+  );
+  const physicalValueCount = getPhysicalValueCount(column, page, definitionLevels);
+  const encodedValues = upload.add(sections.encodedValues, 'values');
+  const compression = planCompression(
+    column,
+    page,
+    sections.encodedValues,
+    encodedValues,
+    sections.decodedValuesByteLength,
+    compressionCodecs,
+    upload
+  );
+  const values = planValues(
+    column,
+    page,
+    sections.encodedValues,
+    physicalType,
+    physicalValueCount,
+    Boolean(compression),
+    upload,
+    dictionary,
+    dictionaryError
+  );
+
+  return Object.freeze({
+    mode: 'gpu' as const,
+    columnIndex,
+    pageIndex,
+    path: Object.freeze([...column.path]),
+    pageType: page.type as 'data-v1' | 'data-v2',
+    pageOrdinal: page.pageOrdinal,
+    physicalType,
+    valueCount: page.valueCount,
+    physicalValueCount,
+    compression,
+    encodedValues,
+    values,
+    repetitionLevels,
+    definitionLevels
+  });
+}
+
+function getPageSections(
+  column: ParquetEncodedColumnChunk,
+  page: ParquetEncodedPage
+): {
+  repetitionLevels?: Uint8Array;
+  definitionLevels?: Uint8Array;
+  encodedValues: Uint8Array;
+  decodedValuesByteLength: number;
+} {
+  if (page.compressionState === 'decompressed') {
+    if (!page.values) {
+      throw new Error('Decompressed Parquet data page is missing its values section');
+    }
+    return {
+      repetitionLevels: getSectionBytes(page, page.repetitionLevels),
+      definitionLevels: getSectionBytes(page, page.definitionLevels),
+      encodedValues: getSectionBytes(page, page.values)!,
+      decodedValuesByteLength: page.values.byteLength
+    };
+  }
+
+  if (page.type === 'data-v1') {
+    if (column.maxDefinitionLevel !== 0 || column.maxRepetitionLevel !== 0) {
+      throw makePlannerError(
+        'compressed-v1-level-framing',
+        'Compressed Parquet V1 pages do not expose level/value boundaries before decompression'
+      );
+    }
+    return {encodedValues: page.data, decodedValuesByteLength: page.uncompressedByteLength};
+  }
+  if (page.type !== 'data-v2' || !page.values) {
+    throw new Error('Compressed Parquet page is missing a GPU-addressable values section');
+  }
+  const levelByteLength =
+    (page.repetitionLevels?.byteLength ?? 0) + (page.definitionLevels?.byteLength ?? 0);
+  const decodedValuesByteLength = page.uncompressedByteLength - levelByteLength;
+  if (decodedValuesByteLength < 0) {
+    throw new Error('Parquet V2 uncompressed values byte length is negative');
+  }
+  return {
+    repetitionLevels: getSectionBytes(page, page.repetitionLevels),
+    definitionLevels: getSectionBytes(page, page.definitionLevels),
+    encodedValues: getSectionBytes(page, page.values)!,
+    decodedValuesByteLength
+  };
+}
+
+function planCompression(
+  column: ParquetEncodedColumnChunk,
+  page: ParquetEncodedPage,
+  compressed: Uint8Array,
+  input: GPUParquetUploadSection,
+  outputByteLength: number,
+  compressionCodecs: ReadonlySet<string>,
+  upload: GPUParquetUploadBuilder
+): GPUParquetCompressionPlan | undefined {
+  if (page.compressionState === 'decompressed') return undefined;
+  if (!compressionCodecs.has(page.compression)) {
+    throw makePlannerError(
+      'unsupported-compression',
+      `Parquet compression ${page.compression} is not enabled for GPU decoding`
+    );
+  }
+  if (page.compression === 'SNAPPY') {
+    const plan = parseSnappyDecompressionPlan(compressed);
+    if (plan.outputByteLength !== outputByteLength) {
+      throw new Error(
+        `Snappy output length ${plan.outputByteLength} does not match Parquet metadata ${outputByteLength}`
+      );
+    }
+    return Object.freeze({
+      codec: 'SNAPPY' as const,
+      input,
+      descriptors: upload.add(plan.descriptors, 'snappy descriptors'),
+      descriptorCount: plan.descriptorCount,
+      outputByteLength
+    });
+  }
+  if (page.compression === 'LZ4_RAW') {
+    const plan = parseLZ4RawDecompressionPlan(compressed);
+    if (plan.outputByteLength !== outputByteLength) {
+      throw new Error(
+        `LZ4_RAW output length ${plan.outputByteLength} does not match Parquet metadata ${outputByteLength}`
+      );
+    }
+    return Object.freeze({
+      codec: 'LZ4_RAW' as const,
+      input,
+      descriptors: upload.add(plan.descriptors, 'lz4 descriptors'),
+      descriptorCount: plan.descriptorCount,
+      outputByteLength
+    });
+  }
+  throw makePlannerError(
+    'unsupported-compression',
+    `Parquet compression ${column.compression} has no GPU planner`
+  );
+}
+
+function planValues(
+  column: ParquetEncodedColumnChunk,
+  page: ParquetEncodedPage,
+  encoded: Uint8Array,
+  physicalType: ParquetPhysicalType,
+  valueCount: number,
+  isCompressed: boolean,
+  upload: GPUParquetUploadBuilder,
+  dictionary: GPUParquetDictionaryPlan | undefined,
+  dictionaryError: PlannerError | undefined
+): GPUParquetValuePlan {
+  const encoding = normalizeEncoding(page.encoding);
+  if (encoding === 'PLAIN') {
+    if (physicalType === 'BOOLEAN') {
+      return Object.freeze({
+        kind: 'plain-boolean' as const,
+        valueCount,
+        decodedByteLength: valueCount * Uint32Array.BYTES_PER_ELEMENT
+      });
+    }
+    if (physicalType === 'BYTE_ARRAY') {
+      if (isCompressed) {
+        throw makePlannerError(
+          'compressed-control-stream',
+          'Compressed PLAIN BYTE_ARRAY length prefixes require CPU decompression before GPU planning'
+        );
+      }
+      const plainPlan = parseParquetPlainByteArrayPlan(encoded, valueCount);
+      return Object.freeze({
+        kind: 'plain-byte-array' as const,
+        valueCount,
+        decodedByteLength: plainPlan.outputByteLength,
+        plainPlan,
+        sourceOffsets: upload.add(plainPlan.sourceOffsets, 'plain source offsets'),
+        valueLengths: upload.add(plainPlan.valueLengths, 'plain value lengths'),
+        valueOffsets: upload.add(plainPlan.valueOffsets, 'plain value offsets')
+      });
+    }
+    const byteWidth = getParquetPhysicalTypeByteWidth(physicalType, column.typeLength);
+    if (byteWidth === null) {
+      throw makePlannerError(
+        'unsupported-physical-type',
+        `PLAIN ${physicalType} does not have an automatic GPU output layout`
+      );
+    }
+    const decodedByteLength = multiplyUint32(valueCount, byteWidth, 'PLAIN decoded byte length');
+    if (!isCompressed && encoded.byteLength !== decodedByteLength) {
+      throw new Error(
+        `PLAIN ${physicalType} payload has ${encoded.byteLength} bytes; expected ${decodedByteLength}`
+      );
+    }
+    return Object.freeze({kind: 'plain-fixed' as const, valueCount, byteWidth, decodedByteLength});
+  }
+
+  if (encoding === 'BYTE_STREAM_SPLIT') {
+    const byteWidth = getParquetPhysicalTypeByteWidth(physicalType, column.typeLength);
+    if (byteWidth === null || physicalType === 'INT96') {
+      throw makePlannerError(
+        'unsupported-physical-type',
+        `BYTE_STREAM_SPLIT does not support ${physicalType}`
+      );
+    }
+    const decodedByteLength = multiplyUint32(
+      valueCount,
+      byteWidth,
+      'BYTE_STREAM_SPLIT decoded byte length'
+    );
+    if (!isCompressed && encoded.byteLength !== decodedByteLength) {
+      throw new Error(
+        `BYTE_STREAM_SPLIT payload has ${encoded.byteLength} bytes; expected ${decodedByteLength}`
+      );
+    }
+    return Object.freeze({
+      kind: 'byte-stream-split' as const,
+      valueCount,
+      byteWidth,
+      decodedByteLength
+    });
+  }
+
+  if (isCompressed) {
+    throw makePlannerError(
+      'compressed-control-stream',
+      `Compressed ${encoding} control headers require CPU decompression before GPU planning`
+    );
+  }
+  if (encoding === 'DELTA_BINARY_PACKED' && physicalType === 'INT32') {
+    const deltaPlan = parseParquetDeltaBinaryPackedPlan(encoded);
+    validatePlannedValueCount(deltaPlan.valueCount, valueCount, encoding);
+    return Object.freeze({
+      kind: 'delta-binary-packed-int32' as const,
+      valueCount,
+      decodedByteLength: multiplyUint32(valueCount, 4, 'INT32 delta output'),
+      deltaPlan,
+      miniBlockDescriptors: upload.add(deltaPlan.miniBlockDescriptors, 'int32 delta descriptors')
+    });
+  }
+  if (encoding === 'DELTA_BINARY_PACKED' && physicalType === 'INT64') {
+    const deltaPlan = parseParquetDeltaBinaryPackedInt64Plan(encoded);
+    validatePlannedValueCount(deltaPlan.valueCount, valueCount, encoding);
+    return Object.freeze({
+      kind: 'delta-binary-packed-int64' as const,
+      valueCount,
+      decodedByteLength: multiplyUint32(valueCount, 8, 'INT64 delta output'),
+      deltaPlan,
+      miniBlockDescriptors: upload.add(deltaPlan.miniBlockDescriptors, 'int64 delta descriptors')
+    });
+  }
+  if (encoding === 'DELTA_LENGTH_BYTE_ARRAY' && physicalType === 'BYTE_ARRAY') {
+    const deltaPlan = parseParquetDeltaLengthByteArrayPlan(encoded);
+    validatePlannedValueCount(deltaPlan.lengthPlan.valueCount, valueCount, encoding);
+    return Object.freeze({
+      kind: 'delta-length-byte-array' as const,
+      valueCount,
+      decodedByteLength: deltaPlan.payloadByteLength,
+      deltaPlan,
+      miniBlockDescriptors: upload.add(
+        deltaPlan.lengthPlan.miniBlockDescriptors,
+        'delta length descriptors'
+      ),
+      payload: upload.add(
+        encoded.subarray(deltaPlan.payloadByteOffset),
+        'delta length byte-array payload'
+      )
+    });
+  }
+  if (encoding === 'RLE_DICTIONARY' || encoding === 'PLAIN_DICTIONARY') {
+    if (!dictionary) {
+      throw (
+        dictionaryError ??
+        makePlannerError(
+          'missing-dictionary',
+          'Dictionary-encoded Parquet data page has no usable dictionary page'
+        )
+      );
+    }
+    const indicesPlan = parseParquetDictionaryIndicesPlan(encoded, valueCount);
+    const decodedByteLength =
+      dictionary.kind === 'fixed'
+        ? multiplyUint32(valueCount, dictionary.byteWidth, 'dictionary decoded byte length')
+        : getDictionaryByteArrayOutputLength(encoded, indicesPlan, dictionary);
+    return Object.freeze({
+      kind:
+        dictionary.kind === 'fixed'
+          ? ('dictionary-fixed' as const)
+          : ('dictionary-byte-array' as const),
+      valueCount,
+      decodedByteLength,
+      dictionary,
+      indicesPlan,
+      runDescriptors: upload.add(indicesPlan.runPlan.runDescriptors, 'dictionary index descriptors')
+    });
+  }
+  throw makePlannerError(
+    'unsupported-encoding',
+    `Parquet encoding ${page.encoding} is not supported by the automatic page adapter`
+  );
+}
+
+function planLevel(
+  page: ParquetEncodedPage,
+  encoded: Uint8Array | undefined,
+  encoding: string | undefined,
+  maxLevel: number,
+  upload: GPUParquetUploadBuilder,
+  name: string
+): GPUParquetLevelPlan | undefined {
+  if (maxLevel === 0) return undefined;
+  if (!encoded) throw new Error(`Parquet ${name} level section is missing`);
+  const bitWidth = getLevelBitWidth(maxLevel);
+  const input = upload.add(encoded, `${name} bytes`);
+  if (encoding === 'RLE') {
+    const runPlan = parseParquetRleBitPackedRunPlan(encoded, bitWidth, page.valueCount);
+    return Object.freeze({
+      encoding: 'RLE' as const,
+      bitWidth,
+      valueCount: page.valueCount,
+      input,
+      runPlan,
+      runDescriptors: upload.add(runPlan.runDescriptors, `${name} descriptors`)
+    });
+  }
+  if (encoding === 'BIT_PACKED') {
+    return Object.freeze({
+      encoding: 'BIT_PACKED' as const,
+      bitWidth,
+      valueCount: page.valueCount,
+      input,
+      bitPackedPlan: parseParquetBitPackedRunPlan(encoded, bitWidth, page.valueCount)
+    });
+  }
+  throw new Error(`Unsupported Parquet ${name} level encoding ${encoding}`);
+}
+
+function getPhysicalValueCount(
+  column: ParquetEncodedColumnChunk,
+  page: ParquetEncodedPage,
+  definitionLevels: GPUParquetLevelPlan | undefined
+): number {
+  if (page.nonNullValueCount !== undefined) {
+    validateUint32(page.nonNullValueCount, 'nonNullValueCount');
+    if (page.nonNullValueCount > page.valueCount) {
+      throw new Error('Parquet nonNullValueCount exceeds valueCount');
+    }
+    return page.nonNullValueCount;
+  }
+  if (column.maxDefinitionLevel === 0) return page.valueCount;
+  if (!definitionLevels) throw new Error('Parquet nullable page has no definition-level plan');
+  if (definitionLevels.encoding === 'BIT_PACKED') {
+    return countBitPackedLevel(
+      getSectionBytes(page, page.definitionLevels)!,
+      definitionLevels.bitWidth,
+      page.valueCount,
+      column.maxDefinitionLevel
+    );
+  }
+  return countRleLevel(
+    getSectionBytes(page, page.definitionLevels)!,
+    definitionLevels,
+    column.maxDefinitionLevel
+  );
+}
+
+function countRleLevel(
+  encoded: Uint8Array,
+  levelPlan: GPUParquetLevelPlan,
+  targetLevel: number
+): number {
+  const descriptors = levelPlan.runPlan!.runDescriptors;
+  let count = 0;
+  for (let descriptorIndex = 0; descriptorIndex < descriptors.length; descriptorIndex += 4) {
+    const valueCount = descriptors[descriptorIndex + 1];
+    const payloadByteOffset = descriptors[descriptorIndex + 2];
+    const isBitPacked = descriptors[descriptorIndex + 3] === 1;
+    if (!isBitPacked) {
+      if (readLittleEndianBits(encoded, payloadByteOffset, levelPlan.bitWidth) === targetLevel) {
+        count += valueCount;
+      }
+      continue;
+    }
+    for (let valueIndex = 0; valueIndex < valueCount; valueIndex++) {
+      if (
+        readPackedBits(encoded, payloadByteOffset, valueIndex, levelPlan.bitWidth) === targetLevel
+      ) {
+        count++;
+      }
+    }
+  }
+  return count;
+}
+
+function getDictionaryByteArrayOutputLength(
+  encoded: Uint8Array,
+  indicesPlan: ParquetDictionaryIndicesPlan,
+  dictionary: Extract<GPUParquetDictionaryPlan, {kind: 'byte-array'}>
+): number {
+  let outputByteLength = 0;
+  const descriptors = indicesPlan.runPlan.runDescriptors;
+  for (let descriptorIndex = 0; descriptorIndex < descriptors.length; descriptorIndex += 4) {
+    const valueCount = descriptors[descriptorIndex + 1];
+    const payloadByteOffset = descriptors[descriptorIndex + 2];
+    const isBitPacked = descriptors[descriptorIndex + 3] === 1;
+    if (!isBitPacked) {
+      const dictionaryIndex = readLittleEndianBits(
+        encoded,
+        payloadByteOffset,
+        indicesPlan.bitWidth
+      );
+      outputByteLength = addDictionaryLengths(
+        outputByteLength,
+        dictionary,
+        dictionaryIndex,
+        valueCount
+      );
+      continue;
+    }
+    for (let valueIndex = 0; valueIndex < valueCount; valueIndex++) {
+      const dictionaryIndex = readPackedBits(
+        encoded,
+        payloadByteOffset,
+        valueIndex,
+        indicesPlan.bitWidth
+      );
+      outputByteLength = addDictionaryLengths(outputByteLength, dictionary, dictionaryIndex, 1);
+    }
+  }
+  return outputByteLength;
+}
+
+function addDictionaryLengths(
+  outputByteLength: number,
+  dictionary: Extract<GPUParquetDictionaryPlan, {kind: 'byte-array'}>,
+  dictionaryIndex: number,
+  count: number
+): number {
+  if (dictionaryIndex >= dictionary.valueCount) {
+    throw new Error(`Parquet dictionary index ${dictionaryIndex} is out of range`);
+  }
+  const result = outputByteLength + dictionary.plainPlan.valueLengths[dictionaryIndex] * count;
+  if (!Number.isSafeInteger(result) || result > 0xffffffff) {
+    throw new Error('Parquet dictionary byte-array output length exceeds uint32');
+  }
+  return result;
+}
+
+function countBitPackedLevel(
+  encoded: Uint8Array,
+  bitWidth: number,
+  valueCount: number,
+  targetLevel: number
+): number {
+  let count = 0;
+  for (let valueIndex = 0; valueIndex < valueCount; valueIndex++) {
+    let value = 0;
+    for (let valueBitIndex = 0; valueBitIndex < bitWidth; valueBitIndex++) {
+      const sourceBitIndex = valueIndex * bitWidth + valueBitIndex;
+      const bit = (encoded[sourceBitIndex >> 3] >> (7 - (sourceBitIndex & 7))) & 1;
+      value |= bit << (bitWidth - 1 - valueBitIndex);
+    }
+    if (value === targetLevel) count++;
+  }
+  return count;
+}
+
+function readLittleEndianBits(bytes: Uint8Array, byteOffset: number, bitWidth: number): number {
+  let value = 0;
+  const byteCount = Math.ceil(bitWidth / 8);
+  for (let byteIndex = 0; byteIndex < byteCount; byteIndex++) {
+    value |= bytes[byteOffset + byteIndex] << (byteIndex * 8);
+  }
+  return bitWidth === 32 ? value >>> 0 : value & (2 ** bitWidth - 1);
+}
+
+function readPackedBits(
+  bytes: Uint8Array,
+  payloadByteOffset: number,
+  valueIndex: number,
+  bitWidth: number
+): number {
+  if (bitWidth === 0) return 0;
+  const bitOffset = valueIndex * bitWidth;
+  let value = 0;
+  for (let valueBitIndex = 0; valueBitIndex < bitWidth; valueBitIndex++) {
+    const sourceBitIndex = bitOffset + valueBitIndex;
+    const bit = (bytes[payloadByteOffset + (sourceBitIndex >> 3)] >> (sourceBitIndex & 7)) & 1;
+    value |= bit << valueBitIndex;
+  }
+  return value >>> 0;
+}
+
+function validateColumn(column: ParquetEncodedColumnChunk): void {
+  if (column.path.length === 0) throw new Error('Parquet encoded column path must not be empty');
+  validateUint32(column.valueCount, `${column.path.join('.')} valueCount`);
+  validateUint32(column.maxDefinitionLevel, `${column.path.join('.')} maxDefinitionLevel`);
+  validateUint32(column.maxRepetitionLevel, `${column.path.join('.')} maxRepetitionLevel`);
+  let valueCount = 0;
+  for (const page of column.pages) {
+    valueCount += page.valueCount;
+    if (!Number.isSafeInteger(valueCount) || valueCount > 0xffffffff) {
+      throw new Error(`Parquet column ${column.path.join('.')} page value count exceeds uint32`);
+    }
+  }
+  if (valueCount !== column.valueCount) {
+    throw new Error(
+      `Parquet column ${column.path.join('.')} declares ${column.valueCount} values but its pages declare ${valueCount}`
+    );
+  }
+  if (column.dictionary) {
+    validatePage(column, column.dictionary, -1);
+    if (column.dictionary.type !== 'dictionary' || column.dictionary.pageOrdinal !== -1) {
+      throw new Error('Parquet dictionary page must use type dictionary and pageOrdinal -1');
+    }
+  }
+}
+
+function validatePage(
+  column: ParquetEncodedColumnChunk,
+  page: ParquetEncodedPage,
+  expectedPageOrdinal: number
+): void {
+  validateUint32(page.valueCount, 'Parquet page valueCount');
+  validateUint32(page.compressedByteLength, 'Parquet compressedByteLength');
+  validateUint32(page.uncompressedByteLength, 'Parquet uncompressedByteLength');
+  if (page.compression !== column.compression) {
+    throw new Error(
+      `Parquet page compression ${page.compression} does not match column compression ${column.compression}`
+    );
+  }
+  if (page.type !== 'dictionary' && page.pageOrdinal !== expectedPageOrdinal) {
+    throw new Error(
+      `Parquet data page ordinal ${page.pageOrdinal} is not the expected ${expectedPageOrdinal}`
+    );
+  }
+  const expectedByteLength =
+    page.compressionState === 'compressed'
+      ? page.compressedByteLength
+      : page.uncompressedByteLength;
+  if (page.data.byteLength !== expectedByteLength) {
+    throw new Error(
+      `Parquet ${page.compressionState} page has ${page.data.byteLength} bytes; expected ${expectedByteLength}`
+    );
+  }
+  validateSection(page, page.repetitionLevels, 'repetitionLevels');
+  validateSection(page, page.definitionLevels, 'definitionLevels');
+  validateSection(page, page.values, 'values');
+}
+
+function validateSection(
+  page: ParquetEncodedPage,
+  section: ParquetEncodedPageSection | undefined,
+  name: string
+): void {
+  if (!section) return;
+  validateUint32(section.byteOffset, `${name}.byteOffset`);
+  validateUint32(section.byteLength, `${name}.byteLength`);
+  if (section.byteOffset + section.byteLength > page.data.byteLength) {
+    throw new Error(`Parquet ${name} section extends beyond the page body`);
+  }
+}
+
+function getSectionBytes(
+  page: ParquetEncodedPage,
+  section: ParquetEncodedPageSection | undefined
+): Uint8Array | undefined {
+  if (!section) return undefined;
+  return page.data.subarray(section.byteOffset, section.byteOffset + section.byteLength);
+}
+
+function parsePhysicalType(physicalType: string): ParquetPhysicalType {
+  switch (physicalType) {
+    case 'BOOLEAN':
+    case 'INT32':
+    case 'INT64':
+    case 'INT96':
+    case 'FLOAT':
+    case 'DOUBLE':
+    case 'BYTE_ARRAY':
+    case 'FIXED_LEN_BYTE_ARRAY':
+      return physicalType;
+    default:
+      throw makePlannerError(
+        'unsupported-physical-type',
+        `Unsupported Parquet physical type ${physicalType}`
+      );
+  }
+}
+
+function normalizeEncoding(encoding: string): string {
+  return encoding === 'RLE_DICTIONARY' || encoding === 'PLAIN_DICTIONARY'
+    ? encoding
+    : encoding.toUpperCase();
+}
+
+function getLevelBitWidth(maxLevel: number): number {
+  return maxLevel === 0 ? 0 : 32 - Math.clz32(maxLevel);
+}
+
+function validatePlannedValueCount(actual: number, expected: number, encoding: string): void {
+  if (actual !== expected) {
+    throw new Error(`${encoding} declares ${actual} values; expected ${expected}`);
+  }
+}
+
+function multiplyUint32(left: number, right: number, name: string): number {
+  const result = left * right;
+  if (!Number.isSafeInteger(result) || result > 0xffffffff) {
+    throw new Error(`${name} exceeds uint32`);
+  }
+  return result;
+}
+
+function validateUint32(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 0 || value > 0xffffffff) {
+    throw new Error(`${name} must be a non-negative uint32`);
+  }
+}
+
+function makeFallback(
+  column: ParquetEncodedColumnChunk,
+  page: ParquetEncodedPage,
+  columnIndex: number,
+  pageIndex: number,
+  reason: CPUParquetPageFallbackPlan['reason'],
+  detail: string
+): CPUParquetPageFallbackPlan {
+  return Object.freeze({
+    mode: 'cpu-fallback' as const,
+    columnIndex,
+    pageIndex,
+    path: Object.freeze([...column.path]),
+    pageOrdinal: page.pageOrdinal,
+    reason,
+    detail,
+    page
+  });
+}
+
+type PlannerError = Error & {reason?: CPUParquetPageFallbackPlan['reason']};
+
+function makePlannerError(
+  reason: CPUParquetPageFallbackPlan['reason'],
+  message: string
+): PlannerError {
+  const error: PlannerError = new Error(message);
+  error.reason = reason;
+  return error;
+}
+
+class GPUParquetUploadBuilder {
+  private readonly chunks: {section: GPUParquetUploadSection; bytes: Uint8Array}[] = [];
+  private byteLength = 0;
+
+  add(bytes: Uint8Array | Uint32Array, name: string): GPUParquetUploadSection {
+    if (bytes.byteLength > 0xffffffff) throw new Error(`Parquet ${name} upload exceeds uint32`);
+    const alignedByteOffset = Math.ceil(this.byteLength / 4) * 4;
+    const nextByteLength = alignedByteOffset + bytes.byteLength;
+    if (!Number.isSafeInteger(nextByteLength) || nextByteLength > 0xffffffff) {
+      throw new Error('Parquet batched upload exceeds uint32');
+    }
+    const section = Object.freeze({byteOffset: alignedByteOffset, byteLength: bytes.byteLength});
+    this.chunks.push({
+      section,
+      bytes: new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+    });
+    this.byteLength = nextByteLength;
+    return section;
+  }
+
+  finish(): Uint8Array {
+    const output = new Uint8Array(Math.ceil(this.byteLength / 4) * 4);
+    for (const chunk of this.chunks) output.set(chunk.bytes, chunk.section.byteOffset);
+    return output;
+  }
+}

--- a/modules/gpgpu/src/gpu-parse/parquet/parquet-encoded-page-batch.ts
+++ b/modules/gpgpu/src/gpu-parse/parquet/parquet-encoded-page-batch.ts
@@ -475,6 +475,7 @@ function planPage(
     sections.encodedValues,
     physicalType,
     physicalValueCount,
+    sections.decodedValuesByteLength,
     Boolean(compression),
     upload,
     dictionary,
@@ -604,6 +605,7 @@ function planValues(
   encoded: Uint8Array,
   physicalType: ParquetPhysicalType,
   valueCount: number,
+  decodedValuesByteLength: number,
   isCompressed: boolean,
   upload: GPUParquetUploadBuilder,
   dictionary: GPUParquetDictionaryPlan | undefined,
@@ -612,6 +614,12 @@ function planValues(
   const encoding = normalizeEncoding(page.encoding);
   if (encoding === 'PLAIN') {
     if (physicalType === 'BOOLEAN') {
+      const encodedByteLength = Math.ceil(valueCount / 8);
+      if (decodedValuesByteLength !== encodedByteLength) {
+        throw new Error(
+          `PLAIN BOOLEAN payload has ${decodedValuesByteLength} decoded bytes; expected ${encodedByteLength}`
+        );
+      }
       return Object.freeze({
         kind: 'plain-boolean' as const,
         valueCount,
@@ -644,9 +652,9 @@ function planValues(
       );
     }
     const decodedByteLength = multiplyUint32(valueCount, byteWidth, 'PLAIN decoded byte length');
-    if (!isCompressed && encoded.byteLength !== decodedByteLength) {
+    if (decodedValuesByteLength !== decodedByteLength) {
       throw new Error(
-        `PLAIN ${physicalType} payload has ${encoded.byteLength} bytes; expected ${decodedByteLength}`
+        `PLAIN ${physicalType} payload has ${decodedValuesByteLength} decoded bytes; expected ${decodedByteLength}`
       );
     }
     return Object.freeze({kind: 'plain-fixed' as const, valueCount, byteWidth, decodedByteLength});
@@ -665,9 +673,9 @@ function planValues(
       byteWidth,
       'BYTE_STREAM_SPLIT decoded byte length'
     );
-    if (!isCompressed && encoded.byteLength !== decodedByteLength) {
+    if (decodedValuesByteLength !== decodedByteLength) {
       throw new Error(
-        `BYTE_STREAM_SPLIT payload has ${encoded.byteLength} bytes; expected ${decodedByteLength}`
+        `BYTE_STREAM_SPLIT payload has ${decodedValuesByteLength} decoded bytes; expected ${decodedByteLength}`
       );
     }
     return Object.freeze({

--- a/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-encoded-page-batch.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-encoded-page-batch.spec.ts
@@ -1,0 +1,288 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {ParquetEncodedPageBatch} from '@loaders.gl/parquet';
+import {Buffer, type Device} from '@luma.gl/core';
+import {GPUCommandGraph, type GraphDataView} from '@luma.gl/gpgpu/gpu-core';
+import {
+  addGPUParquetEncodedPageBatchToGraph,
+  createGPUParquetEncodedPageBatchInputBuffer,
+  planGPUParquetEncodedPageBatch,
+  type GPUParquetDecodedPage
+} from '@luma.gl/gpgpu/gpu-parse';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import test from 'test/utils/vitest-tape';
+
+test('loaders.gl encoded pages batch Snappy, levels, and values in one graph', async testCase => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const expectedValues = new Uint8Array(new Float32Array([1, 2]).buffer);
+  const byteStreamSplit = encodeByteStreamSplit(expectedValues, 2, 4);
+  const snappyValues = Uint8Array.from([8, 28, ...byteStreamSplit]);
+  const batch = makeBatch(Uint8Array.from([4, 1, ...snappyValues]));
+  const plan = planGPUParquetEncodedPageBatch(batch);
+  testCase.equal(plan.gpuPageCount, 1);
+  testCase.equal(plan.pages[0].mode, 'gpu');
+  if (plan.pages[0].mode === 'gpu') {
+    testCase.equal(plan.pages[0].compression?.codec, 'SNAPPY');
+    testCase.equal(plan.pages[0].values.kind, 'byte-stream-split');
+  }
+
+  const inputBuffer = createGPUParquetEncodedPageBatchInputBuffer(device, plan);
+  const graph = new GPUCommandGraph(device, {id: 'gpu-parquet-loader-batch-test'});
+  const result = addGPUParquetEncodedPageBatchToGraph(graph, plan, inputBuffer);
+  const page = result.pages[0] as GPUParquetDecodedPage;
+  testCase.equal(page.mode, 'gpu');
+  testCase.equal(page.values.layout, 'packed-bytes');
+
+  const valueReadback = createReadbackBuffer(device, expectedValues.byteLength);
+  const levelReadback = createReadbackBuffer(device, 8);
+  addReadbackCopy(
+    graph,
+    page.values.layout === 'split-uint64' ? page.values.low : page.values.values,
+    valueReadback,
+    'values'
+  );
+  addReadbackCopy(graph, page.definitionLevels!, levelReadback, 'definition-levels');
+  const compiled = graph.compile();
+
+  try {
+    const commandEncoder = device.createCommandEncoder({id: 'gpu-parquet-loader-batch-encoder'});
+    compiled.encode(commandEncoder, {parameters: undefined});
+    device.submit(commandEncoder.finish());
+    const valueResult = await valueReadback.readAsync();
+    const levelResult = await levelReadback.readAsync();
+    testCase.deepEqual(
+      Array.from(new Uint8Array(valueResult.buffer, valueResult.byteOffset, expectedValues.length)),
+      Array.from(expectedValues),
+      'decompresses and restores value-major bytes'
+    );
+    testCase.deepEqual(
+      Array.from(new Uint32Array(levelResult.buffer, levelResult.byteOffset, 2)),
+      [1, 1],
+      'decodes V2 definition levels alongside values'
+    );
+  } finally {
+    compiled.destroy();
+    inputBuffer.destroy();
+    valueReadback.destroy();
+    levelReadback.destroy();
+  }
+  testCase.end();
+});
+
+test('loaders.gl encoded pages reuse one byte-array dictionary across GPU pages', async testCase => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const plan = planGPUParquetEncodedPageBatch(makeDictionaryBatch());
+  const inputBuffer = createGPUParquetEncodedPageBatchInputBuffer(device, plan);
+  const graph = new GPUCommandGraph(device, {id: 'gpu-parquet-dictionary-batch-test'});
+  const result = addGPUParquetEncodedPageBatchToGraph(graph, plan, inputBuffer);
+  const firstPage = result.pages[0] as GPUParquetDecodedPage;
+  const secondPage = result.pages[1] as GPUParquetDecodedPage;
+  const firstReadback = createReadbackBuffer(device, 4);
+  const secondReadback = createReadbackBuffer(device, 4);
+  if (firstPage.values.layout === 'byte-array' && secondPage.values.layout === 'byte-array') {
+    addReadbackCopy(graph, firstPage.values.values, firstReadback, 'first-dictionary-values');
+    addReadbackCopy(graph, secondPage.values.values, secondReadback, 'second-dictionary-values');
+  }
+  const compiled = graph.compile();
+  try {
+    const commandEncoder = device.createCommandEncoder({id: 'gpu-parquet-dictionary-encoder'});
+    compiled.encode(commandEncoder, {parameters: undefined});
+    device.submit(commandEncoder.finish());
+    const firstResult = await firstReadback.readAsync();
+    const secondResult = await secondReadback.readAsync();
+    testCase.equal(
+      new TextDecoder().decode(new Uint8Array(firstResult.buffer, firstResult.byteOffset, 3)),
+      'abb'
+    );
+    testCase.equal(
+      new TextDecoder().decode(new Uint8Array(secondResult.buffer, secondResult.byteOffset, 2)),
+      'bb'
+    );
+  } finally {
+    compiled.destroy();
+    inputBuffer.destroy();
+    firstReadback.destroy();
+    secondReadback.destroy();
+  }
+  testCase.end();
+});
+
+function makeBatch(data: Uint8Array): ParquetEncodedPageBatch {
+  return {
+    shape: 'parquet-encoded-pages',
+    rowGroup: {
+      index: 0,
+      rowOffset: 0,
+      rowCount: 2,
+      uncompressedByteLength: 10,
+      uncompressedSize: 10,
+      compressedByteLength: data.byteLength,
+      compressedSize: data.byteLength,
+      columns: [],
+      sortingColumns: []
+    },
+    projectedColumns: ['value'],
+    filterColumns: [],
+    columns: [
+      {
+        path: ['value'],
+        physicalType: 'FLOAT',
+        maxRepetitionLevel: 0,
+        maxDefinitionLevel: 1,
+        compression: 'SNAPPY',
+        valueCount: 2,
+        pages: [
+          {
+            type: 'data-v2',
+            pageOrdinal: 0,
+            encoding: 'BYTE_STREAM_SPLIT',
+            repetitionLevelEncoding: 'RLE',
+            definitionLevelEncoding: 'RLE',
+            compression: 'SNAPPY',
+            compressionState: 'compressed',
+            valueCount: 2,
+            nonNullValueCount: 2,
+            data,
+            repetitionLevels: {byteOffset: 0, byteLength: 0},
+            definitionLevels: {byteOffset: 0, byteLength: 2},
+            values: {byteOffset: 2, byteLength: data.byteLength - 2},
+            compressedByteLength: data.byteLength,
+            uncompressedByteLength: 10
+          }
+        ]
+      }
+    ]
+  };
+}
+
+function makeDictionaryBatch(): ParquetEncodedPageBatch {
+  const dictionaryData = Uint8Array.from([1, 0, 0, 0, 97, 2, 0, 0, 0, 98, 98]);
+  const makeDataPage = (pageOrdinal: number, valueCount: number, packedIndices: number) => {
+    const data = Uint8Array.from([1, 3, packedIndices]);
+    return {
+      type: 'data-v2' as const,
+      pageOrdinal,
+      encoding: 'RLE_DICTIONARY',
+      repetitionLevelEncoding: 'RLE',
+      definitionLevelEncoding: 'RLE',
+      compression: 'UNCOMPRESSED',
+      compressionState: 'decompressed' as const,
+      valueCount,
+      nonNullValueCount: valueCount,
+      data,
+      repetitionLevels: {byteOffset: 0, byteLength: 0},
+      definitionLevels: {byteOffset: 0, byteLength: 0},
+      values: {byteOffset: 0, byteLength: data.byteLength},
+      compressedByteLength: data.byteLength,
+      uncompressedByteLength: data.byteLength
+    };
+  };
+  return {
+    shape: 'parquet-encoded-pages',
+    rowGroup: {
+      index: 0,
+      rowOffset: 0,
+      rowCount: 3,
+      uncompressedByteLength: 17,
+      uncompressedSize: 17,
+      compressedByteLength: 17,
+      compressedSize: 17,
+      columns: [],
+      sortingColumns: []
+    },
+    projectedColumns: ['label'],
+    filterColumns: [],
+    columns: [
+      {
+        path: ['label'],
+        physicalType: 'BYTE_ARRAY',
+        maxRepetitionLevel: 0,
+        maxDefinitionLevel: 0,
+        compression: 'UNCOMPRESSED',
+        valueCount: 3,
+        dictionary: {
+          type: 'dictionary',
+          pageOrdinal: -1,
+          encoding: 'PLAIN',
+          compression: 'UNCOMPRESSED',
+          compressionState: 'decompressed',
+          valueCount: 2,
+          nonNullValueCount: 2,
+          data: dictionaryData,
+          values: {byteOffset: 0, byteLength: dictionaryData.byteLength},
+          compressedByteLength: dictionaryData.byteLength,
+          uncompressedByteLength: dictionaryData.byteLength
+        },
+        pages: [makeDataPage(0, 2, 2), makeDataPage(1, 1, 1)]
+      }
+    ]
+  };
+}
+
+function encodeByteStreamSplit(
+  decoded: Uint8Array,
+  valueCount: number,
+  byteWidth: number
+): Uint8Array {
+  const encoded = new Uint8Array(decoded.length);
+  for (let valueIndex = 0; valueIndex < valueCount; valueIndex++) {
+    for (let byteIndex = 0; byteIndex < byteWidth; byteIndex++) {
+      encoded[byteIndex * valueCount + valueIndex] = decoded[valueIndex * byteWidth + byteIndex];
+    }
+  }
+  return encoded;
+}
+
+function createReadbackBuffer(device: Device, byteLength: number): Buffer {
+  return device.createBuffer({
+    byteLength,
+    usage: Buffer.COPY_DST | Buffer.COPY_SRC
+  });
+}
+
+function addReadbackCopy(
+  graph: GPUCommandGraph,
+  source: GraphDataView<'uint32'>,
+  destination: Buffer,
+  id: string
+): void {
+  const destinationHandle = graph.importBuffer(
+    {
+      id: `${id}-readback`,
+      byteLength: destination.byteLength,
+      usage: destination.usage
+    },
+    destination
+  );
+  graph.addCopyPass({
+    id: `${id}-copy`,
+    resources: [
+      {buffer: source, usage: 'copy-source'},
+      {buffer: destinationHandle, usage: 'copy-destination'}
+    ],
+    compile: () => ({
+      encode: ({commandEncoder, getBuffer}) =>
+        commandEncoder.copyBufferToBuffer({
+          sourceBuffer: getBuffer(source),
+          sourceOffset: source.byteOffset,
+          destinationBuffer: getBuffer(destinationHandle),
+          destinationOffset: 0,
+          size: destination.byteLength
+        })
+    })
+  });
+}

--- a/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-encoded-page-batch.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-encoded-page-batch.spec.ts
@@ -77,6 +77,52 @@ test('loaders.gl encoded pages batch Snappy, levels, and values in one graph', a
   testCase.end();
 });
 
+test('compressed PLAIN page outputs remain available for graph readback', async testCase => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const expectedValues = new Uint8Array(new Float32Array([1, 2]).buffer);
+  const snappyValues = Uint8Array.from([8, 28, ...expectedValues]);
+  const plan = planGPUParquetEncodedPageBatch(
+    makeBatch(Uint8Array.from([4, 1, ...snappyValues]), 'PLAIN')
+  );
+  const inputBuffer = createGPUParquetEncodedPageBatchInputBuffer(device, plan);
+  const graph = new GPUCommandGraph(device, {id: 'gpu-parquet-plain-readback-test'});
+  const result = addGPUParquetEncodedPageBatchToGraph(graph, plan, inputBuffer);
+  const page = result.pages[0] as GPUParquetDecodedPage;
+  const readback = createReadbackBuffer(device, expectedValues.byteLength);
+  addReadbackCopy(
+    graph,
+    page.values.layout === 'split-uint64' ? page.values.low : page.values.values,
+    readback,
+    'plain-values'
+  );
+  const compiled = graph.compile();
+
+  try {
+    const commandEncoder = device.createCommandEncoder({id: 'gpu-parquet-plain-encoder'});
+    compiled.encode(commandEncoder, {parameters: undefined});
+    device.submit(commandEncoder.finish());
+    const resultData = await readback.readAsync();
+    testCase.deepEqual(
+      Array.from(
+        new Uint8Array(resultData.buffer, resultData.byteOffset, expectedValues.byteLength)
+      ),
+      Array.from(expectedValues),
+      'copies the decompressed PLAIN output directly'
+    );
+  } finally {
+    compiled.destroy();
+    inputBuffer.destroy();
+    readback.destroy();
+  }
+  testCase.end();
+});
+
 test('loaders.gl encoded pages reuse one byte-array dictionary across GPU pages', async testCase => {
   const device = await getWebGPUTestDevice();
   if (!device) {
@@ -121,7 +167,10 @@ test('loaders.gl encoded pages reuse one byte-array dictionary across GPU pages'
   testCase.end();
 });
 
-function makeBatch(data: Uint8Array): ParquetEncodedPageBatch {
+function makeBatch(
+  data: Uint8Array,
+  encoding: 'PLAIN' | 'BYTE_STREAM_SPLIT' = 'BYTE_STREAM_SPLIT'
+): ParquetEncodedPageBatch {
   return {
     shape: 'parquet-encoded-pages',
     rowGroup: {
@@ -149,7 +198,7 @@ function makeBatch(data: Uint8Array): ParquetEncodedPageBatch {
           {
             type: 'data-v2',
             pageOrdinal: 0,
-            encoding: 'BYTE_STREAM_SPLIT',
+            encoding,
             repetitionLevelEncoding: 'RLE',
             definitionLevelEncoding: 'RLE',
             compression: 'SNAPPY',

--- a/modules/gpgpu/test/gpu-parse/parquet/parquet-encoded-page-batch.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/parquet-encoded-page-batch.node.spec.ts
@@ -1,0 +1,183 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {ParquetEncodedPageBatch} from '@loaders.gl/parquet';
+import {ParquetJSWriter} from '@loaders.gl/parquet';
+import {ParquetSourceLoader} from '@loaders.gl/parquet/parquet-source-loader';
+import {planGPUParquetEncodedPageBatch} from '@luma.gl/gpgpu/gpu-parse';
+import test from 'test/utils/vitest-tape';
+
+test('loaders.gl alpha.4 V1 and V2 pages produce mixed GPU batch plans', async testCase => {
+  testCase.equal(ParquetJSWriter.version, '5.0.0-alpha.4', 'uses the requested loaders.gl release');
+
+  for (const useDataPageV2 of [false, true]) {
+    const batch = await makeEncodedPageBatch(useDataPageV2);
+    const plan = planGPUParquetEncodedPageBatch(batch);
+    testCase.equal(plan.gpuPageCount, 4, `plans every V${useDataPageV2 ? 2 : 1} page`);
+    testCase.equal(plan.cpuFallbackPageCount, 0, 'does not silently fall back');
+    testCase.equal(plan.pages[0].mode, 'gpu', 'first page is GPU-addressable');
+    if (plan.pages[0].mode === 'gpu') {
+      testCase.equal(plan.pages[0].physicalValueCount, 2, 'counts non-null physical values');
+      testCase.equal(plan.pages[0].definitionLevels?.valueCount, 2, 'retains definition levels');
+      testCase.equal(plan.pages[0].values.kind, 'plain-fixed', 'plans fixed PLAIN values');
+    }
+    const allNullPage = plan.pages[3];
+    testCase.equal(allNullPage.mode, 'gpu', 'all-null pages remain valid GPU work');
+    if (allNullPage.mode === 'gpu') {
+      testCase.equal(allNullPage.physicalValueCount, 0, 'all-null page has no physical values');
+      testCase.equal(allNullPage.values.kind, 'plain-byte-array');
+      testCase.equal(allNullPage.values.decodedByteLength, 0);
+    }
+    testCase.ok(plan.uploadData.byteLength % 4 === 0, 'batch upload is word aligned');
+  }
+  testCase.end();
+});
+
+test('GPU Parquet page planner makes thresholds and fallback boundaries explicit', async testCase => {
+  const batch = await makeEncodedPageBatch(true);
+  const thresholdPlan = planGPUParquetEncodedPageBatch(batch, {minimumGPUByteLength: 1024});
+  testCase.equal(thresholdPlan.gpuPageCount, 0);
+  testCase.equal(thresholdPlan.cpuFallbackPageCount, 4);
+  testCase.ok(
+    thresholdPlan.pages.every(page =>
+      page.mode === 'cpu-fallback' ? page.reason === 'below-gpu-threshold' : false
+    ),
+    'every small page reports the threshold decision'
+  );
+
+  const malformed = {
+    ...batch,
+    columns: [
+      {
+        ...batch.columns[0],
+        pages: [
+          {
+            ...batch.columns[0].pages[0],
+            values: {byteOffset: 999, byteLength: 4}
+          },
+          ...batch.columns[0].pages.slice(1)
+        ]
+      },
+      ...batch.columns.slice(1)
+    ]
+  } satisfies ParquetEncodedPageBatch;
+  testCase.throws(
+    () => planGPUParquetEncodedPageBatch(malformed),
+    /values section extends beyond the page body/,
+    'rejects invalid loaders.gl section ranges before upload'
+  );
+  testCase.end();
+});
+
+test('GPU Parquet page planner caches variable dictionaries across data pages', testCase => {
+  const dictionaryData = Uint8Array.from([1, 0, 0, 0, 97, 2, 0, 0, 0, 98, 98]);
+  const makeDictionaryPage = () => ({
+    type: 'dictionary' as const,
+    pageOrdinal: -1,
+    encoding: 'PLAIN',
+    compression: 'UNCOMPRESSED',
+    compressionState: 'decompressed' as const,
+    valueCount: 2,
+    nonNullValueCount: 2,
+    data: dictionaryData,
+    values: {byteOffset: 0, byteLength: dictionaryData.byteLength},
+    compressedByteLength: dictionaryData.byteLength,
+    uncompressedByteLength: dictionaryData.byteLength
+  });
+  const makeDataPage = (pageOrdinal: number, valueCount: number, packedIndices: number) => {
+    const data = Uint8Array.from([1, 3, packedIndices]);
+    return {
+      type: 'data-v2' as const,
+      pageOrdinal,
+      encoding: 'RLE_DICTIONARY',
+      repetitionLevelEncoding: 'RLE',
+      definitionLevelEncoding: 'RLE',
+      compression: 'UNCOMPRESSED',
+      compressionState: 'decompressed' as const,
+      valueCount,
+      nonNullValueCount: valueCount,
+      data,
+      repetitionLevels: {byteOffset: 0, byteLength: 0},
+      definitionLevels: {byteOffset: 0, byteLength: 0},
+      values: {byteOffset: 0, byteLength: data.byteLength},
+      compressedByteLength: data.byteLength,
+      uncompressedByteLength: data.byteLength
+    };
+  };
+  const batch = {
+    shape: 'parquet-encoded-pages' as const,
+    rowGroup: {
+      index: 0,
+      rowOffset: 0,
+      rowCount: 3,
+      uncompressedByteLength: 17,
+      uncompressedSize: 17,
+      compressedByteLength: 17,
+      compressedSize: 17,
+      columns: [],
+      sortingColumns: []
+    },
+    projectedColumns: ['label'],
+    filterColumns: [],
+    columns: [
+      {
+        path: ['label'],
+        physicalType: 'BYTE_ARRAY',
+        maxRepetitionLevel: 0,
+        maxDefinitionLevel: 0,
+        compression: 'UNCOMPRESSED',
+        valueCount: 3,
+        dictionary: makeDictionaryPage(),
+        pages: [makeDataPage(0, 2, 2), makeDataPage(1, 1, 1)]
+      }
+    ]
+  } satisfies ParquetEncodedPageBatch;
+
+  const plan = planGPUParquetEncodedPageBatch(batch);
+  testCase.equal(plan.gpuPageCount, 2);
+  testCase.equal(plan.dictionaries[0]?.kind, 'byte-array');
+  testCase.ok(
+    plan.pages.every(
+      page =>
+        page.mode === 'gpu' &&
+        page.values.kind === 'dictionary-byte-array' &&
+        page.values.dictionary === plan.dictionaries[0]
+    ),
+    'both pages share one immutable dictionary plan'
+  );
+  if (plan.pages[0].mode === 'gpu' && plan.pages[0].values.kind === 'dictionary-byte-array') {
+    testCase.equal(plan.pages[0].values.decodedByteLength, 3, 'plans exact gathered byte size');
+  }
+  if (plan.pages[1].mode === 'gpu' && plan.pages[1].values.kind === 'dictionary-byte-array') {
+    testCase.equal(
+      plan.pages[1].values.decodedByteLength,
+      2,
+      'plans the second page independently'
+    );
+  }
+  testCase.end();
+});
+
+async function makeEncodedPageBatch(useDataPageV2: boolean): Promise<ParquetEncodedPageBatch> {
+  const bytes = await ParquetJSWriter.encode(
+    {
+      shape: 'object-row-table',
+      data: [
+        {value: 1, label: 'alpha'},
+        {value: 2, label: 'beta'},
+        {value: 3, label: null}
+      ]
+    },
+    {parquet: {dictionary: false, pageSize: 2, useDataPageV2}}
+  );
+  const source = ParquetSourceLoader.createDataSource(new Blob([bytes]), {});
+  try {
+    for await (const batch of source.readPages({preserveCompression: ['SNAPPY', 'LZ4_RAW']})) {
+      return batch;
+    }
+  } finally {
+    await source.close();
+  }
+  throw new Error('loaders.gl returned no encoded Parquet page batch');
+}

--- a/modules/gpgpu/test/gpu-parse/parquet/parquet-encoded-page-batch.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/parquet-encoded-page-batch.node.spec.ts
@@ -70,6 +70,60 @@ test('GPU Parquet page planner makes thresholds and fallback boundaries explicit
   testCase.end();
 });
 
+test('GPU Parquet page planner rejects mismatched compressed fixed-width output', testCase => {
+  const data = Uint8Array.from([3, 8, 1, 2, 3]);
+  const batch = {
+    shape: 'parquet-encoded-pages' as const,
+    rowGroup: {
+      index: 0,
+      rowOffset: 0,
+      rowCount: 1,
+      uncompressedByteLength: 3,
+      uncompressedSize: 3,
+      compressedByteLength: data.byteLength,
+      compressedSize: data.byteLength,
+      columns: [],
+      sortingColumns: []
+    },
+    projectedColumns: ['value'],
+    filterColumns: [],
+    columns: [
+      {
+        path: ['value'],
+        physicalType: 'INT32',
+        maxRepetitionLevel: 0,
+        maxDefinitionLevel: 0,
+        compression: 'SNAPPY',
+        valueCount: 1,
+        pages: [
+          {
+            type: 'data-v2' as const,
+            pageOrdinal: 0,
+            encoding: 'PLAIN',
+            repetitionLevelEncoding: 'RLE',
+            definitionLevelEncoding: 'RLE',
+            compression: 'SNAPPY',
+            compressionState: 'compressed' as const,
+            valueCount: 1,
+            nonNullValueCount: 1,
+            data,
+            values: {byteOffset: 0, byteLength: data.byteLength},
+            compressedByteLength: data.byteLength,
+            uncompressedByteLength: 3
+          }
+        ]
+      }
+    ]
+  } satisfies ParquetEncodedPageBatch;
+
+  testCase.throws(
+    () => planGPUParquetEncodedPageBatch(batch),
+    /PLAIN INT32 payload has 3 decoded bytes; expected 4/,
+    'cross-checks codec output metadata against the physical value layout'
+  );
+  testCase.end();
+});
+
 test('GPU Parquet page planner caches variable dictionaries across data pages', testCase => {
   const dictionaryData = Uint8Array.from([1, 0, 0, 0, 97, 2, 0, 0, 0, 98, 98]);
   const makeDictionaryPage = () => ({

--- a/package.json
+++ b/package.json
@@ -54,9 +54,11 @@
   "devDependencies": {
     "@babel/core": "^7.28.3",
     "@babel/preset-env": "^7.28.3",
-    "@loaders.gl/core": "~5.0.0-alpha.1",
-    "@loaders.gl/gltf": "~5.0.0-alpha.1",
-    "@loaders.gl/polyfills": "~5.0.0-alpha.1",
+    "@loaders.gl/core": "~5.0.0-alpha.4",
+    "@loaders.gl/gltf": "~5.0.0-alpha.4",
+    "@loaders.gl/las": "~5.0.0-alpha.4",
+    "@loaders.gl/parquet": "~5.0.0-alpha.4",
+    "@loaders.gl/polyfills": "~5.0.0-alpha.4",
     "@math.gl/dggs-geohash": "^4.1.0",
     "@math.gl/dggs-quadkey": "^4.1.0",
     "@math.gl/dggs-s2": "^4.1.0",
@@ -90,14 +92,14 @@
     "@luma.gl/webgl": "workspace:*"
   },
   "packageExtensions": {
-    "@loaders.gl/gltf@~5.0.0-alpha.1": {
+    "@loaders.gl/gltf@~5.0.0-alpha.4": {
       "peerDependencies": {
-        "@loaders.gl/core": "~5.0.0-alpha.1"
+        "@loaders.gl/core": "~5.0.0-alpha.4"
       }
     },
-    "@loaders.gl/images@~5.0.0-alpha.1": {
+    "@loaders.gl/images@~5.0.0-alpha.4": {
       "peerDependencies": {
-        "@loaders.gl/core": "~5.0.0-alpha.1"
+        "@loaders.gl/core": "~5.0.0-alpha.4"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "playwright": "^1.58.0",
     "pngjs": "^7.0.0",
     "pre-commit": "^1.2.2",
+    "texture-compressor": "^1.0.2",
     "vitest": "^4.0.18",
     "wgsl_reflect": "1.2.3",
     "yaml": "^2.8.1"

--- a/wip/examples-wip/notready/gltf/package.json
+++ b/wip/examples-wip/notready/gltf/package.json
@@ -12,9 +12,9 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "@loaders.gl/core": "~5.0.0-alpha.1",
-    "@loaders.gl/gltf": "~5.0.0-alpha.1",
-    "@loaders.gl/polyfills": "~5.0.0-alpha.1",
+    "@loaders.gl/core": "~5.0.0-alpha.4",
+    "@loaders.gl/gltf": "~5.0.0-alpha.4",
+    "@loaders.gl/polyfills": "~5.0.0-alpha.4",
     "@luma.gl/engine": "~9.3.0",
     "@luma.gl/experimental": "~9.3.0",
     "@luma.gl/webgl": "~9.3.0",

--- a/wip/experimental/package.json
+++ b/wip/experimental/package.json
@@ -49,8 +49,8 @@
     "@luma.gl/test-utils": "~9.3.0"
   },
   "peerDependencies": {
-    "@loaders.gl/gltf": "~5.0.0-alpha.1",
-    "@loaders.gl/images": "~5.0.0-alpha.1"
+    "@loaders.gl/gltf": "~5.0.0-alpha.4",
+    "@loaders.gl/images": "~5.0.0-alpha.4"
   },
   "gitHead": "c636c34b8f1581eed163e94543a8eb1f4382ba8e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8827,6 +8827,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"argparse@npm:^1.0.10":
+  version: 1.0.10
+  resolution: "argparse@npm:1.0.10"
+  dependencies:
+    sprintf-js: "npm:~1.0.2"
+  checksum: 10c0/b2972c5c23c63df66bca144dbc65d180efa74f25f8fd9b7d9a0a6c88ae839db32df3d54770dcb6460cf840d232b60695d1a6b1053f599d84e73f7437087712de
+  languageName: node
+  linkType: hard
+
 "argue-cli@npm:^3.1.0":
   version: 3.1.0
   resolution: "argue-cli@npm:3.1.0"
@@ -13421,6 +13430,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"image-size@npm:^0.7.4":
+  version: 0.7.5
+  resolution: "image-size@npm:0.7.5"
+  bin:
+    image-size: bin/image-size.js
+  checksum: 10c0/74e978c525e7d777df145bc66cfc4a4a7aa56de8e5daead3a69b0872082dbe385deb4a3b80799810df9e34b2031467412ae28810f2f65ec2e5fe08b895aa3491
+  languageName: node
+  linkType: hard
+
 "image-size@npm:^2.0.2":
   version: 2.0.2
   resolution: "image-size@npm:2.0.2"
@@ -16306,6 +16324,7 @@ __metadata:
     pngjs: "npm:^7.0.0"
     pre-commit: "npm:^1.2.2"
     preact: "npm:^10.17.0"
+    texture-compressor: "npm:^1.0.2"
     vitest: "npm:^4.0.18"
     wgsl_reflect: "npm:1.2.3"
     yaml: "npm:^2.8.1"
@@ -21854,6 +21873,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sprintf-js@npm:~1.0.2":
+  version: 1.0.3
+  resolution: "sprintf-js@npm:1.0.3"
+  checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
+  languageName: node
+  linkType: hard
+
 "srcset@npm:^4.0.0":
   version: 4.0.0
   resolution: "srcset@npm:4.0.0"
@@ -22296,6 +22322,18 @@ __metadata:
   bin:
     terser: bin/terser
   checksum: 10c0/45ba6566af976c518ff4e140250348d606761af822e23ea28d95b30fcf60fb69d3fabd93c6fafa4085d9fe31b67207e58b8480a64370b6cca07066c434101602
+  languageName: node
+  linkType: hard
+
+"texture-compressor@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "texture-compressor@npm:1.0.2"
+  dependencies:
+    argparse: "npm:^1.0.10"
+    image-size: "npm:^0.7.4"
+  bin:
+    texture-compressor: ./bin/texture-compressor.js
+  checksum: 10c0/ea0bce1cbda3a64f826867e97ee2a1f17a7219d21d97d7625a6370792afddc697e6832a9b3b39bf2eef0978af7bc0d1dcefaf7fd91d719213658b0a010a83c44
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4466,6 +4466,81 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@loaders.gl/arrow@npm:5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/arrow@npm:5.0.0-alpha.4"
+  dependencies:
+    "@loaders.gl/compression": "npm:5.0.0-alpha.4"
+    "@loaders.gl/gis": "npm:5.0.0-alpha.4"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/wkt": "npm:5.0.0-alpha.4"
+    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.4"
+    "@math.gl/polygon": "npm:4.2.0-alpha.6"
+    apache-arrow: "npm:>= 17.0.0"
+    lz4js: "npm:^0.2.0"
+  peerDependencies:
+    "@loaders.gl/core": ~5.0.0-alpha.0
+  checksum: 10c0/c64558de1ad0f5ad98c8b02df8c526800ee4df0f6e1eb2154aba96a2f053b546d47d52c5055e0ba3477bb602f25d5517ed9ef551ed4f1a60e7bc0c26cb0180b0
+  languageName: node
+  linkType: hard
+
+"@loaders.gl/avro@npm:5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/avro@npm:5.0.0-alpha.4"
+  dependencies:
+    "@loaders.gl/compression": "npm:5.0.0-alpha.4"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    apache-arrow: "npm:>= 17.0.0"
+  checksum: 10c0/02f51df4f43765e479b33cd5ba759773f4dcbcdd54589f8452e4104fd562db9e972c52c22d54364724c41fd62d97a1a018d9498cab6a9006e6010a73b31ed60b
+  languageName: node
+  linkType: hard
+
+"@loaders.gl/bson@npm:5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/bson@npm:5.0.0-alpha.4"
+  dependencies:
+    "@loaders.gl/gis": "npm:5.0.0-alpha.4"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    bson: "npm:4.2.0"
+  peerDependencies:
+    "@loaders.gl/core": ~5.0.0-alpha.0
+  checksum: 10c0/14398e4bf14dc20b3beac05be55ab94501cc881f357d986121e8669da8ccf0e71beceaea4bb8a7e7dd782a659d1ef4afa724bf1a6ed5c0a67d1776a599a5ca35
+  languageName: node
+  linkType: hard
+
+"@loaders.gl/compression@npm:5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/compression@npm:5.0.0-alpha.4"
+  dependencies:
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.4"
+    fflate: "npm:0.7.4"
+    fzstd: "npm:0.1.1"
+    hysnappy: "npm:^1.1.1"
+    snappyjs: "npm:^0.6.1"
+  peerDependencies:
+    "@loaders.gl/core": ~5.0.0-alpha.0
+    compress-utils: ^0.8.0
+    lz4js: ^0.2.0
+    pako: ^2.1.0
+    zstd-codec: ^0.1
+  peerDependenciesMeta:
+    compress-utils:
+      optional: true
+    lz4js:
+      optional: true
+    pako:
+      optional: true
+    zstd-codec:
+      optional: true
+  checksum: 10c0/7cf2ef227ea01be363cb099cb6a27d7c8dd291f38f1875fad42281e77bfd7464c0b49d4a74a12fa066bb629155c70d5187982c285223e4f3eb4aafa9b0445869
+  languageName: node
+  linkType: hard
+
 "@loaders.gl/core@npm:^4.4.1":
   version: 4.4.3
   resolution: "@loaders.gl/core@npm:4.4.3"
@@ -4479,71 +4554,110 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@loaders.gl/core@npm:~5.0.0-alpha.1":
-  version: 5.0.0-alpha.1
-  resolution: "@loaders.gl/core@npm:5.0.0-alpha.1"
+"@loaders.gl/core@npm:~5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/core@npm:5.0.0-alpha.4"
   dependencies:
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.1"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.1"
-    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.1"
-    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.1"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.4"
     "@probe.gl/log": "npm:^4.1.1"
-  checksum: 10c0/bd3a1d502f693060e91e42e182cad3a65128c0493c1d7ea95b02ce6d971c57147c1408371d89dd21608fde40915836c674a8dfd014d73f5b0136f6c7666922d5
+  checksum: 10c0/230b48c1b4b2475a679912d6415c5b3c5bdd45b7e80583552665b2af8bdcf7da8e542e081118c90947f22ccda4962b647d6554da695a90df2e45c13445042f67
   languageName: node
   linkType: hard
 
-"@loaders.gl/crypto@npm:5.0.0-alpha.1":
-  version: 5.0.0-alpha.1
-  resolution: "@loaders.gl/crypto@npm:5.0.0-alpha.1"
+"@loaders.gl/crypto@npm:5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/crypto@npm:5.0.0-alpha.4"
   dependencies:
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.1"
-    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.1"
-    "@types/crypto-js": "npm:^4.0.2"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.4"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/9c1f4600a85a56c9033cd848be0481308604501a8956392c9833f6468b6b7947bc80e51a93da857acb7fb43426d1b70b5b9f55721c31b93d2d419c7ce6febefd
+  checksum: 10c0/c3bc05606af262c29109992945076d89423a976c54459b788161c57549973766cf2504244cb78a989361231c0fcdf4f36a895fafbaa618954bc5b1ee4a139ddb
   languageName: node
   linkType: hard
 
-"@loaders.gl/draco@npm:5.0.0-alpha.1":
-  version: 5.0.0-alpha.1
-  resolution: "@loaders.gl/draco@npm:5.0.0-alpha.1"
+"@loaders.gl/draco@npm:5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/draco@npm:5.0.0-alpha.4"
   dependencies:
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.1"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.1"
-    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.1"
-    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.1"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.4"
     draco3d: "npm:1.5.7"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/61f906aa19d897a802ecbfb06cb70c43ab037457da55d119135ac338ba65b872ec0c3a9189af8b7bc24492180c50297f0b4e90cffc2f94822e74ff4c04cf6d96
+  checksum: 10c0/145b04e17ee286810ba068439a7876f41da973ee8456b125082a84637d665ebffbc39ffce6a4a78370e9654a1fd779b1c179593cc4e8e8595c79406210898d5c
   languageName: node
   linkType: hard
 
-"@loaders.gl/gltf@npm:~5.0.0-alpha.1":
-  version: 5.0.0-alpha.1
-  resolution: "@loaders.gl/gltf@npm:5.0.0-alpha.1"
+"@loaders.gl/geoarrow@npm:5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/geoarrow@npm:5.0.0-alpha.4"
   dependencies:
-    "@loaders.gl/draco": "npm:5.0.0-alpha.1"
-    "@loaders.gl/images": "npm:5.0.0-alpha.1"
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.1"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.1"
-    "@loaders.gl/textures": "npm:5.0.0-alpha.1"
-    "@math.gl/core": "npm:^4.1.0"
+    "@loaders.gl/gis": "npm:5.0.0-alpha.4"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
+    "@math.gl/polygon": "npm:4.2.0-alpha.6"
+    apache-arrow: "npm:>= 17.0.0"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/36cded1341368e22c7d0051a73cf72b74f0657ab7b14f919cbfa72c45ffeb86cd6ea40cd661f1ac5573a3e5a747325d4a428bf92b8503eeea875cc32802e5f19
+  checksum: 10c0/4e0a52f6287745fbbc54c2d8185ef67f5290c194498840b3f5233c49f9ae3e78ca6141e1cbf333707e4bbcf02e11293ae530a1724768c607e86195f6b4f3afc7
   languageName: node
   linkType: hard
 
-"@loaders.gl/images@npm:5.0.0-alpha.1, @loaders.gl/images@npm:~5.0.0-alpha.1":
-  version: 5.0.0-alpha.1
-  resolution: "@loaders.gl/images@npm:5.0.0-alpha.1"
+"@loaders.gl/gis@npm:5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/gis@npm:5.0.0-alpha.4"
   dependencies:
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.1"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
+    "@mapbox/vector-tile": "npm:^1.3.1"
+    "@math.gl/crs": "npm:^4.2.0-alpha.6"
+    "@math.gl/geometry-utils": "npm:4.2.0-alpha.6"
+    "@math.gl/polygon": "npm:4.2.0-alpha.6"
+    apache-arrow: "npm:>= 17.0.0"
+    pbf: "npm:^3.2.1"
+    zod: "npm:^4.1.12"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/8932b9fb9f839148aa89a8205720aaeae78c28cee78a242faf7305ef7e8e15d2a3ad780c75f079650a24b33af0cc70d8adf3e0e165cebd48ecf7865633bb3ca5
+  checksum: 10c0/a61a5067e702f5065bc2fa2c75e059a675312431de31d9ca07e31739dd65be4251d907542954b5fd6f936ec51c03288c5733e52facd7ffc91a07cecf78b8dc7e
+  languageName: node
+  linkType: hard
+
+"@loaders.gl/gltf@npm:~5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/gltf@npm:5.0.0-alpha.4"
+  dependencies:
+    "@loaders.gl/draco": "npm:5.0.0-alpha.4"
+    "@loaders.gl/images": "npm:5.0.0-alpha.4"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/textures": "npm:5.0.0-alpha.4"
+    "@math.gl/core": "npm:4.2.0-alpha.6"
+    "@math.gl/culling": "npm:^4.2.0-alpha.6"
+    meshoptimizer: "npm:^1.2.0"
+    zod: "npm:^4.1.12"
+  peerDependencies:
+    "@loaders.gl/core": ~5.0.0-alpha.0
+  checksum: 10c0/8945dae82272347a3580a3429f34b16ca156e42ea23f37ce059f0bf0ac76137e56878ab6245ba4377c280faf5a8cb6e36d0206f31a4ad034a0393c57be227f0a
+  languageName: node
+  linkType: hard
+
+"@loaders.gl/images@npm:5.0.0-alpha.4, @loaders.gl/images@npm:~5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/images@npm:5.0.0-alpha.4"
+  dependencies:
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+  peerDependencies:
+    "@loaders.gl/core": ~5.0.0-alpha.0
+  checksum: 10c0/383e81cd42f25ddb37e474bd362def4cf7e23e92e178976cefd665cc9b0ca1b0e7504278743f78fd1b3e4e44ecd0c021df5fc61c5a8a8a3194fc08f9f71f9c00
   languageName: node
   linkType: hard
 
@@ -4558,18 +4672,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@loaders.gl/las@npm:~5.0.0-alpha.1":
-  version: 5.0.0-alpha.1
-  resolution: "@loaders.gl/las@npm:5.0.0-alpha.1"
+"@loaders.gl/las@npm:~5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/las@npm:5.0.0-alpha.4"
   dependencies:
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.1"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.1"
-    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.1"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
+    "@math.gl/crs": "npm:^4.2.0-alpha.6"
     copc: "npm:0.0.8"
     laz-perf: "npm:^0.0.7"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/b4101a05eb80e2ca065a7de9527cfe6b258b7ba329d985664e7f780140213308ebb0ef772167bf7bdcf369e49edb90db058b4ae7b8e3dd958e1755a742bc1e24
+  checksum: 10c0/6c9c738333ead85e2fe934d087e9a72bf1a11555310cc0a1f1e7f8ef77d4e09c0987ae921dcd6aa49fb521c5894e901aa7289763e6d7346ad3d29dd51da748c6
   languageName: node
   linkType: hard
 
@@ -4585,34 +4700,60 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@loaders.gl/loader-utils@npm:5.0.0-alpha.1":
-  version: 5.0.0-alpha.1
-  resolution: "@loaders.gl/loader-utils@npm:5.0.0-alpha.1"
+"@loaders.gl/loader-utils@npm:5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/loader-utils@npm:5.0.0-alpha.4"
   dependencies:
-    "@loaders.gl/schema": "npm:5.0.0-alpha.1"
-    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.1"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.4"
+    "@math.gl/crs": "npm:^4.2.0-alpha.6"
     "@probe.gl/log": "npm:^4.1.1"
     "@probe.gl/stats": "npm:^4.1.1"
-  checksum: 10c0/4c81603b22315d6a3966f2f35c79f2c22e07a40dcb630d0c7c0183a260678d736d57c671880586277ffcad6afb1d6e69e6858e9db181dc2c70813c672d808bb2
+  checksum: 10c0/c3a832c91f405413381823dab5a9208dccc88ec19639de297de725de10d951352173fb03b92269a21a0a910f1b879c28220959315f76d9930727bd0701f665e0
   languageName: node
   linkType: hard
 
-"@loaders.gl/polyfills@npm:~5.0.0-alpha.1":
-  version: 5.0.0-alpha.1
-  resolution: "@loaders.gl/polyfills@npm:5.0.0-alpha.1"
+"@loaders.gl/parquet@npm:~5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/parquet@npm:5.0.0-alpha.4"
   dependencies:
-    "@loaders.gl/crypto": "npm:5.0.0-alpha.1"
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.1"
+    "@loaders.gl/arrow": "npm:5.0.0-alpha.4"
+    "@loaders.gl/avro": "npm:5.0.0-alpha.4"
+    "@loaders.gl/bson": "npm:5.0.0-alpha.4"
+    "@loaders.gl/compression": "npm:5.0.0-alpha.4"
+    "@loaders.gl/geoarrow": "npm:5.0.0-alpha.4"
+    "@loaders.gl/gis": "npm:5.0.0-alpha.4"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/wkt": "npm:5.0.0-alpha.4"
+    "@probe.gl/log": "npm:^4.1.1"
+    async-mutex: "npm:^0.2.2"
+    isomorphic-ws: "npm:^5.0.0"
+    object-stream: "npm:0.0.1"
+    parquet-wasm: "npm:0.7.2"
+    varint: "npm:^6.0.0"
+  peerDependencies:
+    "@loaders.gl/core": ~5.0.0-alpha.0
+    apache-arrow: ">= 17.0.0"
+  checksum: 10c0/04c0475b2c57827f986c059346743ddc860d4df9da645b0f45d36b0d98685f4eb428a9a46e760b6896a367369908e8ae2f9878b99347e77731513204e1cef855
+  languageName: node
+  linkType: hard
+
+"@loaders.gl/polyfills@npm:~5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/polyfills@npm:5.0.0-alpha.4"
+  dependencies:
+    "@loaders.gl/crypto": "npm:5.0.0-alpha.4"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
     buffer: "npm:^6.0.3"
     get-pixels: "npm:^3.3.3"
     ndarray: "npm:^1.0.19"
     save-pixels: "npm:^2.3.6"
-    stream-to-async-iterator: "npm:^1.0.0"
-    through: "npm:^2.3.8"
     web-streams-polyfill: "npm:^4.0.0"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/dadd72193d1ba7b3e99c90f0ddd8c019f7ed5b87583333e0ca760894e55329b5f6b8e8da54b46923f624907601ff1d031d0e63437cbbf02b55760140ce8dfb82
+  checksum: 10c0/02004729427a3bf782372e258f19826e2567aa2f038e1495070870459cdbfcd9a24e3e796fb8817f03a986556a699f9e52eb45e231afe885048f589ada6a9575
   languageName: node
   linkType: hard
 
@@ -4629,17 +4770,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@loaders.gl/schema-utils@npm:5.0.0-alpha.1":
-  version: 5.0.0-alpha.1
-  resolution: "@loaders.gl/schema-utils@npm:5.0.0-alpha.1"
+"@loaders.gl/schema-utils@npm:5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/schema-utils@npm:5.0.0-alpha.4"
   dependencies:
-    "@loaders.gl/schema": "npm:5.0.0-alpha.1"
-    "@math.gl/types": "npm:^4.1.0"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    "@math.gl/types": "npm:4.2.0-alpha.6"
     "@types/geojson": "npm:^7946.0.7"
     apache-arrow: "npm:>= 17.0.0"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/51964c38a5ddafa4ecac419eab3be6184db93c3699331c5ac0c521bdf13c9eece50145c2fa85fae823b59d8a15f0179874e57f0513d185072c03b5a3d4ff2190
+  checksum: 10c0/ac4e70041ddb80c0a5adeac7e22e7e4dd851aa03c6bc03cf170151f3a91cfa4b8d4fb3f3fcfa060064fdf3e872d3dced7724ede25c290b479296bd049da37328
   languageName: node
   linkType: hard
 
@@ -4653,30 +4794,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@loaders.gl/schema@npm:5.0.0-alpha.1":
-  version: 5.0.0-alpha.1
-  resolution: "@loaders.gl/schema@npm:5.0.0-alpha.1"
+"@loaders.gl/schema@npm:5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/schema@npm:5.0.0-alpha.4"
   dependencies:
     "@types/geojson": "npm:^7946.0.7"
     apache-arrow: "npm:>= 17.0.0"
-  checksum: 10c0/6caa9f68120ecaa81f7b1907c069f3bc2457d8d8c449347cce6fbfa306477592b3b8fb5a2b3639a95734958ae6c77c90aefd574d1be33a942bd2b7176b024ade
+  checksum: 10c0/bfd9ca3185337e736bf6a34e0b598f559b1a132060863a3f994266244ac10d09abe73b16c8d905ee645079a2ce0defffbdbd68191acae09715ba99356dda9600
   languageName: node
   linkType: hard
 
-"@loaders.gl/textures@npm:5.0.0-alpha.1, @loaders.gl/textures@npm:~5.0.0-alpha.1":
-  version: 5.0.0-alpha.1
-  resolution: "@loaders.gl/textures@npm:5.0.0-alpha.1"
+"@loaders.gl/textures@npm:5.0.0-alpha.4, @loaders.gl/textures@npm:~5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/textures@npm:5.0.0-alpha.4"
   dependencies:
-    "@loaders.gl/images": "npm:5.0.0-alpha.1"
-    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.1"
-    "@loaders.gl/schema": "npm:5.0.0-alpha.1"
-    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.1"
-    "@math.gl/types": "npm:^4.1.0"
-    ktx-parse: "npm:^0.7.0"
-    texture-compressor: "npm:^1.0.2"
+    "@loaders.gl/images": "npm:5.0.0-alpha.4"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    "@loaders.gl/worker-utils": "npm:5.0.0-alpha.4"
+    "@math.gl/types": "npm:4.2.0-alpha.6"
+    zod: "npm:^4.1.12"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/5f04e7e4538e4e228ca190d7511be6ef5774eb47e497cef33050fecccf5645618ac1b0ce9010699fbc3314a04ff1e0d99c8561b9c6db9fbd4c0076408a8c8b31
+    texture-compressor: ^1.0.2
+  peerDependenciesMeta:
+    texture-compressor:
+      optional: true
+  checksum: 10c0/97ff486197ca1b14b2ea93f411958276781476417c2ccde3ecfa7de7bb716065d7d16e0161b13347aee5209a7300ea188cfbcc6a30c41a2fa7ec1a5795d3ad4e
+  languageName: node
+  linkType: hard
+
+"@loaders.gl/wkt@npm:5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/wkt@npm:5.0.0-alpha.4"
+  dependencies:
+    "@loaders.gl/gis": "npm:5.0.0-alpha.4"
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.4"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.4"
+    "@math.gl/crs": "npm:^4.2.0-alpha.6"
+  peerDependencies:
+    "@loaders.gl/core": ~5.0.0-alpha.0
+  checksum: 10c0/62c8f6d21f9c9b0c2872e0c3f1b72e0deb927668e6979379a104afb29a99d29190f8ccb3d3e4bde3d38317cfc6d12445a3739c7f7f07df9f0994c36a12a9451c
   languageName: node
   linkType: hard
 
@@ -4689,12 +4847,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@loaders.gl/worker-utils@npm:5.0.0-alpha.1":
-  version: 5.0.0-alpha.1
-  resolution: "@loaders.gl/worker-utils@npm:5.0.0-alpha.1"
+"@loaders.gl/worker-utils@npm:5.0.0-alpha.4":
+  version: 5.0.0-alpha.4
+  resolution: "@loaders.gl/worker-utils@npm:5.0.0-alpha.4"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
-  checksum: 10c0/ad09a72903cbd09f1d274d3ae4ad070a40a70612a848787a3eb3c82fb0b9144312553ce79fcd97ed7d5ae4ba6f57a94e6ee8e014ea43ac2a2359cd47aefee206
+  checksum: 10c0/b5003cd0c3cec00c45047d20ec88d7a52ce8c592d54a338ab22d51e293fb7803b31269fa0ba330cb3b558cd8c844c09b72602574c2d83f65e9e1a9ee4de685d3
   languageName: node
   linkType: hard
 
@@ -4786,9 +4944,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@luma.gl/gltf@workspace:modules/gltf"
   dependencies:
-    "@loaders.gl/core": "npm:~5.0.0-alpha.1"
-    "@loaders.gl/gltf": "npm:~5.0.0-alpha.1"
-    "@loaders.gl/textures": "npm:~5.0.0-alpha.1"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/gltf": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/textures": "npm:~5.0.0-alpha.4"
     "@math.gl/core": "npm:^4.1.0"
   peerDependencies:
     "@luma.gl/core": ~9.4.0-alpha.1
@@ -4922,6 +5080,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mapbox/point-geometry@npm:~0.1.0":
+  version: 0.1.0
+  resolution: "@mapbox/point-geometry@npm:0.1.0"
+  checksum: 10c0/e4d861908574cb3165f5ad37b000416ebc90a2d6b3e0073191e6b6dc5074a6159d84ac5114d78557399bb429134f0d05bfb529e7902d1cb2b36d722b72ab662c
+  languageName: node
+  linkType: hard
+
 "@mapbox/tiny-sdf@npm:^2.0.7":
   version: 2.0.7
   resolution: "@mapbox/tiny-sdf@npm:2.0.7"
@@ -4933,6 +5098,15 @@ __metadata:
   version: 0.0.1
   resolution: "@mapbox/unitbezier@npm:0.0.1"
   checksum: 10c0/97f39d4fbdf9579d0a1a8be0d536eb113a805d36459e774014f488a7ca6cc9dcfc77ab7a2ebe5af395ad50da6efb4dbf2566de0db3f62b6b8675cddbace8f86a
+  languageName: node
+  linkType: hard
+
+"@mapbox/vector-tile@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@mapbox/vector-tile@npm:1.3.1"
+  dependencies:
+    "@mapbox/point-geometry": "npm:~0.1.0"
+  checksum: 10c0/ffb271b95c383923768295e72bdf95e428efb906434b864ea04d3853a8373cf0de19f039bd6615f7cf018fbfb4dbf4599f27ebaa86c2b7b09f7d69187f8d7da1
   languageName: node
   linkType: hard
 
@@ -5040,6 +5214,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@math.gl/core@npm:4.2.0-alpha.6":
+  version: 4.2.0-alpha.6
+  resolution: "@math.gl/core@npm:4.2.0-alpha.6"
+  dependencies:
+    "@math.gl/types": "npm:4.2.0-alpha.6"
+  checksum: 10c0/3d88f1de4eb58a62fdebf8500e3b34ea74368333e138790e1b3a1f9b1e38a80163c742de056497e90e98faa588b60e8ae3f641a9aea43a41031f1dc8da5d0b18
+  languageName: node
+  linkType: hard
+
+"@math.gl/crs@npm:^4.2.0-alpha.6":
+  version: 4.2.0-alpha.6
+  resolution: "@math.gl/crs@npm:4.2.0-alpha.6"
+  checksum: 10c0/7cfca2183cec0a59dc5561db47457fa6d603368c06e3b71805e53f2de2ceead6073c5c60168b3fd8f86eb865ffcb56bd6ca87d3ada14eac3278a09bbb38aef5d
+  languageName: node
+  linkType: hard
+
+"@math.gl/culling@npm:^4.2.0-alpha.6":
+  version: 4.2.0-alpha.6
+  resolution: "@math.gl/culling@npm:4.2.0-alpha.6"
+  dependencies:
+    "@math.gl/core": "npm:4.2.0-alpha.6"
+    "@math.gl/types": "npm:4.2.0-alpha.6"
+  checksum: 10c0/f1fb56d8510a5ac3f77cfe331630478ba539c81d24817f587a3fd28867cc832b807cc80008e5efee56bdf325bd4e981c6c326cbffc36685554569d59b1c8927d
+  languageName: node
+  linkType: hard
+
 "@math.gl/dggs-geohash@npm:^4.1.0":
   version: 4.1.0
   resolution: "@math.gl/dggs-geohash@npm:4.1.0"
@@ -5069,6 +5269,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@math.gl/geometry-utils@npm:4.2.0-alpha.6":
+  version: 4.2.0-alpha.6
+  resolution: "@math.gl/geometry-utils@npm:4.2.0-alpha.6"
+  dependencies:
+    "@math.gl/core": "npm:4.2.0-alpha.6"
+    "@math.gl/types": "npm:4.2.0-alpha.6"
+  checksum: 10c0/4f8edaa5ffc8bc86c58bdbf8b1415585d6aee96f8a38ec9294b3f6eb8e5a4ddf06424d7981753d4c0dc9392ef65ed599e430c651f99f20562899e268aadff009
+  languageName: node
+  linkType: hard
+
+"@math.gl/polygon@npm:4.2.0-alpha.6":
+  version: 4.2.0-alpha.6
+  resolution: "@math.gl/polygon@npm:4.2.0-alpha.6"
+  dependencies:
+    "@math.gl/core": "npm:4.2.0-alpha.6"
+  checksum: 10c0/fc38e1f4dbafaa9980616e4b23ece06e77f155d2a619735a7205429ed37cd72ab4cfa8d26fec42da36bcb2a75c2c0153717988dbfb606d801032ef6793509633
+  languageName: node
+  linkType: hard
+
 "@math.gl/polygon@npm:^4.1.0":
   version: 4.1.0
   resolution: "@math.gl/polygon@npm:4.1.0"
@@ -5089,6 +5308,13 @@ __metadata:
   version: 4.1.0
   resolution: "@math.gl/types@npm:4.1.0"
   checksum: 10c0/3c4dfa5ac5c9e2cef24d31f56b89c1dde785a5d70fd1a7030386346cb7dd4fa2cce5ba983b89842c1971492e30870dd22a078d64893f9c66887e38367bf992fa
+  languageName: node
+  linkType: hard
+
+"@math.gl/types@npm:4.2.0-alpha.6":
+  version: 4.2.0-alpha.6
+  resolution: "@math.gl/types@npm:4.2.0-alpha.6"
+  checksum: 10c0/fd7e3e3782b3a6834b3aa0f5bb75867743baf390ce63ad8f28de2aa633606c0eeddc4b999d8913d8416463e93b37cb3dac458a5bc0fdf57a265c329d23c56b75
   languageName: node
   linkType: hard
 
@@ -7251,13 +7477,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/crypto-js@npm:^4.0.2":
-  version: 4.2.2
-  resolution: "@types/crypto-js@npm:4.2.2"
-  checksum: 10c0/760a2078f36f2a3a1089ef367b0d13229876adcf4bcd6e8824d00d9e9bfad8118dc7e6a3cc66322b083535e12be3a29044ccdc9603bfb12519ff61551a3322c6
-  languageName: node
-  linkType: hard
-
 "@types/debug@npm:^4.0.0":
   version: 4.1.13
   resolution: "@types/debug@npm:4.1.13"
@@ -8608,15 +8827,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"argparse@npm:^1.0.10":
-  version: 1.0.10
-  resolution: "argparse@npm:1.0.10"
-  dependencies:
-    sprintf-js: "npm:~1.0.2"
-  checksum: 10c0/b2972c5c23c63df66bca144dbc65d180efa74f25f8fd9b7d9a0a6c88ae839db32df3d54770dcb6460cf840d232b60695d1a6b1053f599d84e73f7437087712de
-  languageName: node
-  linkType: hard
-
 "argue-cli@npm:^3.1.0":
   version: 3.1.0
   resolution: "argue-cli@npm:3.1.0"
@@ -8692,6 +8902,15 @@ __metadata:
   bin:
     astring: bin/astring
   checksum: 10c0/e7519544d9824494e80ef0e722bb3a0c543a31440d59691c13aeaceb75b14502af536b23f08db50aa6c632dafaade54caa25f0788aa7550b6b2d6e2df89e0830
+  languageName: node
+  linkType: hard
+
+"async-mutex@npm:^0.2.2":
+  version: 0.2.6
+  resolution: "async-mutex@npm:0.2.6"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  checksum: 10c0/440f1388fdbf2021261ba05952765182124a333681692fdef6af13935c20bfc2017e24e902362f12b29094a77b359ce3131e8dd45b1db42f1d570927ace9e7d9
   languageName: node
   linkType: hard
 
@@ -9133,6 +9352,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bson@npm:4.2.0":
+  version: 4.2.0
+  resolution: "bson@npm:4.2.0"
+  dependencies:
+    buffer: "npm:^5.6.0"
+  checksum: 10c0/50e852996fd630a1d8d40840f1f775b5e0c821616d0a3710abdd45fcfdaec796b215202ed33d4955f517f3ac2119648ea1c0d96654309bbf1fee1d736cf5e0d8
+  languageName: node
+  linkType: hard
+
 "buffer-from@npm:^1.0.0":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
@@ -9140,7 +9368,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:5.7.1, buffer@npm:^5.5.0":
+"buffer@npm:5.7.1, buffer@npm:^5.5.0, buffer@npm:^5.6.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
   dependencies:
@@ -11774,6 +12002,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fflate@npm:0.7.4":
+  version: 0.7.4
+  resolution: "fflate@npm:0.7.4"
+  checksum: 10c0/5e749eb3a6ed61a0f6c55756abf9f4258f06f60505db689e22d18503dd252ca5af656d32668e4b7b20714adf8b313febf695d23863a8352f23e325baee0f672d
+  languageName: node
+  linkType: hard
+
 "figures@npm:3.2.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
@@ -12087,6 +12322,13 @@ __metadata:
   version: 1.1.2
   resolution: "function-bind@npm:1.1.2"
   checksum: 10c0/d8680ee1e5fcd4c197e4ac33b2b4dce03c71f4d91717292785703db200f5c21f977c568d28061226f9b5900cbcd2c84463646134fd5337e7925e0942bc3f46d5
+  languageName: node
+  linkType: hard
+
+"fzstd@npm:0.1.1":
+  version: 0.1.1
+  resolution: "fzstd@npm:0.1.1"
+  checksum: 10c0/c4ae25a4b9e7ac58e9716fcb0c4ec19f3e678d90a67a59e97ce361beb27e4aa4b8666b58b4dc2d715e92db4b65b189c978186a5fedba6fccb5ec9765717dd1cd
   languageName: node
   linkType: hard
 
@@ -13106,6 +13348,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hysnappy@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "hysnappy@npm:1.1.1"
+  checksum: 10c0/d8e2f098ee0452992c13bf77e5d83fbc59247ad67f1310e0d880996e5eba4f26d5a620c9a2366415521c69e8dd38f2fec70fe22fcc5bfcb533b63764e21f5f04
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -13142,7 +13391,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:1.2.1, ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
+"ieee754@npm:1.2.1, ieee754@npm:^1.1.12, ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 10c0/b0782ef5e0935b9f12883a2e2aa37baa75da6e66ce6515c168697b42160807d9330de9a32ec1ed73149aea02e0d822e572bca6f1e22bdcbd2149e13b050b17bb
@@ -13169,15 +13418,6 @@ __metadata:
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
-  languageName: node
-  linkType: hard
-
-"image-size@npm:^0.7.4":
-  version: 0.7.5
-  resolution: "image-size@npm:0.7.5"
-  bin:
-    image-size: bin/image-size.js
-  checksum: 10c0/74e978c525e7d777df145bc66cfc4a4a7aa56de8e5daead3a69b0872082dbe385deb4a3b80799810df9e34b2031467412ae28810f2f65ec2e5fe08b895aa3491
   languageName: node
   linkType: hard
 
@@ -13711,6 +13951,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isomorphic-ws@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "isomorphic-ws@npm:5.0.0"
+  peerDependencies:
+    ws: "*"
+  checksum: 10c0/a058ac8b5e6efe9e46252cb0bc67fd325005d7216451d1a51238bc62d7da8486f828ef017df54ddf742e0fffcbe4b1bcc2a66cc115b027ed0180334cd18df252
+  languageName: node
+  linkType: hard
+
 "isstream@npm:~0.1.2":
   version: 0.1.2
   resolution: "isstream@npm:0.1.2"
@@ -14070,13 +14319,6 @@ __metadata:
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
   checksum: 10c0/cd3a0b8878e7d6d3799e54340efe3591ca787d9f95f109f28129bdd2915e37807bf8918bb295ab86afb8c82196beec5a1adcaf29042ce3f2bd932b038fe3aa4b
-  languageName: node
-  linkType: hard
-
-"ktx-parse@npm:^0.7.0":
-  version: 0.7.1
-  resolution: "ktx-parse@npm:0.7.1"
-  checksum: 10c0/07c0870a0d0fe0bd412b430ac58afd721136a1ca76db83a066b6d20810878822822cbe3b8c8507c15ae8680be0988675b4f5c3d1243262284f161b52c59d09e9
   languageName: node
   linkType: hard
 
@@ -15395,8 +15637,8 @@ __metadata:
   resolution: "luma.gl-examples-gltf-showcase@workspace:examples/showcase/gltf"
   dependencies:
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e"
-    "@loaders.gl/core": "npm:~5.0.0-alpha.1"
-    "@loaders.gl/gltf": "npm:~5.0.0-alpha.1"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/gltf": "npm:~5.0.0-alpha.4"
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
     "@luma.gl/gltf": "npm:9.4.0-alpha.4"
@@ -15440,8 +15682,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "luma.gl-examples-hello-gltf@workspace:examples/tutorials/hello-gltf"
   dependencies:
-    "@loaders.gl/core": "npm:~5.0.0-alpha.1"
-    "@loaders.gl/gltf": "npm:~5.0.0-alpha.1"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/gltf": "npm:~5.0.0-alpha.4"
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
     "@luma.gl/gltf": "npm:9.4.0-alpha.4"
@@ -15570,8 +15812,8 @@ __metadata:
   resolution: "luma.gl-examples-postprocessing@workspace:examples/showcase/postprocessing"
   dependencies:
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e"
-    "@loaders.gl/core": "npm:~5.0.0-alpha.1"
-    "@loaders.gl/gltf": "npm:~5.0.0-alpha.1"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/gltf": "npm:~5.0.0-alpha.4"
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/effects": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
@@ -15647,8 +15889,8 @@ __metadata:
   resolution: "luma.gl-examples-showcase-billion-point-spatial-atlas@workspace:examples/showcase/billion-point-spatial-atlas"
   dependencies:
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e"
-    "@loaders.gl/core": "npm:~5.0.0-alpha.1"
-    "@loaders.gl/las": "npm:~5.0.0-alpha.1"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/las": "npm:~5.0.0-alpha.4"
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/effects": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
@@ -15798,8 +16040,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "luma.gl-examples-showcase-scene@workspace:examples/showcase/scene"
   dependencies:
-    "@loaders.gl/core": "npm:~5.0.0-alpha.1"
-    "@loaders.gl/gltf": "npm:~5.0.0-alpha.1"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/gltf": "npm:~5.0.0-alpha.4"
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/effects": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
@@ -15920,9 +16162,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "luma.gl-examples-texture-tester@workspace:examples/api/texture-tester"
   dependencies:
-    "@loaders.gl/core": "npm:~5.0.0-alpha.1"
-    "@loaders.gl/images": "npm:~5.0.0-alpha.1"
-    "@loaders.gl/textures": "npm:~5.0.0-alpha.1"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/images": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/textures": "npm:~5.0.0-alpha.4"
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
     "@luma.gl/shadertools": "npm:9.4.0-alpha.4"
@@ -16039,9 +16281,11 @@ __metadata:
     "@babel/core": "npm:^7.28.3"
     "@babel/preset-env": "npm:^7.28.3"
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e"
-    "@loaders.gl/core": "npm:~5.0.0-alpha.1"
-    "@loaders.gl/gltf": "npm:~5.0.0-alpha.1"
-    "@loaders.gl/polyfills": "npm:~5.0.0-alpha.1"
+    "@loaders.gl/core": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/gltf": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/las": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/parquet": "npm:~5.0.0-alpha.4"
+    "@loaders.gl/polyfills": "npm:~5.0.0-alpha.4"
     "@math.gl/dggs-geohash": "npm:^4.1.0"
     "@math.gl/dggs-quadkey": "npm:^4.1.0"
     "@math.gl/dggs-s2": "npm:^4.1.0"
@@ -16079,6 +16323,13 @@ __metadata:
   version: 2.3.9
   resolution: "lunr@npm:2.3.9"
   checksum: 10c0/77d7dbb4fbd602aac161e2b50887d8eda28c0fa3b799159cee380fbb311f1e614219126ecbbd2c3a9c685f1720a8109b3c1ca85cc893c39b6c9cc6a62a1d8a8b
+  languageName: node
+  linkType: hard
+
+"lz4js@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "lz4js@npm:0.2.0"
+  checksum: 10c0/73c6dd5117a6fa465e6be1bd5ae34ef4f02e4eb164a47d77f8c2483ccdde43cbdf8509a5e5a4480ef812e5c7a2cb946e026b9c784533775ee5c91861edaefb39
   languageName: node
   linkType: hard
 
@@ -16623,6 +16874,13 @@ __metadata:
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: 10c0/254a8a4605b58f450308fc474c82ac9a094848081bf4c06778200207820e5193726dc563a0d2c16468810516a5c97d9d3ea0ca6585d23c58ccfff2403e8dbbeb
+  languageName: node
+  linkType: hard
+
+"meshoptimizer@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "meshoptimizer@npm:1.2.0"
+  checksum: 10c0/6cfb115dd5af02d2f590266078c609dd3236ee5fada87be3f9b7e9178860b7bf5bec4a1f8c7fc924663489e822688ef91db7c2de854205cd3bb223ecd9fc8234
   languageName: node
   linkType: hard
 
@@ -18105,6 +18363,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-stream@npm:0.0.1":
+  version: 0.0.1
+  resolution: "object-stream@npm:0.0.1"
+  checksum: 10c0/f8ecf919b3e10917daf34fb2bb94521108b85411b8a94d5a996e6d40eb4c6e2246e179067dc528b83e86c51b01b1fd16c617da0e2193dd00f0bf74a1efb8f048
+  languageName: node
+  linkType: hard
+
 "object.assign@npm:^4.1.0":
   version: 4.1.7
   resolution: "object.assign@npm:4.1.7"
@@ -18437,6 +18702,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parquet-wasm@npm:0.7.2":
+  version: 0.7.2
+  resolution: "parquet-wasm@npm:0.7.2"
+  checksum: 10c0/cfdf72c542b7e6768e6b38e386c0ab7d13bd92c9d8c45da5619409846654107c279343177bb3dba8c7fcb40c3f7be09dc154b7d175479a669b599b8bce3210b7
+  languageName: node
+  linkType: hard
+
 "parse-conflict-json@npm:^4.0.0":
   version: 4.0.0
   resolution: "parse-conflict-json@npm:4.0.0"
@@ -18647,6 +18919,18 @@ __metadata:
   version: 2.0.3
   resolution: "pathe@npm:2.0.3"
   checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
+"pbf@npm:^3.2.1":
+  version: 3.3.0
+  resolution: "pbf@npm:3.3.0"
+  dependencies:
+    ieee754: "npm:^1.1.12"
+    resolve-protobuf-schema: "npm:^2.1.0"
+  bin:
+    pbf: bin/pbf
+  checksum: 10c0/79e5dc59a9391789de84b0a6d713fad0dd1e5ce6eb721536af8c9ec49feae04fdebab9f077b760bba858e615a95ac714a7d248ecb43736e904bb8396885e16d6
   languageName: node
   linkType: hard
 
@@ -21398,6 +21682,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"snappyjs@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "snappyjs@npm:0.6.1"
+  checksum: 10c0/6fa62bb62adfc2bad577db78c58b1c52aba5482f749018ff3000f13bf660f13ec5f16ab80673ce4e8792902a16c30e5fb40a3b67dbca9af525658c9d343c5b1c
+  languageName: node
+  linkType: hard
+
 "sockjs@npm:^0.3.24":
   version: 0.3.24
   resolution: "sockjs@npm:0.3.24"
@@ -21563,13 +21854,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sprintf-js@npm:~1.0.2":
-  version: 1.0.3
-  resolution: "sprintf-js@npm:1.0.3"
-  checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
-  languageName: node
-  linkType: hard
-
 "srcset@npm:^4.0.0":
   version: 4.0.0
   resolution: "srcset@npm:4.0.0"
@@ -21648,13 +21932,6 @@ __metadata:
   version: 4.0.0
   resolution: "std-env@npm:4.0.0"
   checksum: 10c0/63b1716eae27947adde49e21b7225a0f75fb2c3d410273ae9de8333c07c7d5fc7a0628ae4c8af6b4b49b4274ed46c2bf118ed69b64f1261c9d8213d76ed1c16c
-  languageName: node
-  linkType: hard
-
-"stream-to-async-iterator@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "stream-to-async-iterator@npm:1.0.0"
-  checksum: 10c0/3d69feb18041e0d39537ba5cea39c8711c24c7b058e84b3143222ec4b0f63a065a87f599c776001979af7ebbaad85c5149c87d0738d6baaaa01a929306a76588
   languageName: node
   linkType: hard
 
@@ -22022,18 +22299,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"texture-compressor@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "texture-compressor@npm:1.0.2"
-  dependencies:
-    argparse: "npm:^1.0.10"
-    image-size: "npm:^0.7.4"
-  bin:
-    texture-compressor: ./bin/texture-compressor.js
-  checksum: 10c0/ea0bce1cbda3a64f826867e97ee2a1f17a7219d21d97d7625a6370792afddc697e6832a9b3b39bf2eef0978af7bc0d1dcefaf7fd91d719213658b0a010a83c44
-  languageName: node
-  linkType: hard
-
 "thingies@npm:^2.5.0":
   version: 2.6.0
   resolution: "thingies@npm:2.6.0"
@@ -22043,7 +22308,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through@npm:^2.3.4, through@npm:^2.3.8":
+"through@npm:^2.3.4":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
@@ -22854,6 +23119,13 @@ __metadata:
   version: 1.0.1
   resolution: "value-equal@npm:1.0.1"
   checksum: 10c0/79068098355483ef29f4d3753999ad880875b87625d7e9055cad9346ea4b7662aad3a66f87976801b0dd7a6f828ba973d28b1669ebcd37eaf88cc5f687c1a691
+  languageName: node
+  linkType: hard
+
+"varint@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "varint@npm:6.0.0"
+  checksum: 10c0/737fc37088a62ed3bd21466e318d21ca7ac4991d0f25546f518f017703be4ed0f9df1c5559f1dd533dddba4435a1b758fd9230e4772c1a930ef72b42f5c750fd
   languageName: node
   linkType: hard
 
@@ -23720,6 +23992,13 @@ __metadata:
   version: 2.1.3
   resolution: "yoctocolors-cjs@npm:2.1.3"
   checksum: 10c0/584168ef98eb5d913473a4858dce128803c4a6cd87c0f09e954fa01126a59a33ab9e513b633ad9ab953786ed16efdd8c8700097a51635aafaeed3fef7712fa79
+  languageName: node
+  linkType: hard
+
+"zod@npm:^4.1.12":
+  version: 4.5.4
+  resolution: "zod@npm:4.5.4"
+  checksum: 10c0/511a2a4d1a6f875dfdd70a1586989a8b14ef126776cd6218a2c760b9f65f14ef389ec20d92ee1aa4fcb4566d4ff3fa012956044f9dc503510d82e4c756a8ba92
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Goals

- Integrate `@luma.gl/gpgpu/gpu-parse` with the deferred encoded-page contract in loaders.gl 5.0.0-alpha.4.
- Implement roadmap tranche 1 (validated page-batch planning and upload batching) and tranche 2 (composable command-graph execution).
- Preserve explicit CPU fallback boundaries for unsupported or unprofitable page work.

## Changes

- Upgrades loaders.gl workspace dependencies from 5.0.0-alpha.1 to 5.0.0-alpha.4 and adds the Parquet package used by conformance tests.
- Adds a dependency-free structural adapter for `ParquetSource.readPages()` batches, with strict metadata/section validation, configurable thresholds, one aligned upload, and observable mixed GPU/CPU plans.
- Plans V1/V2 level streams and PLAIN fixed/boolean/BYTE_ARRAY, BYTE_STREAM_SPLIT, DELTA_BINARY_PACKED INT32/INT64, DELTA_LENGTH_BYTE_ARRAY, dictionary, Snappy, and LZ4_RAW work.
- Adds graph composition for decompression, level decoding, value decoding, and per-column dictionary reuse without intermediate readback.
- Tests real loaders.gl-written V1/V2 pages, malformed boundaries, all-null/nullable columns, fallback policy, exact dictionary allocation/reuse, and real WebGPU composed execution.
- Updates gpu-parse documentation with the alpha.4 integration, complete usage example, execution model, supported/fallback cases, and conformance guarantees.
- Adapts glTF code to alpha.4's widened typed-array types and GLB writer input contract.

## Verification

- `nvm use`: passed (Node 22.22.1).
- `yarn install`: passed with existing peer-dependency warnings.
- `yarn lint fix`: passed; no fixes pending and lockfile valid.
- `yarn build`: passed after final dependency and formatting changes.
- `yarn test-node`: 394 files passed, 1 skipped; 3,070 tests passed, 3 skipped.
- Focused real-WebGPU page-batch suite: 2 passed, including Snappy + BYTE_STREAM_SPLIT + levels and reusable variable dictionaries.
- `yarn test`: Node gate passed. The repository-wide local headless run reproduced seven unrelated WebGPU/browser failures in deck-arrow-layers, splats, DGGS A5, GPU raster NDVI, and ray-tracing lighting; both new gpu-parse tests passed.
- `yarn website:build`: passed.
- `(cd website && yarn build)`: passed.

## Risks and boundaries

- The automatic adapter deliberately falls back for unsupported codecs/encodings, compressed V1 level framing, compressed serial control streams, and unbounded output allocation.
- loaders.gl remains optional at the published gpu-parse boundary; its official types and writer are used in tests, while the runtime adapter accepts a compatible structural contract.
- The APIs remain experimental and WebGPU-only.
