### PR TITLE
feat(gpgpu): add GPU H3 and A5 cell projection

### DIFF
--- a/docs/api-reference/experimental/README.md
+++ b/docs/api-reference/experimental/README.md
@@ -56,6 +56,7 @@ stable Engine models and Shadertools passes.
 | [GPU Raster](/docs/api-reference/experimental/gpu-raster) | Validity-aware raster overviews, statistics, filters, morphology, contours, and bounded residency. |
 | [LuCIM](/docs/api-reference/experimental/lucim) | CuCIM-inspired dense 3D volume thresholding, morphology, connected components, and region measurements. |
 | [GPU Project](/docs/api-reference/experimental/gpu-project) | Adaptive high-precision coordinate projection on WebGPU. |
+| [GPU DGGS cells](/docs/api-reference/experimental/gpu-dggs) | H3 and A5 cell-center decoding for GPU-resident split-uint64 indexes. |
 | [GPU Trace](/docs/api-reference/experimental/gpu-trace) | Large GPU-resident trace scenes, interaction, aggregation, temporal indexing, comparison, and causal analysis. |
 | [GPU Dataframe](/docs/api-reference/experimental/gpu-dataframe) | Immutable GPU-resident dataframe expressions, grouping, aggregation, sorting, indexes, and joins. |
 | [GPU SQL](/docs/api-reference/experimental/gpu-sql) | Bounded SQL planning over registered GPU Dataframe inputs. |

--- a/docs/api-reference/experimental/gpu-a5.md
+++ b/docs/api-reference/experimental/gpu-a5.md
@@ -1,0 +1,76 @@
+import {ExperimentalDocsTabs} from '@site/src/components/docs/experimental-docs-tabs';
+import {DGGSCellProjectionBenchmark} from '@site/src/components/docs/dggs-cell-projection-benchmark';
+
+# GPU A5
+
+<ExperimentalDocsTabs active="gpu-a5" />
+
+`@luma.gl/gpgpu/gpu-a5` brings the same GPU-resident cell-center workflow to A5 indexes. Its API is
+intentionally identical to the H3 adapter, allowing graph builders to change the grid family
+without changing buffer layouts or downstream coordinate consumers.
+
+```ts
+import {GPUA5CellProjection} from '@luma.gl/gpgpu/gpu-a5';
+
+new GPUA5CellProjection({
+  cells,
+  output: longitudeLatitudes,
+  validity,
+  projection: 'lnglat'
+}).addToGraph(graph);
+```
+
+## Try it on this device
+
+Choose **A5** below to measure the public A5 adapter. The source set spans representative
+resolutions and reflected topology; it is repeated to the chosen array size before upload.
+
+<DGGSCellProjectionBenchmark />
+
+## Shared by design
+
+`GPUA5CellProjection` subclasses the public [`GPUDGGSCellProjection`](./gpu-dggs) contributor.
+Buffer validation, word ordering, output formats, validity masks, resource declarations, workload
+estimates, bounded dispatch, and benchmark timing are shared with H3. Only the index validation and
+topology-to-sphere functions differ.
+
+| Property | A5 behavior |
+| --- | --- |
+| `cells` | Packed low-word/high-word `uint32x2` by default |
+| `projection: 'lnglat'` | Writes `float32x2` longitude/latitude degrees |
+| `projection: 'unit-vector'` | Writes normalized `float32x3` Cartesian centers |
+| `validity` | Optional `uint32` mask; reserved zero and malformed cells write `0` |
+
+## Resolution and topology
+
+The shader deserializes the A5 resolution and topology bits from the split index, reconstructs the
+cell's spherical center, and handles resolution-zero centers explicitly. The unit-vector path is a
+natural choice for globe rendering and spatial tests; longitude/latitude is available for labels,
+interchange, and downstream projections.
+
+:::tip
+**One planner for both grids.**
+
+If an application selects A5 or H3 from data metadata, instantiate `GPUDGGSCellProjection` with a
+runtime `family` value. If the grid is fixed, prefer `GPUA5CellProjection`: its import communicates
+intent and prevents accidentally selecting another family.
+:::
+
+## Composition
+
+A5 output is source-aligned and graph-resident. Common continuations include:
+
+- passing unit vectors directly to a globe model;
+- compacting rows with the validity mask;
+- computing dot products or angular thresholds without converting back to degrees;
+- explicitly reading a small selected subset through a readback ring.
+
+No implicit upload or readback occurs. The caller retains ownership of every buffer and controls
+when the compiled graph is submitted.
+
+## Current scope
+
+The module decodes A5 cell centers. Boundary generation, neighborhood traversal, hierarchy
+transforms, and coordinate-to-cell encoding are not part of this first API. They can reuse the
+shared split-64-bit and command-graph infrastructure while defining their own capacity and
+precision contracts.

--- a/docs/api-reference/experimental/gpu-dggs.md
+++ b/docs/api-reference/experimental/gpu-dggs.md
@@ -1,0 +1,129 @@
+import {ExperimentalDocsTabs} from '@site/src/components/docs/experimental-docs-tabs';
+import {DGGSCellProjectionBenchmark} from '@site/src/components/docs/dggs-cell-projection-benchmark';
+
+# GPU DGGS
+
+<ExperimentalDocsTabs active="gpu-dggs" />
+
+Discrete global grid indexes are compact, stable identifiers. Rendering and spatial analysis need
+coordinates. The experimental `@luma.gl/gpgpu/gpu-dggs` module connects those two representations
+without pulling a large cell column back to JavaScript.
+
+| Input | Shared GPU primitive | Output |
+| --- | --- | --- |
+| Packed `uint32x2` cell IDs | validation → topology decode → spherical projection | `float32x2` longitude/latitude or `float32x3` unit vectors |
+
+The same command-graph operation powers the family-specific [`gpu-h3`](./gpu-h3) and
+[`gpu-a5`](./gpu-a5) modules. Use those typed adapters when the grid is known in advance. Use
+`GPUDGGSCellProjection` when a planner or application selects the grid at runtime.
+
+## Live benchmark
+
+This benchmark runs locally on the reader's WebGPU adapter. It validates every result before and
+after timing and reports portable completion-fence latency separately from compute-only timestamp
+queries when the adapter exposes them.
+
+<DGGSCellProjectionBenchmark />
+
+Benchmark input is already resident when timing begins. Upload, shader compilation, and validation
+readback are deliberately excluded. That makes the result representative of a projection pass
+inside a larger GPU pipeline, not a claim about end-to-end file ingestion.
+
+## One contract, three entry points
+
+| Entry point | Primary class | Best fit |
+| --- | --- | --- |
+| `@luma.gl/gpgpu/gpu-dggs` | `GPUDGGSCellProjection` | Runtime-selected H3/A5 workflows and reusable planners |
+| `@luma.gl/gpgpu/gpu-h3` | `GPUH3CellProjection` | H3-specific pipelines and the clearest static types |
+| `@luma.gl/gpgpu/gpu-a5` | `GPUA5CellProjection` | A5-specific pipelines and the clearest static types |
+
+All three classes implement `GPUCommandGraphContributor`. They add one bounded compute pass; they
+do not submit commands, allocate hidden result buffers, or read output back.
+
+```ts
+import {GPUDGGSCellProjection} from '@luma.gl/gpgpu/gpu-dggs';
+
+new GPUDGGSCellProjection({
+  family: selectedGrid, // 'h3' | 'a5'
+  cells,
+  output: centers,
+  validity,
+  projection: 'unit-vector'
+}).addToGraph(graph);
+```
+
+## GPU data contract
+
+`cells` is a packed `GraphDataView<'uint32x2'>`. The default `wordOrder: 'little-endian'` expects
+the low 32-bit word first and matches a native `BigUint64Array` on the browser platforms WebGPU
+targets. Set `wordOrder: 'high-low'` for canonical high-word-first storage.
+
+| Property | Format | Meaning |
+| --- | --- | --- |
+| `cells` | `uint32x2` | One split 64-bit cell index per row |
+| `output`, `projection: 'lnglat'` | `float32x2` | Longitude then latitude, in degrees |
+| `output`, `projection: 'unit-vector'` | `float32x3` | Normalized Earth-centered Cartesian vector |
+| `validity` | optional `uint32` | `1` for a valid cell, `0` for an invalid index |
+
+Invalid rows write zero coordinates. All views must have the same row count, belong to the target
+graph, use packed layouts, and occupy separate buffers. Three-dimensional bounded dispatch removes
+the device's one-dimensional workgroup-count limit for very large arrays.
+
+:::tip
+**Choose unit vectors for GPU-resident geometry.**
+
+Unit vectors compose directly with globe rendering, dot-product distance filters, hemisphere
+tests, and normal generation. They also avoid the inverse trigonometry required to materialize
+longitude and latitude. Choose geographic output when downstream code genuinely needs degrees.
+:::
+
+## Reusable pipeline patterns
+
+The primitive is source-aligned: output row `i` always describes cell row `i`. That makes it easy
+to compose with existing graph operations.
+
+| Goal | Suggested graph |
+| --- | --- |
+| Render cell centers | DGGS projection → model vertex input |
+| Cull invalid data | projection with validity → `GPUCompaction` |
+| Aggregate spatial metrics | unit vectors → expression/filter → reduction |
+| Publish coordinates to the CPU | projection → explicit readback ring |
+| Switch grids at runtime | planner chooses `family` → `GPUDGGSCellProjection` |
+
+The fixed H3 icosahedron basis is currently a 960-byte module-scope WGSL constant. A storage-buffer
+table would add a binding and upload without reducing the working set. The shared family-neutral
+class deliberately leaves that implementation choice behind the API boundary, so a profiled
+adapter-specific table path could be added later without changing application graphs.
+
+## Scope
+
+The current primitive decodes cell indexes to centers. It does not yet encode coordinates to cells,
+generate polygon boundaries, or enumerate neighbors. Those operations have different output and
+precision shapes:
+
+- coordinate-to-cell encoding needs an exact-integer or hybrid verification strategy near cell
+  boundaries;
+- variable-length boundaries fit a count → prefix scan → write graph;
+- neighborhood expansion needs explicit capacity and overflow semantics.
+
+The shared split-64-bit representation, validity handling, bounded dispatch, and graph-contributor
+contract are designed to be reused by those future operations.
+
+## Benchmark API
+
+The live page uses an isolated optional entry point, keeping measurement code out of application
+bundles:
+
+```ts
+import {runGPUDGGSCellProjectionBenchmark} from '@luma.gl/gpgpu/gpu-dggs/benchmarks';
+
+const report = await runGPUDGGSCellProjectionBenchmark(device, {
+  family: 'h3',
+  cells: packedCellWords,
+  projection: 'unit-vector'
+});
+```
+
+The runner accepts low-word/high-word `Uint32Array` input, rejects invalid cells, range-checks
+geographic centers, verifies vector normalization, and returns distributions rather than a single
+best-case sample.

