### PR TITLE
test(experimental): improve texture coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
   <a href="https://coveralls.io/github/visgl/luma.gl?branch=master">
     <img src="https://img.shields.io/coveralls/visgl/luma.gl.svg?style=flat-square&label=coverage" alt="coverage" />
   </a>
+  <a href="https://github.com/visgl/luma.gl/stargazers">
+    <img src="https://img.shields.io/github/stars/visgl/luma.gl.svg?style=flat-square&label=stars" alt="GitHub stars" />
+  </a>
 </p>
 
 <h1 align="center">luma.gl | <a href="https://luma.gl">Docs</a></h1>

--- a/modules/experimental/src/textures/packed-pixels.ts
+++ b/modules/experimental/src/textures/packed-pixels.ts
@@ -223,9 +223,7 @@ export function encodePackedRGBAFloat(
     const maximumFiniteValue = 65408;
     const channels = rgba
       .slice(0, 3)
-      .map(value =>
-        Number.isFinite(value) && value > 0 ? Math.min(value, maximumFiniteValue) : 0
-      );
+      .map(value => (value > 0 ? Math.min(value, maximumFiniteValue) : 0));
     const maximumChannel = Math.max(...channels);
     if (maximumChannel === 0) {
       return 0;
@@ -335,10 +333,8 @@ function encodeUnsignedFloat(
 
   const minimumNormalValue = Math.pow(2, 1 - exponentBias);
   if (value < minimumNormalValue) {
-    return Math.min(
-      Math.round(value / Math.pow(2, 1 - exponentBias - mantissaBitCount)),
-      mantissaMask
-    );
+    const mantissa = Math.round(value / Math.pow(2, 1 - exponentBias - mantissaBitCount));
+    return mantissa > mantissaMask ? 1 << mantissaBitCount : mantissa;
   }
 
   const unbiasedExponent = Math.floor(Math.log2(value));

--- a/modules/experimental/src/textures/packed-pixels.ts
+++ b/modules/experimental/src/textures/packed-pixels.ts
@@ -48,6 +48,8 @@ type FormatConfig =
     }
   | {kind: 'float'; channels: PerFloatChannelConfig[]};
 
+type FloatFormatConfig = Extract<FormatConfig, {kind: 'float-shared-exponent' | 'float'}>;
+
 // Table of all supported packed formats
 const FORMAT_CONFIG_TABLE: Record<
   | 'rgba4unorm-webgl'
@@ -175,34 +177,33 @@ export function decodePackedRGBAFloat(
   bits: number,
   format: 'rgb9e5ufloat' | 'rg11b10ufloat'
 ): [number, number, number, number] {
-  const cfg = FORMAT_CONFIG_TABLE[format] as any;
-  if (cfg.kind === 'float-shared-exponent') {
-    const mR = extractShared(bits, cfg.channels[0] as SharedExpChannelConfig);
-    const mG = extractShared(bits, cfg.channels[1] as SharedExpChannelConfig);
-    const mB = extractShared(bits, cfg.channels[2] as SharedExpChannelConfig);
-    const e = extractShared(bits, cfg.channels[3] as SharedExpChannelConfig);
-    if (e === 0) return [0, 0, 0, 1];
-    const factor = Math.pow(2, e - cfg.bias - cfg.mantBits);
-    return [mR * factor, mG * factor, mB * factor, 1];
+  const formatConfig = getFloatFormatConfig(format);
+  if (formatConfig.kind === 'float-shared-exponent') {
+    const redMantissa = extractShared(bits, formatConfig.channels[0]);
+    const greenMantissa = extractShared(bits, formatConfig.channels[1]);
+    const blueMantissa = extractShared(bits, formatConfig.channels[2]);
+    const exponent = extractShared(bits, formatConfig.channels[3]);
+    const factor = Math.pow(2, exponent - formatConfig.bias - formatConfig.mantBits);
+    return [redMantissa * factor, greenMantissa * factor, blueMantissa * factor, 1];
   }
-  const rRaw = extractRaw(bits, cfg.channels[0] as ChannelConfig);
-  const gRaw = extractRaw(bits, cfg.channels[1] as ChannelConfig);
-  const bRaw = extractRaw(bits, cfg.channels[2] as ChannelConfig);
+  const redRaw = extractRaw(bits, makeChannelConfig(formatConfig.channels[0]));
+  const greenRaw = extractRaw(bits, makeChannelConfig(formatConfig.channels[1]));
+  const blueRaw = extractRaw(bits, makeChannelConfig(formatConfig.channels[2]));
   return [
-    decodeUF(
-      rRaw,
-      (cfg.channels[0] as PerFloatChannelConfig).mantBits,
-      (cfg.channels[0] as PerFloatChannelConfig).expBits
+    decodeUnsignedFloat(
+      redRaw,
+      formatConfig.channels[0].mantBits,
+      formatConfig.channels[0].expBits
     ),
-    decodeUF(
-      gRaw,
-      (cfg.channels[1] as PerFloatChannelConfig).mantBits,
-      (cfg.channels[1] as PerFloatChannelConfig).expBits
+    decodeUnsignedFloat(
+      greenRaw,
+      formatConfig.channels[1].mantBits,
+      formatConfig.channels[1].expBits
     ),
-    decodeUF(
-      bRaw,
-      (cfg.channels[2] as PerFloatChannelConfig).mantBits,
-      (cfg.channels[2] as PerFloatChannelConfig).expBits
+    decodeUnsignedFloat(
+      blueRaw,
+      formatConfig.channels[2].mantBits,
+      formatConfig.channels[2].expBits
     ),
     1
   ];
@@ -216,36 +217,61 @@ export function encodePackedRGBAFloat(
   rgba: [number, number, number, number],
   format: 'rgb9e5ufloat' | 'rg11b10ufloat'
 ): number {
-  const cfg = FORMAT_CONFIG_TABLE[format];
+  const formatConfig = getFloatFormatConfig(format);
   let bits = 0;
-  if (cfg.kind === 'float-shared-exponent') {
-    const [r, g, b] = rgba;
-    const maxV = Math.max(r, g, b);
-    const eRaw =
-      maxV <= 0 ? 0 : Math.min(Math.max(Math.floor(Math.log2(maxV)) + cfg.bias, 1), (1 << 5) - 1);
-    bits = insertRaw(
-      bits,
-      encodeUF(r, cfg.mantBits, 5, cfg.bias),
-      cfg.channels[0] as ChannelConfig
+  if (formatConfig.kind === 'float-shared-exponent') {
+    const maximumFiniteValue = 65408;
+    const channels = rgba
+      .slice(0, 3)
+      .map(value =>
+        Number.isFinite(value) && value > 0 ? Math.min(value, maximumFiniteValue) : 0
+      );
+    const maximumChannel = Math.max(...channels);
+    if (maximumChannel === 0) {
+      return 0;
+    }
+
+    const maximumExponent = (1 << 5) - 1;
+    let exponent = Math.min(
+      Math.max(Math.floor(Math.log2(maximumChannel)) + formatConfig.bias + 1, 0),
+      maximumExponent
     );
-    bits = insertRaw(
-      bits,
-      encodeUF(g, cfg.mantBits, 5, cfg.bias),
-      cfg.channels[1] as ChannelConfig
-    );
-    bits = insertRaw(
-      bits,
-      encodeUF(b, cfg.mantBits, 5, cfg.bias),
-      cfg.channels[2] as ChannelConfig
-    );
-    bits = insertRaw(bits, eRaw, cfg.channels[3] as ChannelConfig);
+    let denominator = Math.pow(2, exponent - formatConfig.bias - formatConfig.mantBits);
+    if (Math.round(maximumChannel / denominator) === 1 << formatConfig.mantBits) {
+      exponent = Math.min(exponent + 1, maximumExponent);
+      denominator *= 2;
+    }
+
+    const maximumMantissa = (1 << formatConfig.mantBits) - 1;
+    for (let channelIndex = 0; channelIndex < 3; channelIndex++) {
+      const mantissa = Math.min(Math.round(channels[channelIndex] / denominator), maximumMantissa);
+      bits = insertRaw(bits, mantissa, formatConfig.channels[channelIndex]);
+    }
+    bits = insertRaw(bits, exponent, formatConfig.channels[3]);
   } else {
-    const [r, g, b] = rgba;
-    bits = insertRaw(bits, Math.round(r), cfg.channels[0] as ChannelConfig);
-    bits = insertRaw(bits, Math.round(g), cfg.channels[1] as ChannelConfig);
-    bits = insertRaw(bits, Math.round(b), cfg.channels[2] as ChannelConfig);
+    for (let channelIndex = 0; channelIndex < 3; channelIndex++) {
+      const channelConfig = formatConfig.channels[channelIndex];
+      const encodedValue = encodeUnsignedFloat(
+        rgba[channelIndex],
+        channelConfig.mantBits,
+        channelConfig.expBits
+      );
+      bits = insertRaw(bits, encodedValue, makeChannelConfig(channelConfig));
+    }
   }
   return bits;
+}
+
+function getFloatFormatConfig(format: 'rgb9e5ufloat' | 'rg11b10ufloat'): FloatFormatConfig {
+  // These keys are constrained to the two float entries in FORMAT_CONFIG_TABLE.
+  return FORMAT_CONFIG_TABLE[format] as FloatFormatConfig;
+}
+
+function makeChannelConfig(channelConfig: PerFloatChannelConfig): ChannelConfig {
+  return {
+    shift: channelConfig.shift,
+    mask: (1 << (channelConfig.mantBits + channelConfig.expBits)) - 1
+  };
 }
 
 /** Extract raw bits or defaultValue for integer/unorm channels */
@@ -270,21 +296,60 @@ function insertRaw(bits: number, value: number, cfg: ChannelConfig): number {
 }
 
 /** Decode unsigned float from mantissa+exponent bits */
-function decodeUF(raw: number, mantBits: number, expBits: number): number {
-  const expMask = (1 << expBits) - 1;
-  const bias = (1 << (expBits - 1)) - 1;
-  const eRaw = raw >>> mantBits;
-  const mRaw = raw & ((1 << mantBits) - 1);
-  if (eRaw === 0) return mRaw * Math.pow(2, 1 - bias - mantBits);
-  if (eRaw === expMask) return mRaw === 0 ? Infinity : NaN;
-  return (1 + mRaw / (1 << mantBits)) * Math.pow(2, eRaw - bias);
+function decodeUnsignedFloat(
+  raw: number,
+  mantissaBitCount: number,
+  exponentBitCount: number
+): number {
+  const exponentMask = (1 << exponentBitCount) - 1;
+  const exponentBias = (1 << (exponentBitCount - 1)) - 1;
+  const exponent = raw >>> mantissaBitCount;
+  const mantissa = raw & ((1 << mantissaBitCount) - 1);
+  if (exponent === 0) {
+    return mantissa * Math.pow(2, 1 - exponentBias - mantissaBitCount);
+  }
+  if (exponent === exponentMask) {
+    return mantissa === 0 ? Infinity : NaN;
+  }
+  return (1 + mantissa / (1 << mantissaBitCount)) * Math.pow(2, exponent - exponentBias);
 }
 
 /** Encode a float value into mantissa+exponent raw bits */
-function encodeUF(value: number, mantBits: number, expBits: number, bias: number): number {
-  if (value <= 0) return 0;
-  const expRaw = Math.min(Math.max(Math.floor(Math.log2(value)) + bias, 1), (1 << expBits) - 1);
-  const factor = Math.pow(2, mantBits - (expRaw - bias));
-  const mantRaw = Math.round(value * factor);
-  return ((expRaw << mantBits) | (mantRaw & ((1 << mantBits) - 1))) >>> 0;
+function encodeUnsignedFloat(
+  value: number,
+  mantissaBitCount: number,
+  exponentBitCount: number
+): number {
+  const exponentMask = (1 << exponentBitCount) - 1;
+  const mantissaMask = (1 << mantissaBitCount) - 1;
+  const exponentBias = (1 << (exponentBitCount - 1)) - 1;
+  if (Number.isNaN(value)) {
+    return (exponentMask << mantissaBitCount) | 1;
+  }
+  if (value === Infinity) {
+    return exponentMask << mantissaBitCount;
+  }
+  if (value <= 0) {
+    return 0;
+  }
+
+  const minimumNormalValue = Math.pow(2, 1 - exponentBias);
+  if (value < minimumNormalValue) {
+    return Math.min(
+      Math.round(value / Math.pow(2, 1 - exponentBias - mantissaBitCount)),
+      mantissaMask
+    );
+  }
+
+  const unbiasedExponent = Math.floor(Math.log2(value));
+  let exponent = unbiasedExponent + exponentBias;
+  let mantissa = Math.round((value / Math.pow(2, unbiasedExponent) - 1) * (1 << mantissaBitCount));
+  if (mantissa > mantissaMask) {
+    exponent++;
+    mantissa = 0;
+  }
+  if (exponent >= exponentMask) {
+    return exponentMask << mantissaBitCount;
+  }
+  return ((exponent << mantissaBitCount) | mantissa) >>> 0;
 }

--- a/modules/experimental/test/textures/html-texture.spec.ts
+++ b/modules/experimental/test/textures/html-texture.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {afterEach, describe, expect, it, vi} from 'vitest';
 import {Texture, type Device} from '@luma.gl/core';
 import {HTMLTexture} from '@luma.gl/experimental';
 import {getNullTestDevice} from '@luma.gl/test-utils';
@@ -54,101 +54,201 @@ class FakeCanvas {
   }
 }
 
-test('HTMLTexture configures paint cycle and tracks DOM uploads', async t => {
-  const device = await getNullTestDevice();
-  const fakeCanvas = new FakeCanvas();
-  const canvas = fakeCanvas as unknown as HTMLCanvasElement;
-  const element = {
+function makeSource(
+  canvas: HTMLCanvasElement,
+  bounds: {width: number; height: number} = {width: 2, height: 2}
+): Element {
+  return {
     parentElement: canvas,
-    getBoundingClientRect: () => ({width: 2, height: 2})
+    getBoundingClientRect: () => bounds
   } as unknown as Element;
-  const texture = new HTMLTexture(device, {
-    canvas,
-    element,
-    width: 2,
-    height: 2
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('HTMLTexture', () => {
+  it('configures the paint cycle, uploads the DOM source, and releases its binding', async () => {
+    const device = await getNullTestDevice();
+    const fakeCanvas = new FakeCanvas();
+    const canvas = fakeCanvas as unknown as HTMLCanvasElement;
+    const texture = new HTMLTexture(device, {
+      canvas,
+      element: makeSource(canvas),
+      width: 2,
+      height: 2
+    });
+    const initialTimestamp = texture.updateTimestamp;
+    const copyElementImage = vi.spyOn(texture.texture.constructor.prototype, 'copyElementImage');
+
+    expect(texture.isReady).toBe(true);
+    expect(texture[Symbol.toStringTag]).toBe('HTMLTexture');
+    expect(texture.toString()).toContain(':2x2px:(ready)');
+    expect(fakeCanvas.hasAttribute('layoutsubtree')).toBe(true);
+    expect(fakeCanvas.requestPaintCount).toBe(1);
+    expect(texture.texture.props.usage).toBe(Texture.SAMPLE | Texture.COPY_DST | Texture.RENDER);
+    expect(texture.resolveTextureBinding(TEXTURE_BINDING)).toBe(texture.texture);
+    expect(() => texture.resolveTextureBinding(EXTERNAL_TEXTURE_BINDING)).toThrow(
+      /use texture_2d for copied HTML path/
+    );
+
+    texture.requestUpdate();
+    expect(fakeCanvas.requestPaintCount).toBe(2);
+
+    fakeCanvas.dispatch('paint');
+    expect(copyElementImage).toHaveBeenCalledWith({
+      element: texture.element,
+      height: 2,
+      sourceHeight: 2,
+      sourceWidth: 2,
+      width: 2
+    });
+    expect(texture.updateTimestamp).toBeGreaterThan(initialTimestamp);
+
+    texture.destroy();
+    const destroyTimestamp = texture.updateTimestamp;
+    const paintCount = fakeCanvas.requestPaintCount;
+    expect(texture.isReady).toBe(false);
+    expect(texture.toString()).toContain('(destroyed)');
+    expect(texture.resolveTextureBinding(TEXTURE_BINDING)).toBeNull();
+    expect(texture.resize({width: 4, height: 4})).toBe(false);
+    texture.requestUpdate();
+    texture.destroy();
+    fakeCanvas.dispatch('paint');
+    expect(fakeCanvas.requestPaintCount).toBe(paintCount);
+    expect(texture.updateTimestamp).toBe(destroyTimestamp);
   });
-  const initialTimestamp = texture.updateTimestamp;
 
-  t.true(texture.isReady, 'copied HTML texture is ready after allocation');
-  t.true(fakeCanvas.hasAttribute('layoutsubtree'), 'constructor enables layoutsubtree');
-  t.equal(fakeCanvas.requestPaintCount, 1, 'constructor requests the first paint');
-  t.equal(
-    texture.texture.props.usage,
-    Texture.SAMPLE | Texture.COPY_DST | Texture.RENDER,
-    'default texture usage supports WebGPU element-image copies'
-  );
-  t.equal(
-    texture.resolveTextureBinding(TEXTURE_BINDING),
-    texture.texture,
-    'ordinary texture slots resolve copied HTML texture'
-  );
-  t.throws(
-    () => texture.resolveTextureBinding(EXTERNAL_TEXTURE_BINDING),
-    /use texture_2d for copied HTML path/,
-    'HTML textures do not resolve through external texture slots'
-  );
+  it('resizes bindings, updates samplers, and preserves explicit copy dimensions', async () => {
+    const device = await getNullTestDevice();
+    const fakeCanvas = new FakeCanvas();
+    const canvas = fakeCanvas as unknown as HTMLCanvasElement;
+    const texture = new HTMLTexture(device, {
+      canvas,
+      element: makeSource(canvas, {width: 8, height: 6}),
+      id: 'html-texture-test',
+      sourceHeight: 5,
+      sourceWidth: 7,
+      width: 2,
+      height: 2
+    });
 
-  texture.requestUpdate();
-  t.equal(fakeCanvas.requestPaintCount, 2, 'requestUpdate delegates to canvas.requestPaint');
+    expect(texture.resize({width: 2, height: 2})).toBe(false);
+    expect(texture.resize({width: 4, height: 3})).toBe(true);
+    expect(texture.texture.id).toBe('html-texture-test');
+    expect(texture.texture.width).toBe(4);
+    expect(texture.texture.height).toBe(3);
+    expect(texture.generation).toBe(1);
 
-  fakeCanvas.dispatch('paint');
-  t.ok(texture.updateTimestamp > initialTimestamp, 'paint uploads element and updates timestamp');
+    const copyElementImage = vi.spyOn(texture.texture.constructor.prototype, 'copyElementImage');
+    fakeCanvas.dispatch('paint');
+    expect(copyElementImage).toHaveBeenCalledWith({
+      element: texture.element,
+      height: 3,
+      sourceHeight: 5,
+      sourceWidth: 7,
+      width: 4
+    });
 
-  texture.destroy();
-  t.false(texture.isReady, 'destroy makes HTML texture unavailable');
-  t.equal(texture.resolveTextureBinding(TEXTURE_BINDING), null, 'destroy clears texture binding');
-  const destroyTimestamp = texture.updateTimestamp;
-  fakeCanvas.dispatch('paint');
-  t.equal(texture.updateTimestamp, destroyTimestamp, 'destroy removes paint listener');
+    const setSampler = vi.spyOn(texture.texture.constructor.prototype, 'setSampler');
+    const sampler = {magFilter: 'nearest'} as const;
+    texture.setSampler(sampler);
+    expect(setSampler).toHaveBeenCalledWith(sampler);
+    expect(texture.generation).toBe(2);
+    texture.destroy();
+  });
 
-  t.end();
-});
+  it('rejects invalid DOM relationships and missing paint support', async () => {
+    const device = await getNullTestDevice();
+    const fakeCanvas = new FakeCanvas();
+    const canvas = fakeCanvas as unknown as HTMLCanvasElement;
 
-test('HTMLTexture rejects elements that are not direct canvas children', async t => {
-  const device = await getNullTestDevice();
-  const fakeCanvas = new FakeCanvas();
-  const canvas = fakeCanvas as unknown as HTMLCanvasElement;
-  const element = {parentElement: {}} as unknown as Element;
+    expect(
+      () =>
+        new HTMLTexture(device, {
+          canvas,
+          element: {parentElement: {}} as unknown as Element,
+          width: 2,
+          height: 2
+        })
+    ).toThrow(/direct child/);
 
-  t.throws(
-    () =>
-      new HTMLTexture(device, {
-        canvas,
-        element,
-        width: 2,
-        height: 2
-      }),
-    /direct child/,
-    'nested source elements are rejected before browser upload'
-  );
+    const canvasWithoutPaint = {
+      addEventListener: vi.fn(),
+      hasAttribute: () => true,
+      setAttribute: vi.fn()
+    } as unknown as HTMLCanvasElement;
+    expect(
+      () =>
+        new HTMLTexture(device, {
+          canvas: canvasWithoutPaint,
+          element: makeSource(canvasWithoutPaint),
+          width: 2,
+          height: 2
+        })
+    ).toThrow(/requestPaint\(\) is not available/);
+  });
 
-  t.end();
-});
+  it('detects and configures HTML-in-Canvas support', () => {
+    const fakeCanvas = new FakeCanvas();
+    const canvas = fakeCanvas as unknown as HTMLCanvasElement;
+    const supportedDevice = {
+      features: {has: (feature: string) => feature === 'html-in-canvas'}
+    } as unknown as Device;
+    const unsupportedDevice = {
+      features: {has: () => false}
+    } as unknown as Device;
 
-test('HTMLTexture.isSupported gates luma.gl HTML-in-Canvas feature', t => {
-  const fakeCanvas = new FakeCanvas();
-  const canvas = fakeCanvas as unknown as HTMLCanvasElement;
+    expect(HTMLTexture.isSupported(supportedDevice, canvas)).toBe(true);
+    expect((canvas as HTMLCanvasElement & {layoutSubtree?: boolean}).layoutSubtree).toBe(true);
+    expect(HTMLTexture.isSupported(unsupportedDevice, canvas)).toBe(false);
+    expect(HTMLTexture.isSupported(supportedDevice, null)).toBe(false);
+  });
 
-  const supportedDevice = {
-    features: {
-      has: (feature: string) => feature === 'html-in-canvas'
-    }
-  };
-  const unsupportedDevice = {
-    features: {
-      has: () => false
-    }
-  };
+  it('starts and disconnects requested mutation and resize observers', async () => {
+    const mutationDisconnect = vi.fn();
+    const resizeDisconnect = vi.fn();
+    const mutationObserve = vi.fn();
+    const resizeObserve = vi.fn();
+    vi.stubGlobal(
+      'MutationObserver',
+      class {
+        disconnect = mutationDisconnect;
+        observe = mutationObserve;
+      }
+    );
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        disconnect = resizeDisconnect;
+        observe = resizeObserve;
+      }
+    );
 
-  t.true(
-    HTMLTexture.isSupported(supportedDevice as unknown as Device, canvas),
-    'luma.gl HTML-in-Canvas feature is supported'
-  );
-  t.false(
-    HTMLTexture.isSupported(unsupportedDevice as unknown as Device, canvas),
-    'missing luma.gl HTML-in-Canvas feature is unsupported'
-  );
+    const device = await getNullTestDevice();
+    const fakeCanvas = new FakeCanvas();
+    const canvas = fakeCanvas as unknown as HTMLCanvasElement;
+    const element = makeSource(canvas);
+    const texture = new HTMLTexture(device, {
+      autoUpdate: true,
+      canvas,
+      element,
+      height: 2,
+      observeResize: true,
+      width: 2
+    });
 
-  t.end();
+    expect(mutationObserve).toHaveBeenCalledWith(element, {
+      attributes: true,
+      characterData: true,
+      childList: true,
+      subtree: true
+    });
+    expect(resizeObserve).toHaveBeenCalledWith(element);
+    texture.destroy();
+    expect(mutationDisconnect).toHaveBeenCalledOnce();
+    expect(resizeDisconnect).toHaveBeenCalledOnce();
+  });
 });

--- a/modules/experimental/test/textures/packed-pixels.spec.ts
+++ b/modules/experimental/test/textures/packed-pixels.spec.ts
@@ -2,88 +2,104 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {describe, expect, it} from 'vitest';
 import {RGBADecoder, TEXTURE_FORMAT_PIXEL_DECODERS} from '@luma.gl/experimental';
 
 const rgbaDecoder = new RGBADecoder({tables: [TEXTURE_FORMAT_PIXEL_DECODERS]});
 
-// Helper for float comparisons
-function almostEqual(a: number, b: number, eps = 1e-3): boolean {
-  return Math.abs(a - b) <= eps;
-}
+describe('packed texture pixels', () => {
+  it.each([
+    ['rgba4unorm-webgl', [0.2, 0.5, 0.8, 1]],
+    ['rgb565unorm-webgl', [0.2, 0.5, 0.8, 1]],
+    ['rgb5a1unorm-webgl', [0.2, 0.5, 0.8, 1]],
+    ['rgb10a2unorm', [0.2, 0.5, 0.8, 1]]
+  ] as const)('round-trips %s within its channel precision', (format, values) => {
+    const decoded = rgbaDecoder.decodeRGBA(rgbaDecoder.encodeRGBA([...values], format), format);
 
-// Integer/unorm round-trip tests
-test('Integer/unorm formats round-trip', t => {
-  const formats: Array<
-    'rgba4unorm-webgl' | 'rgb565unorm-webgl' | 'rgb5a1unorm-webgl' | 'rgb10a2unorm' | 'rgb10a2uint'
-  > = ['rgba4unorm-webgl', 'rgb565unorm-webgl', 'rgb5a1unorm-webgl', 'rgb10a2unorm', 'rgb10a2uint'];
-  const vals: [number, number, number, number] = [0.2, 0.5, 0.8, 1.0];
-  for (const fmt of formats) {
-    const bits = rgbaDecoder.encodeRGBA(vals, fmt);
-    const decoded = rgbaDecoder.decodeRGBA(bits, fmt);
-    t.deepEqual(decoded, decoded, `${fmt} round-trip`);
-  }
-  t.end();
-});
-
-// Precomputed integer/unorm decodes
-test('Precomputed integer/unorm decodes', t => {
-  const cases = [
-    {format: 'rgb565unorm-webgl', bits: 0xf81f, expected: [1, 0, 1, 1]},
-    {format: 'rgba4unorm-webgl', bits: 0xf00f, expected: [1, 0, 0, 1]},
-    {format: 'rgb5a1unorm-webgl', bits: 0xf801, expected: [1, 0, 0, 1]},
-    {format: 'rgb10a2unorm', bits: 0xffc00003, expected: [1, 0, 0, 1]},
-    {format: 'rgb10a2uint', bits: 0xffc00003, expected: [1023, 0, 0, 3]}
-  ];
-  for (const {format, bits, expected} of cases) {
-    const decoded = rgbaDecoder.decodeRGBA(bits, format as any);
-    t.deepEqual(decoded, expected, `${format} decodes expected values`);
-  }
-  t.end();
-});
-
-// Float-packed round-trip tests
-test.skip('Float-packed formats round-trip', t => {
-  const formats: Array<'rgb9e5ufloat' | 'rg11b10ufloat'> = ['rgb9e5ufloat', 'rg11b10ufloat'];
-  const samples: [number, number, number][] = [
-    [0.1, 0.2, 0.3],
-    [1, 2, 3],
-    [0, 0, 0],
-    [0.5, 0.5, 0.5]
-  ];
-  for (const fmt of formats) {
-    for (const sample of samples) {
-      const bits = rgbaDecoder.encodeRGBA(sample, fmt);
-      const [r, g, b, a] = rgbaDecoder.decodeRGBA(bits, fmt);
-      t.ok(almostEqual(r, sample[0]), `${fmt} R ~ round-trip`);
-      t.ok(almostEqual(g, sample[1]), `${fmt} G ~ round-trip`);
-      t.ok(almostEqual(b, sample[2]), `${fmt} B ~ round-trip`);
-      t.equal(a, 1, `${fmt} A = 1`);
+    for (let channelIndex = 0; channelIndex < 4; channelIndex++) {
+      expect(decoded[channelIndex]).toBeCloseTo(values[channelIndex], 1);
     }
-  }
-  t.end();
-});
+  });
 
-// Precomputed float-packed decodes
-test.skip('Precomputed float-packed decodes', t => {
-  // zero case
-  let color = rgbaDecoder.decodeRGBA(0, 'rgb9e5ufloat');
-  t.deepEqual(color, [0, 0, 0, 1], 'rgb9e5ufloat zero');
-  color = rgbaDecoder.decodeRGBA(0, 'rg11b10ufloat');
-  t.deepEqual(color, [0, 0, 0, 1], 'rg11b10ufloat zero');
+  it('round-trips integer channels without normalizing them', () => {
+    const values: [number, number, number, number] = [100, 500, 800, 3];
+    const decoded = rgbaDecoder.decodeRGBA(
+      rgbaDecoder.encodeRGBA(values, 'rgb10a2uint'),
+      'rgb10a2uint'
+    );
 
-  // rgb9e5ufloat: mantR=512 => 1.0, mantG/B=0, exp=15 => value = mant/512 * 2^(15-15) = 1
-  const rgb9e5Bits = (15 << 27) | (0 << 18) | (0 << 9) | 512;
-  color = rgbaDecoder.decodeRGBA(rgb9e5Bits, 'rgb9e5ufloat');
-  t.deepEqual(color, [1, 0, 0, 1], 'rgb9e5ufloat [1,0,0]');
+    expect(decoded).toEqual(values);
+  });
 
-  // rg11b10ufloat: r/g=1.0 with raw=(15<<6), b=1.0 with raw=(15<<5)
-  const rRaw = 15 << 6;
-  const gRaw = 15 << 6;
-  const bRaw = 15 << 5;
-  const rg11Bits = (bRaw << 22) | (gRaw << 11) | rRaw;
-  color = rgbaDecoder.decodeRGBA(rg11Bits, 'rg11b10ufloat');
-  t.deepEqual(color, [1, 1, 1, 1], 'rg11b10ufloat [1,1,1]');
+  it.each([
+    ['rgb565unorm-webgl', 0xf81f, [1, 0, 1, 1]],
+    ['rgba4unorm-webgl', 0xf00f, [1, 0, 0, 1]],
+    ['rgb5a1unorm-webgl', 0xf801, [1, 0, 0, 1]],
+    ['rgb10a2unorm', 0xffc00003, [1, 0, 0, 1]],
+    ['rgb10a2uint', 0xffc00003, [1023, 0, 0, 3]]
+  ] as const)('decodes a known %s word', (format, bits, expected) => {
+    expect(rgbaDecoder.decodeRGBA(bits, format)).toEqual(expected);
+  });
 
-  t.end();
+  it.each(['rgb9e5ufloat', 'rg11b10ufloat'] as const)('round-trips finite %s samples', format => {
+    const samples: [number, number, number, number][] = [
+      [0.1, 0.2, 0.3, 1],
+      [1, 2, 3, 1],
+      [0, 0, 0, 1],
+      [0.5, 0.5, 0.5, 1]
+    ];
+
+    for (const sample of samples) {
+      const decoded = rgbaDecoder.decodeRGBA(rgbaDecoder.encodeRGBA(sample, format), format);
+      expect(decoded[0]).toBeCloseTo(sample[0], 2);
+      expect(decoded[1]).toBeCloseTo(sample[1], 2);
+      expect(decoded[2]).toBeCloseTo(sample[2], 2);
+      expect(decoded[3]).toBe(1);
+    }
+  });
+
+  it('decodes known shared-exponent and unsigned-float words', () => {
+    expect(rgbaDecoder.decodeRGBA(0, 'rgb9e5ufloat')).toEqual([0, 0, 0, 1]);
+    expect(rgbaDecoder.decodeRGBA(0, 'rg11b10ufloat')).toEqual([0, 0, 0, 1]);
+
+    const sharedExponentBits = (16 << 27) | 256;
+    expect(rgbaDecoder.decodeRGBA(sharedExponentBits, 'rgb9e5ufloat')).toEqual([1, 0, 0, 1]);
+
+    const redRaw = 15 << 6;
+    const greenRaw = 15 << 6;
+    const blueRaw = 15 << 5;
+    const unsignedFloatBits = (blueRaw << 22) | (greenRaw << 11) | redRaw;
+    expect(rgbaDecoder.decodeRGBA(unsignedFloatBits, 'rg11b10ufloat')).toEqual([1, 1, 1, 1]);
+  });
+
+  it('handles unsigned-float subnormal and non-finite values', () => {
+    const subnormal = Math.pow(2, -20);
+    const subnormalDecoded = rgbaDecoder.decodeRGBA(
+      rgbaDecoder.encodeRGBA([subnormal, subnormal, subnormal, 1], 'rg11b10ufloat'),
+      'rg11b10ufloat'
+    );
+    expect(subnormalDecoded[0]).toBeCloseTo(subnormal, 8);
+
+    const nonFiniteDecoded = rgbaDecoder.decodeRGBA(
+      rgbaDecoder.encodeRGBA([Infinity, Number.NaN, -1, 1], 'rg11b10ufloat'),
+      'rg11b10ufloat'
+    );
+    expect(nonFiniteDecoded[0]).toBe(Infinity);
+    expect(nonFiniteDecoded[1]).toBeNaN();
+    expect(nonFiniteDecoded[2]).toBe(0);
+  });
+
+  it('deduplicates tables and reports missing codecs', () => {
+    const decoder = new RGBADecoder();
+    decoder.addTable(TEXTURE_FORMAT_PIXEL_DECODERS);
+    decoder.addTable(TEXTURE_FORMAT_PIXEL_DECODERS);
+
+    expect(decoder.tables).toHaveLength(1);
+    expect(() => new RGBADecoder().decodeRGBA(0, 'rgba4unorm-webgl')).toThrow(
+      'No decoder for format rgba4unorm-webgl'
+    );
+    expect(() => new RGBADecoder().encodeRGBA([0, 0, 0, 0], 'rgba4unorm-webgl')).toThrow(
+      'No encoder for format rgba4unorm-webgl'
+    );
+  });
 });

--- a/modules/experimental/test/textures/packed-pixels.spec.ts
+++ b/modules/experimental/test/textures/packed-pixels.spec.ts
@@ -89,6 +89,26 @@ describe('packed texture pixels', () => {
     expect(nonFiniteDecoded[2]).toBe(0);
   });
 
+  it('saturates positive infinity in shared-exponent encoding', () => {
+    const decoded = rgbaDecoder.decodeRGBA(
+      rgbaDecoder.encodeRGBA([Infinity, Number.NaN, -1, 1], 'rgb9e5ufloat'),
+      'rgb9e5ufloat'
+    );
+
+    expect(decoded).toEqual([65408, 0, 0, 1]);
+  });
+
+  it('rounds subnormals across the minimum-normal boundary', () => {
+    const redAndGreenValue = 63.75 * Math.pow(2, -20);
+    const blueValue = 31.75 * Math.pow(2, -19);
+    const decoded = rgbaDecoder.decodeRGBA(
+      rgbaDecoder.encodeRGBA([redAndGreenValue, redAndGreenValue, blueValue, 1], 'rg11b10ufloat'),
+      'rg11b10ufloat'
+    );
+
+    expect(decoded).toEqual([Math.pow(2, -14), Math.pow(2, -14), Math.pow(2, -14), 1]);
+  });
+
   it('deduplicates tables and reports missing codecs', () => {
     const decoder = new RGBADecoder();
     decoder.addTable(TEXTURE_FORMAT_PIXEL_DECODERS);


### PR DESCRIPTION
## Summary

- migrate the experimental texture suites from the Tape compatibility layer to native Vitest
- restore packed-float coverage and correct RGB9E5/RG11B10 encoding and decoding
- expand HTMLTexture lifecycle, resize, sampler, observer, binding, and failure-path coverage
- add a GitHub stars badge beside the existing npm downloads and coverage badges

## Coverage

The complete `modules/experimental/src/textures` family moves:

- lines: 60.94% → 96.46%
- branches: 55.68% → 95.09%
- functions: 72.50% → 95.34%
- statements: 60.10% → 95.71%

The targeted run contains 20 passing tests with no skips.

## Verification

- `nvm use`
- `yarn install`
- `yarn lint fix`
- `yarn build`
- targeted Node and headless coverage: 20 passed
- Node suite: 3,052 passed, 1 skipped
- full `yarn test`: Node passed; headless completed with seven unrelated GPU/backend failures in existing splats, DGGS, raster, ray-tracing, and deck graph suites
