### PR TITLE
Add exact GPU vector search to @luma.gl/gpgpu

### DIFF
--- a/docs/api-reference/arrow/arrow-conversion.mdx
+++ b/docs/api-reference/arrow/arrow-conversion.mdx
@@ -6,6 +6,44 @@ import {ArrowDocsTabs} from '@site/src/components/docs/arrow-docs-tabs';
 
 ## Arrow Vector Factories
 
+## Fixed-Size-List Storage Columns
+
+`makeGPUVectorFromArrow()` and `makeGPUTableFromArrowTable()` upload numeric
+Arrow `FixedSizeList` columns wider than four elements as ordinary
+`GPUVector<'fixed-size-list<format,size>'>` values. The vector remains aligned
+with its containing table: `length` counts source rows, `valueLength` counts
+flattened elements, and original Arrow record batches remain separate GPU
+record batches.
+
+When calling `makeGPUVectorFromArrow()` directly, provide
+`{format: 'fixed-size-list<float32,768>'}` to retain that exact fixed-list
+generic in TypeScript; Arrow's runtime `FixedSizeList` type cannot otherwise
+encode the numeric width in its compile-time type.
+
+```ts
+import {makeGPUTableFromArrowTable} from '@luma.gl/arrow';
+
+const table = makeGPUTableFromArrowTable(device, arrowTable, {
+  shaderLayout: {
+    attributes: [],
+    bindings: [
+      {name: 'embedding', type: 'read-only-storage', group: 0, location: 0},
+      {name: 'sourceIds', type: 'read-only-storage', group: 0, location: 1}
+    ]
+  },
+  validityColumns: {embedding: 'embeddingValidity'}
+});
+```
+
+The optional `validityColumns` mapping materializes a named, table-owned Uint32
+column that combines nullable parent rows and nullable child values. Stable row
+identifiers remain ordinary non-null sibling columns. Use
+`fixedSizeListColumns: ['embedding']` when a short one-to-four-element column
+should intentionally retain fixed-size-list storage semantics instead of its
+default vertex format. For physically padded rows, specify
+`validityColumns: {embedding: {name: 'embeddingValidity', dimensions: 3}}` to
+ignore nullable padding after the three meaningful coordinates.
+
 ## List Columns
 
 Arrow vector factories also support variable-length Arrow list columns whose

--- a/docs/api-reference/arrow/supported-arrow-types.mdx
+++ b/docs/api-reference/arrow/supported-arrow-types.mdx
@@ -58,6 +58,7 @@ migration.
 | `Float32` | `float32` | yes |
 | `FixedSizeList<Float32, 3>` | `float32x3` | yes |
 | `FixedSizeList<Uint8, 4>` as normalized color | `unorm8x4` | yes |
+| `FixedSizeList<Float32, 768>` embedding | `fixed-size-list<float32,768>` | no |
 | `List<FixedSizeList<Float32, 3>>` path coordinates | `vertex-list<float32x3>` | no |
 | `List<FixedSizeList<Uint8, 4>>` vertex colors | `vertex-list<unorm8x4>` | no |
 
@@ -65,6 +66,14 @@ migration.
 metadata owned by the producing adapter. They are not automatically exposed as
 ordinary vertex attributes; path, text, polygon, and geometry adapters must
 expand them or bind their flattened values explicitly.
+
+Numeric `FixedSizeList` columns wider than four elements become first-class
+`fixed-size-list<format,size>` storage columns. Their `GPUVector.length` is the
+logical table-row count, while `valueLength` counts flattened list elements.
+Short fixed-size lists retain their existing vertex-compatible formats unless
+the table adapter explicitly selects them with `fixedSizeListColumns`.
+`validityColumns` can materialize a caller-named Uint32 table column combining
+parent-row and child-coordinate validity.
 
 Status: ✅ directly supported, 🟡 conditionally supported, ❌ not supported.
 The `nullable` column refers to columns with actual null rows, not just nullable
@@ -74,7 +83,7 @@ schema fields with `nullCount: 0`.
 
 | Arrow data type | GPU<br/>upload | nullable | Upload notes | Shader-facing<br/>use | Higher-level<br/>model support |
 | --- | :---: | :---: | --- | --- | --- |
-| `Int8 \| Uint8 \| Int16 \| Uint16 \|`<br/>`Int32 \| Uint32 \| Float16 \| Float32` | ✅ | ❌ | Scalar `GPUVector` or selected `GPUTable` columns. | Scalar attributes or storage rows, subject to shader type and vertex format compatibility. | Numeric table workflows and scalar style rows such as text angles, text sizes, and path widths. |
+| `Int8 \| Uint8 \| Int16 \| Uint16 \|`<br/>`Int32 \| Uint32 \| Float16 \| Float32` | ✅ | ✅ | Scalar `GPUVector` or selected `GPUTable` columns preserve normalized null bitmaps and nullable Arrow readback. | Scalar attributes or storage rows, subject to shader type and vertex format compatibility; consumers must explicitly honor validity. | Numeric table workflows and scalar style rows such as text angles, text sizes, and path widths; stable source-ID consumers reject actual null identifiers. |
 | `Float64` | 🟡 | ❌ | Raw values can be copied into a `GPUVector`, but generic render paths should repack them to `Float32`, origin-relative `Float32`, or `u32` word pairs at conversion boundaries. | No generic `f64` vertex attribute or WGSL scalar path; use prepared Float32 values or custom word-pair helpers. | Matrix columns truncate to Float32; Float64 paths become per-row Float32 deltas plus retained origins. |
 | `Uint64` carrying DGGS cell keys | 🟡 | ❌ | DGGS WebGPU helpers retain Uint64 rows as word-pair storage. | Read through DGGS WGSL helpers or expand through `convertDggsCellKeysToGPUPaths()`; not a generic vertex attribute. | Global grid cell keys parsed from UTF-8 geohash, quadkey, S2, A5, or H3 IDs. |
 | `Bool` | ❌ | ❌ | Arrow Bool values are bit-packed, so they are not a directly uploadable scalar buffer. Repack to `Uint8` or `Uint32` when shaders need flags. | Use as integer 0/1 flags after repacking; otherwise keep on CPU as row metadata. | `closeArrowPaths()` accepts `Vector<Bool>` closed-path flags as CPU input; a future adapter could publish repacked flag columns. |
@@ -83,7 +92,8 @@ schema fields with `nullCount: 0`.
 
 | Arrow data type | GPU<br/>upload | nullable | Upload notes | Shader-facing<br/>use | Higher-level<br/>model support |
 | --- | :---: | :---: | --- | --- | --- |
-| `FixedSizeList<numeric,`<br/>`1 \| 2 \| 3 \| 4>` | ✅ | ❌ | Fixed-width GPU rows.<br/>Planned color adapter support will expand three-component RGB source rows to four-component RGBA rows. `FixedSizeList<Float16, 4>` is the compact scene-linear/HDR color form. | Vector attributes or storage rows; 3-component 8-bit and 16-bit integer formats are WebGL-only unless padded. | Positions, point rows, normalized colors, scene-linear/HDR colors, pixel offsets, clip rectangles, mesh attributes, and path style rows. |
+| `FixedSizeList<numeric,`<br/>`1 \| 2 \| 3 \| 4>` | ✅ | ✅ | Fixed-width GPU rows preserve parent and child validity for Arrow readback; optional `validityColumns` publishes explicit GPU row masks.<br/>Planned color adapter support will expand three-component RGB source rows to four-component RGBA rows. `FixedSizeList<Float16, 4>` is the compact scene-linear/HDR color form. | Vector attributes or storage rows; consuming models must explicitly honor validity, and 3-component 8-bit and 16-bit integer formats are WebGL-only unless padded. | Positions, point rows, normalized colors, scene-linear/HDR colors, pixel offsets, clip rectangles, mesh attributes, and path style rows. |
+| `FixedSizeList<numeric,`<br/>`5 \| 384 \| 768 \| 1536 \| ...>` | ✅ | ✅ | Row-aligned `fixed-size-list<format,size>` GPU table storage; optional `validityColumns` publishes explicit parent/child row masks. | WebGPU storage and compute; never synthesized into a generic vertex attribute. | High-dimensional embeddings, fixed-width feature vectors, and caller-owned table-based compute. |
 | `List<FixedSizeList<Float32,`<br/>`2 \| 3 \| 4>>` | ✅ | ❌ | Flattened GPU path-coordinate values plus copied list-offset metadata. | Not a single generic vertex attribute.<br/>`PathAttributeModel` expands to segment attributes; `PathStorageModel` keeps values in storage. | `ArrowPathRenderer.convertToGPUVectors()` uploads unchanged unless closed-path normalization is requested.<br/>Outputs feed `PathAttributeModel` and `PathStorageModel`. |
 | `List<FixedSizeList<Float64,`<br/>`2 \| 3 \| 4>>` | 🟡 | ❌ | Path conversion emits per-row Float32 deltas plus copied list-offset metadata.<br/>CPU Float64 per-row origins are retained separately. | Not a generic vertex attribute.<br/>Attribute paths convert deltas on CPU; WebGPU storage paths convert them on GPU before rendering. | `ArrowPathRenderer.convertToGPUVectors()` and `convertArrowPathToGPUVectors()` convert attribute paths.<br/>`ArrowPathRenderer.convertToGPUVectors(..., {model: 'storage'})` converts storage paths. |
 | `List<numeric \|`<br/>`FixedSizeList<numeric, 1 \| 2 \| 3 \| 4>>` | ✅ | ❌ | Flattened GPU values plus copied list-offset metadata. | Not a single generic vertex attribute; consume through storage/compute code or model-specific expansion. | Generic variable-length numeric storage/readback. Model support is documented by the model-specific rows above. |

--- a/docs/api-reference/experimental/gpu-tables/gpu-schema.mdx
+++ b/docs/api-reference/experimental/gpu-tables/gpu-schema.mdx
@@ -24,13 +24,13 @@ For the required and optional `GPUVector` inputs accepted by a model, see
 
 ```ts
 import type {VertexFormat} from '@luma.gl/core';
-import type {GPUVectorFormat, VertexList} from '@luma.gl/gpgpu/gpu-data';
+import type {FixedSizeList, GPUVectorFormat, VertexList} from '@luma.gl/gpgpu/gpu-data';
 
 export type GPUTypeMap = Record<string, GPUVectorFormat>;
 
 export type GPUField<
   Name extends string = string,
-  Format extends VertexFormat | VertexList<VertexFormat> = GPUVectorFormat
+  Format extends GPUVectorFormat = GPUVectorFormat
 > = {
   name: Name;
   format?: Format;
@@ -69,6 +69,20 @@ type PathTable = {
 };
 ```
 
+Fixed-size storage values retain their row cardinality in the column format:
+
+```ts
+type EmbeddingTable = {
+  embedding: FixedSizeList<'float32', 768>;
+  sourceId: 'uint32';
+  embeddingValidity: 'uint32';
+};
+```
+
+Every column has the same logical table row count. The embedding allocation
+contains 768 Float32 elements per row; its source IDs and optional GPU-validity
+mask remain independently owned, ordinary row-aligned Uint32 columns.
+
 ## Semantics
 
 `GPUSchema` describes selected GPU-facing columns, not necessarily every source
@@ -80,6 +94,8 @@ path.
 
 - fixed vectors use core `VertexFormat` strings such as `float32x3`;
 - variable-length vertex lists use `vertex-list<format>`;
+- variable-length non-vertex values use `value-list<format>`;
+- fixed-size storage values use `fixed-size-list<format,size>`;
 - shader values remain in `ShaderLayout`, such as `vec3<f32>` or `vec4<f32>`.
 
 Compatibility between `GPUField.format` and shader values is checked separately

--- a/docs/api-reference/experimental/gpu-tables/gpu-table-lifecycle.mdx
+++ b/docs/api-reference/experimental/gpu-tables/gpu-table-lifecycle.mdx
@@ -56,6 +56,9 @@ Packing mutates the table in place. It rebuilds `batches[]` and table-level
 removed batches. Borrowed external buffers are not destroyed.
 Indexed tables are rejected because packed index buffers would need their
 batch-local vertex indices rebased.
+Nullable chunks and chunks carrying producer-owned readback metadata are also
+rejected rather than silently losing source validity or adapter reconstruction
+information. Non-null fixed-size-list columns can still be packed explicitly.
 
 ### Ownership Rules
 

--- a/docs/api-reference/experimental/gpu-tables/gpu-table.mdx
+++ b/docs/api-reference/experimental/gpu-tables/gpu-table.mdx
@@ -95,7 +95,9 @@ This means `table.schema.fields` may contain names absent from
 
 Explicitly merges adjacent physical batches. Constants survive unchanged and do not
 participate in copies. Indexed and variable-length restrictions still apply to the
-varying data being packed.
+varying data being packed. Columns carrying null bitmaps or producer-owned
+readback metadata are rejected until a metadata-preserving packing contract is
+available; ordinary non-null fixed-size-list storage columns remain packable.
 
 ### `addBatch(batch): this`
 

--- a/docs/api-reference/gpgpu/README.md
+++ b/docs/api-reference/gpgpu/README.md
@@ -35,6 +35,8 @@ v9.4.
   across logical rows.
 - [`GPUVectorFormat`](/docs/api-reference/gpgpu/gpu-vector-format) describes stored bytes
   independently from shader-facing value types.
+- [`GPU Vector Search`](/docs/api-reference/gpgpu/gpu-vector-search) performs exact, bounded
+  similarity search over borrowed fixed-size GPU rows.
 
 Each `GPUData` owns or borrows exactly one buffer. A `GPUVector` does not own a separate raw buffer;
 it preserves its ordered `GPUData` chunks and their source batch boundaries. Packing and repacking

--- a/docs/api-reference/gpgpu/gpu-data.mdx
+++ b/docs/api-reference/gpgpu/gpu-data.mdx
@@ -113,7 +113,7 @@ order, offsets, formats, row stride, and optional `stepMode`.
 | `format` | `GPUVectorFormat \| GPUDataStructFields` | `undefined` | A scalar/list format string or an inline record of named fixed-width field formats. |
 | `layout` | `wgsl-storage \| packed` | `wgsl-storage` | Physical packing rules for an inline struct format. Invalid with a scalar/list format. |
 | `length` | `number` | Required | Number of logical rows in this chunk. |
-| `valueLength` | `number` | `length` | Number of fixed rows or flattened vertex-list element values. |
+| `valueLength` | `number` | Derived from `format` | Number of fixed rows, or flattened variable-list/fixed-size-list element values. |
 | `stride` | `number` | Derived from `format` | Number of scalar values represented by one fixed row or flattened element. |
 | `byteOffset` | `number` | `0` | Byte offset of the first logical row in this chunk's buffer. Most adapters use `0` because chunks own their uploaded buffers. |
 | `byteStride` | `number` | Derived from `format` | Bytes between adjacent fixed rows or flattened elements. |
@@ -131,13 +131,30 @@ order, offsets, formats, row stride, and optional `stepMode`.
 | `type` | `unknown` | Deprecated adapter-owned logical metadata. |
 | `dataType` | `unknown` | Deprecated adapter-owned logical metadata. |
 | `length` | `number` | Number of logical rows in this chunk. |
-| `valueLength` | `number` | Number of fixed rows or flattened vertex-list element values. |
+| `valueLength` | `number` | Number of fixed rows, or flattened variable-list/fixed-size-list element values. |
 | `stride` | `number` | Number of scalar values represented by one fixed row or flattened element. |
 | `byteOffset` | `number` | Byte offset of the first logical row. |
 | `byteStride` | `number` | Bytes between adjacent fixed rows or flattened elements. |
 | `rowByteLength` | `number` | Bytes occupied by one fixed row or flattened element payload. |
 | `readbackMetadata` | `unknown` | Optional producer-owned metadata. |
 | `ownsBuffer` | `boolean` | Whether this data range currently owns its backing buffer. |
+
+Fixed-size storage lists preserve table rows independently from flattened scalar
+coordinates:
+
+```ts
+const embeddings = new GPUData({
+  buffer,
+  format: 'fixed-size-list<float32,768>',
+  length: 1000,
+  ownsBuffer: true
+});
+
+embeddings.length; // 1000 logical table rows
+embeddings.valueLength; // 768000 Float32 elements
+embeddings.rowByteLength; // 3072 bytes
+embeddings.byteStride; // 3072 bytes, unless rows are explicitly padded
+```
 
 ## Methods
 

--- a/docs/api-reference/gpgpu/gpu-vector-format.mdx
+++ b/docs/api-reference/gpgpu/gpu-vector-format.mdx
@@ -26,7 +26,15 @@ import type {VertexFormat} from '@luma.gl/core';
 export type VertexList<Format extends VertexFormat = VertexFormat> =
   `vertex-list<${Format}>`;
 
-export type GPUVectorFormat = VertexFormat | VertexList;
+export type ValueList<Format extends VertexFormat = VertexFormat> =
+  `value-list<${Format}>`;
+
+export type FixedSizeList<
+  Format extends VertexFormat = VertexFormat,
+  Size extends number = number
+> = `fixed-size-list<${Format},${Size}>`;
+
+export type GPUVectorFormat = VertexFormat | VertexList | ValueList | FixedSizeList;
 
 export type GPUDataFormat = GPUVectorFormat | GPUDataStructFormat;
 ```
@@ -55,8 +63,25 @@ per-vertex element values. The format inside the angle brackets describes one
 flattened element. Offset buffers, row ranges, closed-path flags, text glyph
 maps, and similar topology metadata are adapter-owned.
 
-Generic `list<format>` is intentionally reserved for a possible future
-non-vertex offset-list type.
+Variable-length non-vertex values use `value-list<format>`. For example,
+`value-list<uint8>` stores flattened UTF-8 bytes with producer-owned row offsets.
+
+Fixed-size storage values keep their logical row width in the format itself:
+
+```ts
+'fixed-size-list<float32,384>'
+'fixed-size-list<float32,768>'
+'fixed-size-list<float32,1536>'
+```
+
+`fixed-size-list<float32,768>` describes 768 stored Float32 values in each table
+row. It does **not** describe a vertex attribute, a WGSL `vec768<f32>`, or a
+new Arrow-owned GPU type. `GPUData.length` and `GPUVector.length` remain logical
+row counts; `valueLength` counts the flattened elements. The default row
+`byteStride` and `rowByteLength` are `768 * 4`, while an explicit larger
+`byteStride` preserves physical row padding.
+
+Generic `list<format>` remains intentionally reserved.
 
 `GPUDataStructFormat` is an object rather than another format string because it
 contains named field formats, offsets, and row-stride metadata. It remains a
@@ -68,7 +93,7 @@ format of one logical vector.
 
 ### `getGPUVectorFormatInfo(format): GPUVectorFormatInfo`
 
-Decodes a fixed or `vertex-list<...>` format string.
+Decodes fixed scalar/vector, variable-list, or fixed-size-list storage formats.
 
 ```ts
 const info = getGPUVectorFormatInfo('vertex-list<float32x3>');
@@ -78,16 +103,34 @@ info.vertexList; // true
 info.components; // 3
 info.byteLength; // 12
 info.primitiveType; // 'f32'
+
+const embedding = getGPUVectorFormatInfo('fixed-size-list<float32,768>');
+
+embedding.elementFormat; // 'float32'
+embedding.fixedSizeList; // true
+embedding.listSize; // 768
+embedding.elementByteLength; // 4
+embedding.byteLength; // 3072 bytes per logical row
 ```
 
 ### `getGPUVectorElementFormat(format): VertexFormat`
 
-Returns the fixed element format. For fixed vectors this is the input format; for
-vertex lists this is the format inside `vertex-list<...>`.
+Returns the fixed element format. For scalar/vector formats this is the input;
+for variable and fixed-size lists it is the element format inside the brackets.
 
 ### `isVertexListGPUVectorFormat(format): boolean`
 
 Returns true for `vertex-list<...>` formats.
+
+### `isValueListGPUVectorFormat(format): boolean`
+
+Returns true for variable-length non-vertex `value-list<...>` formats.
+
+### `isFixedSizeListGPUVectorFormat(format): boolean`
+
+Returns true for canonical `fixed-size-list<format,size>` formats. Sizes are
+positive integers; whitespace, leading zeros, missing sizes, and unsupported
+element formats are rejected.
 
 ### `isGPUVectorFormatCompatibleWithShaderType(format, shaderType): boolean`
 
@@ -102,6 +145,7 @@ Examples:
 | `uint32x2` | `vec2<u32>` | yes | Unsigned integer primitive type matches. |
 | `sint32x2` | `vec2<u32>` | no | Signedness mismatch. |
 | `float32x3` | `vec4<f32>` | no | Component count mismatch. |
+| `fixed-size-list<float32,768>` | `vec4<f32>` | no | Fixed-size lists are storage columns, not vertex attributes. |
 
 ## Buffer Layouts
 
@@ -137,9 +181,10 @@ const positions = new GPUVector({
 });
 ```
 
-`vertex-list<...>` vectors do not synthesize generic vertex-buffer layouts.
-Path, text, polygon, and geometry adapters must either expand them into
-renderable fixed vectors or bind them through an explicit storage/offset path.
+`vertex-list<...>`, `value-list<...>`, and `fixed-size-list<...>` vectors do not
+synthesize generic vertex-buffer layouts. Path, text, polygon, geometry, and
+embedding adapters must either expand compatible values into renderable fixed
+vectors or bind them explicitly through storage.
 
 ## Arrow Mapping
 
@@ -149,8 +194,15 @@ renderable fixed vectors or bind them through an explicit storage/offset path.
 | --- | --- |
 | `FixedSizeList<Float32, 3>` | `float32x3` |
 | `FixedSizeList<Uint8, 4>` as normalized color | `unorm8x4` |
+| `FixedSizeList<Float32, 384>` embedding | `fixed-size-list<float32,384>` |
+| `FixedSizeList<Float32, 768>` embedding | `fixed-size-list<float32,768>` |
+| `FixedSizeList<Float32, 1536>` embedding | `fixed-size-list<float32,1536>` |
 | `List<FixedSizeList<Float32, 3>>` path coordinates | `vertex-list<float32x3>` |
 | `List<FixedSizeList<Uint8, 4>>` vertex colors | `vertex-list<unorm8x4>` |
+
+Short fixed-size lists preserve their existing vertex-attribute mappings. Wide
+fixed-size lists become ordinary row-aligned storage columns without inventing
+unsupported formats such as `float32x768`.
 
 Arrow data types remain adapter/readback metadata. Table core uses
 `GPUVectorFormat`.

--- a/docs/api-reference/gpgpu/gpu-vector-search.md
+++ b/docs/api-reference/gpgpu/gpu-vector-search.md
@@ -1,0 +1,329 @@
+---
+title: GPU Vector Search
+description: Run exact GPU vector similarity search over borrowed fixed-size GPU data.
+---
+
+# GPU Vector Search
+
+## Overview
+
+`@luma.gl/gpgpu/gpu-vector-search` is a headless WebGPU computation backend for high-dimensional vector
+similarity. Applications use its GPU-resident nearest neighbors, scores, and selection counts for
+semantic selection, similar-item highlighting, color encoding, and other visualization workflows.
+
+GPU Vector Search does not provide a graph visualization, graph-based approximate index, embedding explorer,
+vector database, hosted inference, or renderer. Applications retain their existing visualization
+stack and own command submission, output buffers, optional readback, and rendering.
+
+## Concepts
+
+### Why vector similarity belongs in a visualization pipeline
+
+A chart can already filter records by numeric range, category, or visible region. Embeddings add
+another useful relationship: records with nearby coordinates may represent similar documents,
+images, products, or events. A selected record can therefore drive a linked selection of its
+nearest neighbors or provide a reusable similarity-based highlighting and color channel.
+
+Transferring every embedding to the CPU for each interaction makes that relationship expensive and
+breaks composition with GPU-resident filters. GPU Vector Search contributes bounded compute passes to the same
+`GPUCommandGraph` as the existing selection and rendering workflow. The result is ordinary GPU
+data that later passes can consume; applications still decide what to draw and when to submit.
+
+### Why embeddings are table columns rather than a second matrix owner
+
+An embedding is one logical table value containing a fixed number of coordinates. It should stay
+aligned with the same row as its stable identifier, category, validity, or other visualization
+attributes. The canonical `fixed-size-list<float32,768>` GPU format expresses that row shape
+without inventing an unsupported `float32x768` vertex format.
+
+```text
+Arrow FixedSizeList<Float32>[768]
+    -> GPUVector<'fixed-size-list<float32,768>'>
+    -> GPURecordBatch / GPUTable column
+    -> borrowed GraphEmbeddingMatrix view
+    -> exact similarity-search graph passes
+```
+
+`GPUData` owns or borrows one underlying buffer, `GPUVector` preserves its ordered chunks, and
+`GPUTable` preserves source batches and column ownership. `GraphEmbeddingMatrix` is only a
+non-owning, graph-specific description of those existing rows; it neither uploads values nor adds
+another lifetime to destroy. This keeps Apache Arrow in `@luma.gl/arrow`, generic storage in
+`@luma.gl/gpgpu/gpu-data`, and similarity algorithms in the optional
+`@luma.gl/gpgpu/gpu-vector-search` subpath.
+
+### Stable identifiers, logical rows, and validity serve different purposes
+
+A logical row position locates an embedding inside the original ordered batches. A stable source
+identifier names the application record and can be sparse, reordered, or unrelated to that
+position. A validity flag decides whether the row participates. Treating these three values as
+interchangeable would break linked filtering, picking, chunk preservation, or prebuilt indexes.
+
+For example, the second physical row may hold application ID `90`; search returns `90`, but still
+uses row position `1` to read its coordinates and the corresponding source-aligned filter flag.
+`GPURecordBatch.sourceInfo` supplies contiguous source positions when explicit IDs are unnecessary.
+Arbitrary stable IDs and GPU-resident validity remain ordinary caller-selected Uint32 sibling
+columns. Parent or coordinate nulls require an explicit uploaded validity sibling, while null
+stable IDs are rejected because replacing them with zero would silently change record identity.
+
+### Exact search trades a complete scan for a guaranteed answer
+
+`GPUSimilaritySearch` compares each eligible dataset row with every query and retains the best `k`
+results. For `Q` queries, `N` rows, and `D` coordinates, the distance work is `O(Q * N * D)`.
+The implementation processes preserved chunks and bounded storage-binding tiles; it never
+allocates a `Q * N` distance matrix. Persistent caller-owned output contains at most `Q * k` IDs
+and scores, with deterministic source-ID tie breaking.
+
+This is the right baseline when the dataset is modest, the selected population is small, the
+vectors change frequently, or correctness requires the true nearest neighbors. Filters do not
+turn a full scan into an index: they exclude rows from ranking but do not remove the need to
+inspect the relevant source flags. Stable-ID allowlists larger than 16 entries use a bounded GPU
+hash index to avoid linearly rescanning the complete allowlist for every candidate.
+
+### Lifecycle, ownership, and current limits
+
+Applications own the source table, stable-ID and validity columns, and result buffers. A
+`GPUCommandGraph` borrows those imports and owns only its declared transient scratch and
+node-created pipelines or computations after compilation. Contributors add passes; they never
+compile the graph, submit work, read results back, resize caller storage, or destroy borrowed
+allocations.
+
+Repeated encodings of a compiled graph can change queries or selection flags without rebuilding
+the source table. Source data, outputs, and render consumers must share the same WebGPU device.
+Query output and embedding chunks are tiled to active device limits.
+
+The current scope is Float32 fixed-size embeddings, Uint32 row identities, exact
+squared-Euclidean, cosine, or inner-product search, and explicit selection masks. Native Float64
+arithmetic, distributed search, approximate indexes, and direct WebGL interoperation are not
+provided.
+
+### Device loss invalidates compiled graphs
+
+All WebGPU buffers and compiled graph state belong to the device that created them. Applications
+should observe `device.lost` and stop encoding or submitting work when that promise resolves; a
+lost device cannot safely resume an existing graph.
+
+To recover, destroy the compiled graph's owned resources, dispose caller-owned tables and result
+buffers according to their existing ownership rules, and create a new device. Re-upload the
+original Arrow or application data, reconstruct the table and borrowed graph views, and allocate
+new outputs before accepting another query.
+
+## Attribution
+
+GPU Vector Search is inspired by [NVIDIA RAPIDS cuVS](https://github.com/NVIDIA/cuvs), which is distributed under
+the [Apache License 2.0](https://github.com/NVIDIA/cuvs/blob/main/LICENSE).
+
+GPU Vector Search is an independently implemented, MIT-licensed luma.gl WebGPU module. No cuVS source code, CUDA
+kernels, or FAISS implementations are copied into this module. It is not affiliated with or endorsed
+by NVIDIA or the RAPIDS project, and it neither implements a compatible cuVS API nor claims feature
+parity.
+
+## Fixed-size GPU table embedding columns
+
+High-dimensional values such as 384-, 768-, or 1,536-component embeddings are not GPU vertex
+formats: a format such as `float32x768` does not exist. They are ordinary row-aligned GPU table
+columns whose canonical memory format describes a fixed number of scalar elements:
+
+```ts
+import {GPUData, GPUVector, type FixedSizeList} from '@luma.gl/gpgpu/gpu-data';
+
+const embeddingChunk = new GPUData({
+  buffer: embeddingBuffer,
+  format: 'fixed-size-list<float32,768>',
+  length: firstBatchRowCount,
+  ownsBuffer: false
+});
+
+const embeddingColumn = new GPUVector<FixedSizeList<'float32', 768>>({
+  type: 'data',
+  name: 'embedding',
+  format: 'fixed-size-list<float32,768>',
+  data: [embeddingChunk]
+});
+
+embeddingColumn.length; // Number of logical table rows.
+embeddingColumn.valueLength; // Number of flattened Float32 coordinates.
+```
+
+The embedding width is encoded in the format and remains available when a column is detached from
+its table. `GPUData.byteStride` may exceed `rowByteLength` for padded rows; `byteOffset` identifies
+the first logical row in its allocation. `GPUTable` and `GPURecordBatch` preserve batch boundaries,
+source-row provenance, and ownership. Stable source IDs and optional GPU validity are separate,
+ordinary row-aligned Uint32 columns. GPU Vector Search borrows those table resources; it does not introduce a
+second owning matrix abstraction or silently concatenate, repack, or copy source batches.
+Its graph bindings align packed buffer offsets internally; ordinary generic WebGPU table bindings
+still require storage offsets aligned to the active device limit.
+
+Storage bindings are bounded by the active WebGPU device. At a 128 MiB binding limit, one packed
+binding holds about 87,381 rows at 384 dimensions, 43,690 rows at 768 dimensions, or 21,845 rows
+at 1,536 dimensions. GPU Vector Search processes original chunks in bounded tiles and merges their candidates
+into one deterministic global top-K without materializing a complete query-by-dataset score matrix.
+
+## Ingest Apache Arrow embedding columns
+
+Apache Arrow conversion belongs to `@luma.gl/arrow`, not the generic GPU data runtime or vector
+search subpath:
+
+```ts
+import {makeGPUTableFromArrowTable} from '@luma.gl/arrow';
+
+const datasetTable = makeGPUTableFromArrowTable(device, embeddingTable, {
+  shaderLayout: {
+    attributes: [],
+    bindings: [
+      {name: 'embedding', type: 'read-only-storage', group: 0, location: 0},
+      {name: 'sourceIds', type: 'read-only-storage', group: 0, location: 1}
+    ]
+  },
+  validityColumns: {embedding: 'embeddingValidity'}
+});
+```
+
+An Arrow `FixedSizeList<Float32>` field wider than four scalar elements maps directly to
+`GPUVector<'fixed-size-list<float32,768>'>`. Existing short geometry fields preserve their
+`float32x2`, `float32x3`, and `float32x4` vertex formats. Parent-list offsets, child offsets,
+sliced arrays, nullable parent rows, nullable child coordinates, omitted trailing-null child
+values, record-batch identity, and empty source chunks remain represented by the ordinary table.
+
+`validityColumns` explicitly requests a table-owned Uint32 sibling with one source-aligned flag
+per embedding row. Supply a normal, non-null `sourceIds` Arrow column whenever IDs are not the
+contiguous row positions recorded in `GPURecordBatch.sourceInfo`. Null source identifiers are
+rejected instead of being silently interpreted as zero. In particular, Arrow `Vector.slice()` can
+discard preceding chunks and their original provenance; explicit source-ID columns preserve global
+identity across those boundaries.
+
+If an embedding column contains null parent rows or null child coordinates, select its explicit
+GPU validity sibling when importing it into GPU Vector Search. Nullable embedding data without a selected
+validity column is rejected instead of admitting zero-filled null rows as candidate vectors.
+
+```ts
+import {makeGPUVectorFromArrow} from '@luma.gl/arrow';
+
+const embeddingVector = makeGPUVectorFromArrow(device, arrowEmbeddingColumn, {
+  name: 'embedding',
+  format: 'fixed-size-list<float32,768>'
+});
+```
+
+The explicit format also preserves the precise `GPUVector<FixedSizeList<'float32', 768>>`
+TypeScript result when importing a vector directly. The adapter preserves Arrow data chunks and
+logical row counts. Existing GPU allocations can also be wrapped in ordinary borrowed `GPUData`
+and assembled into a `GPURecordBatch`;
+`GPUTable.destroy()` follows the existing per-chunk ownership contract.
+
+## Encode an exact nearest-neighbor search
+
+```ts
+import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
+import {
+  GPUSimilaritySearch,
+  importGPUEmbeddingTable
+} from '@luma.gl/gpgpu/gpu-vector-search';
+
+const graph = new GPUCommandGraph(device, {id: 'semantic-selection'});
+const dataset = importGPUEmbeddingTable(graph, datasetTable, {
+  id: 'dataset',
+  column: 'embedding',
+  sourceRowIds: 'sourceIds',
+  validity: 'embeddingValidity'
+});
+const queries = importGPUEmbeddingTable(graph, queryTable, {
+  id: 'queries',
+  column: 'embedding'
+});
+
+new GPUSimilaritySearch({
+  id: 'nearest-embeddings',
+  dataset,
+  queries,
+  outputIds: resultSourceIds,
+  outputScores: resultScores,
+  resultCounts,
+  candidateCounts,
+  k: 10,
+  metric: 'cosine'
+}).addToGraph(graph);
+
+const compiled = graph.compile();
+const encoder = device.createCommandEncoder({id: 'nearest-embeddings'});
+compiled.encode(encoder, {parameters: undefined});
+device.submit(encoder.finish());
+```
+
+`outputIds` and `outputScores` are caller-owned packed views with `queryCount * k` slots in
+query-major order. `resultCounts` and optional `candidateCounts` contain one Uint32 value per
+query. The graph imports and borrows every source allocation; it does not submit work, read data
+back, or destroy caller-owned tables or buffers. `importGPUEmbeddingVector()` accepts an existing
+fixed-size-list vector directly when a complete table is unnecessary.
+
+The optional `dimensions` import option can select meaningful leading coordinates when an Arrow
+fixed-size-list row intentionally contains trailing padding. Configure the companion mask with
+`validityColumns: {embedding: {name: 'embeddingValidity', dimensions: 768}}` to ignore null padding
+while still rejecting null parent rows or null meaningful coordinates.
+For one-to-four-element Arrow rows, also select `fixedSizeListColumns: ['embedding']` so the
+ordinary table adapter preserves fixed-size-list storage semantics instead of its default
+vertex-compatible format.
+
+Supported metrics are:
+
+| Metric | Ranking | Meaning |
+| --- | --- | --- |
+| `'squared-euclidean'` | Smaller scores first | Squared Euclidean distance; no square root is required. |
+| `'cosine'` | Larger scores first | Cosine similarity computed from the dot product and vector norms. |
+| `'inner-product'` | Larger scores first | Maximum raw vector inner product. |
+
+Equal scores are ordered by stable source-row ID, and duplicate vector rows remain independently
+eligible. Two zero vectors have cosine similarity `1`; one zero vector paired with a nonzero vector
+has cosine similarity `0`. Candidates containing `NaN` or infinity are excluded; a nonfinite query
+produces no matches. Finite embedding values whose Float32 distance or inner product overflows remain
+eligible and are ranked with their positive or negative infinity score; indeterminate `NaN` scores
+are excluded. `k: 0` writes zero result counts, an empty query batch records no search work, and an
+empty dataset or short eligible population leaves unfilled IDs at `0xffffffff`. Unfilled scores are
+positive infinity for squared distance and negative infinity for similarity metrics.
+The sentinel `0xffffffff` is reserved and cannot be used as an explicit source-row identifier.
+`excludeSelf: true` omits candidates whose stable source-row ID equals the corresponding query ID.
+An optional `tileSize` bounds candidate work without changing exact global result order.
+
+## Reuse GPU-resident linked selections
+
+Pass a source-aligned Uint32 view or chunk-preserving vector of selection flags directly into the
+search. Zero rejects the row; nonzero accepts it. The mask can come from GPU Crossfilter, a GPU
+dataframe query, or an application-owned graph pass:
+
+```ts
+import {GPUSimilaritySearch} from '@luma.gl/gpgpu/gpu-vector-search';
+
+new GPUSimilaritySearch({
+  dataset,
+  queries,
+  outputIds,
+  outputScores,
+  resultCounts,
+  candidateCounts,
+  k: 10,
+  filterMask: selectionMask
+}).addToGraph(graph);
+```
+
+Update the mask and encode the previously compiled graph again. The current selection and
+embedding candidates remain on the GPU. Optional `candidateIds` restrict search to stable source
+identifiers. Allowlists with more than 16 entries use a bounded GPU hash index; smaller lists use
+direct membership checks. Oversized allowlists are rejected, so use a source-aligned filter mask
+when the requested identifiers exceed bounded index capacity. Optional `queryFilterMask` supplies
+query-specific source-aligned flags. Candidate counts distinguish no eligible rows from a valid
+but short nearest-neighbor list.
+
+## Integrate GPU results with rendering
+
+Use stable result IDs as an input to selection compaction, highlighting, shader-side color lookup,
+or a deck.gl-compatible WebGPU visualization workflow. Bind the existing GPU buffers directly
+when both compute and rendering use the same WebGPU device; read back only when application UI
+needs concrete CPU values.
+
+WebGPU buffers cannot be handed directly to a renderer that owns an unrelated WebGL context.
+Interoperation with WebGL-based applications such as a WebGL cosmos.gl renderer requires an
+explicit supported transfer or readback boundary; GPU Vector Search does not claim WebGPU-to-WebGL zero-copy.
+
+See [GPU Crossfilter](/docs/api-reference/experimental/gpu-crossfilter),
+[GPU command graphs](/docs/api-reference/experimental/gpu-core/gpu-command-graph), and
+[Apache Arrow GPU conversion](/docs/api-reference/arrow/arrow-conversion) for the related
+filtering, execution, and ingestion contracts.

--- a/docs/api-reference/gpgpu/gpu-vector.mdx
+++ b/docs/api-reference/gpgpu/gpu-vector.mdx
@@ -56,7 +56,7 @@ When the input starts as Apache Arrow, prefer
 | `type` | `unknown` | Deprecated adapter-owned logical metadata. |
 | `dataType` | `unknown` | Deprecated adapter-owned logical metadata. |
 | `length` | `number` | Aggregate logical row count. |
-| `valueLength` | `number` | Aggregate fixed-row or flattened vertex-list element count. |
+| `valueLength` | `number` | Aggregate scalar-row count, flattened variable-list count, or fixed-size-list element count. |
 | `stride` | `number` | Number of scalar values represented by one fixed row or flattened element. |
 | `byteOffset` | `number` | Compatibility metadata for the first row when this vector has one chunk. |
 | `byteStride` | `number` | Bytes between adjacent fixed rows or flattened elements. |
@@ -102,3 +102,29 @@ For `vertex-list<...>` vectors, `length` remains the source row count and
 `valueLength` is the flattened element count. `byteStride` and `rowByteLength`
 describe one flattened element, not one source row. Offsets and other
 variable-length metadata are adapter-owned.
+
+For `fixed-size-list<float32,768>` vectors, `length` remains the number of table
+rows while `valueLength` is `length * 768`. Each `GPUData` chunk stores one
+complete fixed-size-list row per `byteStride`; `rowByteLength` describes its
+meaningful payload and may be smaller than a padded physical stride. These
+columns are storage-only unless an application explicitly expands them into
+shader-compatible attributes. When binding a packed column through generic
+WebGPU table shader/computation helpers, its `byteOffset` must satisfy the
+device's `minStorageBufferOffsetAlignment`; consumers that align bindings
+internally may support additional suballocation offsets.
+
+```ts
+import {GPUVector, type FixedSizeList} from '@luma.gl/gpgpu/gpu-data';
+
+const embeddings = new GPUVector<FixedSizeList<'float32', 768>>({
+  type: 'buffer',
+  name: 'embedding',
+  buffer: embeddingBuffer,
+  format: 'fixed-size-list<float32,768>',
+  length: rowCount
+});
+
+embeddings.length; // Logical source rows.
+embeddings.valueLength; // Flattened Float32 embedding coordinates.
+embeddings.data; // Original caller-owned GPUData batch chunks.
+```

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -667,6 +667,7 @@
         "label": "@luma.gl/gpgpu",
         "items": [
           "api-reference/gpgpu/README",
+          "api-reference/gpgpu/gpu-vector-search",
           {
             "type": "category",
             "label": "GPU Data",

--- a/modules/arrow/src/arrow/gpu/arrow-gpu-data.ts
+++ b/modules/arrow/src/arrow/gpu/arrow-gpu-data.ts
@@ -26,6 +26,14 @@ import {
 /** Compact CPU metadata required to reconstruct variable-width Arrow chunks after GPU readback. */
 export type GPUDataReadbackMetadata =
   | {
+      /** Metadata variant for nullable fixed-width numeric rows. */
+      kind: 'numeric';
+      /** Number of nullable rows in the source Arrow chunk. */
+      nullCount: number;
+      /** Copied row validity bitmap normalized to this data chunk. */
+      nullBitmap: Uint8Array;
+    }
+  | {
       /** Metadata variant for Arrow UTF-8 value bytes. */
       kind: 'utf8';
       /** Chunk-local Arrow value offsets normalized to the copied GPU byte range. */
@@ -48,6 +56,18 @@ export type GPUDataReadbackMetadata =
       nullBitmap?: Uint8Array;
       /** Number of flattened numeric value bytes to read back from the GPU buffer. */
       valueByteLength: number;
+    }
+  | {
+      /** Metadata variant for nullable fixed-size-list storage rows. */
+      kind: 'fixed-size-list';
+      /** Number of nullable parent rows in the source Arrow chunk. */
+      nullCount: number;
+      /** Optional copied parent validity bitmap normalized to this chunk. */
+      nullBitmap?: Uint8Array;
+      /** Number of nullable flattened child values in the uploaded rows. */
+      childNullCount: number;
+      /** Optional copied child validity bitmap normalized to this chunk. */
+      childNullBitmap?: Uint8Array;
     };
 
 type GPUVectorReadableBuffer = Pick<Buffer, 'readAsync'>;
@@ -108,6 +128,10 @@ export function getArrowDataBufferSource<T extends AttributeArrowType>(
   data: Data<T>
 ): NumericArrowType['TArray'];
 export function getArrowDataBufferSource(data: Data): NumericArrowType['TArray'] {
+  if (DataType.isFixedSizeList(data.type)) {
+    return getArrowFixedSizeListDataBufferSource(data as Data<FixedSizeList<NumericArrowType>>);
+  }
+
   const {values, startElement, elementCount} = getArrowDataValueRange(data);
   if (values.length < elementCount) {
     throw new Error('Arrow data values are shorter than the logical upload length');
@@ -181,6 +205,15 @@ export function getArrowVariableLengthAttributeDataBufferSource(
 
 /** Copy compact variable-width reconstruction metadata without retaining Arrow value buffers. */
 export function getArrowGPUDataReadbackMetadata(data: Data): GPUDataReadbackMetadata | undefined {
+  if (DataType.isInt(data.type) || DataType.isFloat(data.type)) {
+    const nullBitmap = copyNormalizedArrowNullBitmap(data);
+    return nullBitmap ? {kind: 'numeric', nullCount: data.nullCount, nullBitmap} : undefined;
+  }
+
+  if (DataType.isFixedSizeList(data.type)) {
+    return getArrowFixedSizeListReadbackMetadata(data as Data<FixedSizeList<NumericArrowType>>);
+  }
+
   if (DataType.isUtf8(data.type)) {
     const values = getArrowUtf8DataBufferSource(data as Data<Utf8>);
     return {
@@ -206,6 +239,35 @@ export function getArrowGPUDataReadbackMetadata(data: Data): GPUDataReadbackMeta
   }
 
   return undefined;
+}
+
+/** Returns row validity for a fixed-size list, including nullable selected child coordinates. */
+export function getArrowFixedSizeListRowValidity(
+  data: Data<FixedSizeList<NumericArrowType>>,
+  dimensions = data.type.listSize
+): Uint32Array | undefined {
+  const childData = data.children[0] as Data<NumericArrowType> | undefined;
+  if (!childData) {
+    throw new Error('Arrow FixedSizeList data has no child values');
+  }
+  if (!Number.isSafeInteger(dimensions) || dimensions < 1 || dimensions > data.type.listSize) {
+    throw new Error('Arrow FixedSizeList validity dimensions must fit within the list width');
+  }
+  if (data.nullCount === 0 && childData.nullCount === 0) {
+    return undefined;
+  }
+
+  const parentChildOffset = getArrowFixedSizeListParentChildOffset(data, childData);
+  const validity = new Uint32Array(data.length);
+  for (let rowIndex = 0; rowIndex < data.length; rowIndex++) {
+    let valid = isArrowDataValueValid(data, rowIndex);
+    for (let dimensionIndex = 0; valid && dimensionIndex < dimensions; dimensionIndex++) {
+      const childIndex = parentChildOffset + rowIndex * data.type.listSize + dimensionIndex;
+      valid = childIndex < childData.length && isArrowDataValueValid(childData, childIndex);
+    }
+    validity[rowIndex] = Number(valid);
+  }
+  return validity;
 }
 
 /** Returns a typed array that can be passed directly to `device.createBuffer()`. */
@@ -362,7 +424,140 @@ export async function readArrowGPUDataAsync<T extends DataType>(data: GPUData): 
     byteOffset: data.byteOffset,
     byteStride: data.byteStride
   });
-  return vector.data[0] as unknown as Data<T>;
+  const packedData = vector.data[0];
+  const metadata = data.readbackMetadata as GPUDataReadbackMetadata | undefined;
+  if (metadata?.kind === 'numeric') {
+    return new Data<T>(dataType, 0, data.length, metadata.nullCount, {
+      [BufferType.DATA]: packedData.values,
+      [BufferType.VALIDITY]: metadata.nullBitmap
+    });
+  }
+  if (DataType.isFixedSizeList(dataType) && metadata?.kind === 'fixed-size-list') {
+    return makeArrowNullableFixedSizeListData(
+      packedData as Data<FixedSizeList<NumericArrowType>>,
+      metadata
+    ) as unknown as Data<T>;
+  }
+  return packedData as unknown as Data<T>;
+}
+
+function getArrowFixedSizeListDataBufferSource(
+  data: Data<FixedSizeList<NumericArrowType>>
+): NumericArrowType['TArray'] {
+  const childData = data.children[0] as Data<NumericArrowType> | undefined;
+  const values = childData?.values as NumericArrowType['TArray'] | undefined;
+  if (!childData || !values) {
+    throw new Error('Arrow FixedSizeList data has no child values');
+  }
+
+  const rowStride = data.type.listSize;
+  const elementCount = data.length * rowStride;
+  const childValuesAlreadySliced =
+    values.length === elementCount || values.length <= childData.length;
+  const startElement = childValuesAlreadySliced
+    ? 0
+    : (childData.offset ?? 0) + data.offset * rowStride;
+  const availableElementCount = Math.max(
+    0,
+    Math.min(
+      elementCount,
+      values.length - startElement,
+      childData.length - (childValuesAlreadySliced ? 0 : data.offset * rowStride)
+    )
+  );
+  if (availableElementCount === elementCount) {
+    return values.subarray(startElement, startElement + elementCount) as NumericArrowType['TArray'];
+  }
+
+  for (
+    let rowIndex = Math.floor(availableElementCount / rowStride);
+    rowIndex < data.length;
+    rowIndex++
+  ) {
+    if (isArrowDataValueValid(data, rowIndex)) {
+      throw new Error('Arrow FixedSizeList child values are shorter than their logical row count');
+    }
+  }
+
+  const paddedValues = createTypedArrayLike(values, elementCount);
+  paddedValues.set(values.subarray(startElement, startElement + availableElementCount) as never);
+  return paddedValues;
+}
+
+function getArrowFixedSizeListReadbackMetadata(
+  data: Data<FixedSizeList<NumericArrowType>>
+): Extract<GPUDataReadbackMetadata, {kind: 'fixed-size-list'}> | undefined {
+  const childData = data.children[0] as Data<NumericArrowType> | undefined;
+  if (!childData) {
+    throw new Error('Arrow FixedSizeList data has no child values');
+  }
+  if (data.nullCount === 0 && childData.nullCount === 0) {
+    return undefined;
+  }
+
+  const flattenedLength = data.length * data.type.listSize;
+  const parentChildOffset = getArrowFixedSizeListParentChildOffset(data, childData);
+  const childNullBitmap = new Uint8Array(Math.ceil(flattenedLength / 8));
+  let childNullCount = 0;
+  for (let childIndex = 0; childIndex < flattenedLength; childIndex++) {
+    const sourceChildIndex = parentChildOffset + childIndex;
+    if (sourceChildIndex < childData.length && isArrowDataValueValid(childData, sourceChildIndex)) {
+      childNullBitmap[childIndex >> 3] |= 1 << (childIndex & 7);
+    } else {
+      childNullCount++;
+    }
+  }
+
+  return {
+    kind: 'fixed-size-list',
+    nullCount: data.nullCount,
+    nullBitmap: copyNormalizedArrowNullBitmap(data),
+    childNullCount,
+    ...(childNullCount > 0 ? {childNullBitmap} : {})
+  };
+}
+
+function getArrowFixedSizeListParentChildOffset(
+  data: Data<FixedSizeList<NumericArrowType>>,
+  childData: Data<NumericArrowType>
+): number {
+  const values = childData.values as NumericArrowType['TArray'];
+  const childValuesAlreadySliced =
+    values.length <= childData.length || values.length === data.length * data.type.listSize;
+  return childValuesAlreadySliced ? 0 : data.offset * data.type.listSize;
+}
+
+function isArrowDataValueValid(data: Data, valueIndex: number): boolean {
+  if (data.nullCount === 0 || !data.nullBitmap) {
+    return true;
+  }
+  const bitmapIndex = data.offset + valueIndex;
+  return ((data.nullBitmap[bitmapIndex >> 3] ?? 0) & (1 << (bitmapIndex & 7))) !== 0;
+}
+
+function makeArrowNullableFixedSizeListData(
+  data: Data<FixedSizeList<NumericArrowType>>,
+  metadata: Extract<GPUDataReadbackMetadata, {kind: 'fixed-size-list'}>
+): Data<FixedSizeList<NumericArrowType>> {
+  const packedChild = data.children[0] as Data<NumericArrowType>;
+  const child = new Data<NumericArrowType>(
+    packedChild.type,
+    0,
+    packedChild.length,
+    metadata.childNullCount,
+    {
+      [BufferType.DATA]: packedChild.values,
+      ...(metadata.childNullBitmap ? {[BufferType.VALIDITY]: metadata.childNullBitmap} : {})
+    }
+  );
+  return new Data<FixedSizeList<NumericArrowType>>(
+    data.type,
+    0,
+    data.length,
+    metadata.nullCount,
+    {...(metadata.nullBitmap ? {[BufferType.VALIDITY]: metadata.nullBitmap} : {})},
+    [child]
+  );
 }
 
 function getArrowDataValueRange(data: Data): {

--- a/modules/arrow/src/arrow/gpu/arrow-gpu-table-adapters.ts
+++ b/modules/arrow/src/arrow/gpu/arrow-gpu-table-adapters.ts
@@ -5,6 +5,7 @@
 import {
   Buffer,
   Device,
+  type BufferLayout,
   type ShaderLayout,
   type SignedDataType,
   type VertexFormat
@@ -13,6 +14,8 @@ import {DynamicBuffer} from '@luma.gl/engine';
 import {
   GPUData,
   GPUVector,
+  getGPUVectorFormatInfo,
+  type FixedSizeList as GPUFixedSizeList,
   type GPUVectorBufferProps,
   type GPUVectorFormat,
   type ValueList,
@@ -42,12 +45,14 @@ import {
   Uint32,
   Uint8,
   Utf8,
-  Vector
+  Vector,
+  makeData
 } from 'apache-arrow';
 import {getArrowFieldByPath, getArrowVectorByPath} from '../arrow-utils/arrow-paths';
 import {getArrowBufferLayout, type ArrowVertexFormatOptions} from '../engine/arrow-shader-layout';
 import {
   getArrowDataBufferSource,
+  getArrowFixedSizeListRowValidity,
   getArrowGPUDataReadbackMetadata,
   getArrowTypeByteStride,
   getArrowTypeStride,
@@ -64,6 +69,7 @@ import {
   isInstanceArrowType,
   isVariableLengthAttributeArrowType,
   type AttributeArrowType,
+  type NumericArrowType,
   type VariableLengthAttributeArrowType
 } from '../arrow-utils/arrow-types';
 import {getArrowMatrixVectorInfo} from '../vectors/arrow-matrix-vector';
@@ -96,6 +102,10 @@ type VertexFormatForArrowType<T extends DataType> =
   T extends FixedSizeList<infer ChildType>
     ? VertexFormatForArrowFixedSizeListType<ChildType>
     : VertexFormatForArrowScalarType<T>;
+type FixedSizeListFormatForArrowScalarType<T extends DataType> =
+  VertexFormatForArrowScalarType<T> extends infer Format extends VertexFormat
+    ? GPUFixedSizeList<Format>
+    : never;
 export type GPUVectorFormatForArrowType<T extends DataType = DataType> = T extends Utf8
   ? ValueList<'uint8'>
   : T extends Dictionary
@@ -104,9 +114,15 @@ export type GPUVectorFormatForArrowType<T extends DataType = DataType> = T exten
       ? VertexFormatForArrowType<ChildType> extends never
         ? GPUVectorFormat
         : VertexList<VertexFormatForArrowType<ChildType>>
-      : VertexFormatForArrowType<T> extends never
-        ? GPUVectorFormat
-        : VertexFormatForArrowType<T>;
+      : T extends FixedSizeList<infer ChildType>
+        ? [VertexFormatForArrowScalarType<ChildType>] extends [never]
+          ? GPUVectorFormat
+          :
+              | VertexFormatForArrowFixedSizeListType<ChildType>
+              | FixedSizeListFormatForArrowScalarType<ChildType>
+        : VertexFormatForArrowType<T> extends never
+          ? GPUVectorFormat
+          : VertexFormatForArrowType<T>;
 
 /** Props for uploading one Arrow vector into GPU storage. */
 export type GPUVectorFromArrowProps<Format extends GPUVectorFormat = GPUVectorFormat> =
@@ -124,6 +140,16 @@ type ArrowGPUDataProps = GPUVectorBufferProps & {
   format?: GPUVectorFormat;
 };
 
+/** Caller-selected row-validity storage sibling for one fixed-size-list Arrow column. */
+export type ArrowGPUValidityColumn =
+  | string
+  | {
+      /** Name of the uint32 GPU table column that receives nonzero-valid row flags. */
+      name: string;
+      /** Meaningful leading child coordinates; nullable trailing padding is ignored. */
+      dimensions?: number;
+    };
+
 /** Props for uploading one Arrow record batch into a generic GPU record batch. */
 export type GPURecordBatchFromArrowRecordBatchProps = ArrowVertexFormatOptions & {
   /** Shader layout that selects which Arrow columns should be uploaded. */
@@ -132,8 +158,12 @@ export type GPURecordBatchFromArrowRecordBatchProps = ArrowVertexFormatOptions &
   arrowPaths?: Record<string, string>;
   /** Buffer props applied to Arrow-backed GPU vectors. */
   bufferProps?: GPUVectorBufferProps;
+  /** Storage-selected columns that should use fixed-size-list format even for short rows. */
+  fixedSizeListColumns?: readonly string[];
   /** Optional source-row identity retained for picking and diagnostics. */
   sourceInfo?: GPURecordBatchSourceInfo;
+  /** Explicitly materialized uint32 row-validity siblings keyed by selected column name. */
+  validityColumns?: Record<string, ArrowGPUValidityColumn>;
 };
 
 /** Props for uploading one Arrow table into a generic GPU table. */
@@ -144,6 +174,10 @@ export type GPUTableFromArrowTableProps = ArrowVertexFormatOptions & {
   arrowPaths?: Record<string, string>;
   /** Buffer props applied to Arrow-backed GPU vectors. */
   bufferProps?: GPUVectorBufferProps;
+  /** Storage-selected columns that should use fixed-size-list format even for short rows. */
+  fixedSizeListColumns?: readonly string[];
+  /** Explicitly materialized uint32 row-validity siblings keyed by selected column name. */
+  validityColumns?: Record<string, ArrowGPUValidityColumn>;
 };
 
 /** Returns the GPUVector memory format implied by an Arrow data type. */
@@ -155,11 +189,14 @@ function getGPUVectorFormatFromArrowDataType(type: DataType): GPUVectorFormat {
     : elementType;
   const size = DataType.isFixedSizeList(elementType) ? elementType.listSize : 1;
 
-  if (!Number.isInteger(size) || size < 1 || size > 4) {
+  if (!Number.isSafeInteger(size) || size < 1 || (size > 4 && isVertexList)) {
     throw new Error(`Cannot synthesize a GPUVector format for Arrow type ${type}`);
   }
 
   const signedDataType = getSignedArrowDataType(scalarType);
+  if (size > 4) {
+    return `fixed-size-list<${signedDataType},${size}>`;
+  }
   if (signedDataType === 'float16' && size === 3) {
     throw new Error('Cannot synthesize a float16x3 GPUVector format');
   }
@@ -221,6 +258,12 @@ export function makeGPUDataFromArrowData<T extends DataType>(
   const arrowType = data.type as T;
   const {format = getGPUVectorFormatForArrowType(arrowType), ...bufferProps} = props;
   const readbackMetadata = getArrowGPUDataReadbackMetadata(data) as GPUDataReadbackMetadata;
+  const variableLengthMetadata =
+    readbackMetadata?.kind === 'utf8' || readbackMetadata?.kind === 'variable-length-attribute'
+      ? readbackMetadata
+      : undefined;
+  const numericNullBitmap =
+    readbackMetadata?.kind === 'numeric' ? readbackMetadata.nullBitmap : undefined;
 
   if (isArrowUtf8DictionaryType(arrowType)) {
     const byteStride = getArrowTypeByteStride(arrowType.indices);
@@ -250,15 +293,15 @@ export function makeGPUDataFromArrowData<T extends DataType>(
       dataType: arrowType,
       format,
       length: data.length,
-      valueLength: readbackMetadata?.valueByteLength ?? 0,
+      valueLength: variableLengthMetadata?.valueByteLength ?? 0,
       stride: 1,
       byteStride: 1,
       rowByteLength: 1,
       ownsBuffer: true,
       readbackMetadata,
-      valueOffsets: readbackMetadata?.valueOffsets,
-      nullBitmap: readbackMetadata?.nullBitmap,
-      valueByteLength: readbackMetadata?.valueByteLength
+      valueOffsets: variableLengthMetadata?.valueOffsets,
+      nullBitmap: variableLengthMetadata?.nullBitmap,
+      valueByteLength: variableLengthMetadata?.valueByteLength
     });
   }
 
@@ -285,9 +328,9 @@ export function makeGPUDataFromArrowData<T extends DataType>(
       rowByteLength: byteStride,
       ownsBuffer: true,
       readbackMetadata,
-      valueOffsets: readbackMetadata?.valueOffsets,
-      nullBitmap: readbackMetadata?.nullBitmap,
-      valueByteLength: readbackMetadata?.valueByteLength
+      valueOffsets: variableLengthMetadata?.valueOffsets,
+      nullBitmap: variableLengthMetadata?.nullBitmap,
+      valueByteLength: variableLengthMetadata?.valueByteLength
     });
   }
 
@@ -305,7 +348,18 @@ export function makeGPUDataFromArrowData<T extends DataType>(
     byteStride,
     rowByteLength: byteStride,
     ownsBuffer: true,
-    readbackMetadata
+    readbackMetadata,
+    ...(readbackMetadata?.kind === 'fixed-size-list'
+      ? {
+          nullBitmap: makeArrowGPUValidityBitmap(
+            getArrowFixedSizeListRowValidity(
+              data as unknown as Data<FixedSizeList<NumericArrowType>>
+            )
+          )
+        }
+      : numericNullBitmap
+        ? {nullBitmap: numericNullBitmap}
+        : {})
   });
 }
 
@@ -332,6 +386,17 @@ export function makeGPUVectorFromArrow<T extends DataType>(
   const arrowType = vector.type as T;
   const matrixInfo = getArrowMatrixVectorInfo(vector);
   const isCanonicalFloat32Matrix = matrixInfo && isCanonicalFloat32ArrowMatrixInfo(matrixInfo);
+  if (
+    !preserveDataChunks &&
+    (DataType.isFixedSizeList(arrowType) ||
+      DataType.isInt(arrowType) ||
+      DataType.isFloat(arrowType)) &&
+    vector.data.some(data => data.nullCount > 0 || (data.children[0]?.nullCount ?? 0) > 0)
+  ) {
+    throw new Error(
+      'Nullable Arrow numeric and FixedSizeList vectors require preserved GPU data chunks'
+    );
+  }
   const requiresChunkedUpload =
     DataType.isUtf8(arrowType) ||
     isArrowUtf8DictionaryType(arrowType) ||
@@ -342,7 +407,12 @@ export function makeGPUVectorFromArrow<T extends DataType>(
     );
   }
 
-  if (!isInstanceArrowType(arrowType) && !isCanonicalFloat32Matrix && !requiresChunkedUpload) {
+  if (
+    !isInstanceArrowType(arrowType) &&
+    !isStorageFixedSizeListArrowType(arrowType) &&
+    !isCanonicalFloat32Matrix &&
+    !requiresChunkedUpload
+  ) {
     throw new Error(`GPUVector does not support Arrow type ${arrowType}`);
   }
 
@@ -389,10 +459,12 @@ export function makeGPUVectorFromArrow<T extends DataType>(
         dataType: arrowType,
         format: vectorFormat,
         length: vector.length,
-        valueLength: vector.data.reduce(
-          (totalValueLength, chunk) => totalValueLength + getArrowDataValueLength(chunk),
-          0
-        ),
+        valueLength: getGPUVectorFormatInfo(vectorFormat).fixedSizeList
+          ? vector.length * (getGPUVectorFormatInfo(vectorFormat).listSize ?? 1)
+          : vector.data.reduce(
+              (totalValueLength, chunk) => totalValueLength + getArrowDataValueLength(chunk),
+              0
+            ),
         stride,
         byteStride,
         rowByteLength: byteStride,
@@ -423,6 +495,9 @@ export function makeGPURecordBatchFromArrowRecordBatch(
   const selectedNames = new Set<string>();
 
   for (const layout of bufferLayout) {
+    if (options.fixedSizeListColumns?.includes(layout.name)) {
+      throw new Error('Arrow fixed-size-list GPU columns require a storage shader binding');
+    }
     const arrowPath = options.arrowPaths?.[layout.name] || layout.name;
     const vector = getArrowVectorByPath(table, arrowPath);
     const sourceField = getArrowFieldByPath(table, arrowPath);
@@ -451,11 +526,12 @@ export function makeGPURecordBatchFromArrowRecordBatch(
     if (!vector || !sourceField) {
       continue;
     }
-    gpuData[storageBinding.name] = makeGPUDataFromArrowRecordBatchVector(
-      device,
-      vector as Vector,
-      options.bufferProps
-    );
+    gpuData[storageBinding.name] = makeGPUDataFromArrowRecordBatchVector(device, vector as Vector, {
+      ...options.bufferProps,
+      ...(options.fixedSizeListColumns?.includes(storageBinding.name)
+        ? {format: getFixedSizeListGPUVectorFormatForArrowType(vector.type)}
+        : {})
+    });
     fields.push({
       name: storageBinding.name,
       format: gpuData[storageBinding.name].format,
@@ -463,6 +539,42 @@ export function makeGPURecordBatchFromArrowRecordBatch(
       metadata: new Map(sourceField.metadata)
     });
     selectedNames.add(storageBinding.name);
+  }
+
+  for (const columnName of options.fixedSizeListColumns ?? []) {
+    if (!selectedNames.has(columnName)) {
+      throw new Error('Arrow fixed-size-list GPU columns require a selected storage binding');
+    }
+  }
+
+  for (const [sourceName, validityColumn] of Object.entries(options.validityColumns ?? {})) {
+    const validityName = typeof validityColumn === 'string' ? validityColumn : validityColumn.name;
+    if (!selectedNames.has(sourceName) || selectedNames.has(validityName)) {
+      throw new Error('Arrow GPU validity columns require a selected source and unique output');
+    }
+    const arrowPath = options.arrowPaths?.[sourceName] || sourceName;
+    const vector = getArrowVectorByPath(table, arrowPath);
+    if (!DataType.isFixedSizeList(vector.type)) {
+      throw new Error('Arrow GPU validity columns require FixedSizeList source data');
+    }
+    const dimensions =
+      typeof validityColumn === 'string'
+        ? vector.type.listSize
+        : (validityColumn.dimensions ?? vector.type.listSize);
+    const [data, ...remainingData] = vector.data;
+    if (!data || remainingData.length > 0) {
+      throw new Error('Arrow RecordBatch columns require exactly one Arrow Data chunk');
+    }
+    const validity =
+      getArrowFixedSizeListRowValidity(data as Data<FixedSizeList<NumericArrowType>>, dimensions) ??
+      new Uint32Array(data.length).fill(1);
+    const validityData = makeData({type: new Uint32(), length: validity.length, data: validity});
+    gpuData[validityName] = makeGPUDataFromArrowData(device, validityData, {
+      ...options.bufferProps,
+      format: 'uint32'
+    });
+    fields.push({name: validityName, format: 'uint32', nullable: false, metadata: new Map()});
+    selectedNames.add(validityName);
   }
 
   return new GPURecordBatch({
@@ -493,7 +605,12 @@ function makeGPUDataFromArrowRecordBatchVector(
       'GPUVector matrix columns require canonical Float32 column-major wgsl-storage values; use convertArrowMatrixToGPUVector() first'
     );
   }
-  if (!isInstanceArrowType(arrowType) && !isCanonicalFloat32Matrix && !requiresChunkedUpload) {
+  if (
+    !isInstanceArrowType(arrowType) &&
+    !isStorageFixedSizeListArrowType(arrowType) &&
+    !isCanonicalFloat32Matrix &&
+    !requiresChunkedUpload
+  ) {
     throw new Error(`GPUVector does not support Arrow type ${arrowType}`);
   }
 
@@ -529,22 +646,15 @@ export function makeGPUTableFromArrowTable(
   const firstBatch = batches[0];
   const bufferLayout =
     firstBatch?.bufferLayout ??
-    getArrowBufferLayout(options.shaderLayout, {
-      arrowTable: table,
-      arrowPaths: options.arrowPaths,
-      allowWebGLOnlyFormats: options.allowWebGLOnlyFormats
-    });
+    (options.shaderLayout.attributes.length === 0 && table.batches.length === 0
+      ? []
+      : getArrowBufferLayout(options.shaderLayout, {
+          arrowTable: table,
+          arrowPaths: options.arrowPaths,
+          allowWebGLOnlyFormats: options.allowWebGLOnlyFormats
+        }));
   const schema = firstBatch?.schema ?? {
-    fields: bufferLayout.map(layout => {
-      const arrowPath = options.arrowPaths?.[layout.name] || layout.name;
-      const sourceField = getArrowFieldByPath(table, arrowPath);
-      return {
-        name: layout.name,
-        format: layout.format as GPUVectorFormat,
-        nullable: sourceField.nullable,
-        metadata: new Map(sourceField.metadata)
-      };
-    }),
+    fields: getArrowEmptyTableGPUFields(table, options, bufferLayout),
     metadata: new Map(table.schema.metadata)
   };
 
@@ -554,6 +664,79 @@ export function makeGPUTableFromArrowTable(
         schema,
         bufferLayout
       });
+}
+
+function getArrowEmptyTableGPUFields(
+  table: Table,
+  options: GPUTableFromArrowTableProps,
+  bufferLayout: BufferLayout[]
+): GPUField[] {
+  const fields: GPUField[] = bufferLayout.map(layout => {
+    const arrowPath = options.arrowPaths?.[layout.name] || layout.name;
+    const sourceField = getArrowFieldByPath(table, arrowPath);
+    return {
+      name: layout.name,
+      format: layout.format as GPUVectorFormat,
+      nullable: sourceField.nullable,
+      metadata: new Map(sourceField.metadata)
+    };
+  });
+  const selectedNames = new Set(fields.map(field => field.name));
+
+  for (const storageBinding of getArrowStorageBindings(options.shaderLayout)) {
+    if (selectedNames.has(storageBinding.name)) {
+      throw new Error(
+        `GPURecordBatch shader input "${storageBinding.name}" cannot be both an attribute and a storage binding`
+      );
+    }
+    const arrowPath = options.arrowPaths?.[storageBinding.name] || storageBinding.name;
+    const sourceField = tryGetArrowFieldByPath(table, arrowPath);
+    if (!sourceField) {
+      continue;
+    }
+    fields.push({
+      name: storageBinding.name,
+      format: options.fixedSizeListColumns?.includes(storageBinding.name)
+        ? getFixedSizeListGPUVectorFormatForArrowType(sourceField.type)
+        : getGPUVectorFormatForArrowType(sourceField.type),
+      nullable: sourceField.nullable,
+      metadata: new Map(sourceField.metadata)
+    });
+    selectedNames.add(storageBinding.name);
+  }
+
+  for (const columnName of options.fixedSizeListColumns ?? []) {
+    if (!selectedNames.has(columnName) || bufferLayout.some(layout => layout.name === columnName)) {
+      throw new Error('Arrow fixed-size-list GPU columns require a selected storage binding');
+    }
+  }
+
+  for (const [sourceName, validityColumn] of Object.entries(options.validityColumns ?? {})) {
+    const validityName = typeof validityColumn === 'string' ? validityColumn : validityColumn.name;
+    if (!selectedNames.has(sourceName) || selectedNames.has(validityName)) {
+      throw new Error('Arrow GPU validity columns require a selected source and unique output');
+    }
+    const arrowPath = options.arrowPaths?.[sourceName] || sourceName;
+    const sourceField = getArrowFieldByPath(table, arrowPath);
+    if (!DataType.isFixedSizeList(sourceField.type)) {
+      throw new Error('Arrow GPU validity columns require FixedSizeList source data');
+    }
+    const dimensions =
+      typeof validityColumn === 'string'
+        ? sourceField.type.listSize
+        : (validityColumn.dimensions ?? sourceField.type.listSize);
+    if (
+      !Number.isSafeInteger(dimensions) ||
+      dimensions < 1 ||
+      dimensions > sourceField.type.listSize
+    ) {
+      throw new Error('Arrow FixedSizeList validity dimensions must fit within the list width');
+    }
+    fields.push({name: validityName, format: 'uint32', nullable: false, metadata: new Map()});
+    selectedNames.add(validityName);
+  }
+
+  return fields;
 }
 
 /** Reads one generic GPU data range back into Arrow `Data`. */
@@ -604,6 +787,14 @@ function isArrowUtf8DictionaryType(type: DataType): type is ArrowUtf8Dictionary 
   );
 }
 
+function isStorageFixedSizeListArrowType(type: DataType): boolean {
+  return (
+    DataType.isFixedSizeList(type) &&
+    type.listSize > 4 &&
+    (DataType.isFloat(type.children[0]?.type) || DataType.isInt(type.children[0]?.type))
+  );
+}
+
 function getGPUVectorFormatForArrowType(type: DataType): GPUVectorFormat {
   const matrixInfo = getArrowMatrixVectorInfo({type});
   if (matrixInfo) {
@@ -621,6 +812,18 @@ function getGPUVectorFormatForArrowType(type: DataType): GPUVectorFormat {
     return getGPUVectorFormatFromArrowDataType(type.indices);
   }
   return getGPUVectorFormatFromArrowDataType(type);
+}
+
+function getFixedSizeListGPUVectorFormatForArrowType(type: DataType): GPUVectorFormat {
+  if (
+    !DataType.isFixedSizeList(type) ||
+    !Number.isSafeInteger(type.listSize) ||
+    type.listSize < 1
+  ) {
+    throw new Error('Arrow fixed-size-list GPU columns require valid FixedSizeList source data');
+  }
+  const signedDataType = getSignedArrowDataType(type.children[0].type);
+  return `fixed-size-list<${signedDataType},${type.listSize}>`;
 }
 
 function isCanonicalFloat32ArrowMatrixInfo(
@@ -646,6 +849,22 @@ function getArrowDataValueLength(data: Data): number {
   const firstValueOffset = valueOffsets[0] ?? 0;
   const lastValueOffset = valueOffsets[data.length] ?? firstValueOffset;
   return Math.max(0, lastValueOffset - firstValueOffset);
+}
+
+function makeArrowGPUValidityBitmap(validity: Uint32Array | undefined): Uint8Array | undefined {
+  if (!validity) {
+    return undefined;
+  }
+  const nullBitmap = new Uint8Array(Math.ceil(validity.length / 8));
+  let hasInvalidRows = false;
+  for (let rowIndex = 0; rowIndex < validity.length; rowIndex++) {
+    if (validity[rowIndex] !== 0) {
+      nullBitmap[rowIndex >> 3] |= 1 << (rowIndex & 7);
+    } else {
+      hasInvalidRows = true;
+    }
+  }
+  return hasInvalidRows ? nullBitmap : undefined;
 }
 
 function getArrowDictionaryIndexBufferSource(data: Data<ArrowUtf8Dictionary>): ArrayBufferView {

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -245,6 +245,7 @@ export {
   makeGPUVectorFromArrow,
   readArrowGPUDataAsync,
   readArrowGPUVectorAsync,
+  type ArrowGPUValidityColumn,
   type GPURecordBatchFromArrowRecordBatchProps,
   type GPUTableFromArrowTableProps,
   type GPUVectorFromArrowProps,

--- a/modules/arrow/test/arrow/arrow-gpu-fixed-size-list.node.spec.ts
+++ b/modules/arrow/test/arrow/arrow-gpu-fixed-size-list.node.spec.ts
@@ -1,0 +1,5 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import './arrow-gpu-fixed-size-list.spec';

--- a/modules/arrow/test/arrow/arrow-gpu-fixed-size-list.spec.ts
+++ b/modules/arrow/test/arrow/arrow-gpu-fixed-size-list.spec.ts
@@ -1,0 +1,882 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  makeArrowFixedSizeListVector,
+  makeGPUDataFromArrowData,
+  makeGPURecordBatchFromArrowRecordBatch,
+  makeGPUTableFromArrowTable,
+  makeGPUVectorFromArrow,
+  readArrowGPUDataAsync,
+  readArrowGPUVectorAsync,
+  type GPUVectorFormatForArrowType
+} from '@luma.gl/arrow';
+import type {ShaderLayout} from '@luma.gl/core';
+import {GPURecordBatch, GPUTable} from '@luma.gl/experimental/gpu-tables';
+import {GPUData, GPUVector, type GPUVectorFormat} from '@luma.gl/gpgpu/gpu-data';
+import {getWebGPUTestDevice, NullDevice} from '@luma.gl/test-utils';
+import * as arrow from 'apache-arrow';
+import {expectTypeOf} from 'vitest';
+
+type ArrowEmbeddingType = arrow.FixedSizeList<arrow.Float32>;
+
+test('unmapped Float16 fixed-size lists retain a usable broad GPU vector format', t => {
+  const device = new NullDevice({});
+  const source = makeArrowFixedSizeListVector(
+    new arrow.Float16(),
+    4,
+    new Uint16Array([0x3c00, 0x4000, 0x4200, 0x4400])
+  );
+  const vector = makeGPUVectorFromArrow(device, source);
+
+  expectTypeOf<
+    GPUVectorFormatForArrowType<arrow.FixedSizeList<arrow.Float16>>
+  >().toEqualTypeOf<GPUVectorFormat>();
+  expectTypeOf(vector).toEqualTypeOf<GPUVector<GPUVectorFormat>>();
+  t.equal(vector.format, 'float16x4', 'retains the supported runtime Float16 vertex format');
+
+  vector.destroy();
+  t.end();
+});
+
+test('Arrow GPU adapters represent high-dimensional FixedSizeList rows as table-native storage', async t => {
+  const device = new NullDevice({});
+
+  for (const dimensions of [5, 384, 768, 1536]) {
+    const values = Float32Array.from({length: dimensions * 2}, (_, index) => index + 0.5);
+    const source = makeArrowEmbeddingVector(dimensions, values);
+    const data = makeGPUDataFromArrowData(device, source.data[0]);
+    const vector = makeGPUVectorFromArrow(device, source, {name: 'embedding'});
+
+    t.equal(data.format, `fixed-size-list<float32,${dimensions}>`, 'data retains its row shape');
+    t.equal(
+      vector.format,
+      `fixed-size-list<float32,${dimensions}>`,
+      'vector retains its row shape'
+    );
+    t.equal(data.length, 2, 'GPUData length counts logical rows');
+    t.equal(vector.length, 2, 'GPUVector length counts logical rows');
+    t.equal(data.valueLength, values.length, 'GPUData value length counts flattened values');
+    t.equal(vector.valueLength, values.length, 'GPUVector value length counts flattened values');
+    t.equal(data.stride, dimensions, 'GPUData stride retains flattened row coordinates');
+    t.equal(vector.byteStride, dimensions * Float32Array.BYTES_PER_ELEMENT, 'retains row bytes');
+    t.deepEqual(await readFloat32Data(data), values, 'GPUData uploads the original coordinates');
+    t.deepEqual(
+      await readFloat32Data(vector.data[0]),
+      values,
+      'GPUVector uploads the original coordinates'
+    );
+
+    const dataBuffer = data.buffer;
+    const vectorBuffer = vector.data[0].buffer;
+    data.destroy();
+    vector.destroy();
+    t.ok(dataBuffer.destroyed, 'GPUData destroys its own buffer');
+    t.ok(vectorBuffer.destroyed, 'GPUVector destroys its owned chunk');
+  }
+
+  t.end();
+});
+
+test('Arrow GPU adapters preserve existing short vertex formats and explicitly requested storage rows', t => {
+  const device = new NullDevice({});
+
+  for (const dimensions of [1, 2, 3, 4]) {
+    const source = makeArrowEmbeddingVector(dimensions, Float32Array.from({length: dimensions}));
+    const vertex = makeGPUVectorFromArrow(device, source);
+    const storage = makeGPUVectorFromArrow(device, source, {
+      format: `fixed-size-list<float32,${dimensions}>`
+    });
+
+    t.equal(
+      vertex.format,
+      dimensions === 1 ? 'float32' : `float32x${dimensions}`,
+      'default short rows remain compatible with existing vertex attributes'
+    );
+    t.equal(
+      storage.format,
+      `fixed-size-list<float32,${dimensions}>`,
+      'explicit short storage rows retain a first-class fixed-size-list format'
+    );
+    t.equal(storage.length, 1, 'explicit storage rows remain row oriented');
+    t.equal(storage.valueLength, dimensions, 'explicit storage rows expose flattened values');
+
+    vertex.destroy();
+    storage.destroy();
+  }
+
+  t.end();
+});
+
+test('Arrow GPU vectors preserve original FixedSizeList chunks, including empty chunks', async t => {
+  const device = new NullDevice({});
+  const source = new arrow.Vector<ArrowEmbeddingType>([
+    makeArrowEmbeddingData(5, new Float32Array([1, 2, 3, 4, 5])),
+    makeArrowEmbeddingData(5, new Float32Array(0)),
+    makeArrowEmbeddingData(5, new Float32Array([6, 7, 8, 9, 10, 11, 12, 13, 14, 15]))
+  ]);
+  const vector = makeGPUVectorFromArrow(device, source);
+
+  t.deepEqual(
+    vector.data.map(data => data.length),
+    [1, 0, 2],
+    'every source chunk, including an empty chunk, remains independently owned'
+  );
+  t.deepEqual(
+    vector.data.map(data => data.valueLength),
+    [5, 0, 10],
+    'flattened coordinates remain chunk aligned'
+  );
+  t.equal(vector.length, 3, 'aggregate vectors count rows');
+  t.equal(vector.valueLength, 15, 'aggregate vectors count flattened coordinates');
+  t.deepEqual(
+    Array.from(await readFloat32Data(vector.data[2])),
+    [6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    'later source chunks start at their own allocation'
+  );
+
+  const reconstructed = await readArrowGPUVectorAsync<ArrowEmbeddingType>(vector);
+  t.equal(reconstructed.data.length, 3, 'Arrow readback preserves all source chunk boundaries');
+  vector.destroy();
+  t.end();
+});
+
+test('explicit non-null FixedSizeList compaction preserves flattened row metadata', async t => {
+  const device = new NullDevice({});
+  const source = new arrow.Vector<ArrowEmbeddingType>([
+    makeArrowEmbeddingData(5, new Float32Array([1, 2, 3, 4, 5])),
+    makeArrowEmbeddingData(5, new Float32Array([6, 7, 8, 9, 10]))
+  ]);
+  const vector = makeGPUVectorFromArrow(device, source, {preserveDataChunks: false});
+
+  t.equal(vector.data.length, 1, 'explicit compaction combines source chunks only when requested');
+  t.equal(vector.length, 2, 'packed fixed-list columns retain logical row counts');
+  t.equal(vector.valueLength, 10, 'packed fixed-list columns retain flattened value counts');
+  t.deepEqual(
+    Array.from(await readFloat32Data(vector.data[0])),
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    'explicit compaction retains every source coordinate'
+  );
+
+  const sourceIds = new arrow.Vector<arrow.Uint32>([
+    arrow.makeData({type: new arrow.Uint32(), length: 1, data: new Uint32Array([11])}),
+    arrow.makeData({type: new arrow.Uint32(), length: 1, data: new Uint32Array([22])})
+  ]);
+  const compactIds = makeGPUVectorFromArrow(device, sourceIds, {preserveDataChunks: false});
+  t.equal(compactIds.data.length, 1, 'explicit non-null scalar compaction remains supported');
+  t.deepEqual(
+    Array.from(await readUint32Data(compactIds.data[0])),
+    [11, 22],
+    'packed non-null source IDs retain their original values'
+  );
+  t.notOk(
+    compactIds.data[0].nullBitmap,
+    'non-null source IDs retain the allocation-free fast path'
+  );
+
+  vector.destroy();
+  compactIds.destroy();
+  t.end();
+});
+
+test('nullable FixedSizeList compaction is rejected rather than discarding Arrow validity', t => {
+  const device = new NullDevice({});
+  const parentNulls = arrow.vectorFromArray(
+    [[1, 2, 3, 4, 5], null],
+    makeArrowEmbeddingType(5)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const childNulls = arrow.vectorFromArray(
+    [[1, null, 3, 4, 5]],
+    makeArrowEmbeddingType(5)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const shortParentNulls = arrow.vectorFromArray(
+    [[1, 2, 3], null],
+    makeArrowEmbeddingType(3)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+
+  for (const source of [parentNulls, childNulls, shortParentNulls]) {
+    t.throws(
+      () => makeGPUVectorFromArrow(device, source, {preserveDataChunks: false}),
+      /require preserved GPU data chunks/,
+      'explicit packing cannot silently discard nullable parent or child metadata'
+    );
+  }
+
+  const nullableSourceIds = arrow.vectorFromArray([11, null, 22], new arrow.Uint32());
+  t.throws(
+    () => makeGPUVectorFromArrow(device, nullableSourceIds, {preserveDataChunks: false}),
+    /require preserved GPU data chunks/,
+    'nullable scalar source IDs cannot be compacted into invented valid zero IDs'
+  );
+
+  t.end();
+});
+
+test('Arrow FixedSizeList uploads apply parent and child displacements exactly once', async t => {
+  const device = new NullDevice({});
+  const backingValues = Float32Array.from({length: 32}, (_, index) => index);
+  const child = new arrow.Data<arrow.Float32>(new arrow.Float32(), 2, 20, 0, {
+    [arrow.BufferType.DATA]: backingValues
+  });
+  const parent = new arrow.Data<ArrowEmbeddingType>(makeArrowEmbeddingType(5), 1, 2, 0, {}, [
+    child
+  ]);
+  const independentOffsets = makeGPUVectorFromArrow(device, new arrow.Vector([parent]));
+
+  t.deepEqual(
+    Array.from(await readFloat32Data(independentOffsets.data[0])),
+    [7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+    'independent parent and child offsets each contribute once'
+  );
+
+  const source = makeArrowEmbeddingVector(
+    5,
+    Float32Array.from({length: 20}, (_, index) => index)
+  );
+  const sliced = makeGPUVectorFromArrow(device, source.slice(1, 3));
+  t.deepEqual(
+    Array.from(await readFloat32Data(sliced.data[0])),
+    [5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+    'already-sliced Arrow child views are not displaced a second time'
+  );
+
+  independentOffsets.destroy();
+  sliced.destroy();
+  t.end();
+});
+
+test('nullable FixedSizeList Arrow readback preserves parent and child validity', async t => {
+  const device = new NullDevice({});
+  const source = arrow.vectorFromArray(
+    [[0, 1, 2, 3, 4], null, [10, null, 12, 13, 14], [15, 16, 17, 18, 19]],
+    makeArrowEmbeddingType(5)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const vector = makeGPUVectorFromArrow(device, source.slice(1, 4));
+  const data = await readArrowGPUDataAsync<ArrowEmbeddingType>(vector.data[0]);
+  const reconstructed = await readArrowGPUVectorAsync<ArrowEmbeddingType>(vector);
+
+  t.equal(vector.data[0].readbackMetadata?.kind, 'fixed-size-list', 'keeps compact null metadata');
+  t.deepEqual(
+    Array.from(vector.data[0].nullBitmap ?? []),
+    [4],
+    'generic row validity combines sliced parent and child nulls'
+  );
+  t.deepEqual(
+    Array.from(vector.data[0].readbackMetadata?.nullBitmap ?? []),
+    [6],
+    'Arrow readback metadata independently preserves original parent validity'
+  );
+  t.equal(data.nullCount, 1, 'retains parent null rows');
+  t.equal(data.children[0].nullCount, 6, 'retains null parent coordinates and nullable children');
+  t.deepEqual(
+    getArrowRows(reconstructed),
+    [null, [10, null, 12, 13, 14], [15, 16, 17, 18, 19]],
+    'readback reconstructs sliced parent and child nulls'
+  );
+
+  vector.destroy();
+  t.end();
+});
+
+test('nullable short FixedSizeList vertex rows retain existing formats and correct readback', async t => {
+  const device = new NullDevice({});
+  const source = arrow.vectorFromArray(
+    [[1, 2, 3], null, [4, null, 6], [7, 8, 9]],
+    makeArrowEmbeddingType(3)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const vector = makeGPUVectorFromArrow(device, source.slice(1, 4));
+
+  t.equal(vector.format, 'float32x3', 'nullable short lists retain the existing vertex format');
+  t.deepEqual(
+    getArrowRows(await readArrowGPUVectorAsync<ArrowEmbeddingType>(vector)),
+    [null, [4, null, 6], [7, 8, 9]],
+    'nullable sliced short-list parents and children survive readback'
+  );
+
+  vector.destroy();
+  t.end();
+});
+
+test('nullable numeric Arrow GPU data retains normalized row validity and readback', async t => {
+  const device = new NullDevice({});
+  const values: Array<number | null> = Array.from({length: 12}, (_, rowIndex) => rowIndex + 10);
+  values[10] = null;
+  const source = arrow.vectorFromArray(values, new arrow.Uint32()).slice(9, 12);
+  const vector = makeGPUVectorFromArrow(device, source);
+  const data = await readArrowGPUDataAsync<arrow.Uint32>(vector.data[0]);
+  const reconstructed = await readArrowGPUVectorAsync<arrow.Uint32>(vector);
+
+  t.equal(vector.format, 'uint32', 'nullable IDs remain ordinary scalar table data');
+  t.deepEqual(Array.from(vector.data[0].nullBitmap ?? []), [5], 'normalizes a sliced row bitmap');
+  t.equal(vector.data[0].readbackMetadata?.kind, 'numeric', 'retains compact scalar null metadata');
+  t.equal(data.nullCount, 1, 'retains nullable row counts on direct chunk readback');
+  t.deepEqual(
+    Array.from(reconstructed),
+    [19, null, 21],
+    'numeric Arrow readback preserves nullable source IDs'
+  );
+
+  const nonNullVector = makeGPUVectorFromArrow(device, arrow.makeVector(new Uint32Array([11, 22])));
+  t.notOk(nonNullVector.data[0].nullBitmap, 'non-null scalar chunks avoid validity copies');
+  t.notOk(nonNullVector.data[0].readbackMetadata, 'non-null scalar readback stays allocation free');
+
+  vector.destroy();
+  nonNullVector.destroy();
+  t.end();
+});
+
+test('Arrow FixedSizeList adapters zero-pad child coordinates omitted for trailing null rows', async t => {
+  const device = new NullDevice({});
+  const values = Float32Array.from({length: 384}, (_, index) => index + 1);
+  const source = arrow.vectorFromArray(
+    [Array.from(values), null, null],
+    makeArrowEmbeddingType(384)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const vector = makeGPUVectorFromArrow(device, source);
+  const uploaded = await readFloat32Data(vector.data[0]);
+
+  t.equal(source.data[0].children[0].length, 384, 'Arrow omitted both trailing null child rows');
+  t.equal(vector.length, 3, 'GPU storage retains every logical parent row');
+  t.equal(vector.valueLength, 3 * 384, 'GPU storage allocates every physical row');
+  t.deepEqual(uploaded.subarray(0, 384), values, 'the present row remains unchanged');
+  t.ok(
+    uploaded.subarray(384).every(value => value === 0),
+    'missing null rows become zero padding'
+  );
+  t.deepEqual(
+    getArrowRows(await readArrowGPUVectorAsync<ArrowEmbeddingType>(vector)),
+    [Array.from(values), null, null],
+    'readback preserves omitted trailing parent null rows'
+  );
+
+  const sliced = makeGPUVectorFromArrow(device, source.slice(1));
+  t.equal(sliced.length, 2, 'sliced trailing null rows remain logical rows');
+  t.ok(
+    (await readFloat32Data(sliced.data[0])).every(value => value === 0),
+    'sliced trailing null coordinates remain safely zero padded'
+  );
+
+  vector.destroy();
+  sliced.destroy();
+  t.end();
+});
+
+test('Arrow FixedSizeList adapters reject missing child values for non-null parent rows', t => {
+  const device = new NullDevice({});
+  const child = arrow.makeData({
+    type: new arrow.Float32(),
+    length: 5,
+    data: new Float32Array([1, 2, 3, 4, 5])
+  });
+  const parent = new arrow.Data<ArrowEmbeddingType>(makeArrowEmbeddingType(5), 0, 2, 0, {}, [
+    child
+  ]);
+
+  t.throws(
+    () => makeGPUDataFromArrowData(device, parent),
+    /shorter than their logical row count/,
+    'corrupt non-null rows are not silently padded'
+  );
+
+  t.end();
+});
+
+test('Arrow GPU tables preserve embedding batches, stable ID columns, and source provenance', async t => {
+  const device = new NullDevice({});
+  const dimensions = 384;
+  const firstBatch = makeArrowEmbeddingBatch(
+    dimensions,
+    Float32Array.from({length: dimensions * 2}, (_, index) => index),
+    new Uint32Array([91, 7])
+  );
+  const secondBatch = makeArrowEmbeddingBatch(
+    dimensions,
+    Float32Array.from({length: dimensions}, (_, index) => index + 1000),
+    new Uint32Array([42])
+  );
+  const table = makeGPUTableFromArrowTable(device, new arrow.Table([firstBatch, secondBatch]), {
+    shaderLayout: makeStorageShaderLayout('embedding', 'sourceIds'),
+    validityColumns: {embedding: 'embeddingValidity'}
+  });
+
+  t.ok(table instanceof GPUTable, 'uses the existing generic table owner');
+  t.ok(table.batches[0] instanceof GPURecordBatch, 'uses existing generic record batches');
+  t.ok(table.gpuVectors.embedding instanceof GPUVector, 'uses existing generic vector views');
+  t.ok(table.batches[0].gpuData.embedding instanceof GPUData, 'uses existing generic data chunks');
+  t.equal(table.gpuVectors.embedding.format, 'fixed-size-list<float32,384>', 'keeps row shape');
+  t.equal(table.gpuVectors.embedding.length, 3, 'embedding column length counts table rows');
+  t.deepEqual(
+    table.gpuVectors.embedding.data.map(data => data.length),
+    [2, 1],
+    'preserves Arrow record-batch boundaries'
+  );
+  t.deepEqual(
+    table.batches.map(batch => batch.sourceInfo),
+    [
+      {sourceBatchIndex: 0, sourceRowIndexOffset: 0, sourceRowCount: 2},
+      {sourceBatchIndex: 1, sourceRowIndexOffset: 2, sourceRowCount: 1}
+    ],
+    'preserves stable source-batch and source-row provenance'
+  );
+  t.deepEqual(
+    Array.from(await readUint32Data(table.batches[0].gpuData.sourceIds)),
+    [91, 7],
+    'stable IDs remain an ordinary uint32 sibling column'
+  );
+  t.deepEqual(
+    Array.from(await readUint32Data(table.batches[1].gpuData.sourceIds)),
+    [42],
+    'stable IDs preserve batch boundaries'
+  );
+  t.deepEqual(
+    Array.from(await readUint32Data(table.batches[0].gpuData.embeddingValidity)),
+    [1, 1],
+    'explicit validity siblings contain nonzero flags for valid rows'
+  );
+  t.deepEqual(table.bufferLayout, [], 'embedding storage does not become a vertex layout');
+
+  const ownedBuffers = table.batches.flatMap(batch =>
+    Object.values(batch.gpuData).map(data => data.buffer)
+  );
+  table.destroy();
+  t.ok(
+    ownedBuffers.every(buffer => buffer.destroyed),
+    'only the table hierarchy owns its buffers'
+  );
+  t.end();
+});
+
+test('Arrow GPU source-ID siblings preserve nullable scalar bitmaps instead of inventing ID zero', async t => {
+  const device = new NullDevice({});
+  const embedding = makeArrowEmbeddingVector(
+    5,
+    Float32Array.from({length: 15}, (_, index) => index)
+  );
+  const sourceIds = arrow.vectorFromArray([11, null, 22], new arrow.Uint32());
+  const table = makeGPUTableFromArrowTable(device, new arrow.Table({embedding, sourceIds}), {
+    shaderLayout: makeStorageShaderLayout('embedding', 'sourceIds')
+  });
+  const sourceIdData = table.batches[0].gpuData.sourceIds;
+
+  t.equal(sourceIdData.format, 'uint32', 'source IDs remain ordinary uint32 table data');
+  t.deepEqual(Array.from(sourceIdData.nullBitmap ?? []), [5], 'null source IDs remain observable');
+  t.deepEqual(
+    Array.from(await readUint32Data(sourceIdData)),
+    [11, 0, 22],
+    'the physical zero placeholder remains distinguishable through the null bitmap'
+  );
+  t.deepEqual(
+    Array.from(await readArrowGPUVectorAsync<arrow.Uint32>(table.gpuVectors.sourceIds)),
+    [11, null, 22],
+    'source-ID Arrow readback retains nulls rather than inventing a valid zero ID'
+  );
+
+  table.destroy();
+  t.end();
+});
+
+test('Arrow GPU record batches expose explicit FixedSizeList validity siblings', async t => {
+  const device = new NullDevice({});
+  const embedding = arrow.vectorFromArray(
+    [[0, 1, 2, 3, 4], null, [10, null, 12, 13, 14], [15, 16, 17, 18, 19]],
+    makeArrowEmbeddingType(5)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const arrowTable = new arrow.Table({
+    embedding: embedding.slice(1),
+    sourceIds: arrow.makeVector(new Uint32Array([90, 70, 50]))
+  });
+  const batch = makeGPURecordBatchFromArrowRecordBatch(device, arrowTable.batches[0], {
+    shaderLayout: makeStorageShaderLayout('embedding', 'sourceIds'),
+    validityColumns: {embedding: 'embeddingValidity'},
+    sourceInfo: {sourceBatchIndex: 3, sourceRowIndexOffset: 25, sourceRowCount: 3}
+  });
+
+  t.equal(batch.gpuData.embedding.format, 'fixed-size-list<float32,5>', 'keeps fixed row format');
+  t.deepEqual(
+    Array.from(await readUint32Data(batch.gpuData.embeddingValidity)),
+    [0, 0, 1],
+    'combines sliced parent validity and child-coordinate validity'
+  );
+  t.deepEqual(
+    Array.from(await readUint32Data(batch.gpuData.sourceIds)),
+    [90, 70, 50],
+    'explicit source IDs remain aligned with the sliced rows'
+  );
+  t.deepEqual(
+    batch.sourceInfo,
+    {sourceBatchIndex: 3, sourceRowIndexOffset: 25, sourceRowCount: 3},
+    'preserves explicit record-batch provenance'
+  );
+  t.deepEqual(
+    batch.schema.fields.map(field => field.name),
+    ['embedding', 'sourceIds', 'embeddingValidity'],
+    'the requested validity sibling participates in the ordinary GPU schema'
+  );
+
+  batch.destroy();
+  t.end();
+});
+
+test('sliced Arrow FixedSizeList validity remains aligned across bitmap byte boundaries', async t => {
+  const device = new NullDevice({});
+  const rows: Array<Array<number | null> | null> = Array.from({length: 12}, (_, rowIndex) =>
+    Array.from({length: 5}, (_, coordinateIndex) => rowIndex * 5 + coordinateIndex)
+  );
+  rows[9] = null;
+  rows[10] = [50, null, 52, 53, 54];
+  const source = arrow.vectorFromArray(
+    rows,
+    makeArrowEmbeddingType(5)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const table = makeGPUTableFromArrowTable(device, new arrow.Table({embedding: source.slice(9)}), {
+    shaderLayout: makeStorageShaderLayout('embedding'),
+    validityColumns: {embedding: 'embeddingValidity'}
+  });
+
+  t.deepEqual(
+    Array.from(await readUint32Data(table.batches[0].gpuData.embeddingValidity)),
+    [0, 0, 1],
+    'parent and child offsets remain correct after crossing bitmap byte boundaries'
+  );
+  t.deepEqual(
+    getArrowRows(await readArrowGPUVectorAsync<ArrowEmbeddingType>(table.gpuVectors.embedding)),
+    [null, [50, null, 52, 53, 54], [55, 56, 57, 58, 59]],
+    'Arrow readback retains sliced validity after the eighth parent row'
+  );
+
+  table.destroy();
+  t.end();
+});
+
+test('Arrow GPU tables distinguish semantic dimensions from nullable physical row padding', async t => {
+  const device = new NullDevice({});
+  const embedding = arrow.vectorFromArray(
+    [[1, 2, 3, null], [4, null, 6, 99], null],
+    makeArrowEmbeddingType(4)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const sourceTable = new arrow.Table({embedding});
+  const semanticTable = makeGPUTableFromArrowTable(device, sourceTable, {
+    shaderLayout: makeStorageShaderLayout('embedding'),
+    fixedSizeListColumns: ['embedding'],
+    validityColumns: {embedding: {name: 'embeddingValidity', dimensions: 3}}
+  });
+  const fullWidthTable = makeGPUTableFromArrowTable(device, sourceTable, {
+    shaderLayout: makeStorageShaderLayout('embedding'),
+    fixedSizeListColumns: ['embedding'],
+    validityColumns: {embedding: 'embeddingValidity'}
+  });
+
+  t.equal(
+    semanticTable.gpuVectors.embedding.format,
+    'fixed-size-list<float32,4>',
+    'explicitly requested short storage rows retain physical width'
+  );
+  t.equal(semanticTable.gpuVectors.embedding.byteStride, 16, 'retains padded row byte stride');
+  t.deepEqual(
+    Array.from(semanticTable.batches[0].gpuData.embedding.nullBitmap ?? []),
+    [0],
+    'generic physical-row validity conservatively includes nullable trailing padding'
+  );
+  t.deepEqual(
+    Array.from(await readUint32Data(semanticTable.batches[0].gpuData.embeddingValidity)),
+    [1, 0, 0],
+    'nullable trailing padding does not invalidate meaningful leading coordinates'
+  );
+  t.deepEqual(
+    Array.from(await readUint32Data(fullWidthTable.batches[0].gpuData.embeddingValidity)),
+    [0, 0, 0],
+    'default validity checks every physical child coordinate'
+  );
+
+  semanticTable.destroy();
+  fullWidthTable.destroy();
+  t.end();
+});
+
+test('Arrow GPU tables preserve existing short-list rendering layouts', t => {
+  const device = new NullDevice({});
+  const positions = makeArrowEmbeddingVector(3, new Float32Array([1, 2, 3, 4, 5, 6]));
+  const sourceTable = new arrow.Table({positions});
+  const vertexTable = makeGPUTableFromArrowTable(device, sourceTable, {
+    shaderLayout: {
+      attributes: [{name: 'positions', location: 0, type: 'vec3<f32>'}],
+      bindings: []
+    }
+  });
+  const storageTable = makeGPUTableFromArrowTable(device, sourceTable, {
+    shaderLayout: makeStorageShaderLayout('positions')
+  });
+
+  t.equal(vertexTable.gpuVectors.positions.format, 'float32x3', 'vertex columns remain unchanged');
+  t.deepEqual(
+    vertexTable.bufferLayout,
+    [{name: 'positions', format: 'float32x3'}],
+    'existing shader-facing vertex layouts remain unchanged'
+  );
+  t.equal(
+    storageTable.gpuVectors.positions.format,
+    'float32x3',
+    'existing short storage columns remain unchanged unless explicitly opted in'
+  );
+
+  vertexTable.destroy();
+  storageTable.destroy();
+  t.end();
+});
+
+test('empty Arrow GPU table schemas preserve FixedSizeList storage columns and validity siblings', t => {
+  const device = new NullDevice({});
+  const schema = new arrow.Schema([
+    new arrow.Field('embedding', makeArrowEmbeddingType(768), true),
+    new arrow.Field('sourceIds', new arrow.Uint32(), false)
+  ]);
+  const sourceTable = new arrow.Table(schema);
+  const table = makeGPUTableFromArrowTable(device, sourceTable, {
+    shaderLayout: makeStorageShaderLayout('embedding', 'sourceIds'),
+    validityColumns: {embedding: 'embeddingValidity'}
+  });
+
+  t.equal(table.numRows, 0, 'the table retains its empty row count');
+  t.equal(table.batches.length, 0, 'no synthetic source batch is introduced');
+  t.deepEqual(
+    table.schema.fields.map(field => [field.name, field.format]),
+    [
+      ['embedding', 'fixed-size-list<float32,768>'],
+      ['sourceIds', 'uint32'],
+      ['embeddingValidity', 'uint32']
+    ],
+    'the empty schema retains every selected storage and validity column'
+  );
+
+  table.destroy();
+  t.end();
+});
+
+test('Arrow GPU table fixed-list and validity options reject inconsistent selections', t => {
+  const device = new NullDevice({});
+  const sourceTable = new arrow.Table({
+    embedding: makeArrowEmbeddingVector(4, new Float32Array([1, 2, 3, 4])),
+    sourceIds: arrow.makeVector(new Uint32Array([10]))
+  });
+  const storageLayout = makeStorageShaderLayout('embedding', 'sourceIds');
+
+  t.throws(
+    () =>
+      makeGPUTableFromArrowTable(device, sourceTable, {
+        shaderLayout: storageLayout,
+        fixedSizeListColumns: ['missing']
+      }),
+    /selected storage binding/,
+    'rejects fixed-list columns that were not selected'
+  );
+  t.throws(
+    () =>
+      makeGPUTableFromArrowTable(device, sourceTable, {
+        shaderLayout: storageLayout,
+        fixedSizeListColumns: ['sourceIds']
+      }),
+    /FixedSizeList source data/,
+    'rejects scalar columns requested as fixed-size lists'
+  );
+  t.throws(
+    () =>
+      makeGPUTableFromArrowTable(device, sourceTable, {
+        shaderLayout: storageLayout,
+        validityColumns: {embedding: 'sourceIds'}
+      }),
+    /unique output/,
+    'rejects validity siblings that collide with existing table columns'
+  );
+  t.throws(
+    () =>
+      makeGPUTableFromArrowTable(device, sourceTable, {
+        shaderLayout: storageLayout,
+        validityColumns: {embedding: {name: 'embeddingValidity', dimensions: 5}}
+      }),
+    /validity dimensions/,
+    'rejects meaningful dimensions wider than the physical Arrow list'
+  );
+  t.throws(
+    () =>
+      makeGPUTableFromArrowTable(device, sourceTable, {
+        shaderLayout: {
+          attributes: [{name: 'embedding', location: 0, type: 'vec4<f32>'}],
+          bindings: []
+        },
+        fixedSizeListColumns: ['embedding']
+      }),
+    /storage shader binding/,
+    'rejects fixed-size-list columns exposed as vertex attributes'
+  );
+
+  t.end();
+});
+
+test('Arrow FixedSizeList table columns upload preserved batches to actual WebGPU buffers', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  for (const dimensions of [384, 768, 1536]) {
+    const firstValues = Float32Array.from({length: dimensions * 2}, (_, index) => index + 0.25);
+    const secondValues = Float32Array.from({length: dimensions}, (_, index) => index + 1000.5);
+    const source = new arrow.Table([
+      makeArrowEmbeddingBatch(dimensions, firstValues, new Uint32Array([12, 40])),
+      makeArrowEmbeddingBatch(dimensions, secondValues, new Uint32Array([8]))
+    ]);
+    const table = makeGPUTableFromArrowTable(device, source, {
+      shaderLayout: makeStorageShaderLayout('embedding', 'sourceIds'),
+      validityColumns: {embedding: 'embeddingValidity'}
+    });
+
+    t.equal(device.type, 'webgpu', 'the adapter uses a real browser WebGPU device');
+    t.deepEqual(
+      table.batches.map(batch => batch.numRows),
+      [2, 1],
+      `${dimensions}-dimensional rows preserve source record batches`
+    );
+    t.deepEqual(
+      await readFloat32Data(table.batches[0].gpuData.embedding),
+      firstValues,
+      `${dimensions}-dimensional first batch uploads intact`
+    );
+    t.deepEqual(
+      await readFloat32Data(table.batches[1].gpuData.embedding),
+      secondValues,
+      `${dimensions}-dimensional second batch uploads intact`
+    );
+    t.deepEqual(
+      Array.from(await readUint32Data(table.batches[0].gpuData.sourceIds)),
+      [12, 40],
+      'GPU-resident stable ID siblings preserve source rows'
+    );
+
+    const ownedBuffers = table.batches.flatMap(batch =>
+      Object.values(batch.gpuData).map(data => data.buffer)
+    );
+    table.destroy();
+    t.ok(
+      ownedBuffers.every(buffer => buffer.destroyed),
+      'the table owns every WebGPU buffer'
+    );
+  }
+
+  t.end();
+});
+
+test('nullable FixedSizeList rows and physical padding upload correctly on actual WebGPU', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const embedding = arrow.vectorFromArray(
+    [[1, 2, 3, null], [4, null, 6, 99], null],
+    makeArrowEmbeddingType(4)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const table = makeGPUTableFromArrowTable(device, new arrow.Table({embedding}), {
+    shaderLayout: makeStorageShaderLayout('embedding'),
+    fixedSizeListColumns: ['embedding'],
+    validityColumns: {embedding: {name: 'embeddingValidity', dimensions: 3}}
+  });
+
+  t.deepEqual(
+    Array.from(await readUint32Data(table.batches[0].gpuData.embeddingValidity)),
+    [1, 0, 0],
+    'actual GPU validity excludes nullable meaningful coordinates and null parents'
+  );
+  t.deepEqual(
+    Array.from(await readFloat32Data(table.batches[0].gpuData.embedding)),
+    [1, 2, 3, 0, 4, 0, 6, 99, 0, 0, 0, 0],
+    'actual GPU storage retains physical row padding and omitted trailing null rows'
+  );
+
+  table.destroy();
+  t.end();
+});
+
+function makeStorageShaderLayout(...names: string[]): ShaderLayout {
+  return {
+    attributes: [],
+    bindings: names.map((name, location) => ({
+      name,
+      type: 'read-only-storage',
+      group: 0,
+      location
+    }))
+  };
+}
+
+function makeArrowEmbeddingType(dimensions: number): ArrowEmbeddingType {
+  return new arrow.FixedSizeList(dimensions, new arrow.Field('value', new arrow.Float32(), true));
+}
+
+function makeArrowEmbeddingData(
+  dimensions: number,
+  values: Float32Array
+): arrow.Data<ArrowEmbeddingType> {
+  const child = arrow.makeData({type: new arrow.Float32(), length: values.length, data: values});
+  return arrow.makeData({
+    type: makeArrowEmbeddingType(dimensions),
+    length: values.length / dimensions,
+    child
+  });
+}
+
+function makeArrowEmbeddingVector(
+  dimensions: number,
+  values: Float32Array
+): arrow.Vector<ArrowEmbeddingType> {
+  return new arrow.Vector<ArrowEmbeddingType>([makeArrowEmbeddingData(dimensions, values)]);
+}
+
+function makeArrowEmbeddingBatch(
+  dimensions: number,
+  values: Float32Array,
+  sourceIds: Uint32Array
+): arrow.RecordBatch {
+  return new arrow.RecordBatch({
+    embedding: makeArrowEmbeddingData(dimensions, values),
+    sourceIds: arrow.makeData({type: new arrow.Uint32(), length: sourceIds.length, data: sourceIds})
+  });
+}
+
+function getArrowRows(
+  vector: arrow.Vector<ArrowEmbeddingType>
+): Array<Array<number | null> | null> {
+  const rows: Array<Array<number | null> | null> = [];
+  for (let rowIndex = 0; rowIndex < vector.length; rowIndex++) {
+    const row = vector.get(rowIndex);
+    rows.push(row ? Array.from(row) : null);
+  }
+  return rows;
+}
+
+async function readFloat32Data(data: GPUData): Promise<Float32Array> {
+  if (data.valueLength === 0) {
+    return new Float32Array(0);
+  }
+  const bytes = await data.buffer.readAsync(
+    data.byteOffset,
+    data.valueLength * Float32Array.BYTES_PER_ELEMENT
+  );
+  return new Float32Array(bytes.buffer, bytes.byteOffset, data.valueLength);
+}
+
+async function readUint32Data(data: GPUData): Promise<Uint32Array> {
+  if (data.length === 0) {
+    return new Uint32Array(0);
+  }
+  const bytes = await data.buffer.readAsync(
+    data.byteOffset,
+    data.length * Uint32Array.BYTES_PER_ELEMENT
+  );
+  return new Uint32Array(bytes.buffer, bytes.byteOffset, data.length);
+}

--- a/modules/arrow/test/index.ts
+++ b/modules/arrow/test/index.ts
@@ -5,6 +5,7 @@
 import './arrow/arrow-paths.spec';
 import './arrow/arrow-column-info.spec';
 import './arrow/arrow-fixed-size-list.spec';
+import './arrow/arrow-gpu-fixed-size-list.spec';
 import './arrow/arrow-variable-length-attribute-gpu-vector.spec';
 import './arrow/arrow-path-model.spec';
 import './arrow/arrow-splats.spec';

--- a/modules/experimental/src/gpu-tables/engine/gpu-table-computation.ts
+++ b/modules/experimental/src/gpu-tables/engine/gpu-table-computation.ts
@@ -5,8 +5,11 @@
 import {type Binding, type ComputePass, Device} from '@luma.gl/core';
 import {Computation, type ComputationProps} from '@luma.gl/engine';
 import {DynamicBuffer} from '@luma.gl/engine';
-import type {GPUData} from '@luma.gl/gpgpu/gpu-data';
-import type {GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import {
+  isFixedSizeListGPUVectorFormat,
+  type GPUData,
+  type GPUVector
+} from '@luma.gl/gpgpu/gpu-data';
 
 /** Metadata supplied to one GPU table computation batch dispatch. */
 export type GPUTableComputationBatch = {
@@ -160,10 +163,19 @@ function getBatchVectorBindings(
 }
 
 function getGPUDataBinding(data: GPUData): Binding {
+  const fixedSizeListByteLength =
+    data.format && isFixedSizeListGPUVectorFormat(data.format)
+      ? data.length === 0
+        ? 0
+        : (data.length - 1) * data.byteStride + data.rowByteLength
+      : undefined;
   return {
     buffer: getGPUDataBuffer(data),
     offset: data.byteOffset,
-    size: data.length * data.byteStride
+    size:
+      fixedSizeListByteLength === undefined
+        ? (data.valueByteLength ?? data.length * data.byteStride)
+        : Math.max(data.valueByteLength ?? 0, fixedSizeListByteLength)
   };
 }
 

--- a/modules/experimental/src/gpu-tables/engine/gpu-table-shader-bindings.ts
+++ b/modules/experimental/src/gpu-tables/engine/gpu-table-shader-bindings.ts
@@ -23,7 +23,7 @@ import {
 import {GPUConstant} from '@luma.gl/gpgpu/gpu-data';
 import type {GPUData} from '@luma.gl/gpgpu/gpu-data';
 import type {GPUTable} from '../table/gpu-table';
-import {getGPUVectorFormatInfo} from '@luma.gl/gpgpu/gpu-data';
+import {getGPUVectorFormatInfo, isFixedSizeListGPUVectorFormat} from '@luma.gl/gpgpu/gpu-data';
 
 type GPUBuffer = Buffer | DynamicBuffer;
 
@@ -530,10 +530,19 @@ function getShaderAttributeBufferLayout(
 }
 
 function getGPUDataBinding(data: GPUData): Binding {
+  const fixedSizeListByteLength =
+    data.format && isFixedSizeListGPUVectorFormat(data.format)
+      ? data.length === 0
+        ? 0
+        : (data.length - 1) * data.byteStride + data.rowByteLength
+      : undefined;
   return {
     buffer: data.buffer instanceof DynamicBuffer ? data.buffer.buffer : data.buffer,
     offset: data.byteOffset,
-    size: data.valueByteLength ?? data.valueLength * data.byteStride
+    size:
+      fixedSizeListByteLength === undefined
+        ? (data.valueByteLength ?? data.valueLength * data.byteStride)
+        : Math.max(data.valueByteLength ?? 0, fixedSizeListByteLength)
   };
 }
 

--- a/modules/experimental/src/gpu-tables/table/gpu-record-batch.ts
+++ b/modules/experimental/src/gpu-tables/table/gpu-record-batch.ts
@@ -8,6 +8,7 @@ import type {GPUField, GPUSchema, GPUTypeMap} from './gpu-schema';
 import {isGPUTableIndexColumnName} from './gpu-schema';
 import {
   getGPUVectorElementFormat,
+  isFixedSizeListGPUVectorFormat,
   isValueListGPUVectorFormat,
   isVertexListGPUVectorFormat
 } from '@luma.gl/gpgpu/gpu-data';
@@ -143,6 +144,9 @@ function synthesizeGPUDataBufferLayout(name: string, data: GPUData): BufferLayou
     throw new Error(
       `GPURecordBatch cannot synthesize a buffer layout for GPUData "${name}" without a format`
     );
+  }
+  if (isFixedSizeListGPUVectorFormat(data.format)) {
+    return [];
   }
   if (isVertexListGPUVectorFormat(data.format)) {
     throw new Error(

--- a/modules/experimental/src/gpu-tables/table/gpu-schema.ts
+++ b/modules/experimental/src/gpu-tables/table/gpu-schema.ts
@@ -18,8 +18,9 @@ export function isGPUTableIndexColumnName(
  * Named GPU table columns mapped to their canonical memory formats.
  *
  * The value type is a memory-layout string such as `float32x3`,
- * `unorm8x4`, `vertex-list<float32x3>`, or `value-list<uint8>`. Shader value declarations live in
- * `ShaderLayout`; compatibility is checked at adapter boundaries.
+ * `unorm8x4`, `vertex-list<float32x3>`, `value-list<uint8>`, or
+ * `fixed-size-list<float32,768>`. Shader value declarations live in `ShaderLayout`;
+ * compatibility is checked at adapter boundaries.
  */
 export type GPUTypeMap = Record<string, GPUVectorFormat>;
 

--- a/modules/experimental/src/gpu-tables/table/gpu-table.ts
+++ b/modules/experimental/src/gpu-tables/table/gpu-table.ts
@@ -13,6 +13,7 @@ import {GPU_TABLE_INDEX_COLUMN_NAME, isGPUTableIndexColumnName} from './gpu-sche
 import {
   getGPUVectorElementFormat,
   type GPUVectorFormat,
+  isFixedSizeListGPUVectorFormat,
   isValueListGPUVectorFormat,
   isVertexListGPUVectorFormat
 } from '@luma.gl/gpgpu/gpu-data';
@@ -218,6 +219,39 @@ export class GPUTable<T extends GPUTypeMap = GPUTypeMap> {
     }
 
     const batchGroups = createGPUPackGroups(this.batches, options.minBatchSize);
+    for (const batchGroup of batchGroups) {
+      if (batchGroup.length <= 1) {
+        continue;
+      }
+      for (const batch of batchGroup) {
+        for (const [columnName, data] of Object.entries(batch.gpuData)) {
+          if (
+            data.format &&
+            (isValueListGPUVectorFormat(data.format) || isVertexListGPUVectorFormat(data.format))
+          ) {
+            throw new Error(
+              `GPUTable.packBatches() does not support variable-length GPUData "${columnName}"`
+            );
+          }
+          const firstData = batchGroup[0].gpuData[columnName];
+          if (
+            data.format &&
+            isFixedSizeListGPUVectorFormat(data.format) &&
+            (data.byteStride !== firstData.byteStride ||
+              data.rowByteLength !== firstData.rowByteLength)
+          ) {
+            throw new Error(
+              `GPUTable.packBatches() requires matching fixed-size-list row layouts for GPUData "${columnName}"`
+            );
+          }
+          if (data.nullBitmap?.length || data.readbackMetadata !== undefined) {
+            throw new Error(
+              `GPUTable.packBatches() cannot preserve null or readback metadata for GPUData "${columnName}"`
+            );
+          }
+        }
+      }
+    }
     const nextBatches: GPURecordBatch[] = [];
     const supersededBatches: GPURecordBatch[] = [];
 
@@ -845,6 +879,9 @@ function synthesizeGPUVectorBufferLayout(
     throw new Error(
       'GPUTable cannot synthesize a buffer layout for vector "' + vector.name + '" without a format'
     );
+  }
+  if (isFixedSizeListGPUVectorFormat(vector.format)) {
+    return [];
   }
   if (isVertexListGPUVectorFormat(vector.format)) {
     if (allowVariableLengthWithoutLayout) {

--- a/modules/experimental/test/gpu-tables/gpu-table-computation.node.spec.ts
+++ b/modules/experimental/test/gpu-tables/gpu-table-computation.node.spec.ts
@@ -1,0 +1,77 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {GPUTableComputation} from '@luma.gl/experimental/gpu-tables';
+import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import {expect, test} from 'vitest';
+
+test('GPUTableComputation binds fixed-size-list rows without trailing physical padding', async () => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return;
+  const embeddings = new GPUVector({
+    type: 'buffer',
+    name: 'embeddings',
+    buffer: device.createBuffer({byteLength: 32}),
+    format: 'fixed-size-list<float32,3>',
+    length: 2,
+    byteOffset: 4,
+    byteStride: 16,
+    ownsBuffer: true
+  });
+  const computation = new GPUTableComputation(device, {inputVectors: {embeddings}});
+
+  expect(computation.bindings.embeddings).toEqual({
+    buffer: embeddings.data[0].buffer,
+    offset: 4,
+    size: 28
+  });
+
+  embeddings.destroy();
+});
+
+test('GPUTableComputation never truncates padded rows with shorter explicit value spans', async () => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return;
+  const limitedData = new GPUData({
+    buffer: device.createBuffer({byteLength: 28}),
+    format: 'fixed-size-list<float32,3>',
+    length: 2,
+    byteStride: 16,
+    valueByteLength: 24,
+    ownsBuffer: true
+  });
+  const limited = new GPUVector({
+    type: 'data',
+    name: 'limited',
+    data: [limitedData],
+    ownsData: false
+  });
+  const empty = new GPUVector({
+    type: 'buffer',
+    name: 'empty',
+    buffer: device.createBuffer({byteLength: 4}),
+    format: 'fixed-size-list<float32,3>',
+    length: 0,
+    byteOffset: 4,
+    ownsBuffer: true
+  });
+  const limitedComputation = new GPUTableComputation(device, {inputVectors: {limited}});
+  const emptyComputation = new GPUTableComputation(device, {inputVectors: {empty}});
+
+  expect(limitedComputation.bindings.limited).toEqual({
+    buffer: limitedData.buffer,
+    offset: 0,
+    size: 28
+  });
+  expect(emptyComputation.bindings.empty).toEqual({
+    buffer: empty.data[0].buffer,
+    offset: 4,
+    size: 0
+  });
+
+  limited.destroy();
+  limitedData.destroy();
+  empty.destroy();
+});

--- a/modules/experimental/test/gpu-tables/gpu-table-shader-bindings.node.spec.ts
+++ b/modules/experimental/test/gpu-tables/gpu-table-shader-bindings.node.spec.ts
@@ -89,6 +89,60 @@ test('GPUTableShaderBindings resolves draw-ready buffers per preserved batch', t
   t.end();
 });
 
+test('GPUTableShaderBindings binds complete fixed-size-list rows without trailing padding', t => {
+  const device = new NullDevice({});
+  const embeddingsData = new GPUData({
+    buffer: device.createBuffer({byteLength: 32}),
+    format: 'fixed-size-list<float32,3>',
+    length: 2,
+    byteOffset: 4,
+    byteStride: 16,
+    valueByteLength: 24,
+    ownsBuffer: true
+  });
+  const embeddings = new GPUVector({
+    type: 'data',
+    name: 'embeddings',
+    data: [embeddingsData],
+    ownsData: true
+  });
+  const table = new GPUTable({vectors: {embeddings}});
+  const gpuInputSchema = [
+    {
+      columnName: 'embeddings',
+      storageBindingName: 'embeddings',
+      kind: 'scalars',
+      required: true,
+      formats: ['fixed-size-list<float32,3>']
+    }
+  ] as const satisfies GPUInputSchema;
+  const shaderBindings = new GPUTableShaderBindings(device, {
+    table,
+    gpuInputSchema,
+    shaderLayout: {
+      attributes: [],
+      bindings: [{name: 'embeddings', type: 'read-only-storage', group: 0, location: 0}]
+    }
+  });
+
+  t.equal(embeddings.valueLength, 6, 'logical rows expose flattened scalar element counts');
+  t.equal(embeddings.rowByteLength, 12, 'row payload excludes physical padding');
+  t.deepEqual(shaderBindings.bufferLayout, [], 'storage-only inputs have no vertex attributes');
+  t.deepEqual(
+    shaderBindings.batches[0].bindings.embeddings,
+    {
+      buffer: embeddings.data[0].buffer,
+      offset: 4,
+      size: 28
+    },
+    'storage binding includes row padding even when explicit value bytes omit that padding'
+  );
+
+  shaderBindings.destroy();
+  table.destroy();
+  t.end();
+});
+
 test('GPUTableShaderBindings validates schema formats', t => {
   const device = new NullDevice({});
   const table = new GPUTable({

--- a/modules/gpgpu/package.json
+++ b/modules/gpgpu/package.json
@@ -62,6 +62,11 @@
       "types": "./dist/gpu-graph/benchmarks.d.ts",
       "import": "./dist/gpu-graph/benchmarks.js",
       "require": "./dist/gpu-graph/benchmarks.cjs"
+    },
+    "./gpu-vector-search": {
+      "types": "./dist/gpu-vector-search/index.d.ts",
+      "import": "./dist/gpu-vector-search/index.js",
+      "require": "./dist/gpu-vector-search/index.cjs"
     }
   },
   "files": [

--- a/modules/gpgpu/src/gpu-core/gpu-command-graph.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-command-graph.ts
@@ -1088,15 +1088,24 @@ export class GPUCommandGraph<Parameters = void> {
       throw new Error(`GPUCommandGraph import "${id}" requires GPUData.format`);
     }
     const coreBuffer = getCoreBuffer(data.buffer);
+    const requirements = {
+      byteLength: getGPUDataEndByteOffset(data),
+      usage: coreBuffer.usage
+    };
     let handle =
       data.buffer instanceof DynamicBuffer
-        ? this.dynamicBufferHandles.get(data.buffer)
-        : this.getImportedBufferHandle(coreBuffer);
+        ? this.getDynamicBufferHandle(data.buffer, requirements)
+        : this.getImportedBufferHandle(coreBuffer, requirements);
     if (!handle) {
       handle = this.importBuffer(
         {id, byteLength: coreBuffer.byteLength, usage: coreBuffer.usage},
         data.buffer
       );
+      if (data.buffer instanceof DynamicBuffer) {
+        this.dynamicBufferHandles.set(data.buffer, handle);
+      } else {
+        this.importedBufferHandles.set(coreBuffer, handle);
+      }
     }
     return this.createDataView(handle, {
       format: data.format,
@@ -1107,20 +1116,57 @@ export class GPUCommandGraph<Parameters = void> {
     });
   }
 
-  private getImportedBufferHandle(buffer: Buffer): GraphBufferHandle | undefined {
+  private getDynamicBufferHandle(
+    buffer: DynamicBuffer,
+    requirements: Pick<GraphBufferDescriptor, 'byteLength' | 'usage'>
+  ): GraphBufferHandle | undefined {
+    const cachedHandle = this.dynamicBufferHandles.get(buffer);
+    if (
+      cachedHandle?.defaultBuffer === buffer &&
+      doesGraphBufferHandleCoverRequirements(cachedHandle, requirements)
+    ) {
+      return cachedHandle;
+    }
+    this.dynamicBufferHandles.delete(buffer);
+    for (const handle of this.buffers.values()) {
+      if (
+        handle.defaultBuffer === buffer &&
+        doesGraphBufferHandleCoverRequirements(handle, requirements)
+      ) {
+        this.dynamicBufferHandles.set(buffer, handle);
+        return handle;
+      }
+    }
+    return undefined;
+  }
+
+  private getImportedBufferHandle(
+    buffer: Buffer,
+    requirements: Pick<GraphBufferDescriptor, 'byteLength' | 'usage'>
+  ): GraphBufferHandle | undefined {
     const cachedHandle = this.importedBufferHandles.get(buffer);
-    if (cachedHandle?.defaultBuffer && getCoreBuffer(cachedHandle.defaultBuffer) === buffer) {
+    if (
+      cachedHandle?.defaultBuffer &&
+      getCoreBuffer(cachedHandle.defaultBuffer) === buffer &&
+      doesGraphBufferHandleCoverRequirements(cachedHandle, requirements)
+    ) {
       return cachedHandle;
     }
     this.importedBufferHandles.delete(buffer);
     for (const [dynamicBuffer, handle] of this.dynamicBufferHandles) {
-      if (dynamicBuffer.buffer === buffer) {
+      if (
+        dynamicBuffer.buffer === buffer &&
+        doesGraphBufferHandleCoverRequirements(handle, requirements)
+      ) {
         this.importedBufferHandles.set(buffer, handle);
         return handle;
       }
     }
     for (const handle of this.buffers.values()) {
-      if (handle.defaultBuffer === buffer) {
+      if (
+        handle.defaultBuffer === buffer &&
+        doesGraphBufferHandleCoverRequirements(handle, requirements)
+      ) {
         this.importedBufferHandles.set(buffer, handle);
         return handle;
       }
@@ -1884,6 +1930,24 @@ export class CompiledGPUCommandGraph<Parameters = void> {
 /** Unwraps a dynamic import to the concrete buffer used for validation and encoding. */
 function getCoreBuffer(buffer: GraphImportedBuffer): Buffer {
   return buffer instanceof DynamicBuffer ? buffer.buffer : buffer;
+}
+
+/** Returns the exclusive physical byte offset required by one typed GPU data import. */
+function getGPUDataEndByteOffset(data: GPUData): number {
+  const byteLength =
+    data.length === 0 ? 0 : (data.length - 1) * data.byteStride + data.rowByteLength;
+  return data.byteOffset + byteLength;
+}
+
+/** Returns whether one canonical handle covers a typed import's capacity and usage. */
+function doesGraphBufferHandleCoverRequirements(
+  handle: GraphBufferHandle,
+  requirements: Pick<GraphBufferDescriptor, 'byteLength' | 'usage'>
+): boolean {
+  return (
+    handle.byteLength >= requirements.byteLength &&
+    (handle.usage & requirements.usage) === requirements.usage
+  );
 }
 
 /** Unwraps a ready dynamic import to the concrete texture used for validation and encoding. */

--- a/modules/gpgpu/src/gpu-core/gpu-command-graph.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-command-graph.ts
@@ -636,7 +636,8 @@ export class GPUCommandGraph<Parameters = void> {
   private readonly buffers = new Map<string, GraphBufferHandle>();
   private readonly textures = new Map<string, GraphTextureHandle>();
   private readonly externalTextures = new Map<string, GraphExternalTextureHandle>();
-  private readonly tableBufferHandles = new Map<Buffer, GraphBufferHandle>();
+  private readonly importedBufferHandles = new Map<Buffer, GraphBufferHandle>();
+  private readonly dynamicBufferHandles = new Map<DynamicBuffer, GraphBufferHandle>();
   private readonly nodes: GPUCommandGraphNode<Parameters>[] = [];
   private readonly nodeIds = new Set<string>();
   private compiled = false;
@@ -678,7 +679,17 @@ export class GPUCommandGraph<Parameters = void> {
     if (defaultBuffer) {
       validateImportedBuffer(defaultBuffer, descriptor, this.device);
     }
-    return this.addBuffer(new GraphBufferHandle(this, descriptor, false, defaultBuffer));
+    const handle = this.addBuffer(new GraphBufferHandle(this, descriptor, false, defaultBuffer));
+    if (defaultBuffer) {
+      const coreBuffer = getCoreBuffer(defaultBuffer);
+      if (!this.importedBufferHandles.has(coreBuffer)) {
+        this.importedBufferHandles.set(coreBuffer, handle);
+      }
+      if (defaultBuffer instanceof DynamicBuffer && !this.dynamicBufferHandles.has(defaultBuffer)) {
+        this.dynamicBufferHandles.set(defaultBuffer, handle);
+      }
+    }
+    return handle;
   }
 
   /**
@@ -1077,13 +1088,15 @@ export class GPUCommandGraph<Parameters = void> {
       throw new Error(`GPUCommandGraph import "${id}" requires GPUData.format`);
     }
     const coreBuffer = getCoreBuffer(data.buffer);
-    let handle = this.tableBufferHandles.get(coreBuffer);
+    let handle =
+      data.buffer instanceof DynamicBuffer
+        ? this.dynamicBufferHandles.get(data.buffer)
+        : this.getImportedBufferHandle(coreBuffer);
     if (!handle) {
       handle = this.importBuffer(
         {id, byteLength: coreBuffer.byteLength, usage: coreBuffer.usage},
         data.buffer
       );
-      this.tableBufferHandles.set(coreBuffer, handle);
     }
     return this.createDataView(handle, {
       format: data.format,
@@ -1092,6 +1105,27 @@ export class GPUCommandGraph<Parameters = void> {
       byteStride: data.byteStride,
       rowByteLength: data.rowByteLength
     });
+  }
+
+  private getImportedBufferHandle(buffer: Buffer): GraphBufferHandle | undefined {
+    const cachedHandle = this.importedBufferHandles.get(buffer);
+    if (cachedHandle?.defaultBuffer && getCoreBuffer(cachedHandle.defaultBuffer) === buffer) {
+      return cachedHandle;
+    }
+    this.importedBufferHandles.delete(buffer);
+    for (const [dynamicBuffer, handle] of this.dynamicBufferHandles) {
+      if (dynamicBuffer.buffer === buffer) {
+        this.importedBufferHandles.set(buffer, handle);
+        return handle;
+      }
+    }
+    for (const handle of this.buffers.values()) {
+      if (handle.defaultBuffer === buffer) {
+        this.importedBufferHandles.set(buffer, handle);
+        return handle;
+      }
+    }
+    return undefined;
   }
 
   private assertBuffer(buffer: GraphBufferHandle): void {

--- a/modules/gpgpu/src/gpu-data/gpu-constant.ts
+++ b/modules/gpgpu/src/gpu-data/gpu-constant.ts
@@ -30,6 +30,9 @@ export class GPUConstant<T extends VertexFormat = VertexFormat> {
 
   constructor({format, value}: GPUConstantProps<T>) {
     const formatInfo = getGPUVectorFormatInfo(format);
+    if (formatInfo.fixedSizeList) {
+      throw new Error('GPUConstant cannot represent fixed-size-list storage columns');
+    }
     const expectedConstructor = getGPUConstantTypedArrayConstructor(format);
     if (value.constructor !== expectedConstructor) {
       throw new Error(

--- a/modules/gpgpu/src/gpu-data/gpu-data.ts
+++ b/modules/gpgpu/src/gpu-data/gpu-data.ts
@@ -42,7 +42,7 @@ type GPUDataFromBufferBaseProps = {
   buffer: Buffer | DynamicBuffer;
   /** Number of logical rows in the data range. */
   length: number;
-  /** Number of fixed rows or flattened vertex-list values in the data range. */
+  /** Number of fixed rows, fixed-list elements, or flattened variable-length values. */
   valueLength?: number;
   /** Number of scalar values represented by one fixed row or flattened element. */
   stride?: number;
@@ -153,7 +153,7 @@ class GPUDataImpl extends GPUDataBufferOwner {
   readonly format?: GPUDataFormat;
   /** Number of logical rows in this chunk. */
   readonly length: number;
-  /** Number of fixed rows or flattened vertex-list values in this chunk. */
+  /** Number of fixed rows, fixed-list elements, or flattened variable-length values. */
   readonly valueLength: number;
   /** Number of scalar values represented by one fixed row or flattened element. */
   readonly stride: number;
@@ -210,10 +210,10 @@ class GPUDataImpl extends GPUDataBufferOwner {
     this.dataType = dataType;
     this.format = canonicalFormat;
     this.length = length;
-    this.valueLength = valueLength ?? length;
+    this.valueLength = valueLength ?? length * (formatInfo?.listSize ?? 1);
     this.stride =
       stride ??
-      formatInfo?.components ??
+      (formatInfo ? formatInfo.components * (formatInfo.listSize ?? 1) : undefined) ??
       structFormat?.components ??
       byteStride ??
       rowByteLength ??
@@ -226,6 +226,44 @@ class GPUDataImpl extends GPUDataBufferOwner {
       byteStride ??
       this.stride;
     this.byteStride = byteStride ?? structFormat?.byteStride ?? this.rowByteLength;
+
+    if (formatInfo?.fixedSizeList) {
+      const expectedValueLength = length * formatInfo.listSize!;
+      if (
+        !Number.isSafeInteger(length) ||
+        length < 0 ||
+        !Number.isSafeInteger(expectedValueLength) ||
+        !Number.isSafeInteger(this.byteOffset) ||
+        this.byteOffset < 0 ||
+        !Number.isSafeInteger(this.byteStride) ||
+        !Number.isSafeInteger(this.rowByteLength) ||
+        !Number.isSafeInteger(this.stride)
+      ) {
+        throw new Error('GPUData fixed-size-list row layout must use safe non-negative integers');
+      }
+      if (this.valueLength !== expectedValueLength) {
+        throw new Error(
+          'GPUData fixed-size-list valueLength must equal its flattened row elements'
+        );
+      }
+      if (this.stride < formatInfo.components * formatInfo.listSize!) {
+        throw new Error('GPUData fixed-size-list stride cannot truncate its row components');
+      }
+      if (this.rowByteLength < formatInfo.byteLength) {
+        throw new Error('GPUData fixed-size-list rowByteLength cannot truncate its row payload');
+      }
+      if (this.byteStride < this.rowByteLength) {
+        throw new Error('GPUData fixed-size-list byteStride cannot overlap its row payload');
+      }
+      const dataByteLength = length === 0 ? 0 : (length - 1) * this.byteStride + this.rowByteLength;
+      const endByteOffset = this.byteOffset + dataByteLength;
+      if (!Number.isSafeInteger(dataByteLength) || !Number.isSafeInteger(endByteOffset)) {
+        throw new Error('GPUData fixed-size-list byte range must use safe integers');
+      }
+      if (endByteOffset > buffer.byteLength) {
+        throw new Error('GPUData fixed-size-list exceeds its backing buffer byte length');
+      }
+    }
 
     // Explicit row overrides may add padding but cannot truncate the computed struct layout.
     if (structFormat) {
@@ -298,7 +336,7 @@ interface GPUDataBase<Format extends GPUDataFormat = GPUDataFormat> {
   readonly format?: Format;
   /** Number of logical rows in this chunk. */
   readonly length: number;
-  /** Number of fixed rows or flattened vertex-list values in this chunk. */
+  /** Number of fixed rows, fixed-list elements, or flattened variable-length values. */
   readonly valueLength: number;
   /** Number of scalar values represented by one fixed row or flattened element. */
   readonly stride: number;

--- a/modules/gpgpu/src/gpu-data/gpu-vector-format.ts
+++ b/modules/gpgpu/src/gpu-data/gpu-vector-format.ts
@@ -30,13 +30,25 @@ export type VertexList<Format extends VertexFormat = VertexFormat> = `vertex-lis
 export type ValueList<Format extends VertexFormat = VertexFormat> = `value-list<${Format}>`;
 
 /**
+ * Fixed-length rows of element values consumed through GPU storage bindings.
+ *
+ * `fixed-size-list<float32,768>` stores exactly 768 `float32` elements in every
+ * logical row. The list describes physical memory, not a shader vertex format.
+ */
+export type FixedSizeList<
+  Format extends VertexFormat = VertexFormat,
+  Size extends number = number
+> = `fixed-size-list<${Format},${Size}>`;
+
+/**
  * Memory-layout string used by GPUVector.
  *
  * Fixed formats reuse core `VertexFormat` strings. Variable-length
  * vertex-aligned formats use `vertex-list<${VertexFormat}>`; other
- * variable-length values use `value-list<${VertexFormat}>`.
+ * variable-length values use `value-list<${VertexFormat}>`. Storage-oriented
+ * fixed-length rows use `fixed-size-list<${VertexFormat},${number}>`.
  */
-export type GPUVectorFormat = VertexFormat | VertexList | ValueList;
+export type GPUVectorFormat = VertexFormat | VertexList | ValueList | FixedSizeList;
 
 /** Decoded memory-layout information for a GPUVector format string. */
 export type GPUVectorFormatInfo = {
@@ -48,6 +60,10 @@ export type GPUVectorFormatInfo = {
   vertexList: boolean;
   /** Whether this vector stores row-offset non-vertex value lists. */
   valueList: boolean;
+  /** Whether every logical row contains a fixed number of storage elements. */
+  fixedSizeList: boolean;
+  /** Number of elements in each fixed-size-list row, when applicable. */
+  listSize?: number;
   /** Component memory data type. */
   type: NormalizedDataType;
   /** Component memory data type without normalization. */
@@ -56,7 +72,9 @@ export type GPUVectorFormatInfo = {
   primitiveType: PrimitiveDataType;
   /** Number of scalar components per fixed row or list element. */
   components: 1 | 2 | 3 | 4;
-  /** Bytes occupied by one fixed row or list element. */
+  /** Bytes occupied by one scalar or vector element. */
+  elementByteLength: number;
+  /** Bytes occupied by one fixed row, or by one variable-length list element. */
   byteLength: number;
   /** Whether shader-visible values are integer values. */
   integer: boolean;
@@ -70,6 +88,7 @@ export type GPUVectorFormatInfo = {
 
 const VERTEX_LIST_FORMAT_REGEXP = /^vertex-list<([^<>]+)>$/;
 const VALUE_LIST_FORMAT_REGEXP = /^value-list<([^<>]+)>$/;
+const FIXED_SIZE_LIST_FORMAT_REGEXP = /^fixed-size-list<([^<>,]+),([1-9][0-9]*)>$/;
 
 /** Returns true when a GPUVector format describes row-offset vertex lists. */
 export function isVertexListGPUVectorFormat(format: string): format is VertexList {
@@ -81,11 +100,20 @@ export function isValueListGPUVectorFormat(format: string): format is ValueList 
   return VALUE_LIST_FORMAT_REGEXP.test(format);
 }
 
+/** Returns true when a GPUVector format describes canonical fixed-length rows. */
+export function isFixedSizeListGPUVectorFormat(format: string): format is FixedSizeList {
+  return Boolean(getFixedSizeListFormatParts(format));
+}
+
 /** Returns the fixed element memory format for fixed and variable-length vectors. */
 export function getGPUVectorElementFormat(format: GPUVectorFormat): VertexFormat {
   const vertexListMatch = VERTEX_LIST_FORMAT_REGEXP.exec(format);
   const valueListMatch = VALUE_LIST_FORMAT_REGEXP.exec(format);
-  const elementFormat = (vertexListMatch?.[1] ?? valueListMatch?.[1] ?? format) as VertexFormat;
+  const fixedSizeListFormat = getFixedSizeListFormatParts(format);
+  const elementFormat = (fixedSizeListFormat?.elementFormat ??
+    vertexListMatch?.[1] ??
+    valueListMatch?.[1] ??
+    format) as VertexFormat;
   try {
     vertexFormatDecoder.getVertexFormatInfo(elementFormat);
   } catch {
@@ -99,7 +127,12 @@ export function getGPUVectorFormatInfo(format: GPUVectorFormat): GPUVectorFormat
   const elementFormat = getGPUVectorElementFormat(format);
   const vertexList = isVertexListGPUVectorFormat(format);
   const valueList = isValueListGPUVectorFormat(format);
+  const fixedSizeListFormat = getFixedSizeListFormatParts(format);
   const vertexFormatInfo = vertexFormatDecoder.getVertexFormatInfo(elementFormat);
+  const byteLength = vertexFormatInfo.byteLength * (fixedSizeListFormat?.listSize ?? 1);
+  if (!Number.isSafeInteger(byteLength)) {
+    throw new Error(`Unsupported GPUVector format ${format}`);
+  }
   const type = vertexFormatInfo.type;
   const normalized = vertexFormatInfo.normalized;
   const primitiveType = getPrimitiveDataType(type, normalized);
@@ -109,11 +142,14 @@ export function getGPUVectorFormatInfo(format: GPUVectorFormat): GPUVectorFormat
     elementFormat,
     vertexList,
     valueList,
+    fixedSizeList: Boolean(fixedSizeListFormat),
+    ...(fixedSizeListFormat ? {listSize: fixedSizeListFormat.listSize} : {}),
     type,
     signedDataType: getSignedDataType(elementFormat, type),
     primitiveType,
     components: vertexFormatInfo.components,
-    byteLength: vertexFormatInfo.byteLength,
+    elementByteLength: vertexFormatInfo.byteLength,
+    byteLength,
     integer: vertexFormatInfo.integer,
     signed: vertexFormatInfo.signed,
     normalized,
@@ -127,6 +163,9 @@ export function isGPUVectorFormatCompatibleWithShaderType(
   shaderType: AttributeShaderType
 ): boolean {
   const formatInfo = getGPUVectorFormatInfo(format);
+  if (formatInfo.fixedSizeList) {
+    return false;
+  }
   const shaderTypeInfo = shaderTypeDecoder.getAttributeShaderTypeInfo(shaderType);
 
   if (formatInfo.components !== shaderTypeInfo.components) {
@@ -145,6 +184,34 @@ export function isGPUVectorFormatCompatibleWithShaderType(
     default:
       return false;
   }
+}
+
+function getFixedSizeListFormatParts(
+  format: string
+): {elementFormat: string; listSize: number} | undefined {
+  const fixedSizeListMatch = FIXED_SIZE_LIST_FORMAT_REGEXP.exec(format);
+  if (!fixedSizeListMatch) {
+    return undefined;
+  }
+  const listSize = Number(fixedSizeListMatch[2]);
+  if (!Number.isSafeInteger(listSize)) {
+    return undefined;
+  }
+  const elementFormat = fixedSizeListMatch[1];
+  try {
+    const elementFormatInfo = vertexFormatDecoder.getVertexFormatInfo(
+      elementFormat as VertexFormat
+    );
+    if (
+      !Number.isSafeInteger(listSize * elementFormatInfo.components) ||
+      !Number.isSafeInteger(listSize * elementFormatInfo.byteLength)
+    ) {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+  return {elementFormat, listSize};
 }
 
 function getPrimitiveDataType(type: NormalizedDataType, normalized: boolean): PrimitiveDataType {

--- a/modules/gpgpu/src/gpu-data/gpu-vector.ts
+++ b/modules/gpgpu/src/gpu-data/gpu-vector.ts
@@ -30,7 +30,7 @@ export type GPUVectorFromBufferProps<T extends GPUVectorFormat = GPUVectorFormat
   format?: T;
   /** Number of logical rows in the buffer. */
   length: number;
-  /** Number of fixed rows or flattened vertex-list values in the buffer. */
+  /** Number of fixed rows, fixed-list elements, or flattened variable-length values. */
   valueLength?: number;
   /** Number of scalar values represented by one fixed row or flattened element. */
   stride?: number;
@@ -58,7 +58,7 @@ export type GPUVectorFromInterleavedProps<T extends GPUVectorFormat = GPUVectorF
   format?: T;
   /** Number of logical rows in the buffer. */
   length: number;
-  /** Number of fixed rows or flattened vertex-list values in the buffer. */
+  /** Number of fixed rows, fixed-list elements, or flattened variable-length values. */
   valueLength?: number;
   /** Byte offset of the first logical row. */
   byteOffset?: number;
@@ -84,7 +84,7 @@ export type GPUVectorFromDataProps<T extends GPUVectorFormat = GPUVectorFormat> 
   data: GPUData<T>[];
   /** Number of scalar values represented by one fixed row or flattened element. */
   stride?: number;
-  /** Number of fixed rows or flattened vertex-list values across all chunks. */
+  /** Number of fixed rows, fixed-list elements, or flattened variable-length values. */
   valueLength?: number;
   /** Bytes between adjacent fixed rows or flattened elements. Defaults to the first chunk stride. */
   byteStride?: number;
@@ -148,7 +148,7 @@ export class GPUVector<T extends GPUVectorFormat = GPUVectorFormat> {
   readonly format?: T;
   /** Number of logical rows represented by the vector. */
   length: number;
-  /** Number of fixed rows or flattened vertex-list values represented by the vector. */
+  /** Number of fixed rows, fixed-list elements, or flattened variable-length values. */
   valueLength: number;
   /** Number of scalar values represented by one fixed row or flattened element. */
   readonly stride: number;
@@ -179,11 +179,12 @@ export class GPUVector<T extends GPUVectorFormat = GPUVectorFormat> {
           buffer,
           format,
           length,
-          valueLength = length,
+          valueLength: explicitValueLength,
           byteOffset = 0,
           ownsBuffer = false
         } = props;
-        const {stride, byteStride, rowByteLength} = getResolvedGPUVectorLayout(props);
+        const {stride, byteStride, rowByteLength, listSize} = getResolvedGPUVectorLayout(props);
+        const valueLength = explicitValueLength ?? length * (listSize ?? 1);
         this.name = name;
         this.dataType = props.dataType;
         this.format = format;
@@ -216,21 +217,27 @@ export class GPUVector<T extends GPUVectorFormat = GPUVectorFormat> {
           buffer,
           format,
           length,
-          valueLength = length,
+          valueLength: explicitValueLength,
           byteOffset = 0,
           byteStride,
           attributes,
           ownsBuffer = false
         } = props;
+        const formatInfo = format ? getGPUVectorFormatInfo(format) : undefined;
+        const valueLength = explicitValueLength ?? length * (formatInfo?.listSize ?? 1);
+        const stride = formatInfo?.fixedSizeList
+          ? formatInfo.components * formatInfo.listSize!
+          : byteStride;
+        const rowByteLength = formatInfo?.fixedSizeList ? formatInfo.byteLength : byteStride;
         this.name = name;
         this.dataType = props.dataType;
         this.format = format;
         this.length = length;
         this.valueLength = valueLength;
-        this.stride = byteStride;
+        this.stride = stride;
         this.byteOffset = byteOffset;
         this.byteStride = byteStride;
-        this.rowByteLength = byteStride;
+        this.rowByteLength = rowByteLength;
         this.bufferLayout = {name, byteStride, attributes};
         this.data.push(
           new GPUData<T>({
@@ -238,10 +245,10 @@ export class GPUVector<T extends GPUVectorFormat = GPUVectorFormat> {
             format,
             length,
             valueLength,
-            stride: byteStride,
+            stride,
             byteOffset,
             byteStride,
-            rowByteLength: byteStride,
+            rowByteLength,
             ownsBuffer,
             dataType: props.dataType
           })
@@ -255,7 +262,8 @@ export class GPUVector<T extends GPUVectorFormat = GPUVectorFormat> {
         const {
           name,
           data,
-          stride = data[0]?.stride ?? formatInfo?.components ?? 1,
+          stride = data[0]?.stride ??
+            (formatInfo ? formatInfo.components * (formatInfo.listSize ?? 1) : 1),
           valueLength = data.reduce(
             (totalValueLength, chunk) => totalValueLength + chunk.valueLength,
             0
@@ -411,16 +419,20 @@ function getResolvedGPUVectorLayout<T extends GPUVectorFormat>(props: {
   stride?: number;
   byteStride?: number;
   rowByteLength?: number;
-}): {stride: number; byteStride: number; rowByteLength: number} {
+}): {stride: number; byteStride: number; rowByteLength: number; listSize?: number} {
   const formatInfo = props.format ? getGPUVectorFormatInfo(props.format) : undefined;
-  const rowByteLength = props.rowByteLength ?? props.byteStride ?? formatInfo?.byteLength;
+  const rowByteLength =
+    props.rowByteLength ??
+    (formatInfo?.fixedSizeList ? formatInfo.byteLength : props.byteStride) ??
+    formatInfo?.byteLength;
   if (rowByteLength === undefined) {
     throw new Error('GPUVector requires format or explicit rowByteLength');
   }
   return {
-    stride: props.stride ?? formatInfo?.components ?? 1,
+    stride: props.stride ?? (formatInfo ? formatInfo.components * (formatInfo.listSize ?? 1) : 1),
     byteStride: props.byteStride ?? rowByteLength,
-    rowByteLength
+    rowByteLength,
+    ...(formatInfo?.listSize ? {listSize: formatInfo.listSize} : {})
   };
 }
 

--- a/modules/gpgpu/src/gpu-data/index.ts
+++ b/modules/gpgpu/src/gpu-data/index.ts
@@ -48,9 +48,11 @@ export {
 export {
   getGPUVectorElementFormat,
   getGPUVectorFormatInfo,
+  isFixedSizeListGPUVectorFormat,
   isGPUVectorFormatCompatibleWithShaderType,
   isValueListGPUVectorFormat,
   isVertexListGPUVectorFormat,
+  type FixedSizeList,
   type GPUVectorFormat,
   type GPUVectorFormatInfo,
   type ValueList,

--- a/modules/gpgpu/src/gpu-vector-search/embedding-matrix.ts
+++ b/modules/gpgpu/src/gpu-vector-search/embedding-matrix.ts
@@ -1,0 +1,381 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuVS.
+
+import {
+  getGPUVectorFormatInfo,
+  isFixedSizeListGPUVectorFormat,
+  type FixedSizeList,
+  type GPUData,
+  type GPUVector,
+  type GPUVectorFormat
+} from '@luma.gl/gpgpu/gpu-data';
+import type {GPUCommandGraph, GraphDataView} from '@luma.gl/gpgpu/gpu-core';
+import type {GraphEmbeddingMatrix, GraphEmbeddingMatrixChunk} from './types';
+
+const FLOAT32_BYTE_LENGTH = Float32Array.BYTES_PER_ELEMENT;
+const INVALID_SOURCE_ROW_ID = 0xffff_ffff;
+const DEFAULT_GPU_TABLE_INDEX_COLUMN_NAME = 'indices';
+
+/** Structural schema field required by the vector-search table adapter. */
+export type GPUEmbeddingTableField = {
+  name: string;
+  format?: GPUVectorFormat;
+};
+
+/** Structural record-batch input accepted without depending on a table implementation package. */
+export type GPUEmbeddingRecordBatch = {
+  schema: {fields: readonly GPUEmbeddingTableField[]};
+  numRows: number;
+  gpuData: Record<string, GPUData>;
+  sourceInfo?: {sourceRowIndexOffset: number};
+};
+
+/** Structural table input accepted from `@luma.gl/experimental/gpu-tables` or application code. */
+export type GPUEmbeddingTable = {
+  schema: {fields: readonly GPUEmbeddingTableField[]};
+  numRows: number;
+  batches: readonly GPUEmbeddingRecordBatch[];
+};
+
+/** Table or record-batch shape consumed by {@link importGPUEmbeddingTable}. */
+export type GPUEmbeddingTableSource = GPUEmbeddingTable | GPUEmbeddingRecordBatch;
+
+/** Optional row-aligned metadata for importing a caller-owned embedding column. */
+export type ImportGPUEmbeddingVectorOptions = {
+  /** Prefix shared by the imported caller-owned graph buffers. */
+  id?: string;
+  /** Optional meaningful feature count when trailing fixed-list coordinates are padding. */
+  dimensions?: number;
+  /** Optional chunk-preserving stable identifiers for the embedding rows. */
+  sourceRowIds?: GPUVector<'uint32'>;
+  /** Optional chunk-preserving validity flags; zero rejects a row. */
+  validity?: GPUVector<'uint32'>;
+  /** Position of the first source row when chunk offsets are consecutive. */
+  sourceRowOffset?: number;
+  /** Explicit first source-row position for each preserved embedding chunk. */
+  sourceRowOffsets?: readonly number[];
+};
+
+/** Selects one caller-owned embedding column and optional row-aligned table columns. */
+export type ImportGPUEmbeddingTableOptions = {
+  /** Name of the fixed-size-list<float32,N> table or record-batch column. */
+  column: string;
+  /** Prefix shared by the imported caller-owned graph buffers. */
+  id?: string;
+  /** Optional meaningful feature count when trailing fixed-list coordinates are padding. */
+  dimensions?: number;
+  /** Optional name of the uint32 column providing stable source-row identifiers. */
+  sourceRowIds?: string;
+  /** Optional name of the uint32 column providing nonzero-valid row flags. */
+  validity?: string;
+};
+
+/** Caller-owned batch data that becomes one non-owning command-graph embedding chunk. */
+type GPUEmbeddingChunkSource = {
+  data: GPUData<FixedSizeList<'float32'>>;
+  sourceRowOffset: number;
+  sourceRowIds?: GPUData<'uint32'>;
+  validity?: GPUData<'uint32'>;
+};
+
+/**
+ * Borrows one first-class fixed-size-list<float32,N> GPU table column for graph-native search.
+ *
+ * GPUData chunks remain caller-owned and keep their logical row counts, byte offsets, physical
+ * padding, optional row metadata, and ordered batch boundaries. No GPU memory is allocated.
+ */
+export function importGPUEmbeddingVector<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  vector: GPUVector<FixedSizeList<'float32'>>,
+  options: ImportGPUEmbeddingVectorOptions = {}
+): GraphEmbeddingMatrix {
+  const dimensions = getEmbeddingDimensions(vector.format, 'Embedding vector', options.dimensions);
+  if (!Number.isSafeInteger(vector.length) || vector.length < 0) {
+    throw new Error('Embedding vector row count must be a non-negative safe integer');
+  }
+  validateOptionalRowVector(options.sourceRowIds, vector, 'source-row IDs');
+  validateOptionalRowVector(options.validity, vector, 'validity flags');
+  if (options.sourceRowOffsets && options.sourceRowOffsets.length !== vector.data.length) {
+    throw new Error('Embedding source-row offsets must preserve the vector chunk topology');
+  }
+
+  let nextSourceRowOffset = options.sourceRowOffset ?? 0;
+  const sources = vector.data.map((data, chunkIndex): GPUEmbeddingChunkSource => {
+    const sourceRowOffset = options.sourceRowOffsets?.[chunkIndex] ?? nextSourceRowOffset;
+    nextSourceRowOffset = sourceRowOffset + data.length;
+    return {
+      data,
+      sourceRowOffset,
+      ...(options.sourceRowIds ? {sourceRowIds: options.sourceRowIds.data[chunkIndex]} : {}),
+      ...(options.validity ? {validity: options.validity.data[chunkIndex]} : {})
+    };
+  });
+
+  return importEmbeddingChunks(
+    graph,
+    dimensions,
+    vector.length,
+    sources,
+    options.id ?? vector.name ?? 'embedding-vector'
+  );
+}
+
+/**
+ * Borrows one first-class embedding column from an existing GPU table or record batch.
+ *
+ * Existing GPURecordBatch.sourceInfo preserves source-row positions. Explicit stable identifiers
+ * and validity remain ordinary caller-selected uint32 sibling columns owned by the source table.
+ */
+export function importGPUEmbeddingTable<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  source: GPUEmbeddingTableSource,
+  options: ImportGPUEmbeddingTableOptions
+): GraphEmbeddingMatrix {
+  const field = source.schema.fields.find(candidate => candidate.name === options.column);
+  if (!field) {
+    throw new Error(`Embedding table does not contain column "${options.column}"`);
+  }
+  const dimensions = getEmbeddingDimensions(
+    field.format,
+    `Embedding column "${options.column}"`,
+    options.dimensions
+  );
+  const batches = isGPUEmbeddingRecordBatch(source) ? [source] : source.batches;
+  let nextSourceRowOffset = 0;
+
+  const sources = batches.map((batch, batchIndex): GPUEmbeddingChunkSource => {
+    const data = batch.gpuData[options.column];
+    assertEmbeddingData(data, field.format, options.column);
+    const sourceRowOffset = batch.sourceInfo?.sourceRowIndexOffset ?? nextSourceRowOffset;
+    nextSourceRowOffset = sourceRowOffset + batch.numRows;
+    const sourceIdsName =
+      options.sourceRowIds ??
+      (batch.gpuData[DEFAULT_GPU_TABLE_INDEX_COLUMN_NAME]?.format === 'uint32'
+        ? DEFAULT_GPU_TABLE_INDEX_COLUMN_NAME
+        : undefined);
+    const sourceRowIds = sourceIdsName
+      ? getBatchRowData(batch, sourceIdsName, 'source-row IDs', batchIndex)
+      : undefined;
+    const validity = options.validity
+      ? getBatchRowData(batch, options.validity, 'validity flags', batchIndex)
+      : undefined;
+    return {
+      data,
+      sourceRowOffset,
+      ...(sourceRowIds ? {sourceRowIds} : {}),
+      ...(validity ? {validity} : {})
+    };
+  });
+
+  return importEmbeddingChunks(
+    graph,
+    dimensions,
+    source.numRows,
+    sources,
+    options.id ?? options.column
+  );
+}
+
+function getEmbeddingDimensions(
+  format: string | undefined,
+  name: string,
+  requestedDimensions?: number
+): number {
+  if (!format || !isFixedSizeListGPUVectorFormat(format)) {
+    throw new Error(`${name} must use a fixed-size-list<float32,N> GPU vector format`);
+  }
+  const formatInfo = getGPUVectorFormatInfo(format);
+  if (formatInfo.elementFormat !== 'float32' || !formatInfo.listSize) {
+    throw new Error(`${name} must use a fixed-size-list<float32,N> GPU vector format`);
+  }
+  const dimensions = requestedDimensions ?? formatInfo.listSize;
+  if (!Number.isSafeInteger(dimensions) || dimensions < 1 || dimensions > formatInfo.listSize) {
+    throw new Error(`${name} dimensions must be positive and fit within its fixed-size-list rows`);
+  }
+  return dimensions;
+}
+
+function assertEmbeddingData(
+  data: GPUData | undefined,
+  expectedFormat: string | undefined,
+  column: string
+): asserts data is GPUData<FixedSizeList<'float32'>> {
+  if (!data || data.format !== expectedFormat) {
+    throw new Error(`Embedding column "${column}" must retain the same format in every batch`);
+  }
+}
+
+function validateOptionalRowVector(
+  metadata: GPUVector<'uint32'> | undefined,
+  embeddings: GPUVector<FixedSizeList<'float32'>>,
+  name: string
+): void {
+  if (!metadata) return;
+  if (
+    metadata.format !== 'uint32' ||
+    metadata.length !== embeddings.length ||
+    metadata.data.length !== embeddings.data.length ||
+    metadata.data.some((data, chunkIndex) => data.length !== embeddings.data[chunkIndex].length)
+  ) {
+    throw new Error(`Embedding ${name} must be a chunk-aligned uint32 GPU vector`);
+  }
+}
+
+function getBatchRowData(
+  batch: GPUEmbeddingRecordBatch,
+  column: string,
+  name: string,
+  batchIndex: number
+): GPUData<'uint32'> {
+  const data = batch.gpuData[column];
+  assertBatchRowData(data, batch.numRows, name, batchIndex);
+  return data;
+}
+
+function isGPUEmbeddingRecordBatch(
+  source: GPUEmbeddingTableSource
+): source is GPUEmbeddingRecordBatch {
+  return 'gpuData' in source;
+}
+
+function assertBatchRowData(
+  data: GPUData | undefined,
+  rowCount: number,
+  name: string,
+  batchIndex: number
+): asserts data is GPUData<'uint32'> {
+  if (!data || data.format !== 'uint32' || data.length !== rowCount) {
+    throw new Error(`Embedding ${name} must be a row-aligned uint32 column in batch ${batchIndex}`);
+  }
+}
+
+function importEmbeddingChunks<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  dimensions: number,
+  rowCount: number,
+  sources: readonly GPUEmbeddingChunkSource[],
+  identifier: string
+): GraphEmbeddingMatrix {
+  let totalRowCount = 0;
+  for (const source of sources) {
+    validateEmbeddingChunk(source, dimensions);
+    totalRowCount += source.data.length;
+  }
+  if (totalRowCount !== rowCount || totalRowCount > INVALID_SOURCE_ROW_ID) {
+    throw new Error('Embedding row count must equal its source chunk rows and fit into uint32');
+  }
+  const chunks = sources.map((source, chunkIndex) =>
+    importEmbeddingChunk(graph, source, dimensions, `${identifier}-chunk-${chunkIndex}`)
+  );
+  return {dimensions, rowCount, chunks};
+}
+
+function validateEmbeddingChunk(source: GPUEmbeddingChunkSource, dimensions: number): void {
+  const data = source.data;
+  const formatInfo = data.format ? getGPUVectorFormatInfo(data.format) : undefined;
+  const listSize = formatInfo?.listSize ?? 0;
+  const expectedValueLength = data.length * listSize;
+  if (
+    !Number.isSafeInteger(data.length) ||
+    data.length < 0 ||
+    !formatInfo?.fixedSizeList ||
+    formatInfo.elementFormat !== 'float32' ||
+    dimensions > listSize ||
+    !Number.isSafeInteger(expectedValueLength) ||
+    data.valueLength !== expectedValueLength ||
+    !Number.isSafeInteger(data.byteOffset) ||
+    data.byteOffset < 0 ||
+    data.byteOffset % FLOAT32_BYTE_LENGTH !== 0 ||
+    !Number.isSafeInteger(data.byteStride) ||
+    data.byteStride < listSize * FLOAT32_BYTE_LENGTH ||
+    data.byteStride % FLOAT32_BYTE_LENGTH !== 0 ||
+    !Number.isSafeInteger(data.rowByteLength) ||
+    data.rowByteLength < listSize * FLOAT32_BYTE_LENGTH ||
+    data.rowByteLength > data.byteStride ||
+    !Number.isSafeInteger(source.sourceRowOffset) ||
+    source.sourceRowOffset < 0 ||
+    source.sourceRowOffset + data.length > INVALID_SOURCE_ROW_ID
+  ) {
+    throw new Error('Embedding chunk must describe aligned, bounded fixed-size float32 rows');
+  }
+  const byteLength =
+    data.length === 0 ? 0 : (data.length - 1) * data.byteStride + dimensions * FLOAT32_BYTE_LENGTH;
+  if (
+    !Number.isSafeInteger(byteLength) ||
+    !Number.isSafeInteger(data.byteOffset + byteLength) ||
+    data.byteOffset + byteLength > data.buffer.byteLength
+  ) {
+    throw new Error('Embedding chunk rows exceed their declared GPUData byte range');
+  }
+  for (const metadata of [source.sourceRowIds, source.validity]) {
+    if (
+      metadata &&
+      (metadata.format !== 'uint32' ||
+        metadata.length !== data.length ||
+        metadata.byteStride !== Uint32Array.BYTES_PER_ELEMENT ||
+        metadata.rowByteLength !== Uint32Array.BYTES_PER_ELEMENT)
+    ) {
+      throw new Error('Embedding row metadata must be packed, row-aligned uint32 GPUData');
+    }
+  }
+  if (source.sourceRowIds && hasNullEmbeddingRows(source.sourceRowIds)) {
+    throw new Error('Embedding source-row IDs must not contain null values');
+  }
+  if (!source.validity && hasNullEmbeddingRows(data)) {
+    throw new Error('Embedding rows containing null values require explicit GPU validity flags');
+  }
+}
+
+function hasNullEmbeddingRows(data: GPUData): boolean {
+  const nullBitmap = data.nullBitmap;
+  if (!nullBitmap) return false;
+  for (let rowIndex = 0; rowIndex < data.length; rowIndex++) {
+    if ((nullBitmap[rowIndex >>> 3] & (1 << (rowIndex & 7))) === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function importEmbeddingChunk<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  source: GPUEmbeddingChunkSource,
+  dimensions: number,
+  identifier: string
+): GraphEmbeddingMatrixChunk {
+  const importedData = graph.importGPUData(`${identifier}-values`, source.data);
+  const rowStride = source.data.byteStride / FLOAT32_BYTE_LENGTH;
+  const valueLength =
+    source.data.length === 0 ? 0 : (source.data.length - 1) * rowStride + dimensions;
+  const values = graph.createDataView(importedData.buffer, {
+    format: 'float32',
+    length: valueLength,
+    byteOffset: source.data.byteOffset
+  });
+  const sourceRowIds = importOptionalRowData(
+    graph,
+    source.sourceRowIds,
+    `${identifier}-source-row-ids`
+  );
+  const validity = importOptionalRowData(graph, source.validity, `${identifier}-validity`);
+
+  return {
+    values,
+    rowCount: source.data.length,
+    rowStride,
+    byteOffset: source.data.byteOffset,
+    sourceRowOffset: source.sourceRowOffset,
+    ...(sourceRowIds ? {sourceRowIds} : {}),
+    ...(validity ? {validity} : {})
+  };
+}
+
+function importOptionalRowData<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  data: GPUData<'uint32'> | undefined,
+  identifier: string
+): GraphDataView<'uint32'> | undefined {
+  return data ? graph.importGPUData(identifier, data) : undefined;
+}

--- a/modules/gpgpu/src/gpu-vector-search/gpu-similarity-search.ts
+++ b/modules/gpgpu/src/gpu-vector-search/gpu-similarity-search.ts
@@ -1,0 +1,1138 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuVS.
+
+import type {Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {
+  createTransientView,
+  doGraphDataViewsOverlap,
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource,
+  getViewBinding,
+  getViewBindingRange,
+  getViewElementOffset,
+  GPUHashIndex,
+  type GPUCommandGraph,
+  type GPUCommandGraphContributor,
+  type GraphBufferUse,
+  type GraphDataView,
+  type GraphVectorView,
+  validatePackedUint32View,
+  validatePackedView
+} from '@luma.gl/gpgpu/gpu-core';
+import type {
+  GPUEmbeddingFilterMask,
+  GPUEmbeddingMetric,
+  GPUSimilaritySearchProps,
+  GraphEmbeddingMatrix,
+  GraphEmbeddingMatrixChunk
+} from './types';
+
+const SEARCH_WORKGROUP_SIZE = 64;
+const INVALID_SOURCE_ROW_ID = 0xffff_ffff;
+const STORAGE_BINDING_ALIGNMENT = 256;
+const SCALAR_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
+const LINEAR_CANDIDATE_ALLOWLIST_LIMIT = 16;
+
+type CandidateMembershipIndex = {
+  keys: GraphDataView<'uint32'>;
+  statistics: GraphDataView<'uint32'>;
+  capacity: number;
+};
+
+type DatasetTile = {
+  chunk: GraphEmbeddingMatrixChunk;
+  chunkIndex: number;
+  chunkRowOffset: number;
+  sourceRowOffset: number;
+  rowCount: number;
+  values: GraphDataView<'float32'>;
+  sourceRowIds?: GraphDataView<'uint32'>;
+  validity?: GraphDataView<'uint32'>;
+  filterMask?: GraphDataView<'uint32'>;
+};
+
+type QueryTile = {
+  logicalRowOffset: number;
+  rowCount: number;
+  values: GraphDataView<'float32'>;
+  rowStride: number;
+  sourceRowOffset: number;
+  sourceRowIds?: GraphDataView<'uint32'>;
+  validity?: GraphDataView<'uint32'>;
+  rowMetadata: GraphDataView<'uint32'>;
+  outputIds: GraphDataView<'uint32'>;
+  outputScores: GraphDataView<'float32'>;
+  resultCounts: GraphDataView<'uint32'>;
+  candidateCounts?: GraphDataView<'uint32'>;
+};
+
+/**
+ * Exact, bounded, chunk-preserving WebGPU embedding similarity search.
+ *
+ * Squared Euclidean distance sorts ascending; inner product and cosine similarity sort descending.
+ * Equal scores always sort by stable source-row ID. Non-finite rows are excluded. Cosine similarity
+ * is one for two zero vectors and zero when exactly one vector is zero. Unfilled result slots use
+ * source ID `0xffffffff` and the metric's worst infinite score.
+ *
+ * Original allocations are sharded at the device storage-binding limit. Each query invocation keeps
+ * only its caller-owned top-K output, so no query-by-dataset distance matrix is materialized.
+ */
+export class GPUSimilaritySearch implements GPUCommandGraphContributor {
+  /** Prefix shared by bounded graph passes and transient eligibility metadata. */
+  readonly id: string;
+  /** Caller-owned, chunk-preserving dataset embeddings. */
+  readonly dataset: GraphEmbeddingMatrix;
+  /** Caller-owned, chunk-preserving query embeddings. */
+  readonly queries: GraphEmbeddingMatrix;
+  /** Packed, query-major stable source IDs. */
+  readonly outputIds: GraphDataView<'uint32'>;
+  /** Packed, query-major float32 distance or similarity scores. */
+  readonly outputScores: GraphDataView<'float32'>;
+  /** Number of actual top-K results for each query row. */
+  readonly resultCounts: GraphDataView<'uint32'>;
+  /** Optional total eligible candidate count before top-K truncation. */
+  readonly candidateCounts?: GraphDataView<'uint32'>;
+  /** Maximum result count per query. */
+  readonly k: number;
+  /** Score metric and corresponding ordering direction. */
+  readonly metric: GPUEmbeddingMetric;
+  /** Optional source-row-aligned LuxFilter-compatible selection flags. */
+  readonly filterMask?: GPUEmbeddingFilterMask;
+  /** Optional stable-ID candidate allowlist. */
+  readonly candidateIds?: GraphDataView<'uint32'>;
+  /** Optional query-major, source-row-aligned selection flags. */
+  readonly queryFilterMask?: GraphDataView<'uint32'>;
+  /** Whether candidates sharing the query's stable ID are rejected. */
+  readonly excludeSelf: boolean;
+  /** Optional additional per-pass candidate-row ceiling. */
+  readonly tileSize: number;
+
+  private registered = false;
+
+  /** Validates caller-owned resources without encoding, submitting, or reading GPU work. */
+  constructor(props: GPUSimilaritySearchProps) {
+    this.id = props.id ?? 'gpu-similarity-search';
+    this.dataset = props.dataset;
+    this.queries = props.queries;
+    this.outputIds = props.outputIds;
+    this.outputScores = props.outputScores;
+    this.resultCounts = props.resultCounts;
+    this.candidateCounts = props.candidateCounts;
+    this.k = props.k;
+    this.metric = props.metric ?? 'squared-euclidean';
+    this.filterMask = props.filterMask;
+    this.candidateIds = props.candidateIds;
+    this.queryFilterMask = props.queryFilterMask;
+    this.excludeSelf = props.excludeSelf ?? false;
+    this.tileSize = props.tileSize ?? INVALID_SOURCE_ROW_ID;
+
+    validateSearchConfiguration(this);
+  }
+
+  /**
+   * Adds reusable bounded passes without implicit submission or hidden CPU synchronization.
+   *
+   * Every pass declares all physical source/destination dependencies. Imported buffer overrides are
+   * resolved only during graph encoding, so one compiled search can run repeatedly with new inputs.
+   */
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    if (this.registered) {
+      throw new Error(`${this.id} similarity search has already been added to a command graph`);
+    }
+    validateSearchGraphOwnership(this, graph);
+    if (this.queries.rowCount === 0) {
+      this.registered = true;
+      return;
+    }
+
+    const sourceSpan = getSourceRowSpan(this.dataset);
+    const queryTiles = createQueryTiles(graph, this, sourceSpan);
+    for (const [queryTileIndex, queryTile] of queryTiles.entries()) {
+      addInitializeQueryPass(graph, this, queryTile, queryTileIndex);
+    }
+
+    if (this.dataset.rowCount === 0 || (this.k === 0 && !this.candidateCounts)) {
+      this.registered = true;
+      return;
+    }
+
+    const candidateMembership = createCandidateMembershipIndex(graph, this);
+    const datasetTiles = createDatasetTiles(graph, this);
+    for (const [datasetTileIndex, datasetTile] of datasetTiles.entries()) {
+      const eligibleSourceIds = createTransientView(
+        graph,
+        `${this.id}-eligible-source-ids-${datasetTileIndex}`,
+        'uint32',
+        datasetTile.rowCount
+      );
+      addPrepareDatasetTilePass(
+        graph,
+        this,
+        datasetTile,
+        datasetTileIndex,
+        eligibleSourceIds,
+        candidateMembership
+      );
+
+      for (const [queryTileIndex, queryTile] of queryTiles.entries()) {
+        const queryFilterMask = this.queryFilterMask
+          ? createQueryFilterTileView(
+              graph,
+              this.queryFilterMask,
+              queryTile,
+              datasetTile,
+              sourceSpan
+            )
+          : undefined;
+        if (queryTile.candidateCounts) {
+          addCountCandidatesPass(
+            graph,
+            this,
+            datasetTile,
+            queryTile,
+            datasetTileIndex,
+            queryTileIndex,
+            eligibleSourceIds,
+            queryFilterMask,
+            sourceSpan
+          );
+        }
+        if (this.k > 0) {
+          addSearchDatasetTilePass(
+            graph,
+            this,
+            datasetTile,
+            queryTile,
+            datasetTileIndex,
+            queryTileIndex,
+            eligibleSourceIds,
+            queryFilterMask,
+            sourceSpan
+          );
+        }
+      }
+    }
+    this.registered = true;
+  }
+}
+
+function validateSearchConfiguration(search: GPUSimilaritySearch): void {
+  if (
+    !Number.isSafeInteger(search.dataset.dimensions) ||
+    search.dataset.dimensions < 1 ||
+    search.dataset.dimensions !== search.queries.dimensions
+  ) {
+    throw new Error(`${search.id} dataset and query embedding dimensions must match`);
+  }
+  if (
+    !Number.isSafeInteger(search.k) ||
+    search.k < 0 ||
+    search.k > INVALID_SOURCE_ROW_ID ||
+    !Number.isSafeInteger(search.k * search.queries.rowCount) ||
+    search.k * search.queries.rowCount > INVALID_SOURCE_ROW_ID
+  ) {
+    throw new Error(`${search.id} result count and query-major output length must fit into uint32`);
+  }
+  if (!['squared-euclidean', 'inner-product', 'cosine'].includes(search.metric)) {
+    throw new Error(`${search.id} metric must be squared-euclidean, inner-product, or cosine`);
+  }
+  if (!Number.isSafeInteger(search.tileSize) || search.tileSize < 1) {
+    throw new Error(`${search.id} tileSize must be a positive safe integer`);
+  }
+
+  validateGraphEmbeddingMatrix(search.dataset, `${search.id} dataset`);
+  validateGraphEmbeddingMatrix(search.queries, `${search.id} queries`);
+  validatePackedUint32View(search.outputIds, `${search.id} output IDs`);
+  validatePackedView(search.outputScores, ['float32'], `${search.id} output scores`);
+  validatePackedUint32View(search.resultCounts, `${search.id} result counts`);
+  const outputLength = search.queries.rowCount * search.k;
+  if (search.outputIds.length < outputLength || search.outputScores.length < outputLength) {
+    throw new Error(`${search.id} result destinations must contain queryCount * k values`);
+  }
+  if (search.resultCounts.length < search.queries.rowCount) {
+    throw new Error(`${search.id} result counts must contain one value per query`);
+  }
+  if (search.candidateCounts) {
+    validatePackedUint32View(search.candidateCounts, `${search.id} candidate counts`);
+    if (search.candidateCounts.length < search.queries.rowCount) {
+      throw new Error(`${search.id} candidate counts must contain one value per query`);
+    }
+  }
+  if (search.candidateIds) {
+    validatePackedUint32View(search.candidateIds, `${search.id} candidate IDs`);
+  }
+  const sourceSpan = getSourceRowSpan(search.dataset);
+  if (search.filterMask) {
+    validateSearchFilterMask(search, sourceSpan);
+  }
+  if (search.queryFilterMask) {
+    validatePackedUint32View(search.queryFilterMask, `${search.id} query filter mask`);
+    if (
+      !Number.isSafeInteger(sourceSpan * search.queries.rowCount) ||
+      search.queryFilterMask.length < sourceSpan * search.queries.rowCount
+    ) {
+      throw new Error(`${search.id} query filter mask must contain query-major source flags`);
+    }
+  }
+  validateDistinctSearchOutputs(search);
+}
+
+function validateGraphEmbeddingMatrix(matrix: GraphEmbeddingMatrix, name: string): void {
+  if (!Number.isSafeInteger(matrix.rowCount) || matrix.rowCount < 0) {
+    throw new Error(`${name} row count must be a non-negative safe integer`);
+  }
+  let totalRowCount = 0;
+  for (const chunk of matrix.chunks) {
+    validatePackedView(chunk.values, ['float32'], `${name} flat values`);
+    if (
+      !Number.isSafeInteger(chunk.rowCount) ||
+      chunk.rowCount < 0 ||
+      !Number.isSafeInteger(chunk.rowStride) ||
+      chunk.rowStride < matrix.dimensions ||
+      chunk.byteOffset !== chunk.values.byteOffset ||
+      !Number.isSafeInteger(chunk.sourceRowOffset) ||
+      chunk.sourceRowOffset < 0 ||
+      chunk.sourceRowOffset + chunk.rowCount > INVALID_SOURCE_ROW_ID ||
+      (chunk.rowCount > 0 &&
+        chunk.values.length < (chunk.rowCount - 1) * chunk.rowStride + matrix.dimensions)
+    ) {
+      throw new Error(`${name} chunk must preserve aligned, bounded float32 embedding rows`);
+    }
+    for (const rowView of [chunk.sourceRowIds, chunk.validity]) {
+      if (rowView) {
+        validatePackedUint32View(rowView, `${name} row metadata`);
+        if (rowView.length < chunk.rowCount) {
+          throw new Error(`${name} row metadata must align with its source chunk`);
+        }
+      }
+    }
+    totalRowCount += chunk.rowCount;
+  }
+  if (totalRowCount !== matrix.rowCount || totalRowCount > INVALID_SOURCE_ROW_ID) {
+    throw new Error(`${name} row count must match its chunk rows and fit into uint32`);
+  }
+}
+
+function validateSearchFilterMask(search: GPUSimilaritySearch, sourceSpan: number): void {
+  const filterMask = search.filterMask;
+  if (!filterMask) return;
+  if (isGraphVectorView(filterMask)) {
+    if (
+      filterMask.data.length !== search.dataset.chunks.length ||
+      filterMask.data.some(
+        (chunk, chunkIndex) => chunk.length !== search.dataset.chunks[chunkIndex].rowCount
+      )
+    ) {
+      throw new Error(`${search.id} filter mask must preserve the dataset chunk topology`);
+    }
+    for (const chunk of filterMask.data) {
+      validatePackedUint32View(chunk, `${search.id} filter mask`);
+    }
+  } else {
+    validatePackedUint32View(filterMask, `${search.id} filter mask`);
+    if (filterMask.length < sourceSpan) {
+      throw new Error(`${search.id} filter mask must contain source-aligned selection flags`);
+    }
+  }
+}
+
+function validateDistinctSearchOutputs(search: GPUSimilaritySearch): void {
+  const inputs: GraphDataView[] = [
+    ...search.dataset.chunks.flatMap(getEmbeddingChunkViews),
+    ...search.queries.chunks.flatMap(getEmbeddingChunkViews),
+    ...(search.filterMask
+      ? isGraphVectorView(search.filterMask)
+        ? search.filterMask.data
+        : [search.filterMask]
+      : []),
+    ...(search.candidateIds ? [search.candidateIds] : []),
+    ...(search.queryFilterMask ? [search.queryFilterMask] : [])
+  ];
+  const outputs: GraphDataView[] = [
+    search.outputIds,
+    search.outputScores,
+    search.resultCounts,
+    ...(search.candidateCounts ? [search.candidateCounts] : [])
+  ];
+  for (const [outputIndex, output] of outputs.entries()) {
+    if (
+      inputs.some(input => doGraphDataViewsOverlap(input, output)) ||
+      outputs.slice(0, outputIndex).some(previous => doGraphDataViewsOverlap(previous, output))
+    ) {
+      throw new Error(`${search.id} writable outputs must not overlap source or destination data`);
+    }
+  }
+}
+
+function validateSearchGraphOwnership<Parameters>(
+  search: GPUSimilaritySearch,
+  graph: GPUCommandGraph<Parameters>
+): void {
+  const views = [
+    ...search.dataset.chunks.flatMap(getEmbeddingChunkViews),
+    ...search.queries.chunks.flatMap(getEmbeddingChunkViews),
+    search.outputIds,
+    search.outputScores,
+    search.resultCounts,
+    ...(search.candidateCounts ? [search.candidateCounts] : []),
+    ...(search.candidateIds ? [search.candidateIds] : []),
+    ...(search.queryFilterMask ? [search.queryFilterMask] : []),
+    ...(search.filterMask
+      ? isGraphVectorView(search.filterMask)
+        ? search.filterMask.data
+        : [search.filterMask]
+      : [])
+  ];
+  if (views.some(view => view.buffer.graph !== graph)) {
+    throw new Error(`${search.id} inputs and outputs must belong to their target command graph`);
+  }
+}
+
+function getEmbeddingChunkViews(chunk: GraphEmbeddingMatrixChunk): GraphDataView[] {
+  return [
+    chunk.values,
+    ...(chunk.sourceRowIds ? [chunk.sourceRowIds] : []),
+    ...(chunk.validity ? [chunk.validity] : [])
+  ];
+}
+
+function createDatasetTiles<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  search: GPUSimilaritySearch
+): DatasetTile[] {
+  const maximumBindingSize = graph.device.limits.maxStorageBufferBindingSize;
+  const tiles: DatasetTile[] = [];
+  for (const [chunkIndex, chunk] of search.dataset.chunks.entries()) {
+    let chunkRowOffset = 0;
+    while (chunkRowOffset < chunk.rowCount) {
+      const rowCount = Math.min(
+        chunk.rowCount - chunkRowOffset,
+        search.tileSize,
+        getMaximumEmbeddingTileRows(
+          chunk,
+          chunkRowOffset,
+          search.dataset.dimensions,
+          maximumBindingSize
+        ),
+        Math.max(
+          1,
+          Math.floor((maximumBindingSize - STORAGE_BINDING_ALIGNMENT + 1) / SCALAR_BYTE_LENGTH)
+        )
+      );
+      const values = createEmbeddingTileView(
+        graph,
+        chunk,
+        chunkRowOffset,
+        rowCount,
+        search.dataset.dimensions
+      );
+      const tile: DatasetTile = {
+        chunk,
+        chunkIndex,
+        chunkRowOffset,
+        sourceRowOffset: chunk.sourceRowOffset + chunkRowOffset,
+        rowCount,
+        values,
+        ...(chunk.sourceRowIds
+          ? {sourceRowIds: createScalarSubview(graph, chunk.sourceRowIds, chunkRowOffset, rowCount)}
+          : {}),
+        ...(chunk.validity
+          ? {validity: createScalarSubview(graph, chunk.validity, chunkRowOffset, rowCount)}
+          : {})
+      };
+      const filterMask = createDatasetFilterTileView(graph, search.filterMask, tile);
+      if (filterMask) {
+        tile.filterMask = filterMask;
+      }
+      tiles.push(tile);
+      chunkRowOffset += rowCount;
+    }
+  }
+  return tiles;
+}
+
+function createQueryTiles<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  search: GPUSimilaritySearch,
+  sourceSpan: number
+): QueryTile[] {
+  const maximumBindingSize = graph.device.limits.maxStorageBufferBindingSize;
+  const maximumOutputRows = Math.max(
+    1,
+    Math.floor(
+      (maximumBindingSize - STORAGE_BINDING_ALIGNMENT + 1) /
+        (Math.max(search.k, 1) * SCALAR_BYTE_LENGTH)
+    )
+  );
+  const maximumFilterRows = search.queryFilterMask
+    ? Math.max(
+        1,
+        Math.floor(
+          (maximumBindingSize - STORAGE_BINDING_ALIGNMENT + 1) /
+            (Math.max(sourceSpan, 1) * SCALAR_BYTE_LENGTH)
+        )
+      )
+    : INVALID_SOURCE_ROW_ID;
+  const maximumRows = Math.min(maximumOutputRows, maximumFilterRows);
+  const queryTiles: QueryTile[] = [];
+  let logicalRowOffset = 0;
+  for (const chunk of search.queries.chunks) {
+    let chunkRowOffset = 0;
+    while (chunkRowOffset < chunk.rowCount) {
+      const rowCount = Math.min(
+        chunk.rowCount - chunkRowOffset,
+        maximumRows,
+        getMaximumEmbeddingTileRows(
+          chunk,
+          chunkRowOffset,
+          search.queries.dimensions,
+          maximumBindingSize
+        )
+      );
+      const queryOffset = logicalRowOffset + chunkRowOffset;
+      const outputOffset = queryOffset * search.k;
+      const queryTile: QueryTile = {
+        logicalRowOffset: queryOffset,
+        rowCount,
+        values: createEmbeddingTileView(
+          graph,
+          chunk,
+          chunkRowOffset,
+          rowCount,
+          search.queries.dimensions
+        ),
+        rowStride: chunk.rowStride,
+        sourceRowOffset: chunk.sourceRowOffset + chunkRowOffset,
+        rowMetadata: createTransientView(
+          graph,
+          `${search.id}-query-metadata-${queryTiles.length}`,
+          'uint32',
+          rowCount
+        ),
+        outputIds: createScalarSubview(graph, search.outputIds, outputOffset, rowCount * search.k),
+        outputScores: createScalarSubview(
+          graph,
+          search.outputScores,
+          outputOffset,
+          rowCount * search.k
+        ),
+        resultCounts: createScalarSubview(graph, search.resultCounts, queryOffset, rowCount),
+        ...(search.candidateCounts
+          ? {
+              candidateCounts: createScalarSubview(
+                graph,
+                search.candidateCounts,
+                queryOffset,
+                rowCount
+              )
+            }
+          : {}),
+        ...(chunk.sourceRowIds
+          ? {sourceRowIds: createScalarSubview(graph, chunk.sourceRowIds, chunkRowOffset, rowCount)}
+          : {}),
+        ...(chunk.validity
+          ? {validity: createScalarSubview(graph, chunk.validity, chunkRowOffset, rowCount)}
+          : {})
+      };
+      queryTiles.push(queryTile);
+      chunkRowOffset += rowCount;
+    }
+    logicalRowOffset += chunk.rowCount;
+  }
+  return queryTiles;
+}
+
+function createEmbeddingTileView<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  chunk: GraphEmbeddingMatrixChunk,
+  rowOffset: number,
+  rowCount: number,
+  dimensions: number
+): GraphDataView<'float32'> {
+  return graph.createDataView(chunk.values.buffer, {
+    format: 'float32',
+    length: rowCount === 0 ? 0 : (rowCount - 1) * chunk.rowStride + dimensions,
+    byteOffset: chunk.byteOffset + rowOffset * chunk.rowStride * Float32Array.BYTES_PER_ELEMENT
+  });
+}
+
+function createScalarSubview<Format extends 'float32' | 'uint32', Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  view: GraphDataView<Format>,
+  rowOffset: number,
+  rowCount: number
+): GraphDataView<Format> {
+  return graph.createDataView(view.buffer, {
+    format: view.format,
+    length: rowCount,
+    byteOffset: view.byteOffset + rowOffset * SCALAR_BYTE_LENGTH
+  });
+}
+
+function createDatasetFilterTileView<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  filterMask: GPUEmbeddingFilterMask | undefined,
+  tile: DatasetTile
+): GraphDataView<'uint32'> | undefined {
+  if (!filterMask) return undefined;
+  if (isGraphVectorView(filterMask)) {
+    return createScalarSubview(
+      graph,
+      filterMask.data[tile.chunkIndex],
+      tile.chunkRowOffset,
+      tile.rowCount
+    );
+  }
+  return createScalarSubview(graph, filterMask, tile.sourceRowOffset, tile.rowCount);
+}
+
+function createQueryFilterTileView<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  queryFilterMask: GraphDataView<'uint32'>,
+  queryTile: QueryTile,
+  datasetTile: DatasetTile,
+  sourceSpan: number
+): GraphDataView<'uint32'> {
+  const firstRowOffset = queryTile.logicalRowOffset * sourceSpan + datasetTile.sourceRowOffset;
+  const rowCount = (queryTile.rowCount - 1) * sourceSpan + datasetTile.rowCount;
+  const view = createScalarSubview(graph, queryFilterMask, firstRowOffset, rowCount);
+  if (getViewBindingRange(view).size > graph.device.limits.maxStorageBufferBindingSize) {
+    throw new Error('GPU embedding query filter tile exceeds maxStorageBufferBindingSize');
+  }
+  return view;
+}
+
+function getMaximumEmbeddingTileRows(
+  chunk: GraphEmbeddingMatrixChunk,
+  rowOffset: number,
+  dimensions: number,
+  maximumBindingSize: number
+): number {
+  const byteOffset = chunk.byteOffset + rowOffset * chunk.rowStride * SCALAR_BYTE_LENGTH;
+  const alignmentPrefix = byteOffset % STORAGE_BINDING_ALIGNMENT;
+  const requiredRowBytes = dimensions * SCALAR_BYTE_LENGTH;
+  const availableBytes = maximumBindingSize - alignmentPrefix;
+  if (availableBytes < requiredRowBytes) {
+    throw new Error('GPU embedding row exceeds maxStorageBufferBindingSize');
+  }
+  return (
+    Math.floor((availableBytes - requiredRowBytes) / (chunk.rowStride * SCALAR_BYTE_LENGTH)) + 1
+  );
+}
+
+function getSourceRowSpan(matrix: GraphEmbeddingMatrix): number {
+  return matrix.chunks.reduce(
+    (maximum, chunk) => Math.max(maximum, chunk.sourceRowOffset + chunk.rowCount),
+    0
+  );
+}
+
+function isGraphVectorView(view: GPUEmbeddingFilterMask): view is GraphVectorView<'uint32'> {
+  return Array.isArray((view as GraphVectorView<'uint32'>).data);
+}
+
+/** Builds bounded GPU membership for substantial allowlists without O(datasetRows * ID count). */
+function createCandidateMembershipIndex<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  search: GPUSimilaritySearch
+): CandidateMembershipIndex | undefined {
+  if (!search.candidateIds) return undefined;
+  const maximumBindingSize = graph.device.limits.maxStorageBufferBindingSize;
+  if (getViewBindingRange(search.candidateIds).size > maximumBindingSize) {
+    throw new Error(`${search.id} candidate IDs exceed maxStorageBufferBindingSize`);
+  }
+  if (search.candidateIds.length <= LINEAR_CANDIDATE_ALLOWLIST_LIMIT) {
+    return undefined;
+  }
+
+  let capacity = 2;
+  const requestedCapacity = search.candidateIds.length * 2;
+  while (capacity < requestedCapacity) {
+    capacity *= 2;
+  }
+  if (capacity * SCALAR_BYTE_LENGTH > maximumBindingSize) {
+    throw new Error(
+      `${search.id} candidate-ID membership exceeds maxStorageBufferBindingSize; use a source-aligned filter mask`
+    );
+  }
+
+  const tableKeys = createTransientView(
+    graph,
+    `${search.id}-candidate-index-keys`,
+    'uint32',
+    capacity
+  );
+  const tableValues = createTransientView(
+    graph,
+    `${search.id}-candidate-index-values`,
+    'uint32',
+    capacity
+  );
+  const statistics = createTransientView(
+    graph,
+    `${search.id}-candidate-index-statistics`,
+    'uint32',
+    6
+  );
+  new GPUHashIndex({
+    id: `${search.id}-candidate-index`,
+    keys: search.candidateIds,
+    tableKeys,
+    tableValues,
+    statistics
+  }).addToGraph(graph);
+  return {keys: tableKeys, statistics, capacity};
+}
+
+function addInitializeQueryPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  search: GPUSimilaritySearch,
+  tile: QueryTile,
+  tileIndex: number
+): void {
+  const id = `${search.id}-initialize-query-tile-${tileIndex}`;
+  const bindings: Record<string, GraphDataView> = {
+    queryValues: tile.values,
+    queryMetadata: tile.rowMetadata,
+    outputIds: tile.outputIds,
+    outputScores: tile.outputScores,
+    resultCounts: tile.resultCounts,
+    ...(tile.candidateCounts ? {candidateCounts: tile.candidateCounts} : {}),
+    ...(tile.validity ? {queryValidity: tile.validity} : {}),
+    ...(tile.sourceRowIds ? {querySourceIds: tile.sourceRowIds} : {})
+  };
+  const source = /* wgsl */ `
+${getCommonWGSLConstants(search, tile.rowCount)}
+const QUERY_OFFSET: u32 = ${getViewElementOffset(tile.values)}u;
+const QUERY_STRIDE: u32 = ${tile.rowStride}u;
+const QUERY_SOURCE_OFFSET: u32 = ${tile.sourceRowOffset}u;
+const QUERY_METADATA_OFFSET: u32 = ${getViewElementOffset(tile.rowMetadata)}u;
+const OUTPUT_ID_OFFSET: u32 = ${getViewElementOffset(tile.outputIds)}u;
+const OUTPUT_SCORE_OFFSET: u32 = ${getViewElementOffset(tile.outputScores)}u;
+const RESULT_COUNT_OFFSET: u32 = ${getViewElementOffset(tile.resultCounts)}u;
+${tile.candidateCounts ? `const CANDIDATE_COUNT_OFFSET: u32 = ${getViewElementOffset(tile.candidateCounts)}u;` : ''}
+${tile.validity ? `const QUERY_VALIDITY_OFFSET: u32 = ${getViewElementOffset(tile.validity)}u;` : ''}
+${tile.sourceRowIds ? `const QUERY_SOURCE_ID_OFFSET: u32 = ${getViewElementOffset(tile.sourceRowIds)}u;` : ''}
+@group(0) @binding(auto) var<storage, read> queryValues: array<f32>;
+@group(0) @binding(auto) var<storage, read_write> queryMetadata: array<u32>;
+@group(0) @binding(auto) var<storage, read_write> outputIds: array<u32>;
+@group(0) @binding(auto) var<storage, read_write> outputScores: array<u32>;
+@group(0) @binding(auto) var<storage, read_write> resultCounts: array<u32>;
+${tile.candidateCounts ? '@group(0) @binding(auto) var<storage, read_write> candidateCounts: array<u32>;' : ''}
+${tile.validity ? '@group(0) @binding(auto) var<storage, read> queryValidity: array<u32>;' : ''}
+${tile.sourceRowIds ? '@group(0) @binding(auto) var<storage, read> querySourceIds: array<u32>;' : ''}
+
+${getFiniteFloatWGSL()}
+
+@compute @workgroup_size(${SEARCH_WORKGROUP_SIZE})
+fn main(@builtin(workgroup_id) workgroupId: vec3u, @builtin(local_invocation_index) localInvocationIndex: u32) {
+  ${getInvocationIndexSource(id, tile.rowCount, graph)}
+  if (index >= QUERY_COUNT) { return; }
+  var valid = ${tile.validity ? 'queryValidity[QUERY_VALIDITY_OFFSET + index] != 0u' : 'true'};
+  for (var dimension = 0u; dimension < DIMENSIONS; dimension++) {
+    if (!isFiniteFloat(queryValues[QUERY_OFFSET + index * QUERY_STRIDE + dimension])) {
+      valid = false;
+    }
+  }
+  let sourceId = ${tile.sourceRowIds ? 'querySourceIds[QUERY_SOURCE_ID_OFFSET + index]' : 'QUERY_SOURCE_OFFSET + index'};
+  queryMetadata[QUERY_METADATA_OFFSET + index] = select(INVALID_ID, sourceId, valid && sourceId != INVALID_ID);
+  resultCounts[RESULT_COUNT_OFFSET + index] = 0u;
+  ${tile.candidateCounts ? 'candidateCounts[CANDIDATE_COUNT_OFFSET + index] = 0u;' : ''}
+  for (var resultIndex = 0u; resultIndex < MAX_RESULTS; resultIndex++) {
+    let outputIndex = index * MAX_RESULTS + resultIndex;
+    outputIds[OUTPUT_ID_OFFSET + outputIndex] = INVALID_ID;
+    outputScores[OUTPUT_SCORE_OFFSET + outputIndex] = ${search.metric === 'squared-euclidean' ? '0x7f800000u' : '0xff800000u'};
+  }
+}`;
+  addSearchComputationPass(
+    graph,
+    id,
+    source,
+    bindings,
+    tile.rowCount,
+    new Set(['queryValues', 'queryValidity', 'querySourceIds'])
+  );
+}
+
+function addPrepareDatasetTilePass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  search: GPUSimilaritySearch,
+  tile: DatasetTile,
+  tileIndex: number,
+  eligibleSourceIds: GraphDataView<'uint32'>,
+  candidateMembership: CandidateMembershipIndex | undefined
+): void {
+  const id = `${search.id}-prepare-dataset-tile-${tileIndex}`;
+  const bindings: Record<string, GraphDataView> = {
+    datasetValues: tile.values,
+    eligibleSourceIds,
+    ...(tile.sourceRowIds ? {sourceRowIds: tile.sourceRowIds} : {}),
+    ...(tile.validity ? {sourceValidity: tile.validity} : {}),
+    ...(tile.filterMask ? {selectionMask: tile.filterMask} : {}),
+    ...(candidateMembership
+      ? {
+          candidateIndexKeys: candidateMembership.keys,
+          candidateIndexStatistics: candidateMembership.statistics,
+          candidateIds: search.candidateIds!
+        }
+      : search.candidateIds
+        ? {candidateIds: search.candidateIds}
+        : {})
+  };
+  const source = /* wgsl */ `
+${getCommonWGSLConstants(search, tile.rowCount)}
+const ROW_COUNT: u32 = ${tile.rowCount}u;
+const DATASET_OFFSET: u32 = ${getViewElementOffset(tile.values)}u;
+const DATASET_STRIDE: u32 = ${tile.chunk.rowStride}u;
+const SOURCE_ROW_OFFSET: u32 = ${tile.sourceRowOffset}u;
+const ELIGIBLE_OFFSET: u32 = ${getViewElementOffset(eligibleSourceIds)}u;
+${tile.sourceRowIds ? `const SOURCE_ID_OFFSET: u32 = ${getViewElementOffset(tile.sourceRowIds)}u;` : ''}
+${tile.validity ? `const VALIDITY_OFFSET: u32 = ${getViewElementOffset(tile.validity)}u;` : ''}
+${tile.filterMask ? `const SELECTION_OFFSET: u32 = ${getViewElementOffset(tile.filterMask)}u;` : ''}
+${
+  candidateMembership
+    ? `const CANDIDATE_INDEX_OFFSET: u32 = ${getViewElementOffset(candidateMembership.keys)}u;\nconst CANDIDATE_INDEX_MASK: u32 = ${candidateMembership.capacity - 1}u;\nconst CANDIDATE_INDEX_CAPACITY: u32 = ${candidateMembership.capacity}u;\nconst CANDIDATE_STATISTICS_OFFSET: u32 = ${getViewElementOffset(candidateMembership.statistics)}u;\nconst CANDIDATE_ID_OFFSET: u32 = ${getViewElementOffset(search.candidateIds!)}u;\nconst CANDIDATE_ID_COUNT: u32 = ${search.candidateIds!.length}u;`
+    : search.candidateIds
+      ? `const CANDIDATE_ID_OFFSET: u32 = ${getViewElementOffset(search.candidateIds)}u;\nconst CANDIDATE_ID_COUNT: u32 = ${search.candidateIds.length}u;`
+      : ''
+}
+@group(0) @binding(auto) var<storage, read> datasetValues: array<f32>;
+@group(0) @binding(auto) var<storage, read_write> eligibleSourceIds: array<u32>;
+${tile.sourceRowIds ? '@group(0) @binding(auto) var<storage, read> sourceRowIds: array<u32>;' : ''}
+${tile.validity ? '@group(0) @binding(auto) var<storage, read> sourceValidity: array<u32>;' : ''}
+${tile.filterMask ? '@group(0) @binding(auto) var<storage, read> selectionMask: array<u32>;' : ''}
+${
+  candidateMembership
+    ? '@group(0) @binding(auto) var<storage, read> candidateIndexKeys: array<u32>;\n@group(0) @binding(auto) var<storage, read> candidateIndexStatistics: array<u32>;\n@group(0) @binding(auto) var<storage, read> candidateIds: array<u32>;'
+    : search.candidateIds
+      ? '@group(0) @binding(auto) var<storage, read> candidateIds: array<u32>;'
+      : ''
+}
+
+${getFiniteFloatWGSL()}
+${
+  candidateMembership
+    ? `fn hashCandidateKey(key: u32) -> u32 {\n  var value = key;\n  value = (value ^ (value >> 16u)) * 0x7feb352du;\n  value = (value ^ (value >> 15u)) * 0x846ca68bu;\n  return value ^ (value >> 16u);\n}`
+    : ''
+}
+
+@compute @workgroup_size(${SEARCH_WORKGROUP_SIZE})
+fn main(@builtin(workgroup_id) workgroupId: vec3u, @builtin(local_invocation_index) localInvocationIndex: u32) {
+  ${getInvocationIndexSource(id, tile.rowCount, graph)}
+  if (index >= ROW_COUNT) { return; }
+  let sourceId = ${tile.sourceRowIds ? 'sourceRowIds[SOURCE_ID_OFFSET + index]' : 'SOURCE_ROW_OFFSET + index'};
+  var eligible = sourceId != INVALID_ID;
+  ${tile.validity ? 'eligible = eligible && sourceValidity[VALIDITY_OFFSET + index] != 0u;' : ''}
+  ${tile.filterMask ? 'eligible = eligible && selectionMask[SELECTION_OFFSET + index] != 0u;' : ''}
+  for (var dimension = 0u; dimension < DIMENSIONS; dimension++) {
+    if (!isFiniteFloat(datasetValues[DATASET_OFFSET + index * DATASET_STRIDE + dimension])) {
+      eligible = false;
+    }
+  }
+  ${
+    candidateMembership
+      ? `var allowed = false;\n  if (candidateIndexStatistics[CANDIDATE_STATISTICS_OFFSET + 2u] == 0u) {\n    let firstSlot = hashCandidateKey(sourceId) & CANDIDATE_INDEX_MASK;\n    for (var probe = 0u; probe < CANDIDATE_INDEX_CAPACITY; probe++) {\n      let stored = candidateIndexKeys[CANDIDATE_INDEX_OFFSET + ((firstSlot + probe) & CANDIDATE_INDEX_MASK)];\n      if (stored == INVALID_ID) { break; }\n      if (stored == sourceId) { allowed = true; break; }\n    }\n  } else {\n    for (var candidateIndex = 0u; candidateIndex < CANDIDATE_ID_COUNT; candidateIndex++) {\n      allowed = allowed || candidateIds[CANDIDATE_ID_OFFSET + candidateIndex] == sourceId;\n    }\n  }\n  eligible = eligible && allowed;`
+      : search.candidateIds
+        ? `var allowed = false;\n  for (var candidateIndex = 0u; candidateIndex < CANDIDATE_ID_COUNT; candidateIndex++) {\n    allowed = allowed || candidateIds[CANDIDATE_ID_OFFSET + candidateIndex] == sourceId;\n  }\n  eligible = eligible && allowed;`
+        : ''
+  }
+  eligibleSourceIds[ELIGIBLE_OFFSET + index] = select(INVALID_ID, sourceId, eligible);
+}`;
+  addSearchComputationPass(
+    graph,
+    id,
+    source,
+    bindings,
+    tile.rowCount,
+    new Set(Object.keys(bindings).filter(name => name !== 'eligibleSourceIds'))
+  );
+}
+
+function addCountCandidatesPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  search: GPUSimilaritySearch,
+  datasetTile: DatasetTile,
+  queryTile: QueryTile,
+  datasetTileIndex: number,
+  queryTileIndex: number,
+  eligibleSourceIds: GraphDataView<'uint32'>,
+  queryFilterMask: GraphDataView<'uint32'> | undefined,
+  sourceSpan: number
+): void {
+  if (!queryTile.candidateCounts) return;
+  const id = `${search.id}-count-candidates-${datasetTileIndex}-${queryTileIndex}`;
+  const bindings: Record<string, GraphDataView> = {
+    eligibleSourceIds,
+    queryMetadata: queryTile.rowMetadata,
+    candidateCounts: queryTile.candidateCounts,
+    ...(queryFilterMask ? {queryFilterMask} : {})
+  };
+  const source = /* wgsl */ `
+${getCommonWGSLConstants(search, queryTile.rowCount)}
+const ROW_COUNT: u32 = ${datasetTile.rowCount}u;
+const ELIGIBLE_OFFSET: u32 = ${getViewElementOffset(eligibleSourceIds)}u;
+const QUERY_METADATA_OFFSET: u32 = ${getViewElementOffset(queryTile.rowMetadata)}u;
+const CANDIDATE_COUNT_OFFSET: u32 = ${getViewElementOffset(queryTile.candidateCounts)}u;
+${queryFilterMask ? `const QUERY_FILTER_OFFSET: u32 = ${getViewElementOffset(queryFilterMask)}u;\nconst SOURCE_SPAN: u32 = ${sourceSpan}u;` : ''}
+@group(0) @binding(auto) var<storage, read> eligibleSourceIds: array<u32>;
+@group(0) @binding(auto) var<storage, read> queryMetadata: array<u32>;
+@group(0) @binding(auto) var<storage, read_write> candidateCounts: array<u32>;
+${queryFilterMask ? '@group(0) @binding(auto) var<storage, read> queryFilterMask: array<u32>;' : ''}
+
+@compute @workgroup_size(${SEARCH_WORKGROUP_SIZE})
+fn main(@builtin(workgroup_id) workgroupId: vec3u, @builtin(local_invocation_index) localInvocationIndex: u32) {
+  ${getInvocationIndexSource(id, queryTile.rowCount, graph)}
+  if (index >= QUERY_COUNT) { return; }
+  let querySourceId = queryMetadata[QUERY_METADATA_OFFSET + index];
+  if (querySourceId == INVALID_ID) { return; }
+  var count = candidateCounts[CANDIDATE_COUNT_OFFSET + index];
+  for (var candidateIndex = 0u; candidateIndex < ROW_COUNT; candidateIndex++) {
+    let sourceId = eligibleSourceIds[ELIGIBLE_OFFSET + candidateIndex];
+    var accepted = sourceId != INVALID_ID;
+    ${search.excludeSelf ? 'accepted = accepted && sourceId != querySourceId;' : ''}
+    ${queryFilterMask ? 'accepted = accepted && queryFilterMask[QUERY_FILTER_OFFSET + index * SOURCE_SPAN + candidateIndex] != 0u;' : ''}
+    if (accepted) { count++; }
+  }
+  candidateCounts[CANDIDATE_COUNT_OFFSET + index] = count;
+}`;
+  addSearchComputationPass(
+    graph,
+    id,
+    source,
+    bindings,
+    queryTile.rowCount,
+    new Set(['eligibleSourceIds', 'queryMetadata', 'queryFilterMask'])
+  );
+}
+
+function addSearchDatasetTilePass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  search: GPUSimilaritySearch,
+  datasetTile: DatasetTile,
+  queryTile: QueryTile,
+  datasetTileIndex: number,
+  queryTileIndex: number,
+  eligibleSourceIds: GraphDataView<'uint32'>,
+  queryFilterMask: GraphDataView<'uint32'> | undefined,
+  sourceSpan: number
+): void {
+  const id = `${search.id}-search-dataset-${datasetTileIndex}-queries-${queryTileIndex}`;
+  const bindings: Record<string, GraphDataView> = {
+    queryValues: queryTile.values,
+    datasetValues: datasetTile.values,
+    eligibleSourceIds,
+    queryMetadata: queryTile.rowMetadata,
+    outputIds: queryTile.outputIds,
+    outputScores: queryTile.outputScores,
+    resultCounts: queryTile.resultCounts,
+    ...(queryFilterMask ? {queryFilterMask} : {})
+  };
+  const source = /* wgsl */ `
+${getCommonWGSLConstants(search, queryTile.rowCount)}
+const ROW_COUNT: u32 = ${datasetTile.rowCount}u;
+const QUERY_OFFSET: u32 = ${getViewElementOffset(queryTile.values)}u;
+const QUERY_STRIDE: u32 = ${queryTile.rowStride}u;
+const DATASET_OFFSET: u32 = ${getViewElementOffset(datasetTile.values)}u;
+const DATASET_STRIDE: u32 = ${datasetTile.chunk.rowStride}u;
+const ELIGIBLE_OFFSET: u32 = ${getViewElementOffset(eligibleSourceIds)}u;
+const QUERY_METADATA_OFFSET: u32 = ${getViewElementOffset(queryTile.rowMetadata)}u;
+const OUTPUT_ID_OFFSET: u32 = ${getViewElementOffset(queryTile.outputIds)}u;
+const OUTPUT_SCORE_OFFSET: u32 = ${getViewElementOffset(queryTile.outputScores)}u;
+const RESULT_COUNT_OFFSET: u32 = ${getViewElementOffset(queryTile.resultCounts)}u;
+${queryFilterMask ? `const QUERY_FILTER_OFFSET: u32 = ${getViewElementOffset(queryFilterMask)}u;\nconst SOURCE_SPAN: u32 = ${sourceSpan}u;` : ''}
+@group(0) @binding(auto) var<storage, read> queryValues: array<f32>;
+@group(0) @binding(auto) var<storage, read> datasetValues: array<f32>;
+@group(0) @binding(auto) var<storage, read> eligibleSourceIds: array<u32>;
+@group(0) @binding(auto) var<storage, read> queryMetadata: array<u32>;
+@group(0) @binding(auto) var<storage, read_write> outputIds: array<u32>;
+@group(0) @binding(auto) var<storage, read_write> outputScores: array<f32>;
+@group(0) @binding(auto) var<storage, read_write> resultCounts: array<u32>;
+${queryFilterMask ? '@group(0) @binding(auto) var<storage, read> queryFilterMask: array<u32>;' : ''}
+
+${getFiniteFloatWGSL()}
+
+struct CandidateScore {
+  value: f32,
+  valid: bool
+}
+
+fn candidateScore(queryIndex: u32, candidateIndex: u32) -> CandidateScore {
+  var dotProduct = 0.0;
+  var queryNorm = 0.0;
+  var candidateNorm = 0.0;
+  var squaredDistance = 0.0;
+  var queryScale = 0.0;
+  var candidateScale = 0.0;
+  ${search.metric === 'inner-product' ? 'var hasPositiveInfiniteProduct = false;\n  var hasNegativeInfiniteProduct = false;' : ''}
+  for (var dimension = 0u; dimension < DIMENSIONS; dimension++) {
+    let queryValue = queryValues[QUERY_OFFSET + queryIndex * QUERY_STRIDE + dimension];
+    let candidateValue = datasetValues[DATASET_OFFSET + candidateIndex * DATASET_STRIDE + dimension];
+    ${
+      search.metric === 'squared-euclidean'
+        ? 'let delta = queryValue - candidateValue;\n    squaredDistance += delta * delta;'
+        : search.metric === 'inner-product'
+          ? `let componentProduct = queryValue * candidateValue;
+    let componentProductBits = bitcast<u32>(componentProduct);
+    if ((componentProductBits & 0x7fffffffu) == 0x7f800000u) {
+      hasNegativeInfiniteProduct = hasNegativeInfiniteProduct || (componentProductBits & 0x80000000u) != 0u;
+      hasPositiveInfiniteProduct = hasPositiveInfiniteProduct || (componentProductBits & 0x80000000u) == 0u;
+    }
+    dotProduct += componentProduct;`
+          : 'queryScale = max(queryScale, abs(queryValue));\n    candidateScale = max(candidateScale, abs(candidateValue));'
+    }
+  }
+  ${
+    search.metric === 'squared-euclidean'
+      ? 'return CandidateScore(squaredDistance, true);'
+      : search.metric === 'inner-product'
+        ? 'return CandidateScore(dotProduct, !(hasPositiveInfiniteProduct && hasNegativeInfiniteProduct));'
+        : `if (queryScale == 0.0 && candidateScale == 0.0) { return CandidateScore(1.0, true); }\n  if (queryScale == 0.0 || candidateScale == 0.0) { return CandidateScore(0.0, true); }\n  // Clamp divisors so reciprocal-lowering GPU backends never flush them to zero.\n  let minimumDivisor = bitcast<f32>(0x00800000u);\n  let maximumDivisor = bitcast<f32>(0x7e800000u);\n  let queryDivisor = clamp(queryScale, minimumDivisor, maximumDivisor);\n  let candidateDivisor = clamp(candidateScale, minimumDivisor, maximumDivisor);\n  for (var dimension = 0u; dimension < DIMENSIONS; dimension++) {\n    let normalizedQuery = queryValues[QUERY_OFFSET + queryIndex * QUERY_STRIDE + dimension] / queryDivisor;\n    let normalizedCandidate = datasetValues[DATASET_OFFSET + candidateIndex * DATASET_STRIDE + dimension] / candidateDivisor;\n    dotProduct += normalizedQuery * normalizedCandidate;\n    queryNorm += normalizedQuery * normalizedQuery;\n    candidateNorm += normalizedCandidate * normalizedCandidate;\n  }\n  return CandidateScore(dotProduct / (sqrt(queryNorm) * sqrt(candidateNorm)), true);`
+  }
+}
+
+fn isBetter(score: f32, sourceId: u32, previousScore: f32, previousId: u32) -> bool {
+  if (previousId == INVALID_ID) { return true; }
+  if (score == previousScore) { return sourceId < previousId; }
+  return score ${search.metric === 'squared-euclidean' ? '<' : '>'} previousScore;
+}
+
+@compute @workgroup_size(${SEARCH_WORKGROUP_SIZE})
+fn main(@builtin(workgroup_id) workgroupId: vec3u, @builtin(local_invocation_index) localInvocationIndex: u32) {
+  ${getInvocationIndexSource(id, queryTile.rowCount, graph)}
+  if (index >= QUERY_COUNT) { return; }
+  let querySourceId = queryMetadata[QUERY_METADATA_OFFSET + index];
+  if (querySourceId == INVALID_ID) { return; }
+  let queryResultOffset = index * MAX_RESULTS;
+  var resultCount = resultCounts[RESULT_COUNT_OFFSET + index];
+  for (var candidateIndex = 0u; candidateIndex < ROW_COUNT; candidateIndex++) {
+    let sourceId = eligibleSourceIds[ELIGIBLE_OFFSET + candidateIndex];
+    if (sourceId == INVALID_ID) { continue; }
+    ${search.excludeSelf ? 'if (sourceId == querySourceId) { continue; }' : ''}
+    ${queryFilterMask ? 'if (queryFilterMask[QUERY_FILTER_OFFSET + index * SOURCE_SPAN + candidateIndex] == 0u) { continue; }' : ''}
+    let candidateScoreResult = candidateScore(index, candidateIndex);
+    if (!candidateScoreResult.valid) { continue; }
+    let score = candidateScoreResult.value;
+    // Finite source values may legitimately overflow a Float32 distance or inner product.
+    if ((bitcast<u32>(score) & 0x7fffffffu) > 0x7f800000u) { continue; }
+
+    var insertionIndex = min(resultCount, MAX_RESULTS);
+    for (var resultIndex = 0u; resultIndex < resultCount; resultIndex++) {
+      let currentId = outputIds[OUTPUT_ID_OFFSET + queryResultOffset + resultIndex];
+      let currentScore = outputScores[OUTPUT_SCORE_OFFSET + queryResultOffset + resultIndex];
+      if (isBetter(score, sourceId, currentScore, currentId)) {
+        insertionIndex = resultIndex;
+        break;
+      }
+    }
+    if (insertionIndex >= MAX_RESULTS) { continue; }
+    var destinationIndex = min(resultCount, MAX_RESULTS - 1u);
+    while (destinationIndex > insertionIndex) {
+      let destination = queryResultOffset + destinationIndex;
+      let previous = destination - 1u;
+      outputIds[OUTPUT_ID_OFFSET + destination] = outputIds[OUTPUT_ID_OFFSET + previous];
+      outputScores[OUTPUT_SCORE_OFFSET + destination] = outputScores[OUTPUT_SCORE_OFFSET + previous];
+      destinationIndex--;
+    }
+    outputIds[OUTPUT_ID_OFFSET + queryResultOffset + insertionIndex] = sourceId;
+    outputScores[OUTPUT_SCORE_OFFSET + queryResultOffset + insertionIndex] = score;
+    resultCount = min(resultCount + 1u, MAX_RESULTS);
+  }
+  resultCounts[RESULT_COUNT_OFFSET + index] = resultCount;
+}`;
+  addSearchComputationPass(
+    graph,
+    id,
+    source,
+    bindings,
+    queryTile.rowCount,
+    new Set([
+      'queryValues',
+      'datasetValues',
+      'eligibleSourceIds',
+      'queryMetadata',
+      'queryFilterMask'
+    ])
+  );
+}
+
+function addSearchComputationPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  id: string,
+  source: string,
+  views: Record<string, GraphDataView>,
+  elementCount: number,
+  readOnlyBindings: ReadonlySet<string>
+): void {
+  const resources: GraphBufferUse[] = Object.entries(views).map(([name, buffer]) => ({
+    buffer,
+    usage: readOnlyBindings.has(name) ? 'storage-read' : 'storage-read-write'
+  }));
+  const layout = getBoundedDispatchLayout(
+    id,
+    elementCount,
+    SEARCH_WORKGROUP_SIZE,
+    graph.device.limits.maxComputeWorkgroupsPerDimension
+  );
+  graph.addComputePass({
+    id,
+    resources,
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id,
+        source,
+        shaderLayout: {
+          bindings: Object.keys(views).map((name, location) => ({
+            name,
+            type: 'storage' as const,
+            group: 0,
+            location
+          }))
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const bindings: Record<string, Binding> = {};
+          for (const [name, view] of Object.entries(views)) {
+            if (getViewBindingRange(view).size > device.limits.maxStorageBufferBindingSize) {
+              throw new Error(`${id} storage binding exceeds maxStorageBufferBindingSize`);
+            }
+            bindings[name] = getViewBinding(view, getBuffer);
+          }
+          computation.setBindings(bindings);
+          computation.dispatch(computePass, layout.x, layout.y, layout.z);
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+function getInvocationIndexSource<Parameters>(
+  operationName: string,
+  elementCount: number,
+  graph: GPUCommandGraph<Parameters>
+): string {
+  const layout = getBoundedDispatchLayout(
+    operationName,
+    elementCount,
+    SEARCH_WORKGROUP_SIZE,
+    graph.device.limits.maxComputeWorkgroupsPerDimension
+  );
+  return getBoundedInvocationIndexSource(layout, SEARCH_WORKGROUP_SIZE);
+}
+
+function getCommonWGSLConstants(search: GPUSimilaritySearch, queryCount: number): string {
+  return `const INVALID_ID: u32 = 0xffffffffu;
+const DIMENSIONS: u32 = ${search.dataset.dimensions}u;
+const QUERY_COUNT: u32 = ${queryCount}u;
+const MAX_RESULTS: u32 = ${search.k}u;`;
+}
+
+function getFiniteFloatWGSL(): string {
+  return `fn isFiniteFloat(value: f32) -> bool {
+  return (bitcast<u32>(value) & 0x7f800000u) != 0x7f800000u;
+}`;
+}

--- a/modules/gpgpu/src/gpu-vector-search/index.ts
+++ b/modules/gpgpu/src/gpu-vector-search/index.ts
@@ -1,0 +1,23 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuVS.
+
+export {
+  importGPUEmbeddingTable,
+  importGPUEmbeddingVector,
+  type GPUEmbeddingRecordBatch,
+  type GPUEmbeddingTable,
+  type GPUEmbeddingTableField,
+  type GPUEmbeddingTableSource,
+  type ImportGPUEmbeddingTableOptions,
+  type ImportGPUEmbeddingVectorOptions
+} from './embedding-matrix';
+export {GPUSimilaritySearch} from './gpu-similarity-search';
+export type {
+  GPUEmbeddingFilterMask,
+  GPUEmbeddingMetric,
+  GPUSimilaritySearchProps,
+  GraphEmbeddingMatrix,
+  GraphEmbeddingMatrixChunk
+} from './types';

--- a/modules/gpgpu/src/gpu-vector-search/types.ts
+++ b/modules/gpgpu/src/gpu-vector-search/types.ts
@@ -1,0 +1,72 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuVS.
+
+import type {GraphDataView, GraphVectorView} from '@luma.gl/gpgpu/gpu-core';
+
+/** Exact distance or similarity used to order embedding search results. */
+export type GPUEmbeddingMetric = 'squared-euclidean' | 'inner-product' | 'cosine';
+
+/** Non-owning graph metadata and borrowed views for one fixed-size-list embedding chunk. */
+export type GraphEmbeddingMatrixChunk = {
+  /** Flat scalar view beginning at the first logical embedding row. */
+  readonly values: GraphDataView<'float32'>;
+  /** Number of logical embedding rows represented by this graph view. */
+  readonly rowCount: number;
+  /** Number of float32 elements between consecutive embedding rows. */
+  readonly rowStride: number;
+  /** Physical byte offset of the first logical row in the values buffer. */
+  readonly byteOffset: number;
+  /** Stable source position of the first logical row in this chunk. */
+  readonly sourceRowOffset: number;
+  /** Optional chunk-row-aligned stable source identifiers. */
+  readonly sourceRowIds?: GraphDataView<'uint32'>;
+  /** Optional chunk-row-aligned nonzero-valid row flags. */
+  readonly validity?: GraphDataView<'uint32'>;
+};
+
+/** Non-owning embedding-column view imported into one caller-owned GPU command graph. */
+export type GraphEmbeddingMatrix = {
+  /** Logical embedding dimensionality, independent from GPU vertex formats. */
+  readonly dimensions: number;
+  /** Total number of rows across original source chunks. */
+  readonly rowCount: number;
+  /** Ordered, source-preserving views over GPUData chunks owned by the source table or vector. */
+  readonly chunks: readonly GraphEmbeddingMatrixChunk[];
+};
+
+/** Source-aligned selection flags, including chunk-preserving LuxFilter output. */
+export type GPUEmbeddingFilterMask = GraphDataView<'uint32'> | GraphVectorView<'uint32'>;
+
+/** Properties accepted by an exact, graph-native embedding similarity search. */
+export type GPUSimilaritySearchProps = {
+  /** Prefix shared by generated graph nodes and bounded scratch resources. */
+  id?: string;
+  /** Chunk-preserving candidate embedding rows. */
+  dataset: GraphEmbeddingMatrix;
+  /** Chunk-preserving query embedding rows with matching dimensions. */
+  queries: GraphEmbeddingMatrix;
+  /** Caller-owned packed result identifiers, with `queryCount * k` slots. */
+  outputIds: GraphDataView<'uint32'>;
+  /** Caller-owned packed float32 distances or similarity scores. */
+  outputScores: GraphDataView<'float32'>;
+  /** Caller-owned number of actual results for each query row. */
+  resultCounts: GraphDataView<'uint32'>;
+  /** Optional caller-owned number of eligible candidates for each query. */
+  candidateCounts?: GraphDataView<'uint32'>;
+  /** Requested maximum result count for each query. */
+  k: number;
+  /** Distance or similarity metric. Defaults to squared Euclidean distance. */
+  metric?: GPUEmbeddingMetric;
+  /** Optional source-row-aligned selection flags, including LuxFilter masks. */
+  filterMask?: GPUEmbeddingFilterMask;
+  /** Optional stable source identifiers restricting eligible candidates. */
+  candidateIds?: GraphDataView<'uint32'>;
+  /** Optional packed query-major, source-row-aligned selection flags. */
+  queryFilterMask?: GraphDataView<'uint32'>;
+  /** Reject candidates whose stable source ID matches their query row ID. */
+  excludeSelf?: boolean;
+  /** Optional upper bound on dataset rows visited by one graph pass. */
+  tileSize?: number;
+};

--- a/modules/gpgpu/test/gpu-core/gpu-command-graph-alias.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-command-graph-alias.node.spec.ts
@@ -11,6 +11,7 @@ import {
   type GraphDataView,
   type GraphImportedBuffer
 } from '@luma.gl/gpgpu/gpu-core';
+import {GPUData} from '@luma.gl/gpgpu/gpu-data';
 import {NullDevice} from '@luma.gl/test-utils';
 import {describe, expect, test, vi} from 'vitest';
 
@@ -19,6 +20,7 @@ type GraphAliasFixture = {
   graph: GPUCommandGraph;
   buffers: Buffer[];
   dynamicBuffers: DynamicBuffer[];
+  data: GPUData[];
 };
 
 describe('GPUCommandGraph physical imported-buffer ownership', () => {
@@ -315,6 +317,115 @@ describe('GPUCommandGraph physical imported-buffer ownership', () => {
     }
   });
 
+  test('canonicalizes typed imports with raw buffer handles in either import order', () => {
+    const fixture = createGraphAliasFixture('typed-raw-canonicalization');
+    const rawFirstBuffer = createGraphAliasBuffer(fixture, 'raw-first');
+    const rawFirstHandle = importGraphAliasBuffer(fixture, 'raw-first', rawFirstBuffer);
+    const rawFirstData = createGraphAliasData(fixture, rawFirstBuffer);
+
+    const tableFirstBuffer = createGraphAliasBuffer(fixture, 'table-first');
+    const tableFirstData = createGraphAliasData(fixture, tableFirstBuffer);
+    const tableFirstView = fixture.graph.importGPUData('table-first', tableFirstData);
+    const tableFirstAlias = importGraphAliasBuffer(fixture, 'table-first-alias', tableFirstBuffer);
+
+    try {
+      expect(fixture.graph.importGPUData('raw-first-data', rawFirstData).buffer).toBe(
+        rawFirstHandle
+      );
+      expect(tableFirstAlias).not.toBe(tableFirstView.buffer);
+      expect(fixture.graph.importGPUData('table-first-again', tableFirstData).buffer).toBe(
+        tableFirstView.buffer
+      );
+    } finally {
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
+  test('preserves a typed DynamicBuffer wrapper imported after its raw backing', () => {
+    const fixture = createGraphAliasFixture('typed-dynamic-wrapper');
+    const originalBuffer = createGraphAliasBuffer(fixture, 'original-backing');
+    const rawHandle = importGraphAliasBuffer(fixture, 'raw-backing', originalBuffer);
+    const dynamicBuffer = createGraphAliasDynamicBuffer(fixture, 'dynamic-wrapper', originalBuffer);
+    const dynamicData = createGraphAliasData(fixture, dynamicBuffer);
+    const rawData = createGraphAliasData(fixture, originalBuffer);
+    const firstView = fixture.graph.importGPUData('dynamic-data', dynamicData);
+    const resolvedBuffers: Buffer[] = [];
+
+    expect(firstView.buffer).not.toBe(rawHandle);
+    expect(firstView.buffer.defaultBuffer).toBe(dynamicBuffer);
+    expect(fixture.graph.importGPUData('dynamic-data-again', dynamicData).buffer).toBe(
+      firstView.buffer
+    );
+    expect(fixture.graph.importGPUData('raw-data', rawData).buffer).toBe(rawHandle);
+
+    fixture.graph.addCopyPass({
+      id: 'observe-dynamic-data',
+      resources: [{buffer: firstView, usage: 'storage-read'}],
+      compile: () => ({encode: ({getBuffer}) => resolvedBuffers.push(getBuffer(firstView))})
+    });
+    const compiled = fixture.graph.compile();
+
+    try {
+      encodeGraphAliasFixture(fixture, compiled);
+      dynamicBuffer.resize({byteLength: 32});
+      encodeGraphAliasFixture(fixture, compiled);
+      expect(resolvedBuffers).toEqual([originalBuffer, dynamicBuffer.buffer]);
+    } finally {
+      compiled.destroy();
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
+  test('maps a resized DynamicBuffer backing to its canonical wrapper handle', () => {
+    const fixture = createGraphAliasFixture('resized-dynamic-backing');
+    const dynamicBuffer = createGraphAliasDynamicBuffer(fixture, 'dynamic-backing');
+    const dynamicHandle = importGraphAliasBuffer(fixture, 'dynamic', dynamicBuffer);
+    dynamicBuffer.resize({byteLength: 32});
+    const replacementData = createGraphAliasData(fixture, dynamicBuffer.buffer);
+    const replacementView = fixture.graph.importGPUData('replacement-data', replacementData);
+    const explicitAlias = importGraphAliasBuffer(
+      fixture,
+      'replacement-alias',
+      dynamicBuffer.buffer
+    );
+
+    try {
+      expect(replacementView.buffer).toBe(dynamicHandle);
+      expect(explicitAlias).not.toBe(dynamicHandle);
+      expect(fixture.graph.importGPUData('replacement-data-again', replacementData).buffer).toBe(
+        dynamicHandle
+      );
+    } finally {
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
+  test('falls back to a raw alias after a borrowed DynamicBuffer replaces its backing', () => {
+    const fixture = createGraphAliasFixture('replaced-dynamic-backing');
+    const originalBuffer = createGraphAliasBuffer(fixture, 'preserved-backing');
+    const dynamicBuffer = createGraphAliasDynamicBuffer(
+      fixture,
+      'borrowed-dynamic',
+      originalBuffer
+    );
+    const dynamicHandle = importGraphAliasBuffer(fixture, 'dynamic', dynamicBuffer);
+    const preservedHandle = importGraphAliasBuffer(fixture, 'preserved', originalBuffer);
+    dynamicBuffer.resize({byteLength: 32});
+    const preservedData = createGraphAliasData(fixture, originalBuffer);
+    const replacementData = createGraphAliasData(fixture, dynamicBuffer.buffer);
+
+    try {
+      expect(fixture.graph.importGPUData('preserved-data', preservedData).buffer).toBe(
+        preservedHandle
+      );
+      expect(fixture.graph.importGPUData('replacement-data', replacementData).buffer).toBe(
+        dynamicHandle
+      );
+    } finally {
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
   test('allows multiple active ranges over one canonical logical buffer handle', () => {
     const fixture = createGraphAliasFixture('shared-logical-handle');
     const sharedBuffer = createGraphAliasBuffer(fixture, 'shared-ranges');
@@ -389,7 +500,8 @@ function createGraphAliasFixture(identifier: string): GraphAliasFixture {
     device,
     graph: new GPUCommandGraph(device, {id: identifier}),
     buffers: [],
-    dynamicBuffers: []
+    dynamicBuffers: [],
+    data: []
   };
 }
 
@@ -405,6 +517,33 @@ function createGraphAliasBuffer(
   });
   fixture.buffers.push(buffer);
   return buffer;
+}
+
+function createGraphAliasDynamicBuffer(
+  fixture: GraphAliasFixture,
+  identifier: string,
+  buffer?: Buffer
+): DynamicBuffer {
+  const dynamicBuffer = new DynamicBuffer(fixture.device, {
+    id: identifier,
+    ...(buffer ? {buffer, ownsBuffer: false} : {byteLength: 16, usage: Buffer.STORAGE})
+  });
+  fixture.dynamicBuffers.push(dynamicBuffer);
+  return dynamicBuffer;
+}
+
+function createGraphAliasData(
+  fixture: GraphAliasFixture,
+  buffer: Buffer | DynamicBuffer
+): GPUData<'uint32'> {
+  const data = new GPUData({
+    buffer,
+    format: 'uint32',
+    length: 4,
+    ownsBuffer: false
+  });
+  fixture.data.push(data);
+  return data;
 }
 
 function importGraphAliasBuffer(
@@ -446,6 +585,7 @@ function encodeGraphAliasFixture(
 }
 
 function destroyGraphAliasFixture(fixture: GraphAliasFixture): void {
+  for (const data of fixture.data) data.destroy();
   for (const dynamicBuffer of fixture.dynamicBuffers) dynamicBuffer.destroy();
   for (const buffer of fixture.buffers) buffer.destroy();
   fixture.device.destroy();

--- a/modules/gpgpu/test/gpu-core/gpu-command-graph-alias.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-command-graph-alias.node.spec.ts
@@ -341,6 +341,71 @@ describe('GPUCommandGraph physical imported-buffer ownership', () => {
     }
   });
 
+  test('promotes typed imports beyond an undersized canonical raw handle', () => {
+    const fixture = createGraphAliasFixture('typed-capacity-promotion');
+    const sharedBuffer = fixture.device.createBuffer({
+      id: 'larger-physical-buffer',
+      byteLength: 32,
+      usage: Buffer.STORAGE
+    });
+    fixture.buffers.push(sharedBuffer);
+    const rawHandle = fixture.graph.importBuffer(
+      {id: 'partial-raw-import', byteLength: 16, usage: Buffer.STORAGE},
+      sharedBuffer
+    );
+    const data = new GPUData({
+      buffer: sharedBuffer,
+      format: 'uint32',
+      length: 4,
+      byteOffset: 16,
+      ownsBuffer: false
+    });
+    fixture.data.push(data);
+    const view = fixture.graph.importGPUData('complete-typed-import', data);
+
+    try {
+      expect(view.buffer).not.toBe(rawHandle);
+      expect(view.buffer.byteLength).toBe(32);
+      expect(fixture.graph.importGPUData('complete-typed-import-again', data).buffer).toBe(
+        view.buffer
+      );
+    } finally {
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
+  test('promotes typed imports beyond canonical raw-handle usage flags', () => {
+    const fixture = createGraphAliasFixture('typed-usage-promotion');
+    const sharedBuffer = createGraphAliasBuffer(
+      fixture,
+      'multi-usage-physical-buffer',
+      Buffer.STORAGE | Buffer.COPY_SRC
+    );
+    const rawHandle = fixture.graph.importBuffer(
+      {id: 'storage-only-raw-import', byteLength: 16, usage: Buffer.STORAGE},
+      sharedBuffer
+    );
+    const data = createGraphAliasData(fixture, sharedBuffer);
+    const view = fixture.graph.importGPUData('multi-usage-typed-import', data);
+
+    try {
+      expect(view.buffer).not.toBe(rawHandle);
+      expect(view.buffer.usage & Buffer.COPY_SRC).toBe(Buffer.COPY_SRC);
+      expect(() =>
+        fixture.graph.addCopyPass({
+          id: 'read-promoted-copy-source',
+          resources: [{buffer: view, usage: 'copy-source'}],
+          compile: () => ({encode: vi.fn()})
+        })
+      ).not.toThrow();
+      expect(fixture.graph.importGPUData('multi-usage-typed-import-again', data).buffer).toBe(
+        view.buffer
+      );
+    } finally {
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
   test('preserves a typed DynamicBuffer wrapper imported after its raw backing', () => {
     const fixture = createGraphAliasFixture('typed-dynamic-wrapper');
     const originalBuffer = createGraphAliasBuffer(fixture, 'original-backing');

--- a/modules/gpgpu/test/gpu-data/gpu-constant.node.spec.ts
+++ b/modules/gpgpu/test/gpu-data/gpu-constant.node.spec.ts
@@ -25,6 +25,15 @@ test('GPUConstant validates and owns one fixed-width payload', t => {
     /requires exactly 8 bytes/,
     'rejects incomplete rows'
   );
+  t.throws(
+    () =>
+      new GPUConstant({
+        format: 'fixed-size-list<float32,3>' as never,
+        value: new Float32Array([1, 2, 3])
+      }),
+    /cannot represent fixed-size-list storage columns/,
+    'rejects unchecked fixed-size-list formats rather than treating storage rows as constants'
+  );
   t.end();
 });
 

--- a/modules/gpgpu/test/gpu-data/gpu-data-types.node.spec.ts
+++ b/modules/gpgpu/test/gpu-data/gpu-data-types.node.spec.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {NullDevice} from '@luma.gl/test-utils';
-import {GPUData, type GPUDataView} from '@luma.gl/gpgpu/gpu-data';
+import {GPUData, GPUVector, type FixedSizeList, type GPUDataView} from '@luma.gl/gpgpu/gpu-data';
 import {expectTypeOf, test} from 'vitest';
 
 test('GPUData infers inline struct field types', () => {
@@ -28,5 +28,26 @@ test('GPUData infers inline struct field types', () => {
   const scalarData = new GPUData({buffer, length: 2, format: 'float32'});
   expectTypeOf(scalarData.format).toEqualTypeOf<'float32' | undefined>();
 
+  buffer.destroy();
+});
+
+test('GPUData and GPUVector preserve literal fixed-size-list formats', () => {
+  const device = new NullDevice({});
+  const buffer = device.createBuffer({byteLength: 32});
+  const data = new GPUData({
+    buffer,
+    length: 2,
+    format: 'fixed-size-list<float32,4>'
+  });
+  const vector = new GPUVector({
+    type: 'data',
+    name: 'embeddings',
+    data: [data]
+  });
+
+  expectTypeOf(data.format).toEqualTypeOf<FixedSizeList<'float32', 4> | undefined>();
+  expectTypeOf(vector.format).toEqualTypeOf<FixedSizeList<'float32', 4> | undefined>();
+
+  vector.destroy();
   buffer.destroy();
 });

--- a/modules/gpgpu/test/gpu-data/gpu-vector-format.node.spec.ts
+++ b/modules/gpgpu/test/gpu-data/gpu-vector-format.node.spec.ts
@@ -11,6 +11,7 @@ import {
   getGPUVectorFormatInfo,
   getGPUVectorData,
   getRequiredGPUVector,
+  isFixedSizeListGPUVectorFormat,
   isGPUVectorFormatCompatibleWithShaderType,
   isValueListGPUVectorFormat,
   isVertexListGPUVectorFormat
@@ -22,10 +23,14 @@ test('GPUVector format helpers parse fixed and variable-length formats', t => {
   const fixedInfo = getGPUVectorFormatInfo('float32x3');
   const vertexListInfo = getGPUVectorFormatInfo('vertex-list<unorm8x4>');
   const valueListInfo = getGPUVectorFormatInfo('value-list<uint8>');
+  const fixedSizeListInfo = getGPUVectorFormatInfo('fixed-size-list<float32,768>');
+  const fixedSizeVectorListInfo = getGPUVectorFormatInfo('fixed-size-list<float32x3,2>');
 
   t.equal(fixedInfo.elementFormat, 'float32x3', 'fixed vector element format is unchanged');
   t.equal(fixedInfo.vertexList, false, 'fixed vector is not a vertex list');
   t.equal(fixedInfo.valueList, false, 'fixed vector is not a value list');
+  t.equal(fixedInfo.fixedSizeList, false, 'fixed vector is not a fixed-size list');
+  t.equal(fixedInfo.elementByteLength, 12, 'fixed vector element byte length is decoded');
   t.equal(fixedInfo.byteLength, 12, 'fixed vector byte length is decoded');
   t.equal(vertexListInfo.elementFormat, 'unorm8x4', 'vertex-list exposes its element format');
   t.equal(vertexListInfo.vertexList, true, 'vertex-list marker is decoded');
@@ -34,15 +39,76 @@ test('GPUVector format helpers parse fixed and variable-length formats', t => {
   t.equal(valueListInfo.elementFormat, 'uint8', 'value-list exposes its element format');
   t.equal(valueListInfo.vertexList, false, 'value-list is not a vertex-list');
   t.equal(valueListInfo.valueList, true, 'value-list marker is decoded');
+  t.equal(fixedSizeListInfo.elementFormat, 'float32', 'fixed-size list exposes its element format');
+  t.equal(fixedSizeListInfo.fixedSizeList, true, 'fixed-size-list marker is decoded');
+  t.equal(fixedSizeListInfo.vertexList, false, 'fixed-size list is not a vertex list');
+  t.equal(
+    fixedSizeListInfo.valueList,
+    false,
+    'fixed-size list is not a variable-length value list'
+  );
+  t.equal(fixedSizeListInfo.listSize, 768, 'fixed-size list exposes its logical row cardinality');
+  t.equal(fixedSizeListInfo.components, 1, 'fixed-size list preserves scalar element components');
+  t.equal(fixedSizeListInfo.elementByteLength, 4, 'fixed-size list exposes element byte length');
+  t.equal(fixedSizeListInfo.byteLength, 3072, 'fixed-size list byte length describes one full row');
+  t.equal(fixedSizeVectorListInfo.components, 3, 'vector-valued fixed lists retain element shape');
+  t.equal(fixedSizeVectorListInfo.elementByteLength, 12, 'vector-valued lists expose element size');
+  t.equal(fixedSizeVectorListInfo.byteLength, 24, 'vector-valued lists expose complete row size');
   t.equal(getGPUVectorElementFormat('vertex-list<unorm8x4>'), 'unorm8x4');
   t.equal(getGPUVectorElementFormat('value-list<uint8>'), 'uint8');
+  t.equal(getGPUVectorElementFormat('fixed-size-list<float32,768>'), 'float32');
   t.ok(isVertexListGPUVectorFormat('vertex-list<unorm8x4>'), 'recognizes vertex-list syntax');
   t.ok(isValueListGPUVectorFormat('value-list<uint8>'), 'recognizes value-list syntax');
+  t.ok(
+    isFixedSizeListGPUVectorFormat('fixed-size-list<float32,768>'),
+    'recognizes canonical fixed-size-list syntax'
+  );
   t.notOk(isVertexListGPUVectorFormat('list<unorm8x4>'), 'generic list syntax is not accepted');
   t.throws(
     () => getGPUVectorFormatInfo('list<unorm8x4>' as never),
     /Unsupported GPUVector format/,
     'generic list syntax is reserved'
+  );
+
+  t.end();
+});
+
+test('GPUVector fixed-size-list formats require canonical positive safe cardinalities', t => {
+  const invalidFormats = [
+    'fixed-size-list<float32,0>',
+    'fixed-size-list<float32,-1>',
+    'fixed-size-list<float32,+1>',
+    'fixed-size-list<float32,01>',
+    'fixed-size-list<float32,1.0>',
+    'fixed-size-list<float32, 1>',
+    'fixed-size-list<float32,1 >',
+    'fixed-size-list<float32,9007199254740992>',
+    'fixed-size-list<float32,9007199254740991>',
+    'fixed-size-list<bogus,3>',
+    'fixed-size-list<float32>',
+    'fixed-list<float32,1>'
+  ];
+
+  for (const invalidFormat of invalidFormats) {
+    t.notOk(
+      isFixedSizeListGPUVectorFormat(invalidFormat),
+      `rejects noncanonical fixed-size-list syntax ${invalidFormat}`
+    );
+    t.throws(
+      () => getGPUVectorFormatInfo(invalidFormat as never),
+      /Unsupported GPUVector format/,
+      `cannot decode invalid fixed-size-list format ${invalidFormat}`
+    );
+  }
+  t.throws(
+    () => getGPUVectorFormatInfo('fixed-size-list<float32,9007199254740991>'),
+    /Unsupported GPUVector format/,
+    'rejects fixed-size-list rows whose physical byte length exceeds a safe integer'
+  );
+  t.throws(
+    () => getGPUVectorFormatInfo('fixed-size-list<float64,3>' as never),
+    /Unsupported GPUVector format/,
+    'rejects an unsupported fixed-size-list element format'
   );
 
   t.end();
@@ -65,7 +131,215 @@ test('GPUVector format helpers validate shader compatibility', t => {
     isGPUVectorFormatCompatibleWithShaderType('float32x3', 'vec4<f32>'),
     'component mismatch is rejected'
   );
+  t.notOk(
+    isGPUVectorFormatCompatibleWithShaderType('fixed-size-list<float32,1>', 'f32'),
+    'fixed-size-list storage columns never masquerade as vertex shader attributes'
+  );
 
+  t.end();
+});
+
+test('GPUData derives complete fixed-size-list row and flattened-value metadata', t => {
+  const device = new NullDevice({});
+  const packedData = new GPUData({
+    buffer: device.createBuffer({byteLength: 2 * 768 * Float32Array.BYTES_PER_ELEMENT}),
+    format: 'fixed-size-list<float32,768>',
+    length: 2,
+    ownsBuffer: true
+  });
+  const paddedData = new GPUData({
+    buffer: device.createBuffer({byteLength: 6176}),
+    format: 'fixed-size-list<float32,768>',
+    length: 2,
+    byteStride: 3104,
+    ownsBuffer: true
+  });
+  const vectorElementData = new GPUData({
+    buffer: device.createBuffer({byteLength: 24}),
+    format: 'fixed-size-list<float32x3,2>',
+    length: 1,
+    ownsBuffer: true
+  });
+  const emptyData = new GPUData({
+    buffer: device.createBuffer({byteLength: 0}),
+    format: 'fixed-size-list<float32,384>',
+    length: 0,
+    ownsBuffer: true
+  });
+
+  t.equal(packedData.length, 2, 'length remains the logical row count');
+  t.equal(packedData.valueLength, 1536, 'valueLength counts flattened fixed-list elements');
+  t.equal(packedData.stride, 768, 'stride counts scalar components in one logical row');
+  t.equal(packedData.rowByteLength, 3072, 'row payload spans all fixed-list elements');
+  t.equal(packedData.byteStride, 3072, 'packed row stride defaults to the complete row payload');
+  t.equal(paddedData.rowByteLength, 3072, 'padding does not change the logical row payload');
+  t.equal(paddedData.byteStride, 3104, 'explicit padded row stride is preserved');
+  t.equal(vectorElementData.valueLength, 2, 'vector-valued lists count flattened vector elements');
+  t.equal(vectorElementData.stride, 6, 'vector-valued rows count every scalar component');
+  t.equal(vectorElementData.rowByteLength, 24, 'vector-valued rows span their complete payload');
+  t.equal(emptyData.valueLength, 0, 'empty fixed-size lists expose no flattened values');
+  t.equal(emptyData.rowByteLength, 1536, 'empty fixed-size lists retain their complete row format');
+
+  packedData.destroy();
+  paddedData.destroy();
+  vectorElementData.destroy();
+  emptyData.destroy();
+  t.end();
+});
+
+test('GPUData rejects malformed fixed-size-list row layouts and out-of-range views', t => {
+  const device = new NullDevice({});
+  const buffer = device.createBuffer({byteLength: 28});
+  const format = 'fixed-size-list<float32,3>' as const;
+
+  t.throws(
+    () => new GPUData({buffer, format, length: 2, valueLength: 5}),
+    /valueLength must equal its flattened row elements/,
+    'rejects flattened counts that do not match fixed row cardinality'
+  );
+  t.throws(
+    () => new GPUData({buffer, format, length: 1, stride: 2}),
+    /stride cannot truncate its row components/,
+    'rejects scalar strides smaller than the fixed row cardinality'
+  );
+  t.throws(
+    () => new GPUData({buffer, format, length: 1, rowByteLength: 8}),
+    /rowByteLength cannot truncate its row payload/,
+    'rejects row payloads that omit fixed-list elements'
+  );
+  t.throws(
+    () => new GPUData({buffer, format, length: 2, byteStride: 8}),
+    /byteStride cannot overlap its row payload/,
+    'rejects row strides that overlap adjacent fixed-list rows'
+  );
+  t.throws(
+    () => new GPUData({buffer, format, length: 2, byteOffset: 5}),
+    /exceeds its backing buffer byte length/,
+    'rejects fixed-list ranges that run beyond the physical allocation'
+  );
+  t.throws(
+    () => new GPUData({buffer, format, length: 1, byteOffset: -1}),
+    /safe non-negative integers/,
+    'rejects negative row byte offsets'
+  );
+  t.throws(
+    () => new GPUData({buffer, format, length: 2, byteStride: Number.MAX_SAFE_INTEGER}),
+    /byte range must use safe integers/,
+    'rejects final-row spans that overflow safe integer arithmetic'
+  );
+  t.throws(
+    () => new GPUData({buffer, format, length: Number.MAX_SAFE_INTEGER}),
+    /safe non-negative integers/,
+    'rejects flattened element counts that overflow safe integer arithmetic'
+  );
+
+  const paddedData = new GPUData({buffer, format, length: 2, byteStride: 16});
+  t.equal(paddedData.rowByteLength, 12, 'accepts padded rows without requiring final-row padding');
+
+  paddedData.destroy();
+  buffer.destroy();
+  t.end();
+});
+
+test('GPUVector preserves fixed-size-list rows, padded layouts, and source chunks', t => {
+  const device = new NullDevice({});
+  const packedVector = new GPUVector({
+    type: 'buffer',
+    name: 'embeddings',
+    buffer: device.createBuffer({byteLength: 3 * 384 * Float32Array.BYTES_PER_ELEMENT}),
+    format: 'fixed-size-list<float32,384>',
+    length: 3,
+    ownsBuffer: true
+  });
+  const paddedVector = new GPUVector({
+    type: 'buffer',
+    name: 'paddedEmbeddings',
+    buffer: device.createBuffer({byteLength: 3104 + 3072}),
+    format: 'fixed-size-list<float32,768>',
+    length: 2,
+    byteStride: 3104,
+    ownsBuffer: true
+  });
+  const firstChunk = new GPUData({
+    buffer: device.createBuffer({byteLength: 1536}),
+    format: 'fixed-size-list<float32,384>',
+    length: 1,
+    ownsBuffer: true
+  });
+  const secondChunk = new GPUData({
+    buffer: device.createBuffer({byteLength: 3072}),
+    format: 'fixed-size-list<float32,384>',
+    length: 2,
+    ownsBuffer: true
+  });
+  const chunkedVector = new GPUVector({
+    type: 'data',
+    name: 'chunkedEmbeddings',
+    data: [firstChunk, secondChunk],
+    ownsData: false
+  });
+
+  t.equal(packedVector.length, 3, 'buffer-backed vectors retain logical rows');
+  t.equal(packedVector.valueLength, 1152, 'buffer-backed vectors count flattened elements');
+  t.equal(packedVector.stride, 384, 'buffer-backed vectors derive scalar row stride');
+  t.equal(packedVector.byteStride, 1536, 'buffer-backed vectors derive complete row bytes');
+  t.equal(paddedVector.rowByteLength, 3072, 'padded vectors retain the actual row payload');
+  t.equal(paddedVector.byteStride, 3104, 'padded vectors retain explicit physical row stride');
+  t.equal(chunkedVector.length, 3, 'chunk-backed vectors aggregate logical rows');
+  t.equal(chunkedVector.valueLength, 1152, 'chunk-backed vectors aggregate flattened elements');
+  t.equal(chunkedVector.data.length, 2, 'chunk-backed vectors preserve source chunk boundaries');
+  t.equal(
+    chunkedVector.data[0],
+    firstChunk,
+    'chunk-backed vectors borrow the original first chunk'
+  );
+  t.equal(
+    chunkedVector.data[1],
+    secondChunk,
+    'chunk-backed vectors borrow the original second chunk'
+  );
+
+  chunkedVector.destroy();
+  t.notOk(firstChunk.buffer.destroyed, 'borrowed chunk ownership remains with the original owner');
+  packedVector.destroy();
+  paddedVector.destroy();
+  firstChunk.destroy();
+  secondChunk.destroy();
+  t.end();
+});
+
+test('Appendable GPUVector preserves fixed-size-list rows without implicit packing', t => {
+  const device = new NullDevice({});
+  const embeddings = new GPUVector({
+    type: 'appendable',
+    name: 'embeddings',
+    device,
+    format: 'fixed-size-list<float32,384>'
+  });
+  const firstChunk = new GPUData({
+    buffer: device.createBuffer({byteLength: 1536}),
+    format: 'fixed-size-list<float32,384>',
+    length: 1,
+    ownsBuffer: true
+  });
+  const secondChunk = new GPUData({
+    buffer: device.createBuffer({byteLength: 3072}),
+    format: 'fixed-size-list<float32,384>',
+    length: 2,
+    ownsBuffer: true
+  });
+
+  embeddings.appendDataChunk(firstChunk);
+  embeddings.appendDataChunk(secondChunk);
+
+  t.equal(embeddings.length, 3, 'appendable fixed-size lists count logical rows');
+  t.equal(embeddings.valueLength, 1152, 'appendable fixed-size lists count flattened elements');
+  t.equal(embeddings.byteStride, 1536, 'appendable fixed-size lists retain full-row byte stride');
+  t.equal(embeddings.data.length, 2, 'appending preserves separately owned source chunks');
+
+  embeddings.destroy();
+  t.ok(firstChunk.buffer.destroyed, 'appendable vector destroys the first owned chunk');
+  t.ok(secondChunk.buffer.destroyed, 'appendable vector destroys the second owned chunk');
   t.end();
 });
 
@@ -86,6 +360,348 @@ test('GPUVector accepts format as canonical metadata and synthesizes table layou
   t.equal(colors.format, 'unorm8x4', 'stores the canonical GPUVector format');
   t.notOk('type' in colors, 'drops the deprecated type alias');
   t.equal(table.bufferLayout[0].format, 'unorm8x4', 'table layout uses GPUVector.format');
+
+  table.destroy();
+  t.end();
+});
+
+test('GPU tables preserve explicit fixed-size-list attribute expansion', t => {
+  const device = new NullDevice({});
+  const embeddings = new GPUVector({
+    type: 'interleaved',
+    name: 'embeddings',
+    buffer: device.createBuffer({byteLength: 32}),
+    format: 'fixed-size-list<float32,4>',
+    length: 2,
+    byteStride: 16,
+    attributes: [
+      {attribute: 'embeddingPart0', format: 'float32x2', byteOffset: 0},
+      {attribute: 'embeddingPart1', format: 'float32x2', byteOffset: 8}
+    ],
+    ownsBuffer: true
+  });
+  const table = new GPUTable({vectors: {embeddings}});
+
+  t.equal(embeddings.valueLength, 8, 'explicitly expanded columns retain flattened element counts');
+  t.equal(embeddings.stride, 4, 'explicitly expanded columns retain scalar row cardinality');
+  t.equal(table.bufferLayout.length, 1, 'retains the caller-owned explicit attribute layout');
+  t.deepEqual(
+    table.bufferLayout[0].attributes?.map(attribute => attribute.attribute),
+    ['embeddingPart0', 'embeddingPart1'],
+    'does not replace an adapter-provided attribute expansion'
+  );
+
+  table.destroy();
+  t.end();
+});
+
+test('GPU tables retain fixed-size-list storage columns without synthetic vertex attributes', t => {
+  const device = new NullDevice({});
+  const embeddings = new GPUVector({
+    type: 'buffer',
+    name: 'embeddings',
+    buffer: device.createBuffer({byteLength: 2 * 1536 * Float32Array.BYTES_PER_ELEMENT}),
+    format: 'fixed-size-list<float32,1536>',
+    length: 2,
+    ownsBuffer: true
+  });
+  const identifiers = new GPUVector({
+    type: 'buffer',
+    name: 'identifiers',
+    buffer: device.createBuffer({byteLength: 2 * Uint32Array.BYTES_PER_ELEMENT}),
+    format: 'uint32',
+    length: 2,
+    ownsBuffer: true
+  });
+  const table = new GPUTable({vectors: {embeddings, identifiers}});
+
+  t.equal(table.numRows, 2, 'fixed-size-list vector lengths remain table row counts');
+  t.equal(table.gpuVectors.embeddings.valueLength, 3072, 'table retains flattened element counts');
+  t.equal(
+    table.schema.fields.find(field => field.name === 'embeddings')?.format,
+    'fixed-size-list<float32,1536>',
+    'schema retains the complete fixed-size-list memory format'
+  );
+  t.deepEqual(
+    table.bufferLayout.map(layout => layout.name),
+    ['identifiers'],
+    'only vertex-compatible columns receive synthesized buffer layouts'
+  );
+  t.equal(
+    table.batches[0].gpuData.embeddings.format,
+    'fixed-size-list<float32,1536>',
+    'record batches retain row-aligned storage columns'
+  );
+
+  table.destroy();
+  t.end();
+});
+
+test('GPU tables preserve fixed-size-list batches until explicitly packed', t => {
+  const device = new NullDevice({});
+  const firstBatch = new GPURecordBatch({
+    gpuData: {
+      embeddings: new GPUData({
+        buffer: device.createBuffer({byteLength: 1536}),
+        format: 'fixed-size-list<float32,384>',
+        length: 1,
+        ownsBuffer: true
+      })
+    }
+  });
+  const secondBatch = new GPURecordBatch({
+    gpuData: {
+      embeddings: new GPUData({
+        buffer: device.createBuffer({byteLength: 3072}),
+        format: 'fixed-size-list<float32,384>',
+        length: 2,
+        ownsBuffer: true
+      })
+    }
+  });
+  const table = new GPUTable({batches: [firstBatch, secondBatch]});
+
+  t.equal(table.batches.length, 2, 'table construction preserves source batch boundaries');
+  t.equal(table.numRows, 3, 'preserved batches contribute logical rows');
+  t.equal(
+    table.gpuVectors.embeddings.valueLength,
+    1152,
+    'aggregate vector tracks flattened values'
+  );
+  t.equal(table.gpuVectors.embeddings.data.length, 2, 'aggregate vector borrows both batch chunks');
+
+  table.packBatches();
+
+  t.equal(
+    table.batches.length,
+    1,
+    'only explicit packing combines adjacent fixed-size-list batches'
+  );
+  t.equal(table.numRows, 3, 'explicit packing preserves logical rows');
+  t.equal(
+    table.gpuVectors.embeddings.valueLength,
+    1152,
+    'explicit packing preserves list elements'
+  );
+  t.equal(table.gpuVectors.embeddings.data.length, 1, 'explicit packing creates one owned chunk');
+  t.equal(
+    table.batches[0].gpuData.embeddings.byteStride,
+    1536,
+    'explicit packing preserves complete fixed-size-list row stride'
+  );
+
+  table.destroy();
+  t.end();
+});
+
+test('GPU tables reject packing incompatible fixed-size-list physical row layouts', t => {
+  const device = new NullDevice({});
+  const incompatibleLayouts = [
+    [
+      {byteStride: 16, rowByteLength: 12},
+      {byteStride: 20, rowByteLength: 12}
+    ],
+    [
+      {byteStride: 20, rowByteLength: 12},
+      {byteStride: 20, rowByteLength: 16}
+    ]
+  ];
+
+  for (const layouts of incompatibleLayouts) {
+    const batches = layouts.map(
+      ({byteStride, rowByteLength}) =>
+        new GPURecordBatch({
+          gpuData: {
+            embeddings: new GPUData({
+              buffer: device.createBuffer({byteLength: byteStride + rowByteLength}),
+              format: 'fixed-size-list<float32,3>',
+              length: 2,
+              byteStride,
+              rowByteLength,
+              ownsBuffer: true
+            })
+          }
+        })
+    );
+    const table = new GPUTable({batches});
+
+    t.deepEqual(table.bufferLayout, [], 'storage-only list layouts remain intentionally empty');
+    t.throws(
+      () => table.packBatches(),
+      /matching fixed-size-list row layouts.*embeddings/,
+      'rejects incompatible physical row layouts before copying source buffers'
+    );
+    t.equal(table.batches.length, 2, 'rejected packing preserves every original batch');
+    t.notOk(
+      batches.some(batch => batch.gpuData.embeddings.buffer.destroyed),
+      'failed packing leaves caller-owned source buffers intact'
+    );
+
+    table.destroy();
+  }
+
+  t.end();
+});
+
+test('GPU tables preserve variable-length packing errors before validating adapter metadata', t => {
+  const device = new NullDevice({});
+  const batches = [0, 1].map(
+    () =>
+      new GPURecordBatch({
+        gpuData: {
+          texts: new GPUData({
+            buffer: device.createBuffer({byteLength: 5}),
+            format: 'value-list<uint8>',
+            length: 1,
+            valueLength: 5,
+            byteStride: 1,
+            rowByteLength: 1,
+            readbackMetadata: {adapter: 'utf8'},
+            ownsBuffer: true
+          })
+        },
+        bufferLayout: []
+      })
+  );
+  const table = new GPUTable({batches});
+
+  t.throws(
+    () => table.packBatches(),
+    /does not support variable-length GPUData "texts"/,
+    'retains the existing variable-length rejection before inspecting adapter metadata'
+  );
+  t.equal(table.batches.length, 2, 'failed packing leaves both source batches unchanged');
+
+  table.destroy();
+  t.end();
+});
+
+test('GPU tables reject packing nullable fixed-size-list rows and scalar source identifiers', t => {
+  const device = new NullDevice({});
+  const firstEmbeddings = new GPUData({
+    buffer: device.createBuffer({byteLength: 12}),
+    format: 'fixed-size-list<float32,3>',
+    length: 1,
+    nullBitmap: new Uint8Array([0]),
+    ownsBuffer: true
+  });
+  const secondEmbeddings = new GPUData({
+    buffer: device.createBuffer({byteLength: 12}),
+    format: 'fixed-size-list<float32,3>',
+    length: 1,
+    ownsBuffer: true
+  });
+  const nullableEmbeddings = new GPUTable({
+    batches: [
+      new GPURecordBatch({gpuData: {embeddings: firstEmbeddings}}),
+      new GPURecordBatch({gpuData: {embeddings: secondEmbeddings}})
+    ]
+  });
+
+  t.throws(
+    () => nullableEmbeddings.packBatches(),
+    /cannot preserve null or readback metadata.*embeddings/,
+    'does not silently erase nullable fixed-size-list row eligibility'
+  );
+  t.equal(nullableEmbeddings.batches.length, 2, 'failed packing preserves every source batch');
+  t.deepEqual(
+    Array.from(nullableEmbeddings.batches[0].gpuData.embeddings.nullBitmap ?? []),
+    [0],
+    'failed packing retains normalized fixed-size-list validity metadata'
+  );
+
+  const firstSourceIdentifiers = new GPUData({
+    buffer: device.createBuffer({byteLength: 4}),
+    format: 'uint32',
+    length: 1,
+    nullBitmap: new Uint8Array([0]),
+    readbackMetadata: {adapter: 'numeric-validity'},
+    ownsBuffer: true
+  });
+  const secondSourceIdentifiers = new GPUData({
+    buffer: device.createBuffer({byteLength: 4}),
+    format: 'uint32',
+    length: 1,
+    ownsBuffer: true
+  });
+  const nullableIdentifiers = new GPUTable({
+    batches: [
+      new GPURecordBatch({gpuData: {sourceIdentifiers: firstSourceIdentifiers}}),
+      new GPURecordBatch({gpuData: {sourceIdentifiers: secondSourceIdentifiers}})
+    ]
+  });
+
+  t.throws(
+    () => nullableIdentifiers.packBatches(),
+    /cannot preserve null or readback metadata.*sourceIdentifiers/,
+    'does not turn null stable source identifiers into valid physical zero values'
+  );
+  t.equal(
+    nullableIdentifiers.batches.length,
+    2,
+    'failed identifier packing preserves both batches'
+  );
+  t.equal(
+    nullableIdentifiers.batches[0].gpuData.sourceIdentifiers.readbackMetadata?.adapter,
+    'numeric-validity',
+    'failed packing retains adapter-owned numeric readback metadata'
+  );
+
+  nullableEmbeddings.destroy();
+  nullableIdentifiers.destroy();
+  t.end();
+});
+
+test('GPU tables reject packing adapter readback metadata even without a row bitmap', t => {
+  const device = new NullDevice({});
+  const firstData = new GPUData({
+    buffer: device.createBuffer({byteLength: 4}),
+    format: 'uint32',
+    length: 1,
+    readbackMetadata: {adapter: 'custom-source-metadata'},
+    ownsBuffer: true
+  });
+  const secondData = new GPUData({
+    buffer: device.createBuffer({byteLength: 4}),
+    format: 'uint32',
+    length: 1,
+    ownsBuffer: true
+  });
+  const table = new GPUTable({
+    batches: [
+      new GPURecordBatch({gpuData: {values: firstData}}),
+      new GPURecordBatch({gpuData: {values: secondData}})
+    ]
+  });
+
+  t.throws(
+    () => table.packBatches(),
+    /cannot preserve null or readback metadata.*values/,
+    'generic tables never silently discard adapter-owned reconstruction metadata'
+  );
+  t.equal(table.batches.length, 2, 'metadata rejection occurs before any batch is replaced');
+
+  table.destroy();
+  t.end();
+});
+
+test('GPURecordBatch synthesizes fixed-size-list schemas without vertex layouts', t => {
+  const device = new NullDevice({});
+  const embeddings = new GPUData({
+    buffer: device.createBuffer({byteLength: 2 * 768 * Float32Array.BYTES_PER_ELEMENT}),
+    format: 'fixed-size-list<float32,768>',
+    length: 2,
+    ownsBuffer: true
+  });
+  const batch = new GPURecordBatch({gpuData: {embeddings}});
+  const table = new GPUTable({batches: [batch]});
+
+  t.equal(batch.numRows, 2, 'record batches infer logical fixed-size-list rows');
+  t.equal(batch.gpuData.embeddings.valueLength, 1536, 'record batches retain flattened values');
+  t.equal(batch.schema.fields[0].format, 'fixed-size-list<float32,768>', 'schema keeps row shape');
+  t.deepEqual(batch.bufferLayout, [], 'storage-only batches have no synthetic vertex layouts');
+  t.deepEqual(table.bufferLayout, [], 'storage-only tables have no synthetic vertex layouts');
+  t.equal(table.gpuVectors.embeddings.length, 2, 'aggregate vectors retain logical rows');
 
   table.destroy();
   t.end();

--- a/modules/gpgpu/test/gpu-vector-search/gpu-vector-search.node.spec.ts
+++ b/modules/gpgpu/test/gpu-vector-search/gpu-vector-search.node.spec.ts
@@ -1,0 +1,5 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import './gpu-vector-search.spec';

--- a/modules/gpgpu/test/gpu-vector-search/gpu-vector-search.spec.ts
+++ b/modules/gpgpu/test/gpu-vector-search/gpu-vector-search.spec.ts
@@ -1,0 +1,2254 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {makeGPUTableFromArrowTable} from '@luma.gl/arrow';
+import {Buffer, type Device, type ShaderLayout} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPURecordBatch, GPUTable} from '@luma.gl/experimental/gpu-tables';
+import {
+  getViewBinding,
+  getViewElementOffset,
+  GPUCommandGraph,
+  GPUHashIndex,
+  type GraphDataView,
+  type GraphVectorView
+} from '@luma.gl/gpgpu/gpu-core';
+import {GPUData, GPUVector, type FixedSizeList} from '@luma.gl/gpgpu/gpu-data';
+import {getWebGPUTestDevice, NullDevice} from '@luma.gl/test-utils';
+import * as arrow from 'apache-arrow';
+import test, {type Test} from 'test/utils/vitest-tape';
+import {
+  importGPUEmbeddingTable,
+  importGPUEmbeddingVector
+} from '../../src/gpu-vector-search/embedding-matrix';
+import {GPUSimilaritySearch} from '../../src/gpu-vector-search/gpu-similarity-search';
+import type {GPUEmbeddingMetric, GraphEmbeddingMatrix} from '../../src/gpu-vector-search/types';
+
+const INVALID_SOURCE_ROW_ID = 0xffff_ffff;
+
+type EmbeddingChunkFixture = {
+  rows: readonly (readonly number[])[];
+  rowStride?: number;
+  prefix?: readonly number[];
+  sourceRowOffset?: number;
+  sourceRowIds?: readonly number[];
+  validity?: readonly number[];
+};
+
+type SimilaritySearchFixture = {
+  dimensions: number;
+  dataset: readonly EmbeddingChunkFixture[];
+  queries: readonly EmbeddingChunkFixture[];
+  k: number;
+  metric?: GPUEmbeddingMetric;
+  filterMask?: readonly number[];
+  chunkedFilterMask?: readonly (readonly number[])[];
+  queryFilterMask?: readonly number[];
+  candidateIds?: readonly number[];
+  excludeSelf?: boolean;
+  tileSize?: number;
+  candidateCounts?: boolean;
+};
+
+type CPUSourceEmbeddingRow = {
+  values: number[];
+  sourceRowId: number;
+  sourceRowPosition: number;
+  valid: boolean;
+  chunkIndex: number;
+  chunkRowIndex: number;
+};
+
+/** One caller-owned, row-oriented fixed-size-list column plus optional sibling metadata. */
+type GPUEmbeddingVectorFixture = {
+  vector: GPUVector<FixedSizeList<'float32'>>;
+  sourceRowIds?: GPUVector<'uint32'>;
+  validity?: GPUVector<'uint32'>;
+  sourceRowOffsets: number[];
+  rows: CPUSourceEmbeddingRow[];
+};
+
+type CPUSimilarityResult = {
+  sourceRowIds: number[];
+  scores: number[];
+  resultCounts: number[];
+  candidateCounts: number[];
+};
+
+type SearchExecution = {
+  sourceRowIds: number[];
+  scores: number[];
+  resultCounts: number[];
+  candidateCounts?: number[];
+  nodeOrder: readonly string[];
+  logicalTransientCount: number;
+  physicalTransientCount: number;
+  importedBuffersSurviveDestruction: boolean;
+};
+
+let fixtureSequence = 0;
+
+test('GPUSimilaritySearch CPU oracle independently defines metrics, zero vectors, and tie ordering', t => {
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 2,
+    dataset: [
+      {
+        rows: [
+          [1, 0],
+          [-1, 0],
+          [0, 0],
+          [1, 0]
+        ],
+        sourceRowIds: [9, 4, 2, 3]
+      }
+    ],
+    queries: [
+      {
+        rows: [
+          [1, 0],
+          [0, 0]
+        ]
+      }
+    ],
+    k: 4,
+    candidateCounts: true
+  };
+  const dataset = getCPUFixtureRows(fixture.dataset, fixture.dimensions);
+  const queries = getCPUFixtureRows(fixture.queries, fixture.dimensions);
+
+  const euclidean = getIndependentCPUSimilarityResults(fixture, dataset, queries);
+  t.deepEqual(
+    euclidean.sourceRowIds.slice(0, 4),
+    [3, 9, 2, 4],
+    'distance ties use stable source IDs'
+  );
+  t.deepEqual(euclidean.scores.slice(0, 4), [0, 0, 1, 4], 'squared Euclidean distances are exact');
+
+  const innerProduct = getIndependentCPUSimilarityResults(
+    {...fixture, metric: 'inner-product'},
+    dataset,
+    queries
+  );
+  t.deepEqual(
+    innerProduct.sourceRowIds.slice(0, 4),
+    [3, 9, 2, 4],
+    'inner products sort descending'
+  );
+  t.deepEqual(
+    innerProduct.scores.slice(0, 4),
+    [1, 1, 0, -1],
+    'inner-product values are independent'
+  );
+
+  const cosine = getIndependentCPUSimilarityResults(
+    {...fixture, metric: 'cosine'},
+    dataset,
+    queries
+  );
+  t.deepEqual(
+    cosine.sourceRowIds.slice(4, 8),
+    [2, 3, 4, 9],
+    'zero-query cosine ties remain stable'
+  );
+  t.deepEqual(
+    cosine.scores.slice(4, 8),
+    [1, 0, 0, 0],
+    'two zero vectors have unit cosine similarity'
+  );
+  t.deepEqual(cosine.candidateCounts, [4, 4], 'candidate counts remain independent from top-K');
+  t.end();
+});
+
+test('GPUSimilaritySearch validates generic matrix shape and independent writable outputs', t => {
+  const device = new NullDevice({});
+  Object.defineProperty(device, 'type', {value: 'webgpu'});
+  const graph = new GPUCommandGraph(device, {id: 'similarity-node-validation'});
+  const ownedVectors: GPUVector[] = [];
+  const dataset = createEmbeddingVector(
+    device,
+    'validation-dataset',
+    2,
+    [{rows: [[1, 2]]}],
+    ownedVectors
+  );
+  const queries = createEmbeddingVector(
+    device,
+    'validation-queries',
+    2,
+    [{rows: [[1, 2]]}],
+    ownedVectors
+  );
+  const importedDataset = importEmbeddingFixture(graph, dataset, 'dataset');
+  const importedQueries = importEmbeddingFixture(graph, queries, 'queries');
+  const outputIds = createUint32View(graph, ownedVectors, 'output-ids', 1);
+  const outputScores = createFloat32View(graph, ownedVectors, 'output-scores', 1);
+  const resultCounts = createUint32View(graph, ownedVectors, 'result-counts', 1);
+  const validProps = {
+    dataset: importedDataset,
+    queries: importedQueries,
+    outputIds,
+    outputScores,
+    resultCounts,
+    k: 1
+  };
+
+  t.doesNotThrow(
+    () => new GPUSimilaritySearch(validProps),
+    'accepts distinct caller-owned buffers'
+  );
+  t.throws(
+    () => new GPUSimilaritySearch({...validProps, k: -1}),
+    /result count/,
+    'rejects negative result counts'
+  );
+  t.throws(
+    () => new GPUSimilaritySearch({...validProps, tileSize: 0}),
+    /tileSize/,
+    'rejects nonpositive tile bounds'
+  );
+  t.throws(
+    () =>
+      new GPUSimilaritySearch({
+        ...validProps,
+        metric: 'euclidean' as GPUEmbeddingMetric
+      }),
+    /metric/,
+    'rejects unsupported metrics'
+  );
+  t.throws(
+    () => new GPUSimilaritySearch({...validProps, resultCounts: outputIds}),
+    /must not overlap/,
+    'rejects aliased writable result buffers'
+  );
+  const malformedStride = new GPUData<FixedSizeList<'float32', 2>>({
+    buffer: dataset.vector.data[0].buffer,
+    format: 'fixed-size-list<float32,2>',
+    length: 1,
+    byteStride: 2 * Float32Array.BYTES_PER_ELEMENT,
+    rowByteLength: 2 * Float32Array.BYTES_PER_ELEMENT
+  });
+  Object.defineProperty(malformedStride, 'byteStride', {value: Float32Array.BYTES_PER_ELEMENT});
+  const malformedVector = new GPUVector({
+    type: 'data',
+    name: 'malformed-embedding-stride',
+    format: 'fixed-size-list<float32,2>',
+    data: [malformedStride]
+  });
+  t.throws(
+    () => importGPUEmbeddingVector(graph, malformedVector),
+    /aligned, bounded fixed-size float32 rows/,
+    'rejects physical row strides narrower than the embedding dimensions'
+  );
+
+  const mismatchedRows = new GPUVector({
+    type: 'data',
+    name: 'mismatched-embedding-rows',
+    format: 'fixed-size-list<float32,2>',
+    data: dataset.vector.data
+  });
+  Object.defineProperty(mismatchedRows, 'length', {value: 2});
+  t.throws(
+    () => importGPUEmbeddingVector(graph, mismatchedRows),
+    /source chunk rows/,
+    'rejects aggregate row counts that disagree with source topology'
+  );
+  t.throws(
+    () =>
+      importGPUEmbeddingVector(graph, dataset.vector, {
+        id: 'invalid-source-offset',
+        sourceRowOffset: INVALID_SOURCE_ROW_ID
+      }),
+    /aligned, bounded fixed-size float32 rows/,
+    'reserves the maximum uint32 value for invalid result slots'
+  );
+
+  const boundedValues = new GPUVector<FixedSizeList<'float32', 2>>({
+    type: 'buffer',
+    name: 'bounded-embedding-values',
+    buffer: device.createBuffer({
+      data: Float32Array.from([1, 2, 90, 91]),
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    }),
+    format: 'fixed-size-list<float32,2>',
+    length: 1,
+    byteOffset: 2 * Float32Array.BYTES_PER_ELEMENT,
+    ownsBuffer: true
+  });
+  Object.defineProperty(boundedValues, 'length', {value: 2});
+  Object.defineProperty(boundedValues.data[0], 'length', {value: 2});
+  Object.defineProperty(boundedValues.data[0], 'valueLength', {value: 4});
+  ownedVectors.push(boundedValues);
+  t.throws(
+    () => importGPUEmbeddingVector(graph, boundedValues),
+    /declared GPUData byte range/,
+    'never exposes unrelated bytes beyond the declared GPUData slice'
+  );
+
+  t.throws(
+    () => importGPUEmbeddingVector(graph, dataset.vector, {dimensions: 3}),
+    /fit within its fixed-size-list rows/,
+    'rejects meaningful dimensions beyond the physical fixed-size-list cardinality'
+  );
+  t.throws(
+    () => importGPUEmbeddingVector(graph, dataset.vector, {dimensions: 0}),
+    /fit within its fixed-size-list rows/,
+    'rejects zero meaningful embedding dimensions'
+  );
+
+  destroyOwnedVectors(ownedVectors);
+  t.end();
+});
+
+test('importGPUEmbeddingTable borrows fixed-size-list batches and row-aligned table metadata', t => {
+  const device = new NullDevice({});
+  Object.defineProperty(device, 'type', {value: 'webgpu'});
+  const graph = new GPUCommandGraph(device, {id: 'embedding-table-node-validation'});
+  const ownedVectors: GPUVector[] = [];
+  const fixture = createEmbeddingVector(
+    device,
+    'table-source',
+    3,
+    [
+      {
+        rows: [
+          [1, 2, 3],
+          [4, 5, 6]
+        ],
+        rowStride: 5,
+        prefix: [777],
+        sourceRowOffset: 9,
+        sourceRowIds: [90, 12]
+      },
+      {rows: [], sourceRowOffset: 11},
+      {
+        rows: [[7, 8, 9]],
+        sourceRowOffset: 27,
+        sourceRowIds: [44],
+        validity: [0]
+      }
+    ],
+    ownedVectors
+  );
+  const batches = fixture.vector.data.map(
+    (data, batchIndex) =>
+      new GPURecordBatch({
+        gpuData: {
+          embedding: data,
+          stableId: fixture.sourceRowIds!.data[batchIndex],
+          valid: fixture.validity!.data[batchIndex]
+        },
+        sourceInfo: {
+          sourceBatchIndex: batchIndex,
+          sourceRowIndexOffset: fixture.sourceRowOffsets[batchIndex],
+          sourceRowCount: data.length
+        }
+      })
+  );
+  const table = new GPUTable({batches});
+  const imported = importGPUEmbeddingTable(graph, table, {
+    column: 'embedding',
+    sourceRowIds: 'stableId',
+    validity: 'valid',
+    id: 'table-column'
+  });
+
+  t.equal(imported.dimensions, 3, 'embedding dimensions come from fixed-size-list schema metadata');
+  t.equal(imported.rowCount, 3, 'logical row count is independent from flattened coordinate count');
+  t.deepEqual(
+    imported.chunks.map(chunk => chunk.rowCount),
+    [2, 0, 1],
+    'empty and uneven record-batch boundaries are preserved without packing'
+  );
+  t.deepEqual(
+    imported.chunks.map(chunk => chunk.sourceRowOffset),
+    [9, 11, 27],
+    'existing record-batch source provenance becomes the implicit stable row positions'
+  );
+  t.equal(imported.chunks[0].rowStride, 5, 'padded physical row stride stays in float32 units');
+  t.equal(
+    imported.chunks[0].byteOffset,
+    Float32Array.BYTES_PER_ELEMENT,
+    'nonzero GPUData offsets are preserved'
+  );
+  t.equal(imported.chunks[0].values.length, 8, 'the final row does not require trailing padding');
+  t.ok(
+    imported.chunks.every(chunk => chunk.sourceRowIds),
+    'stable IDs remain table-owned columns'
+  );
+  t.ok(
+    imported.chunks.every(chunk => chunk.validity),
+    'validity remains a table-owned column'
+  );
+  t.equal(table.gpuVectors.embedding.length, 3, 'the aggregate source column remains row-oriented');
+  t.equal(table.gpuVectors.embedding.valueLength, 9, 'flattened value count remains separate');
+
+  const singleBatch = importGPUEmbeddingTable(graph, batches[0], {
+    column: 'embedding',
+    dimensions: 2,
+    sourceRowIds: 'stableId',
+    validity: 'valid',
+    id: 'single-batch'
+  });
+  t.equal(singleBatch.dimensions, 2, 'callers may explicitly ignore trailing fixed-list features');
+  t.equal(singleBatch.chunks[0].rowStride, 5, 'physical row stride survives feature truncation');
+  t.equal(singleBatch.chunks[0].values.length, 7, 'only meaningful coordinates enter the view');
+
+  const sourceIdData = fixture.sourceRowIds!.data[0];
+  Object.defineProperty(sourceIdData, 'nullBitmap', {value: Uint8Array.from([0b11])});
+  t.doesNotThrow(
+    () =>
+      importGPUEmbeddingTable(graph, batches[0], {
+        id: 'nullable-schema-all-valid',
+        column: 'embedding',
+        sourceRowIds: 'stableId'
+      }),
+    'nullable source-ID schemas are allowed when every actual row remains valid'
+  );
+  Object.defineProperty(sourceIdData, 'nullBitmap', {value: Uint8Array.from([0b01])});
+  t.throws(
+    () =>
+      importGPUEmbeddingVector(graph, fixture.vector, {
+        id: 'nullable-source-id-vector',
+        sourceRowIds: fixture.sourceRowIds
+      }),
+    /source-row IDs must not contain null/,
+    'vector imports reject actual null stable IDs without GPU readback'
+  );
+  t.throws(
+    () =>
+      importGPUEmbeddingTable(graph, table, {
+        id: 'nullable-source-id-table',
+        column: 'embedding',
+        sourceRowIds: 'stableId'
+      }),
+    /source-row IDs must not contain null/,
+    'table imports reject null stable IDs before treating physical zero as a real ID'
+  );
+  Object.defineProperty(sourceIdData, 'nullBitmap', {value: undefined});
+
+  const embeddingData = fixture.vector.data[0];
+  Object.defineProperty(embeddingData, 'nullBitmap', {value: Uint8Array.from([0b01])});
+  t.throws(
+    () => importGPUEmbeddingVector(graph, fixture.vector, {id: 'nullable-vector-without-mask'}),
+    /null values require explicit GPU validity flags/,
+    'nullable vector rows cannot silently enter search without a caller-owned GPU validity mask'
+  );
+  t.throws(
+    () =>
+      importGPUEmbeddingTable(graph, batches[0], {
+        id: 'nullable-table-without-mask',
+        column: 'embedding'
+      }),
+    /null values require explicit GPU validity flags/,
+    'nullable table rows cannot silently enter search without a selected GPU validity column'
+  );
+  t.doesNotThrow(
+    () =>
+      importGPUEmbeddingVector(graph, fixture.vector, {
+        id: 'nullable-vector-with-mask',
+        validity: fixture.validity
+      }),
+    'an explicitly selected GPU validity vector permits intentional nullable-row filtering'
+  );
+  t.doesNotThrow(
+    () =>
+      importGPUEmbeddingTable(graph, batches[0], {
+        id: 'nullable-table-with-mask',
+        column: 'embedding',
+        validity: 'valid'
+      }),
+    'an explicitly selected GPU validity column permits intentional nullable-row filtering'
+  );
+  Object.defineProperty(embeddingData, 'nullBitmap', {value: undefined});
+
+  t.throws(
+    () => importGPUEmbeddingTable(graph, table, {column: 'missing'}),
+    /does not contain column/,
+    'rejects missing embedding columns'
+  );
+  t.throws(
+    () => importGPUEmbeddingTable(graph, table, {column: 'embedding', validity: 'missing'}),
+    /row-aligned uint32 column/,
+    'rejects absent explicitly requested validity columns'
+  );
+  t.throws(
+    () => importGPUEmbeddingTable(graph, table, {column: 'embedding', dimensions: 4}),
+    /fit within its fixed-size-list rows/,
+    'rejects meaningful dimensions beyond the existing fixed-list cardinality'
+  );
+
+  const compiled = graph.compile();
+  compiled.destroy();
+  t.ok(
+    ownedVectors.every(vector => vector.data.every(chunk => !chunk.buffer.destroyed)),
+    'graph destruction never destroys buffers owned by existing table columns'
+  );
+  destroyOwnedVectors(ownedVectors);
+  t.end();
+});
+
+test('importGPUEmbeddingTable retains schema dimensions for an empty caller-owned GPU table', t => {
+  const device = new NullDevice({});
+  Object.defineProperty(device, 'type', {value: 'webgpu'});
+  const graph = new GPUCommandGraph(device, {id: 'empty-embedding-table'});
+  const table = new GPUTable({
+    schema: {
+      fields: [{name: 'embedding', format: 'fixed-size-list<float32,768>'}],
+      metadata: new Map()
+    }
+  });
+  const imported = importGPUEmbeddingTable(graph, table, {column: 'embedding'});
+  t.equal(imported.dimensions, 768, 'schema metadata remains available without uploaded batches');
+  t.equal(imported.rowCount, 0, 'empty table imports have no logical rows');
+  t.deepEqual(imported.chunks, [], 'no placeholder GPU allocations are invented');
+  t.end();
+});
+
+test('GPUSimilaritySearch consumes nullable Arrow fixed-size lists through ordinary GPU tables', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const embeddingType = new arrow.FixedSizeList(
+    4,
+    new arrow.Field('feature', new arrow.Float32(), true)
+  );
+  const firstBatch = new arrow.Table({
+    embedding: arrow.vectorFromArray(
+      [
+        [0, 0, 0, null],
+        [1, 0, 0, null]
+      ],
+      embeddingType
+    ),
+    sourceIds: arrow.vectorFromArray([42, 7], new arrow.Uint32())
+  }).batches[0];
+  const secondBatch = new arrow.Table({
+    embedding: arrow.vectorFromArray([null, [0, 0, 1, null]], embeddingType),
+    sourceIds: arrow.vectorFromArray([99, 3], new arrow.Uint32())
+  }).batches[0];
+  const querySource = new arrow.Table({
+    embedding: arrow.vectorFromArray([[0, 0, 0, null]], embeddingType),
+    sourceIds: arrow.vectorFromArray([500], new arrow.Uint32())
+  });
+  const shaderLayout: ShaderLayout = {
+    attributes: [],
+    bindings: [
+      {name: 'embedding', type: 'read-only-storage', group: 0, location: 0},
+      {name: 'sourceIds', type: 'read-only-storage', group: 0, location: 1}
+    ]
+  };
+  const tableOptions = {
+    shaderLayout,
+    fixedSizeListColumns: ['embedding'],
+    validityColumns: {embedding: {name: 'embeddingValidity', dimensions: 3}}
+  };
+  const datasetTable = makeGPUTableFromArrowTable(
+    device,
+    new arrow.Table([firstBatch, secondBatch]),
+    tableOptions
+  );
+  const queryTable = makeGPUTableFromArrowTable(device, querySource, tableOptions);
+  const graph = new GPUCommandGraph(device, {id: 'arrow-fixed-size-list-similarity'});
+  const ownedVectors: GPUVector[] = [];
+  t.throws(
+    () =>
+      importGPUEmbeddingTable(graph, datasetTable, {
+        id: 'dataset-without-validity',
+        column: 'embedding',
+        dimensions: 3,
+        sourceRowIds: 'sourceIds'
+      }),
+    /null values require explicit GPU validity flags/,
+    'nullable Arrow parent rows and nullable padding cannot bypass explicit GPU validity'
+  );
+  const dataset = importGPUEmbeddingTable(graph, datasetTable, {
+    id: 'dataset',
+    column: 'embedding',
+    dimensions: 3,
+    sourceRowIds: 'sourceIds',
+    validity: 'embeddingValidity'
+  });
+  const queries = importGPUEmbeddingTable(graph, queryTable, {
+    id: 'queries',
+    column: 'embedding',
+    dimensions: 3,
+    validity: 'embeddingValidity'
+  });
+  const outputIds = createUint32View(graph, ownedVectors, 'arrow-result-ids', 3);
+  const outputScores = createFloat32View(graph, ownedVectors, 'arrow-result-scores', 3);
+  const resultCounts = createUint32View(graph, ownedVectors, 'arrow-result-counts', 1);
+  const candidateCounts = createUint32View(graph, ownedVectors, 'arrow-candidate-counts', 1);
+
+  new GPUSimilaritySearch({
+    id: 'arrow-fixed-size-list',
+    dataset,
+    queries,
+    outputIds,
+    outputScores,
+    resultCounts,
+    candidateCounts,
+    k: 3
+  }).addToGraph(graph);
+  const compiled = graph.compile();
+  try {
+    const encoder = device.createCommandEncoder({id: 'arrow-fixed-size-list-encoder'});
+    compiled.encode(encoder, {parameters: undefined});
+    device.submit(encoder.finish());
+
+    t.equal(datasetTable.gpuVectors.embedding.format, 'fixed-size-list<float32,4>');
+    t.equal(datasetTable.gpuVectors.embedding.length, 4, 'embedding values remain table rows');
+    t.equal(
+      datasetTable.gpuVectors.embedding.valueLength,
+      16,
+      'physical coordinates remain values'
+    );
+    t.deepEqual(
+      dataset.chunks.map(chunk => chunk.rowCount),
+      [2, 2],
+      'Arrow batches stay distinct'
+    );
+    t.equal(
+      dataset.dimensions,
+      3,
+      'explicit dimensions ignore the nullable fourth padding feature'
+    );
+    t.equal(dataset.chunks[0].rowStride, 4, 'physical Arrow fixed-list cardinality stays intact');
+    t.deepEqual(
+      await readUint32View(ownedVectors, outputIds, 3),
+      [42, 3, 7],
+      'parent-null rows are removed while nullable padding and stable Arrow source IDs are honored'
+    );
+    t.deepEqual(await readFloat32View(ownedVectors, outputScores, 3), [0, 1, 1]);
+    t.deepEqual(await readUint32View(ownedVectors, resultCounts, 1), [3]);
+    t.deepEqual(await readUint32View(ownedVectors, candidateCounts, 1), [3]);
+
+    compiled.destroy();
+    t.ok(
+      datasetTable.batches.every(batch =>
+        Object.values(batch.gpuData).every(data => !data.buffer.destroyed)
+      ),
+      'graph destruction never takes ownership away from the ordinary GPU table'
+    );
+  } finally {
+    compiled.destroy();
+    destroyOwnedVectors(ownedVectors);
+    datasetTable.destroy();
+    queryTable.destroy();
+  }
+  t.end();
+});
+
+test('GPUSimilaritySearch searches 384-, 768-, and 1536-dimensional fixed-size GPU table rows', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  for (const dimensions of [384, 768, 1536]) {
+    const identifier = `high-dimensional-table-${dimensions}`;
+    const format: FixedSizeList<'float32'> = `fixed-size-list<float32,${dimensions}>`;
+    const physicalRowStride = dimensions + 1;
+    const datasetValues = new Float32Array(1 + physicalRowStride + dimensions);
+    datasetValues[0] = 777;
+    datasetValues[1] = 1;
+    datasetValues[1 + physicalRowStride + dimensions - 1] = 1;
+    const queryValues = new Float32Array(dimensions);
+    queryValues[dimensions - 1] = 1;
+    const datasetData = new GPUData<FixedSizeList<'float32'>>({
+      buffer: device.createBuffer({
+        id: `${identifier}-dataset-values`,
+        data: datasetValues,
+        usage: Buffer.STORAGE | Buffer.COPY_DST
+      }),
+      format,
+      length: 2,
+      byteOffset: Float32Array.BYTES_PER_ELEMENT,
+      byteStride: physicalRowStride * Float32Array.BYTES_PER_ELEMENT,
+      ownsBuffer: true
+    });
+    const sourceIds = new GPUData<'uint32'>({
+      buffer: device.createBuffer({
+        id: `${identifier}-source-ids`,
+        data: Uint32Array.from([80, 7]),
+        usage: Buffer.STORAGE | Buffer.COPY_DST
+      }),
+      format: 'uint32',
+      length: 2,
+      ownsBuffer: true
+    });
+    const queryData = new GPUData<FixedSizeList<'float32'>>({
+      buffer: device.createBuffer({
+        id: `${identifier}-query-values`,
+        data: queryValues,
+        usage: Buffer.STORAGE | Buffer.COPY_DST
+      }),
+      format,
+      length: 1,
+      ownsBuffer: true
+    });
+    const datasetTable = new GPUTable({
+      batches: [
+        new GPURecordBatch({
+          gpuData: {embedding: datasetData, sourceIds},
+          sourceInfo: {sourceBatchIndex: 0, sourceRowIndexOffset: 5, sourceRowCount: 2}
+        })
+      ]
+    });
+    const queryTable = new GPUTable({
+      batches: [new GPURecordBatch({gpuData: {embedding: queryData}})]
+    });
+    const graph = new GPUCommandGraph(device, {id: identifier});
+    const ownedVectors: GPUVector[] = [];
+    const dataset = importGPUEmbeddingTable(graph, datasetTable, {
+      id: `${identifier}-dataset`,
+      column: 'embedding',
+      sourceRowIds: 'sourceIds'
+    });
+    const queries = importGPUEmbeddingTable(graph, queryTable, {
+      id: `${identifier}-query`,
+      column: 'embedding'
+    });
+    const outputIds = createUint32View(graph, ownedVectors, `${identifier}-result-ids`, 2);
+    const outputScores = createFloat32View(graph, ownedVectors, `${identifier}-result-scores`, 2);
+    const resultCounts = createUint32View(graph, ownedVectors, `${identifier}-result-counts`, 1);
+    new GPUSimilaritySearch({
+      id: `${identifier}-search`,
+      dataset,
+      queries,
+      outputIds,
+      outputScores,
+      resultCounts,
+      k: 2,
+      tileSize: 1
+    }).addToGraph(graph);
+    const compiled = graph.compile();
+
+    try {
+      const encoder = device.createCommandEncoder({id: `${identifier}-encoder`});
+      compiled.encode(encoder, {parameters: undefined});
+      device.submit(encoder.finish());
+      t.equal(dataset.dimensions, dimensions, `${dimensions} features derive from table schema`);
+      t.equal(dataset.chunks[0].rowStride, dimensions + 1, 'physical row padding is retained');
+      t.equal(dataset.chunks[0].byteOffset, 4, 'table chunk offsets survive graph import');
+      t.equal(
+        dataset.chunks[0].values.length,
+        2 * dimensions + 1,
+        'the final padded row needs only its meaningful payload'
+      );
+      t.equal(dataset.chunks[0].sourceRowOffset, 5, 'record-batch source provenance survives');
+      t.deepEqual(
+        await readUint32View(ownedVectors, outputIds, 2),
+        [7, 80],
+        `${dimensions}-dimensional rows search their original table-owned buffers`
+      );
+      t.deepEqual(await readFloat32View(ownedVectors, outputScores, 2), [0, 2]);
+      t.deepEqual(await readUint32View(ownedVectors, resultCounts, 1), [2]);
+    } finally {
+      compiled.destroy();
+      destroyOwnedVectors(ownedVectors);
+      datasetTable.destroy();
+      queryTable.destroy();
+    }
+  }
+  t.end();
+});
+
+test('importGPUEmbeddingTable rejects sliced nullable Arrow source IDs across preserved batches', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const embeddingType = new arrow.FixedSizeList(
+    2,
+    new arrow.Field('feature', new arrow.Float32(), false)
+  );
+  const slicedSourceIds = arrow.vectorFromArray([900, 11, null], new arrow.Uint32()).slice(1, 3);
+  const firstBatch = new arrow.Table({
+    embedding: arrow.vectorFromArray(
+      [
+        [0, 0],
+        [1, 0]
+      ],
+      embeddingType
+    ),
+    sourceIds: slicedSourceIds
+  }).batches[0];
+  const secondBatch = new arrow.Table({
+    embedding: arrow.vectorFromArray([[2, 0]], embeddingType),
+    sourceIds: arrow.vectorFromArray([22], new arrow.Uint32())
+  }).batches[0];
+  const table = makeGPUTableFromArrowTable(device, new arrow.Table([firstBatch, secondBatch]), {
+    shaderLayout: {
+      attributes: [],
+      bindings: [
+        {name: 'embedding', type: 'read-only-storage', group: 0, location: 0},
+        {name: 'sourceIds', type: 'read-only-storage', group: 0, location: 1}
+      ]
+    },
+    fixedSizeListColumns: ['embedding']
+  });
+  const graph = new GPUCommandGraph(device, {id: 'nullable-arrow-source-row-ids'});
+
+  try {
+    t.equal(table.batches.length, 2, 'the Arrow upload retains both source record batches');
+    t.ok(
+      table.batches[0].gpuData.sourceIds.nullBitmap,
+      'nullable numeric IDs retain generic validity'
+    );
+    t.throws(
+      () =>
+        importGPUEmbeddingTable(graph, table, {
+          column: 'embedding',
+          sourceRowIds: 'sourceIds'
+        }),
+      /source-row IDs must not contain null/,
+      'sliced null IDs never silently collide with a real stable ID of zero'
+    );
+  } finally {
+    table.destroy();
+  }
+  t.end();
+});
+
+test('GPUSimilaritySearch matches independent CPU exact search for every metric', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const sharedFixture = {
+    dimensions: 5,
+    dataset: [
+      {
+        rows: [
+          [1, 2, 3, 0, 0],
+          [-1, 0, 2, 1, 0],
+          [1, 2, 3, 0, 0]
+        ],
+        sourceRowIds: [30, 7, 4]
+      },
+      {
+        rows: [
+          [0, 0, 0, 0, 0],
+          [2, -1, 0.5, 4, 1]
+        ],
+        sourceRowIds: [20, 13]
+      }
+    ],
+    queries: [
+      {
+        rows: [
+          [1, 2, 3, 0, 0],
+          [-2, 1, 0, 0, 2],
+          [0, 0, 0, 0, 0]
+        ]
+      }
+    ],
+    k: 4,
+    candidateCounts: true
+  } satisfies SimilaritySearchFixture;
+
+  for (const metric of ['squared-euclidean', 'inner-product', 'cosine'] as const) {
+    const fixture = {...sharedFixture, metric};
+    const result = await runGPUSimilaritySearch(device, fixture);
+    assertMatchesIndependentCPU(t, fixture, result, `${metric} batched exact search`);
+  }
+
+  t.end();
+});
+
+test('GPUSimilaritySearch preserves chunk boundaries, offsets, padding, validity, and global ties', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 3,
+    dataset: [
+      {
+        rows: [
+          [2, 0, 0],
+          [1, 0, 0]
+        ],
+        prefix: [111, 222],
+        rowStride: 5,
+        sourceRowIds: [19, 80]
+      },
+      {rows: [], rowStride: 3},
+      {
+        rows: [
+          [1, 0, 0],
+          [99, 99, 99],
+          [0, 1, 0]
+        ],
+        rowStride: 4,
+        prefix: [333],
+        sourceRowIds: [4, 2, 11],
+        validity: [1, 0, 1]
+      }
+    ],
+    queries: [
+      {rows: [[1, 0, 0]], rowStride: 4, prefix: [777]},
+      {rows: [], rowStride: 3},
+      {rows: [[0, 1, 0]], rowStride: 5, prefix: [888, 999]}
+    ],
+    k: 4,
+    tileSize: 1,
+    candidateCounts: true
+  };
+  const result = await runGPUSimilaritySearch(device, fixture);
+
+  assertMatchesIndependentCPU(t, fixture, result, 'chunk-preserving globally merged top-K');
+  t.deepEqual(result.sourceRowIds.slice(0, 2), [4, 80], 'cross-shard score ties sort by source ID');
+  t.ok(
+    result.nodeOrder.filter(identifier => identifier.includes('prepare-dataset-tile')).length === 5,
+    'bounded tiles preserve every nonempty source row without materializing a distance matrix'
+  );
+  t.ok(result.importedBuffersSurviveDestruction, 'graph destruction preserves caller-owned chunks');
+  t.end();
+});
+
+test('GPUSimilaritySearch defines zero-vector cosine and rejects invalid, NaN, and Infinity rows', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 3,
+    dataset: [
+      {
+        rows: [
+          [0, 0, 0],
+          [1, 0, 0],
+          [Number.NaN, 1, 0],
+          [Number.POSITIVE_INFINITY, 0, 1],
+          [0, -2, 0]
+        ],
+        sourceRowIds: [10, 4, 3, 2, 7],
+        validity: [1, 1, 1, 1, 1]
+      }
+    ],
+    queries: [
+      {
+        rows: [
+          [0, 0, 0],
+          [1, 0, 0],
+          [Number.NaN, 0, 0],
+          [0, Number.NEGATIVE_INFINITY, 0],
+          [0, 1, 0]
+        ],
+        validity: [1, 1, 1, 1, 0]
+      }
+    ],
+    metric: 'cosine',
+    k: 4,
+    candidateCounts: true
+  };
+  const result = await runGPUSimilaritySearch(device, fixture);
+
+  assertMatchesIndependentCPU(t, fixture, result, 'nonfinite-aware cosine semantics');
+  t.equal(result.sourceRowIds[0], 10, 'two zero vectors are the best cosine match');
+  t.equal(result.scores[0], 1, 'two zero vectors have unit cosine similarity');
+  t.deepEqual(result.resultCounts, [3, 3, 0, 0, 0], 'invalid query rows produce no matches');
+  t.deepEqual(result.candidateCounts, [3, 3, 0, 0, 0], 'invalid query rows report no candidates');
+  t.end();
+});
+
+test('GPUSimilaritySearch retains infinite scores produced by finite Float32 embeddings', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const magnitude = Math.fround(3e38);
+  const innerProduct = await runGPUSimilaritySearch(device, {
+    dimensions: 1,
+    dataset: [{rows: [[magnitude], [1], [-magnitude]], sourceRowIds: [9, 5, 2]}],
+    queries: [{rows: [[magnitude]]}],
+    metric: 'inner-product',
+    k: 3,
+    candidateCounts: true
+  });
+
+  t.deepEqual(
+    innerProduct.sourceRowIds,
+    [9, 5, 2],
+    'positive and negative overflow remain ordered around finite inner products'
+  );
+  t.equal(innerProduct.scores[0], Number.POSITIVE_INFINITY, 'positive overflow remains a result');
+  t.equal(innerProduct.scores[2], Number.NEGATIVE_INFINITY, 'negative overflow remains a result');
+  t.deepEqual(innerProduct.resultCounts, [3], 'all finite embedding rows fill the top-K outputs');
+  t.deepEqual(innerProduct.candidateCounts, [3], 'candidate and result populations stay aligned');
+
+  const squaredDistance = await runGPUSimilaritySearch(device, {
+    dimensions: 1,
+    dataset: [{rows: [[magnitude], [0], [-magnitude]], sourceRowIds: [9, 5, 2]}],
+    queries: [{rows: [[magnitude]]}],
+    metric: 'squared-euclidean',
+    k: 3,
+    candidateCounts: true
+  });
+
+  t.deepEqual(
+    squaredDistance.sourceRowIds,
+    [9, 2, 5],
+    'overflowed squared distances remain deterministic under stable source-ID ties'
+  );
+  t.deepEqual(
+    squaredDistance.scores,
+    [0, Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY],
+    'valid finite rows keep their overflowed Float32 distance values'
+  );
+  t.deepEqual(squaredDistance.resultCounts, [3], 'infinite distances still fill oversized top-K');
+
+  const indeterminateInnerProduct = await runGPUSimilaritySearch(device, {
+    dimensions: 2,
+    dataset: [
+      {
+        rows: [
+          [magnitude, magnitude],
+          [magnitude, 0]
+        ],
+        sourceRowIds: [4, 7]
+      }
+    ],
+    queries: [{rows: [[magnitude, -magnitude]]}],
+    metric: 'inner-product',
+    k: 2,
+    candidateCounts: true
+  });
+
+  t.deepEqual(
+    indeterminateInnerProduct.sourceRowIds,
+    [7, INVALID_SOURCE_ROW_ID],
+    'indeterminate infinity-minus-infinity scores remain excluded'
+  );
+  t.deepEqual(indeterminateInnerProduct.resultCounts, [1], 'only non-NaN scores become results');
+  t.deepEqual(
+    indeterminateInnerProduct.candidateCounts,
+    [2],
+    'candidate counts still describe finite eligible source rows'
+  );
+  t.end();
+});
+
+test('GPUSimilaritySearch preserves finite-magnitude cosine ordering without intermediate overflow', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  for (const magnitude of [1e10, 1e20, 3e38, 1e-20]) {
+    const fixture: SimilaritySearchFixture = {
+      dimensions: 2,
+      dataset: [
+        {
+          rows: [
+            [magnitude, 0],
+            [0, magnitude],
+            [-magnitude, 0]
+          ],
+          sourceRowIds: [9, 2, 4]
+        }
+      ],
+      queries: [{rows: [[magnitude, 0]]}],
+      metric: 'cosine',
+      k: 3,
+      candidateCounts: true
+    };
+    const result = await runGPUSimilaritySearch(device, fixture);
+
+    assertMatchesIndependentCPU(t, fixture, result, `finite ${magnitude}-magnitude cosine search`);
+    t.deepEqual(
+      result.sourceRowIds,
+      [9, 2, 4],
+      `${magnitude}-magnitude aligned, orthogonal, and opposite vectors remain ordered`
+    );
+    for (const [scoreIndex, expectedScore] of [1, 0, -1].entries()) {
+      t.ok(
+        Math.abs(result.scores[scoreIndex] - expectedScore) < 0.000001,
+        `${magnitude}-magnitude cosine ${scoreIndex} stays within Float32 rounding tolerance`
+      );
+    }
+  }
+  t.end();
+});
+
+test('GPUSimilaritySearch applies packed source-aligned GPU masks at sparse source offsets', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const baseFixture = {
+    dimensions: 2,
+    dataset: [
+      {
+        rows: [
+          [0, 0],
+          [1, 0],
+          [2, 0],
+          [3, 0]
+        ],
+        sourceRowOffset: 5,
+        sourceRowIds: [90, 40, 70, 20]
+      }
+    ],
+    queries: [{rows: [[0.5, 0]]}],
+    k: 5,
+    candidateCounts: true
+  } satisfies SimilaritySearchFixture;
+
+  for (const filterMask of [
+    [0, 0, 0, 0, 0, 1, 1, 1, 1],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 1, 0, 1],
+    [0, 0, 0, 0, 0, 1, 1, 1, 0]
+  ]) {
+    const fixture = {...baseFixture, filterMask};
+    const result = await runGPUSimilaritySearch(device, fixture);
+    assertMatchesIndependentCPU(
+      t,
+      fixture,
+      result,
+      `packed filter ${filterMask.slice(5).join('')}`
+    );
+  }
+
+  t.end();
+});
+
+test('GPUSimilaritySearch accepts LuxFilter-compatible chunk-preserving selection masks', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 2,
+    dataset: [
+      {
+        rows: [
+          [0, 0],
+          [1, 0]
+        ],
+        sourceRowIds: [80, 7]
+      },
+      {rows: [], sourceRowIds: []},
+      {
+        rows: [
+          [2, 0],
+          [3, 0],
+          [4, 0]
+        ],
+        sourceRowIds: [2, 50, 11]
+      }
+    ],
+    queries: [
+      {
+        rows: [
+          [2.1, 0],
+          [0, 0]
+        ]
+      }
+    ],
+    chunkedFilterMask: [[0, 1], [], [1, 0, 1]],
+    k: 4,
+    tileSize: 2,
+    candidateCounts: true
+  };
+  const result = await runGPUSimilaritySearch(device, fixture);
+
+  assertMatchesIndependentCPU(t, fixture, result, 'LuxFilter-compatible chunked GPU masks');
+  t.deepEqual(result.candidateCounts, [3, 3], 'sparse chunk masks expose exact eligible counts');
+  t.end();
+});
+
+test('GPUSimilaritySearch combines query-specific GPU masks and stable candidate-ID allowlists', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 2,
+    dataset: [
+      {
+        rows: [
+          [0, 0],
+          [1, 0]
+        ],
+        sourceRowOffset: 2,
+        sourceRowIds: [90, 20]
+      },
+      {
+        rows: [
+          [2, 0],
+          [3, 0]
+        ],
+        sourceRowOffset: 4,
+        sourceRowIds: [70, 10]
+      }
+    ],
+    queries: [
+      {
+        rows: [
+          [0, 0],
+          [3, 0]
+        ]
+      }
+    ],
+    queryFilterMask: [0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 1],
+    candidateIds: [90, 70, 10],
+    k: 4,
+    tileSize: 1,
+    candidateCounts: true
+  };
+  const result = await runGPUSimilaritySearch(device, fixture);
+
+  assertMatchesIndependentCPU(t, fixture, result, 'per-query masks with stable-ID allowlists');
+  t.deepEqual(
+    result.candidateCounts,
+    [2, 2],
+    'candidate counts include every combined restriction'
+  );
+  t.end();
+});
+
+test('GPUSimilaritySearch indexes substantial stable candidate-ID allowlists on the GPU', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const rows = Array.from({length: 64}, (_, rowIndex) => [rowIndex, rowIndex % 5]);
+  const sourceRowIds = rows.map((_, rowIndex) => 4000 + rowIndex * 17);
+  const selectedIds = sourceRowIds.filter((_, rowIndex) => rowIndex % 3 === 0);
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 2,
+    dataset: [{rows, sourceRowIds}],
+    queries: [
+      {
+        rows: [
+          [20.25, 1],
+          [61, 0]
+        ]
+      }
+    ],
+    candidateIds: [...selectedIds, selectedIds[2], selectedIds[6]],
+    k: 6,
+    tileSize: 7,
+    candidateCounts: true
+  };
+  const result = await runGPUSimilaritySearch(device, fixture);
+
+  assertMatchesIndependentCPU(t, fixture, result, 'hashed stable candidate-ID membership');
+  t.ok(
+    result.nodeOrder.some(nodeId => nodeId.includes('-candidate-index-build')),
+    'substantial allowlists build bounded GPU membership instead of repeated linear scans'
+  );
+  t.deepEqual(
+    result.candidateCounts,
+    [selectedIds.length, selectedIds.length],
+    'duplicate requested IDs do not duplicate eligible dataset rows'
+  );
+  t.end();
+});
+
+test('GPUSimilaritySearch preserves every allowlisted ID when bounded GPU hash insertion overflows', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const sourceRowIds = Array.from({length: 24}, (_, rowIndex) => 7000 + rowIndex * 13);
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 2,
+    dataset: [{rows: sourceRowIds.map((_, rowIndex) => [rowIndex, rowIndex % 3]), sourceRowIds}],
+    queries: [{rows: [[12, 0]]}],
+    candidateIds: sourceRowIds,
+    candidateCounts: true,
+    k: 6
+  };
+  const originalAddToGraph = GPUHashIndex.prototype.addToGraph;
+  GPUHashIndex.prototype.addToGraph = function <Parameters>(graph: GPUCommandGraph<Parameters>) {
+    originalAddToGraph.call(this, graph);
+    const index = this;
+    const identifier = `${index.id}-simulate-candidate-overflow`;
+    const source = /* wgsl */ `
+@group(0) @binding(0) var<storage, read_write> tableKeys: array<u32>;
+@group(0) @binding(1) var<storage, read_write> statistics: array<u32>;
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) globalInvocationId: vec3u) {
+  let slot = globalInvocationId.x;
+  if (slot < ${index.tableKeys.length}u) {
+    tableKeys[${getViewElementOffset(index.tableKeys)}u + slot] = 0xffffffffu;
+  }
+  if (slot == 0u) {
+    statistics[${getViewElementOffset(index.statistics)}u + 2u] = 1u;
+  }
+}`;
+    graph.addComputePass({
+      id: identifier,
+      resources: [
+        {buffer: index.tableKeys, usage: 'storage-read-write'},
+        {buffer: index.statistics, usage: 'storage-read-write'}
+      ],
+      compile: ({device: graphDevice}) => {
+        const computation = new Computation(graphDevice, {
+          id: identifier,
+          source,
+          shaderLayout: {
+            bindings: [
+              {name: 'tableKeys', type: 'storage', group: 0, location: 0},
+              {name: 'statistics', type: 'storage', group: 0, location: 1}
+            ]
+          }
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            computation.setBindings({
+              tableKeys: getViewBinding(index.tableKeys, getBuffer),
+              statistics: getViewBinding(index.statistics, getBuffer)
+            });
+            computation.dispatch(computePass, Math.ceil(index.tableKeys.length / 64), 1, 1);
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+  };
+
+  try {
+    const result = await runGPUSimilaritySearch(device, fixture);
+    assertMatchesIndependentCPU(t, fixture, result, 'overflowed GPU candidate index fallback');
+    t.ok(
+      result.nodeOrder.some(nodeId => nodeId.includes('-simulate-candidate-overflow')),
+      'the real GPU build reports overflow after every hash-table key is removed'
+    );
+    t.deepEqual(result.candidateCounts, [sourceRowIds.length], 'no allowlisted row disappears');
+  } finally {
+    GPUHashIndex.prototype.addToGraph = originalAddToGraph;
+  }
+  t.end();
+});
+
+test('GPUSimilaritySearch excludes query source IDs without conflating row position and identity', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 2,
+    dataset: [
+      {
+        rows: [
+          [0, 0],
+          [1, 0]
+        ],
+        sourceRowIds: [40, 8]
+      },
+      {
+        rows: [
+          [2, 0],
+          [3, 0]
+        ],
+        sourceRowIds: [20, 2]
+      }
+    ],
+    queries: [
+      {
+        rows: [
+          [1, 0],
+          [3, 0]
+        ],
+        sourceRowIds: [8, 2]
+      }
+    ],
+    k: 4,
+    excludeSelf: true,
+    candidateCounts: true,
+    tileSize: 1
+  };
+  const result = await runGPUSimilaritySearch(device, fixture);
+
+  assertMatchesIndependentCPU(t, fixture, result, 'explicit stable-ID self exclusion');
+  t.deepEqual(result.candidateCounts, [3, 3], 'self-exclusion reduces eligible candidate counts');
+  t.notOk(
+    result.sourceRowIds.slice(0, 4).includes(8),
+    'the first query excludes its own source ID'
+  );
+  t.notOk(
+    result.sourceRowIds.slice(4, 8).includes(2),
+    'the second query excludes its own source ID'
+  );
+  t.end();
+});
+
+test('GPUSimilaritySearch handles zero K, oversized K, empty datasets, and zero query rows', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const edgeFixtures: SimilaritySearchFixture[] = [
+    {
+      dimensions: 2,
+      dataset: [
+        {
+          rows: [
+            [1, 0],
+            [2, 0]
+          ]
+        }
+      ],
+      queries: [
+        {
+          rows: [
+            [0, 0],
+            [3, 0]
+          ]
+        }
+      ],
+      k: 0,
+      candidateCounts: true
+    },
+    {
+      dimensions: 2,
+      dataset: [
+        {
+          rows: [
+            [1, 0],
+            [2, 0]
+          ]
+        }
+      ],
+      queries: [{rows: [[0, 0]]}],
+      k: 5,
+      candidateCounts: true
+    },
+    {
+      dimensions: 2,
+      dataset: [{rows: []}, {rows: []}],
+      queries: [
+        {
+          rows: [
+            [0, 0],
+            [1, 1]
+          ]
+        }
+      ],
+      k: 3,
+      candidateCounts: true
+    },
+    {
+      dimensions: 2,
+      dataset: [{rows: [[1, 0]]}],
+      queries: [{rows: []}],
+      k: 3,
+      candidateCounts: true
+    }
+  ];
+
+  for (const [fixtureIndex, fixture] of edgeFixtures.entries()) {
+    const result = await runGPUSimilaritySearch(device, fixture);
+    assertMatchesIndependentCPU(t, fixture, result, `empty-result edge case ${fixtureIndex}`);
+  }
+
+  t.end();
+});
+
+test('GPUSimilaritySearch globally merges bounded shards with exact stable ordering', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const rows = Array.from({length: 41}, (_, rowIndex) => [
+    ((rowIndex * 17) % 23) - 11,
+    ((rowIndex * 13) % 19) - 9,
+    rowIndex % 3
+  ]);
+  const sourceRowIds = Array.from({length: rows.length}, (_, rowIndex) => rows.length - rowIndex);
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 3,
+    dataset: [
+      {rows: rows.slice(0, 8), sourceRowIds: sourceRowIds.slice(0, 8)},
+      {rows: []},
+      {rows: rows.slice(8, 27), rowStride: 5, sourceRowIds: sourceRowIds.slice(8, 27)},
+      {rows: rows.slice(27), sourceRowIds: sourceRowIds.slice(27)}
+    ],
+    queries: [
+      {
+        rows: [
+          [0, 0, 0],
+          [4, -2, 1]
+        ]
+      },
+      {
+        rows: [
+          [-7, 3, 2],
+          [11, 8, 0]
+        ]
+      }
+    ],
+    k: 7,
+    tileSize: 3,
+    candidateCounts: true
+  };
+  const result = await runGPUSimilaritySearch(device, fixture);
+
+  assertMatchesIndependentCPU(t, fixture, result, 'globally merged bounded shard selection');
+  t.ok(
+    result.nodeOrder.filter(identifier => identifier.includes('prepare-dataset-tile')).length >= 14,
+    'small tile limits produce independent bounded candidate passes'
+  );
+  t.equal(result.candidateCounts?.[0], 41, 'global candidate counts include every source chunk');
+  t.end();
+});
+
+test('GPUSimilaritySearch shards physical bindings while preserving padded rows and exact results', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 3,
+    dataset: [
+      {
+        rows: Array.from({length: 57}, (_, rowIndex) => [
+          rowIndex % 13,
+          (rowIndex * 3) % 17,
+          rowIndex % 5
+        ]),
+        prefix: new Array(63).fill(-99),
+        rowStride: 5
+      }
+    ],
+    queries: [
+      {
+        rows: [
+          [1, 2, 3],
+          [8, 4, 1],
+          [0, 0, 0]
+        ]
+      }
+    ],
+    k: 5,
+    candidateCounts: true
+  };
+
+  const result = await withReducedDeviceLimits(device, {maxStorageBufferBindingSize: 512}, () =>
+    runGPUSimilaritySearch(device, fixture)
+  );
+  assertMatchesIndependentCPU(t, fixture, result, 'storage-binding-aware physical sharding');
+  t.ok(
+    result.nodeOrder.filter(identifier => identifier.includes('prepare-dataset-tile')).length > 1,
+    'artificially small storage bindings force exact multi-pass sharding'
+  );
+  t.end();
+});
+
+test('GPUSimilaritySearch uses bounded multidimensional dispatch for query batches', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 2,
+    dataset: [
+      {
+        rows: [
+          [0, 0],
+          [1, 0],
+          [2, 0],
+          [3, 0]
+        ]
+      }
+    ],
+    queries: [
+      {
+        rows: Array.from({length: 257}, (_, rowIndex) => [rowIndex % 4, 0])
+      }
+    ],
+    k: 2,
+    candidateCounts: true
+  };
+  const result = await withReducedDeviceLimits(device, {maxComputeWorkgroupsPerDimension: 2}, () =>
+    runGPUSimilaritySearch(device, fixture)
+  );
+
+  assertMatchesIndependentCPU(t, fixture, result, 'bounded multidimensional query dispatch');
+  t.equal(result.resultCounts.length, 257, 'every query survives the artificial dispatch limit');
+  t.end();
+});
+
+test('GPUSimilaritySearch reuses compiled graphs for dynamic GPU selections and buffer overrides', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const identifier = `similarity-repeat-${fixtureSequence++}`;
+  const graph = new GPUCommandGraph(device, {id: identifier});
+  const ownedVectors: GPUVector[] = [];
+  const dataset = createEmbeddingVector(
+    device,
+    `${identifier}-dataset`,
+    2,
+    [
+      {
+        rows: [
+          [0, 0],
+          [2, 0]
+        ],
+        sourceRowIds: [50, 3]
+      }
+    ],
+    ownedVectors
+  );
+  const queries = createEmbeddingVector(
+    device,
+    `${identifier}-queries`,
+    2,
+    [{rows: [[0, 0]], sourceRowIds: [90]}],
+    ownedVectors
+  );
+  const importedDataset = importEmbeddingFixture(graph, dataset, `${identifier}-dataset`);
+  const importedQueries = importEmbeddingFixture(graph, queries, `${identifier}-queries`);
+  const outputIds = createUint32View(graph, ownedVectors, `${identifier}-output-ids`, 2);
+  const outputScores = createFloat32View(graph, ownedVectors, `${identifier}-output-scores`, 2);
+  const resultCounts = createUint32View(graph, ownedVectors, `${identifier}-result-counts`, 1);
+  const candidateCounts = createUint32View(
+    graph,
+    ownedVectors,
+    `${identifier}-candidate-counts`,
+    1
+  );
+  const filterMask = createUint32View(
+    graph,
+    ownedVectors,
+    `${identifier}-filter-mask`,
+    2,
+    new Uint32Array([1, 0])
+  );
+  const search = new GPUSimilaritySearch({
+    id: identifier,
+    dataset: importedDataset,
+    queries: importedQueries,
+    outputIds,
+    outputScores,
+    resultCounts,
+    candidateCounts,
+    filterMask,
+    k: 2
+  });
+  search.addToGraph(graph);
+  const compiled = graph.compile();
+  const replacementQuery = device.createBuffer({
+    id: `${identifier}-replacement-query`,
+    data: new Float32Array([2, 0]),
+    usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+
+  try {
+    const firstEncoder = device.createCommandEncoder({id: `${identifier}-first-encoder`});
+    compiled.encode(firstEncoder, {parameters: undefined});
+    device.submit(firstEncoder.finish());
+    t.deepEqual(
+      await readUint32View(ownedVectors, outputIds, 2),
+      [50, INVALID_SOURCE_ROW_ID],
+      'the first graph encoding consumes the current source selection'
+    );
+    t.deepEqual(await readUint32View(ownedVectors, candidateCounts, 1), [1]);
+
+    const selectionVector = ownedVectors.find(vector => vector.name === filterMask.buffer.id);
+    selectionVector!.data[0].buffer.write(new Uint32Array([0, 1]));
+    const secondEncoder = device.createCommandEncoder({id: `${identifier}-second-encoder`});
+    compiled.encode(secondEncoder, {parameters: undefined});
+    device.submit(secondEncoder.finish());
+    t.deepEqual(
+      await readUint32View(ownedVectors, outputIds, 2),
+      [3, INVALID_SOURCE_ROW_ID],
+      'dynamic GPU selection changes are observed without graph recompilation'
+    );
+    t.deepEqual(
+      await readUint32View(ownedVectors, candidateCounts, 1),
+      [1],
+      'repeated graph encodings reset candidate counts instead of accumulating stale results'
+    );
+
+    selectionVector!.data[0].buffer.write(new Uint32Array([1, 1]));
+    const thirdEncoder = device.createCommandEncoder({id: `${identifier}-third-encoder`});
+    compiled.encode(thirdEncoder, {
+      parameters: undefined,
+      buffers: {[`${identifier}-queries-chunk-0-values`]: replacementQuery}
+    });
+    device.submit(thirdEncoder.finish());
+    t.deepEqual(
+      await readUint32View(ownedVectors, outputIds, 2),
+      [3, 50],
+      'encoded buffer overrides replace query values without recompilation'
+    );
+    t.deepEqual(await readUint32View(ownedVectors, resultCounts, 1), [2]);
+    t.deepEqual(await readUint32View(ownedVectors, candidateCounts, 1), [2]);
+
+    compiled.destroy();
+    t.ok(
+      ownedVectors.every(vector => vector.data.every(chunk => !chunk.buffer.destroyed)),
+      'compiled graph destruction never claims original caller-owned buffers'
+    );
+    t.notOk(replacementQuery.destroyed, 'compiled graph destruction never claims override buffers');
+  } finally {
+    compiled.destroy();
+    replacementQuery.destroy();
+    destroyOwnedVectors(ownedVectors);
+  }
+
+  t.end();
+});
+
+function finishWithoutWebGPU(testContext: Test): void {
+  testContext.comment('WebGPU is not available');
+  testContext.end();
+}
+
+function getCPUFixtureRows(
+  chunks: readonly EmbeddingChunkFixture[],
+  dimensions: number
+): CPUSourceEmbeddingRow[] {
+  const rows: CPUSourceEmbeddingRow[] = [];
+  let nextSourceRowOffset = 0;
+  for (const [chunkIndex, chunk] of chunks.entries()) {
+    const sourceRowOffset = chunk.sourceRowOffset ?? nextSourceRowOffset;
+    for (const [chunkRowIndex, row] of chunk.rows.entries()) {
+      rows.push({
+        values: Array.from(Float32Array.from(row.slice(0, dimensions))),
+        sourceRowId: chunk.sourceRowIds?.[chunkRowIndex] ?? sourceRowOffset + chunkRowIndex,
+        sourceRowPosition: sourceRowOffset + chunkRowIndex,
+        valid: chunk.validity?.[chunkRowIndex] !== 0,
+        chunkIndex,
+        chunkRowIndex
+      });
+    }
+    nextSourceRowOffset = sourceRowOffset + chunk.rows.length;
+  }
+  return rows;
+}
+
+function getIndependentCPUSimilarityResults(
+  fixture: SimilaritySearchFixture,
+  dataset: readonly CPUSourceEmbeddingRow[],
+  queries: readonly CPUSourceEmbeddingRow[]
+): CPUSimilarityResult {
+  const metric = fixture.metric ?? 'squared-euclidean';
+  const sourceSpan = dataset.reduce(
+    (maximum, candidate) => Math.max(maximum, candidate.sourceRowPosition + 1),
+    0
+  );
+  const sourceRowIds: number[] = [];
+  const scores: number[] = [];
+  const resultCounts: number[] = [];
+  const candidateCounts: number[] = [];
+  const candidateIdSet = fixture.candidateIds ? new Set(fixture.candidateIds) : undefined;
+
+  for (const [queryIndex, query] of queries.entries()) {
+    const matches: {sourceRowId: number; score: number}[] = [];
+    let eligibleCount = 0;
+    const queryIsValid =
+      query.valid &&
+      query.sourceRowId !== INVALID_SOURCE_ROW_ID &&
+      query.values.every(value => Number.isFinite(value));
+
+    if (queryIsValid) {
+      for (const candidate of dataset) {
+        const sourceMaskSelected = fixture.filterMask
+          ? fixture.filterMask[candidate.sourceRowPosition] !== 0
+          : true;
+        const chunkMaskSelected = fixture.chunkedFilterMask
+          ? fixture.chunkedFilterMask[candidate.chunkIndex][candidate.chunkRowIndex] !== 0
+          : true;
+        const queryMaskSelected = fixture.queryFilterMask
+          ? fixture.queryFilterMask[queryIndex * sourceSpan + candidate.sourceRowPosition] !== 0
+          : true;
+        const allowedCandidate = candidateIdSet ? candidateIdSet.has(candidate.sourceRowId) : true;
+        if (
+          !candidate.valid ||
+          candidate.sourceRowId === INVALID_SOURCE_ROW_ID ||
+          !candidate.values.every(value => Number.isFinite(value)) ||
+          !sourceMaskSelected ||
+          !chunkMaskSelected ||
+          !queryMaskSelected ||
+          !allowedCandidate ||
+          (fixture.excludeSelf && candidate.sourceRowId === query.sourceRowId)
+        ) {
+          continue;
+        }
+
+        eligibleCount++;
+        const score = calculateIndependentCPUScore(metric, query.values, candidate.values);
+        if (Number.isFinite(score)) {
+          matches.push({sourceRowId: candidate.sourceRowId, score});
+        }
+      }
+    }
+
+    matches.sort((first, second) => {
+      const scoreOrder =
+        metric === 'squared-euclidean' ? first.score - second.score : second.score - first.score;
+      return scoreOrder || first.sourceRowId - second.sourceRowId;
+    });
+    const selected = matches.slice(0, fixture.k);
+    resultCounts.push(selected.length);
+    candidateCounts.push(eligibleCount);
+    for (let resultIndex = 0; resultIndex < fixture.k; resultIndex++) {
+      sourceRowIds.push(selected[resultIndex]?.sourceRowId ?? INVALID_SOURCE_ROW_ID);
+      scores.push(
+        selected[resultIndex]?.score ??
+          (metric === 'squared-euclidean' ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY)
+      );
+    }
+  }
+
+  return {sourceRowIds, scores, resultCounts, candidateCounts};
+}
+
+function calculateIndependentCPUScore(
+  metric: GPUEmbeddingMetric,
+  query: readonly number[],
+  candidate: readonly number[]
+): number {
+  let dotProduct = 0;
+  let queryNorm = 0;
+  let candidateNorm = 0;
+  let squaredDistance = 0;
+  for (let dimensionIndex = 0; dimensionIndex < query.length; dimensionIndex++) {
+    const queryValue = query[dimensionIndex];
+    const candidateValue = candidate[dimensionIndex];
+    const difference = queryValue - candidateValue;
+    squaredDistance += difference * difference;
+    dotProduct += queryValue * candidateValue;
+    queryNorm += queryValue * queryValue;
+    candidateNorm += candidateValue * candidateValue;
+  }
+  if (metric === 'squared-euclidean') return squaredDistance;
+  if (metric === 'inner-product') return dotProduct;
+  if (queryNorm === 0 && candidateNorm === 0) return 1;
+  if (queryNorm === 0 || candidateNorm === 0) return 0;
+  return dotProduct / Math.sqrt(queryNorm * candidateNorm);
+}
+
+function assertMatchesIndependentCPU(
+  testContext: Test,
+  fixture: SimilaritySearchFixture,
+  result: SearchExecution,
+  message: string
+): void {
+  const expected = getIndependentCPUSimilarityResults(
+    fixture,
+    getCPUFixtureRows(fixture.dataset, fixture.dimensions),
+    getCPUFixtureRows(fixture.queries, fixture.dimensions)
+  );
+  testContext.deepEqual(result.sourceRowIds, expected.sourceRowIds, `${message}: source IDs`);
+  testContext.deepEqual(result.resultCounts, expected.resultCounts, `${message}: result counts`);
+  if (fixture.candidateCounts) {
+    testContext.deepEqual(
+      result.candidateCounts,
+      expected.candidateCounts,
+      `${message}: candidate counts`
+    );
+  }
+  testContext.equal(result.scores.length, expected.scores.length, `${message}: score count`);
+  for (const [scoreIndex, score] of result.scores.entries()) {
+    const expectedScore = expected.scores[scoreIndex];
+    const matches = Number.isFinite(expectedScore)
+      ? Math.abs(score - expectedScore) <= 0.00005 * Math.max(1, Math.abs(expectedScore))
+      : Object.is(score, expectedScore);
+    testContext.ok(
+      matches,
+      `${message}: score ${scoreIndex} equals ${expectedScore} (got ${score})`
+    );
+  }
+}
+
+async function runGPUSimilaritySearch(
+  device: Device,
+  fixture: SimilaritySearchFixture
+): Promise<SearchExecution> {
+  const identifier = `similarity-fixture-${fixtureSequence++}`;
+  const graph = new GPUCommandGraph(device, {id: identifier});
+  const ownedVectors: GPUVector[] = [];
+  const dataset = createEmbeddingVector(
+    device,
+    `${identifier}-dataset`,
+    fixture.dimensions,
+    fixture.dataset,
+    ownedVectors
+  );
+  const queries = createEmbeddingVector(
+    device,
+    `${identifier}-queries`,
+    fixture.dimensions,
+    fixture.queries,
+    ownedVectors
+  );
+  const importedDataset = importEmbeddingFixture(graph, dataset, `${identifier}-dataset`);
+  const importedQueries = importEmbeddingFixture(graph, queries, `${identifier}-queries`);
+  const outputLength = queries.vector.length * fixture.k;
+  const outputIds = createUint32View(graph, ownedVectors, `${identifier}-output-ids`, outputLength);
+  const outputScores = createFloat32View(
+    graph,
+    ownedVectors,
+    `${identifier}-output-scores`,
+    outputLength
+  );
+  const resultCounts = createUint32View(
+    graph,
+    ownedVectors,
+    `${identifier}-result-counts`,
+    queries.vector.length
+  );
+  const candidateCounts = fixture.candidateCounts
+    ? createUint32View(graph, ownedVectors, `${identifier}-candidate-counts`, queries.vector.length)
+    : undefined;
+  const filterMask = fixture.filterMask
+    ? createUint32View(
+        graph,
+        ownedVectors,
+        `${identifier}-filter-mask`,
+        fixture.filterMask.length,
+        Uint32Array.from(fixture.filterMask)
+      )
+    : fixture.chunkedFilterMask
+      ? createChunkedFilterMask(
+          graph,
+          ownedVectors,
+          `${identifier}-filter-mask`,
+          fixture.chunkedFilterMask
+        )
+      : undefined;
+  const queryFilterMask = fixture.queryFilterMask
+    ? createUint32View(
+        graph,
+        ownedVectors,
+        `${identifier}-query-filter-mask`,
+        fixture.queryFilterMask.length,
+        Uint32Array.from(fixture.queryFilterMask)
+      )
+    : undefined;
+  const candidateIds = fixture.candidateIds
+    ? createUint32View(
+        graph,
+        ownedVectors,
+        `${identifier}-candidate-ids`,
+        fixture.candidateIds.length,
+        Uint32Array.from(fixture.candidateIds)
+      )
+    : undefined;
+
+  const search = new GPUSimilaritySearch({
+    id: identifier,
+    dataset: importedDataset,
+    queries: importedQueries,
+    outputIds,
+    outputScores,
+    resultCounts,
+    ...(candidateCounts ? {candidateCounts} : {}),
+    ...(filterMask ? {filterMask} : {}),
+    ...(queryFilterMask ? {queryFilterMask} : {}),
+    ...(candidateIds ? {candidateIds} : {}),
+    ...(fixture.metric ? {metric: fixture.metric} : {}),
+    ...(fixture.tileSize ? {tileSize: fixture.tileSize} : {}),
+    excludeSelf: fixture.excludeSelf,
+    k: fixture.k
+  });
+  search.addToGraph(graph);
+  const compiled = graph.compile();
+  let importedBuffersSurviveDestruction = false;
+
+  try {
+    const encoder = device.createCommandEncoder({id: `${identifier}-encoder`});
+    compiled.encode(encoder, {parameters: undefined});
+    device.submit(encoder.finish());
+
+    const [sourceRowIds, scores, actualResultCounts, actualCandidateCounts] = await Promise.all([
+      readUint32View(ownedVectors, outputIds, outputLength),
+      readFloat32View(ownedVectors, outputScores, outputLength),
+      readUint32View(ownedVectors, resultCounts, queries.vector.length),
+      candidateCounts
+        ? readUint32View(ownedVectors, candidateCounts, queries.vector.length)
+        : Promise.resolve(undefined)
+    ]);
+    const nodeOrder = compiled.stats.nodeOrder.slice();
+    const logicalTransientCount = compiled.stats.logicalTransientBufferCount;
+    const physicalTransientCount = compiled.stats.physicalTransientBufferCount;
+
+    compiled.destroy();
+    importedBuffersSurviveDestruction = ownedVectors.every(vector =>
+      vector.data.every(chunk => !chunk.buffer.destroyed)
+    );
+    return {
+      sourceRowIds,
+      scores,
+      resultCounts: actualResultCounts,
+      ...(actualCandidateCounts ? {candidateCounts: actualCandidateCounts} : {}),
+      nodeOrder,
+      logicalTransientCount,
+      physicalTransientCount,
+      importedBuffersSurviveDestruction
+    };
+  } finally {
+    compiled.destroy();
+    destroyOwnedVectors(ownedVectors);
+  }
+}
+
+function createEmbeddingVector(
+  device: Device,
+  identifier: string,
+  dimensions: number,
+  chunks: readonly EmbeddingChunkFixture[],
+  ownedVectors: GPUVector[]
+): GPUEmbeddingVectorFixture {
+  const rows = getCPUFixtureRows(chunks, dimensions);
+  const format: FixedSizeList<'float32'> = `fixed-size-list<float32,${dimensions}>`;
+  const hasSourceRowIds = chunks.some(chunk => chunk.sourceRowIds !== undefined);
+  const hasValidity = chunks.some(chunk => chunk.validity !== undefined);
+  const valuesData: GPUData<FixedSizeList<'float32'>>[] = [];
+  const sourceRowIdsData: GPUData<'uint32'>[] = [];
+  const validityData: GPUData<'uint32'>[] = [];
+  const sourceRowOffsets: number[] = [];
+  let nextSourceRowOffset = 0;
+  for (const [chunkIndex, chunk] of chunks.entries()) {
+    const rowStride = chunk.rowStride ?? dimensions;
+    const prefix = chunk.prefix ?? [];
+    const sourceRowOffset = chunk.sourceRowOffset ?? nextSourceRowOffset;
+    const flattenedValues = new Float32Array(prefix.length + chunk.rows.length * rowStride);
+    flattenedValues.set(prefix, 0);
+    for (const [rowIndex, row] of chunk.rows.entries()) {
+      flattenedValues.set(row.slice(0, dimensions), prefix.length + rowIndex * rowStride);
+      for (let paddingIndex = dimensions; paddingIndex < rowStride; paddingIndex++) {
+        flattenedValues[prefix.length + rowIndex * rowStride + paddingIndex] = -12345;
+      }
+    }
+    const storage = flattenedValues.length > 0 ? flattenedValues : new Float32Array(1);
+    const byteOffset = prefix.length * Float32Array.BYTES_PER_ELEMENT;
+    const valueBuffer = device.createBuffer({
+      id: `${identifier}-${chunkIndex}-values`,
+      data: storage,
+      usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC
+    });
+    const valueData = new GPUData<FixedSizeList<'float32'>>({
+      buffer: valueBuffer,
+      format,
+      length: chunk.rows.length,
+      byteStride: rowStride * Float32Array.BYTES_PER_ELEMENT,
+      rowByteLength: dimensions * Float32Array.BYTES_PER_ELEMENT,
+      byteOffset,
+      ownsBuffer: true
+    });
+    valuesData.push(valueData);
+    sourceRowOffsets.push(sourceRowOffset);
+    if (hasSourceRowIds) {
+      const sourceIds =
+        chunk.sourceRowIds ??
+        Array.from({length: chunk.rows.length}, (_, rowIndex) => sourceRowOffset + rowIndex);
+      sourceRowIdsData.push(
+        createOwnedUint32Vector(
+          device,
+          ownedVectors,
+          `${identifier}-${chunkIndex}-source-row-ids`,
+          Uint32Array.from(sourceIds)
+        ).data[0]
+      );
+    }
+    if (hasValidity) {
+      const validityFlags = chunk.validity ?? Array.from({length: chunk.rows.length}, () => 1);
+      validityData.push(
+        createOwnedUint32Vector(
+          device,
+          ownedVectors,
+          `${identifier}-${chunkIndex}-validity`,
+          Uint32Array.from(validityFlags)
+        ).data[0]
+      );
+    }
+    nextSourceRowOffset = sourceRowOffset + chunk.rows.length;
+  }
+  const vector = new GPUVector<FixedSizeList<'float32'>>({
+    type: 'data',
+    name: `${identifier}-values`,
+    format,
+    data: valuesData,
+    ownsData: true
+  });
+  ownedVectors.push(vector);
+  const sourceRowIds = hasSourceRowIds
+    ? new GPUVector({
+        type: 'data',
+        name: `${identifier}-source-row-ids`,
+        format: 'uint32',
+        data: sourceRowIdsData
+      })
+    : undefined;
+  const validity = hasValidity
+    ? new GPUVector({
+        type: 'data',
+        name: `${identifier}-validity`,
+        format: 'uint32',
+        data: validityData
+      })
+    : undefined;
+  return {
+    vector,
+    ...(sourceRowIds ? {sourceRowIds} : {}),
+    ...(validity ? {validity} : {}),
+    sourceRowOffsets,
+    rows
+  };
+}
+
+function importEmbeddingFixture(
+  graph: GPUCommandGraph,
+  fixture: GPUEmbeddingVectorFixture,
+  identifier: string
+): GraphEmbeddingMatrix {
+  return importGPUEmbeddingVector(graph, fixture.vector, {
+    id: identifier,
+    sourceRowOffsets: fixture.sourceRowOffsets,
+    ...(fixture.sourceRowIds ? {sourceRowIds: fixture.sourceRowIds} : {}),
+    ...(fixture.validity ? {validity: fixture.validity} : {})
+  });
+}
+
+function createOwnedUint32Vector(
+  device: Device,
+  ownedVectors: GPUVector[],
+  identifier: string,
+  values: Uint32Array
+): GPUVector<'uint32'> {
+  const buffer = device.createBuffer({
+    id: identifier,
+    data: values.length > 0 ? values : new Uint32Array(1),
+    usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC
+  });
+  const vector = new GPUVector({
+    type: 'buffer',
+    name: identifier,
+    buffer,
+    format: 'uint32',
+    length: values.length,
+    ownsBuffer: true
+  });
+  ownedVectors.push(vector);
+  return vector;
+}
+
+function createUint32View(
+  graph: GPUCommandGraph,
+  ownedVectors: GPUVector[],
+  identifier: string,
+  length: number,
+  values: Uint32Array = new Uint32Array(length)
+): GraphDataView<'uint32'> {
+  const vector = createOwnedUint32Vector(graph.device, ownedVectors, identifier, values);
+  return graph.importGPUData(identifier, vector.data[0]);
+}
+
+function createFloat32View(
+  graph: GPUCommandGraph,
+  ownedVectors: GPUVector[],
+  identifier: string,
+  length: number
+): GraphDataView<'float32'> {
+  const buffer = graph.device.createBuffer({
+    id: identifier,
+    byteLength: Math.max(length, 1) * Float32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+  const vector = new GPUVector({
+    type: 'buffer',
+    name: identifier,
+    buffer,
+    format: 'float32',
+    length,
+    ownsBuffer: true
+  });
+  ownedVectors.push(vector);
+  return graph.importGPUData(identifier, vector.data[0]);
+}
+
+function createChunkedFilterMask(
+  graph: GPUCommandGraph,
+  ownedVectors: GPUVector[],
+  identifier: string,
+  chunks: readonly (readonly number[])[]
+): GraphVectorView<'uint32'> {
+  const data = chunks.map((chunk, chunkIndex) => {
+    const vector = createOwnedUint32Vector(
+      graph.device,
+      ownedVectors,
+      `${identifier}-${chunkIndex}`,
+      Uint32Array.from(chunk)
+    );
+    return vector.data[0];
+  });
+  const vector = new GPUVector({
+    type: 'data',
+    name: identifier,
+    format: 'uint32',
+    data,
+    ownsData: false
+  });
+  ownedVectors.push(vector);
+  return graph.importGPUVector(identifier, vector);
+}
+
+async function readUint32View(
+  ownedVectors: readonly GPUVector[],
+  view: GraphDataView<'uint32'>,
+  length: number
+): Promise<number[]> {
+  if (length === 0) return [];
+  const vector = ownedVectors.find(candidate => candidate.name === view.buffer.id);
+  if (!vector) throw new Error(`Missing owned output vector ${view.buffer.id}`);
+  const bytes = await vector.data[0].buffer.readAsync(
+    view.byteOffset,
+    length * Uint32Array.BYTES_PER_ELEMENT
+  );
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, length));
+}
+
+async function readFloat32View(
+  ownedVectors: readonly GPUVector[],
+  view: GraphDataView<'float32'>,
+  length: number
+): Promise<number[]> {
+  if (length === 0) return [];
+  const vector = ownedVectors.find(candidate => candidate.name === view.buffer.id);
+  if (!vector) throw new Error(`Missing owned output vector ${view.buffer.id}`);
+  const bytes = await vector.data[0].buffer.readAsync(
+    view.byteOffset,
+    length * Float32Array.BYTES_PER_ELEMENT
+  );
+  return Array.from(new Float32Array(bytes.buffer, bytes.byteOffset, length));
+}
+
+function destroyOwnedVectors(vectors: readonly GPUVector[]): void {
+  for (const vector of vectors) vector.destroy();
+}
+
+async function withReducedDeviceLimits<Result>(
+  device: Device,
+  overrides: Partial<
+    Pick<Device['limits'], 'maxStorageBufferBindingSize' | 'maxComputeWorkgroupsPerDimension'>
+  >,
+  callback: () => Promise<Result>
+): Promise<Result> {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(device, 'limits');
+  const originalLimits = device.limits;
+  Object.defineProperty(device, 'limits', {
+    configurable: true,
+    enumerable: originalDescriptor?.enumerable ?? true,
+    writable: true,
+    value: new Proxy(originalLimits, {
+      get(target, property) {
+        if (property === 'maxStorageBufferBindingSize' && overrides.maxStorageBufferBindingSize) {
+          return overrides.maxStorageBufferBindingSize;
+        }
+        if (
+          property === 'maxComputeWorkgroupsPerDimension' &&
+          overrides.maxComputeWorkgroupsPerDimension
+        ) {
+          return overrides.maxComputeWorkgroupsPerDimension;
+        }
+        return Reflect.get(target, property, target);
+      }
+    })
+  });
+  try {
+    return await callback();
+  } finally {
+    if (originalDescriptor) {
+      Object.defineProperty(device, 'limits', originalDescriptor);
+    } else {
+      Object.defineProperty(device, 'limits', {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: originalLimits
+      });
+    }
+  }
+}

--- a/test/examples/gpu-module-naming.node.spec.ts
+++ b/test/examples/gpu-module-naming.node.spec.ts
@@ -11,6 +11,7 @@ import * as gpuData from '@luma.gl/gpgpu/gpu-data';
 import * as gpuCrossfilter from '@luma.gl/experimental/gpu-crossfilter';
 import * as gpuDataframe from '@luma.gl/experimental/gpu-dataframe';
 import * as gpuGraphModule from '@luma.gl/gpgpu/gpu-graph';
+import * as gpuVectorSearch from '@luma.gl/gpgpu/gpu-vector-search';
 import * as gpuProject from '@luma.gl/experimental/gpu-project';
 import * as gpuRaster from '@luma.gl/experimental/gpu-raster';
 import * as gpuTables from '@luma.gl/experimental/gpu-tables';
@@ -18,7 +19,7 @@ import * as models from '@luma.gl/experimental/models';
 import * as gpuTrace from '@luma.gl/experimental/gpu-trace';
 import {describe, expect, test} from 'vitest';
 
-const GPGPU_MODULES = ['gpu-data', 'gpu-core', 'gpu-graph'] as const;
+const GPGPU_MODULES = ['gpu-data', 'gpu-core', 'gpu-graph', 'gpu-vector-search'] as const;
 const EXPERIMENTAL_MODULES = [
   'gpu-tables',
   'models',
@@ -34,6 +35,7 @@ const UNPUBLISHED_WORKING_NAMES = [
   'luraster',
   'luproj',
   'ludf',
+  'luvs',
   'luxfilter',
   'lutrace'
 ] as const;
@@ -93,6 +95,7 @@ describe('experimental GPU module naming', () => {
       '@luma.gl/gpgpu/gpu-core',
       '@luma.gl/gpgpu/gpu-graph',
       '@luma.gl/gpgpu/gpu-graph/benchmarks',
+      '@luma.gl/gpgpu/gpu-vector-search',
       '@luma.gl/experimental/gpu-tables',
       '@luma.gl/experimental/models'
     ]) {
@@ -115,6 +118,7 @@ describe('experimental GPU module naming', () => {
     expect(gpuData.getDataTypeByteLength).toBeTypeOf('function');
     expect(gpuCore.GPUCommandGraph).toBeTypeOf('function');
     expect(gpuGraphModule.GPUGraph).toBeTypeOf('function');
+    expect(gpuVectorSearch.GPUSimilaritySearch).toBeTypeOf('function');
     expect(gpuTables.GPURecordBatch).toBeTypeOf('function');
     expect(gpuTables.GPUTable).toBeTypeOf('function');
     expect(models.PathStorageModel).toBeTypeOf('function');
@@ -133,7 +137,7 @@ describe('experimental GPU module naming', () => {
       expect(exportName in experimentalRoot, exportName).toBe(false);
     }
 
-    for (const moduleExports of [gpuGraphModule, gpuDataframe, gpuCrossfilter]) {
+    for (const moduleExports of [gpuGraphModule, gpuVectorSearch, gpuDataframe, gpuCrossfilter]) {
       expect(Object.keys(moduleExports).some(exportName => /^Lu|^Lux/u.test(exportName))).toBe(
         false
       );
@@ -142,6 +146,8 @@ describe('experimental GPU module naming', () => {
 
   test('publishes only canonical documentation routes', () => {
     const experimentalDocumentation = path.join(process.cwd(), 'docs/api-reference/experimental');
+    const gpgpuDocumentation = path.join(process.cwd(), 'docs/api-reference/gpgpu');
+    expect(existsSync(path.join(gpgpuDocumentation, 'gpu-vector-search.md'))).toBe(true);
     for (const moduleName of [
       'gpu-core',
       'gpu-graph',


### PR DESCRIPTION
Goals

- Land exact, graph-native GPU vector similarity search at `@luma.gl/gpgpu/gpu-vector-search`.
- Unblock the downstream vector-search stack while landing the command-graph, fixed-size GPU data, and Arrow foundations that are independently useful.
- Keep primitive GPU storage in `@luma.gl/gpgpu/gpu-data`, table behavior in `@luma.gl/experimental/gpu-tables`, and Apache Arrow conversion in `@luma.gl/arrow`.

Changes

- Canonicalize repeated `GPUCommandGraph` imports of the same raw or dynamic buffer so graph passes share stable handles.
- Add canonical `fixed-size-list<format,size>` GPU vector formats, layout metadata, validation, table packing, and shader-binding behavior.
- Add Arrow `FixedSizeList` GPU upload/readback, slicing, null/validity handling, and precise TypeScript formats.
- Add `GPUSimilaritySearch` with exact squared-Euclidean, inner-product, and cosine ranking.
- Preserve source chunks, stable IDs, row validity, selection masks, query-specific masks, deterministic tie breaking, bounded tiles, and caller-owned output buffers.
- Export the new optional `@luma.gl/gpgpu/gpu-vector-search` subpath and document its ownership model, scope, and limits.
- Add focused node and real-WebGPU coverage for the complete stack.

Verification

- `nvm use` — passed with Node 22.22.1.
- `yarn install` — passed with existing peer-dependency warnings.
- `yarn lint fix` — passed; no fixes required.
- `yarn build` — passed, including `dist/gpu-vector-search/index.cjs`.
- Focused headless vector-search suite — 23/23 passed.
- `yarn test` node phase after merging current master — 400 files passed, 1 skipped; 3,170 tests passed, 3 skipped.
- `yarn test` headless phase after merging current master — 283 files passed; 1,878 tests passed, 23 skipped; five unrelated device-sensitive failures listed below.
- `yarn website:build` — passed.
- `(cd website && yarn build)` — passed.

Known headless failures

After merging current master and addressing review feedback, the final complete headless run reports five device-sensitive failures, all outside files changed by this stack. The deck keyboard case passed in the preceding post-merge run and failed in the final rerun:

- deck-arrow graph keyboard slider event
- two sparse splat ordering assertions
- deterministic ray-tracing lighting sample
- GPU raster NDVI edge case

Risks and scope

- This is a large landing because exact search depends on first-class fixed-size rows and stable graph imports, but the history is split into four focused commits so each foundation can be reviewed independently.
- `@luma.gl/gpgpu` and `@luma.gl/experimental` do not gain an `apache-arrow` dependency.
- This PR intentionally provides exact search only; approximate indexes, hosted inference, rendering UI, and vector-database behavior remain follow-ups.

Related to #2943.