### PR TITLE
test: expand native Vitest migration across engine utilities

### DIFF
--- a/modules/constants/test/webgl-constants.spec.ts
+++ b/modules/constants/test/webgl-constants.spec.ts
@@ -2,34 +2,29 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 
 import {GL} from '@luma.gl/constants';
 
-test('@luma.gl/constants', t => {
-  t.equal(typeof GL, 'object', '@luma.gl/constants is an object');
-  t.end();
+it('@luma.gl/constants', () => {
+  expect(typeof GL, '@luma.gl/constants is an object').toBe('object');
 });
 
-test('@luma.gl/constants#WebGL2RenderingContext comparison', async t => {
+it('@luma.gl/constants#WebGL2RenderingContext comparison', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   for (const device of [webglDevice]) {
     // @ts-ignore
     const gl = device.gl;
-    let count = 0;
     for (const key in gl) {
       const value = gl[key];
       if (Number.isFinite(value) && key.toUpperCase() === key && GL[key] !== undefined) {
         // Avoid generating too much test log
         if (GL[key] !== value) {
-          t.equals(GL[key], value, `GL.${key} is equal to gl.${key}`);
+          expect(GL[key], `GL.${key} is equal to gl.${key}`).toBe(value);
         }
-        count++;
       }
     }
-    t.comment(`Checked ${count} GL constants against platform WebGL2 context`);
   }
-  t.end();
 });

--- a/modules/core/test/adapter-utils/buffer-layout-utils.spec.ts
+++ b/modules/core/test/adapter-utils/buffer-layout-utils.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {
   type BufferLayout,
   type ShaderLayout,
@@ -21,7 +21,7 @@ const shaderLayout: ShaderLayout = {
   ]
 };
 
-test('resolveLogicalAttributeMappings resolves interleaved, shorthand, and default mappings', t => {
+it('resolveLogicalAttributeMappings resolves interleaved, shorthand, and default mappings', () => {
   const bufferLayout: BufferLayout[] = [
     {
       name: 'particles',
@@ -33,7 +33,7 @@ test('resolveLogicalAttributeMappings resolves interleaved, shorthand, and defau
     {name: 'vertexPositions', format: 'float32x3'}
   ];
 
-  t.deepEqual(resolveLogicalAttributeMappings(shaderLayout, bufferLayout), [
+  expect(resolveLogicalAttributeMappings(shaderLayout, bufferLayout)).toEqual([
     {
       attributeName: 'instancePositions',
       bufferName: 'particles',
@@ -71,29 +71,25 @@ test('resolveLogicalAttributeMappings resolves interleaved, shorthand, and defau
       stepMode: 'vertex'
     }
   ]);
-  t.end();
 });
 
-test('resolveLogicalAttributeMappings distinguishes zero from omitted stride', t => {
+it('resolveLogicalAttributeMappings distinguishes zero from omitted stride', () => {
   const mappings = resolveLogicalAttributeMappings(shaderLayout, [
     {name: 'vertexPositions', format: 'float32x3', byteStride: 0},
     {name: 'colors', format: 'float32x4'}
   ]);
 
-  t.equal(
+  expect(
     mappings.find(mapping => mapping.attributeName === 'vertexPositions')?.byteStride,
-    0,
     'preserves an explicit zero stride'
-  );
-  t.equal(
+  ).toBe(0);
+  expect(
     mappings.find(mapping => mapping.attributeName === 'colors')?.byteStride,
-    16,
     'resolves an omitted stride to the packed format size'
-  );
-  t.end();
+  ).toBe(16);
 });
 
-test('getLogicalBufferSlots keeps logical layout order and appends unmapped shader attributes', t => {
+it('getLogicalBufferSlots keeps logical layout order and appends unmapped shader attributes', () => {
   const bufferLayout: BufferLayout[] = [
     {name: 'vertexPositions', format: 'float32x3'},
     {
@@ -102,16 +98,15 @@ test('getLogicalBufferSlots keeps logical layout order and appends unmapped shad
     }
   ];
 
-  t.deepEqual(getLogicalBufferSlots(shaderLayout, bufferLayout), {
+  expect(getLogicalBufferSlots(shaderLayout, bufferLayout)).toEqual({
     vertexPositions: 0,
     particles: 1,
     instanceVelocities: 2,
     colors: 3
   });
-  t.end();
 });
 
-test('getBufferLayoutMinAttributeLocation returns the first referenced shader location', t => {
+it('getBufferLayoutMinAttributeLocation returns the first referenced shader location', () => {
   const bufferLayout: BufferLayout = {
     name: 'particles',
     attributes: [
@@ -120,10 +115,8 @@ test('getBufferLayoutMinAttributeLocation returns the first referenced shader lo
     ]
   };
 
-  t.equal(
+  expect(
     getBufferLayoutMinAttributeLocation(bufferLayout, shaderLayout),
-    0,
     'minimum shader location is derived from the referenced attributes'
-  );
-  t.end();
+  ).toBe(0);
 });

--- a/modules/core/test/adapter-utils/format-compiler-log.node.spec.ts
+++ b/modules/core/test/adapter-utils/format-compiler-log.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerFormatCompilerLogTests} from './format-compiler-log.spec.shared';
 
-registerFormatCompilerLogTests(test);
+registerFormatCompilerLogTests();

--- a/modules/core/test/adapter-utils/format-compiler-log.spec.shared.ts
+++ b/modules/core/test/adapter-utils/format-compiler-log.spec.shared.ts
@@ -4,7 +4,7 @@
 
 import type {CompilerMessage} from '@luma.gl/core';
 import {formatCompilerLog} from '@luma.gl/core/adapter-utils/format-compiler-log';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 const ERROR_LOG: CompilerMessage[] = [
   {
@@ -146,52 +146,58 @@ void main() {
 }
 `;
 
-export function registerFormatCompilerLogTests(test: TapeTestFunction): void {
-  test('formatCompilerLog', t => {
+export function registerFormatCompilerLogTests(): void {
+  it('formatCompilerLog', () => {
     const formatted = formatCompilerLog(ERROR_LOG, SHADER_SOURCE);
-    t.ok(
+    expect(
       formatted.includes("ERROR: 'project_scale' : no matching overloaded function found"),
       'default formatting includes error messages'
-    );
-    t.ok(!formatted.includes(' 264:'), 'default formatting omits source lines');
+    ).toBe(true);
+    expect(!formatted.includes(' 264:'), 'default formatting omits source lines').toBe(true);
 
     const withIssues = formatCompilerLog(
       [{type: 'error', linePos: 2, lineNum: 10, message: 'broken shader'}],
       SHADER_SOURCE,
       {showSourceCode: 'issues'}
     );
-    t.ok(withIssues.includes('  10:'), 'issues view includes numbered source lines');
-    t.ok(withIssues.includes('^^^'), 'issues view includes a position indicator');
+    expect(withIssues.includes('  10:'), 'issues view includes numbered source lines').toBe(true);
+    expect(withIssues.includes('^^^'), 'issues view includes a position indicator').toBe(true);
 
     const withAllSource = formatCompilerLog(
       [{type: 'warning', linePos: 0, lineNum: 4, message: 'watch this'}],
       SHADER_SOURCE,
       {showSourceCode: 'all'}
     );
-    t.ok(withAllSource.includes('#define AMD_GPU'), 'all view includes the full source body');
-    t.ok(withAllSource.includes('WARNING: watch this'), 'all view includes inline warnings');
+    expect(
+      withAllSource.includes('#define AMD_GPU'),
+      'all view includes the full source body'
+    ).toBe(true);
+    expect(withAllSource.includes('WARNING: watch this'), 'all view includes inline warnings').toBe(
+      true
+    );
 
     const htmlFormatted = formatCompilerLog(
       [{type: 'error', linePos: 1, lineNum: 6, message: 'html error'}],
       SHADER_SOURCE,
       {showSourceCode: 'all', html: true}
     );
-    t.ok(
+    expect(
       htmlFormatted.includes('luma-compiler-log-error'),
       'html formatting renders wrapped messages'
-    );
-    t.ok(htmlFormatted.includes('style="color:red;"'), 'html formatting applies the error color');
+    ).toBe(true);
+    expect(
+      htmlFormatted.includes('style="color:red;"'),
+      'html formatting applies the error color'
+    ).toBe(true);
 
     const trailingMessage = formatCompilerLog(
       [{type: 'error', linePos: 0, lineNum: 999, message: 'late error'}],
       'void main() {}',
       {showSourceCode: 'all'}
     );
-    t.ok(
+    expect(
       trailingMessage.includes('ERROR: late error'),
       'messages after the source are still reported'
-    );
-
-    t.end();
+    ).toBe(true);
   });
 }

--- a/modules/core/test/adapter-utils/format-compiler-log.spec.ts
+++ b/modules/core/test/adapter-utils/format-compiler-log.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerFormatCompilerLogTests} from './format-compiler-log.spec.shared';
 
-registerFormatCompilerLogTests(test);
+registerFormatCompilerLogTests();

--- a/modules/core/test/adapter-utils/get-attribute-from-layout.spec.ts
+++ b/modules/core/test/adapter-utils/get-attribute-from-layout.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {
   ShaderLayout,
   getAttributeInfosFromLayouts,
@@ -190,15 +190,12 @@ const resolvedLayout: Record<string, AttributeInfo> = {
   }
 };
 
-test('getAttributeInfosFromLayouts', t => {
+it('getAttributeInfosFromLayouts', () => {
   const result = getAttributeInfosFromLayouts(shaderLayout, bufferLayout);
   for (const key of Object.keys(resolvedLayout)) {
-    t.deepEqual(
-      result[key],
-      resolvedLayout[key],
-      `Interleaved attribute info for ${key} are correct`
+    expect(result[key], `Interleaved attribute info for ${key} are correct`).toEqual(
+      resolvedLayout[key]
     );
     // t.comment(JSON.stringify(result[key], null, 2));
   }
-  t.end();
 });

--- a/modules/core/test/adapter-utils/is-uniform-value.spec.ts
+++ b/modules/core/test/adapter-utils/is-uniform-value.spec.ts
@@ -4,23 +4,26 @@
 
 import {isUniformValue} from '@luma.gl/core/adapter-utils/is-uniform-value';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('isUniformValue', async t => {
+it('isUniformValue', async () => {
   const device = await getWebGLTestDevice();
 
-  t.ok(isUniformValue(3), 'Number is uniform value');
-  t.ok(isUniformValue(3.412), 'Number is uniform value');
-  t.ok(isUniformValue(0), 'Number is uniform value');
-  t.ok(isUniformValue(false), 'Boolean is uniform value');
-  t.ok(isUniformValue(true), 'Boolean is uniform value');
-  t.ok(isUniformValue([1, 2, 3, 4]), 'Number array is uniform value');
-  t.ok(isUniformValue(new Float32Array([1, 2, 3, 4])), 'Number array is uniform value');
+  expect(isUniformValue(3), 'Number is uniform value').toBe(true);
+  expect(isUniformValue(3.412), 'Number is uniform value').toBe(true);
+  expect(isUniformValue(0), 'Number is uniform value').toBe(true);
+  expect(isUniformValue(false), 'Boolean is uniform value').toBe(true);
+  expect(isUniformValue(true), 'Boolean is uniform value').toBe(true);
+  expect(isUniformValue([1, 2, 3, 4]), 'Number array is uniform value').toBe(true);
+  expect(isUniformValue(new Float32Array([1, 2, 3, 4])), 'Number array is uniform value').toBe(
+    true
+  );
 
-  t.notOk(
+  expect(
     isUniformValue(device.createTexture({width: 1, height: 1})),
     'WEBGLTexture is not a uniform value'
+  ).toBe(false);
+  expect(isUniformValue(device.createSampler({})), 'WEBGLSampler is not a uniform value').toBe(
+    false
   );
-  t.notOk(isUniformValue(device.createSampler({})), 'WEBGLSampler is not a uniform value');
-  t.end();
 });

--- a/modules/engine/test/compute/buffer-transform.spec.ts
+++ b/modules/engine/test/compute/buffer-transform.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 import {BufferTransform} from '@luma.gl/engine';
 import {Buffer, Device} from '@luma.gl/core';
@@ -21,14 +21,13 @@ out vec4 fragColor;
 void main() { fragColor.x = dst; }
 `;
 
-test('BufferTransform#constructor', async t => {
+it('BufferTransform#constructor', async () => {
   const webglDevice = await getWebGLTestDevice();
 
-  t.ok(createBufferTransform(webglDevice), 'WebGL succeeds');
-  t.end();
+  expect(createBufferTransform(webglDevice), 'WebGL succeeds').toBeTruthy();
 });
 
-test('BufferTransform#run', async t => {
+it('BufferTransform#run', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   const SRC_ARRAY = new Float32Array([0, 1, 2, 3, 4, 5]);
@@ -43,9 +42,7 @@ test('BufferTransform#run', async t => {
 
   const bytes = await transform.readAsync('dst');
   const array = new Float32Array(bytes.buffer, bytes.byteOffset, elementCount);
-  t.deepEqual(array, DST_ARRAY, 'output transformed');
-
-  t.end();
+  expect(array, 'output transformed').toEqual(DST_ARRAY);
 });
 
 function createBufferTransform(

--- a/modules/engine/test/compute/swap.spec.ts
+++ b/modules/engine/test/compute/swap.spec.ts
@@ -1,126 +1,117 @@
-import test from 'test/utils/vitest-tape';
+import {describe, expect, it} from 'vitest';
 import {Swap, SwapFramebuffers} from '../../src/compute/swap';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 
 // TODO - these tests could run on NullDevice
 
-test('Swap#constructor', async t => {
-  const webglDevice = await getWebGLTestDevice();
+describe('Swap', () => {
+  it('constructor', async () => {
+    const webglDevice = await getWebGLTestDevice();
 
-  const current = webglDevice.createBuffer({byteLength: 1});
-  const next = webglDevice.createBuffer({byteLength: 1});
-  const swap = new Swap({current, next});
+    const current = webglDevice.createBuffer({byteLength: 1});
+    const next = webglDevice.createBuffer({byteLength: 1});
+    const swap = new Swap({current, next});
 
-  t.equal(swap.current, current, 'should set the current resource correctly');
-  t.equal(swap.next, next, 'should set the next resource correctly');
-
-  t.end();
-});
-
-test('Swap#destroy', async t => {
-  const webglDevice = await getWebGLTestDevice();
-
-  const current = webglDevice.createBuffer({byteLength: 1});
-  const next = webglDevice.createBuffer({byteLength: 1});
-  const swap = new Swap({current, next});
-
-  t.equal(swap.current.destroyed, false, 'should not yet have destroyed the current resource');
-  t.equal(swap.next.destroyed, false, 'should not yet have destroyed the next resource');
-
-  swap.destroy();
-
-  t.equal(swap.current.destroyed, true, 'should destroy the current resource');
-  t.equal(swap.next.destroyed, true, 'should destroy the next resource');
-
-  t.end();
-});
-
-test('Swap#swap', async t => {
-  const webglDevice = await getWebGLTestDevice();
-
-  const current = webglDevice.createBuffer({byteLength: 1});
-  const next = webglDevice.createBuffer({byteLength: 1});
-  const swap = new Swap({current, next});
-
-  swap.swap();
-
-  t.equal(swap.current, next, 'should make the next resource the current resource');
-  t.equal(swap.next, current, 'should reuse the current resource as the next resource');
-
-  t.end();
-});
-
-test('SwapFramebuffers#resize', async t => {
-  const webglDevice = await getWebGLTestDevice();
-
-  const swap = new SwapFramebuffers(webglDevice, {
-    colorAttachments: ['rgba8unorm'],
-    width: 4,
-    height: 4
+    expect(swap.current, 'should set the current resource correctly').toBe(current);
+    expect(swap.next, 'should set the next resource correctly').toBe(next);
   });
 
-  const currentTexture = swap.current.colorAttachments[0].texture;
-  const nextTexture = swap.next.colorAttachments[0].texture;
+  it('destroy', async () => {
+    const webglDevice = await getWebGLTestDevice();
 
-  let resized = swap.resize({width: 4, height: 4});
-  t.equal(resized, false, 'resize with same size returns false');
-  t.equal(
-    swap.current.colorAttachments[0].texture,
-    currentTexture,
-    'current framebuffer texture unchanged'
-  );
-  t.equal(swap.next.colorAttachments[0].texture, nextTexture, 'next framebuffer texture unchanged');
+    const current = webglDevice.createBuffer({byteLength: 1});
+    const next = webglDevice.createBuffer({byteLength: 1});
+    const swap = new Swap({current, next});
 
-  resized = swap.resize({width: 8, height: 8});
-  t.equal(resized, true, 'resize with new size returns true');
-  t.equal(currentTexture.destroyed, true, 'resize destroys the previous current texture');
-  t.equal(nextTexture.destroyed, true, 'resize destroys the previous next texture');
-  t.equal(swap.current.width, 8, 'current framebuffer width updated');
-  t.equal(swap.current.height, 8, 'current framebuffer height updated');
-  t.notEqual(
-    swap.current.colorAttachments[0].texture,
-    currentTexture,
-    'current framebuffer texture replaced after resize'
-  );
+    expect(swap.current.destroyed, 'should not yet have destroyed the current resource').toBe(
+      false
+    );
+    expect(swap.next.destroyed, 'should not yet have destroyed the next resource').toBe(false);
 
-  const newCurrent = swap.current.colorAttachments[0].texture;
-  const newNext = swap.next.colorAttachments[0].texture;
-  resized = swap.resize({width: 8, height: 8});
-  t.equal(resized, false, 'resize with same size again returns false');
-  t.equal(
-    swap.current.colorAttachments[0].texture,
-    newCurrent,
-    'current framebuffer texture unchanged after no-op'
-  );
-  t.equal(
-    swap.next.colorAttachments[0].texture,
-    newNext,
-    'next framebuffer texture unchanged after no-op'
-  );
+    swap.destroy();
 
-  swap.destroy();
-  t.equal(newCurrent.destroyed, true, 'destroy releases the current framebuffer texture');
-  t.equal(newNext.destroyed, true, 'destroy releases the next framebuffer texture');
-
-  t.end();
-});
-
-test('SwapFramebuffers preserves borrowed attachment ownership', async t => {
-  const webglDevice = await getWebGLTestDevice();
-  const borrowedTexture = webglDevice.createTexture({
-    format: 'rgba8unorm',
-    width: 4,
-    height: 4
-  });
-  const swap = new SwapFramebuffers(webglDevice, {
-    colorAttachments: [borrowedTexture],
-    width: 4,
-    height: 4
+    expect(swap.current.destroyed, 'should destroy the current resource').toBe(true);
+    expect(swap.next.destroyed, 'should destroy the next resource').toBe(true);
   });
 
-  swap.destroy();
-  t.equal(borrowedTexture.destroyed, false, 'destroy does not release a borrowed texture');
-  borrowedTexture.destroy();
+  it('swap', async () => {
+    const webglDevice = await getWebGLTestDevice();
 
-  t.end();
+    const current = webglDevice.createBuffer({byteLength: 1});
+    const next = webglDevice.createBuffer({byteLength: 1});
+    const swap = new Swap({current, next});
+
+    swap.swap();
+
+    expect(swap.current, 'should make the next resource the current resource').toBe(next);
+    expect(swap.next, 'should reuse the current resource as the next resource').toBe(current);
+  });
+
+  it('SwapFramebuffers#resize', async () => {
+    const webglDevice = await getWebGLTestDevice();
+
+    const swap = new SwapFramebuffers(webglDevice, {
+      colorAttachments: ['rgba8unorm'],
+      width: 4,
+      height: 4
+    });
+
+    const currentTexture = swap.current.colorAttachments[0].texture;
+    const nextTexture = swap.next.colorAttachments[0].texture;
+
+    let resized = swap.resize({width: 4, height: 4});
+    expect(resized, 'resize with same size returns false').toBe(false);
+    expect(swap.current.colorAttachments[0].texture, 'current framebuffer texture unchanged').toBe(
+      currentTexture
+    );
+    expect(swap.next.colorAttachments[0].texture, 'next framebuffer texture unchanged').toBe(
+      nextTexture
+    );
+
+    resized = swap.resize({width: 8, height: 8});
+    expect(resized, 'resize with new size returns true').toBe(true);
+    expect(currentTexture.destroyed, 'resize destroys the previous current texture').toBe(true);
+    expect(nextTexture.destroyed, 'resize destroys the previous next texture').toBe(true);
+    expect(swap.current.width, 'current framebuffer width updated').toBe(8);
+    expect(swap.current.height, 'current framebuffer height updated').toBe(8);
+    expect(
+      swap.current.colorAttachments[0].texture,
+      'current framebuffer texture replaced after resize'
+    ).not.toBe(currentTexture);
+
+    const newCurrent = swap.current.colorAttachments[0].texture;
+    const newNext = swap.next.colorAttachments[0].texture;
+    resized = swap.resize({width: 8, height: 8});
+    expect(resized, 'resize with same size again returns false').toBe(false);
+    expect(
+      swap.current.colorAttachments[0].texture,
+      'current framebuffer texture unchanged after no-op'
+    ).toBe(newCurrent);
+    expect(
+      swap.next.colorAttachments[0].texture,
+      'next framebuffer texture unchanged after no-op'
+    ).toBe(newNext);
+
+    swap.destroy();
+    expect(newCurrent.destroyed, 'destroy releases the current framebuffer texture').toBe(true);
+    expect(newNext.destroyed, 'destroy releases the next framebuffer texture').toBe(true);
+  });
+
+  it('SwapFramebuffers preserves borrowed attachment ownership', async () => {
+    const webglDevice = await getWebGLTestDevice();
+    const borrowedTexture = webglDevice.createTexture({
+      format: 'rgba8unorm',
+      width: 4,
+      height: 4
+    });
+    const swap = new SwapFramebuffers(webglDevice, {
+      colorAttachments: [borrowedTexture],
+      width: 4,
+      height: 4
+    });
+
+    swap.destroy();
+    expect(borrowedTexture.destroyed, 'destroy does not release a borrowed texture').toBe(false);
+    borrowedTexture.destroy();
+  });
 });

--- a/modules/engine/test/compute/texture-transform.spec.ts
+++ b/modules/engine/test/compute/texture-transform.spec.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 import {TextureTransform} from '@luma.gl/engine';
 import {Device, Texture} from '@luma.gl/core';
 
 /** Creates a minimal, no-op transform. */
-test('TextureTransform#constructor', async t => {
+it('TextureTransform#constructor', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   const targetTexture = webglDevice.createTexture({
@@ -25,13 +25,11 @@ test('TextureTransform#constructor', async t => {
     targetTextureVarying: 'vSrc',
     vertexCount: 1
   });
-  t.ok(transform, 'creates transform');
-
-  t.end();
+  expect(transform, 'creates transform').toBeTruthy();
 });
 
 /** Computes a sum over vertex attribute values by writing to framebuffer. */
-test('TextureTransform#attribute', async t => {
+it('TextureTransform#attribute', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   const src = webglDevice.createBuffer({data: new Float32Array([10, 20, 30, 70, 80, 90])});
@@ -65,15 +63,13 @@ test('TextureTransform#attribute', async t => {
   transform.run({clearColor: [0, 0, 0, 0]});
 
   const sum = await readF32(webglDevice, source, 16);
-  t.is(sum[0], 300, 'computes sum');
+  expect(sum[0], 'computes sum').toBe(300);
 
   transform.destroy();
-
-  t.end();
 });
 
 /** Computes a sum over texture pixels by writing to framebuffer. */
-test('TextureTransform#texture', async t => {
+it('TextureTransform#texture', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   const srcData = new Uint8Array([2, 10, 255, 255]);
@@ -114,18 +110,16 @@ test('TextureTransform#texture', async t => {
   // least mimic its API by accepting a RenderPass in .run().
   transform.run({clearColor: [0, 0, 0, 0]});
   let blend = await readU8(webglDevice, targetTexture, 4);
-  t.deepEqual(Array.from(blend), Array.from(dstData), 'computes blend');
+  expect(Array.from(blend), 'computes blend').toEqual(Array.from(dstData));
 
   const offset = 100 / 255;
   transform.run({clearColor: [offset, offset, offset, 1]});
   blend = await readU8(webglDevice, targetTexture, 4);
-  t.deepEqual(Array.from(blend), Array.from(dstOffsetData), 'computes blend');
+  expect(Array.from(blend), 'computes blend').toEqual(Array.from(dstOffsetData));
 
   transform.destroy();
   inputTexture.destroy();
   targetTexture.destroy();
-
-  t.end();
 });
 
 async function readF32(

--- a/modules/engine/test/geometry/geometries.node.spec.ts
+++ b/modules/engine/test/geometry/geometries.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerGeometriesTests} from './geometries.spec.shared';
 
-registerGeometriesTests(test);
+registerGeometriesTests();

--- a/modules/engine/test/geometry/geometries.spec.shared.ts
+++ b/modules/engine/test/geometry/geometries.spec.shared.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {TypedArrayConstructor} from '@math.gl/types';
+import {expect, it} from 'vitest';
 import {
   ConeGeometry,
   CubeGeometry,
@@ -12,7 +13,6 @@ import {
   SphereGeometry,
   TruncatedConeGeometry
 } from '@luma.gl/engine';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
 
 const GEOMETRY_TESTS = [
   {name: 'ConeGeometry', Geometry: ConeGeometry, props: [{height: 2}, {verticalAxis: 'z'}]},
@@ -53,38 +53,39 @@ function checkAttribute(attribute, type: TypedArrayConstructor[] = [Float32Array
   );
 }
 
-export function registerGeometriesTests(test: TapeTestFunction): void {
-  test('Object#Geometries', t => {
+export function registerGeometriesTests(): void {
+  it('Object#Geometries', () => {
     for (const geometryTest of GEOMETRY_TESTS) {
       const {name, Geometry} = geometryTest;
       const testProps = [undefined].concat(geometryTest.props || []);
 
       for (const props of testProps) {
         if (props?._shouldThrow) {
-          t.throws(() => new Geometry(props), `${name}: should throw`);
+          expect(() => new Geometry(props), `${name}: should throw`).toThrow();
           continue; // eslint-disable-line no-continue
         }
 
         const geometry = new Geometry(props);
 
-        t.is(typeof geometry.topology, 'string', `${name}: .topology is a string`);
-        t.is(typeof geometry.vertexCount, 'number', `${name}: .vertexCount is a number`);
-        t.ok(geometry.vertexCount > 0, `${name}: .vertexCount is positive`);
+        expect(typeof geometry.topology, `${name}: .topology is a string`).toBe('string');
+        expect(typeof geometry.vertexCount, `${name}: .vertexCount is a number`).toBe('number');
+        expect(geometry.vertexCount > 0, `${name}: .vertexCount is positive`).toBe(true);
 
         const attributes = geometry.attributes;
 
-        t.ok(checkAttribute(attributes.POSITION), `${name}: POSITION is Float32Array`);
-        t.ok(checkAttribute(attributes.NORMAL), `${name}: NORMAL is Float32Array`);
-        t.ok(checkAttribute(attributes.TEXCOORD_0), `${name}: TEXCOORD_0 is Float32Array`);
-        t.ok(geometry.bufferLayout.length > 0, `${name}: bufferLayout is populated`);
+        expect(checkAttribute(attributes.POSITION), `${name}: POSITION is Float32Array`).toBe(true);
+        expect(checkAttribute(attributes.NORMAL), `${name}: NORMAL is Float32Array`).toBe(true);
+        expect(checkAttribute(attributes.TEXCOORD_0), `${name}: TEXCOORD_0 is Float32Array`).toBe(
+          true
+        );
+        expect(geometry.bufferLayout.length > 0, `${name}: bufferLayout is populated`).toBe(true);
         if (geometry.indices) {
-          t.ok(
+          expect(
             checkAttribute(geometry.indices, [Uint16Array, Uint32Array]),
             `${name}: indices is Uint{16/32}Array`
-          );
+          ).toBe(true);
         }
       }
     }
-    t.end();
   });
 }

--- a/modules/engine/test/geometry/geometries.spec.ts
+++ b/modules/engine/test/geometry/geometries.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerGeometriesTests} from './geometries.spec.shared';
 
-registerGeometriesTests(test);
+registerGeometriesTests();

--- a/modules/engine/test/geometry/geometry-utils.spec.ts
+++ b/modules/engine/test/geometry/geometry-utils.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {Geometry} from '@luma.gl/engine';
 import {
   makeInterleavedGeometry,
@@ -49,22 +49,18 @@ const TEST_CASES = [
   }
 ];
 
-test('unpackIndexedGeometry', t => {
+it('unpackIndexedGeometry', () => {
   for (const testCase of TEST_CASES) {
     const {attributes} = unpackIndexedGeometry(testCase.input);
     for (const name in testCase.output.attributes) {
-      t.deepEqual(
-        attributes[name],
-        testCase.output.attributes[name],
-        `${testCase.title}: ${name} matches`
+      expect(attributes[name], `${testCase.title}: ${name} matches`).toEqual(
+        testCase.output.attributes[name]
       );
     }
   }
-
-  t.end();
 });
 
-test('makeInterleavedGeometry', t => {
+it('makeInterleavedGeometry', () => {
   const geometry = new Geometry({
     topology: 'triangle-list',
     attributes: {
@@ -76,39 +72,33 @@ test('makeInterleavedGeometry', t => {
 
   const interleavedGeometry = makeInterleavedGeometry(geometry);
 
-  t.ok(interleavedGeometry instanceof Geometry, 'returns a Geometry');
-  t.is(interleavedGeometry.vertexCount, 2, 'vertexCount is preserved');
-  t.deepEqual(
+  expect(interleavedGeometry instanceof Geometry, 'returns a Geometry').toBe(true);
+  expect(interleavedGeometry.vertexCount, 'vertexCount is preserved').toBe(2);
+  expect(
     interleavedGeometry.bufferLayout,
-    [
-      {
-        name: 'geometry',
-        stepMode: 'vertex',
-        byteStride: 32,
-        attributes: [
-          {attribute: 'positions', format: 'float32x3', byteOffset: 0},
-          {attribute: 'normals', format: 'float32x3', byteOffset: 12},
-          {attribute: 'texCoords', format: 'float32x2', byteOffset: 24}
-        ]
-      }
-    ],
     'bufferLayout describes one interleaved geometry buffer'
-  );
-  t.deepEqual(
+  ).toEqual([
+    {
+      name: 'geometry',
+      stepMode: 'vertex',
+      byteStride: 32,
+      attributes: [
+        {attribute: 'positions', format: 'float32x3', byteOffset: 0},
+        {attribute: 'normals', format: 'float32x3', byteOffset: 12},
+        {attribute: 'texCoords', format: 'float32x2', byteOffset: 24}
+      ]
+    }
+  ]);
+  expect(
     Array.from(new Float32Array(interleavedGeometry.attributes.geometry.value.buffer)),
-    [0, 1, 2, 10, 11, 12, 20, 21, 3, 4, 5, 13, 14, 15, 22, 23],
     'attributes are interleaved per vertex'
+  ).toEqual([0, 1, 2, 10, 11, 12, 20, 21, 3, 4, 5, 13, 14, 15, 22, 23]);
+  expect(makeInterleavedGeometry(interleavedGeometry), 'interleaving is idempotent').toBe(
+    interleavedGeometry
   );
-  t.is(
-    makeInterleavedGeometry(interleavedGeometry),
-    interleavedGeometry,
-    'interleaving is idempotent'
-  );
-
-  t.end();
 });
 
-test('makeInterleavedGeometry aligns mixed attribute types', t => {
+it('makeInterleavedGeometry aligns mixed attribute types', () => {
   const geometry = new Geometry({
     topology: 'triangle-list',
     attributes: {
@@ -120,24 +110,21 @@ test('makeInterleavedGeometry aligns mixed attribute types', t => {
   const interleavedGeometry = makeInterleavedGeometry(geometry);
   const bytes = interleavedGeometry.attributes.geometry.value;
 
-  t.ok(interleavedGeometry instanceof Geometry, 'returns a Geometry');
-  t.deepEqual(
+  expect(interleavedGeometry instanceof Geometry, 'returns a Geometry').toBe(true);
+  expect(
     interleavedGeometry.bufferLayout,
-    [
-      {
-        name: 'geometry',
-        stepMode: 'vertex',
-        byteStride: 16,
-        attributes: [
-          {attribute: 'positions', format: 'float32x3', byteOffset: 0},
-          {attribute: 'colors', format: 'unorm8x4', byteOffset: 12}
-        ]
-      }
-    ],
     'mixed typed attributes are packed into a four-byte-aligned layout'
-  );
-  t.deepEqual(Array.from(bytes.slice(12, 16)), [1, 2, 3, 4], 'first color is aligned');
-  t.deepEqual(Array.from(bytes.slice(28, 32)), [5, 6, 7, 8], 'second color is aligned');
-
-  t.end();
+  ).toEqual([
+    {
+      name: 'geometry',
+      stepMode: 'vertex',
+      byteStride: 16,
+      attributes: [
+        {attribute: 'positions', format: 'float32x3', byteOffset: 0},
+        {attribute: 'colors', format: 'unorm8x4', byteOffset: 12}
+      ]
+    }
+  ]);
+  expect(Array.from(bytes.slice(12, 16)), 'first color is aligned').toEqual([1, 2, 3, 4]);
+  expect(Array.from(bytes.slice(28, 32)), 'second color is aligned').toEqual([5, 6, 7, 8]);
 });

--- a/modules/engine/test/geometry/geometry.spec.ts
+++ b/modules/engine/test/geometry/geometry.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {Geometry, GeometryProps} from '@luma.gl/engine';
 import {TypedArray} from '@math.gl/types';
 
@@ -70,31 +70,25 @@ const TEST_CASES: {title: string; props: GeometryProps; [key: string]: any}[] = 
   }
 ];
 
-test('Geometry#constructor', t => {
+it('Geometry#constructor', () => {
   for (const testCase of TEST_CASES) {
     if (testCase.shouldThrow) {
-      t.throws(() => new Geometry(testCase.props), `${testCase.title}: should throw`);
+      expect(() => new Geometry(testCase.props), `${testCase.title}: should throw`).toThrow();
     } else {
       const geometry = new Geometry(testCase.props);
 
-      t.is(geometry.topology, testCase.topology, `${testCase.title}: topology is correct`);
-      t.is(
-        geometry.getVertexCount(),
-        testCase.vertexCount,
-        `${testCase.title}: vertexCount is correct`
+      expect(geometry.topology, `${testCase.title}: topology is correct`).toBe(testCase.topology);
+      expect(geometry.getVertexCount(), `${testCase.title}: vertexCount is correct`).toBe(
+        testCase.vertexCount
       );
-      t.deepEqual(
-        geometry.bufferLayout,
-        testCase.bufferLayout,
-        `${testCase.title}: bufferLayout is correct`
+      expect(geometry.bufferLayout, `${testCase.title}: bufferLayout is correct`).toEqual(
+        testCase.bufferLayout
       );
     }
   }
-
-  t.end();
 });
 
-test('Geometry#constructor preserves source attribute and explicit layout names', t => {
+it('Geometry#constructor preserves source attribute and explicit layout names', () => {
   const geometry = new Geometry({
     topology: 'triangle-list',
     attributes: {
@@ -103,9 +97,9 @@ test('Geometry#constructor preserves source attribute and explicit layout names'
     bufferLayout: [{name: 'POSITION', format: 'float32x3'}]
   });
 
-  t.ok(geometry.attributes.POSITION, 'semantic attribute name is preserved');
-  t.notOk(geometry.attributes.positions, 'semantic attribute has no shader-name alias');
-  t.deepEqual(geometry.bufferLayout, [{name: 'POSITION', format: 'float32x3'}]);
+  expect(geometry.attributes.POSITION, 'semantic attribute name is preserved').toBeTruthy();
+  expect(geometry.attributes.positions, 'semantic attribute has no shader-name alias').toBeFalsy();
+  expect(geometry.bufferLayout).toEqual([{name: 'POSITION', format: 'float32x3'}]);
 
   const positions = {value: new Float32Array([1, 1, 1]), size: 3};
   const geometryWithShaderNameOverride = new Geometry({
@@ -116,13 +110,14 @@ test('Geometry#constructor preserves source attribute and explicit layout names'
     }
   });
 
-  t.notOk(
+  expect(
     geometryWithShaderNameOverride.attributes.POSITION,
     'shader-name override replaces semantic'
+  ).toBeFalsy();
+  expect(geometryWithShaderNameOverride.attributes.positions, 'shader-name override wins').toBe(
+    positions
   );
-  t.is(geometryWithShaderNameOverride.attributes.positions, positions, 'shader-name override wins');
-  t.deepEqual(geometryWithShaderNameOverride.bufferLayout, [
+  expect(geometryWithShaderNameOverride.bufferLayout).toEqual([
     {name: 'positions', format: 'float32x3'}
   ]);
-  t.end();
 });

--- a/modules/engine/test/geometry/gpu-geometry.spec.ts
+++ b/modules/engine/test/geometry/gpu-geometry.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {
   ConeGeometry,
   CubeGeometry,
@@ -25,57 +25,56 @@ const BUILT_IN_GEOMETRY_TESTS = [
   {name: 'TruncatedConeGeometry', Geometry: TruncatedConeGeometry}
 ];
 
-test('CubeGeometry exposes stable face indices for indexed and non-indexed cubes', t => {
+it('CubeGeometry exposes stable face indices for indexed and non-indexed cubes', () => {
   const indexedCube = new CubeGeometry({indices: true});
   const nonIndexedCube = new CubeGeometry({indices: false});
 
-  t.ok(indexedCube.attributes.faceIndex, 'indexed cube includes faceIndex');
-  t.deepEqual(
+  expect(indexedCube.attributes.faceIndex, 'indexed cube includes faceIndex').toBeTruthy();
+  expect(
     indexedCube.attributes.faceIndex?.value,
-    new Uint32Array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5]),
     'indexed cube stores one semantic face id per duplicated vertex'
+  ).toEqual(
+    new Uint32Array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5])
   );
-  t.ok(nonIndexedCube.attributes.faceIndex, 'non-indexed cube includes faceIndex');
-  t.deepEqual(
+  expect(nonIndexedCube.attributes.faceIndex, 'non-indexed cube includes faceIndex').toBeTruthy();
+  expect(
     nonIndexedCube.attributes.faceIndex?.value,
+    'non-indexed cube preserves semantic face ids across its vertex block order'
+  ).toEqual(
     new Uint32Array([
       3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 2, 2, 2, 2, 2, 2, 5, 5, 5, 5, 5, 5, 0, 0, 0, 0, 0, 0, 1,
       1, 1, 1, 1, 1
-    ]),
-    'non-indexed cube preserves semantic face ids across its vertex block order'
+    ])
   );
-
-  t.end();
 });
 
-test('makeGPUGeometry interleaves built-in geometry attributes', async t => {
+it('makeGPUGeometry interleaves built-in geometry attributes', async () => {
   const device = await getWebGLTestDevice();
 
   for (const {name, Geometry} of BUILT_IN_GEOMETRY_TESTS) {
     const gpuGeometry = makeGPUGeometry(device, new Geometry());
     const bufferLayout = gpuGeometry.bufferLayout[0];
 
-    t.deepEqual(
-      Object.keys(gpuGeometry.attributes),
-      ['geometry'],
-      `${name}: has one vertex buffer`
-    );
-    t.is(gpuGeometry.bufferLayout.length, 1, `${name}: has one buffer layout`);
-    t.is(bufferLayout.name, 'geometry', `${name}: buffer layout is named geometry`);
-    t.ok(bufferLayout.attributes?.length, `${name}: buffer layout maps geometry attributes`);
-    t.ok(gpuGeometry.indices, `${name}: keeps index buffer`);
+    expect(Object.keys(gpuGeometry.attributes), `${name}: has one vertex buffer`).toEqual([
+      'geometry'
+    ]);
+    expect(gpuGeometry.bufferLayout.length, `${name}: has one buffer layout`).toBe(1);
+    expect(bufferLayout.name, `${name}: buffer layout is named geometry`).toBe('geometry');
+    expect(
+      bufferLayout.attributes?.length,
+      `${name}: buffer layout maps geometry attributes`
+    ).toBeTruthy();
+    expect(gpuGeometry.indices, `${name}: keeps index buffer`).toBeTruthy();
 
     gpuGeometry.destroy();
   }
-
-  t.end();
 });
 
-test('makeGPUGeometry interleaves cube geometry into one vertex buffer', async t => {
+it('makeGPUGeometry interleaves cube geometry into one vertex buffer', async () => {
   const device = await getWebGLTestDevice();
   const gpuGeometry = makeGPUGeometry(device, new CubeGeometry({indices: true}));
 
-  t.deepEqual(gpuGeometry.bufferLayout, [
+  expect(gpuGeometry.bufferLayout).toEqual([
     {
       name: 'geometry',
       stepMode: 'vertex',
@@ -88,14 +87,11 @@ test('makeGPUGeometry interleaves cube geometry into one vertex buffer', async t
       ]
     }
   ]);
-  t.is(
-    gpuGeometry.attributes.geometry.byteLength,
-    24 * 36,
-    'cube has one interleaved vertex buffer'
+  expect(gpuGeometry.attributes.geometry.byteLength, 'cube has one interleaved vertex buffer').toBe(
+    24 * 36
   );
-  t.is(gpuGeometry.vertexCount, 36, 'indexed cube draw count is preserved');
-  t.ok(gpuGeometry.indices, 'indexed cube keeps index buffer');
+  expect(gpuGeometry.vertexCount, 'indexed cube draw count is preserved').toBe(36);
+  expect(gpuGeometry.indices, 'indexed cube keeps index buffer').toBeTruthy();
 
   gpuGeometry.destroy();
-  t.end();
 });

--- a/modules/engine/test/utils/buffer-layout-order.spec.ts
+++ b/modules/engine/test/utils/buffer-layout-order.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {type ShaderLayout, type BufferLayout} from '@luma.gl/core';
 import {sortedBufferLayoutByShaderSourceLocations} from '@luma.gl/engine/utils/buffer-layout-order';
 
@@ -134,11 +134,9 @@ const sortedBufferLayout = [
   }
 ];
 
-test('sortedBufferLayoutByShaderSourceLocations', t => {
+it('sortedBufferLayoutByShaderSourceLocations', () => {
   const result = sortedBufferLayoutByShaderSourceLocations(shaderLayout, bufferLayout);
   for (let i = 0; i < sortedBufferLayout.length; i++) {
-    t.deepEqual(result[i], sortedBufferLayout[i], `Buffer layout order is correct`);
-    // t.comment(JSON.stringify(result[i], null, 2));
+    expect(result[i], 'Buffer layout order is correct').toEqual(sortedBufferLayout[i]);
   }
-  t.end();
 });

--- a/modules/engine/test/utils/deep-equal.node.spec.ts
+++ b/modules/engine/test/utils/deep-equal.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerDeepEqualTests} from './deep-equal.spec.shared';
 
-registerDeepEqualTests(test);
+registerDeepEqualTests();

--- a/modules/engine/test/utils/deep-equal.spec.shared.ts
+++ b/modules/engine/test/utils/deep-equal.spec.shared.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
 import {deepEqual} from '@luma.gl/engine/utils/deep-equal';
+import {expect, it} from 'vitest';
 
 const obj = {longitude: -70, latitude: 40.7, zoom: 12};
 const TEST_CASES = [
@@ -66,13 +66,11 @@ const TEST_CASES = [
   {a: {x: 1}, b: null, depth: 1, output: false}
 ];
 
-export function registerDeepEqualTests(test: TapeTestFunction): void {
-  test('utils#deepEqual', t => {
+export function registerDeepEqualTests(): void {
+  it('utils#deepEqual', () => {
     TEST_CASES.forEach(({a, b, depth, output}) => {
       const result = deepEqual(a, b, depth as number);
-      t.is(result, output, `should ${output ? '' : 'not '}be equal`);
+      expect(result, `should ${output ? '' : 'not '}be equal`).toBe(output);
     });
-
-    t.end();
   });
 }

--- a/modules/engine/test/utils/deep-equal.spec.ts
+++ b/modules/engine/test/utils/deep-equal.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerDeepEqualTests} from './deep-equal.spec.shared';
 
-registerDeepEqualTests(test);
+registerDeepEqualTests();

--- a/modules/engine/test/utils/shader-module-utils.spec.ts
+++ b/modules/engine/test/utils/shader-module-utils.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import type {ShaderLayout} from '../../../core/src';
 import type {ShaderModule} from '../../../shadertools/src';
 import {lighting, pbrMaterial} from '../../../shadertools/src';
@@ -11,13 +11,12 @@ import {
   mergeShaderModuleBindingsIntoLayout
 } from '../../src/utils/shader-module-utils';
 
-test('mergeShaderModuleBindingsIntoLayout does not create placeholder layouts', t => {
+it('mergeShaderModuleBindingsIntoLayout does not create placeholder layouts', () => {
   const shaderLayout = mergeShaderModuleBindingsIntoLayout<ShaderLayout | null>(null, [lighting]);
-  t.equal(shaderLayout, null, 'null shader layouts stay null until a real layout is inferred');
-  t.end();
+  expect(shaderLayout, 'null shader layouts stay null until a real layout is inferred').toBeNull();
 });
 
-test('mergeShaderModuleBindingsIntoLayout remaps companion sampler bindings', t => {
+it('mergeShaderModuleBindingsIntoLayout remaps companion sampler bindings', () => {
   const shaderLayout: ShaderLayout = {
     bindings: [
       {name: 'pbr_baseColorSampler', location: 1, group: 0},
@@ -28,21 +27,17 @@ test('mergeShaderModuleBindingsIntoLayout remaps companion sampler bindings', t 
 
   const mergedLayout = mergeShaderModuleBindingsIntoLayout(shaderLayout, [pbrMaterial]);
 
-  t.equal(
+  expect(
     mergedLayout?.bindings.find(binding => binding.name === 'pbr_baseColorSampler')?.group,
-    3,
     'texture binding group is remapped'
-  );
-  t.equal(
+  ).toBe(3);
+  expect(
     mergedLayout?.bindings.find(binding => binding.name === 'pbr_baseColorSamplerSampler')?.group,
-    3,
     'companion sampler binding group is remapped'
-  );
-
-  t.end();
+  ).toBe(3);
 });
 
-test('mergeInferredShaderLayout merges compatible attributes and rejects conflicts', t => {
+it('mergeInferredShaderLayout merges compatible attributes and rejects conflicts', () => {
   const explicitLayout: ShaderLayout = {
     attributes: [{name: 'positions', location: 0, type: 'vec2<f32>', stepMode: 'instance'}],
     bindings: []
@@ -56,44 +51,36 @@ test('mergeInferredShaderLayout merges compatible attributes and rejects conflic
   };
   const mergedLayout = mergeInferredShaderLayout(explicitLayout, inferredLayout, ['filterValues']);
 
-  t.deepEqual(
+  expect(
     mergedLayout?.attributes,
-    [
-      {name: 'positions', location: 0, type: 'vec2<f32>', stepMode: 'instance'},
-      {name: 'filterValues', location: 1, type: 'f32'}
-    ],
     'explicit metadata wins and inferred plugin attributes are appended'
-  );
-  t.throws(
-    () =>
-      mergeInferredShaderLayout(
-        explicitLayout,
-        {
-          attributes: [{name: 'filterValues', location: 0, type: 'f32'}],
-          bindings: []
-        },
-        ['filterValues']
-      ),
-    /both use location 0/,
-    'different names cannot share a location'
-  );
-  t.throws(
-    () =>
-      mergeInferredShaderLayout(
-        explicitLayout,
-        {
-          attributes: [{name: 'positions', location: 0, type: 'vec3<f32>'}],
-          bindings: []
-        },
-        ['positions']
-      ),
-    /conflicts with its inferred type or location/,
-    'same-name declarations must have compatible types and locations'
-  );
-  t.end();
+  ).toEqual([
+    {name: 'positions', location: 0, type: 'vec2<f32>', stepMode: 'instance'},
+    {name: 'filterValues', location: 1, type: 'f32'}
+  ]);
+  expect(() =>
+    mergeInferredShaderLayout(
+      explicitLayout,
+      {
+        attributes: [{name: 'filterValues', location: 0, type: 'f32'}],
+        bindings: []
+      },
+      ['filterValues']
+    )
+  ).toThrow(/both use location 0/);
+  expect(() =>
+    mergeInferredShaderLayout(
+      explicitLayout,
+      {
+        attributes: [{name: 'positions', location: 0, type: 'vec3<f32>'}],
+        bindings: []
+      },
+      ['positions']
+    )
+  ).toThrow(/conflicts with its inferred type or location/);
 });
 
-test('mergeShaderModuleBindingsIntoLayout merges binding visibility', t => {
+it('mergeShaderModuleBindingsIntoLayout merges binding visibility', () => {
   const shaderLayout: ShaderLayout = {
     bindings: [{type: 'storage', name: 'fragments', location: 1, group: 0}],
     attributes: []
@@ -105,10 +92,8 @@ test('mergeShaderModuleBindingsIntoLayout merges binding visibility', t => {
 
   const mergedLayout = mergeShaderModuleBindingsIntoLayout(shaderLayout, [fragmentStorageModule]);
 
-  t.equal(
+  expect(
     mergedLayout?.bindings.find(binding => binding.name === 'fragments')?.visibility,
-    0x2,
     'module binding visibility is merged into inferred bindings'
-  );
-  t.end();
+  ).toBe(0x2);
 });

--- a/modules/engine/test/utils/split-uniforms-and-bindings.node.spec.ts
+++ b/modules/engine/test/utils/split-uniforms-and-bindings.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerSplitUniformsAndBindingsTests} from './split-uniforms-and-bindings.spec.shared';
 
-registerSplitUniformsAndBindingsTests(test);
+registerSplitUniformsAndBindingsTests();

--- a/modules/engine/test/utils/split-uniforms-and-bindings.spec.shared.ts
+++ b/modules/engine/test/utils/split-uniforms-and-bindings.spec.shared.ts
@@ -3,10 +3,10 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {splitUniformsAndBindings} from '@luma.gl/engine/model/split-uniforms-and-bindings';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-export function registerSplitUniformsAndBindingsTests(test: TapeTestFunction): void {
-  test('splitUniformsAndBindings', t => {
+export function registerSplitUniformsAndBindingsTests(): void {
+  it('splitUniformsAndBindings', () => {
     const mixed: Parameters<typeof splitUniformsAndBindings>[0] = {
       array: [1, 2, 3, 4],
       boolean: true,
@@ -15,16 +15,15 @@ export function registerSplitUniformsAndBindingsTests(test: TapeTestFunction): v
       texture: {texture: true} as any
     };
     const {bindings, uniforms} = splitUniformsAndBindings(mixed);
-    t.deepEquals(Object.keys(bindings), ['sampler', 'texture'], 'bindings correctly extracted');
-    t.deepEquals(
-      Object.keys(uniforms),
-      ['array', 'boolean', 'number'],
-      'bindings correctly extracted'
-    );
-    t.end();
+    expect(Object.keys(bindings), 'bindings correctly extracted').toEqual(['sampler', 'texture']);
+    expect(Object.keys(uniforms), 'uniforms correctly extracted').toEqual([
+      'array',
+      'boolean',
+      'number'
+    ]);
   });
 
-  test('splitUniformsAndBindings respects declared struct uniforms', t => {
+  it('splitUniformsAndBindings respects declared struct uniforms', () => {
     const mixed = {
       light: {
         position: [1, 2, 3],
@@ -41,18 +40,16 @@ export function registerSplitUniformsAndBindingsTests(test: TapeTestFunction): v
       }
     });
 
-    t.deepEquals(Object.keys(uniforms), ['light'], 'struct uniform preserved');
-    t.deepEquals(Object.keys(bindings), ['sampler', 'texture'], 'bindings remain bindings');
-    t.deepEqual(uniforms.light, mixed.light, 'struct uniform value retained');
-    t.end();
+    expect(Object.keys(uniforms), 'struct uniform preserved').toEqual(['light']);
+    expect(Object.keys(bindings), 'bindings remain bindings').toEqual(['sampler', 'texture']);
+    expect(uniforms.light, 'struct uniform value retained').toEqual(mixed.light);
   });
 
-  test('splitUniformsAndBindings treats undeclared objects as bindings', t => {
+  it('splitUniformsAndBindings treats undeclared objects as bindings', () => {
     const nestedUniform = {thresholds: [1, 2, 3], metadata: {enabled: true}};
     const {bindings, uniforms} = splitUniformsAndBindings({config: nestedUniform});
 
-    t.deepEquals(uniforms, {}, 'undeclared objects are not treated as uniforms');
-    t.deepEqual(bindings.config, nestedUniform as any, 'undeclared objects fall back to bindings');
-    t.end();
+    expect(uniforms, 'undeclared objects are not treated as uniforms').toEqual({});
+    expect(bindings.config, 'undeclared objects fall back to bindings').toEqual(nestedUniform);
   });
 }

--- a/modules/engine/test/utils/split-uniforms-and-bindings.spec.ts
+++ b/modules/engine/test/utils/split-uniforms-and-bindings.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerSplitUniformsAndBindingsTests} from './split-uniforms-and-bindings.spec.shared';
 
-registerSplitUniformsAndBindingsTests(test);
+registerSplitUniformsAndBindingsTests();


### PR DESCRIPTION
## Summary

Expand the Tape-to-Vitest migration after #3150 by converting the remaining engine geometry and utility suites plus core adapter utility suites to native Vitest syntax.

## Changes

- migrate engine geometry, geometry utility, buffer-layout ordering, deep-equality, and uniform/binding split suites
- migrate core compiler-log formatting and attribute-layout resolution suites
- remove vitest-tape wrappers and t.end compatibility calls while preserving existing assertions and error-path coverage
- keep the browser/node shared suite structure intact for both runners

## Verification

- nvm use
- yarn install
- yarn lint fix
- yarn build
- yarn test-node: 402 files passed, 3,188 tests passed, 1 skipped
- yarn test: Node passed; headless reproduced four unrelated baseline failures (five tests: splat graph ordering, deck slider interaction, scene lighting parity, and GPU-raster NDVI)

This larger package-focused step includes the eight suites from #3150 and adds 16 more changed test files, continuing the path toward removing the remaining Tape compatibility surface and reaching 90% coverage.