### PR TITLE
feat(shadertools): WebGPU implementation of tan_fp32

### DIFF
--- a/modules/gpgpu/src/operations/webgpu/arithmetic.ts
+++ b/modules/gpgpu/src/operations/webgpu/arithmetic.ts
@@ -2,152 +2,12 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import type {Device} from '@luma.gl/core';
+import {fp32} from '@luma.gl/shadertools';
 import {OperationHandler} from '../../operation/operation';
 import {compileExpression} from '../../utils/expression';
 import {ARITHMETIC_OPERATIONS, type ArithmeticOperationInputs} from '../arithmetic-expression';
 import {runRowComputation} from './common/row-transform';
 import {formatLiteralValue, getWGSLType, getZeroValue} from './common/helper';
-
-// Port of the shadertools fp32 tan workaround for platforms with poor built-in tan precision.
-const tanFP32WGSL = `const TWO_PI: f32 = 6.2831854820251465;
-const PI_2: f32 = 1.5707963705062866;
-const PI_16: f32 = 0.1963495463132858;
-
-const SIN_TABLE_0: f32 = 0.19509032368659973;
-const SIN_TABLE_1: f32 = 0.3826834261417389;
-const SIN_TABLE_2: f32 = 0.5555702447891235;
-const SIN_TABLE_3: f32 = 0.7071067690849304;
-
-const COS_TABLE_0: f32 = 0.9807852506637573;
-const COS_TABLE_1: f32 = 0.9238795042037964;
-const COS_TABLE_2: f32 = 0.8314695954322815;
-const COS_TABLE_3: f32 = 0.7071067690849304;
-
-const INVERSE_FACTORIAL_3: f32 = 1.666666716337204e-01;
-const INVERSE_FACTORIAL_5: f32 = 8.333333767950535e-03;
-const INVERSE_FACTORIAL_7: f32 = 1.9841270113829523e-04;
-const INVERSE_FACTORIAL_9: f32 = 2.75573188446287533e-06;
-
-const FP32_OVERFLOW = 3.402823466e+38;
-
-fn sin_taylor_fp32(a: f32) -> f32 {
-  if (a == 0.0) {
-    return 0.0;
-  }
-
-  let x = -a * a;
-  var s = a;
-  var r = a;
-
-  r = r * x;
-  s = s + r * INVERSE_FACTORIAL_3;
-
-  r = r * x;
-  s = s + r * INVERSE_FACTORIAL_5;
-
-  r = r * x;
-  s = s + r * INVERSE_FACTORIAL_7;
-
-  r = r * x;
-  s = s + r * INVERSE_FACTORIAL_9;
-
-  return s;
-}
-
-fn sincos_taylor_fp32(a: f32) -> vec2<f32> {
-  if (a == 0.0) {
-    return vec2<f32>(0.0, 1.0);
-  }
-
-  let sin_t = sin_taylor_fp32(a);
-  let cos_t = sqrt(1.0 - sin_t * sin_t);
-  return vec2<f32>(sin_t, cos_t);
-}
-
-fn tan_taylor_fp32(a: f32) -> f32 {
-  if (a == 0.0) {
-    return 0.0;
-  }
-
-  let z = floor(a / TWO_PI);
-  let r = a - TWO_PI * z;
-
-  var q = floor(r / PI_2 + 0.5);
-  let j = i32(q);
-
-  if (j < -2 || j > 2) {
-    return FP32_OVERFLOW;
-  }
-
-  var t = r - PI_2 * q;
-
-  q = floor(t / PI_16 + 0.5);
-  let k = i32(q);
-  let abs_k = abs(k);
-
-  if (abs_k > 4) {
-    return FP32_OVERFLOW;
-  }
-
-  t = t - PI_16 * q;
-
-  let sincos_t = sincos_taylor_fp32(t);
-  let sin_t = sincos_t.x;
-  let cos_t = sincos_t.y;
-
-  var u = 0.0;
-  var v = 0.0;
-
-  if (abs_k == 1) {
-    u = COS_TABLE_0;
-    v = SIN_TABLE_0;
-  } else if (abs_k == 2) {
-    u = COS_TABLE_1;
-    v = SIN_TABLE_1;
-  } else if (abs_k == 3) {
-    u = COS_TABLE_2;
-    v = SIN_TABLE_2;
-  } else if (abs_k == 4) {
-    u = COS_TABLE_3;
-    v = SIN_TABLE_3;
-  }
-
-  var s = sin_t;
-  var c = cos_t;
-
-  if (k > 0) {
-    s = u * sin_t + v * cos_t;
-    c = u * cos_t - v * sin_t;
-  } else if (k < 0) {
-    s = u * sin_t - v * cos_t;
-    c = u * cos_t + v * sin_t;
-  }
-
-  var sin_a = 0.0;
-  var cos_a = 0.0;
-
-  if (j == 0) {
-    sin_a = s;
-    cos_a = c;
-  } else if (j == 1) {
-    sin_a = c;
-    cos_a = -s;
-  } else if (j == -1) {
-    sin_a = -c;
-    cos_a = s;
-  } else {
-    sin_a = -s;
-    cos_a = -c;
-  }
-
-  return sin_a / cos_a;
-}
-
-fn tan_fp32(a: f32) -> f32 {
-  return tan_taylor_fp32(a);
-}
-`;
 
 const arithmeticSource = `fn arithmetic_add(x: {TYPE}, y: {TYPE}) -> {TYPE} {
   return x + y;
@@ -166,22 +26,11 @@ fn arithmetic_divide(x: {TYPE}, y: {TYPE}) -> {TYPE} {
 }
 
 fn arithmetic_tan(x: f32) -> f32 {
-  return {TAN_IMPL}(x);
+  return tan_fp32(x);
 }
 `;
 