--- a/docs/api-reference/experimental/gpu-dggs.md
+++ b/docs/api-reference/experimental/gpu-dggs.md
@@ -120,10 +120,13 @@ import {runGPUDGGSCellProjectionBenchmark} from '@luma.gl/gpgpu/gpu-dggs/benchma
 const report = await runGPUDGGSCellProjectionBenchmark(device, {
   family: 'h3',
   cells: packedCellWords,
+  referenceValues: precomputedUnitVectorCenters,
   projection: 'unit-vector'
 });
 ```
 
-The runner accepts low-word/high-word `Uint32Array` input, rejects invalid cells, range-checks
-geographic centers, verifies vector normalization, and returns distributions rather than a single
-best-case sample.
+The runner accepts low-word/high-word `Uint32Array` input plus row-matched CPU or precomputed
+reference centers. It rejects invalid cells, compares every output component with that oracle,
+range-checks geographic centers, verifies vector normalization, and returns distributions rather
+than a single best-case sample. Use `referenceTolerance` to override the default `0.03°` geographic
+or `0.002` unit-vector component tolerance.

--- a/docs/api-reference/experimental/gpu-h3.md
+++ b/docs/api-reference/experimental/gpu-h3.md
@@ -1,0 +1,101 @@
+import {ExperimentalDocsTabs} from '@site/src/components/docs/experimental-docs-tabs';
+import {DGGSCellProjectionBenchmark} from '@site/src/components/docs/dggs-cell-projection-benchmark';
+
+# GPU H3
+
+<ExperimentalDocsTabs active="gpu-h3" />
+
+`@luma.gl/gpgpu/gpu-h3` decodes GPU-resident H3 cell indexes into center coordinates. It covers
+every H3 resolution, pentagon topology, and face transition while retaining one output row per
+input cell.
+
+```ts
+import {GPUH3CellProjection} from '@luma.gl/gpgpu/gpu-h3';
+
+new GPUH3CellProjection({
+  cells,
+  output: unitVectors,
+  validity,
+  projection: 'unit-vector'
+}).addToGraph(graph);
+```
+
+The operation is the H3-typed adapter over the shared
+[`GPUDGGSCellProjection`](./gpu-dggs) primitive. It adds no family-specific JavaScript overhead.
+
+## Try it on this device
+
+Choose **H3** in the benchmark below. The six repeated source cells span both hemispheres and a
+wide longitude range; larger row counts expose steady-state throughput without requiring a large
+network download.
+
+<DGGSCellProjectionBenchmark />
+
+## What happens per cell
+
+1. Validate the split-64-bit H3 mode, resolution, base cell, and digit sequence.
+2. Rotate and descend the aperture-7 hierarchy, including Class II/Class III orientation.
+3. Apply pentagon deleted-subsequence rules and leading-digit correction.
+4. Resolve FaceIJK overage across icosahedron faces.
+5. Write either spherical longitude/latitude or an Earth-centered unit vector.
+
+Integer index logic remains exact in WGSL `u32` operations. The final spherical coordinates use
+portable `f32` arithmetic.
+
+## Choosing an output
+
+| Need | Projection | Output | Notes |
+| --- | --- | --- | --- |
+| Globe vertices, angular tests, lighting | `'unit-vector'` | `float32x3` | Lower-transcendental path; naturally normalized |
+| Labels, tooltips, CPU interoperability | `'lnglat'` | `float32x2` | Longitude then latitude in degrees |
+
+The unit-vector path uses precomputed per-face tangent bases and gnomonic normalization. Its fixed
+table is small enough to remain a module-scope shader constant; callers do not manage a table
+buffer or extra binding.
+
+## Preparing H3 indexes
+
+For native little-endian 64-bit storage, a zero-copy word view is sufficient:
+
+```ts
+const h3Indexes = BigUint64Array.from(h3Strings, value => BigInt(`0x${value}`));
+const cellWords = new Uint32Array(h3Indexes.buffer);
+```
+
+Upload `cellWords`, import the buffer into a `GPUCommandGraph`, and create a packed `uint32x2` data
+view. If a data source already stores the high word first, pass `wordOrder: 'high-low'` rather than
+repacking it.
+
+:::note
+**Precision and exact cell encoding.**
+
+Index validation and topology traversal are integer operations. Center projection ends in `f32`,
+so longitude/latitude is intended for visualization and massively parallel analysis rather than
+bit-for-bit reproduction of a CPU `f64` implementation.
+
+The inverse operation—latitude/longitude to H3 cell—is more sensitive. At high resolutions, an
+`f32` coordinate near an edge can select a neighbor. A realistic encoder should generate candidates
+on the GPU and send only boundary-ambiguous rows through an exact CPU verification step.
+:::
+
+## Correctness envelope
+
+The browser test suite compares the GPU path with `h3-js` across:
+
+- all resolutions from 0 through 15;
+- every resolution-zero base cell;
+- globally distributed latitude/longitude samples;
+- neighborhoods around every pentagon at representative resolutions;
+- longitude/latitude and unit-vector output;
+- malformed and reserved split-64-bit indexes.
+
+## Next reusable H3 primitives
+
+The center decoder already supplies the hard pieces future operations need: split-64-bit helpers,
+index validation, hierarchy rotations, pentagon handling, FaceIJK conversion, bounded dispatch, and
+source-aligned validity. Likely follow-ups are:
+
+- a two-pass boundary writer using count → `GPUScan` → write;
+- a hybrid coordinate encoder with an ambiguity mask;
+- fixed-radius neighborhood expansion with explicit output capacity;
+- parent/child transforms that remain entirely in integer space.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -540,7 +540,10 @@
             "label": "GPU Project",
             "items": [
               "api-reference/experimental/gpu-project",
-              "api-reference/experimental/geospatial"
+              "api-reference/experimental/geospatial",
+              "api-reference/experimental/gpu-dggs",
+              "api-reference/experimental/gpu-h3",
+              "api-reference/experimental/gpu-a5"
             ]
           },
           {

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -78,6 +78,10 @@ v10 execution model.
   `@luma.gl/experimental/models`.
 - **Arrow and text stay close to their data** - `@luma.gl/arrow` preserves source batches and type
   metadata. `@luma.gl/text` supports streamed GPU text and shared font resources.
+- **DGGS indexes decode where they are consumed** - Experimental `@luma.gl/gpgpu/gpu-dggs`,
+  `gpu-h3`, and `gpu-a5` command-graph passes project packed cell indexes to longitude/latitude or
+  unit-vector centers without CPU readback. A live, correctness-gated browser benchmark reports
+  completion-fence and compute-only timing on the reader's adapter.
 - **A glimpse of v10 is already running underneath** - Some focused APIs use `GPUCommandGraph`
   internally. Graph authoring, inspection, and tuning remain a v10 preview; 9.4 applications use
   the feature APIs directly.

--- a/modules/gpgpu/README.md
+++ b/modules/gpgpu/README.md
@@ -3,14 +3,18 @@
 General-purpose GPU data and computation for luma.gl.
 
 The stable package root provides the existing portable GPGPU evaluators. Version 9.4 also exposes
-three explicitly experimental subpaths that are not re-exported from the root:
+explicitly experimental subpaths that are not re-exported from the root:
 
 - `@luma.gl/gpgpu/gpu-data` for `GPUData`, `GPUDataView`, `GPUVector`, `GPUConstant`, memory formats,
   and basic buffer/layout helpers;
 - `@luma.gl/gpgpu/gpu-core` for WebGPU command graphs, execution planning, inspection, autotuning,
   and generic algorithms;
 - `@luma.gl/gpgpu/gpu-graph` for graph data structures, topology, analytics, and layouts, plus the
-  optional `@luma.gl/gpgpu/gpu-graph/benchmarks` entry point.
+  optional `@luma.gl/gpgpu/gpu-graph/benchmarks` entry point;
+- `@luma.gl/gpgpu/gpu-dggs` for the shared split-uint64 cell projection primitive, plus the optional
+  `@luma.gl/gpgpu/gpu-dggs/benchmarks` entry point;
+- `@luma.gl/gpgpu/gpu-h3` for GPU-native H3 cell-center decoding; and
+- `@luma.gl/gpgpu/gpu-a5` for the corresponding A5 cell-center projection API.
 
 These experimental subpaths have no 9.4 semver compatibility promise. Higher-level record batches,
 tables, schemas, bindings, and table planners live in `@luma.gl/experimental/gpu-tables`; path and

--- a/modules/gpgpu/package.json
+++ b/modules/gpgpu/package.json
@@ -62,6 +62,26 @@
       "types": "./dist/gpu-graph/benchmarks.d.ts",
       "import": "./dist/gpu-graph/benchmarks.js",
       "require": "./dist/gpu-graph/benchmarks.cjs"
+    },
+    "./gpu-dggs": {
+      "types": "./dist/gpu-dggs/index.d.ts",
+      "import": "./dist/gpu-dggs/index.js",
+      "require": "./dist/gpu-dggs/index.cjs"
+    },
+    "./gpu-dggs/benchmarks": {
+      "types": "./dist/gpu-dggs/benchmarks.d.ts",
+      "import": "./dist/gpu-dggs/benchmarks.js",
+      "require": "./dist/gpu-dggs/benchmarks.cjs"
+    },
+    "./gpu-h3": {
+      "types": "./dist/gpu-h3/index.d.ts",
+      "import": "./dist/gpu-h3/index.js",
+      "require": "./dist/gpu-h3/index.cjs"
+    },
+    "./gpu-a5": {
+      "types": "./dist/gpu-a5/index.d.ts",
+      "import": "./dist/gpu-a5/index.js",
+      "require": "./dist/gpu-a5/index.cjs"
     }
   },
   "files": [

--- a/modules/gpgpu/src/gpu-a5/gpu-a5-cell-projection.ts
+++ b/modules/gpgpu/src/gpu-a5/gpu-a5-cell-projection.ts
@@ -1,0 +1,18 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  GPUDGGSCellProjection,
+  type GPUDGGSCellProjectionProps
+} from '../gpu-dggs/gpu-dggs-cell-projection';
+
+/** Properties for projecting packed A5 cell indexes to geographic centers. */
+export type GPUA5CellProjectionProps = Omit<GPUDGGSCellProjectionProps, 'family'>;
+
+/** Projects A5 cell indexes to center longitude/latitude pairs or unit vectors on the GPU. */
+export class GPUA5CellProjection extends GPUDGGSCellProjection {
+  constructor(props: GPUA5CellProjectionProps) {
+    super({...props, id: props.id ?? 'gpu-a5-cell-projection', family: 'a5'});
+  }
+}

--- a/modules/gpgpu/src/gpu-a5/index.ts
+++ b/modules/gpgpu/src/gpu-a5/index.ts
@@ -1,0 +1,10 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export {GPUA5CellProjection} from './gpu-a5-cell-projection';
+export type {GPUA5CellProjectionProps} from './gpu-a5-cell-projection';
+export type {
+  DGGSCellProjectionKind as GPUA5CellProjectionKind,
+  DGGSCellWordOrder as GPUA5CellWordOrder
+} from '../gpu-dggs/gpu-dggs-cell-projection';

--- a/modules/gpgpu/src/gpu-dggs/benchmarks.ts
+++ b/modules/gpgpu/src/gpu-dggs/benchmarks.ts
@@ -1,0 +1,10 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export {runGPUDGGSCellProjectionBenchmark} from './gpu-dggs-cell-projection-benchmark';
+export type {
+  GPUDGGSCellProjectionBenchmarkDistribution,
+  GPUDGGSCellProjectionBenchmarkProps,
+  GPUDGGSCellProjectionBenchmarkReport
+} from './gpu-dggs-cell-projection-benchmark';

--- a/modules/gpgpu/src/gpu-dggs/gpu-dggs-cell-projection-benchmark.ts
+++ b/modules/gpgpu/src/gpu-dggs/gpu-dggs-cell-projection-benchmark.ts
@@ -1,0 +1,319 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer, type Device, type QuerySet} from '@luma.gl/core';
+import {type CompiledGPUCommandGraph, GPUCommandGraph} from '../gpu-core/gpu-command-graph';
+import {
+  type DGGSCellFamily,
+  type DGGSCellProjectionKind,
+  GPUDGGSCellProjection
+} from './gpu-dggs-cell-projection';
+
+const DEFAULT_WARMUP_ITERATIONS = 2;
+const DEFAULT_MEASURED_ITERATIONS = 7;
+
+/** Distribution of measured DGGS projection durations in milliseconds. */
+export type GPUDGGSCellProjectionBenchmarkDistribution = {
+  minimum: number;
+  median: number;
+  percentile95: number;
+  maximum: number;
+};
+
+/** Options for the correctness-gated DGGS cell-center benchmark. */
+export type GPUDGGSCellProjectionBenchmarkProps = {
+  id?: string;
+  family: DGGSCellFamily;
+  /** Low-word/high-word packed cells. Every cell must be valid for the selected family. */
+  cells: Uint32Array;
+  projection?: DGGSCellProjectionKind;
+  warmupIterations?: number;
+  measuredIterations?: number;
+};
+
+/** Live-device timing report for one DGGS cell projection path. */
+export type GPUDGGSCellProjectionBenchmarkReport = {
+  family: DGGSCellFamily;
+  projection: DGGSCellProjectionKind;
+  cellCount: number;
+  measuredIterations: number;
+  timestampQueries: boolean;
+  memoryByteLength: number;
+  cpuEncodeTimeMilliseconds: GPUDGGSCellProjectionBenchmarkDistribution;
+  synchronizedTimeMilliseconds: GPUDGGSCellProjectionBenchmarkDistribution;
+  synchronizedCellsPerSecond: number;
+  gpuTimeMilliseconds?: GPUDGGSCellProjectionBenchmarkDistribution;
+  gpuCellsPerSecond?: number;
+  validationReadbackTimeMilliseconds: number;
+};
+
+type BenchmarkExecution = {
+  cpuEncodeTimeMilliseconds: number;
+  synchronizedTimeMilliseconds: number;
+  gpuTimeMilliseconds?: number;
+};
+
+/**
+ * Measures one real command-graph DGGS projection on the supplied WebGPU adapter.
+ *
+ * Upload, compilation, and correctness readback are excluded from measured submissions. Every
+ * timing waits for a completion fence, and results are validated before and after measurement.
+ */
+export async function runGPUDGGSCellProjectionBenchmark(
+  device: Device,
+  props: GPUDGGSCellProjectionBenchmarkProps
+): Promise<GPUDGGSCellProjectionBenchmarkReport> {
+  const id = props.id ?? `gpu-${props.family}-cell-projection-benchmark`;
+  const projection = props.projection ?? 'unit-vector';
+  const warmupIterations = props.warmupIterations ?? DEFAULT_WARMUP_ITERATIONS;
+  const measuredIterations = props.measuredIterations ?? DEFAULT_MEASURED_ITERATIONS;
+  validateBenchmarkProps(props.cells, warmupIterations, measuredIterations);
+
+  const cellCount = props.cells.length / 2;
+  const componentCount = projection === 'lnglat' ? 2 : 3;
+  const inputBuffer = device.createBuffer({
+    id: `${id}-cells`,
+    data: props.cells,
+    usage: Buffer.STORAGE | Buffer.COPY_DST
+  });
+  const outputBuffer = device.createBuffer({
+    id: `${id}-output`,
+    byteLength: cellCount * componentCount * Float32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  const validityBuffer = device.createBuffer({
+    id: `${id}-validity`,
+    byteLength: cellCount * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  const graph = new GPUCommandGraph(device, {id});
+  const input = graph.createDataView(
+    graph.importBuffer(
+      {id: `${id}-cells`, byteLength: inputBuffer.byteLength, usage: inputBuffer.usage},
+      inputBuffer
+    ),
+    {format: 'uint32x2', length: cellCount}
+  );
+  const output = graph.createDataView(
+    graph.importBuffer(
+      {id: `${id}-output`, byteLength: outputBuffer.byteLength, usage: outputBuffer.usage},
+      outputBuffer
+    ),
+    {format: projection === 'lnglat' ? 'float32x2' : 'float32x3', length: cellCount}
+  );
+  const validity = graph.createDataView(
+    graph.importBuffer(
+      {
+        id: `${id}-validity`,
+        byteLength: validityBuffer.byteLength,
+        usage: validityBuffer.usage
+      },
+      validityBuffer
+    ),
+    {format: 'uint32', length: cellCount}
+  );
+  new GPUDGGSCellProjection({
+    id,
+    family: props.family,
+    cells: input,
+    output,
+    validity,
+    projection
+  }).addToGraph(graph);
+  const compiled = graph.compile();
+
+  try {
+    await executeBenchmark(device, compiled, `${id}-validation`);
+    let validationReadbackTimeMilliseconds = await validateBenchmarkOutput(
+      outputBuffer,
+      validityBuffer,
+      cellCount,
+      projection
+    );
+    for (let iteration = 0; iteration < warmupIterations; iteration++) {
+      await executeBenchmark(device, compiled, `${id}-warmup-${iteration}`);
+    }
+
+    const executions: BenchmarkExecution[] = [];
+    for (let iteration = 0; iteration < measuredIterations; iteration++) {
+      const querySet = device.features.has('timestamp-query')
+        ? device.createQuerySet({id: `${id}-timestamps-${iteration}`, type: 'timestamp', count: 2})
+        : undefined;
+      try {
+        executions.push(
+          await executeBenchmark(device, compiled, `${id}-measured-${iteration}`, querySet)
+        );
+      } finally {
+        querySet?.destroy();
+      }
+    }
+    validationReadbackTimeMilliseconds = Math.max(
+      validationReadbackTimeMilliseconds,
+      await validateBenchmarkOutput(outputBuffer, validityBuffer, cellCount, projection)
+    );
+
+    const synchronizedTimeMilliseconds = summarizeBenchmarkSamples(
+      executions.map(execution => execution.synchronizedTimeMilliseconds)
+    );
+    const gpuSamples = executions.flatMap(execution =>
+      execution.gpuTimeMilliseconds === undefined ? [] : [execution.gpuTimeMilliseconds]
+    );
+    const gpuTimeMilliseconds =
+      gpuSamples.length > 0 ? summarizeBenchmarkSamples(gpuSamples) : undefined;
+
+    return {
+      family: props.family,
+      projection,
+      cellCount,
+      measuredIterations,
+      timestampQueries: device.features.has('timestamp-query'),
+      memoryByteLength:
+        inputBuffer.byteLength + outputBuffer.byteLength + validityBuffer.byteLength,
+      cpuEncodeTimeMilliseconds: summarizeBenchmarkSamples(
+        executions.map(execution => execution.cpuEncodeTimeMilliseconds)
+      ),
+      synchronizedTimeMilliseconds,
+      synchronizedCellsPerSecond: getThroughput(cellCount, synchronizedTimeMilliseconds.median),
+      ...(gpuTimeMilliseconds
+        ? {
+            gpuTimeMilliseconds,
+            gpuCellsPerSecond: getThroughput(cellCount, gpuTimeMilliseconds.median)
+          }
+        : {}),
+      validationReadbackTimeMilliseconds
+    };
+  } finally {
+    compiled.destroy();
+    validityBuffer.destroy();
+    outputBuffer.destroy();
+    inputBuffer.destroy();
+  }
+}
+
+async function executeBenchmark(
+  device: Device,
+  compiled: CompiledGPUCommandGraph<void>,
+  id: string,
+  querySet?: QuerySet
+): Promise<BenchmarkExecution> {
+  const commandEncoder = device.createCommandEncoder({
+    id,
+    ...(querySet ? {timeProfilingQuerySet: querySet} : {})
+  });
+  let submitted = false;
+  try {
+    const encoding = compiled.encode(commandEncoder, {parameters: undefined});
+    const startTime = getTime();
+    device.submit(commandEncoder.finish());
+    submitted = true;
+    const fence = device.createFence();
+    try {
+      await fence.signaled;
+    } finally {
+      fence.destroy();
+    }
+    const synchronizedTimeMilliseconds = getTime() - startTime;
+    const timing = await encoding.readTimings();
+    return {
+      cpuEncodeTimeMilliseconds: timing.cpuEncodeTimeMilliseconds,
+      synchronizedTimeMilliseconds,
+      gpuTimeMilliseconds: timing.gpuTimeMilliseconds
+    };
+  } catch (error) {
+    if (!submitted) {
+      commandEncoder.destroy();
+    }
+    throw error;
+  }
+}
+
+async function validateBenchmarkOutput(
+  outputBuffer: Buffer,
+  validityBuffer: Buffer,
+  cellCount: number,
+  projection: DGGSCellProjectionKind
+): Promise<number> {
+  const startTime = getTime();
+  const [outputBytes, validityBytes] = await Promise.all([
+    outputBuffer.readAsync(),
+    validityBuffer.readAsync()
+  ]);
+  const componentCount = projection === 'lnglat' ? 2 : 3;
+  const values = new Float32Array(
+    outputBytes.buffer,
+    outputBytes.byteOffset,
+    cellCount * componentCount
+  );
+  const validity = new Uint32Array(validityBytes.buffer, validityBytes.byteOffset, cellCount);
+  for (let cellIndex = 0; cellIndex < cellCount; cellIndex++) {
+    if (validity[cellIndex] !== 1) {
+      throw new Error('DGGS projection benchmark input contains an invalid cell');
+    }
+    const valueOffset = cellIndex * componentCount;
+    if (projection === 'lnglat') {
+      const longitude = values[valueOffset];
+      const latitude = values[valueOffset + 1];
+      if (
+        !Number.isFinite(longitude) ||
+        !Number.isFinite(latitude) ||
+        longitude < -180 ||
+        longitude > 180 ||
+        latitude < -90 ||
+        latitude > 90
+      ) {
+        throw new Error('DGGS projection benchmark produced an invalid geographic center');
+      }
+    } else {
+      const length = Math.hypot(
+        values[valueOffset],
+        values[valueOffset + 1],
+        values[valueOffset + 2]
+      );
+      if (!Number.isFinite(length) || Math.abs(length - 1) > 0.002) {
+        throw new Error('DGGS projection benchmark produced a non-normalized unit vector');
+      }
+    }
+  }
+  return getTime() - startTime;
+}
+
+function validateBenchmarkProps(
+  cells: Uint32Array,
+  warmupIterations: number,
+  measuredIterations: number
+): void {
+  if (cells.length === 0 || cells.length % 2 !== 0) {
+    throw new Error('DGGS projection benchmark cells must contain complete uint32x2 rows');
+  }
+  for (const [name, count] of [
+    ['warmupIterations', warmupIterations],
+    ['measuredIterations', measuredIterations]
+  ] as const) {
+    if (!Number.isSafeInteger(count) || count < (name === 'measuredIterations' ? 1 : 0)) {
+      throw new Error(`DGGS projection benchmark ${name} is invalid`);
+    }
+  }
+}
+
+function summarizeBenchmarkSamples(
+  samples: readonly number[]
+): GPUDGGSCellProjectionBenchmarkDistribution {
+  const sortedSamples = [...samples].sort((left, right) => left - right);
+  const percentile = (fraction: number): number =>
+    sortedSamples[Math.max(0, Math.ceil(fraction * sortedSamples.length) - 1)];
+  return {
+    minimum: sortedSamples[0],
+    median: percentile(0.5),
+    percentile95: percentile(0.95),
+    maximum: sortedSamples[sortedSamples.length - 1]
+  };
+}
+
+function getThroughput(cellCount: number, durationMilliseconds: number): number {
+  return (cellCount * 1000) / durationMilliseconds;
+}
+
+function getTime(): number {
+  return globalThis.performance?.now() ?? Date.now();
+}

--- a/modules/gpgpu/src/gpu-dggs/gpu-dggs-cell-projection-benchmark.ts
+++ b/modules/gpgpu/src/gpu-dggs/gpu-dggs-cell-projection-benchmark.ts
@@ -12,6 +12,8 @@ import {
 
 const DEFAULT_WARMUP_ITERATIONS = 2;
 const DEFAULT_MEASURED_ITERATIONS = 7;
+const DEFAULT_LNGLAT_TOLERANCE = 0.03;
+const DEFAULT_UNIT_VECTOR_TOLERANCE = 0.002;
 
 /** Distribution of measured DGGS projection durations in milliseconds. */
 export type GPUDGGSCellProjectionBenchmarkDistribution = {
@@ -27,7 +29,11 @@ export type GPUDGGSCellProjectionBenchmarkProps = {
   family: DGGSCellFamily;
   /** Low-word/high-word packed cells. Every cell must be valid for the selected family. */
   cells: Uint32Array;
+  /** Row-major CPU or precomputed reference centers matching `cells` and `projection`. */
+  referenceValues: Float32Array;
   projection?: DGGSCellProjectionKind;
+  /** Maximum absolute component error. Longitude differences wrap across the antimeridian. */
+  referenceTolerance?: number;
   warmupIterations?: number;
   measuredIterations?: number;
 };
@@ -46,6 +52,7 @@ export type GPUDGGSCellProjectionBenchmarkReport = {
   gpuTimeMilliseconds?: GPUDGGSCellProjectionBenchmarkDistribution;
   gpuCellsPerSecond?: number;
   validationReadbackTimeMilliseconds: number;
+  referenceTolerance: number;
 };
 
 type BenchmarkExecution = {
@@ -68,68 +75,85 @@ export async function runGPUDGGSCellProjectionBenchmark(
   const projection = props.projection ?? 'unit-vector';
   const warmupIterations = props.warmupIterations ?? DEFAULT_WARMUP_ITERATIONS;
   const measuredIterations = props.measuredIterations ?? DEFAULT_MEASURED_ITERATIONS;
-  validateBenchmarkProps(props.cells, warmupIterations, measuredIterations);
-
   const cellCount = props.cells.length / 2;
   const componentCount = projection === 'lnglat' ? 2 : 3;
-  const inputBuffer = device.createBuffer({
-    id: `${id}-cells`,
-    data: props.cells,
-    usage: Buffer.STORAGE | Buffer.COPY_DST
-  });
-  const outputBuffer = device.createBuffer({
-    id: `${id}-output`,
-    byteLength: cellCount * componentCount * Float32Array.BYTES_PER_ELEMENT,
-    usage: Buffer.STORAGE | Buffer.COPY_SRC
-  });
-  const validityBuffer = device.createBuffer({
-    id: `${id}-validity`,
-    byteLength: cellCount * Uint32Array.BYTES_PER_ELEMENT,
-    usage: Buffer.STORAGE | Buffer.COPY_SRC
-  });
-  const graph = new GPUCommandGraph(device, {id});
-  const input = graph.createDataView(
-    graph.importBuffer(
-      {id: `${id}-cells`, byteLength: inputBuffer.byteLength, usage: inputBuffer.usage},
-      inputBuffer
-    ),
-    {format: 'uint32x2', length: cellCount}
+  const referenceTolerance =
+    props.referenceTolerance ??
+    (projection === 'lnglat' ? DEFAULT_LNGLAT_TOLERANCE : DEFAULT_UNIT_VECTOR_TOLERANCE);
+  validateBenchmarkProps(
+    props.cells,
+    props.referenceValues,
+    componentCount,
+    referenceTolerance,
+    warmupIterations,
+    measuredIterations
   );
-  const output = graph.createDataView(
-    graph.importBuffer(
-      {id: `${id}-output`, byteLength: outputBuffer.byteLength, usage: outputBuffer.usage},
-      outputBuffer
-    ),
-    {format: projection === 'lnglat' ? 'float32x2' : 'float32x3', length: cellCount}
-  );
-  const validity = graph.createDataView(
-    graph.importBuffer(
-      {
-        id: `${id}-validity`,
-        byteLength: validityBuffer.byteLength,
-        usage: validityBuffer.usage
-      },
-      validityBuffer
-    ),
-    {format: 'uint32', length: cellCount}
-  );
-  new GPUDGGSCellProjection({
-    id,
-    family: props.family,
-    cells: input,
-    output,
-    validity,
-    projection
-  }).addToGraph(graph);
-  const compiled = graph.compile();
+
+  let inputBuffer: Buffer | undefined;
+  let outputBuffer: Buffer | undefined;
+  let validityBuffer: Buffer | undefined;
+  let compiled: CompiledGPUCommandGraph<void> | undefined;
 
   try {
+    inputBuffer = device.createBuffer({
+      id: `${id}-cells`,
+      data: props.cells,
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+    outputBuffer = device.createBuffer({
+      id: `${id}-output`,
+      byteLength: cellCount * componentCount * Float32Array.BYTES_PER_ELEMENT,
+      usage: Buffer.STORAGE | Buffer.COPY_SRC
+    });
+    validityBuffer = device.createBuffer({
+      id: `${id}-validity`,
+      byteLength: cellCount * Uint32Array.BYTES_PER_ELEMENT,
+      usage: Buffer.STORAGE | Buffer.COPY_SRC
+    });
+    const graph = new GPUCommandGraph(device, {id});
+    const input = graph.createDataView(
+      graph.importBuffer(
+        {id: `${id}-cells`, byteLength: inputBuffer.byteLength, usage: inputBuffer.usage},
+        inputBuffer
+      ),
+      {format: 'uint32x2', length: cellCount}
+    );
+    const output = graph.createDataView(
+      graph.importBuffer(
+        {id: `${id}-output`, byteLength: outputBuffer.byteLength, usage: outputBuffer.usage},
+        outputBuffer
+      ),
+      {format: projection === 'lnglat' ? 'float32x2' : 'float32x3', length: cellCount}
+    );
+    const validity = graph.createDataView(
+      graph.importBuffer(
+        {
+          id: `${id}-validity`,
+          byteLength: validityBuffer.byteLength,
+          usage: validityBuffer.usage
+        },
+        validityBuffer
+      ),
+      {format: 'uint32', length: cellCount}
+    );
+    new GPUDGGSCellProjection({
+      id,
+      family: props.family,
+      cells: input,
+      output,
+      validity,
+      projection
+    }).addToGraph(graph);
+    compiled = graph.compile();
+
     await executeBenchmark(device, compiled, `${id}-validation`);
     let validationReadbackTimeMilliseconds = await validateBenchmarkOutput(
       outputBuffer,
       validityBuffer,
       cellCount,
-      projection
+      projection,
+      props.referenceValues,
+      referenceTolerance
     );
     for (let iteration = 0; iteration < warmupIterations; iteration++) {
       await executeBenchmark(device, compiled, `${id}-warmup-${iteration}`);
@@ -150,7 +174,14 @@ export async function runGPUDGGSCellProjectionBenchmark(
     }
     validationReadbackTimeMilliseconds = Math.max(
       validationReadbackTimeMilliseconds,
-      await validateBenchmarkOutput(outputBuffer, validityBuffer, cellCount, projection)
+      await validateBenchmarkOutput(
+        outputBuffer,
+        validityBuffer,
+        cellCount,
+        projection,
+        props.referenceValues,
+        referenceTolerance
+      )
     );
 
     const synchronizedTimeMilliseconds = summarizeBenchmarkSamples(
@@ -181,13 +212,14 @@ export async function runGPUDGGSCellProjectionBenchmark(
             gpuCellsPerSecond: getThroughput(cellCount, gpuTimeMilliseconds.median)
           }
         : {}),
-      validationReadbackTimeMilliseconds
+      validationReadbackTimeMilliseconds,
+      referenceTolerance
     };
   } finally {
-    compiled.destroy();
-    validityBuffer.destroy();
-    outputBuffer.destroy();
-    inputBuffer.destroy();
+    compiled?.destroy();
+    validityBuffer?.destroy();
+    outputBuffer?.destroy();
+    inputBuffer?.destroy();
   }
 }
 
@@ -232,7 +264,9 @@ async function validateBenchmarkOutput(
   outputBuffer: Buffer,
   validityBuffer: Buffer,
   cellCount: number,
-  projection: DGGSCellProjectionKind
+  projection: DGGSCellProjectionKind,
+  referenceValues: Float32Array,
+  referenceTolerance: number
 ): Promise<number> {
   const startTime = getTime();
   const [outputBytes, validityBytes] = await Promise.all([
@@ -274,17 +308,37 @@ async function validateBenchmarkOutput(
         throw new Error('DGGS projection benchmark produced a non-normalized unit vector');
       }
     }
+    for (let componentIndex = 0; componentIndex < componentCount; componentIndex++) {
+      const value = values[valueOffset + componentIndex];
+      const referenceValue = referenceValues[valueOffset + componentIndex];
+      const difference =
+        projection === 'lnglat' && componentIndex === 0
+          ? getLongitudeDifference(value, referenceValue)
+          : Math.abs(value - referenceValue);
+      if (!Number.isFinite(referenceValue) || difference > referenceTolerance) {
+        throw new Error('DGGS projection benchmark output does not match reference values');
+      }
+    }
   }
   return getTime() - startTime;
 }
 
 function validateBenchmarkProps(
   cells: Uint32Array,
+  referenceValues: Float32Array,
+  componentCount: number,
+  referenceTolerance: number,
   warmupIterations: number,
   measuredIterations: number
 ): void {
   if (cells.length === 0 || cells.length % 2 !== 0) {
     throw new Error('DGGS projection benchmark cells must contain complete uint32x2 rows');
+  }
+  if (referenceValues.length !== (cells.length / 2) * componentCount) {
+    throw new Error('DGGS projection benchmark reference values must match every output component');
+  }
+  if (!Number.isFinite(referenceTolerance) || referenceTolerance < 0) {
+    throw new Error('DGGS projection benchmark reference tolerance is invalid');
   }
   for (const [name, count] of [
     ['warmupIterations', warmupIterations],
@@ -294,6 +348,11 @@ function validateBenchmarkProps(
       throw new Error(`DGGS projection benchmark ${name} is invalid`);
     }
   }
+}
+
+function getLongitudeDifference(left: number, right: number): number {
+  const difference = Math.abs(left - right) % 360;
+  return Math.min(difference, 360 - difference);
 }
 
 function summarizeBenchmarkSamples(

--- a/modules/gpgpu/src/gpu-dggs/gpu-dggs-cell-projection.ts
+++ b/modules/gpgpu/src/gpu-dggs/gpu-dggs-cell-projection.ts
@@ -1,0 +1,232 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {dggs} from '@luma.gl/shadertools';
+import {
+  GPUCommandGraph,
+  type GPUCommandGraphContributor,
+  type GraphDataView
+} from '../gpu-core/gpu-command-graph';
+import {
+  getViewBinding,
+  getViewElementOffset,
+  validatePackedUint32View,
+  validatePackedView
+} from '../gpu-core/graph-data-view-utils';
+import {
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource
+} from '../gpu-core/gpu-dispatch-utils';
+
+const DGGS_CELL_PROJECTION_WORKGROUP_SIZE = 256;
+
+export type DGGSCellProjectionKind = 'lnglat' | 'unit-vector';
+export type DGGSCellWordOrder = 'little-endian' | 'high-low';
+export type DGGSCellProjectionOutputFormat = 'float32x2' | 'float32x3';
+
+/** DGGS index families implemented by the shared cell projection kernel. */
+export type DGGSCellFamily = 'h3' | 'a5';
+
+/** Properties for the family-neutral split-uint64 DGGS projection primitive. */
+export type GPUDGGSCellProjectionProps = {
+  id?: string;
+  family: 'h3' | 'a5';
+  cells: GraphDataView<'uint32x2'>;
+  output: GraphDataView<DGGSCellProjectionOutputFormat>;
+  validity?: GraphDataView<'uint32'>;
+  projection?: DGGSCellProjectionKind;
+  wordOrder?: DGGSCellWordOrder;
+};
+
+type NormalizedDGGSCellProjectionProps = Required<
+  Pick<GPUDGGSCellProjectionProps, 'id' | 'family' | 'projection' | 'wordOrder'>
+> &
+  Pick<GPUDGGSCellProjectionProps, 'cells' | 'output' | 'validity'>;
+
+/**
+ * Family-neutral command-graph primitive for projecting packed DGGS cell indexes.
+ *
+ * Prefer the H3 and A5 subclasses when the family is known statically. This class is useful for
+ * planners, benchmarks, and applications that select a supported grid at runtime.
+ */
+export class GPUDGGSCellProjection implements GPUCommandGraphContributor {
+  readonly id: string;
+  readonly family: DGGSCellFamily;
+  readonly cells: GraphDataView<'uint32x2'>;
+  readonly output: GraphDataView<DGGSCellProjectionOutputFormat>;
+  readonly validity?: GraphDataView<'uint32'>;
+  readonly projection: DGGSCellProjectionKind;
+  readonly wordOrder: DGGSCellWordOrder;
+
+  constructor(props: GPUDGGSCellProjectionProps) {
+    this.id = props.id ?? `gpu-${props.family}-cell-projection`;
+    this.family = props.family;
+    this.cells = props.cells;
+    this.output = props.output;
+    this.validity = props.validity;
+    this.projection = props.projection ?? 'lnglat';
+    this.wordOrder = props.wordOrder ?? 'little-endian';
+    validateDGGSCellProjection(this);
+  }
+
+  /** Adds one source-aligned projection pass without submitting or reading data back. */
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    addDGGSCellProjectionToGraph(graph, this);
+  }
+}
+
+function validateDGGSCellProjection(props: NormalizedDGGSCellProjectionProps): void {
+  validatePackedView(props.cells, ['uint32x2'], `${props.id} cells`);
+  validatePackedView(props.output, ['float32x2', 'float32x3'], `${props.id} output`);
+  if (props.validity) {
+    validatePackedUint32View(props.validity, `${props.id} validity`);
+  }
+  const expectedFormat = props.projection === 'lnglat' ? 'float32x2' : 'float32x3';
+  if (props.output.format !== expectedFormat) {
+    throw new Error(`${props.id} ${props.projection} output must use ${expectedFormat}`);
+  }
+  if (
+    props.output.length !== props.cells.length ||
+    (props.validity && props.validity.length !== props.cells.length)
+  ) {
+    throw new Error(`${props.id} cells, output, and validity must have matching lengths`);
+  }
+  if (
+    props.output.buffer === props.cells.buffer ||
+    props.validity?.buffer === props.cells.buffer ||
+    props.validity?.buffer === props.output.buffer
+  ) {
+    throw new Error(`${props.id} cells, output, and validity must use separate buffers`);
+  }
+}
+
+function addDGGSCellProjectionToGraph<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  props: NormalizedDGGSCellProjectionProps
+): void {
+  for (const view of [props.cells, props.output, props.validity]) {
+    if (view && view.buffer.graph !== graph) {
+      throw new Error(`${props.id} views must belong to the target graph`);
+    }
+  }
+  if (props.cells.length === 0) {
+    return;
+  }
+
+  const dispatchLayout = getBoundedDispatchLayout(
+    props.id,
+    props.cells.length,
+    DGGS_CELL_PROJECTION_WORKGROUP_SIZE,
+    graph.device.limits.maxComputeWorkgroupsPerDimension
+  );
+  const source = getDGGSCellProjectionShaderSource(props, dispatchLayout);
+  const views = {
+    cells: props.cells,
+    projectedValues: props.output,
+    ...(props.validity ? {validity: props.validity} : {})
+  };
+  graph.addComputePass({
+    id: props.id,
+    workload: {
+      operation: `${props.family.toUpperCase()}CellProjection`,
+      commandCount: 1,
+      maximumWorkgroupCount: dispatchLayout.x * dispatchLayout.y * dispatchLayout.z,
+      maximumInvocationCount:
+        dispatchLayout.x *
+        dispatchLayout.y *
+        dispatchLayout.z *
+        DGGS_CELL_PROJECTION_WORKGROUP_SIZE,
+      readByteLength: props.cells.length * 2 * Uint32Array.BYTES_PER_ELEMENT,
+      writeByteLength:
+        props.output.length * props.output.rowByteLength +
+        (props.validity?.length ?? 0) * Uint32Array.BYTES_PER_ELEMENT
+    },
+    resources: [
+      {buffer: props.cells, usage: 'storage-read'},
+      {buffer: props.output, usage: 'storage-write'},
+      ...(props.validity ? [{buffer: props.validity, usage: 'storage-write'} as const] : [])
+    ],
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id: props.id,
+        source,
+        shaderLayout: {
+          bindings: Object.keys(views).map((name, location) => ({
+            name,
+            type: name === 'cells' ? ('read-only-storage' as const) : ('storage' as const),
+            group: 0,
+            location
+          }))
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const bindings: Record<string, Binding> = {};
+          for (const [name, view] of Object.entries(views)) {
+            bindings[name] = getViewBinding(view, getBuffer);
+          }
+          computation.setBindings(bindings);
+          computation.dispatch(computePass, dispatchLayout.x, dispatchLayout.y, dispatchLayout.z);
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+function getDGGSCellProjectionShaderSource(
+  props: NormalizedDGGSCellProjectionProps,
+  dispatchLayout: {x: number; y: number; z: number}
+): string {
+  const componentCount = props.projection === 'lnglat' ? 2 : 3;
+  const projectionFunction = `dggs_${props.family}_get_center_${
+    props.projection === 'lnglat' ? 'lnglat' : 'unit_vector'
+  }`;
+  const validityExpression =
+    props.family === 'h3'
+      ? 'dggs_h3_is_valid_cell_id(cell)'
+      : 'dggs_a5_deserialize(cell).valid != 0u && !dggs_u64_is_zero(cell)';
+  const canonicalCell =
+    props.wordOrder === 'little-endian' ? 'dggs_u64_from_little_endian_words(words)' : 'words';
+  const validityBinding = props.validity
+    ? '@group(0) @binding(2) var<storage, read_write> validity: array<u32>;'
+    : '';
+  const validityWrite = props.validity
+    ? `validity[${getViewElementOffset(props.validity)}u + index] = select(0u, 1u, isValid);`
+    : '';
+
+  return /* wgsl */ `${dggs.source}
+const CELL_COUNT: u32 = ${props.cells.length}u;
+const CELLS_OFFSET: u32 = ${getViewElementOffset(props.cells)}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
+
+@group(0) @binding(0) var<storage, read> cells: array<u32>;
+@group(0) @binding(1) var<storage, read_write> projectedValues: array<f32>;
+${validityBinding}
+
+@compute @workgroup_size(${DGGS_CELL_PROJECTION_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3u,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getBoundedInvocationIndexSource(dispatchLayout, DGGS_CELL_PROJECTION_WORKGROUP_SIZE)}
+  if (index >= CELL_COUNT) {
+    return;
+  }
+  let wordOffset = CELLS_OFFSET + index * 2u;
+  let words = vec2u(cells[wordOffset], cells[wordOffset + 1u]);
+  let cell = ${canonicalCell};
+  let isValid = ${validityExpression};
+  let projected = select(${props.projection === 'lnglat' ? 'vec2f(0.0)' : 'vec3f(0.0)'}, ${projectionFunction}(cell), isValid);
+  let outputOffset = OUTPUT_OFFSET + index * ${componentCount}u;
+  ${Array.from(
+    {length: componentCount},
+    (_, componentIndex) =>
+      `projectedValues[outputOffset + ${componentIndex}u] = projected[${componentIndex}u];`
+  ).join('\n  ')}
+  ${validityWrite}
+}`;
+}

--- a/modules/gpgpu/src/gpu-dggs/index.ts
+++ b/modules/gpgpu/src/gpu-dggs/index.ts
@@ -1,0 +1,12 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export {GPUDGGSCellProjection} from './gpu-dggs-cell-projection';
+export type {
+  DGGSCellFamily,
+  DGGSCellProjectionKind,
+  DGGSCellProjectionOutputFormat,
+  DGGSCellWordOrder,
+  GPUDGGSCellProjectionProps
+} from './gpu-dggs-cell-projection';

--- a/modules/gpgpu/src/gpu-h3/gpu-h3-cell-projection.ts
+++ b/modules/gpgpu/src/gpu-h3/gpu-h3-cell-projection.ts
@@ -1,0 +1,24 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  GPUDGGSCellProjection,
+  type GPUDGGSCellProjectionProps
+} from '../gpu-dggs/gpu-dggs-cell-projection';
+
+/** Properties for projecting packed H3 cell indexes to geographic centers. */
+export type GPUH3CellProjectionProps = Omit<GPUDGGSCellProjectionProps, 'family'>;
+
+/**
+ * Projects H3 cell indexes to center longitude/latitude pairs or unit vectors on the GPU.
+ *
+ * The operation implements split-uint64 validation, pentagon digit handling, and icosahedron face
+ * overage without CPU readback. Invalid rows produce zero coordinates and may be exposed through a
+ * separate validity view.
+ */
+export class GPUH3CellProjection extends GPUDGGSCellProjection {
+  constructor(props: GPUH3CellProjectionProps) {
+    super({...props, id: props.id ?? 'gpu-h3-cell-projection', family: 'h3'});
+  }
+}

--- a/modules/gpgpu/src/gpu-h3/index.ts
+++ b/modules/gpgpu/src/gpu-h3/index.ts
@@ -1,0 +1,10 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export {GPUH3CellProjection} from './gpu-h3-cell-projection';
+export type {GPUH3CellProjectionProps} from './gpu-h3-cell-projection';
+export type {
+  DGGSCellProjectionKind as GPUH3CellProjectionKind,
+  DGGSCellWordOrder as GPUH3CellWordOrder
+} from '../gpu-dggs/gpu-dggs-cell-projection';

--- a/modules/gpgpu/test/gpu-a5/gpu-a5-cell-projection.spec.ts
+++ b/modules/gpgpu/test/gpu-a5/gpu-a5-cell-projection.spec.ts
@@ -1,0 +1,129 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {GPUA5CellProjection} from '@luma.gl/gpgpu/gpu-a5';
+import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import test from 'test/utils/vitest-tape';
+
+const A5_CELLS = [
+  0x0200000000000000n,
+  0x0500000000000000n,
+  0x1a38000000000000n,
+  0x2628000000000000n,
+  0x35bd75e8fee1100dn
+];
+
+test('GPUA5CellProjection projects representative A5 resolutions to geographic centers', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const longitudeLatitudes = await runA5Projection(device, A5_CELLS, 'lnglat');
+  const unitVectors = await runA5Projection(device, A5_CELLS, 'unit-vector');
+  for (let cellIndex = 0; cellIndex < A5_CELLS.length; cellIndex++) {
+    const longitude = longitudeLatitudes.values[cellIndex * 2];
+    const latitude = longitudeLatitudes.values[cellIndex * 2 + 1];
+    t.ok(
+      Number.isFinite(longitude) && longitude >= -180 && longitude <= 180,
+      `cell ${A5_CELLS[cellIndex].toString(16)} longitude ${longitude} is finite`
+    );
+    t.ok(
+      Number.isFinite(latitude) && latitude >= -90 && latitude <= 90,
+      `cell ${A5_CELLS[cellIndex].toString(16)} latitude ${latitude} is finite`
+    );
+    t.equal(longitudeLatitudes.validity[cellIndex], 1, 'valid A5 cell sets the validity mask');
+
+    const x = unitVectors.values[cellIndex * 3];
+    const y = unitVectors.values[cellIndex * 3 + 1];
+    const z = unitVectors.values[cellIndex * 3 + 2];
+    t.ok(Math.abs(Math.hypot(x, y, z) - 1) < 0.001, 'unit-vector output is normalized');
+    t.equal(unitVectors.validity[cellIndex], 1, 'unit-vector projection preserves validity');
+  }
+  t.end();
+});
+
+test('GPUA5CellProjection rejects the reserved zero index', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const result = await runA5Projection(device, [0n], 'lnglat');
+  t.deepEqual(Array.from(result.values), [0, 0], 'invalid rows produce zero coordinates');
+  t.deepEqual(Array.from(result.validity), [0], 'invalid rows clear the validity mask');
+  t.end();
+});
+
+type A5ProjectionKind = 'lnglat' | 'unit-vector';
+
+async function runA5Projection(
+  device: Device,
+  cells: bigint[],
+  projection: A5ProjectionKind
+): Promise<{values: Float32Array; validity: Uint32Array}> {
+  const componentCount = projection === 'lnglat' ? 2 : 3;
+  const inputBuffer = device.createBuffer({
+    data: new Uint32Array(BigUint64Array.from(cells).buffer),
+    usage: Buffer.STORAGE | Buffer.COPY_DST
+  });
+  const outputBuffer = device.createBuffer({
+    byteLength: cells.length * componentCount * Float32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  const validityBuffer = device.createBuffer({
+    byteLength: cells.length * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  const graph = new GPUCommandGraph(device);
+  const inputHandle = graph.importBuffer(
+    {id: 'cells', byteLength: inputBuffer.byteLength, usage: inputBuffer.usage},
+    inputBuffer
+  );
+  const outputHandle = graph.importBuffer(
+    {id: 'output', byteLength: outputBuffer.byteLength, usage: outputBuffer.usage},
+    outputBuffer
+  );
+  const validityHandle = graph.importBuffer(
+    {id: 'validity', byteLength: validityBuffer.byteLength, usage: validityBuffer.usage},
+    validityBuffer
+  );
+  const input = graph.createDataView(inputHandle, {format: 'uint32x2', length: cells.length});
+  const output = graph.createDataView(outputHandle, {
+    format: projection === 'lnglat' ? 'float32x2' : 'float32x3',
+    length: cells.length
+  });
+  const validity = graph.createDataView(validityHandle, {format: 'uint32', length: cells.length});
+  new GPUA5CellProjection({cells: input, output, validity, projection}).addToGraph(graph);
+  const compiled = graph.compile();
+
+  try {
+    const commandEncoder = device.createCommandEncoder({id: `gpu-a5-${projection}-test`});
+    compiled.encode(commandEncoder, {parameters: undefined});
+    device.submit(commandEncoder.finish());
+    const [valueBytes, validityBytes] = await Promise.all([
+      outputBuffer.readAsync(),
+      validityBuffer.readAsync()
+    ]);
+    return {
+      values: new Float32Array(
+        valueBytes.buffer,
+        valueBytes.byteOffset,
+        cells.length * componentCount
+      ),
+      validity: new Uint32Array(validityBytes.buffer, validityBytes.byteOffset, cells.length)
+    };
+  } finally {
+    compiled.destroy();
+    inputBuffer.destroy();
+    outputBuffer.destroy();
+    validityBuffer.destroy();
+  }
+}

--- a/modules/gpgpu/test/gpu-dggs/gpu-dggs-cell-projection-benchmark.spec.ts
+++ b/modules/gpgpu/test/gpu-dggs/gpu-dggs-cell-projection-benchmark.spec.ts
@@ -1,0 +1,53 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {runGPUDGGSCellProjectionBenchmark} from '@luma.gl/gpgpu/gpu-dggs/benchmarks';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import test from 'test/utils/vitest-tape';
+
+const H3_CELLS = [0x089283082803ffffn, 0x089754e64993ffffn];
+const A5_CELLS = [0x0200000000000000n, 0x35bd75e8fee1100dn];
+
+test('DGGS cell projection benchmark validates and measures H3 and A5 paths', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  for (const [family, cells] of [
+    ['h3', H3_CELLS],
+    ['a5', A5_CELLS]
+  ] as const) {
+    const report = await runGPUDGGSCellProjectionBenchmark(device, {
+      family,
+      cells: makeLittleEndianWords(cells, 256),
+      projection: 'unit-vector',
+      warmupIterations: 0,
+      measuredIterations: 1
+    });
+    t.equal(report.family, family, `${family} family is reported`);
+    t.equal(report.cellCount, 256, `${family} row count is reported`);
+    t.ok(
+      Number.isFinite(report.synchronizedCellsPerSecond) && report.synchronizedCellsPerSecond > 0,
+      `${family} synchronized throughput is measured`
+    );
+    t.ok(
+      report.validationReadbackTimeMilliseconds >= 0,
+      `${family} correctness readback is measured separately`
+    );
+  }
+  t.end();
+});
+
+function makeLittleEndianWords(cells: readonly bigint[], cellCount: number): Uint32Array {
+  const words = new Uint32Array(cellCount * 2);
+  for (let cellIndex = 0; cellIndex < cellCount; cellIndex++) {
+    const cell = cells[cellIndex % cells.length];
+    words[cellIndex * 2] = Number(cell & 0xffffffffn);
+    words[cellIndex * 2 + 1] = Number(cell >> 32n);
+  }
+  return words;
+}

--- a/modules/gpgpu/test/gpu-dggs/gpu-dggs-cell-projection-benchmark.spec.ts
+++ b/modules/gpgpu/test/gpu-dggs/gpu-dggs-cell-projection-benchmark.spec.ts
@@ -5,9 +5,27 @@
 import {runGPUDGGSCellProjectionBenchmark} from '@luma.gl/gpgpu/gpu-dggs/benchmarks';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import test from 'test/utils/vitest-tape';
+import {expect} from 'vitest';
 
 const H3_CELLS = [0x089283082803ffffn, 0x089754e64993ffffn];
-const A5_CELLS = [0x0200000000000000n, 0x35bd75e8fee1100dn];
+const A5_CELLS = [
+  0x0200000000000000n,
+  0x0500000000000000n,
+  0x1a38000000000000n,
+  0x2628000000000000n,
+  0x35bd75e8fee1100dn
+];
+const H3_REFERENCE_LNGLATS = [
+  [-122.4182710369247, 37.773515097238146],
+  [-0.0010418183700719888, 0.0005857701415174007]
+] as const;
+const A5_REFERENCE_LNGLATS = [
+  [-93, 90],
+  [123, 69.09240188013534],
+  [-120.36040534450211, 38.61273252471863],
+  [-70.23755667780222, 43.618118491958555],
+  [-122.41999998343744, 37.77999999438284]
+] as const;
 
 test('DGGS cell projection benchmark validates and measures H3 and A5 paths', async t => {
   const device = await getWebGPUTestDevice();
@@ -17,13 +35,14 @@ test('DGGS cell projection benchmark validates and measures H3 and A5 paths', as
     return;
   }
 
-  for (const [family, cells] of [
-    ['h3', H3_CELLS],
-    ['a5', A5_CELLS]
+  for (const [family, cells, referenceLongitudeLatitudes] of [
+    ['h3', H3_CELLS, H3_REFERENCE_LNGLATS],
+    ['a5', A5_CELLS, A5_REFERENCE_LNGLATS]
   ] as const) {
     const report = await runGPUDGGSCellProjectionBenchmark(device, {
       family,
       cells: makeLittleEndianWords(cells, 256),
+      referenceValues: makeUnitVectorReferences(referenceLongitudeLatitudes, 256),
       projection: 'unit-vector',
       warmupIterations: 0,
       measuredIterations: 1
@@ -39,8 +58,40 @@ test('DGGS cell projection benchmark validates and measures H3 and A5 paths', as
       `${family} correctness readback is measured separately`
     );
   }
+
+  const incorrectReferences = makeUnitVectorReferences(H3_REFERENCE_LNGLATS, H3_CELLS.length);
+  incorrectReferences[0] = 0;
+  await expect(
+    runGPUDGGSCellProjectionBenchmark(device, {
+      family: 'h3',
+      cells: makeLittleEndianWords(H3_CELLS, H3_CELLS.length),
+      referenceValues: incorrectReferences,
+      projection: 'unit-vector',
+      warmupIterations: 0,
+      measuredIterations: 1
+    })
+  ).rejects.toThrow(/reference values/);
   t.end();
 });
+
+function makeUnitVectorReferences(
+  longitudeLatitudes: ReadonlyArray<readonly [number, number]>,
+  cellCount: number
+): Float32Array {
+  const values = new Float32Array(cellCount * 3);
+  for (let cellIndex = 0; cellIndex < cellCount; cellIndex++) {
+    const [longitudeDegrees, latitudeDegrees] =
+      longitudeLatitudes[cellIndex % longitudeLatitudes.length];
+    const longitude = longitudeDegrees * (Math.PI / 180);
+    const latitude = latitudeDegrees * (Math.PI / 180);
+    const cosLatitude = Math.cos(latitude);
+    values.set(
+      [cosLatitude * Math.cos(longitude), cosLatitude * Math.sin(longitude), Math.sin(latitude)],
+      cellIndex * 3
+    );
+  }
+  return values;
+}
 
 function makeLittleEndianWords(cells: readonly bigint[], cellCount: number): Uint32Array {
   const words = new Uint32Array(cellCount * 2);

--- a/modules/gpgpu/test/gpu-h3/gpu-h3-cell-projection.spec.ts
+++ b/modules/gpgpu/test/gpu-h3/gpu-h3-cell-projection.spec.ts
@@ -33,7 +33,7 @@ test('GPUH3CellProjection matches h3-js for global, pentagon, and high-resolutio
     t.ok(
       longitudeError <= GEOGRAPHIC_TOLERANCE_DEGREES &&
         latitudeError <= GEOGRAPHIC_TOLERANCE_DEGREES,
-      `cell ${cells[cellIndex]} center agrees with h3-js`
+      `cell ${cells[cellIndex]} center agrees with h3-js (GPU ${longitudeLatitudes.values[cellIndex * 2]}, ${longitudeLatitudes.values[cellIndex * 2 + 1]}; CPU ${longitude}, ${latitude})`
     );
     t.equal(longitudeLatitudes.validity[cellIndex], 1, 'valid cell sets the validity mask');
 

--- a/modules/gpgpu/test/gpu-h3/gpu-h3-cell-projection.spec.ts
+++ b/modules/gpgpu/test/gpu-h3/gpu-h3-cell-projection.spec.ts
@@ -1,0 +1,179 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
+import {GPUH3CellProjection} from '@luma.gl/gpgpu/gpu-h3';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import {cellToLatLng, getPentagons, getRes0Cells, gridDisk, latLngToCell} from 'h3-js';
+import test from 'test/utils/vitest-tape';
+
+const GEOGRAPHIC_TOLERANCE_DEGREES = 0.03;
+const UNIT_VECTOR_TOLERANCE = 0.0006;
+
+test('GPUH3CellProjection matches h3-js for global, pentagon, and high-resolution cells', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const cells = makeH3Cells();
+  const longitudeLatitudes = await runH3Projection(device, cells, 'lnglat');
+  const unitVectors = await runH3Projection(device, cells, 'unit-vector');
+
+  for (let cellIndex = 0; cellIndex < cells.length; cellIndex++) {
+    const [latitude, longitude] = cellToLatLng(cells[cellIndex]);
+    const longitudeError = Math.abs(
+      normalizeLongitude(longitudeLatitudes.values[cellIndex * 2] - longitude)
+    );
+    const latitudeError = Math.abs(longitudeLatitudes.values[cellIndex * 2 + 1] - latitude);
+    t.ok(
+      longitudeError <= GEOGRAPHIC_TOLERANCE_DEGREES &&
+        latitudeError <= GEOGRAPHIC_TOLERANCE_DEGREES,
+      `cell ${cells[cellIndex]} center agrees with h3-js`
+    );
+    t.equal(longitudeLatitudes.validity[cellIndex], 1, 'valid cell sets the validity mask');
+
+    const expectedUnitVector = makeUnitVector(longitude, latitude);
+    for (let component = 0; component < 3; component++) {
+      t.ok(
+        Math.abs(unitVectors.values[cellIndex * 3 + component] - expectedUnitVector[component]) <=
+          UNIT_VECTOR_TOLERANCE,
+        `cell ${cells[cellIndex]} unit-vector component ${component} agrees with h3-js`
+      );
+    }
+    t.equal(unitVectors.validity[cellIndex], 1, 'unit-vector projection preserves validity');
+  }
+
+  t.end();
+});
+
+test('GPUH3CellProjection rejects invalid split-uint64 rows', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const validCell = latLngToCell(37.775, -122.418, 9);
+  const invalidCells = [0n, BigInt(`0x${validCell}`) | (1n << 63n)];
+  const result = await runH3Projection(device, invalidCells, 'lnglat');
+  t.deepEqual(Array.from(result.values), [0, 0, 0, 0], 'invalid rows produce zero coordinates');
+  t.deepEqual(Array.from(result.validity), [0, 0], 'invalid rows clear the validity mask');
+  t.end();
+});
+
+type H3ProjectionKind = 'lnglat' | 'unit-vector';
+
+async function runH3Projection(
+  device: Device,
+  cells: Array<string | bigint>,
+  projection: H3ProjectionKind
+): Promise<{values: Float32Array; validity: Uint32Array}> {
+  const cellWords = makeLittleEndianWords(cells);
+  const componentCount = projection === 'lnglat' ? 2 : 3;
+  const inputBuffer = device.createBuffer({
+    data: cellWords,
+    usage: Buffer.STORAGE | Buffer.COPY_DST
+  });
+  const outputBuffer = device.createBuffer({
+    byteLength: Math.max(cells.length, 1) * componentCount * Float32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  const validityBuffer = device.createBuffer({
+    byteLength: Math.max(cells.length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  const graph = new GPUCommandGraph(device);
+  const inputHandle = graph.importBuffer(
+    {id: 'cells', byteLength: inputBuffer.byteLength, usage: inputBuffer.usage},
+    inputBuffer
+  );
+  const outputHandle = graph.importBuffer(
+    {id: 'output', byteLength: outputBuffer.byteLength, usage: outputBuffer.usage},
+    outputBuffer
+  );
+  const validityHandle = graph.importBuffer(
+    {id: 'validity', byteLength: validityBuffer.byteLength, usage: validityBuffer.usage},
+    validityBuffer
+  );
+  const input = graph.createDataView(inputHandle, {format: 'uint32x2', length: cells.length});
+  const output = graph.createDataView(outputHandle, {
+    format: projection === 'lnglat' ? 'float32x2' : 'float32x3',
+    length: cells.length
+  });
+  const validity = graph.createDataView(validityHandle, {format: 'uint32', length: cells.length});
+  new GPUH3CellProjection({cells: input, output, validity, projection}).addToGraph(graph);
+  const compiled = graph.compile();
+
+  try {
+    const commandEncoder = device.createCommandEncoder({id: `gpu-h3-${projection}-test`});
+    compiled.encode(commandEncoder, {parameters: undefined});
+    device.submit(commandEncoder.finish());
+    const [valueBytes, validityBytes] = await Promise.all([
+      outputBuffer.readAsync(),
+      validityBuffer.readAsync()
+    ]);
+    return {
+      values: new Float32Array(
+        valueBytes.buffer,
+        valueBytes.byteOffset,
+        cells.length * componentCount
+      ),
+      validity: new Uint32Array(validityBytes.buffer, validityBytes.byteOffset, cells.length)
+    };
+  } finally {
+    compiled.destroy();
+    inputBuffer.destroy();
+    outputBuffer.destroy();
+    validityBuffer.destroy();
+  }
+}
+
+function makeH3Cells(): string[] {
+  const cells = new Set<string>(getRes0Cells());
+  const resolutions = Array.from({length: 16}, (_, resolution) => resolution);
+  for (let sample = 0; sample < 128; sample++) {
+    const latitude = -88 + (176 * sample) / 127;
+    const longitude = normalizeLongitude(sample * 137.50776405003785);
+    for (const resolution of resolutions) {
+      cells.add(latLngToCell(latitude, longitude, resolution));
+    }
+  }
+  for (const resolution of [0, 1, 5, 9, 15]) {
+    for (const pentagon of getPentagons(resolution)) {
+      for (const nearbyCell of gridDisk(pentagon, 1)) {
+        cells.add(nearbyCell);
+      }
+    }
+  }
+  return Array.from(cells);
+}
+
+function makeLittleEndianWords(cells: Array<string | bigint>): Uint32Array {
+  const indexes = BigUint64Array.from(
+    cells,
+    cell => (typeof cell === 'bigint' ? cell : BigInt(`0x${cell}`)) & 0xffffffffffffffffn
+  );
+  return new Uint32Array(indexes.buffer);
+}
+
+function makeUnitVector(longitude: number, latitude: number): [number, number, number] {
+  const radians = Math.PI / 180;
+  const longitudeRadians = longitude * radians;
+  const latitudeRadians = latitude * radians;
+  const cosLatitude = Math.cos(latitudeRadians);
+  return [
+    cosLatitude * Math.cos(longitudeRadians),
+    cosLatitude * Math.sin(longitudeRadians),
+    Math.sin(latitudeRadians)
+  ];
+}
+
+function normalizeLongitude(longitude: number): number {
+  return ((((longitude + 180) % 360) + 360) % 360) - 180;
+}

--- a/modules/shadertools/src/modules/geospatial/dggs/dggs-wgsl.ts
+++ b/modules/shadertools/src/modules/geospatial/dggs/dggs-wgsl.ts
@@ -1,6 +1,9 @@
 // luma.gl
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT AND Apache-2.0
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright 2016-2024 Uber Technologies, Inc.
+
+// H3 topology and projection constants and algorithms are derived from Uber's Apache-2.0 H3.
 
 /** WGSL source implementing 64-bit DGGS cell key and boundary helpers. */
 export const dggsWGSL = /* wgsl */ `\
@@ -239,6 +242,11 @@ struct DggsH3FaceIJK {
   face : u32,
   coord : vec3i,
   valid : u32,
+};
+
+struct DggsH3FaceIJKOverage {
+  faceIJK : DggsH3FaceIJK,
+  overage : u32,
 };
 
 struct DggsH3BoundaryVertex {
@@ -976,7 +984,10 @@ fn dggs_a5_normalize_longitude_to_center(longitude : f32, centerLongitude : f32)
 
 fn dggs_a5_sphere_to_lnglat(cartesian : vec3f) -> vec2f {
   let point = dggs_a5_normalize_vec3(cartesian);
-  let theta = atan2(point.y, point.x);
+  var theta = 0.0;
+  if (dot(point.xy, point.xy) > 1.0e-12) {
+    theta = atan2(point.y, point.x);
+  }
   let phi = acos(clamp(point.z, -1.0, 1.0));
   let longitude = dggs_a5_normalize_longitude(theta * DGGS_RADIANS_TO_DEGREES - DGGS_A5_LONGITUDE_OFFSET);
   let authalicLatitude = DGGS_PI_OVER_2 - phi;
@@ -996,6 +1007,33 @@ fn dggs_a5_face_to_lnglat(facePoint : vec2f, origin : u32) -> vec2f {
   );
   return dggs_a5_sphere_to_lnglat(
     dggs_a5_polyhedral_inverse(facePoint, faceTriangle, sphericalTriangle)
+  );
+}
+
+fn dggs_a5_get_center_lnglat(index : vec2u) -> vec2f {
+  let cell = dggs_a5_deserialize(index);
+  if (cell.valid == 0u || dggs_u64_is_zero(index)) {
+    return vec2f(0.0);
+  }
+  if (cell.resolution == 0u) {
+    return dggs_a5_sphere_to_lnglat(dggs_a5_quaternion_rotate(
+      vec3f(0.0, 0.0, 1.0),
+      dggs_a5_get_origin_quaternion(cell.origin)
+    ));
+  }
+  return dggs_a5_face_to_lnglat(
+    dggs_a5_get_cell_center_face_point(index, cell),
+    cell.origin
+  );
+}
+
+fn dggs_a5_get_center_unit_vector(index : vec2u) -> vec3f {
+  let longitudeLatitude = dggs_a5_get_center_lnglat(index) * DGGS_DEGREES_TO_RADIANS;
+  let cosLatitude = cos(longitudeLatitude.y);
+  return vec3f(
+    cosLatitude * cos(longitudeLatitude.x),
+    cosLatitude * sin(longitudeLatitude.x),
+    sin(longitudeLatitude.y)
   );
 }
 
@@ -1049,6 +1087,7 @@ fn dggs_h3_get_digit(index: vec2u, resolution: u32) -> u32 {
 fn dggs_h3_is_valid_cell_id(index: vec2u) -> bool {
   let cellResolution = dggs_h3_get_resolution(index);
   if (
+    (dggs_u64_high(index) >> 24u) != 8u ||
     !dggs_h3_is_cell_mode(index) ||
     cellResolution > DGGS_H3_MAX_RESOLUTION ||
     dggs_h3_get_base_cell(index) > DGGS_H3_MAX_BASE_CELL
@@ -1071,6 +1110,12 @@ fn dggs_h3_is_valid_cell_id(index: vec2u) -> bool {
       return false;
     }
     digitResolution += 1u;
+  }
+  if (
+    dggs_h3_is_base_cell_pentagon(dggs_h3_get_base_cell(index)) &&
+    dggs_h3_get_leading_non_zero_digit(index) == 1u
+  ) {
+    return false;
   }
   return true;
 }
@@ -1140,6 +1185,22 @@ fn dggs_h3_is_base_cell_pentagon(baseCell: u32) -> bool {
     baseCell == 97u ||
     baseCell == 107u ||
     baseCell == 117u;
+}
+
+fn dggs_h3_get_leading_non_zero_digit(index: vec2u) -> u32 {
+  let cellResolution = dggs_h3_get_resolution(index);
+  var resolution = 1u;
+  loop {
+    if (resolution > cellResolution) {
+      break;
+    }
+    let digit = dggs_h3_get_digit(index, resolution);
+    if (digit != 0u) {
+      return digit;
+    }
+    resolution += 1u;
+  }
+  return 0u;
 }
 
 fn dggs_h3_get_base_cell_home(baseCell: u32) -> DggsH3FaceIJK {
@@ -1327,6 +1388,74 @@ fn dggs_h3_get_face_axis_azimuths(face: u32) -> vec3f {
   return values[min(face, 19u)];
 }
 
+// Per face: unit-sphere center, Class II hex x axis, and Class II hex y axis.
+const DGGS_H3_FACE_UNIT_VECTOR_BASES = array<vec4f, 60>(
+    vec4f(0.219930779140, 0.658369178027, 0.719847537893, 0.0),
+    vec4f(0.404214808693, -0.733089476282, 0.546982822580, 0.0),
+    vec4f(0.887829285854, 0.170674676471, -0.427351511044, 0.0),
+    vec4f(-0.213923483450, 0.147817182955, 0.965601793521, 0.0),
+    vec4f(0.972137411506, -0.064768238220, 0.225286325522, 0.0),
+    vec4f(0.095841516985, 0.986891663629, -0.129843166477, 0.0),
+    vec4f(0.109262527878, -0.481195157287, 0.869777512129, 0.0),
+    vec4f(0.549081430333, 0.758619604829, 0.350721938339, 0.0),
+    vec4f(-0.828595970824, 0.439257914866, 0.347104020954, 0.0),
+    vec4f(0.742856730159, -0.359394167828, 0.564800593652, 0.0),
+    vec4f(-0.280304147989, 0.599180039695, 0.749941907518, 0.0),
+    vec4f(-0.607941989895, -0.715415342415, 0.344365249059, 0.0),
+    vec4f(0.811253470914, 0.344895323764, 0.472138773641, 0.0),
+    vec4f(-0.369836643998, -0.322746873758, 0.871237804641, 0.0),
+    vec4f(0.452867157880, -0.881408912551, -0.134274592492, 0.0),
+    vec4f(-0.105549814961, 0.979445729641, 0.171887461001, 0.0),
+    vec4f(-0.447904449344, 0.107499848833, -0.887595283200, 0.0),
+    vec4f(-0.887829285854, -0.170674676471, 0.427351511044, 0.0),
+    vec4f(-0.807540757997, 0.153355248590, 0.569526199488, 0.0),
+    vec4f(-0.581972789566, -0.050269394156, -0.811653041771, 0.0),
+    vec4f(-0.095841516985, -0.986891663629, 0.129843166477, 0.0),
+    vec4f(-0.284614806979, -0.864408097265, 0.414479255247, 0.0),
+    vec4f(-0.482102819721, -0.244644896962, -0.841264373195, 0.0),
+    vec4f(0.828595970824, -0.439257914866, -0.347104020954, 0.0),
+    vec4f(0.740562147385, -0.667329956457, -0.078983764633, 0.0),
+    vec4f(-0.286311443679, -0.207006321288, -0.935507423896, 0.0),
+    vec4f(0.607941989895, 0.715415342415, -0.344365249059, 0.0),
+    vec4f(0.851230398647, 0.472234378858, -0.228913738869, 0.0),
+    vec4f(-0.265175688426, 0.010631100574, -0.964141501009, 0.0),
+    vec4f(-0.452867157880, 0.881408912551, 0.134274592492, 0.0),
+    vec4f(-0.740562147385, 0.667329956457, 0.078983764633, 0.0),
+    vec4f(0.286311443679, 0.207006321288, 0.935507423896, 0.0),
+    vec4f(0.607941989895, 0.715415342415, -0.344365249059, 0.0),
+    vec4f(-0.851230398647, -0.472234378858, 0.228913738869, 0.0),
+    vec4f(0.265175688426, -0.010631100574, 0.964141501009, 0.0),
+    vec4f(-0.452867157880, 0.881408912551, 0.134274592492, 0.0),
+    vec4f(0.105549814961, -0.979445729641, -0.171887461001, 0.0),
+    vec4f(0.447904449344, -0.107499848833, 0.887595283200, 0.0),
+    vec4f(-0.887829285854, -0.170674676471, 0.427351511044, 0.0),
+    vec4f(0.807540757997, -0.153355248590, -0.569526199488, 0.0),
+    vec4f(0.581972789566, 0.050269394156, 0.811653041771, 0.0),
+    vec4f(-0.095841516985, -0.986891663629, 0.129843166477, 0.0),
+    vec4f(0.284614806979, 0.864408097265, -0.414479255247, 0.0),
+    vec4f(0.482102819721, 0.244644896962, 0.841264373195, 0.0),
+    vec4f(0.828595970824, -0.439257914866, -0.347104020954, 0.0),
+    vec4f(-0.742856730159, 0.359394167828, -0.564800593652, 0.0),
+    vec4f(0.280304147989, -0.599180039695, -0.749941907518, 0.0),
+    vec4f(-0.607941989895, -0.715415342415, 0.344365249059, 0.0),
+    vec4f(-0.811253470914, -0.344895323764, -0.472138773641, 0.0),
+    vec4f(0.369836643998, 0.322746873758, -0.871237804641, 0.0),
+    vec4f(0.452867157880, -0.881408912551, -0.134274592492, 0.0),
+    vec4f(-0.219930779140, -0.658369178027, -0.719847537893, 0.0),
+    vec4f(-0.404214808693, 0.733089476282, -0.546982822580, 0.0),
+    vec4f(0.887829285854, 0.170674676471, -0.427351511044, 0.0),
+    vec4f(0.213923483450, -0.147817182955, -0.965601793521, 0.0),
+    vec4f(-0.972137411506, 0.064768238220, -0.225286325522, 0.0),
+    vec4f(0.095841516985, 0.986891663629, -0.129843166477, 0.0),
+    vec4f(-0.109262527878, 0.481195157287, -0.869777512129, 0.0),
+    vec4f(-0.549081430333, -0.758619604829, -0.350721938339, 0.0),
+    vec4f(-0.828595970824, 0.439257914866, 0.347104020954, 0.0)
+);
+
+fn dggs_h3_get_face_unit_vector_basis(face: u32, basisIndex: u32) -> vec3f {
+  return DGGS_H3_FACE_UNIT_VECTOR_BASES[min(face, 19u) * 3u + min(basisIndex, 2u)].xyz;
+}
+
 fn dggs_h3_get_max_dim_by_cii_resolution(resolution: u32) -> i32 {
   let values = array<i32, 17>(
     2, -1, 14, -1, 98, -1, 686, -1, 4802, -1, 33614, -1, 235298, -1, 1647086, -1, 11529602
@@ -1416,18 +1545,127 @@ fn dggs_h3_down_ap7r(coord: vec3i) -> vec3i {
   return dggs_h3_ijk_normalize(iVector + jVector + kVector);
 }
 
+fn dggs_h3_divide_round_nearest_seven(value: i32) -> i32 {
+  return select((value - 3) / 7, (value + 3) / 7, value >= 0);
+}
+
+fn dggs_h3_up_ap7r(coord: vec3i) -> vec3i {
+  let i = coord.x - coord.z;
+  let j = coord.y - coord.z;
+  return dggs_h3_ijk_normalize(vec3i(
+    dggs_h3_divide_round_nearest_seven(2 * i + j),
+    dggs_h3_divide_round_nearest_seven(3 * j - i),
+    0
+  ));
+}
+
+fn dggs_h3_ijk_rotate_60_ccw(coord: vec3i) -> vec3i {
+  let iVector = vec3i(1, 1, 0) * coord.x;
+  let jVector = vec3i(0, 1, 1) * coord.y;
+  let kVector = vec3i(1, 0, 1) * coord.z;
+  return dggs_h3_ijk_normalize(iVector + jVector + kVector);
+}
+
+fn dggs_h3_ijk_rotate_60_cw(coord: vec3i) -> vec3i {
+  let iVector = vec3i(1, 0, 1) * coord.x;
+  let jVector = vec3i(1, 1, 0) * coord.y;
+  let kVector = vec3i(0, 1, 1) * coord.z;
+  return dggs_h3_ijk_normalize(iVector + jVector + kVector);
+}
+
+fn dggs_h3_rotate_digit_60_cw(digit: u32) -> u32 {
+  let values = array<u32, 8>(0u, 3u, 6u, 2u, 5u, 1u, 4u, 7u);
+  return values[min(digit, 7u)];
+}
+
+fn dggs_h3_get_face_neighbor(face: u32, quadrant: u32) -> DggsH3FaceIJK {
+  let neighborFaces = array<vec3u, 20>(
+    vec3u(4u, 1u, 5u),
+    vec3u(0u, 2u, 6u),
+    vec3u(1u, 3u, 7u),
+    vec3u(2u, 4u, 8u),
+    vec3u(3u, 0u, 9u),
+    vec3u(10u, 14u, 0u),
+    vec3u(11u, 10u, 1u),
+    vec3u(12u, 11u, 2u),
+    vec3u(13u, 12u, 3u),
+    vec3u(14u, 13u, 4u),
+    vec3u(5u, 6u, 15u),
+    vec3u(6u, 7u, 16u),
+    vec3u(7u, 8u, 17u),
+    vec3u(8u, 9u, 18u),
+    vec3u(9u, 5u, 19u),
+    vec3u(16u, 19u, 10u),
+    vec3u(17u, 15u, 11u),
+    vec3u(18u, 16u, 12u),
+    vec3u(19u, 17u, 13u),
+    vec3u(15u, 18u, 14u)
+  );
+  let neighborFace = neighborFaces[min(face, 19u)][min(quadrant, 3u) - 1u];
+  let isOuterBand = face < 5u || face >= 15u;
+  var translate = vec3i(0, 2, 2);
+  if (quadrant == 1u) {
+    translate = select(vec3i(2, 2, 0), vec3i(2, 0, 2), isOuterBand);
+  } else if (quadrant == 2u) {
+    translate = select(vec3i(2, 0, 2), vec3i(2, 2, 0), isOuterBand);
+  }
+  var counterClockwiseRotations = 3u;
+  if (isOuterBand && quadrant == 1u) {
+    counterClockwiseRotations = 1u;
+  } else if (isOuterBand && quadrant == 2u) {
+    counterClockwiseRotations = 5u;
+  }
+  return DggsH3FaceIJK(neighborFace, translate, counterClockwiseRotations);
+}
+
+fn dggs_h3_adjust_overage_class_ii(
+  input: DggsH3FaceIJK,
+  resolution: u32,
+  pentagonLeading4: bool
+) -> DggsH3FaceIJKOverage {
+  var faceIJK = input;
+  let maximumDimension = dggs_h3_get_max_dim_by_cii_resolution(resolution);
+  if (faceIJK.coord.x + faceIJK.coord.y + faceIJK.coord.z <= maximumDimension) {
+    return DggsH3FaceIJKOverage(faceIJK, 0u);
+  }
+
+  var quadrant = 1u;
+  if (faceIJK.coord.z > 0) {
+    quadrant = select(2u, 3u, faceIJK.coord.y > 0);
+    if (quadrant == 2u && pentagonLeading4) {
+      let origin = vec3i(maximumDimension, 0, 0);
+      faceIJK.coord = dggs_h3_ijk_rotate_60_cw(faceIJK.coord - origin) + origin;
+    }
+  }
+
+  let neighbor = dggs_h3_get_face_neighbor(faceIJK.face, quadrant);
+  faceIJK.face = neighbor.face;
+  var rotation = 0u;
+  loop {
+    if (rotation >= neighbor.valid) {
+      break;
+    }
+    faceIJK.coord = dggs_h3_ijk_rotate_60_ccw(faceIJK.coord);
+    rotation += 1u;
+  }
+  faceIJK.coord = dggs_h3_ijk_normalize(
+    faceIJK.coord + neighbor.coord * (maximumDimension / 2)
+  );
+  faceIJK.valid = 1u;
+  return DggsH3FaceIJKOverage(faceIJK, 2u);
+}
+
 fn dggs_h3_get_center_face_ijk(index: vec2u) -> DggsH3FaceIJK {
   if (!dggs_h3_is_valid_cell_id(index)) {
     return DggsH3FaceIJK(0u, vec3i(0), 0u);
   }
 
   let baseCell = dggs_h3_get_base_cell(index);
-  if (dggs_h3_is_base_cell_pentagon(baseCell)) {
-    return DggsH3FaceIJK(0u, vec3i(0), 0u);
-  }
-
   var faceIJK = dggs_h3_get_base_cell_home(baseCell);
   let cellResolution = dggs_h3_get_resolution(index);
+  let isPentagonBaseCell = dggs_h3_is_base_cell_pentagon(baseCell);
+  let leadingDigit = dggs_h3_get_leading_non_zero_digit(index);
+  let rotateDigits = isPentagonBaseCell && leadingDigit == 5u;
   var resolution = 1u;
   loop {
     if (resolution > cellResolution) {
@@ -1439,10 +1677,48 @@ fn dggs_h3_get_center_face_ijk(index: vec2u) -> DggsH3FaceIJK {
     } else {
       faceIJK.coord = dggs_h3_down_ap7r(faceIJK.coord);
     }
-    faceIJK.coord = dggs_h3_neighbor(faceIJK.coord, dggs_h3_get_digit(index, resolution));
+    var digit = dggs_h3_get_digit(index, resolution);
+    if (rotateDigits) {
+      digit = dggs_h3_rotate_digit_60_cw(digit);
+    }
+    faceIJK.coord = dggs_h3_neighbor(faceIJK.coord, digit);
     resolution += 1u;
   }
 
+  let originalCoord = faceIJK.coord;
+  var adjustedResolution = cellResolution;
+  if (dggs_h3_is_resolution_class_iii(cellResolution)) {
+    faceIJK.coord = dggs_h3_down_ap7r(faceIJK.coord);
+    adjustedResolution += 1u;
+  }
+
+  var adjustment = dggs_h3_adjust_overage_class_ii(
+    faceIJK,
+    adjustedResolution,
+    isPentagonBaseCell && leadingDigit == 4u
+  );
+  if (adjustment.overage != 0u) {
+    faceIJK = adjustment.faceIJK;
+    if (isPentagonBaseCell) {
+      var adjustmentCount = 0u;
+      loop {
+        if (adjustmentCount >= 4u) {
+          break;
+        }
+        adjustment = dggs_h3_adjust_overage_class_ii(faceIJK, adjustedResolution, false);
+        if (adjustment.overage == 0u) {
+          break;
+        }
+        faceIJK = adjustment.faceIJK;
+        adjustmentCount += 1u;
+      }
+    }
+    if (adjustedResolution != cellResolution) {
+      faceIJK.coord = dggs_h3_up_ap7r(faceIJK.coord);
+    }
+  } else if (adjustedResolution != cellResolution) {
+    faceIJK.coord = originalCoord;
+  }
   return faceIJK;
 }
 
@@ -1515,6 +1791,51 @@ fn dggs_h3_ijk_to_hex2d(coord: vec3i) -> vec2f {
   let i = f32(coord.x - coord.z);
   let j = f32(coord.y - coord.z);
   return vec2f(i - 0.5 * j, j * DGGS_H3_SQRT3_2);
+}
+
+fn dggs_h3_get_center_lnglat(index: vec2u) -> vec2f {
+  let center = dggs_h3_get_center_face_ijk(index);
+  if (center.valid == 0u) {
+    return vec2f(0.0);
+  }
+  return dggs_h3_hex2d_to_lnglat(
+    dggs_h3_ijk_to_hex2d(center.coord),
+    center.face,
+    dggs_h3_get_resolution(index),
+    false
+  );
+}
+
+fn dggs_h3_get_center_unit_vector(index: vec2u) -> vec3f {
+  let center = dggs_h3_get_center_face_ijk(index);
+  if (center.valid == 0u) {
+    return vec3f(0.0);
+  }
+
+  var hexPoint = dggs_h3_ijk_to_hex2d(center.coord);
+  let resolution = dggs_h3_get_resolution(index);
+  if (dggs_h3_is_resolution_class_iii(resolution)) {
+    hexPoint = vec2f(
+      0.944911182523 * hexPoint.x - 0.327326835354 * hexPoint.y,
+      0.327326835354 * hexPoint.x + 0.944911182523 * hexPoint.y
+    );
+  }
+  var scale = DGGS_H3_RES0_U_GNOMONIC;
+  var resolutionIndex = 0u;
+  loop {
+    if (resolutionIndex >= resolution) {
+      break;
+    }
+    scale *= DGGS_H3_RSQRT7;
+    resolutionIndex += 1u;
+  }
+  return normalize(
+    dggs_h3_get_face_unit_vector_basis(center.face, 0u) +
+    scale * (
+      hexPoint.x * dggs_h3_get_face_unit_vector_basis(center.face, 1u) +
+      hexPoint.y * dggs_h3_get_face_unit_vector_basis(center.face, 2u)
+    )
+  );
 }
 
 fn dggs_h3_geo_az_distance_rads(center: vec2f, azimuth: f32, distance: f32) -> vec2f {

--- a/modules/shadertools/src/modules/geospatial/dggs/dggs-wgsl.ts
+++ b/modules/shadertools/src/modules/geospatial/dggs/dggs-wgsl.ts
@@ -1747,8 +1747,37 @@ fn dggs_h3_get_vertex_offset(resolution: u32, vertexIndex: u32) -> vec3i {
   return vertices[pointIndex];
 }
 
+// Boundary generation retains the original home-face coordinates. Center projection applies face
+// overage separately because rewriting the center face changes the substrate vertex construction.
+fn dggs_h3_get_boundary_center_face_ijk(index: vec2u) -> DggsH3FaceIJK {
+  if (!dggs_h3_is_valid_cell_id(index)) {
+    return DggsH3FaceIJK(0u, vec3i(0), 0u);
+  }
+  let baseCell = dggs_h3_get_base_cell(index);
+  if (dggs_h3_is_base_cell_pentagon(baseCell)) {
+    return DggsH3FaceIJK(0u, vec3i(0), 0u);
+  }
+
+  var faceIJK = dggs_h3_get_base_cell_home(baseCell);
+  let cellResolution = dggs_h3_get_resolution(index);
+  var resolution = 1u;
+  loop {
+    if (resolution > cellResolution) {
+      break;
+    }
+    if (dggs_h3_is_resolution_class_iii(resolution)) {
+      faceIJK.coord = dggs_h3_down_ap7(faceIJK.coord);
+    } else {
+      faceIJK.coord = dggs_h3_down_ap7r(faceIJK.coord);
+    }
+    faceIJK.coord = dggs_h3_neighbor(faceIJK.coord, dggs_h3_get_digit(index, resolution));
+    resolution += 1u;
+  }
+  return faceIJK;
+}
+
 fn dggs_h3_get_boundary_vertex(index: vec2u, vertexIndex: u32) -> DggsH3BoundaryVertex {
-  let center = dggs_h3_get_center_face_ijk(index);
+  let center = dggs_h3_get_boundary_center_face_ijk(index);
   if (center.valid == 0u) {
     return DggsH3BoundaryVertex(0u, vec3i(0), 0u, 0u);
   }
@@ -1793,19 +1822,6 @@ fn dggs_h3_ijk_to_hex2d(coord: vec3i) -> vec2f {
   return vec2f(i - 0.5 * j, j * DGGS_H3_SQRT3_2);
 }
 
-fn dggs_h3_get_center_lnglat(index: vec2u) -> vec2f {
-  let center = dggs_h3_get_center_face_ijk(index);
-  if (center.valid == 0u) {
-    return vec2f(0.0);
-  }
-  return dggs_h3_hex2d_to_lnglat(
-    dggs_h3_ijk_to_hex2d(center.coord),
-    center.face,
-    dggs_h3_get_resolution(index),
-    false
-  );
-}
-
 fn dggs_h3_get_center_unit_vector(index: vec2u) -> vec3f {
   let center = dggs_h3_get_center_face_ijk(index);
   if (center.valid == 0u) {
@@ -1835,6 +1851,17 @@ fn dggs_h3_get_center_unit_vector(index: vec2u) -> vec3f {
       hexPoint.x * dggs_h3_get_face_unit_vector_basis(center.face, 1u) +
       hexPoint.y * dggs_h3_get_face_unit_vector_basis(center.face, 2u)
     )
+  );
+}
+
+fn dggs_h3_get_center_lnglat(index: vec2u) -> vec2f {
+  let unitVector = dggs_h3_get_center_unit_vector(index);
+  if (dot(unitVector, unitVector) < 0.5) {
+    return vec2f(0.0);
+  }
+  return vec2f(
+    atan2(unitVector.y, unitVector.x) * DGGS_RADIANS_TO_DEGREES,
+    atan2(unitVector.z, length(unitVector.xy)) * DGGS_RADIANS_TO_DEGREES
   );
 }
 

--- a/modules/shadertools/src/modules/geospatial/dggs/dggs-wgsl.ts
+++ b/modules/shadertools/src/modules/geospatial/dggs/dggs-wgsl.ts
@@ -617,6 +617,10 @@ fn dggs_a5_get_base_pentagon_vertex(vertexIndex : u32) -> vec2f {
   return vertices[min(vertexIndex, 4u)];
 }
 
+fn dggs_a5_get_base_pentagon_center() -> vec2f {
+  return vec2f(0.4106967627362, 0.1648883597942);
+}
+
 fn dggs_a5_get_base_triangle_vertex(vertexIndex : u32) -> vec2f {
   let vertices = array<vec2f, 3>(
     vec2f(0.0, 0.0),
@@ -667,6 +671,36 @@ fn dggs_a5_get_pentagon_vertex(
   return dggs_a5_rotate_face_point(point, anchor.quintant);
 }
 
+// Transforming the center directly preserves sub-cell precision when individual vertices collapse
+// to the same f32 coordinate at the highest resolutions.
+fn dggs_a5_get_pentagon_center(anchor : DggsA5Anchor, hilbertResolution : u32) -> vec2f {
+  let flipSum = anchor.flips.x + anchor.flips.y;
+  let reflectsY = ((flipSum == -2 || flipSum == 2) && anchor.q > 1u) ||
+    (flipSum == 0 && (anchor.q == 0u || anchor.q == 3u));
+  var point = dggs_a5_get_base_pentagon_center();
+
+  if (anchor.flips.x == 1 && anchor.flips.y == -1) {
+    point = -point;
+  }
+  if (reflectsY) {
+    point.y = -point.y;
+  }
+  if (anchor.flips.x == -1 && anchor.flips.y == -1) {
+    point = -point;
+  } else if (anchor.flips.x == -1) {
+    point += vec2f(-0.618033988750, 0.449027976580);
+  } else if (anchor.flips.y == -1) {
+    point += vec2f(0.618033988750, -0.449027976580);
+  }
+
+  let translation = vec2f(
+    f32(anchor.offset.x) * 0.618033988750 + f32(anchor.offset.y) * 0.618033988750,
+    f32(anchor.offset.x) * 0.449027976580 + f32(anchor.offset.y) * -0.449027976580
+  );
+  point = (point + translation) / f32(1u << hilbertResolution);
+  return dggs_a5_rotate_face_point(point, anchor.quintant);
+}
+
 fn dggs_a5_get_shape_vertex_count(cell : DggsA5Cell) -> u32 {
   return select(5u, 3u, cell.resolution == 1u);
 }
@@ -691,6 +725,12 @@ fn dggs_a5_get_cell_shape_face_point(index : vec2u, cell : DggsA5Cell, shapeInde
 }
 
 fn dggs_a5_get_cell_center_face_point(index : vec2u, cell : DggsA5Cell) -> vec2f {
+  if (cell.resolution >= 2u) {
+    return dggs_a5_get_pentagon_center(
+      dggs_a5_make_anchor(index, cell, dggs_a5_segment_to_anchor_info(cell)),
+      cell.hilbertResolution
+    );
+  }
   let shapeVertexCount = dggs_a5_get_shape_vertex_count(cell);
   var center = vec2f(0.0);
   var vertexIndex = 0u;
@@ -705,7 +745,11 @@ fn dggs_a5_get_cell_center_face_point(index : vec2u, cell : DggsA5Cell) -> vec2f
 }
 
 fn dggs_a5_to_polar(point : vec2f) -> vec2f {
-  return vec2f(length(point), atan2(point.y, point.x));
+  var angle = 0.0;
+  if (dot(point, point) > 1.0e-12) {
+    angle = atan2(point.y, point.x);
+  }
+  return vec2f(length(point), angle);
 }
 
 fn dggs_a5_to_cartesian(thetaPhi : vec2f) -> vec3f {

--- a/test/examples/gpu-dggs-live-benchmark-docs.node.spec.ts
+++ b/test/examples/gpu-dggs-live-benchmark-docs.node.spec.ts
@@ -1,0 +1,40 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'node:fs';
+
+import {describe, expect, test} from 'vitest';
+
+const documentationPages = ['gpu-dggs', 'gpu-h3', 'gpu-a5'].map(page =>
+  readFileSync(new URL(`../../docs/api-reference/experimental/${page}.md`, import.meta.url), 'utf8')
+);
+const benchmarkComponent = readFileSync(
+  new URL('../../website/src/components/docs/dggs-cell-projection-benchmark.tsx', import.meta.url),
+  'utf8'
+);
+const packageManifest = readFileSync(
+  new URL('../../modules/gpgpu/package.json', import.meta.url),
+  'utf8'
+);
+
+describe('GPU DGGS documentation', () => {
+  test('publishes shared, H3, and A5 pages with one live benchmark', () => {
+    for (const documentation of documentationPages) {
+      expect(documentation).toContain('<DGGSCellProjectionBenchmark />');
+      expect(documentation).toContain(
+        "import {DGGSCellProjectionBenchmark} from '@site/src/components/docs/dggs-cell-projection-benchmark';"
+      );
+    }
+    expect(benchmarkComponent).toContain('runGPUDGGSCellProjectionBenchmark');
+    expect(benchmarkComponent).toContain('Live DGGS cell-center projection');
+    expect(benchmarkComponent).toContain('Correctness checks');
+  });
+
+  test('keeps the reusable primitive and optional benchmark in isolated package entry points', () => {
+    expect(packageManifest).toContain('"./gpu-dggs"');
+    expect(packageManifest).toContain('"./gpu-dggs/benchmarks"');
+    expect(documentationPages[0]).toContain('GPUDGGSCellProjection');
+    expect(documentationPages[0]).toContain("'@luma.gl/gpgpu/gpu-dggs/benchmarks'");
+  });
+});

--- a/website/src/components/docs/dggs-cell-projection-benchmark.tsx
+++ b/website/src/components/docs/dggs-cell-projection-benchmark.tsx
@@ -1,0 +1,232 @@
+import React, {type ReactNode, useEffect, useId, useState} from 'react';
+
+import type {DGGSCellFamily, DGGSCellProjectionKind} from '@luma.gl/gpgpu/gpu-dggs';
+import {
+  runGPUDGGSCellProjectionBenchmark,
+  type GPUDGGSCellProjectionBenchmarkReport
+} from '@luma.gl/gpgpu/gpu-dggs/benchmarks';
+
+import {createDevice, useStore} from '../../react-luma/store/device-store';
+import {LiveBenchmarkPanel} from './live-benchmark-panel';
+
+const CELL_COUNTS = [16_384, 65_536, 262_144, 1_048_576] as const;
+const H3_CELLS = [
+  0x089283082803ffffn,
+  0x089754e64993ffffn,
+  0x089194ad14d7ffffn,
+  0x089be0e35c27ffffn,
+  0x089005065cdbffffn,
+  0x089ef0d126a7ffffn
+];
+const A5_CELLS = [
+  0x0200000000000000n,
+  0x0500000000000000n,
+  0x1a38000000000000n,
+  0x2628000000000000n,
+  0x35bd75e8fee1100dn
+];
+
+/** Measures H3 and A5 cell-center projection on the reader's actual WebGPU adapter. */
+export function DGGSCellProjectionBenchmark(): ReactNode {
+  const selectedDevice = useStore(store => store.presentationDevice || store.device);
+  const [family, setFamily] = useState<DGGSCellFamily>('h3');
+  const [projection, setProjection] = useState<DGGSCellProjectionKind>('unit-vector');
+  const [cellCount, setCellCount] = useState<number>(262_144);
+  const [webGPUUnavailable, setWebGPUUnavailable] = useState(false);
+  const familyId = useId();
+  const projectionId = useId();
+  const cellCountId = useId();
+
+  useEffect(() => {
+    setWebGPUUnavailable(typeof navigator === 'undefined' || !('gpu' in navigator));
+  }, []);
+
+  return (
+    <LiveBenchmarkPanel
+      title="Live DGGS cell-center projection"
+      description="Decode a repeated, globally distributed set of valid H3 or A5 indexes with the public command-graph primitive. Correctness checks, upload, compilation, and readback stay outside measured submissions."
+      runLabel="Run cell projection benchmark"
+      controls={
+        <div className="luma-live-benchmark__controls">
+          <label htmlFor={familyId}>
+            Grid
+            <select
+              id={familyId}
+              onChange={event => setFamily(event.target.value as DGGSCellFamily)}
+              value={family}
+            >
+              <option value="h3">H3</option>
+              <option value="a5">A5</option>
+            </select>
+          </label>
+          <label htmlFor={projectionId}>
+            Output
+            <select
+              id={projectionId}
+              onChange={event =>
+                setProjection(event.target.value as DGGSCellProjectionKind)
+              }
+              value={projection}
+            >
+              <option value="unit-vector">Unit vector</option>
+              <option value="lnglat">Longitude / latitude</option>
+            </select>
+          </label>
+          <label htmlFor={cellCountId}>
+            Cells
+            <select
+              id={cellCountId}
+              onChange={event => setCellCount(Number(event.target.value))}
+              value={cellCount}
+            >
+              {CELL_COUNTS.map(count => (
+                <option key={count} value={count}>
+                  {count.toLocaleString()}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      }
+      idleContent={<DGGSBenchmarkIdle cellCount={cellCount} family={family} projection={projection} />}
+      runningContent={<DGGSBenchmarkRunning cellCount={cellCount} family={family} />}
+      unsupportedReason={
+        webGPUUnavailable
+          ? 'WebGPU is unavailable in this browser. Use a WebGPU-capable browser and a secure origin.'
+          : undefined
+      }
+      onRun={async () => {
+        const device =
+          selectedDevice?.type === 'webgpu' ? selectedDevice : await createDevice('webgpu-core');
+        const report = await runGPUDGGSCellProjectionBenchmark(device, {
+          family,
+          projection,
+          cells: makeRepeatedCellWords(family, cellCount),
+          warmupIterations: 2,
+          measuredIterations: 7
+        });
+        return (
+          <DGGSBenchmarkResults
+            report={report}
+            deviceLabel={device.info.renderer || device.info.vendor || device.info.gpu}
+          />
+        );
+      }}
+    />
+  );
+}
+
+function DGGSBenchmarkIdle({
+  cellCount,
+  family,
+  projection
+}: {
+  cellCount: number;
+  family: DGGSCellFamily;
+  projection: DGGSCellProjectionKind;
+}): ReactNode {
+  return (
+    <p style={{margin: '14px 0 4px'}}>
+      Ready to decode <strong>{cellCount.toLocaleString()}</strong> {family.toUpperCase()} indexes
+      into <strong>{projection === 'unit-vector' ? 'normalized vectors' : 'geographic centers'}</strong>.
+    </p>
+  );
+}
+
+function DGGSBenchmarkRunning({
+  cellCount,
+  family
+}: {
+  cellCount: number;
+  family: DGGSCellFamily;
+}): ReactNode {
+  return (
+    <p style={{margin: '14px 0 4px'}}>
+      Validating and measuring <strong>{cellCount.toLocaleString()}</strong>{' '}
+      {family.toUpperCase()} indexes…
+    </p>
+  );
+}
+
+function DGGSBenchmarkResults({
+  report,
+  deviceLabel
+}: {
+  report: GPUDGGSCellProjectionBenchmarkReport;
+  deviceLabel: string;
+}): ReactNode {
+  return (
+    <div>
+      <p style={{margin: '14px 0 10px'}}>
+        <strong>{report.cellCount.toLocaleString()}</strong> {report.family.toUpperCase()} indexes ·{' '}
+        <strong>{formatBytes(report.memoryByteLength)}</strong> working buffers ·{' '}
+        <strong>{report.measuredIterations}</strong> measured submissions · {deviceLabel}
+      </p>
+      <div style={{overflowX: 'auto'}}>
+        <table style={{fontSize: 13, minWidth: 650, width: '100%'}}>
+          <thead>
+            <tr>
+              <th>Measurement</th>
+              <th>Median</th>
+              <th>p95</th>
+              <th>Throughput</th>
+              <th>Includes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Portable synchronized</td>
+              <td>{formatMilliseconds(report.synchronizedTimeMilliseconds.median)}</td>
+              <td>{formatMilliseconds(report.synchronizedTimeMilliseconds.percentile95)}</td>
+              <td>{formatThroughput(report.synchronizedCellsPerSecond)}</td>
+              <td>Submit + completion fence</td>
+            </tr>
+            {report.gpuTimeMilliseconds && report.gpuCellsPerSecond ? (
+              <tr>
+                <td>GPU timestamp</td>
+                <td>{formatMilliseconds(report.gpuTimeMilliseconds.median)}</td>
+                <td>{formatMilliseconds(report.gpuTimeMilliseconds.percentile95)}</td>
+                <td>{formatThroughput(report.gpuCellsPerSecond)}</td>
+                <td>Compute pass only</td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+      <p style={{fontSize: 12, margin: '10px 0 0'}}>
+        Every input row is validated. Geographic output is range-checked; unit vectors must be
+        normalized. The validation readback took{' '}
+        {formatMilliseconds(report.validationReadbackTimeMilliseconds)} and is not included above.
+      </p>
+      {!report.timestampQueries ? (
+        <p style={{fontSize: 12, margin: '8px 0 0'}}>
+          This adapter does not expose timestamp queries, so only the portable completion-fence
+          measurement is shown.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function makeRepeatedCellWords(family: DGGSCellFamily, cellCount: number): Uint32Array {
+  const sourceCells = family === 'h3' ? H3_CELLS : A5_CELLS;
+  const words = new Uint32Array(cellCount * 2);
+  for (let cellIndex = 0; cellIndex < cellCount; cellIndex++) {
+    const cell = sourceCells[cellIndex % sourceCells.length];
+    words[cellIndex * 2] = Number(cell & 0xffffffffn);
+    words[cellIndex * 2 + 1] = Number(cell >> 32n);
+  }
+  return words;
+}
+
+function formatMilliseconds(milliseconds: number): string {
+  return `${milliseconds.toFixed(3)} ms`;
+}
+
+function formatThroughput(cellsPerSecond: number): string {
+  return `${(cellsPerSecond / 1_000_000).toFixed(2)}M cells/s`;
+}
+
+function formatBytes(byteLength: number): string {
+  return `${(byteLength / 1024 / 1024).toFixed(1)} MiB`;
+}

--- a/website/src/components/docs/dggs-cell-projection-benchmark.tsx
+++ b/website/src/components/docs/dggs-cell-projection-benchmark.tsx
@@ -25,6 +25,23 @@ const A5_CELLS = [
   0x2628000000000000n,
   0x35bd75e8fee1100dn
 ];
+// Precomputed with h3-js 4.4 and a5-js 0.8. Keeping the oracle out of the measured path also keeps
+// those CPU implementations out of this live benchmark's browser bundle.
+const H3_REFERENCE_LNGLATS: ReadonlyArray<readonly [number, number]> = [
+  [-122.4182710369247, 37.773515097238146],
+  [-0.0010418183700719888, 0.0005857701415174007],
+  [-0.12145034273233364, 51.50008600604053],
+  [151.19803529715963, -33.860401280822074],
+  [19.985975059398097, 85.00014538237319],
+  [-59.99596159336479, -79.99961280701646]
+];
+const A5_REFERENCE_LNGLATS: ReadonlyArray<readonly [number, number]> = [
+  [-93, 90],
+  [123, 69.09240188013534],
+  [-120.36040534450211, 38.61273252471863],
+  [-70.23755667780222, 43.618118491958555],
+  [-122.41999998343744, 37.77999999438284]
+];
 
 /** Measures H3 and A5 cell-center projection on the reader's actual WebGPU adapter. */
 export function DGGSCellProjectionBenchmark(): ReactNode {
@@ -98,10 +115,12 @@ export function DGGSCellProjectionBenchmark(): ReactNode {
       onRun={async () => {
         const device =
           selectedDevice?.type === 'webgpu' ? selectedDevice : await createDevice('webgpu-core');
+        const cells = makeRepeatedCellWords(family, cellCount);
         const report = await runGPUDGGSCellProjectionBenchmark(device, {
           family,
           projection,
-          cells: makeRepeatedCellWords(family, cellCount),
+          cells,
+          referenceValues: makeRepeatedReferenceValues(family, projection, cellCount),
           warmupIterations: 2,
           measuredIterations: 7
         });
@@ -194,7 +213,8 @@ function DGGSBenchmarkResults({
         </table>
       </div>
       <p style={{fontSize: 12, margin: '10px 0 0'}}>
-        Every input row is validated. Geographic output is range-checked; unit vectors must be
+        Every output component is checked against precomputed CPU reference centers within{' '}
+        {report.referenceTolerance}. Geographic output is also range-checked; unit vectors must be
         normalized. The validation readback took{' '}
         {formatMilliseconds(report.validationReadbackTimeMilliseconds)} and is not included above.
       </p>
@@ -217,6 +237,37 @@ function makeRepeatedCellWords(family: DGGSCellFamily, cellCount: number): Uint3
     words[cellIndex * 2 + 1] = Number(cell >> 32n);
   }
   return words;
+}
+
+function makeRepeatedReferenceValues(
+  family: DGGSCellFamily,
+  projection: DGGSCellProjectionKind,
+  cellCount: number
+): Float32Array {
+  const sourceLongitudeLatitudes =
+    family === 'h3' ? H3_REFERENCE_LNGLATS : A5_REFERENCE_LNGLATS;
+  const componentCount = projection === 'lnglat' ? 2 : 3;
+  const values = new Float32Array(cellCount * componentCount);
+  for (let cellIndex = 0; cellIndex < cellCount; cellIndex++) {
+    const longitudeLatitude =
+      sourceLongitudeLatitudes[cellIndex % sourceLongitudeLatitudes.length];
+    if (projection === 'lnglat') {
+      values.set(longitudeLatitude, cellIndex * componentCount);
+    } else {
+      const longitude = longitudeLatitude[0] * (Math.PI / 180);
+      const latitude = longitudeLatitude[1] * (Math.PI / 180);
+      const cosLatitude = Math.cos(latitude);
+      values.set(
+        [
+          cosLatitude * Math.cos(longitude),
+          cosLatitude * Math.sin(longitude),
+          Math.sin(latitude)
+        ],
+        cellIndex * componentCount
+      );
+    }
+  }
+  return values;
 }
 
 function formatMilliseconds(milliseconds: number): string {

--- a/website/src/components/docs/experimental-docs-catalog.ts
+++ b/website/src/components/docs/experimental-docs-catalog.ts
@@ -14,6 +14,9 @@ export type ExperimentalDocsTabId =
   | 'pbr-environment'
   | 'gpu-project'
   | 'geospatial'
+  | 'gpu-dggs'
+  | 'gpu-h3'
+  | 'gpu-a5'
   | 'gpu-raster'
   | 'gpu-raster-concepts'
   | 'gpu-raster-operations'
@@ -122,7 +125,10 @@ export const EXPERIMENTAL_DOCS_TAB_GROUPS: readonly DocsTabGroup<ExperimentalDoc
     label: 'GPU Project',
     tabs: [
       {id: 'gpu-project', label: 'Projection', href: '/docs/api-reference/experimental/gpu-project'},
-      {id: 'geospatial', label: 'Geospatial Kernels', href: '/docs/api-reference/experimental/geospatial'}
+      {id: 'geospatial', label: 'Geospatial Kernels', href: '/docs/api-reference/experimental/geospatial'},
+      {id: 'gpu-dggs', label: 'DGGS', href: '/docs/api-reference/experimental/gpu-dggs'},
+      {id: 'gpu-h3', label: 'H3', href: '/docs/api-reference/experimental/gpu-h3'},
+      {id: 'gpu-a5', label: 'A5', href: '/docs/api-reference/experimental/gpu-a5'}
     ]
   },
   {


### PR DESCRIPTION
## Goals

- Decode large GPU-resident arrays of H3 and A5 cell indexes without CPU readback.
- Provide reusable DGGS primitives that compose with `GPUCommandGraph`.
- Document the precision envelope, partial-GPU opportunities, and measured live-device performance.

## Changes

- Add `@luma.gl/gpgpu/gpu-dggs` with the reusable `GPUDGGSCellProjection` command-graph contributor.
- Add thin `@luma.gl/gpgpu/gpu-h3` and `@luma.gl/gpgpu/gpu-a5` family adapters.
- Implement split-uint64 validation, H3 resolutions 0-15, pentagon handling, FaceIJK overage, A5 center decoding, longitude/latitude output, and normalized unit-vector output in WGSL.
- Add an isolated `@luma.gl/gpgpu/gpu-dggs/benchmarks` entry point with correctness-gated completion-fence and timestamp-query timing.
- Add shared DGGS, H3, and A5 documentation pages with a responsive live WebGPU benchmark.
- Add global, pentagon, high-resolution, invalid-index, benchmark, and documentation contract tests.

## Verification

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn test-node` — 396 files passed, 1 skipped; 3098 tests passed, 3 skipped
- Focused Chromium WebGPU tests — 3 files and 5 tests passed
- `yarn website:build`
- Desktop and 390 px documentation visual QA

## Scope and follow-up

This PR implements cell-index-to-center decoding. Exact coordinate-to-cell encoding remains a candidate-plus-CPU-verification workflow near cell boundaries. Variable-length boundaries are a natural count/scan/write follow-up. The fixed H3 face basis remains a 960-byte shader constant; a storage-buffer variant can be revisited if adapter profiling demonstrates a benefit.