-function getArithmeticSource(device: Device): string {
-  const {gpu} = device.info;
-  // Equivalent to modules/shadertools/src/lib/shader-assembly/platform-defines.ts LUMA_FP32_TAN_PRECISION_WORKAROUND
-  const useFp32TanPrecisionWorkaround = gpu !== 'nvidia' && gpu !== 'amd';
-  if (useFp32TanPrecisionWorkaround) {
-    return `${tanFP32WGSL}\n${arithmeticSource.replace('{TAN_IMPL}', 'tan_fp32')}`;
-  }
-  return arithmeticSource.replace('{TAN_IMPL}', 'tan');
-}
-
 export const arithmetic: OperationHandler<ArithmeticOperationInputs> = ({
-  device,
   inputs,
   output,
   target
@@ -190,10 +39,9 @@ export const arithmetic: OperationHandler<ArithmeticOperationInputs> = ({
   const scalarType = getWGSLType(operationType);
   const zeroLiteral = getZeroValue(operationType);
   const namedInputs = inputs.namedInputs;
-  const source = getArithmeticSource(device);
 
   runRowComputation({
-    module: {name: 'arithmetic', source},
+    module: {name: 'arithmetic', source: arithmeticSource, dependencies: [fp32]},
     inputs: namedInputs,
     output,
     operationType,

--- a/modules/gpgpu/src/operations/webgpu/common/row-transform.ts
+++ b/modules/gpgpu/src/operations/webgpu/common/row-transform.ts
@@ -80,6 +80,7 @@ ${getComputeBlock(module.name, inputEntries, output, elementWise, expression)}
 
   const computation = new Computation(outputBuffer.device, {
     source,
+    modules: module.dependencies,
     shaderAssembler: GPGPU_SHADER_ASSEMBLER,
     shaderLayout: {
       bindings: [

--- a/modules/shadertools/src/lib/shader-assembler.ts
+++ b/modules/shadertools/src/lib/shader-assembler.ts
@@ -238,6 +238,11 @@ export class WGSLShaderAssembler extends ShaderAssembler {
     return {
       LUMA_SUPPORTS_VERTEX_STORAGE_BUFFERS:
         platformInfo.type === 'webgpu' && (limits['maxStorageBuffersInVertexStage'] || 0) > 0,
+      // Native tan() does not provide enough precision on all WebGPU implementations.
+      LUMA_FP32_TAN_PRECISION_WORKAROUND:
+        platformInfo.type === 'webgpu' &&
+        platformInfo.gpu.toLowerCase() !== 'nvidia' &&
+        platformInfo.gpu.toLowerCase() !== 'amd',
       // Metal may reassociate the floating-point transforms used by classic
       // double-single arithmetic. The integer path makes each rounding point
       // explicit while preserving the public vec2<f32> representation.

--- a/modules/shadertools/src/modules/math/fp32/fp32.ts
+++ b/modules/shadertools/src/modules/math/fp32/fp32.ts
@@ -157,10 +157,135 @@ float tan_fp32(float a) {
 }
 `;
 
+const fp32WGSL = /* wgsl */ `\
+#ifdef LUMA_FP32_TAN_PRECISION_WORKAROUND
+const FP32_TWO_PI: f32 = 6.2831854820251465;
+const FP32_PI_2: f32 = 1.5707963705062866;
+const FP32_PI_16: f32 = 0.1963495463132858;
+
+const FP32_SIN_TABLE_0: f32 = 0.19509032368659973;
+const FP32_SIN_TABLE_1: f32 = 0.3826834261417389;
+const FP32_SIN_TABLE_2: f32 = 0.5555702447891235;
+const FP32_SIN_TABLE_3: f32 = 0.7071067690849304;
+
+const FP32_COS_TABLE_0: f32 = 0.9807852506637573;
+const FP32_COS_TABLE_1: f32 = 0.9238795042037964;
+const FP32_COS_TABLE_2: f32 = 0.8314695954322815;
+const FP32_COS_TABLE_3: f32 = 0.7071067690849304;
+
+const FP32_INVERSE_FACTORIAL_3: f32 = 1.666666716337204e-01;
+const FP32_INVERSE_FACTORIAL_5: f32 = 8.333333767950535e-03;
+const FP32_INVERSE_FACTORIAL_7: f32 = 1.9841270113829523e-04;
+const FP32_INVERSE_FACTORIAL_9: f32 = 2.75573188446287533e-06;
+const FP32_OVERFLOW: f32 = 3.402823466e+38;
+
+fn sin_taylor_fp32(a: f32) -> f32 {
+  if (a == 0.0) {
+    return 0.0;
+  }
+
+  let x = -a * a;
+  var sum = a;
+  var term = a;
+
+  term = term * x;
+  sum = sum + term * FP32_INVERSE_FACTORIAL_3;
+  term = term * x;
+  sum = sum + term * FP32_INVERSE_FACTORIAL_5;
+  term = term * x;
+  sum = sum + term * FP32_INVERSE_FACTORIAL_7;
+  term = term * x;
+  sum = sum + term * FP32_INVERSE_FACTORIAL_9;
+
+  return sum;
+}
+
+fn tan_taylor_fp32(a: f32) -> f32 {
+  if (a == 0.0) {
+    return 0.0;
+  }
+
+  let z = floor(a / FP32_TWO_PI);
+  let reduced = a - FP32_TWO_PI * z;
+
+  var quadrantValue = floor(reduced / FP32_PI_2 + 0.5);
+  let quadrant = i32(quadrantValue);
+  if (quadrant < -2 || quadrant > 2) {
+    return FP32_OVERFLOW;
+  }
+
+  var angle = reduced - FP32_PI_2 * quadrantValue;
+  quadrantValue = floor(angle / FP32_PI_16 + 0.5);
+  let tableIndex = i32(quadrantValue);
+  let absoluteTableIndex = abs(tableIndex);
+  if (absoluteTableIndex > 4) {
+    return FP32_OVERFLOW;
+  }
+
+  angle = angle - FP32_PI_16 * quadrantValue;
+  let sinAngle = sin_taylor_fp32(angle);
+  let cosAngle = sqrt(1.0 - sinAngle * sinAngle);
+
+  var tableCos = 0.0;
+  var tableSin = 0.0;
+  if (absoluteTableIndex == 1) {
+    tableCos = FP32_COS_TABLE_0;
+    tableSin = FP32_SIN_TABLE_0;
+  } else if (absoluteTableIndex == 2) {
+    tableCos = FP32_COS_TABLE_1;
+    tableSin = FP32_SIN_TABLE_1;
+  } else if (absoluteTableIndex == 3) {
+    tableCos = FP32_COS_TABLE_2;
+    tableSin = FP32_SIN_TABLE_2;
+  } else if (absoluteTableIndex == 4) {
+    tableCos = FP32_COS_TABLE_3;
+    tableSin = FP32_SIN_TABLE_3;
+  }
+
+  var sinReduced = sinAngle;
+  var cosReduced = cosAngle;
+  if (tableIndex > 0) {
+    sinReduced = tableCos * sinAngle + tableSin * cosAngle;
+    cosReduced = tableCos * cosAngle - tableSin * sinAngle;
+  } else if (tableIndex < 0) {
+    sinReduced = tableCos * sinAngle - tableSin * cosAngle;
+    cosReduced = tableCos * cosAngle + tableSin * sinAngle;
+  }
+
+  var sinValue = 0.0;
+  var cosValue = 0.0;
+  if (quadrant == 0) {
+    sinValue = sinReduced;
+    cosValue = cosReduced;
+  } else if (quadrant == 1) {
+    sinValue = cosReduced;
+    cosValue = -sinReduced;
+  } else if (quadrant == -1) {
+    sinValue = -cosReduced;
+    cosValue = sinReduced;
+  } else {
+    sinValue = -sinReduced;
+    cosValue = -cosReduced;
+  }
+
+  return sinValue / cosValue;
+}
+
+fn tan_fp32(a: f32) -> f32 {
+  return tan_taylor_fp32(a);
+}
+#else
+fn tan_fp32(a: f32) -> f32 {
+  return tan(a);
+}
+#endif
+`;
+
 /**
  * 32 bit math library (fixups for GPUs)
  */
 export const fp32 = {
   name: 'fp32',
+  source: fp32WGSL,
   vs: fp32shader
 };

--- a/modules/shadertools/test/lib/shader-assembly/assemble-wgsl-auto-bindings.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembly/assemble-wgsl-auto-bindings.spec.ts
@@ -9,6 +9,7 @@ import {ibl} from '../../../src/modules/lighting/ibl/ibl';
 import {lighting} from '../../../src/modules/lighting/lights/lighting';
 import {dirlight} from '../../../src/modules/lighting/no-material/dirlight';
 import {pbrProjection} from '../../../src/modules/lighting/pbr-material/pbr-projection';
+import {fp32} from '../../../src/modules/math/fp32/fp32';
 import {fp64arithmetic} from '../../../src/modules/math/fp64/fp64';
 
 const PLATFORM_INFO: PlatformInfo = {
@@ -50,6 +51,37 @@ fn vertexMain(@builtin(vertex_index) vertexIndex: u32) -> @builtin(position) vec
   return vec4<f32>(x, 0.0, 0.0, 1.0);
 }
 `;
+
+test('assembleWGSLShader#selects precise fp32 tan implementation', t => {
+  const shaderAssembler = new WGSLShaderAssembler();
+  const assemble = (gpu: string, defines?: Record<string, boolean>) =>
+    shaderAssembler.assembleWGSLShader({
+      platformInfo: {...PLATFORM_INFO, gpu},
+      source: APP_WGSL,
+      modules: [fp32],
+      defines
+    }).source;
+
+  const appleSource = assemble('apple');
+  t.ok(appleSource.includes('fn tan_taylor_fp32'), 'Apple WebGPU selects Taylor tan');
+  t.notOk(appleSource.includes('return tan(a);'), 'Apple WebGPU omits native tan');
+
+  const defaultSource = assemble('test-gpu');
+  t.ok(defaultSource.includes('fn tan_taylor_fp32'), 'unknown WebGPU adapters select Taylor tan');
+
+  const nvidiaSource = assemble('nvidia');
+  t.notOk(nvidiaSource.includes('fn tan_taylor_fp32'), 'NVIDIA WebGPU omits Taylor tan');
+  t.ok(nvidiaSource.includes('return tan(a);'), 'NVIDIA WebGPU selects native tan');
+
+  const forcedSource = assemble('nvidia', {LUMA_FP32_TAN_PRECISION_WORKAROUND: true});
+  t.ok(forcedSource.includes('fn tan_taylor_fp32'), 'callers can force Taylor tan');
+
+  const disabledSource = assemble('apple', {LUMA_FP32_TAN_PRECISION_WORKAROUND: false});
+  t.ok(disabledSource.includes('return tan(a);'), 'callers can disable Taylor tan');
+  t.notOk(disabledSource.includes('fn tan_taylor_fp32'), 'false override removes Taylor tan');
+
+  t.end();
+});
 
 test('assembleWGSLShader#selects optimizer-independent fp64 arithmetic', t => {
   const shaderAssembler = new WGSLShaderAssembler();


### PR DESCRIPTION
deck.gl's WebGPU renderer is currently using native `tan` for web mercator projection, whose precision is too low.

#### Change List
- Port the taylor-series tan_fp32 function to WGSL
- Add `LUMA_FP32_TAN_PRECISION_WORKAROUND` preprocessing flag
- Delete adhoc implementation in gpgpu