### PR TITLE
test: migrate engine scenegraph and animation suites to Vitest

### DIFF
--- a/modules/constants/test/webgl-constants.spec.ts
+++ b/modules/constants/test/webgl-constants.spec.ts
@@ -2,34 +2,29 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 
 import {GL} from '@luma.gl/constants';
 
-test('@luma.gl/constants', t => {
-  t.equal(typeof GL, 'object', '@luma.gl/constants is an object');
-  t.end();
+it('@luma.gl/constants', () => {
+  expect(typeof GL, '@luma.gl/constants is an object').toBe('object');
 });
 
-test('@luma.gl/constants#WebGL2RenderingContext comparison', async t => {
+it('@luma.gl/constants#WebGL2RenderingContext comparison', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   for (const device of [webglDevice]) {
     // @ts-ignore
     const gl = device.gl;
-    let count = 0;
     for (const key in gl) {
       const value = gl[key];
       if (Number.isFinite(value) && key.toUpperCase() === key && GL[key] !== undefined) {
         // Avoid generating too much test log
         if (GL[key] !== value) {
-          t.equals(GL[key], value, `GL.${key} is equal to gl.${key}`);
+          expect(GL[key], `GL.${key} is equal to gl.${key}`).toBe(value);
         }
-        count++;
       }
     }
-    t.comment(`Checked ${count} GL constants against platform WebGL2 context`);
   }
-  t.end();
 });

--- a/modules/core/test/adapter-utils/buffer-layout-utils.spec.ts
+++ b/modules/core/test/adapter-utils/buffer-layout-utils.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {
   type BufferLayout,
   type ShaderLayout,
@@ -21,7 +21,7 @@ const shaderLayout: ShaderLayout = {
   ]
 };
 
-test('resolveLogicalAttributeMappings resolves interleaved, shorthand, and default mappings', t => {
+it('resolveLogicalAttributeMappings resolves interleaved, shorthand, and default mappings', () => {
   const bufferLayout: BufferLayout[] = [
     {
       name: 'particles',
@@ -33,7 +33,7 @@ test('resolveLogicalAttributeMappings resolves interleaved, shorthand, and defau
     {name: 'vertexPositions', format: 'float32x3'}
   ];
 
-  t.deepEqual(resolveLogicalAttributeMappings(shaderLayout, bufferLayout), [
+  expect(resolveLogicalAttributeMappings(shaderLayout, bufferLayout)).toEqual([
     {
       attributeName: 'instancePositions',
       bufferName: 'particles',
@@ -71,29 +71,25 @@ test('resolveLogicalAttributeMappings resolves interleaved, shorthand, and defau
       stepMode: 'vertex'
     }
   ]);
-  t.end();
 });
 
-test('resolveLogicalAttributeMappings distinguishes zero from omitted stride', t => {
+it('resolveLogicalAttributeMappings distinguishes zero from omitted stride', () => {
   const mappings = resolveLogicalAttributeMappings(shaderLayout, [
     {name: 'vertexPositions', format: 'float32x3', byteStride: 0},
     {name: 'colors', format: 'float32x4'}
   ]);
 
-  t.equal(
+  expect(
     mappings.find(mapping => mapping.attributeName === 'vertexPositions')?.byteStride,
-    0,
     'preserves an explicit zero stride'
-  );
-  t.equal(
+  ).toBe(0);
+  expect(
     mappings.find(mapping => mapping.attributeName === 'colors')?.byteStride,
-    16,
     'resolves an omitted stride to the packed format size'
-  );
-  t.end();
+  ).toBe(16);
 });
 
-test('getLogicalBufferSlots keeps logical layout order and appends unmapped shader attributes', t => {
+it('getLogicalBufferSlots keeps logical layout order and appends unmapped shader attributes', () => {
   const bufferLayout: BufferLayout[] = [
     {name: 'vertexPositions', format: 'float32x3'},
     {
@@ -102,16 +98,15 @@ test('getLogicalBufferSlots keeps logical layout order and appends unmapped shad
     }
   ];
 
-  t.deepEqual(getLogicalBufferSlots(shaderLayout, bufferLayout), {
+  expect(getLogicalBufferSlots(shaderLayout, bufferLayout)).toEqual({
     vertexPositions: 0,
     particles: 1,
     instanceVelocities: 2,
     colors: 3
   });
-  t.end();
 });
 
-test('getBufferLayoutMinAttributeLocation returns the first referenced shader location', t => {
+it('getBufferLayoutMinAttributeLocation returns the first referenced shader location', () => {
   const bufferLayout: BufferLayout = {
     name: 'particles',
     attributes: [
@@ -120,10 +115,8 @@ test('getBufferLayoutMinAttributeLocation returns the first referenced shader lo
     ]
   };
 
-  t.equal(
+  expect(
     getBufferLayoutMinAttributeLocation(bufferLayout, shaderLayout),
-    0,
     'minimum shader location is derived from the referenced attributes'
-  );
-  t.end();
+  ).toBe(0);
 });

--- a/modules/core/test/adapter-utils/format-compiler-log.node.spec.ts
+++ b/modules/core/test/adapter-utils/format-compiler-log.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerFormatCompilerLogTests} from './format-compiler-log.spec.shared';
 
-registerFormatCompilerLogTests(test);
+registerFormatCompilerLogTests();

--- a/modules/core/test/adapter-utils/format-compiler-log.spec.shared.ts
+++ b/modules/core/test/adapter-utils/format-compiler-log.spec.shared.ts
@@ -4,7 +4,7 @@
 
 import type {CompilerMessage} from '@luma.gl/core';
 import {formatCompilerLog} from '@luma.gl/core/adapter-utils/format-compiler-log';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 const ERROR_LOG: CompilerMessage[] = [
   {
@@ -146,52 +146,58 @@ void main() {
 }
 `;
 
-export function registerFormatCompilerLogTests(test: TapeTestFunction): void {
-  test('formatCompilerLog', t => {
+export function registerFormatCompilerLogTests(): void {
+  it('formatCompilerLog', () => {
     const formatted = formatCompilerLog(ERROR_LOG, SHADER_SOURCE);
-    t.ok(
+    expect(
       formatted.includes("ERROR: 'project_scale' : no matching overloaded function found"),
       'default formatting includes error messages'
-    );
-    t.ok(!formatted.includes(' 264:'), 'default formatting omits source lines');
+    ).toBe(true);
+    expect(!formatted.includes(' 264:'), 'default formatting omits source lines').toBe(true);
 
     const withIssues = formatCompilerLog(
       [{type: 'error', linePos: 2, lineNum: 10, message: 'broken shader'}],
       SHADER_SOURCE,
       {showSourceCode: 'issues'}
     );
-    t.ok(withIssues.includes('  10:'), 'issues view includes numbered source lines');
-    t.ok(withIssues.includes('^^^'), 'issues view includes a position indicator');
+    expect(withIssues.includes('  10:'), 'issues view includes numbered source lines').toBe(true);
+    expect(withIssues.includes('^^^'), 'issues view includes a position indicator').toBe(true);
 
     const withAllSource = formatCompilerLog(
       [{type: 'warning', linePos: 0, lineNum: 4, message: 'watch this'}],
       SHADER_SOURCE,
       {showSourceCode: 'all'}
     );
-    t.ok(withAllSource.includes('#define AMD_GPU'), 'all view includes the full source body');
-    t.ok(withAllSource.includes('WARNING: watch this'), 'all view includes inline warnings');
+    expect(
+      withAllSource.includes('#define AMD_GPU'),
+      'all view includes the full source body'
+    ).toBe(true);
+    expect(withAllSource.includes('WARNING: watch this'), 'all view includes inline warnings').toBe(
+      true
+    );
 
     const htmlFormatted = formatCompilerLog(
       [{type: 'error', linePos: 1, lineNum: 6, message: 'html error'}],
       SHADER_SOURCE,
       {showSourceCode: 'all', html: true}
     );
-    t.ok(
+    expect(
       htmlFormatted.includes('luma-compiler-log-error'),
       'html formatting renders wrapped messages'
-    );
-    t.ok(htmlFormatted.includes('style="color:red;"'), 'html formatting applies the error color');
+    ).toBe(true);
+    expect(
+      htmlFormatted.includes('style="color:red;"'),
+      'html formatting applies the error color'
+    ).toBe(true);
 
     const trailingMessage = formatCompilerLog(
       [{type: 'error', linePos: 0, lineNum: 999, message: 'late error'}],
       'void main() {}',
       {showSourceCode: 'all'}
     );
-    t.ok(
+    expect(
       trailingMessage.includes('ERROR: late error'),
       'messages after the source are still reported'
-    );
-
-    t.end();
+    ).toBe(true);
   });
 }

--- a/modules/core/test/adapter-utils/format-compiler-log.spec.ts
+++ b/modules/core/test/adapter-utils/format-compiler-log.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerFormatCompilerLogTests} from './format-compiler-log.spec.shared';
 
-registerFormatCompilerLogTests(test);
+registerFormatCompilerLogTests();

--- a/modules/core/test/adapter-utils/get-attribute-from-layout.spec.ts
+++ b/modules/core/test/adapter-utils/get-attribute-from-layout.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {
   ShaderLayout,
   getAttributeInfosFromLayouts,
@@ -190,15 +190,12 @@ const resolvedLayout: Record<string, AttributeInfo> = {
   }
 };
 
-test('getAttributeInfosFromLayouts', t => {
+it('getAttributeInfosFromLayouts', () => {
   const result = getAttributeInfosFromLayouts(shaderLayout, bufferLayout);
   for (const key of Object.keys(resolvedLayout)) {
-    t.deepEqual(
-      result[key],
-      resolvedLayout[key],
-      `Interleaved attribute info for ${key} are correct`
+    expect(result[key], `Interleaved attribute info for ${key} are correct`).toEqual(
+      resolvedLayout[key]
     );
     // t.comment(JSON.stringify(result[key], null, 2));
   }
-  t.end();
 });

--- a/modules/core/test/adapter-utils/is-uniform-value.spec.ts
+++ b/modules/core/test/adapter-utils/is-uniform-value.spec.ts
@@ -4,23 +4,26 @@
 
 import {isUniformValue} from '@luma.gl/core/adapter-utils/is-uniform-value';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('isUniformValue', async t => {
+it('isUniformValue', async () => {
   const device = await getWebGLTestDevice();
 
-  t.ok(isUniformValue(3), 'Number is uniform value');
-  t.ok(isUniformValue(3.412), 'Number is uniform value');
-  t.ok(isUniformValue(0), 'Number is uniform value');
-  t.ok(isUniformValue(false), 'Boolean is uniform value');
-  t.ok(isUniformValue(true), 'Boolean is uniform value');
-  t.ok(isUniformValue([1, 2, 3, 4]), 'Number array is uniform value');
-  t.ok(isUniformValue(new Float32Array([1, 2, 3, 4])), 'Number array is uniform value');
+  expect(isUniformValue(3), 'Number is uniform value').toBe(true);
+  expect(isUniformValue(3.412), 'Number is uniform value').toBe(true);
+  expect(isUniformValue(0), 'Number is uniform value').toBe(true);
+  expect(isUniformValue(false), 'Boolean is uniform value').toBe(true);
+  expect(isUniformValue(true), 'Boolean is uniform value').toBe(true);
+  expect(isUniformValue([1, 2, 3, 4]), 'Number array is uniform value').toBe(true);
+  expect(isUniformValue(new Float32Array([1, 2, 3, 4])), 'Number array is uniform value').toBe(
+    true
+  );
 
-  t.notOk(
+  expect(
     isUniformValue(device.createTexture({width: 1, height: 1})),
     'WEBGLTexture is not a uniform value'
+  ).toBe(false);
+  expect(isUniformValue(device.createSampler({})), 'WEBGLSampler is not a uniform value').toBe(
+    false
   );
-  t.notOk(isUniformValue(device.createSampler({})), 'WEBGLSampler is not a uniform value');
-  t.end();
 });

--- a/modules/core/test/adapter/helpers/parse-shader-compiler-log.spec.ts
+++ b/modules/core/test/adapter/helpers/parse-shader-compiler-log.spec.ts
@@ -4,7 +4,6 @@
 
 /* eslint-disable quotes */
 
-import test from 'test/utils/vitest-tape';
 import {registerParseShaderCompilerLogTests} from 'test/utils/parse-shader-compiler-log.spec.shared';
 
-registerParseShaderCompilerLogTests(test);
+registerParseShaderCompilerLogTests();

--- a/modules/engine/test/animation/animator.spec.ts
+++ b/modules/engine/test/animation/animator.spec.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {AnimationClipController, Animator} from '@luma.gl/engine';
+import {expect, it} from 'vitest';
 
 class TestClip extends AnimationClipController {
   localTimes: number[] = [];
@@ -13,27 +13,23 @@ class TestClip extends AnimationClipController {
   }
 }
 
-test('Animation#Animator clip controllers resolve local clip time from wall-clock ms', t => {
+it('Animation#Animator clip controllers resolve local clip time from wall-clock ms', () => {
   const clip = new TestClip({name: 'test-clip', startTime: 0.5, speed: 2});
 
   clip.setTime(1250);
 
-  t.deepEqual(clip.localTimes, [1.5], 'clip converts milliseconds to local seconds');
-  t.equal(clip.name, 'test-clip', 'clip exposes configured name');
-
-  t.end();
+  expect(clip.localTimes, 'clip converts milliseconds to local seconds').toEqual([1.5]);
+  expect(clip.name, 'clip exposes configured name').toBe('test-clip');
 });
 
-test('Animation#Animator skips paused clips and exposes compatibility aliases', t => {
+it('Animation#Animator skips paused clips and exposes compatibility aliases', () => {
   const activeClip = new TestClip({name: 'active'});
   const pausedClip = new TestClip({name: 'paused', playing: false});
   const animator = new Animator([activeClip, pausedClip]);
 
   animator.setTime(500);
 
-  t.deepEqual(activeClip.localTimes, [0.5], 'active clip advances');
-  t.deepEqual(pausedClip.localTimes, [], 'paused clip does not advance');
-  t.equal(animator.animations, animator.getAnimations(), 'animations alias matches clip list');
-
-  t.end();
+  expect(activeClip.localTimes, 'active clip advances').toEqual([0.5]);
+  expect(pausedClip.localTimes, 'paused clip does not advance').toEqual([]);
+  expect(animator.animations, 'animations alias matches clip list').toBe(animator.getAnimations());
 });

--- a/modules/engine/test/animation/morph-targets.spec.ts
+++ b/modules/engine/test/animation/morph-targets.spec.ts
@@ -3,9 +3,9 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {applyMorphTargets} from '@luma.gl/engine';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('Animation#applyMorphTargets preserves immutable bases and combines all target weights', t => {
+it('Animation#applyMorphTargets preserves immutable bases and combines all target weights', () => {
   const positions = new Float32Array([1, 2, 3, 4, 5, 6]);
   const normals = new Float32Array([0, 0, 1, 0, 1, 0]);
   const tangents = new Float32Array([1, 0, 0, -1, 0, 1, 0, 1]);
@@ -22,28 +22,24 @@ test('Animation#applyMorphTargets preserves immutable bases and combines all tar
     [0.5, 0.25]
   );
 
-  t.deepEqual(Array.from(positions), [1, 2, 3, 4, 5, 6], 'leaves source positions untouched');
-  t.deepEqual(
-    Array.from(morphed.POSITION || []),
-    [2, 3, 3, 4, 6, 7],
-    'combines weighted positions'
-  );
-  t.ok(
+  expect(Array.from(positions), 'leaves source positions untouched').toEqual([1, 2, 3, 4, 5, 6]);
+  expect(Array.from(morphed.POSITION || []), 'combines weighted positions').toEqual([
+    2, 3, 3, 4, 6, 7
+  ]);
+  expect(
     Math.abs(Math.hypot(...Array.from(morphed.NORMAL?.slice(0, 3) || [])) - 1) < 1e-6,
     'renormalizes morphed normals'
-  );
-  t.equal(morphed.TANGENT?.[3], -1, 'preserves tangent handedness');
-  t.equal(morphed.TANGENT?.[7], 1, 'preserves every tangent handedness component');
-  t.end();
+  ).toBe(true);
+  expect(morphed.TANGENT?.[3], 'preserves tangent handedness').toBe(-1);
+  expect(morphed.TANGENT?.[7], 'preserves every tangent handedness component').toBe(1);
 });
 
-test('Animation#applyMorphTargets handles more than four independent target weights', t => {
+it('Animation#applyMorphTargets handles more than four independent target weights', () => {
   const targets = Array.from({length: 8}, (_, index) => ({
     POSITION: new Float32Array([index + 1, 0, 0])
   }));
   const weights = Array.from({length: 8}, () => 0.25);
   const morphed = applyMorphTargets({POSITION: new Float32Array([0, 0, 0])}, targets, weights);
 
-  t.equal(morphed.POSITION?.[0], 9, 'applies the complete MorphStressTest-sized target set');
-  t.end();
+  expect(morphed.POSITION?.[0], 'applies the complete MorphStressTest-sized target set').toBe(9);
 });

--- a/modules/engine/test/animation/skin.node.spec.ts
+++ b/modules/engine/test/animation/skin.node.spec.ts
@@ -4,9 +4,9 @@
 
 import {GroupNode, updateSkinJointMatrices} from '@luma.gl/engine';
 import {Matrix4} from '@math.gl/core';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('Animation#updateSkinJointMatrices evaluates shared joints in mesh-local space', testContext => {
+it('Animation#updateSkinJointMatrices evaluates shared joints in mesh-local space', () => {
   const meshNode = new GroupNode({id: 'mesh'});
   const firstJoint = new GroupNode({id: 'first-joint'});
   const secondJoint = new GroupNode({id: 'second-joint'});
@@ -29,9 +29,9 @@ test('Animation#updateSkinJointMatrices evaluates shared joints in mesh-local sp
     target
   });
 
-  testContext.equal(jointMatrices, target, 'reuses adapter-owned output storage');
-  testContext.equal(jointMatrices[12], 1, 'evaluates the first joint relative to the skinned mesh');
-  testContext.equal(jointMatrices[16 + 13], 2, 'applies authored inverse bind transforms');
+  expect(jointMatrices, 'reuses adapter-owned output storage').toBe(target);
+  expect(jointMatrices[12], 'evaluates the first joint relative to the skinned mesh').toBe(1);
+  expect(jointMatrices[16 + 13], 'applies authored inverse bind transforms').toBe(2);
 
   worldMatrices.set(secondJoint, new Matrix4().translate([10, 7, 0]));
   updateSkinJointMatrices({
@@ -42,18 +42,16 @@ test('Animation#updateSkinJointMatrices evaluates shared joints in mesh-local sp
     target
   });
 
-  testContext.equal(jointMatrices[16 + 13], 5, 'updates animated joints without reallocating');
-  testContext.end();
+  expect(jointMatrices[16 + 13], 'updates animated joints without reallocating').toBe(5);
 });
 
-test('Animation#updateSkinJointMatrices defaults missing inverse bind matrices', testContext => {
+it('Animation#updateSkinJointMatrices defaults missing inverse bind matrices', () => {
   const joint = new GroupNode({id: 'joint', position: [0, 3, 0]});
   const matrices = updateSkinJointMatrices({
     joints: [joint],
     worldMatrices: new Map([[joint, new Matrix4().translate([0, 3, 0])]])
   });
 
-  testContext.equal(matrices.length, 16, 'allocates only the authored joint palette');
-  testContext.equal(matrices[13], 3, 'uses an identity inverse bind transform by default');
-  testContext.end();
+  expect(matrices.length, 'allocates only the authored joint palette').toBe(16);
+  expect(matrices[13], 'uses an identity inverse bind transform by default').toBe(3);
 });

--- a/modules/engine/test/application-utils/load-file.spec.ts
+++ b/modules/engine/test/application-utils/load-file.spec.ts
@@ -2,45 +2,42 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {_resolveLoadFileUrl, setPathPrefix} from '@luma.gl/engine';
+import {expect, it} from 'vitest';
 
-test('load-file resolves only bare relative asset URLs against the configured prefix', t => {
+it('load-file resolves only bare relative asset URLs against the configured prefix', () => {
   setPathPrefix(
     'https://raw.githubusercontent.com/visgl/luma.gl/master/examples/showcase/water-globe/'
   );
 
-  t.equal(
+  expect(
     _resolveLoadFileUrl('earth.jpg'),
-    'https://raw.githubusercontent.com/visgl/luma.gl/master/examples/showcase/water-globe/earth.jpg',
     'bare relative asset paths use the configured prefix'
+  ).toBe(
+    'https://raw.githubusercontent.com/visgl/luma.gl/master/examples/showcase/water-globe/earth.jpg'
   );
-  t.equal(
+  expect(
     _resolveLoadFileUrl('./assets/images/earth.jpg'),
-    'https://raw.githubusercontent.com/visgl/luma.gl/master/examples/showcase/water-globe/./assets/images/earth.jpg',
     'dot-relative asset paths use the configured prefix'
+  ).toBe(
+    'https://raw.githubusercontent.com/visgl/luma.gl/master/examples/showcase/water-globe/./assets/images/earth.jpg'
   );
-  t.equal(
+  expect(
     _resolveLoadFileUrl('/assets/images/earth.jpg'),
-    '/assets/images/earth.jpg',
     'root-relative asset paths do not use the configured prefix'
-  );
-  t.equal(
+  ).toBe('/assets/images/earth.jpg');
+  expect(
     _resolveLoadFileUrl('https://example.com/earth.jpg'),
-    'https://example.com/earth.jpg',
     'absolute http urls do not use the configured prefix'
-  );
-  t.equal(
+  ).toBe('https://example.com/earth.jpg');
+  expect(
     _resolveLoadFileUrl('blob:https://example.com/earth'),
-    'blob:https://example.com/earth',
     'blob urls do not use the configured prefix'
-  );
-  t.equal(
+  ).toBe('blob:https://example.com/earth');
+  expect(
     _resolveLoadFileUrl('data:image/png;base64,abc'),
-    'data:image/png;base64,abc',
     'data urls do not use the configured prefix'
-  );
+  ).toBe('data:image/png;base64,abc');
 
   setPathPrefix('');
-  t.end();
 });

--- a/modules/engine/test/compute/buffer-transform.spec.ts
+++ b/modules/engine/test/compute/buffer-transform.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 import {BufferTransform} from '@luma.gl/engine';
 import {Buffer, Device} from '@luma.gl/core';
@@ -21,14 +21,13 @@ out vec4 fragColor;
 void main() { fragColor.x = dst; }
 `;
 
-test('BufferTransform#constructor', async t => {
+it('BufferTransform#constructor', async () => {
   const webglDevice = await getWebGLTestDevice();
 
-  t.ok(createBufferTransform(webglDevice), 'WebGL succeeds');
-  t.end();
+  expect(createBufferTransform(webglDevice), 'WebGL succeeds').toBeTruthy();
 });
 
-test('BufferTransform#run', async t => {
+it('BufferTransform#run', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   const SRC_ARRAY = new Float32Array([0, 1, 2, 3, 4, 5]);
@@ -43,9 +42,7 @@ test('BufferTransform#run', async t => {
 
   const bytes = await transform.readAsync('dst');
   const array = new Float32Array(bytes.buffer, bytes.byteOffset, elementCount);
-  t.deepEqual(array, DST_ARRAY, 'output transformed');
-
-  t.end();
+  expect(array, 'output transformed').toEqual(DST_ARRAY);
 });
 
 function createBufferTransform(

--- a/modules/engine/test/compute/swap.spec.ts
+++ b/modules/engine/test/compute/swap.spec.ts
@@ -1,126 +1,117 @@
-import test from 'test/utils/vitest-tape';
+import {describe, expect, it} from 'vitest';
 import {Swap, SwapFramebuffers} from '../../src/compute/swap';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 
 // TODO - these tests could run on NullDevice
 
-test('Swap#constructor', async t => {
-  const webglDevice = await getWebGLTestDevice();
+describe('Swap', () => {
+  it('constructor', async () => {
+    const webglDevice = await getWebGLTestDevice();
 
-  const current = webglDevice.createBuffer({byteLength: 1});
-  const next = webglDevice.createBuffer({byteLength: 1});
-  const swap = new Swap({current, next});
+    const current = webglDevice.createBuffer({byteLength: 1});
+    const next = webglDevice.createBuffer({byteLength: 1});
+    const swap = new Swap({current, next});
 
-  t.equal(swap.current, current, 'should set the current resource correctly');
-  t.equal(swap.next, next, 'should set the next resource correctly');
-
-  t.end();
-});
-
-test('Swap#destroy', async t => {
-  const webglDevice = await getWebGLTestDevice();
-
-  const current = webglDevice.createBuffer({byteLength: 1});
-  const next = webglDevice.createBuffer({byteLength: 1});
-  const swap = new Swap({current, next});
-
-  t.equal(swap.current.destroyed, false, 'should not yet have destroyed the current resource');
-  t.equal(swap.next.destroyed, false, 'should not yet have destroyed the next resource');
-
-  swap.destroy();
-
-  t.equal(swap.current.destroyed, true, 'should destroy the current resource');
-  t.equal(swap.next.destroyed, true, 'should destroy the next resource');
-
-  t.end();
-});
-
-test('Swap#swap', async t => {
-  const webglDevice = await getWebGLTestDevice();
-
-  const current = webglDevice.createBuffer({byteLength: 1});
-  const next = webglDevice.createBuffer({byteLength: 1});
-  const swap = new Swap({current, next});
-
-  swap.swap();
-
-  t.equal(swap.current, next, 'should make the next resource the current resource');
-  t.equal(swap.next, current, 'should reuse the current resource as the next resource');
-
-  t.end();
-});
-
-test('SwapFramebuffers#resize', async t => {
-  const webglDevice = await getWebGLTestDevice();
-
-  const swap = new SwapFramebuffers(webglDevice, {
-    colorAttachments: ['rgba8unorm'],
-    width: 4,
-    height: 4
+    expect(swap.current, 'should set the current resource correctly').toBe(current);
+    expect(swap.next, 'should set the next resource correctly').toBe(next);
   });
 
-  const currentTexture = swap.current.colorAttachments[0].texture;
-  const nextTexture = swap.next.colorAttachments[0].texture;
+  it('destroy', async () => {
+    const webglDevice = await getWebGLTestDevice();
 
-  let resized = swap.resize({width: 4, height: 4});
-  t.equal(resized, false, 'resize with same size returns false');
-  t.equal(
-    swap.current.colorAttachments[0].texture,
-    currentTexture,
-    'current framebuffer texture unchanged'
-  );
-  t.equal(swap.next.colorAttachments[0].texture, nextTexture, 'next framebuffer texture unchanged');
+    const current = webglDevice.createBuffer({byteLength: 1});
+    const next = webglDevice.createBuffer({byteLength: 1});
+    const swap = new Swap({current, next});
 
-  resized = swap.resize({width: 8, height: 8});
-  t.equal(resized, true, 'resize with new size returns true');
-  t.equal(currentTexture.destroyed, true, 'resize destroys the previous current texture');
-  t.equal(nextTexture.destroyed, true, 'resize destroys the previous next texture');
-  t.equal(swap.current.width, 8, 'current framebuffer width updated');
-  t.equal(swap.current.height, 8, 'current framebuffer height updated');
-  t.notEqual(
-    swap.current.colorAttachments[0].texture,
-    currentTexture,
-    'current framebuffer texture replaced after resize'
-  );
+    expect(swap.current.destroyed, 'should not yet have destroyed the current resource').toBe(
+      false
+    );
+    expect(swap.next.destroyed, 'should not yet have destroyed the next resource').toBe(false);
 
-  const newCurrent = swap.current.colorAttachments[0].texture;
-  const newNext = swap.next.colorAttachments[0].texture;
-  resized = swap.resize({width: 8, height: 8});
-  t.equal(resized, false, 'resize with same size again returns false');
-  t.equal(
-    swap.current.colorAttachments[0].texture,
-    newCurrent,
-    'current framebuffer texture unchanged after no-op'
-  );
-  t.equal(
-    swap.next.colorAttachments[0].texture,
-    newNext,
-    'next framebuffer texture unchanged after no-op'
-  );
+    swap.destroy();
 
-  swap.destroy();
-  t.equal(newCurrent.destroyed, true, 'destroy releases the current framebuffer texture');
-  t.equal(newNext.destroyed, true, 'destroy releases the next framebuffer texture');
-
-  t.end();
-});
-
-test('SwapFramebuffers preserves borrowed attachment ownership', async t => {
-  const webglDevice = await getWebGLTestDevice();
-  const borrowedTexture = webglDevice.createTexture({
-    format: 'rgba8unorm',
-    width: 4,
-    height: 4
-  });
-  const swap = new SwapFramebuffers(webglDevice, {
-    colorAttachments: [borrowedTexture],
-    width: 4,
-    height: 4
+    expect(swap.current.destroyed, 'should destroy the current resource').toBe(true);
+    expect(swap.next.destroyed, 'should destroy the next resource').toBe(true);
   });
 
-  swap.destroy();
-  t.equal(borrowedTexture.destroyed, false, 'destroy does not release a borrowed texture');
-  borrowedTexture.destroy();
+  it('swap', async () => {
+    const webglDevice = await getWebGLTestDevice();
 
-  t.end();
+    const current = webglDevice.createBuffer({byteLength: 1});
+    const next = webglDevice.createBuffer({byteLength: 1});
+    const swap = new Swap({current, next});
+
+    swap.swap();
+
+    expect(swap.current, 'should make the next resource the current resource').toBe(next);
+    expect(swap.next, 'should reuse the current resource as the next resource').toBe(current);
+  });
+
+  it('SwapFramebuffers#resize', async () => {
+    const webglDevice = await getWebGLTestDevice();
+
+    const swap = new SwapFramebuffers(webglDevice, {
+      colorAttachments: ['rgba8unorm'],
+      width: 4,
+      height: 4
+    });
+
+    const currentTexture = swap.current.colorAttachments[0].texture;
+    const nextTexture = swap.next.colorAttachments[0].texture;
+
+    let resized = swap.resize({width: 4, height: 4});
+    expect(resized, 'resize with same size returns false').toBe(false);
+    expect(swap.current.colorAttachments[0].texture, 'current framebuffer texture unchanged').toBe(
+      currentTexture
+    );
+    expect(swap.next.colorAttachments[0].texture, 'next framebuffer texture unchanged').toBe(
+      nextTexture
+    );
+
+    resized = swap.resize({width: 8, height: 8});
+    expect(resized, 'resize with new size returns true').toBe(true);
+    expect(currentTexture.destroyed, 'resize destroys the previous current texture').toBe(true);
+    expect(nextTexture.destroyed, 'resize destroys the previous next texture').toBe(true);
+    expect(swap.current.width, 'current framebuffer width updated').toBe(8);
+    expect(swap.current.height, 'current framebuffer height updated').toBe(8);
+    expect(
+      swap.current.colorAttachments[0].texture,
+      'current framebuffer texture replaced after resize'
+    ).not.toBe(currentTexture);
+
+    const newCurrent = swap.current.colorAttachments[0].texture;
+    const newNext = swap.next.colorAttachments[0].texture;
+    resized = swap.resize({width: 8, height: 8});
+    expect(resized, 'resize with same size again returns false').toBe(false);
+    expect(
+      swap.current.colorAttachments[0].texture,
+      'current framebuffer texture unchanged after no-op'
+    ).toBe(newCurrent);
+    expect(
+      swap.next.colorAttachments[0].texture,
+      'next framebuffer texture unchanged after no-op'
+    ).toBe(newNext);
+
+    swap.destroy();
+    expect(newCurrent.destroyed, 'destroy releases the current framebuffer texture').toBe(true);
+    expect(newNext.destroyed, 'destroy releases the next framebuffer texture').toBe(true);
+  });
+
+  it('SwapFramebuffers preserves borrowed attachment ownership', async () => {
+    const webglDevice = await getWebGLTestDevice();
+    const borrowedTexture = webglDevice.createTexture({
+      format: 'rgba8unorm',
+      width: 4,
+      height: 4
+    });
+    const swap = new SwapFramebuffers(webglDevice, {
+      colorAttachments: [borrowedTexture],
+      width: 4,
+      height: 4
+    });
+
+    swap.destroy();
+    expect(borrowedTexture.destroyed, 'destroy does not release a borrowed texture').toBe(false);
+    borrowedTexture.destroy();
+  });
 });

--- a/modules/engine/test/compute/texture-transform.spec.ts
+++ b/modules/engine/test/compute/texture-transform.spec.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 import {TextureTransform} from '@luma.gl/engine';
 import {Device, Texture} from '@luma.gl/core';
 
 /** Creates a minimal, no-op transform. */
-test('TextureTransform#constructor', async t => {
+it('TextureTransform#constructor', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   const targetTexture = webglDevice.createTexture({
@@ -25,13 +25,11 @@ test('TextureTransform#constructor', async t => {
     targetTextureVarying: 'vSrc',
     vertexCount: 1
   });
-  t.ok(transform, 'creates transform');
-
-  t.end();
+  expect(transform, 'creates transform').toBeTruthy();
 });
 
 /** Computes a sum over vertex attribute values by writing to framebuffer. */
-test('TextureTransform#attribute', async t => {
+it('TextureTransform#attribute', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   const src = webglDevice.createBuffer({data: new Float32Array([10, 20, 30, 70, 80, 90])});
@@ -65,15 +63,13 @@ test('TextureTransform#attribute', async t => {
   transform.run({clearColor: [0, 0, 0, 0]});
 
   const sum = await readF32(webglDevice, source, 16);
-  t.is(sum[0], 300, 'computes sum');
+  expect(sum[0], 'computes sum').toBe(300);
 
   transform.destroy();
-
-  t.end();
 });
 
 /** Computes a sum over texture pixels by writing to framebuffer. */
-test('TextureTransform#texture', async t => {
+it('TextureTransform#texture', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   const srcData = new Uint8Array([2, 10, 255, 255]);
@@ -114,18 +110,16 @@ test('TextureTransform#texture', async t => {
   // least mimic its API by accepting a RenderPass in .run().
   transform.run({clearColor: [0, 0, 0, 0]});
   let blend = await readU8(webglDevice, targetTexture, 4);
-  t.deepEqual(Array.from(blend), Array.from(dstData), 'computes blend');
+  expect(Array.from(blend), 'computes blend').toEqual(Array.from(dstData));
 
   const offset = 100 / 255;
   transform.run({clearColor: [offset, offset, offset, 1]});
   blend = await readU8(webglDevice, targetTexture, 4);
-  t.deepEqual(Array.from(blend), Array.from(dstOffsetData), 'computes blend');
+  expect(Array.from(blend), 'computes blend').toEqual(Array.from(dstOffsetData));
 
   transform.destroy();
   inputTexture.destroy();
   targetTexture.destroy();
-
-  t.end();
 });
 
 async function readF32(

--- a/modules/engine/test/geometry/geometries.node.spec.ts
+++ b/modules/engine/test/geometry/geometries.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerGeometriesTests} from './geometries.spec.shared';
 
-registerGeometriesTests(test);
+registerGeometriesTests();

--- a/modules/engine/test/geometry/geometries.spec.shared.ts
+++ b/modules/engine/test/geometry/geometries.spec.shared.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {TypedArrayConstructor} from '@math.gl/types';
+import {expect, it} from 'vitest';
 import {
   ConeGeometry,
   CubeGeometry,
@@ -12,7 +13,6 @@ import {
   SphereGeometry,
   TruncatedConeGeometry
 } from '@luma.gl/engine';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
 
 const GEOMETRY_TESTS = [
   {name: 'ConeGeometry', Geometry: ConeGeometry, props: [{height: 2}, {verticalAxis: 'z'}]},
@@ -53,38 +53,39 @@ function checkAttribute(attribute, type: TypedArrayConstructor[] = [Float32Array
   );
 }
 
-export function registerGeometriesTests(test: TapeTestFunction): void {
-  test('Object#Geometries', t => {
+export function registerGeometriesTests(): void {
+  it('Object#Geometries', () => {
     for (const geometryTest of GEOMETRY_TESTS) {
       const {name, Geometry} = geometryTest;
       const testProps = [undefined].concat(geometryTest.props || []);
 
       for (const props of testProps) {
         if (props?._shouldThrow) {
-          t.throws(() => new Geometry(props), `${name}: should throw`);
+          expect(() => new Geometry(props), `${name}: should throw`).toThrow();
           continue; // eslint-disable-line no-continue
         }
 
         const geometry = new Geometry(props);
 
-        t.is(typeof geometry.topology, 'string', `${name}: .topology is a string`);
-        t.is(typeof geometry.vertexCount, 'number', `${name}: .vertexCount is a number`);
-        t.ok(geometry.vertexCount > 0, `${name}: .vertexCount is positive`);
+        expect(typeof geometry.topology, `${name}: .topology is a string`).toBe('string');
+        expect(typeof geometry.vertexCount, `${name}: .vertexCount is a number`).toBe('number');
+        expect(geometry.vertexCount > 0, `${name}: .vertexCount is positive`).toBe(true);
 
         const attributes = geometry.attributes;
 
-        t.ok(checkAttribute(attributes.POSITION), `${name}: POSITION is Float32Array`);
-        t.ok(checkAttribute(attributes.NORMAL), `${name}: NORMAL is Float32Array`);
-        t.ok(checkAttribute(attributes.TEXCOORD_0), `${name}: TEXCOORD_0 is Float32Array`);
-        t.ok(geometry.bufferLayout.length > 0, `${name}: bufferLayout is populated`);
+        expect(checkAttribute(attributes.POSITION), `${name}: POSITION is Float32Array`).toBe(true);
+        expect(checkAttribute(attributes.NORMAL), `${name}: NORMAL is Float32Array`).toBe(true);
+        expect(checkAttribute(attributes.TEXCOORD_0), `${name}: TEXCOORD_0 is Float32Array`).toBe(
+          true
+        );
+        expect(geometry.bufferLayout.length > 0, `${name}: bufferLayout is populated`).toBe(true);
         if (geometry.indices) {
-          t.ok(
+          expect(
             checkAttribute(geometry.indices, [Uint16Array, Uint32Array]),
             `${name}: indices is Uint{16/32}Array`
-          );
+          ).toBe(true);
         }
       }
     }
-    t.end();
   });
 }

--- a/modules/engine/test/geometry/geometries.spec.ts
+++ b/modules/engine/test/geometry/geometries.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerGeometriesTests} from './geometries.spec.shared';
 
-registerGeometriesTests(test);
+registerGeometriesTests();

--- a/modules/engine/test/geometry/geometry-utils.spec.ts
+++ b/modules/engine/test/geometry/geometry-utils.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {Geometry} from '@luma.gl/engine';
 import {
   makeInterleavedGeometry,
@@ -49,22 +49,18 @@ const TEST_CASES = [
   }
 ];
 
-test('unpackIndexedGeometry', t => {
+it('unpackIndexedGeometry', () => {
   for (const testCase of TEST_CASES) {
     const {attributes} = unpackIndexedGeometry(testCase.input);
     for (const name in testCase.output.attributes) {
-      t.deepEqual(
-        attributes[name],
-        testCase.output.attributes[name],
-        `${testCase.title}: ${name} matches`
+      expect(attributes[name], `${testCase.title}: ${name} matches`).toEqual(
+        testCase.output.attributes[name]
       );
     }
   }
-
-  t.end();
 });
 
-test('makeInterleavedGeometry', t => {
+it('makeInterleavedGeometry', () => {
   const geometry = new Geometry({
     topology: 'triangle-list',
     attributes: {
@@ -76,39 +72,33 @@ test('makeInterleavedGeometry', t => {
 
   const interleavedGeometry = makeInterleavedGeometry(geometry);
 
-  t.ok(interleavedGeometry instanceof Geometry, 'returns a Geometry');
-  t.is(interleavedGeometry.vertexCount, 2, 'vertexCount is preserved');
-  t.deepEqual(
+  expect(interleavedGeometry instanceof Geometry, 'returns a Geometry').toBe(true);
+  expect(interleavedGeometry.vertexCount, 'vertexCount is preserved').toBe(2);
+  expect(
     interleavedGeometry.bufferLayout,
-    [
-      {
-        name: 'geometry',
-        stepMode: 'vertex',
-        byteStride: 32,
-        attributes: [
-          {attribute: 'positions', format: 'float32x3', byteOffset: 0},
-          {attribute: 'normals', format: 'float32x3', byteOffset: 12},
-          {attribute: 'texCoords', format: 'float32x2', byteOffset: 24}
-        ]
-      }
-    ],
     'bufferLayout describes one interleaved geometry buffer'
-  );
-  t.deepEqual(
+  ).toEqual([
+    {
+      name: 'geometry',
+      stepMode: 'vertex',
+      byteStride: 32,
+      attributes: [
+        {attribute: 'positions', format: 'float32x3', byteOffset: 0},
+        {attribute: 'normals', format: 'float32x3', byteOffset: 12},
+        {attribute: 'texCoords', format: 'float32x2', byteOffset: 24}
+      ]
+    }
+  ]);
+  expect(
     Array.from(new Float32Array(interleavedGeometry.attributes.geometry.value.buffer)),
-    [0, 1, 2, 10, 11, 12, 20, 21, 3, 4, 5, 13, 14, 15, 22, 23],
     'attributes are interleaved per vertex'
+  ).toEqual([0, 1, 2, 10, 11, 12, 20, 21, 3, 4, 5, 13, 14, 15, 22, 23]);
+  expect(makeInterleavedGeometry(interleavedGeometry), 'interleaving is idempotent').toBe(
+    interleavedGeometry
   );
-  t.is(
-    makeInterleavedGeometry(interleavedGeometry),
-    interleavedGeometry,
-    'interleaving is idempotent'
-  );
-
-  t.end();
 });
 
-test('makeInterleavedGeometry aligns mixed attribute types', t => {
+it('makeInterleavedGeometry aligns mixed attribute types', () => {
   const geometry = new Geometry({
     topology: 'triangle-list',
     attributes: {
@@ -120,24 +110,21 @@ test('makeInterleavedGeometry aligns mixed attribute types', t => {
   const interleavedGeometry = makeInterleavedGeometry(geometry);
   const bytes = interleavedGeometry.attributes.geometry.value;
 
-  t.ok(interleavedGeometry instanceof Geometry, 'returns a Geometry');
-  t.deepEqual(
+  expect(interleavedGeometry instanceof Geometry, 'returns a Geometry').toBe(true);
+  expect(
     interleavedGeometry.bufferLayout,
-    [
-      {
-        name: 'geometry',
-        stepMode: 'vertex',
-        byteStride: 16,
-        attributes: [
-          {attribute: 'positions', format: 'float32x3', byteOffset: 0},
-          {attribute: 'colors', format: 'unorm8x4', byteOffset: 12}
-        ]
-      }
-    ],
     'mixed typed attributes are packed into a four-byte-aligned layout'
-  );
-  t.deepEqual(Array.from(bytes.slice(12, 16)), [1, 2, 3, 4], 'first color is aligned');
-  t.deepEqual(Array.from(bytes.slice(28, 32)), [5, 6, 7, 8], 'second color is aligned');
-
-  t.end();
+  ).toEqual([
+    {
+      name: 'geometry',
+      stepMode: 'vertex',
+      byteStride: 16,
+      attributes: [
+        {attribute: 'positions', format: 'float32x3', byteOffset: 0},
+        {attribute: 'colors', format: 'unorm8x4', byteOffset: 12}
+      ]
+    }
+  ]);
+  expect(Array.from(bytes.slice(12, 16)), 'first color is aligned').toEqual([1, 2, 3, 4]);
+  expect(Array.from(bytes.slice(28, 32)), 'second color is aligned').toEqual([5, 6, 7, 8]);
 });

--- a/modules/engine/test/geometry/geometry.spec.ts
+++ b/modules/engine/test/geometry/geometry.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {Geometry, GeometryProps} from '@luma.gl/engine';
 import {TypedArray} from '@math.gl/types';
 
@@ -70,31 +70,25 @@ const TEST_CASES: {title: string; props: GeometryProps; [key: string]: any}[] = 
   }
 ];
 
-test('Geometry#constructor', t => {
+it('Geometry#constructor', () => {
   for (const testCase of TEST_CASES) {
     if (testCase.shouldThrow) {
-      t.throws(() => new Geometry(testCase.props), `${testCase.title}: should throw`);
+      expect(() => new Geometry(testCase.props), `${testCase.title}: should throw`).toThrow();
     } else {
       const geometry = new Geometry(testCase.props);
 
-      t.is(geometry.topology, testCase.topology, `${testCase.title}: topology is correct`);
-      t.is(
-        geometry.getVertexCount(),
-        testCase.vertexCount,
-        `${testCase.title}: vertexCount is correct`
+      expect(geometry.topology, `${testCase.title}: topology is correct`).toBe(testCase.topology);
+      expect(geometry.getVertexCount(), `${testCase.title}: vertexCount is correct`).toBe(
+        testCase.vertexCount
       );
-      t.deepEqual(
-        geometry.bufferLayout,
-        testCase.bufferLayout,
-        `${testCase.title}: bufferLayout is correct`
+      expect(geometry.bufferLayout, `${testCase.title}: bufferLayout is correct`).toEqual(
+        testCase.bufferLayout
       );
     }
   }
-
-  t.end();
 });
 
-test('Geometry#constructor preserves source attribute and explicit layout names', t => {
+it('Geometry#constructor preserves source attribute and explicit layout names', () => {
   const geometry = new Geometry({
     topology: 'triangle-list',
     attributes: {
@@ -103,9 +97,9 @@ test('Geometry#constructor preserves source attribute and explicit layout names'
     bufferLayout: [{name: 'POSITION', format: 'float32x3'}]
   });
 
-  t.ok(geometry.attributes.POSITION, 'semantic attribute name is preserved');
-  t.notOk(geometry.attributes.positions, 'semantic attribute has no shader-name alias');
-  t.deepEqual(geometry.bufferLayout, [{name: 'POSITION', format: 'float32x3'}]);
+  expect(geometry.attributes.POSITION, 'semantic attribute name is preserved').toBeTruthy();
+  expect(geometry.attributes.positions, 'semantic attribute has no shader-name alias').toBeFalsy();
+  expect(geometry.bufferLayout).toEqual([{name: 'POSITION', format: 'float32x3'}]);
 
   const positions = {value: new Float32Array([1, 1, 1]), size: 3};
   const geometryWithShaderNameOverride = new Geometry({
@@ -116,13 +110,14 @@ test('Geometry#constructor preserves source attribute and explicit layout names'
     }
   });
 
-  t.notOk(
+  expect(
     geometryWithShaderNameOverride.attributes.POSITION,
     'shader-name override replaces semantic'
+  ).toBeFalsy();
+  expect(geometryWithShaderNameOverride.attributes.positions, 'shader-name override wins').toBe(
+    positions
   );
-  t.is(geometryWithShaderNameOverride.attributes.positions, positions, 'shader-name override wins');
-  t.deepEqual(geometryWithShaderNameOverride.bufferLayout, [
+  expect(geometryWithShaderNameOverride.bufferLayout).toEqual([
     {name: 'positions', format: 'float32x3'}
   ]);
-  t.end();
 });

--- a/modules/engine/test/geometry/gpu-geometry.spec.ts
+++ b/modules/engine/test/geometry/gpu-geometry.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {
   ConeGeometry,
   CubeGeometry,
@@ -25,57 +25,56 @@ const BUILT_IN_GEOMETRY_TESTS = [
   {name: 'TruncatedConeGeometry', Geometry: TruncatedConeGeometry}
 ];
 
-test('CubeGeometry exposes stable face indices for indexed and non-indexed cubes', t => {
+it('CubeGeometry exposes stable face indices for indexed and non-indexed cubes', () => {
   const indexedCube = new CubeGeometry({indices: true});
   const nonIndexedCube = new CubeGeometry({indices: false});
 
-  t.ok(indexedCube.attributes.faceIndex, 'indexed cube includes faceIndex');
-  t.deepEqual(
+  expect(indexedCube.attributes.faceIndex, 'indexed cube includes faceIndex').toBeTruthy();
+  expect(
     indexedCube.attributes.faceIndex?.value,
-    new Uint32Array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5]),
     'indexed cube stores one semantic face id per duplicated vertex'
+  ).toEqual(
+    new Uint32Array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5])
   );
-  t.ok(nonIndexedCube.attributes.faceIndex, 'non-indexed cube includes faceIndex');
-  t.deepEqual(
+  expect(nonIndexedCube.attributes.faceIndex, 'non-indexed cube includes faceIndex').toBeTruthy();
+  expect(
     nonIndexedCube.attributes.faceIndex?.value,
+    'non-indexed cube preserves semantic face ids across its vertex block order'
+  ).toEqual(
     new Uint32Array([
       3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 2, 2, 2, 2, 2, 2, 5, 5, 5, 5, 5, 5, 0, 0, 0, 0, 0, 0, 1,
       1, 1, 1, 1, 1
-    ]),
-    'non-indexed cube preserves semantic face ids across its vertex block order'
+    ])
   );
-
-  t.end();
 });
 
-test('makeGPUGeometry interleaves built-in geometry attributes', async t => {
+it('makeGPUGeometry interleaves built-in geometry attributes', async () => {
   const device = await getWebGLTestDevice();
 
   for (const {name, Geometry} of BUILT_IN_GEOMETRY_TESTS) {
     const gpuGeometry = makeGPUGeometry(device, new Geometry());
     const bufferLayout = gpuGeometry.bufferLayout[0];
 
-    t.deepEqual(
-      Object.keys(gpuGeometry.attributes),
-      ['geometry'],
-      `${name}: has one vertex buffer`
-    );
-    t.is(gpuGeometry.bufferLayout.length, 1, `${name}: has one buffer layout`);
-    t.is(bufferLayout.name, 'geometry', `${name}: buffer layout is named geometry`);
-    t.ok(bufferLayout.attributes?.length, `${name}: buffer layout maps geometry attributes`);
-    t.ok(gpuGeometry.indices, `${name}: keeps index buffer`);
+    expect(Object.keys(gpuGeometry.attributes), `${name}: has one vertex buffer`).toEqual([
+      'geometry'
+    ]);
+    expect(gpuGeometry.bufferLayout.length, `${name}: has one buffer layout`).toBe(1);
+    expect(bufferLayout.name, `${name}: buffer layout is named geometry`).toBe('geometry');
+    expect(
+      bufferLayout.attributes?.length,
+      `${name}: buffer layout maps geometry attributes`
+    ).toBeTruthy();
+    expect(gpuGeometry.indices, `${name}: keeps index buffer`).toBeTruthy();
 
     gpuGeometry.destroy();
   }
-
-  t.end();
 });
 
-test('makeGPUGeometry interleaves cube geometry into one vertex buffer', async t => {
+it('makeGPUGeometry interleaves cube geometry into one vertex buffer', async () => {
   const device = await getWebGLTestDevice();
   const gpuGeometry = makeGPUGeometry(device, new CubeGeometry({indices: true}));
 
-  t.deepEqual(gpuGeometry.bufferLayout, [
+  expect(gpuGeometry.bufferLayout).toEqual([
     {
       name: 'geometry',
       stepMode: 'vertex',
@@ -88,14 +87,11 @@ test('makeGPUGeometry interleaves cube geometry into one vertex buffer', async t
       ]
     }
   ]);
-  t.is(
-    gpuGeometry.attributes.geometry.byteLength,
-    24 * 36,
-    'cube has one interleaved vertex buffer'
+  expect(gpuGeometry.attributes.geometry.byteLength, 'cube has one interleaved vertex buffer').toBe(
+    24 * 36
   );
-  t.is(gpuGeometry.vertexCount, 36, 'indexed cube draw count is preserved');
-  t.ok(gpuGeometry.indices, 'indexed cube keeps index buffer');
+  expect(gpuGeometry.vertexCount, 'indexed cube draw count is preserved').toBe(36);
+  expect(gpuGeometry.indices, 'indexed cube keeps index buffer').toBeTruthy();
 
   gpuGeometry.destroy();
-  t.end();
 });

--- a/modules/engine/test/scenegraph/group-node.spec.ts
+++ b/modules/engine/test/scenegraph/group-node.spec.ts
@@ -2,32 +2,31 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 import {GroupNode, ScenegraphNode, ModelNode, Model} from '@luma.gl/engine';
 import {Matrix4} from '@math.gl/core';
 import {DUMMY_VS, DUMMY_FS} from './model-node.spec';
+import {expect, it} from 'vitest';
 
-test('GroupNode#construction', async t => {
+it('GroupNode#construction', async () => {
   const grandChild = new ScenegraphNode();
   const child1 = new GroupNode([grandChild]);
   const child2 = new GroupNode();
   const groupNode = new GroupNode({children: [child1, child2]});
   const invalidNode = {id: 'invalidNode'};
 
-  t.ok(child1 instanceof GroupNode, 'construction with array is successful');
-  t.ok(groupNode instanceof GroupNode, 'construction with object is successful');
+  expect(child1 instanceof GroupNode, 'construction with array is successful').toBe(true);
+  expect(groupNode instanceof GroupNode, 'construction with object is successful').toBe(true);
 
   // @ts-expect-error
-  t.throws(() => new GroupNode({children: [invalidNode]}));
+  expect(() => new GroupNode({children: [invalidNode]})).toThrow();
   // @ts-expect-error
-  t.throws(() => new GroupNode({children: [invalidNode, child1]}));
+  expect(() => new GroupNode({children: [invalidNode, child1]})).toThrow();
   // @ts-expect-error
-  t.throws(() => new GroupNode({children: [child1, invalidNode]}));
-  t.end();
+  expect(() => new GroupNode({children: [child1, invalidNode]})).toThrow();
 });
 
-test('GroupNode#add', async t => {
+it('GroupNode#add', async () => {
   const child1 = new GroupNode();
   const child2 = new GroupNode();
   const child3 = new GroupNode();
@@ -36,11 +35,10 @@ test('GroupNode#add', async t => {
   // @ts-expect-error Need to fix nested types
   groupNode.add([child1, [child2, child3]]);
 
-  t.ok(groupNode.children.length === 3, 'add: should unpack nested arrays');
-  t.end();
+  expect(groupNode.children.length === 3, 'add: should unpack nested arrays').toBe(true);
 });
 
-test('GroupNode#remove', async t => {
+it('GroupNode#remove', async () => {
   const child1 = new GroupNode();
   const child2 = new GroupNode();
   const child3 = new GroupNode();
@@ -49,14 +47,13 @@ test('GroupNode#remove', async t => {
   groupNode.add([child1, child2]);
 
   groupNode.remove(child3);
-  t.ok(groupNode.children.length === 2, 'remove: should ignore non child node');
+  expect(groupNode.children.length === 2, 'remove: should ignore non child node').toBe(true);
 
   groupNode.remove(child2);
-  t.ok(groupNode.children.length === 1, 'remove: should remove child');
-  t.end();
+  expect(groupNode.children.length === 1, 'remove: should remove child').toBe(true);
 });
 
-test('GroupNode#removeAll', async t => {
+it('GroupNode#removeAll', async () => {
   const child1 = new GroupNode();
   const child2 = new GroupNode();
   const child3 = new GroupNode();
@@ -65,11 +62,10 @@ test('GroupNode#removeAll', async t => {
 
   groupNode.removeAll();
 
-  t.ok(groupNode.children.length === 0, 'removeAll: should remove all');
-  t.end();
+  expect(groupNode.children.length === 0, 'removeAll: should remove all').toBe(true);
 });
 
-test('GroupNode#destroy', async t => {
+it('GroupNode#destroy', async () => {
   const grandChild = new GroupNode();
   const child1 = new GroupNode([grandChild]);
   const child2 = new GroupNode();
@@ -77,12 +73,11 @@ test('GroupNode#destroy', async t => {
 
   groupNode.destroy();
 
-  t.ok(groupNode.children.length === 0, 'destroy: should remove all');
-  t.ok(child1.children.length === 0, 'destroy: should destroy children');
-  t.end();
+  expect(groupNode.children.length === 0, 'destroy: should remove all').toBe(true);
+  expect(child1.children.length === 0, 'destroy: should destroy children').toBe(true);
 });
 
-test('GroupNode#traverse', async t => {
+it('GroupNode#traverse', async () => {
   const modelMatrices = {};
   const matrix = new Matrix4().identity().scale(2);
 
@@ -97,17 +92,13 @@ test('GroupNode#traverse', async t => {
 
   groupNode.traverse(visitor);
 
-  t.deepEqual(modelMatrices[childSNode.id], matrix, 'should update child matrix');
-  t.deepEqual(
-    modelMatrices[grandChildSNode.id],
-    new Matrix4().identity().scale(4),
-    'should update grand child matrix'
+  expect(modelMatrices[childSNode.id], 'should update child matrix').toEqual(matrix);
+  expect(modelMatrices[grandChildSNode.id], 'should update grand child matrix').toEqual(
+    new Matrix4().identity().scale(4)
   );
-
-  t.end();
 });
 
-test('GroupNode#getBounds', async t => {
+it('GroupNode#getBounds', async () => {
   const device = await getWebGLTestDevice();
 
   const matrix = new Matrix4().translate([0, 0, 1]).scale(2);
@@ -119,7 +110,7 @@ test('GroupNode#getBounds', async t => {
   const child1 = new GroupNode({id: 'child-1', matrix, children: [grandChildSNode]});
   const groupNode = new GroupNode({id: 'parent', matrix, children: [child1, childSNode]});
 
-  t.deepEqual(groupNode.getBounds(), null, 'child bounds are not defined');
+  expect(groupNode.getBounds(), 'child bounds are not defined').toBeNull();
 
   childSNode.bounds = [
     [0, 0, 0],
@@ -130,18 +121,13 @@ test('GroupNode#getBounds', async t => {
     [0, 0, 0]
   ];
 
-  t.deepEqual(
-    groupNode.getBounds(),
-    [
-      [-4, -4, -1],
-      [2, 2, 3]
-    ],
-    'bounds calculated'
-  );
-  t.end();
+  expect(groupNode.getBounds(), 'bounds calculated').toEqual([
+    [-4, -4, -1],
+    [2, 2, 3]
+  ]);
 });
 
-test('GroupNode#getBounds applies leaf transforms and rotated box corners', async t => {
+it('GroupNode#getBounds applies leaf transforms and rotated box corners', async () => {
   const device = await getWebGLTestDevice();
   const model = new Model(device, {vs: DUMMY_VS, fs: DUMMY_FS});
   const node = new ModelNode({
@@ -159,23 +145,22 @@ test('GroupNode#getBounds applies leaf transforms and rotated box corners', asyn
   const bounds = group.getBounds();
   const rotatedHalfExtent = 3 / Math.sqrt(2);
 
-  t.ok(bounds, 'transformed model contributes bounds');
-  t.ok(
+  expect(bounds, 'transformed model contributes bounds').toBeTruthy();
+  expect(
     Math.abs(bounds![0][0] - (3 - rotatedHalfExtent)) < 0.000001 &&
       Math.abs(bounds![1][0] - (3 + rotatedHalfExtent)) < 0.000001,
     'all rotated horizontal corners contribute to the aggregate bounds'
-  );
-  t.ok(
+  ).toBe(true);
+  expect(
     Math.abs(bounds![0][1] - (2 - rotatedHalfExtent)) < 0.000001 &&
       Math.abs(bounds![1][1] - (2 + rotatedHalfExtent)) < 0.000001,
     'leaf and parent transforms are included in world-space bounds'
-  );
+  ).toBe(true);
 
   group.destroy();
-  t.end();
 });
 
-test('GroupNode#traverseDepthSorted orders transformed leaf bounds by camera depth', async t => {
+it('GroupNode#traverseDepthSorted orders transformed leaf bounds by camera depth', async () => {
   const nearNode = new ScenegraphNode({
     id: 'near',
     matrix: new Matrix4().translate([0, 0, -2])
@@ -214,29 +199,26 @@ test('GroupNode#traverseDepthSorted orders transformed leaf bounds by camera dep
     {viewMatrix: new Matrix4()}
   );
 
-  t.deepEqual(
-    backToFrontIds,
-    ['far', 'middle', 'near'],
-    'default traversal visits far nodes first'
-  );
-  t.deepEqual(depths, [9, 5, 2], 'nested and leaf transforms contribute to camera depth');
+  expect(backToFrontIds, 'default traversal visits far nodes first').toEqual([
+    'far',
+    'middle',
+    'near'
+  ]);
+  expect(depths, 'nested and leaf transforms contribute to camera depth').toEqual([9, 5, 2]);
 
   const frontToBackIds: string[] = [];
   group.traverseDepthSorted((node: ScenegraphNode) => frontToBackIds.push(node.id), {
     viewMatrix: new Matrix4(),
     order: 'front-to-back'
   });
-  t.deepEqual(frontToBackIds, ['near', 'middle', 'far'], 'front-to-back traversal is available');
+  expect(frontToBackIds, 'front-to-back traversal is available').toEqual(['near', 'middle', 'far']);
 
   const reverseViewIds: string[] = [];
   group.traverseDepthSorted((node: ScenegraphNode) => reverseViewIds.push(node.id), {
     viewMatrix: new Matrix4().lookAt({eye: [0, 0, -20], center: [0, 0, 0], up: [0, 1, 0]})
   });
-  t.deepEqual(
+  expect(
     reverseViewIds,
-    ['near', 'middle', 'far'],
     'camera direction determines ordering instead of fixed world-space depth'
-  );
-
-  t.end();
+  ).toEqual(['near', 'middle', 'far']);
 });

--- a/modules/engine/test/scenegraph/model-node.spec.ts
+++ b/modules/engine/test/scenegraph/model-node.spec.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 // import {makeSpy} from '@probe.gl/test-utils';
 import {Model, ModelNode} from '@luma.gl/engine';
 import {Matrix4} from '@math.gl/core';
+import {expect, it} from 'vitest';
 
 export const DUMMY_VS = `\
 #version 300 es
@@ -20,34 +20,29 @@ out vec4 fragmentColor;
 void main() { fragmentColor = vec4(1.0); }
 `;
 
-test('ModelNode#constructor', async t => {
+it('ModelNode#constructor', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   for (const device of [webglDevice]) {
     const model = new Model(device, {vs: DUMMY_VS, fs: DUMMY_FS});
 
     const mNode1 = new ModelNode({model});
-    t.ok(mNode1.model instanceof Model, 'should get constructed with model');
+    expect(mNode1.model instanceof Model, 'should get constructed with model').toBe(true);
   }
-  t.end();
 });
 
-test('ModelNode#setProps', async t => {
+it('ModelNode#setProps', async () => {
   const webglDevice = await getWebGLTestDevice();
   const model = new Model(webglDevice, {vs: DUMMY_VS, fs: DUMMY_FS});
   const modelNode = new ModelNode({model});
 
   modelNode.setProps({position: [1, 2, 3]});
-  t.deepEqual(
-    Array.from(modelNode.position),
-    [1, 2, 3],
-    'setProps updates position on scenegraph node'
-  );
-
-  t.end();
+  expect(Array.from(modelNode.position), 'setProps updates position on scenegraph node').toEqual([
+    1, 2, 3
+  ]);
 });
 
-test('ModelNode#getBounds combines transformed instance bounds', async t => {
+it('ModelNode#getBounds combines transformed instance bounds', async () => {
   const device = await getWebGLTestDevice();
   const model = new Model(device, {vs: DUMMY_VS, fs: DUMMY_FS});
   const node = new ModelNode({
@@ -62,14 +57,13 @@ test('ModelNode#getBounds combines transformed instance bounds', async t => {
     ]
   });
 
-  t.deepEqual(
+  expect(
     node.getBounds(),
-    [
-      [-3, -2, -4],
-      [3.5, 2, 2]
-    ],
     'one model node exposes aggregate bounds for every transformed instance'
-  );
+  ).toEqual([
+    [-3, -2, -4],
+    [3.5, 2, 2]
+  ]);
 
   const emptyNode = new ModelNode({
     model: new Model(device, {vs: DUMMY_VS, fs: DUMMY_FS}),
@@ -79,9 +73,8 @@ test('ModelNode#getBounds combines transformed instance bounds', async t => {
     ],
     instanceMatrices: []
   });
-  t.equal(emptyNode.getBounds(), null, 'an empty instanced model has no visible bounds');
+  expect(emptyNode.getBounds(), 'an empty instanced model has no visible bounds').toBeNull();
 
   node.destroy();
   emptyNode.destroy();
-  t.end();
 });

--- a/modules/engine/test/scenegraph/scenegraph-node.spec.ts
+++ b/modules/engine/test/scenegraph/scenegraph-node.spec.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {ScenegraphNode} from '@luma.gl/engine';
 import {Matrix4, Vector3} from '@math.gl/core';
+import {expect, it} from 'vitest';
 
 const PROPS = {
   display: true,
@@ -14,101 +14,90 @@ const PROPS = {
   matrix: new Matrix4().scale(4)
 };
 
-test('ScenegraphNode#constructor', t => {
+it('ScenegraphNode#constructor', () => {
   const sgNode = new ScenegraphNode(PROPS);
-  t.ok(sgNode instanceof ScenegraphNode, 'should construct the object');
+  expect(sgNode instanceof ScenegraphNode, 'should construct the object').toBe(true);
   for (const key in PROPS) {
-    t.deepEqual(sgNode.props[key], PROPS[key], `prop: ${key} should get set on the object.props`);
-    t.deepEqual(sgNode[key], PROPS[key], `prop: ${key} should get set on the object`);
+    expect(sgNode.props[key], `prop: ${key} should get set on the object.props`).toEqual(
+      PROPS[key]
+    );
+    expect(sgNode[key], `prop: ${key} should get set on the object`).toEqual(PROPS[key]);
   }
-  t.end();
 });
 
-test('ScenegraphNode#delete', t => {
+it('ScenegraphNode#delete', () => {
   const sgNode = new ScenegraphNode();
-  t.doesNotThrow(() => sgNode.destroy(), 'delete should work');
-
-  t.end();
+  expect(() => sgNode.destroy(), 'delete should work').not.toThrow();
 });
 
-test('ScenegraphNode#setProps', t => {
+it('ScenegraphNode#setProps', () => {
   const sgNode = new ScenegraphNode();
   sgNode.setProps(PROPS);
   for (const key in PROPS) {
-    t.deepEqual(sgNode.props[key], PROPS[key], `prop: ${key} should get set on the object.props`);
-    t.deepEqual(sgNode[key], PROPS[key], `prop: ${key} should get set on the object`);
+    expect(sgNode.props[key], `prop: ${key} should get set on the object.props`).toEqual(
+      PROPS[key]
+    );
+    expect(sgNode[key], `prop: ${key} should get set on the object`).toEqual(PROPS[key]);
   }
-  t.end();
 });
 
-test('ScenegraphNode#toString', t => {
+it('ScenegraphNode#toString', () => {
   const sgNode = new ScenegraphNode();
-  t.doesNotThrow(() => sgNode.toString(), 'delete should work');
-
-  t.end();
+  expect(() => sgNode.toString(), 'delete should work').not.toThrow();
 });
 
-test('ScenegraphNode#setMatrix', t => {
+it('ScenegraphNode#setMatrix', () => {
   const sgNode = new ScenegraphNode();
   const matrix = new Matrix4().scale(1.5);
 
   sgNode.setMatrix(matrix);
-  t.deepEqual(sgNode.matrix, matrix, 'should copy the matrix');
+  expect(sgNode.matrix, 'should copy the matrix').toEqual(matrix);
 
   sgNode.setMatrix(matrix, false);
-  t.equal(sgNode.matrix, matrix, 'should asign the matrix');
-
-  t.end();
+  expect(sgNode.matrix, 'should asign the matrix').toBe(matrix);
 });
 
-test('ScenegraphNode#setMatrixComponents', t => {
+it('ScenegraphNode#setMatrixComponents', () => {
   const sgNode = new ScenegraphNode();
   const position = new Vector3(1, 1, 1);
   const rotation = new Vector3(2, 2, 2);
   const scale = new Vector3(3, 3, 3);
 
   sgNode.setMatrixComponents({update: false});
-  t.deepEqual(sgNode.matrix, new Matrix4(), 'should not update the matrix');
+  expect(sgNode.matrix, 'should not update the matrix').toEqual(new Matrix4());
 
   sgNode.setMatrixComponents({position, rotation, scale});
-  t.deepEqual(
-    sgNode.matrix,
-    new Matrix4().translate(position).rotateXYZ(rotation).scale(scale),
-    'should update the matrix'
+  expect(sgNode.matrix, 'should update the matrix').toEqual(
+    new Matrix4().translate(position).rotateXYZ(rotation).scale(scale)
   );
-
-  t.end();
 });
 
-test('ScenegraphNode#update', t => {
+it('ScenegraphNode#update', () => {
   const sgNode = new ScenegraphNode();
   const position = new Vector3(1, 1, 1);
   const rotation = new Vector3(2, 2, 2);
   const scale = new Vector3(3, 3, 3);
 
   sgNode.update();
-  t.deepEqual(sgNode.matrix, new Matrix4(), 'should update the matrix');
+  expect(sgNode.matrix, 'should update the matrix').toEqual(new Matrix4());
 
   sgNode.update({position, rotation, scale});
-  t.deepEqual(
-    sgNode.matrix,
-    new Matrix4().translate(position).rotateXYZ(rotation).scale(scale),
-    'should update the matrix'
+  expect(sgNode.matrix, 'should update the matrix').toEqual(
+    new Matrix4().translate(position).rotateXYZ(rotation).scale(scale)
   );
-
-  t.end();
 });
 
-test('ScenegraphNode#getCoordinateUniforms', t => {
+it('ScenegraphNode#getCoordinateUniforms', () => {
   const sgNode = new ScenegraphNode();
 
   const uniforms = sgNode.getCoordinateUniforms(new Matrix4());
-  t.ok(uniforms.viewMatrix, 'should return viewMatrix');
-  t.ok(uniforms.modelMatrix, 'should return modelMatrix');
-  t.ok(uniforms.objectMatrix, 'should return objectMatrix');
-  t.ok(uniforms.worldMatrix, 'should return worldMatrix');
-  t.ok(uniforms.worldInverseMatrix, 'should return worldInverseMatrix');
-  t.ok(uniforms.worldInverseTransposeMatrix, 'should return worldInverseTransposeMatrix');
-
-  t.end();
+  expect(uniforms.viewMatrix, 'should return viewMatrix').toBeTruthy();
+  expect(uniforms.modelMatrix, 'should return modelMatrix').toBeTruthy();
+  expect(uniforms.objectMatrix, 'should return objectMatrix').toBeTruthy();
+  expect(uniforms.worldMatrix, 'should return worldMatrix').toBeTruthy();
+  expect(uniforms.worldInverseMatrix, 'should return worldInverseMatrix').toBeTruthy();
+  expect(
+    uniforms.worldInverseTransposeMatrix,
+    'should return worldInverseTransposeMatrix'
+  ).toBeTruthy();
 });

--- a/modules/engine/test/utils/buffer-layout-order.spec.ts
+++ b/modules/engine/test/utils/buffer-layout-order.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {type ShaderLayout, type BufferLayout} from '@luma.gl/core';
 import {sortedBufferLayoutByShaderSourceLocations} from '@luma.gl/engine/utils/buffer-layout-order';
 
@@ -134,11 +134,9 @@ const sortedBufferLayout = [
   }
 ];
 
-test('sortedBufferLayoutByShaderSourceLocations', t => {
+it('sortedBufferLayoutByShaderSourceLocations', () => {
   const result = sortedBufferLayoutByShaderSourceLocations(shaderLayout, bufferLayout);
   for (let i = 0; i < sortedBufferLayout.length; i++) {
-    t.deepEqual(result[i], sortedBufferLayout[i], `Buffer layout order is correct`);
-    // t.comment(JSON.stringify(result[i], null, 2));
+    expect(result[i], 'Buffer layout order is correct').toEqual(sortedBufferLayout[i]);
   }
-  t.end();
 });

--- a/modules/engine/test/utils/deep-equal.node.spec.ts
+++ b/modules/engine/test/utils/deep-equal.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerDeepEqualTests} from './deep-equal.spec.shared';
 
-registerDeepEqualTests(test);
+registerDeepEqualTests();

--- a/modules/engine/test/utils/deep-equal.spec.shared.ts
+++ b/modules/engine/test/utils/deep-equal.spec.shared.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
 import {deepEqual} from '@luma.gl/engine/utils/deep-equal';
+import {expect, it} from 'vitest';
 
 const obj = {longitude: -70, latitude: 40.7, zoom: 12};
 const TEST_CASES = [
@@ -66,13 +66,11 @@ const TEST_CASES = [
   {a: {x: 1}, b: null, depth: 1, output: false}
 ];
 
-export function registerDeepEqualTests(test: TapeTestFunction): void {
-  test('utils#deepEqual', t => {
+export function registerDeepEqualTests(): void {
+  it('utils#deepEqual', () => {
     TEST_CASES.forEach(({a, b, depth, output}) => {
       const result = deepEqual(a, b, depth as number);
-      t.is(result, output, `should ${output ? '' : 'not '}be equal`);
+      expect(result, `should ${output ? '' : 'not '}be equal`).toBe(output);
     });
-
-    t.end();
   });
 }

--- a/modules/engine/test/utils/deep-equal.spec.ts
+++ b/modules/engine/test/utils/deep-equal.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerDeepEqualTests} from './deep-equal.spec.shared';
 
-registerDeepEqualTests(test);
+registerDeepEqualTests();

--- a/modules/engine/test/utils/shader-module-utils.spec.ts
+++ b/modules/engine/test/utils/shader-module-utils.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import type {ShaderLayout} from '../../../core/src';
 import type {ShaderModule} from '../../../shadertools/src';
 import {lighting, pbrMaterial} from '../../../shadertools/src';
@@ -11,13 +11,12 @@ import {
   mergeShaderModuleBindingsIntoLayout
 } from '../../src/utils/shader-module-utils';
 
-test('mergeShaderModuleBindingsIntoLayout does not create placeholder layouts', t => {
+it('mergeShaderModuleBindingsIntoLayout does not create placeholder layouts', () => {
   const shaderLayout = mergeShaderModuleBindingsIntoLayout<ShaderLayout | null>(null, [lighting]);
-  t.equal(shaderLayout, null, 'null shader layouts stay null until a real layout is inferred');
-  t.end();
+  expect(shaderLayout, 'null shader layouts stay null until a real layout is inferred').toBeNull();
 });
 
-test('mergeShaderModuleBindingsIntoLayout remaps companion sampler bindings', t => {
+it('mergeShaderModuleBindingsIntoLayout remaps companion sampler bindings', () => {
   const shaderLayout: ShaderLayout = {
     bindings: [
       {name: 'pbr_baseColorSampler', location: 1, group: 0},
@@ -28,21 +27,17 @@ test('mergeShaderModuleBindingsIntoLayout remaps companion sampler bindings', t 
 
   const mergedLayout = mergeShaderModuleBindingsIntoLayout(shaderLayout, [pbrMaterial]);
 
-  t.equal(
+  expect(
     mergedLayout?.bindings.find(binding => binding.name === 'pbr_baseColorSampler')?.group,
-    3,
     'texture binding group is remapped'
-  );
-  t.equal(
+  ).toBe(3);
+  expect(
     mergedLayout?.bindings.find(binding => binding.name === 'pbr_baseColorSamplerSampler')?.group,
-    3,
     'companion sampler binding group is remapped'
-  );
-
-  t.end();
+  ).toBe(3);
 });
 
-test('mergeInferredShaderLayout merges compatible attributes and rejects conflicts', t => {
+it('mergeInferredShaderLayout merges compatible attributes and rejects conflicts', () => {
   const explicitLayout: ShaderLayout = {
     attributes: [{name: 'positions', location: 0, type: 'vec2<f32>', stepMode: 'instance'}],
     bindings: []
@@ -56,44 +51,36 @@ test('mergeInferredShaderLayout merges compatible attributes and rejects conflic
   };
   const mergedLayout = mergeInferredShaderLayout(explicitLayout, inferredLayout, ['filterValues']);
 
-  t.deepEqual(
+  expect(
     mergedLayout?.attributes,
-    [
-      {name: 'positions', location: 0, type: 'vec2<f32>', stepMode: 'instance'},
-      {name: 'filterValues', location: 1, type: 'f32'}
-    ],
     'explicit metadata wins and inferred plugin attributes are appended'
-  );
-  t.throws(
-    () =>
-      mergeInferredShaderLayout(
-        explicitLayout,
-        {
-          attributes: [{name: 'filterValues', location: 0, type: 'f32'}],
-          bindings: []
-        },
-        ['filterValues']
-      ),
-    /both use location 0/,
-    'different names cannot share a location'
-  );
-  t.throws(
-    () =>
-      mergeInferredShaderLayout(
-        explicitLayout,
-        {
-          attributes: [{name: 'positions', location: 0, type: 'vec3<f32>'}],
-          bindings: []
-        },
-        ['positions']
-      ),
-    /conflicts with its inferred type or location/,
-    'same-name declarations must have compatible types and locations'
-  );
-  t.end();
+  ).toEqual([
+    {name: 'positions', location: 0, type: 'vec2<f32>', stepMode: 'instance'},
+    {name: 'filterValues', location: 1, type: 'f32'}
+  ]);
+  expect(() =>
+    mergeInferredShaderLayout(
+      explicitLayout,
+      {
+        attributes: [{name: 'filterValues', location: 0, type: 'f32'}],
+        bindings: []
+      },
+      ['filterValues']
+    )
+  ).toThrow(/both use location 0/);
+  expect(() =>
+    mergeInferredShaderLayout(
+      explicitLayout,
+      {
+        attributes: [{name: 'positions', location: 0, type: 'vec3<f32>'}],
+        bindings: []
+      },
+      ['positions']
+    )
+  ).toThrow(/conflicts with its inferred type or location/);
 });
 
-test('mergeShaderModuleBindingsIntoLayout merges binding visibility', t => {
+it('mergeShaderModuleBindingsIntoLayout merges binding visibility', () => {
   const shaderLayout: ShaderLayout = {
     bindings: [{type: 'storage', name: 'fragments', location: 1, group: 0}],
     attributes: []
@@ -105,10 +92,8 @@ test('mergeShaderModuleBindingsIntoLayout merges binding visibility', t => {
 
   const mergedLayout = mergeShaderModuleBindingsIntoLayout(shaderLayout, [fragmentStorageModule]);
 
-  t.equal(
+  expect(
     mergedLayout?.bindings.find(binding => binding.name === 'fragments')?.visibility,
-    0x2,
     'module binding visibility is merged into inferred bindings'
-  );
-  t.end();
+  ).toBe(0x2);
 });

--- a/modules/engine/test/utils/split-uniforms-and-bindings.node.spec.ts
+++ b/modules/engine/test/utils/split-uniforms-and-bindings.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerSplitUniformsAndBindingsTests} from './split-uniforms-and-bindings.spec.shared';
 
-registerSplitUniformsAndBindingsTests(test);
+registerSplitUniformsAndBindingsTests();

--- a/modules/engine/test/utils/split-uniforms-and-bindings.spec.shared.ts
+++ b/modules/engine/test/utils/split-uniforms-and-bindings.spec.shared.ts
@@ -3,10 +3,10 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {splitUniformsAndBindings} from '@luma.gl/engine/model/split-uniforms-and-bindings';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-export function registerSplitUniformsAndBindingsTests(test: TapeTestFunction): void {
-  test('splitUniformsAndBindings', t => {
+export function registerSplitUniformsAndBindingsTests(): void {
+  it('splitUniformsAndBindings', () => {
     const mixed: Parameters<typeof splitUniformsAndBindings>[0] = {
       array: [1, 2, 3, 4],
       boolean: true,
@@ -15,16 +15,15 @@ export function registerSplitUniformsAndBindingsTests(test: TapeTestFunction): v
       texture: {texture: true} as any
     };
     const {bindings, uniforms} = splitUniformsAndBindings(mixed);
-    t.deepEquals(Object.keys(bindings), ['sampler', 'texture'], 'bindings correctly extracted');
-    t.deepEquals(
-      Object.keys(uniforms),
-      ['array', 'boolean', 'number'],
-      'bindings correctly extracted'
-    );
-    t.end();
+    expect(Object.keys(bindings), 'bindings correctly extracted').toEqual(['sampler', 'texture']);
+    expect(Object.keys(uniforms), 'uniforms correctly extracted').toEqual([
+      'array',
+      'boolean',
+      'number'
+    ]);
   });
 
-  test('splitUniformsAndBindings respects declared struct uniforms', t => {
+  it('splitUniformsAndBindings respects declared struct uniforms', () => {
     const mixed = {
       light: {
         position: [1, 2, 3],
@@ -41,18 +40,16 @@ export function registerSplitUniformsAndBindingsTests(test: TapeTestFunction): v
       }
     });
 
-    t.deepEquals(Object.keys(uniforms), ['light'], 'struct uniform preserved');
-    t.deepEquals(Object.keys(bindings), ['sampler', 'texture'], 'bindings remain bindings');
-    t.deepEqual(uniforms.light, mixed.light, 'struct uniform value retained');
-    t.end();
+    expect(Object.keys(uniforms), 'struct uniform preserved').toEqual(['light']);
+    expect(Object.keys(bindings), 'bindings remain bindings').toEqual(['sampler', 'texture']);
+    expect(uniforms.light, 'struct uniform value retained').toEqual(mixed.light);
   });
 
-  test('splitUniformsAndBindings treats undeclared objects as bindings', t => {
+  it('splitUniformsAndBindings treats undeclared objects as bindings', () => {
     const nestedUniform = {thresholds: [1, 2, 3], metadata: {enabled: true}};
     const {bindings, uniforms} = splitUniformsAndBindings({config: nestedUniform});
 
-    t.deepEquals(uniforms, {}, 'undeclared objects are not treated as uniforms');
-    t.deepEqual(bindings.config, nestedUniform as any, 'undeclared objects fall back to bindings');
-    t.end();
+    expect(uniforms, 'undeclared objects are not treated as uniforms').toEqual({});
+    expect(bindings.config, 'undeclared objects fall back to bindings').toEqual(nestedUniform);
   });
 }

--- a/modules/engine/test/utils/split-uniforms-and-bindings.spec.ts
+++ b/modules/engine/test/utils/split-uniforms-and-bindings.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerSplitUniformsAndBindingsTests} from './split-uniforms-and-bindings.spec.shared';
 
-registerSplitUniformsAndBindingsTests(test);
+registerSplitUniformsAndBindingsTests();

--- a/modules/gltf/test/gltf/gltf-extension-support.spec.ts
+++ b/modules/gltf/test/gltf/gltf-extension-support.spec.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import type {GLTFPostprocessed} from '@loaders.gl/gltf';
 import type {TextureFormat} from '@luma.gl/core';
 import {NullDevice} from '@luma.gl/test-utils';
+import {expect, it} from 'vitest';
 
 import {
   assertSupportedGLTFExtensions,
@@ -26,7 +26,7 @@ type GLTFPostprocessedWithRemovedExtensions = GLTFPostprocessed & {
   lights?: unknown[];
 };
 
-test('gltf#getGLTFExtensionSupport collects and annotates used extensions', t => {
+it('gltf#getGLTFExtensionSupport collects and annotates used extensions', () => {
   const gltf: GLTFPostprocessedWithRemovedExtensions = {
     id: 'test-gltf',
     extensionsUsed: ['KHR_texture_transform', 'KHR_materials_specular', 'CUSTOM_unknown_extension'],
@@ -51,44 +51,37 @@ test('gltf#getGLTFExtensionSupport collects and annotates used extensions', t =>
 
   const extensionSupport = getGLTFExtensionSupport(gltf);
 
-  t.deepEqual(
+  expect(
     Array.from(extensionSupport.keys()),
-    [
-      'CUSTOM_unknown_extension',
-      'KHR_animation_pointer',
-      'KHR_draco_mesh_compression',
-      'KHR_lights_punctual',
-      'KHR_materials_specular',
-      'KHR_materials_unlit',
-      'KHR_texture_transform'
-    ],
     'used, required, removed, and inferred extensions are included'
-  );
-  t.equal(
+  ).toEqual([
+    'CUSTOM_unknown_extension',
+    'KHR_animation_pointer',
+    'KHR_draco_mesh_compression',
+    'KHR_lights_punctual',
+    'KHR_materials_specular',
+    'KHR_materials_unlit',
+    'KHR_texture_transform'
+  ]);
+  expect(
     extensionSupport.get('KHR_draco_mesh_compression')?.supported,
-    true,
     'built-in extension is marked as supported'
-  );
-  t.equal(
+  ).toBe(true);
+  expect(
     extensionSupport.get('KHR_animation_pointer')?.supported,
-    true,
     'parsed-and-wired extension is marked as supported'
-  );
-  t.equal(
+  ).toBe(true);
+  expect(
     extensionSupport.get('KHR_materials_specular')?.supported,
-    true,
     'stock-shader material extensions are reported as built-in support'
-  );
-  t.equal(
+  ).toBe(true);
+  expect(
     extensionSupport.get('CUSTOM_unknown_extension')?.comment,
-    'Not currently listed in the luma.gl glTF extension support registry.',
     'unknown extensions get a fallback note'
-  );
-
-  t.end();
+  ).toBe('Not currently listed in the luma.gl glTF extension support registry.');
 });
 
-test('gltf#getGLTFExtensionSupport distinguishes actual loader implementations', t => {
+it('gltf#getGLTFExtensionSupport distinguishes actual loader implementations', () => {
   const extensionNames = [
     'EXT_mesh_features',
     'EXT_meshopt_compression',
@@ -104,41 +97,33 @@ test('gltf#getGLTFExtensionSupport distinguishes actual loader implementations',
   } as GLTFPostprocessed;
   const support = getGLTFExtensionSupport(gltf);
 
-  t.equal(
+  expect(
     support.get('EXT_meshopt_compression')?.supportLevel,
-    'built-in',
     'the installed loaders.gl decoder handles EXT meshopt buffer views'
-  );
-  t.equal(
+  ).toBe('built-in');
+  expect(
     support.get('KHR_meshopt_compression')?.supportLevel,
-    'built-in',
     'the loaders.gl v5 decoder handles KHR meshopt buffer views'
-  );
-  t.equal(
+  ).toBe('built-in');
+  expect(
     support.get('EXT_mesh_features')?.supportLevel,
-    'loader-only',
     'feature identifiers are decoded but have no automatic luma.gl runtime'
-  );
-  t.equal(
+  ).toBe('loader-only');
+  expect(
     support.get('EXT_structural_metadata')?.supportLevel,
-    'loader-only',
     'structural metadata is decoded but remains application-owned'
-  );
-  t.equal(
+  ).toBe('loader-only');
+  expect(
     support.get('EXT_texture_webp')?.supportLevel,
-    'loader-only',
     'WebP source selection is conditional on browser image support'
-  );
-  t.equal(
+  ).toBe('loader-only');
+  expect(
     support.get('EXT_texture_avif')?.supportLevel,
-    'none',
     'generic AVIF image decoding does not imply glTF extension source selection'
-  );
-
-  t.end();
+  ).toBe('none');
 });
 
-test('gltf#getGLTFExtensionSupport applies BasisU device format capabilities', t => {
+it('gltf#getGLTFExtensionSupport applies BasisU device format capabilities', () => {
   const gltf = {
     extensionsUsed: ['KHR_texture_basisu'],
     extensionsRequired: ['KHR_texture_basisu'],
@@ -168,68 +153,59 @@ test('gltf#getGLTFExtensionSupport applies BasisU device format capabilities', t
   const unsupported = getGLTFExtensionSupport(gltf, unsupportedDevice).get('KHR_texture_basisu');
   const supported = getGLTFExtensionSupport(gltf, supportedDevice).get('KHR_texture_basisu');
 
-  t.equal(unsupported?.supported, false, 'unsupported transcode format is reported truthfully');
-  t.equal(unsupported?.supportLevel, 'none', 'device gap fails strict extension support');
-  t.match(unsupported?.comment || '', /does not support.*bc7-rgba-unorm/);
-  t.equal(supported?.supported, true, 'supported transcode format retains built-in support');
-  t.throws(
+  expect(unsupported?.supported, 'unsupported transcode format is reported truthfully').toBe(false);
+  expect(unsupported?.supportLevel, 'device gap fails strict extension support').toBe('none');
+  expect(unsupported?.comment || '').toMatch(/does not support.*bc7-rgba-unorm/);
+  expect(supported?.supported, 'supported transcode format retains built-in support').toBe(true);
+  expect(
     () => assertSupportedGLTFExtensions(gltf, unsupportedDevice),
-    /KHR_texture_basisu/,
     'required BasisU rejects an unsupported selected GPU format'
-  );
-  t.throws(
+  ).toThrow(/KHR_texture_basisu/);
+  expect(
     () => createScenegraphsFromGLTF(unsupportedDevice, gltf, {strictExtensions: true}),
-    /KHR_texture_basisu/,
     'strict scenegraph creation checks the active device before allocating resources'
-  );
-  t.doesNotThrow(
+  ).toThrow(/KHR_texture_basisu/);
+  expect(
     () => assertSupportedGLTFExtensions(gltf, supportedDevice),
     'required BasisU accepts a selected GPU format supported by the device'
-  );
+  ).not.toThrow();
 
   unsupportedDevice.destroy();
   supportedDevice.destroy();
-  t.end();
 });
 
-test('gltf#getRegisteredGLTFExtensions exposes generated support and maturity summaries', t => {
+it('gltf#getRegisteredGLTFExtensions exposes generated support and maturity summaries', () => {
   const extensions = getRegisteredGLTFExtensions();
   const summary = getGLTFExtensionSupportSummary();
 
-  t.deepEqual(
+  expect(
     extensions.map(extension => extension.extensionName),
-    [...extensions.map(extension => extension.extensionName)].sort(),
     'registry entries are returned in stable extension-name order'
-  );
-  t.deepEqual(
+  ).toEqual([...extensions.map(extension => extension.extensionName)].sort());
+  expect(
     summary,
-    {
-      total: 35,
-      supported: 26,
-      bySupportLevel: {'built-in': 20, 'parsed-and-wired': 6, 'loader-only': 4, none: 5},
-      byStandardStatus: {
-        ratified: 26,
-        'release-candidate': 2,
-        'multi-vendor': 2,
-        vendor: 1,
-        draft: 2,
-        archived: 2,
-        unknown: 0
-      }
-    },
     'summary is derived from the registry rather than copied into documentation'
-  );
-  t.equal(
+  ).toEqual({
+    total: 35,
+    supported: 26,
+    bySupportLevel: {'built-in': 20, 'parsed-and-wired': 6, 'loader-only': 4, none: 5},
+    byStandardStatus: {
+      ratified: 26,
+      'release-candidate': 2,
+      'multi-vendor': 2,
+      vendor: 1,
+      draft: 2,
+      archived: 2,
+      unknown: 0
+    }
+  });
+  expect(
     extensions.find(extension => extension.extensionName === 'KHR_meshopt_compression')
       ?.standardStatus,
-    'release-candidate',
     'a KHR prefix does not imply ratification'
-  );
-  t.equal(
+  ).toBe('release-candidate');
+  expect(
     extensions.find(extension => extension.extensionName === 'MSFT_lod')?.standardStatus,
-    'vendor',
     'vendor extensions retain their source maturity'
-  );
-
-  t.end();
+  ).toBe('vendor');
 });

--- a/modules/gltf/test/gltf/gltf-native-extensions.spec.ts
+++ b/modules/gltf/test/gltf/gltf-native-extensions.spec.ts
@@ -9,9 +9,9 @@ import {ModelNode} from '@luma.gl/engine';
 import {createScenegraphsFromGLTF} from '@luma.gl/gltf';
 import {getTestDevices} from '@luma.gl/test-utils';
 import {Matrix4} from '@math.gl/core';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('glTF renders official EXT_mesh_gpu_instancing through one real draw on available backends', async testCase => {
+it('glTF renders official EXT_mesh_gpu_instancing through one real draw on available backends', async () => {
   const source = postProcessGLTF(
     await load(new URL('../data/SimpleInstancing.glb', import.meta.url).href, GLTFLoader, {
       gltf: {loadImages: false}
@@ -47,7 +47,7 @@ test('glTF renders official EXT_mesh_gpu_instancing through one real draw on ava
         }
       });
 
-      testCase.ok(modelNode, `${device.type} creates one instanced primitive`);
+      expect(modelNode, `${device.type} creates one instanced primitive`).toBeTruthy();
       if (modelNode) {
         const identity = Array.from(new Matrix4());
         modelNode.model.shaderInputs.setProps({
@@ -63,15 +63,18 @@ test('glTF renders official EXT_mesh_gpu_instancing through one real draw on ava
           clearColor: [0, 0, 0, 0],
           clearDepth: 1
         });
-        testCase.ok(modelNode.model.draw(renderPass), `${device.type} executes an instanced draw`);
+        expect(
+          modelNode.model.draw(renderPass),
+          `${device.type} executes an instanced draw`
+        ).toBeTruthy();
         renderPass.end();
         device.submit();
 
-        testCase.ok(modelNode.model.isInstanced, `${device.type} enables GPU instancing`);
-        testCase.ok(
+        expect(modelNode.model.isInstanced, `${device.type} enables GPU instancing`).toBeTruthy();
+        expect(
           modelNode.model.instanceCount > 1,
           `${device.type} submits every authored source instance`
-        );
+        ).toBe(true);
       }
     } finally {
       for (const scene of scenegraphs.scenes) {
@@ -82,6 +85,4 @@ test('glTF renders official EXT_mesh_gpu_instancing through one real draw on ava
       depthTexture.destroy();
     }
   }
-
-  testCase.end();
 });

--- a/modules/gltf/test/gltf/gltf-production-animation.node.spec.ts
+++ b/modules/gltf/test/gltf/gltf-production-animation.node.spec.ts
@@ -13,7 +13,7 @@ import {
   GLTFSkinController
 } from '@luma.gl/gltf';
 import {NullDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 async function loadSimpleSkin() {
   const asset = await readFile(
@@ -22,43 +22,44 @@ async function loadSimpleSkin() {
   return postProcessGLTF(await parse(asset, GLTFLoader, {gltf: {loadImages: false}}));
 }
 
-test('glTF SimpleSkin automatically binds and animates existing primitive joint palettes', async testContext => {
+it('glTF SimpleSkin automatically binds and animates existing primitive joint palettes', async () => {
   const source = await loadSimpleSkin();
   const device = new NullDevice({});
   const scenegraphs = createScenegraphsFromGLTF(device, source);
   const binding = scenegraphs.skins.getBinding(0);
 
-  testContext.ok(scenegraphs.skins instanceof GLTFSkinController, 'exposes source-owned skins');
-  testContext.equal(scenegraphs.skins.bindings.length, 1, 'binds the authored skinned node');
-  testContext.equal(binding?.skinIndex, 0, 'resolves a postprocessed source skin');
-  testContext.equal(binding?.joints.length, 2, 'preserves both authored joints');
-  testContext.equal(binding?.models.length, 1, 'binds the existing primitive model');
-  testContext.equal(binding?.jointMatrices.length, 32, 'allocates only authored joint matrices');
+  expect(scenegraphs.skins instanceof GLTFSkinController, 'exposes source-owned skins').toBe(true);
+  expect(scenegraphs.skins.bindings.length, 'binds the authored skinned node').toBe(1);
+  expect(binding?.skinIndex, 'resolves a postprocessed source skin').toBe(0);
+  expect(binding?.joints.length, 'preserves both authored joints').toBe(2);
+  expect(binding?.models.length, 'binds the existing primitive model').toBe(1);
+  expect(binding?.jointMatrices.length, 'allocates only authored joint matrices').toBe(32);
 
   if (binding) {
     const startingPalette = Array.from(binding.jointMatrices);
     const storage = binding.jointMatrices;
     scenegraphs.animator.setTime(500);
 
-    testContext.equal(binding.jointMatrices, storage, 'reuses the same palette every frame');
-    testContext.notDeepEqual(
+    expect(binding.jointMatrices, 'reuses the same palette every frame').toBe(storage);
+    expect(
       Array.from(binding.jointMatrices),
-      startingPalette,
       'the existing imported clip updates its joint transforms'
-    );
+    ).not.toEqual(startingPalette);
 
     const uniforms = binding.models[0].model.shaderInputs.getUniformValues();
-    testContext.ok(uniforms['skin'], 'the existing skin shader receives the automatic palette');
+    expect(
+      uniforms['skin'],
+      'the existing skin shader receives the automatic palette'
+    ).toBeTruthy();
   }
 
   for (const scene of scenegraphs.scenes) {
     scene.destroy();
   }
   device.destroy();
-  testContext.end();
 });
 
-test('GLTFSkinController preserves independent skins and mesh-local transforms', testContext => {
+it('GLTFSkinController preserves independent skins and mesh-local transforms', () => {
   const firstMeshNode = new GroupNode({id: 'mesh-node-a', position: [10, 0, 0]});
   const secondMeshNode = new GroupNode({id: 'mesh-node-b', position: [20, 0, 0]});
   const firstJoint = new GroupNode({id: 'joint-a', position: [12, 0, 0]});
@@ -92,25 +93,19 @@ test('GLTFSkinController preserves independent skins and mesh-local transforms',
     ])
   });
 
-  testContext.equal(controller.bindings.length, 2, 'keeps both authored skins independent');
-  testContext.equal(controller.getBinding(0)?.jointMatrices[12], 2, 'localizes the first skin');
-  testContext.equal(
+  expect(controller.bindings.length, 'keeps both authored skins independent').toBe(2);
+  expect(controller.getBinding(0)?.jointMatrices[12], 'localizes the first skin').toBe(2);
+  expect(
     controller.getBinding(secondMeshNode)?.jointMatrices[12],
-    5,
     'localizes the second skin'
-  );
+  ).toBe(5);
 
   secondJoint.setPosition([28, 0, 0]).updateMatrix();
   controller.update();
-  testContext.equal(
-    controller.getBinding(1)?.jointMatrices[12],
-    8,
-    'updates only authored transforms'
-  );
-  testContext.end();
+  expect(controller.getBinding(1)?.jointMatrices[12], 'updates only authored transforms').toBe(8);
 });
 
-test('GLTFAnimator advances wall-clock crossfades and supports explicit clip selection', testContext => {
+it('GLTFAnimator advances wall-clock crossfades and supports explicit clip selection', () => {
   const node = new GroupNode({id: 'animated'});
   let updateCount = 0;
   const makeAnimation = (name: string, position: number): GLTFAnimation => ({
@@ -138,23 +133,18 @@ test('GLTFAnimator advances wall-clock crossfades and supports explicit clip sel
     onUpdate: () => updateCount++
   });
 
-  testContext.equal(animator.activeClip, 'walk', 'initially selects the first authored clip');
-  testContext.false(animator.clips[1].action.playing, 'does not blend unrelated authored clips');
+  expect(animator.activeClip, 'initially selects the first authored clip').toBe('walk');
+  expect(animator.clips[1].action.playing, 'does not blend unrelated authored clips').toBe(false);
   animator.setTime(0);
   animator.selectClip('run', {crossFadeDuration: 1});
   animator.setTime(500);
 
-  testContext.equal(animator.activeClip, 'run', 'exposes the newly selected authored clip');
-  testContext.equal(
-    node.position[0],
-    5,
-    'legacy millisecond playback advances both crossfade weights'
-  );
-  testContext.equal(updateCount, 2, 'runs dependent skin updates once per animation frame');
+  expect(animator.activeClip, 'exposes the newly selected authored clip').toBe('run');
+  expect(node.position[0], 'legacy millisecond playback advances both crossfade weights').toBe(5);
+  expect(updateCount, 'runs dependent skin updates once per animation frame').toBe(2);
 
   animator.setTime(1000);
-  testContext.equal(node.position[0], 10, 'crossfades finish at the incoming clip');
-  testContext.equal(updateCount, 3, 'does not evaluate dependent skins twice');
-  testContext.throws(() => animator.selectClip('missing'), 'unknown clip names remain explicit');
-  testContext.end();
+  expect(node.position[0], 'crossfades finish at the incoming clip').toBe(10);
+  expect(updateCount, 'does not evaluate dependent skins twice').toBe(3);
+  expect(() => animator.selectClip('missing'), 'unknown clip names remain explicit').toThrow();
 });

--- a/modules/gltf/test/gltf/lights.spec.ts
+++ b/modules/gltf/test/gltf/lights.spec.ts
@@ -1,8 +1,8 @@
-import test from 'test/utils/vitest-tape';
 import {parseGLTFLights} from '@luma.gl/gltf/parsers/parse-gltf-lights';
 import type {GLTFPostprocessed} from '@loaders.gl/gltf';
+import {expect, it} from 'vitest';
 
-test('gltf#parseGLTFLights - directional', t => {
+it('gltf#parseGLTFLights - directional', () => {
   const gltf: GLTFPostprocessed = {
     nodes: [
       {
@@ -26,18 +26,19 @@ test('gltf#parseGLTFLights - directional', t => {
   } as any;
 
   const lights = parseGLTFLights(gltf);
-  t.equal(lights.length, 1, 'one light parsed');
+  expect(lights.length, 'one light parsed').toBe(1);
   const light = lights[0] as any;
-  t.equals(light.type, 'directional');
-  t.deepEquals(light.color, [51, 76.5, 102], 'glTF colors are normalized to luma light range');
-  t.equals(light.intensity, 2);
+  expect(light.type).toBe('directional');
+  expect(light.color, 'glTF colors are normalized to luma light range').toEqual([51, 76.5, 102]);
+  expect(light.intensity).toBe(2);
 
   const floatLights = parseGLTFLights(gltf, {useByteColors: false});
-  t.deepEquals((floatLights[0] as any).color, [0.2, 0.3, 0.4], 'float mode preserves glTF colors');
-  t.end();
+  expect((floatLights[0] as any).color, 'float mode preserves glTF colors').toEqual([
+    0.2, 0.3, 0.4
+  ]);
 });
 
-test('gltf#parseGLTFLights - point', t => {
+it('gltf#parseGLTFLights - point', () => {
   const gltf: GLTFPostprocessed = {
     nodes: [
       {
@@ -60,16 +61,15 @@ test('gltf#parseGLTFLights - point', t => {
     }
   } as any;
   const lights = parseGLTFLights(gltf);
-  t.equal(lights.length, 1, 'one light parsed');
+  expect(lights.length, 'one light parsed').toBe(1);
   const light = lights[0] as any;
-  t.equals(light.type, 'point');
-  t.deepEquals(light.position, [1, 2, 3]);
-  t.equals(light.intensity, 5);
-  t.equals(light.attenuation[2], 1 / 100);
-  t.end();
+  expect(light.type).toBe('point');
+  expect(light.position).toEqual([1, 2, 3]);
+  expect(light.intensity).toBe(5);
+  expect(light.attenuation[2]).toBe(1 / 100);
 });
 
-test('gltf#parseGLTFLights - spot', t => {
+it('gltf#parseGLTFLights - spot', () => {
   const gltf: GLTFPostprocessed = {
     nodes: [
       {
@@ -99,30 +99,28 @@ test('gltf#parseGLTFLights - spot', t => {
   } as any;
 
   const lights = parseGLTFLights(gltf);
-  t.equal(lights.length, 1, 'one spot light parsed');
+  expect(lights.length, 'one spot light parsed').toBe(1);
   const light = lights[0] as any;
-  t.equals(light.type, 'spot');
-  t.deepEquals(light.position, [1, 2, 3]);
-  t.deepEquals(light.direction, [0, 0, -1]);
-  t.deepEquals(light.color, [51, 76.5, 102], 'glTF colors are normalized to luma light range');
-  t.equals(light.intensity, 7);
-  t.equals(light.innerConeAngle, 0.1);
-  t.equals(light.outerConeAngle, 0.5);
-  t.equals(light.attenuation[2], 1 / 400);
-  t.end();
+  expect(light.type).toBe('spot');
+  expect(light.position).toEqual([1, 2, 3]);
+  expect(light.direction).toEqual([0, 0, -1]);
+  expect(light.color, 'glTF colors are normalized to luma light range').toEqual([51, 76.5, 102]);
+  expect(light.intensity).toBe(7);
+  expect(light.innerConeAngle).toBe(0.1);
+  expect(light.outerConeAngle).toBe(0.5);
+  expect(light.attenuation[2]).toBe(1 / 400);
 });
 
-test('gltf#parseGLTFLights - missing extension', t => {
+it('gltf#parseGLTFLights - missing extension', () => {
   const gltf: GLTFPostprocessed = {
     nodes: [],
     scenes: []
   } as any;
   const lights = parseGLTFLights(gltf);
-  t.equal(lights.length, 0, 'no lights parsed');
-  t.end();
+  expect(lights.length, 'no lights parsed').toBe(0);
 });
 
-test('gltf#parseGLTFLights - postprocessed lights with node matrix', t => {
+it('gltf#parseGLTFLights - postprocessed lights with node matrix', () => {
   const gltf: GLTFPostprocessed = {
     nodes: [
       {
@@ -141,15 +139,14 @@ test('gltf#parseGLTFLights - postprocessed lights with node matrix', t => {
   } as any;
 
   const lights = parseGLTFLights(gltf);
-  t.equal(lights.length, 1, 'one postprocessed light parsed');
+  expect(lights.length, 'one postprocessed light parsed').toBe(1);
   const light = lights[0] as any;
-  t.equals(light.type, 'point');
-  t.deepEquals(light.position, [4, 5, 6]);
-  t.equals(light.intensity, 3);
-  t.end();
+  expect(light.type).toBe('point');
+  expect(light.position).toEqual([4, 5, 6]);
+  expect(light.intensity).toBe(3);
 });
 
-test('gltf#parseGLTFLights - nested node transforms are resolved in world space', t => {
+it('gltf#parseGLTFLights - nested node transforms are resolved in world space', () => {
   const gltf: GLTFPostprocessed = {
     nodes: [
       {
@@ -179,12 +176,11 @@ test('gltf#parseGLTFLights - nested node transforms are resolved in world space'
   } as any;
 
   const lights = parseGLTFLights(gltf);
-  t.equal(lights.length, 1, 'one nested light parsed');
+  expect(lights.length, 'one nested light parsed').toBe(1);
   const light = lights[0] as any;
-  t.equals(light.type, 'spot');
-  t.deepEquals(light.position, [9, 2, -3], 'position includes parent rotation and translation');
-  t.deepEquals(light.direction, [0, 0, 1], 'direction includes parent rotation');
-  t.deepEquals(light.color, [255, 255, 255], 'white glTF light is normalized to 255');
-  t.equals(light.intensity, 4);
-  t.end();
+  expect(light.type).toBe('spot');
+  expect(light.position, 'position includes parent rotation and translation').toEqual([9, 2, -3]);
+  expect(light.direction, 'direction includes parent rotation').toEqual([0, 0, 1]);
+  expect(light.color, 'white glTF light is normalized to 255').toEqual([255, 255, 255]);
+  expect(light.intensity).toBe(4);
 });

--- a/modules/gltf/test/parsers/parse-pbr-sampler.node.spec.ts
+++ b/modules/gltf/test/parsers/parse-pbr-sampler.node.spec.ts
@@ -1,8 +1,8 @@
 import {parsePBRMaterial} from '@luma.gl/gltf';
 import {NullDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('glTF PBR parser preserves authored postprocessed sampler parameters', testContext => {
+it('glTF PBR parser preserves authored postprocessed sampler parameters', () => {
   const device = new NullDevice({});
   const parsedMaterial = parsePBRMaterial(
     device,
@@ -42,15 +42,14 @@ test('glTF PBR parser preserves authored postprocessed sampler parameters', test
   );
 
   const sampler = parsedMaterial.bindings.pbr_baseColorSampler?.sampler.props;
-  testContext.equal(sampler?.addressModeU, 'clamp-to-edge', 'horizontal wrapping remains authored');
-  testContext.equal(sampler?.addressModeV, 'mirror-repeat', 'vertical wrapping remains authored');
-  testContext.equal(sampler?.magFilter, 'nearest', 'magnification filtering remains authored');
-  testContext.equal(sampler?.minFilter, 'nearest', 'minification filtering remains authored');
-  testContext.equal(sampler?.mipmapFilter, 'linear', 'mipmap filtering remains authored');
+  expect(sampler?.addressModeU, 'horizontal wrapping remains authored').toBe('clamp-to-edge');
+  expect(sampler?.addressModeV, 'vertical wrapping remains authored').toBe('mirror-repeat');
+  expect(sampler?.magFilter, 'magnification filtering remains authored').toBe('nearest');
+  expect(sampler?.minFilter, 'minification filtering remains authored').toBe('nearest');
+  expect(sampler?.mipmapFilter, 'mipmap filtering remains authored').toBe('linear');
 
   for (const texture of parsedMaterial.generatedTextures) {
     texture.destroy();
   }
   device.destroy();
-  testContext.end();
 });

--- a/modules/gltf/test/parsers/parse-pbr-sampler.spec.ts
+++ b/modules/gltf/test/parsers/parse-pbr-sampler.spec.ts
@@ -5,9 +5,9 @@
 import {Buffer} from '@luma.gl/core';
 import {createGLTFTexture} from '@luma.gl/gltf';
 import {getWebGLTestDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('gltf#createGLTFTexture generates authored mipmaps on WebGL and WebGPU', async testContext => {
+it('gltf#createGLTFTexture generates authored mipmaps on WebGL and WebGPU', async () => {
   const image = await createImageBitmap(
     new ImageData(
       new Uint8ClampedArray([0, 0, 0, 255, 4, 0, 0, 255, 8, 0, 0, 255, 12, 0, 0, 255]),
@@ -40,17 +40,15 @@ test('gltf#createGLTFTexture generates authored mipmaps on WebGL and WebGPU', as
       });
 
       try {
-        testContext.equal(texture.mipLevels, 2, `${device.type} allocates the full mip chain`);
-        testContext.equal(
-          texture.format,
-          colorSpace === 'srgb' ? 'rgba8unorm-srgb' : 'rgba8unorm',
-          `${device.type} decodes ${colorSpace} textures exactly once`
+        expect(texture.mipLevels, `${device.type} allocates the full mip chain`).toBe(2);
+        expect(texture.format, `${device.type} decodes ${colorSpace} textures exactly once`).toBe(
+          colorSpace === 'srgb' ? 'rgba8unorm-srgb' : 'rgba8unorm'
         );
 
         texture.readBuffer({mipLevel: 1, width: 1, height: 1}, buffer);
         const mipLevel = new Uint8Array(await buffer.readAsync(0, layout.byteLength));
-        testContext.ok(mipLevel[0] > 0, `${device.type} generates ${colorSpace} mip texels`);
-        testContext.equal(mipLevel[3], 255, `${device.type} preserves authored mip opacity`);
+        expect(mipLevel[0] > 0, `${device.type} generates ${colorSpace} mip texels`).toBe(true);
+        expect(mipLevel[3], `${device.type} preserves authored mip opacity`).toBe(255);
       } finally {
         buffer.destroy();
         texture.destroy();
@@ -59,5 +57,4 @@ test('gltf#createGLTFTexture generates authored mipmaps on WebGL and WebGPU', as
   }
 
   image.close();
-  testContext.end();
 });

--- a/modules/gltf/test/webgl-to-webgpu/convert-webgl-sampler.node.spec.ts
+++ b/modules/gltf/test/webgl-to-webgpu/convert-webgl-sampler.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerConvertWebGLSamplerTests} from './convert-webgl-sampler.spec.shared';
 
-registerConvertWebGLSamplerTests(test);
+registerConvertWebGLSamplerTests();

--- a/modules/gltf/test/webgl-to-webgpu/convert-webgl-sampler.spec.shared.ts
+++ b/modules/gltf/test/webgl-to-webgpu/convert-webgl-sampler.spec.shared.ts
@@ -8,10 +8,10 @@ import {
 } from '@luma.gl/gltf/webgl-to-webgpu/convert-webgl-sampler';
 import {GLEnum} from '@luma.gl/gltf/webgl-to-webgpu/gltf-webgl-constants';
 import {convertSamplerParametersToWebGL} from '@luma.gl/webgl/adapter/converters/sampler-parameters';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-export function registerConvertWebGLSamplerTests(test: TapeTestFunction): void {
-  test('pbr#convertSampler#minFilter', async t => {
+export function registerConvertWebGLSamplerTests(): void {
+  it('pbr#convertSampler#minFilter', () => {
     [
       GLEnum.NEAREST,
       GLEnum.LINEAR,
@@ -24,37 +24,33 @@ export function registerConvertWebGLSamplerTests(test: TapeTestFunction): void {
       const gl = convertSamplerParametersToWebGL(props);
       const glValues = Object.values(gl);
 
-      t.equals(glValues.length, 1, 'Should return 1 value');
-      t.equals(glValues[0], minFilter, 'Value matches minFilter');
+      expect(glValues.length, 'Should return 1 value').toBe(1);
+      expect(glValues[0], 'Value matches minFilter').toBe(minFilter);
     });
 
-    t.deepEqual(convertSampler({}), {}, 'undefined sampler values are omitted');
-
-    t.end();
+    expect(convertSampler({}), 'undefined sampler values are omitted').toEqual({});
   });
 
-  test('pbr#convertSampler#magFilter', async t => {
+  it('pbr#convertSampler#magFilter', () => {
     [GLEnum.NEAREST, GLEnum.LINEAR].forEach(magFilter => {
       const props = convertSampler({magFilter});
       const gl = convertSamplerParametersToWebGL(props);
       const glValues = Object.values(gl);
 
-      t.equals(glValues.length, 1, 'Should return 1 value');
-      t.equals(glValues[0], magFilter, 'Value matches magFilter');
+      expect(glValues.length, 'Should return 1 value').toBe(1);
+      expect(glValues[0], 'Value matches magFilter').toBe(magFilter);
     });
-
-    t.end();
   });
 
-  test('pbr#convertSampler#wrap', async t => {
+  it('pbr#convertSampler#wrap', () => {
     [GLEnum.CLAMP_TO_EDGE, GLEnum.REPEAT, GLEnum.MIRRORED_REPEAT].forEach(wrap => {
       const props = convertSampler({wrapS: wrap, wrapT: wrap});
       const gl = convertSamplerParametersToWebGL(props);
       const glValues = Object.values(gl);
 
-      t.equals(glValues.length, 2, 'Should return 2 values');
-      t.equals(glValues[0], wrap, 'Value matches wrapT');
-      t.equals(glValues[1], wrap, 'Value matches wrapS');
+      expect(glValues.length, 'Should return 2 values').toBe(2);
+      expect(glValues[0], 'Value matches wrapT').toBe(wrap);
+      expect(glValues[1], 'Value matches wrapS').toBe(wrap);
     });
 
     const mixed = convertSampler({
@@ -63,22 +59,16 @@ export function registerConvertWebGLSamplerTests(test: TapeTestFunction): void {
       minFilter: GLEnum.LINEAR_MIPMAP_LINEAR,
       magFilter: GLEnum.LINEAR
     });
-    t.deepEqual(
-      mixed,
-      {
-        addressModeU: 'repeat',
-        addressModeV: 'clamp-to-edge',
-        minFilter: 'linear',
-        mipmapFilter: 'linear',
-        magFilter: 'linear'
-      },
-      'mixed sampler props are converted without dropping fields'
-    );
-
-    t.end();
+    expect(mixed, 'mixed sampler props are converted without dropping fields').toEqual({
+      addressModeU: 'repeat',
+      addressModeV: 'clamp-to-edge',
+      minFilter: 'linear',
+      mipmapFilter: 'linear',
+      magFilter: 'linear'
+    });
   });
 
-  test('pbr#convertSampler preserves postprocessed loaders.gl sampler parameters', async t => {
+  it('pbr#convertSampler preserves postprocessed loaders.gl sampler parameters', () => {
     const sampler = convertSampler({
       parameters: {
         [GLEnum.TEXTURE_WRAP_S]: GLEnum.CLAMP_TO_EDGE,
@@ -88,29 +78,26 @@ export function registerConvertWebGLSamplerTests(test: TapeTestFunction): void {
       }
     });
 
-    t.deepEqual(
+    expect(
       sampler,
-      {
-        addressModeU: 'clamp-to-edge',
-        addressModeV: 'mirror-repeat',
-        magFilter: 'nearest',
-        minFilter: 'nearest',
-        mipmapFilter: 'linear'
-      },
       'numeric postprocessed WebGL parameter keys preserve filtering and wrapping'
-    );
-    t.deepEqual(
+    ).toEqual({
+      addressModeU: 'clamp-to-edge',
+      addressModeV: 'mirror-repeat',
+      magFilter: 'nearest',
+      minFilter: 'nearest',
+      mipmapFilter: 'linear'
+    });
+    expect(
       convertSampler({
         wrapS: GLEnum.REPEAT,
         parameters: {[GLEnum.TEXTURE_WRAP_S]: GLEnum.CLAMP_TO_EDGE}
       }),
-      {addressModeU: 'repeat'},
       'explicit source glTF fields override postprocessed fallback values'
-    );
-    t.end();
+    ).toEqual({addressModeU: 'repeat'});
   });
 
-  test('pbr#convertSamplerToGLTF preserves every minification and mipmap combination', async t => {
+  it('pbr#convertSamplerToGLTF preserves every minification and mipmap combination', () => {
     for (const minFilter of [
       GLEnum.NEAREST,
       GLEnum.LINEAR,
@@ -119,14 +106,13 @@ export function registerConvertWebGLSamplerTests(test: TapeTestFunction): void {
       GLEnum.NEAREST_MIPMAP_LINEAR,
       GLEnum.LINEAR_MIPMAP_LINEAR
     ]) {
-      t.equal(
+      expect(
         convertSamplerToGLTF(convertSampler({minFilter})).minFilter,
-        minFilter,
         'glTF filtering round-trips through canonical portable sampler props'
-      );
+      ).toBe(minFilter);
     }
 
-    t.deepEqual(
+    expect(
       convertSamplerToGLTF({
         addressModeU: 'clamp-to-edge',
         addressModeV: 'mirror-repeat',
@@ -134,14 +120,12 @@ export function registerConvertWebGLSamplerTests(test: TapeTestFunction): void {
         minFilter: 'linear',
         mipmapFilter: 'nearest'
       }),
-      {
-        wrapS: GLEnum.CLAMP_TO_EDGE,
-        wrapT: GLEnum.MIRRORED_REPEAT,
-        magFilter: GLEnum.NEAREST,
-        minFilter: GLEnum.LINEAR_MIPMAP_NEAREST
-      },
       'authored portable sampler settings serialize into glTF WebGL enums'
-    );
-    t.end();
+    ).toEqual({
+      wrapS: GLEnum.CLAMP_TO_EDGE,
+      wrapT: GLEnum.MIRRORED_REPEAT,
+      magFilter: GLEnum.NEAREST,
+      minFilter: GLEnum.LINEAR_MIPMAP_NEAREST
+    });
   });
 }

--- a/modules/gltf/test/webgl-to-webgpu/convert-webgl-sampler.spec.ts
+++ b/modules/gltf/test/webgl-to-webgpu/convert-webgl-sampler.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerConvertWebGLSamplerTests} from './convert-webgl-sampler.spec.shared';
 
-registerConvertWebGLSamplerTests(test);
+registerConvertWebGLSamplerTests();

--- a/modules/shadertools/test/lib/generator/captialize.node.spec.ts
+++ b/modules/shadertools/test/lib/generator/captialize.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerCapitalizeTests} from './captialize.spec.shared';
 
-registerCapitalizeTests(test);
+registerCapitalizeTests();

--- a/modules/shadertools/test/lib/generator/captialize.spec.shared.ts
+++ b/modules/shadertools/test/lib/generator/captialize.spec.shared.ts
@@ -3,14 +3,15 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {capitalize} from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-export function registerCapitalizeTests(test: TapeTestFunction): void {
-  test('shadertools#capitalize', t => {
-    t.equal(capitalize('hello world'), 'Hello world', 'should capitalize string');
-    t.equal(capitalize('Hello world'), 'Hello world', 'should return already capitalized string');
-    t.equal(capitalize('1'), '1', 'should ignore non-alphabetic string');
-    t.equal(capitalize(''), '', 'should preserve empty strings');
-    t.end();
+export function registerCapitalizeTests(): void {
+  it('shadertools#capitalize', () => {
+    expect(capitalize('hello world'), 'should capitalize string').toBe('Hello world');
+    expect(capitalize('Hello world'), 'should return already capitalized string').toBe(
+      'Hello world'
+    );
+    expect(capitalize('1'), 'should ignore non-alphabetic string').toBe('1');
+    expect(capitalize(''), 'should preserve empty strings').toBe('');
   });
 }

--- a/modules/shadertools/test/lib/generator/captialize.spec.ts
+++ b/modules/shadertools/test/lib/generator/captialize.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerCapitalizeTests} from './captialize.spec.shared';
 
-registerCapitalizeTests(test);
+registerCapitalizeTests();

--- a/modules/shadertools/test/lib/generator/generate-shader.node.spec.ts
+++ b/modules/shadertools/test/lib/generator/generate-shader.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerGenerateShaderTests} from './generate-shader.spec.shared';
 
-registerGenerateShaderTests(test);
+registerGenerateShaderTests();

--- a/modules/shadertools/test/lib/generator/generate-shader.spec.shared.ts
+++ b/modules/shadertools/test/lib/generator/generate-shader.spec.shared.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {ShaderModule, generateShaderForModule, ShaderGenerationOptions} from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 const module: ShaderModule = {
   name: 'test',
@@ -59,14 +59,14 @@ var<uniform> test : Test;`
   }
 ];
 
-export function registerGenerateShaderTests(test: TapeTestFunction): void {
-  test('shadertools#generateGLSLForModule', t => {
+export function registerGenerateShaderTests(): void {
+  it('shadertools#generateGLSLForModule', () => {
     for (const testCase of TEST_CASES) {
       const generatedShader = generateShaderForModule(testCase.module, testCase.options);
-      t.equal(generatedShader, testCase.result, JSON.stringify(testCase.options));
+      expect(generatedShader, JSON.stringify(testCase.options)).toBe(testCase.result);
     }
 
-    t.throws(
+    expect(
       () =>
         generateShaderForModule(
           {
@@ -77,10 +77,7 @@ export function registerGenerateShaderTests(test: TapeTestFunction): void {
           } as ShaderModule,
           {shaderLanguage: 'wgsl'}
         ),
-      /Composite uniform types/,
       'WGSL generation rejects composite uniform types'
-    );
-
-    t.end();
+    ).toThrow(/Composite uniform types/);
   });
 }

--- a/modules/shadertools/test/lib/generator/generate-shader.spec.ts
+++ b/modules/shadertools/test/lib/generator/generate-shader.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerGenerateShaderTests} from './generate-shader.spec.shared';
 
-registerGenerateShaderTests(test);
+registerGenerateShaderTests();

--- a/modules/shadertools/test/lib/glsl-utils/shader-utils.node.spec.ts
+++ b/modules/shadertools/test/lib/glsl-utils/shader-utils.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerShaderUtilsTests} from './shader-utils.spec.shared';
 
-registerShaderUtilsTests(test);
+registerShaderUtilsTests();

--- a/modules/shadertools/test/lib/glsl-utils/shader-utils.spec.shared.ts
+++ b/modules/shadertools/test/lib/glsl-utils/shader-utils.spec.shared.ts
@@ -9,12 +9,12 @@ import {
   typeToChannelSuffix,
   typeToChannelCount
 } from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 type ChannelCount = 1 | 2 | 3 | 4;
 
-export function registerShaderUtilsTests(test: TapeTestFunction): void {
-  test('shader-utils#getQualifierDetails', t => {
+export function registerShaderUtilsTests(): void {
+  it('shader-utils#getQualifierDetails', () => {
     const QUALIFIER_TEST_CASES = [
       {
         line: 'uniform vec2 size;',
@@ -48,16 +48,14 @@ export function registerShaderUtilsTests(test: TapeTestFunction): void {
 
     QUALIFIER_TEST_CASES.forEach(testCase => {
       const result = getQualifierDetails(testCase.line, testCase.qualifiers);
-      t.deepEqual(
+      expect(
         result,
-        testCase.expected,
         `getQualifierDetails should return valid values when line=${testCase.line}`
-      );
+      ).toEqual(testCase.expected);
     });
-    t.end();
   });
 
-  test('shader-utils#getPassthroughFS', t => {
+  it('shader-utils#getPassthroughFS', () => {
     const PASSTHROUGH_TEST_CASES = [
       {
         input: 'myInput',
@@ -91,61 +89,50 @@ void main() {
         inputChannels: testCase.inputChannels,
         output: testCase.output
       });
-      t.equal(
+      expect(
         result,
-        testCase.expected,
         `Passthrough shader should match when channels=${testCase.inputChannels}`
-      );
+      ).toBe(testCase.expected);
     });
 
-    t.ok(
+    expect(
       getPassthroughFS().includes('transform_output'),
       'default passthrough shader is returned without input'
-    );
-    t.throws(() => getPassthroughFS({input: 'myInput'}), /inputChannels/, 'missing channels throw');
-    t.end();
+    ).toBe(true);
+    expect(() => getPassthroughFS({input: 'myInput'})).toThrow(/inputChannels/);
   });
 
-  test('shader-utils#typeToChannelSuffix', t => {
-    t.equal(typeToChannelSuffix('float'), 'x', 'typeToChannelSuffix should return x for float');
-    t.equal(typeToChannelSuffix('vec2'), 'xy', 'typeToChannelSuffix should return xy for vec2');
-    t.equal(typeToChannelSuffix('vec3'), 'xyz', 'typeToChannelSuffix should return xyz for vec3');
-    t.equal(typeToChannelSuffix('vec4'), 'xyzw', 'typeToChannelSuffix should return xyzw for vec4');
-    t.throws(() => typeToChannelSuffix('mat4'), /mat4/, 'invalid suffix types throw');
-    t.end();
+  it('shader-utils#typeToChannelSuffix', () => {
+    expect(typeToChannelSuffix('float'), 'typeToChannelSuffix should return x for float').toBe('x');
+    expect(typeToChannelSuffix('vec2'), 'typeToChannelSuffix should return xy for vec2').toBe('xy');
+    expect(typeToChannelSuffix('vec3'), 'typeToChannelSuffix should return xyz for vec3').toBe(
+      'xyz'
+    );
+    expect(typeToChannelSuffix('vec4'), 'typeToChannelSuffix should return xyzw for vec4').toBe(
+      'xyzw'
+    );
+    expect(() => typeToChannelSuffix('mat4')).toThrow(/mat4/);
   });
 
-  test('shader-utils#typeToChannelCount', t => {
-    t.equal(typeToChannelCount('float'), 1, 'typeToChannelCount should return 1 for float');
-    t.equal(typeToChannelCount('vec2'), 2, 'typeToChannelCount should return 2 for vec2');
-    t.equal(typeToChannelCount('vec3'), 3, 'typeToChannelCount should return 3 for vec3');
-    t.equal(typeToChannelCount('vec4'), 4, 'typeToChannelCount should return 4 for vec4');
-    t.throws(() => typeToChannelCount('mat4'), /mat4/, 'invalid channel count types throw');
-    t.end();
+  it('shader-utils#typeToChannelCount', () => {
+    expect(typeToChannelCount('float'), 'typeToChannelCount should return 1 for float').toBe(1);
+    expect(typeToChannelCount('vec2'), 'typeToChannelCount should return 2 for vec2').toBe(2);
+    expect(typeToChannelCount('vec3'), 'typeToChannelCount should return 3 for vec3').toBe(3);
+    expect(typeToChannelCount('vec4'), 'typeToChannelCount should return 4 for vec4').toBe(4);
+    expect(() => typeToChannelCount('mat4')).toThrow(/mat4/);
   });
 
-  test('shader-utils#convertToVec4', t => {
-    t.equal(
-      convertToVec4('one', 1),
-      'vec4(one, 0.0, 0.0, 1.0)',
-      'convertToVec4 should return right value for float'
+  it('shader-utils#convertToVec4', () => {
+    expect(convertToVec4('one', 1), 'convertToVec4 should return right value for float').toBe(
+      'vec4(one, 0.0, 0.0, 1.0)'
     );
-    t.equal(
-      convertToVec4('one', 2),
-      'vec4(one, 0.0, 1.0)',
-      'convertToVec4 should return right value for vec2'
+    expect(convertToVec4('one', 2), 'convertToVec4 should return right value for vec2').toBe(
+      'vec4(one, 0.0, 1.0)'
     );
-    t.equal(
-      convertToVec4('one', 3),
-      'vec4(one, 1.0)',
-      'convertToVec4 should return right value for vec3'
+    expect(convertToVec4('one', 3), 'convertToVec4 should return right value for vec3').toBe(
+      'vec4(one, 1.0)'
     );
-    t.equal(convertToVec4('one', 4), 'one', 'convertToVec4 should return right value for vec4');
-    t.throws(
-      () => convertToVec4('one', 5 as never),
-      /invalid channels/,
-      'invalid channel counts throw'
-    );
-    t.end();
+    expect(convertToVec4('one', 4), 'convertToVec4 should return right value for vec4').toBe('one');
+    expect(() => convertToVec4('one', 5 as never)).toThrow(/invalid channels/);
   });
 }

--- a/modules/shadertools/test/lib/glsl-utils/shader-utils.spec.ts
+++ b/modules/shadertools/test/lib/glsl-utils/shader-utils.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerShaderUtilsTests} from './shader-utils.spec.shared';
 
-registerShaderUtilsTests(test);
+registerShaderUtilsTests();

--- a/modules/shadertools/test/lib/preprocessor/preprocessor.node.spec.ts
+++ b/modules/shadertools/test/lib/preprocessor/preprocessor.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerPreprocessorTests} from './preprocessor.spec.shared';
 
-registerPreprocessorTests(test);
+registerPreprocessorTests();

--- a/modules/shadertools/test/lib/preprocessor/preprocessor.spec.shared.ts
+++ b/modules/shadertools/test/lib/preprocessor/preprocessor.spec.shared.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {preprocess} from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 const TEST_CASES = [
   {
@@ -97,29 +97,17 @@ var attributePath = 1;
   }
 ];
 
-export function registerPreprocessorTests(test: TapeTestFunction): void {
-  test('preprocess', t => {
+export function registerPreprocessorTests(): void {
+  it('preprocess', () => {
     for (const testCase of TEST_CASES) {
       const result = preprocess(testCase.source, testCase.options);
-      t.equal(result, testCase.result, testCase.title);
+      expect(result, testCase.title).toBe(testCase.result);
     }
 
-    t.throws(
-      () => preprocess('#else\nvalue\n#endif'),
-      /Encountered #else/,
-      'orphaned #else throws'
+    expect(() => preprocess('#else\nvalue\n#endif')).toThrow(/Encountered #else/);
+    expect(() => preprocess('#ifdef USE_SHADOWS\nvalue')).toThrow(/Unterminated conditional block/);
+    expect(() => preprocess('#if USE_A && USE_B\nvalue\n#endif')).toThrow(
+      /Unsupported #if expression/
     );
-    t.throws(
-      () => preprocess('#ifdef USE_SHADOWS\nvalue'),
-      /Unterminated conditional block/,
-      'unterminated conditionals throw'
-    );
-    t.throws(
-      () => preprocess('#if USE_A && USE_B\nvalue\n#endif'),
-      /Unsupported #if expression/,
-      'unsupported #if expressions throw'
-    );
-
-    t.end();
   });
 }

--- a/modules/shadertools/test/lib/preprocessor/preprocessor.spec.ts
+++ b/modules/shadertools/test/lib/preprocessor/preprocessor.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerPreprocessorTests} from './preprocessor.spec.shared';
 
-registerPreprocessorTests(test);
+registerPreprocessorTests();

--- a/modules/shadertools/test/modules/lighting/dirlight.node.spec.ts
+++ b/modules/shadertools/test/modules/lighting/dirlight.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerDirlightTests} from './dirlight.spec.shared';
 
-registerDirlightTests(test);
+registerDirlightTests();

--- a/modules/shadertools/test/modules/lighting/dirlight.spec.shared.ts
+++ b/modules/shadertools/test/modules/lighting/dirlight.spec.shared.ts
@@ -4,30 +4,29 @@
 
 import {checkType} from '@luma.gl/test-utils';
 import {dirlight, ShaderModule} from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 checkType<ShaderModule>(dirlight);
 
-export function registerDirlightTests(test: TapeTestFunction): void {
-  test('shadertools#dirlight', t => {
-    t.deepEqual(
+export function registerDirlightTests(): void {
+  it('shadertools#dirlight', () => {
+    expect(
       dirlight.getUniforms(),
-      {lightDirection: [1, 1, 2]},
       'default dirlight uniforms use the exported default direction'
-    );
-    t.deepEqual(dirlight.getUniforms({}), {}, 'explicit empty dirlight props stay empty');
-    t.deepEqual(
+    ).toEqual({lightDirection: [1, 1, 2]});
+    expect(dirlight.getUniforms({}), 'explicit empty dirlight props stay empty').toEqual({});
+    expect(
       dirlight.getUniforms({lightDirection: [2, 3, 4]}),
-      {lightDirection: [2, 3, 4]},
       'custom lightDirection is preserved'
+    ).toEqual({lightDirection: [2, 3, 4]});
+    expect(dirlight.defaultUniforms.lightDirection, 'default uniforms remain exported').toEqual([
+      1, 1, 2
+    ]);
+    expect(dirlight.fs.includes('dirlight_filterColor'), 'fragment shader source is exported').toBe(
+      true
     );
-    t.deepEqual(
-      dirlight.defaultUniforms.lightDirection,
-      [1, 1, 2],
-      'default uniforms remain exported'
+    expect(dirlight.vs.includes('dirlight_setNormal'), 'vertex shader source is exported').toBe(
+      true
     );
-    t.ok(dirlight.fs.includes('dirlight_filterColor'), 'fragment shader source is exported');
-    t.ok(dirlight.vs.includes('dirlight_setNormal'), 'vertex shader source is exported');
-    t.end();
   });
 }

--- a/modules/shadertools/test/modules/lighting/dirlight.spec.ts
+++ b/modules/shadertools/test/modules/lighting/dirlight.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerDirlightTests} from './dirlight.spec.shared';
 
-registerDirlightTests(test);
+registerDirlightTests();

--- a/modules/shadertools/test/modules/lighting/gouraud-material.node.spec.ts
+++ b/modules/shadertools/test/modules/lighting/gouraud-material.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerGouraudMaterialTests} from './gouraud-material.spec.shared';
 
-registerGouraudMaterialTests(test);
+registerGouraudMaterialTests();

--- a/modules/shadertools/test/modules/lighting/gouraud-material.spec.shared.ts
+++ b/modules/shadertools/test/modules/lighting/gouraud-material.spec.shared.ts
@@ -4,12 +4,12 @@
 
 import type {UniformValue} from '@luma.gl/core';
 import {gouraudMaterial} from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-export function registerGouraudMaterialTests(test: TapeTestFunction): void {
-  test('shadertools#gouraudMaterial', t => {
+export function registerGouraudMaterialTests(): void {
+  it('shadertools#gouraudMaterial', () => {
     let uniforms: Record<string, UniformValue | any> = gouraudMaterial.getUniforms?.({})!;
-    t.deepEqual(uniforms, gouraudMaterial.defaultUniforms, 'Default phong lighting uniforms ok');
+    expect(uniforms, 'Default phong lighting uniforms ok').toEqual(gouraudMaterial.defaultUniforms);
 
     uniforms = gouraudMaterial.getUniforms?.({
       unlit: true,
@@ -18,41 +18,42 @@ export function registerGouraudMaterialTests(test: TapeTestFunction): void {
       shininess: 0.0,
       specularColor: [255, 0, 0]
     })!;
-    t.is(uniforms.unlit, true, 'unlit');
-    t.is(uniforms.ambient, 0, 'ambient');
-    t.is(uniforms.diffuse, 0, 'diffuse');
-    t.is(uniforms.shininess, 0, 'shininess');
-    t.deepEqual(uniforms.specularColor, [255, 0, 0], 'specularColor');
+    expect(uniforms.unlit, 'unlit').toBe(true);
+    expect(uniforms.ambient, 'ambient').toBe(0);
+    expect(uniforms.diffuse, 'diffuse').toBe(0);
+    expect(uniforms.shininess, 'shininess').toBe(0);
+    expect(uniforms.specularColor, 'specularColor').toEqual([255, 0, 0]);
 
     uniforms = gouraudMaterial.getUniforms?.({})!;
-    t.equal(uniforms.unlit, false, 'unlit');
-    t.equal(uniforms.ambient, 0.35, 'ambient');
-    t.equal(uniforms.diffuse, 0.6, 'diffuse');
-    t.equal(uniforms.shininess, 32, 'shininess');
-    t.deepEqual(uniforms.specularColor, [38.25, 38.25, 38.25], 'specularColor');
-    t.ok(gouraudMaterial.defines?.LIGHTING_VERTEX, 'gouraudMaterial enables vertex lighting');
+    expect(uniforms.unlit, 'unlit').toBe(false);
+    expect(uniforms.ambient, 'ambient').toBe(0.35);
+    expect(uniforms.diffuse, 'diffuse').toBe(0.6);
+    expect(uniforms.shininess, 'shininess').toBe(32);
+    expect(uniforms.specularColor, 'specularColor').toEqual([38.25, 38.25, 38.25]);
+    expect(
+      gouraudMaterial.defines?.LIGHTING_VERTEX,
+      'gouraudMaterial enables vertex lighting'
+    ).toBeTruthy();
 
     uniforms = gouraudMaterial.getUniforms?.({
       specularColor: [2, 1, 0.5]
     })!;
-    t.deepEqual(uniforms.specularColor, [2, 1, 0.5], 'float specular colors pass through');
-    t.notOk(
+    expect(uniforms.specularColor, 'float specular colors pass through').toEqual([2, 1, 0.5]);
+    expect(
       'useByteColors' in gouraudMaterial.uniformTypes,
       'gouraudMaterial no longer owns useByteColors'
-    );
-    t.ok(
+    ).toBe(false);
+    expect(
       gouraudMaterial.dependencies?.some(module => module.name === 'floatColors'),
       'gouraudMaterial depends on floatColors'
-    );
-    t.ok(
+    ).toBe(true);
+    expect(
       gouraudMaterial.vs?.includes('floatColors_normalize(material.specularColor)'),
       'vertex shader normalizes specularColor through floatColors'
-    );
-    t.ok(
+    ).toBe(true);
+    expect(
       gouraudMaterial.source?.includes('floatColors_normalize(gouraudMaterial.specularColor)'),
       'WGSL shader normalizes specularColor through floatColors'
-    );
-
-    t.end();
+    ).toBe(true);
   });
 }

--- a/modules/shadertools/test/modules/lighting/gouraud-material.spec.ts
+++ b/modules/shadertools/test/modules/lighting/gouraud-material.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerGouraudMaterialTests} from './gouraud-material.spec.shared';
 
-registerGouraudMaterialTests(test);
+registerGouraudMaterialTests();

--- a/modules/shadertools/test/modules/lighting/lambert-material.node.spec.ts
+++ b/modules/shadertools/test/modules/lighting/lambert-material.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerLambertMaterialTests} from './lambert-material.spec.shared';
 
-registerLambertMaterialTests(test);
+registerLambertMaterialTests();

--- a/modules/shadertools/test/modules/lighting/lambert-material.spec.shared.ts
+++ b/modules/shadertools/test/modules/lighting/lambert-material.spec.shared.ts
@@ -3,28 +3,31 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {lambertMaterial} from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-export function registerLambertMaterialTests(test: TapeTestFunction): void {
-  test('shadertools#lambertMaterial', t => {
+export function registerLambertMaterialTests(): void {
+  it('shadertools#lambertMaterial', () => {
     let uniforms = lambertMaterial.getUniforms({});
-    t.deepEqual(uniforms, lambertMaterial.defaultUniforms, 'Default lambert lighting uniforms ok');
+    expect(uniforms, 'Default lambert lighting uniforms ok').toEqual(
+      lambertMaterial.defaultUniforms
+    );
 
     uniforms = lambertMaterial.getUniforms({
       unlit: true,
       ambient: 0.0,
       diffuse: 0.0
     });
-    t.is(uniforms.unlit, true, 'unlit');
-    t.is(uniforms.ambient, 0, 'ambient');
-    t.is(uniforms.diffuse, 0, 'diffuse');
+    expect(uniforms.unlit, 'unlit').toBe(true);
+    expect(uniforms.ambient, 'ambient').toBe(0);
+    expect(uniforms.diffuse, 'diffuse').toBe(0);
 
     uniforms = lambertMaterial.getUniforms({});
-    t.equal(uniforms.unlit, false, 'unlit');
-    t.equal(uniforms.ambient, 0.35, 'ambient');
-    t.equal(uniforms.diffuse, 0.6, 'diffuse');
-    t.ok(lambertMaterial.defines?.LIGHTING_FRAGMENT, 'lambertMaterial enables fragment lighting');
-
-    t.end();
+    expect(uniforms.unlit, 'unlit').toBe(false);
+    expect(uniforms.ambient, 'ambient').toBe(0.35);
+    expect(uniforms.diffuse, 'diffuse').toBe(0.6);
+    expect(
+      lambertMaterial.defines?.LIGHTING_FRAGMENT,
+      'lambertMaterial enables fragment lighting'
+    ).toBeTruthy();
   });
 }

--- a/modules/shadertools/test/modules/lighting/lambert-material.spec.ts
+++ b/modules/shadertools/test/modules/lighting/lambert-material.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerLambertMaterialTests} from './lambert-material.spec.shared';
 
-registerLambertMaterialTests(test);
+registerLambertMaterialTests();

--- a/modules/shadertools/test/modules/lighting/phong-material.node.spec.ts
+++ b/modules/shadertools/test/modules/lighting/phong-material.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerPhongMaterialTests} from './phong-material.spec.shared';
 
-registerPhongMaterialTests(test);
+registerPhongMaterialTests();

--- a/modules/shadertools/test/modules/lighting/phong-material.spec.shared.ts
+++ b/modules/shadertools/test/modules/lighting/phong-material.spec.shared.ts
@@ -3,12 +3,12 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {phongMaterial} from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-export function registerPhongMaterialTests(test: TapeTestFunction): void {
-  test('shadertools#phongMaterial', t => {
+export function registerPhongMaterialTests(): void {
+  it('shadertools#phongMaterial', () => {
     let uniforms = phongMaterial.getUniforms({});
-    t.deepEqual(uniforms, phongMaterial.defaultUniforms, 'Default phong lighting uniforms ok');
+    expect(uniforms, 'Default phong lighting uniforms ok').toEqual(phongMaterial.defaultUniforms);
 
     uniforms = phongMaterial.getUniforms({
       unlit: true,
@@ -17,41 +17,42 @@ export function registerPhongMaterialTests(test: TapeTestFunction): void {
       shininess: 0.0,
       specularColor: [255, 0, 0]
     });
-    t.is(uniforms.unlit, true, 'unlit');
-    t.is(uniforms.ambient, 0, 'ambient');
-    t.is(uniforms.diffuse, 0, 'diffuse');
-    t.is(uniforms.shininess, 0, 'shininess');
-    t.deepEqual(uniforms.specularColor, [255, 0, 0], 'specularColor');
+    expect(uniforms.unlit, 'unlit').toBe(true);
+    expect(uniforms.ambient, 'ambient').toBe(0);
+    expect(uniforms.diffuse, 'diffuse').toBe(0);
+    expect(uniforms.shininess, 'shininess').toBe(0);
+    expect(uniforms.specularColor, 'specularColor').toEqual([255, 0, 0]);
 
     uniforms = phongMaterial.getUniforms({});
-    t.equal(uniforms.unlit, false, 'unlit');
-    t.equal(uniforms.ambient, 0.35, 'ambient');
-    t.equal(uniforms.diffuse, 0.6, 'diffuse');
-    t.equal(uniforms.shininess, 32, 'shininess');
-    t.deepEqual(uniforms.specularColor, [38.25, 38.25, 38.25], 'specularColor');
-    t.ok(phongMaterial.defines?.LIGHTING_FRAGMENT, 'phongMaterial enables fragment lighting');
+    expect(uniforms.unlit, 'unlit').toBe(false);
+    expect(uniforms.ambient, 'ambient').toBe(0.35);
+    expect(uniforms.diffuse, 'diffuse').toBe(0.6);
+    expect(uniforms.shininess, 'shininess').toBe(32);
+    expect(uniforms.specularColor, 'specularColor').toEqual([38.25, 38.25, 38.25]);
+    expect(
+      phongMaterial.defines?.LIGHTING_FRAGMENT,
+      'phongMaterial enables fragment lighting'
+    ).toBeTruthy();
 
     uniforms = phongMaterial.getUniforms({
       specularColor: [2, 1, 0.5]
     });
-    t.deepEqual(uniforms.specularColor, [2, 1, 0.5], 'float specular colors pass through');
-    t.notOk(
+    expect(uniforms.specularColor, 'float specular colors pass through').toEqual([2, 1, 0.5]);
+    expect(
       'useByteColors' in phongMaterial.uniformTypes,
       'phongMaterial no longer owns useByteColors'
-    );
-    t.ok(
+    ).toBe(false);
+    expect(
       phongMaterial.dependencies?.some(module => module.name === 'floatColors'),
       'phongMaterial depends on floatColors'
-    );
-    t.ok(
+    ).toBe(true);
+    expect(
       phongMaterial.fs.includes('floatColors_normalize(material.specularColor)'),
       'fragment shader normalizes specularColor through floatColors'
-    );
-    t.ok(
+    ).toBe(true);
+    expect(
       phongMaterial.source.includes('floatColors_normalize(phongMaterial.specularColor)'),
       'WGSL shader normalizes specularColor through floatColors'
-    );
-
-    t.end();
+    ).toBe(true);
   });
 }

--- a/modules/shadertools/test/modules/lighting/phong-material.spec.ts
+++ b/modules/shadertools/test/modules/lighting/phong-material.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerPhongMaterialTests} from './phong-material.spec.shared';
 
-registerPhongMaterialTests(test);
+registerPhongMaterialTests();

--- a/modules/shadertools/test/modules/utils/random.spec.ts
+++ b/modules/shadertools/test/modules/utils/random.spec.ts
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {random} from '@luma.gl/shadertools';
+import {expect, it} from 'vitest';
 
-test('random#build', t => {
-  t.ok(random.fs, 'random module fs is ok');
-  t.end();
+it('random#build', () => {
+  expect(random.fs, 'random module fs is ok').toBeTruthy();
 });

--- a/modules/webgl/test/adapter/device-helpers/webgl-device-info.spec.ts
+++ b/modules/webgl/test/adapter/device-helpers/webgl-device-info.spec.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {GL} from '@luma.gl/webgl/constants';
 import {getDeviceInfo} from '../../../src/adapter/device-helpers/webgl-device-info';
+import {expect, it} from 'vitest';
 
 function createMockGL(options: {
   vendor: string;
@@ -33,26 +33,24 @@ function createMockGL(options: {
   } as WebGL2RenderingContext;
 }
 
-test('getDeviceInfo classifies Apple Silicon WebGL GPUs as integrated', t => {
+it('getDeviceInfo classifies Apple Silicon WebGL GPUs as integrated', () => {
   const gl = createMockGL({
     vendor: 'Apple',
     renderer: 'ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version'
   });
 
   const info = getDeviceInfo(gl, {});
-  t.equal(info.gpu, 'apple', 'identifies Apple GPU vendor');
-  t.equal(info.gpuType, 'integrated', 'classifies Apple Silicon as integrated');
-  t.end();
+  expect(info.gpu, 'identifies Apple GPU vendor').toBe('apple');
+  expect(info.gpuType, 'classifies Apple Silicon as integrated').toBe('integrated');
 });
 
-test('getDeviceInfo leaves ambiguous Apple WebGL GPUs as unknown type', t => {
+it('getDeviceInfo leaves ambiguous Apple WebGL GPUs as unknown type', () => {
   const gl = createMockGL({
     vendor: 'Apple',
     renderer: 'Apple'
   });
 
   const info = getDeviceInfo(gl, {});
-  t.equal(info.gpu, 'apple', 'identifies Apple GPU vendor');
-  t.equal(info.gpuType, 'unknown', 'does not default ambiguous Apple GPUs to discrete');
-  t.end();
+  expect(info.gpu, 'identifies Apple GPU vendor').toBe('apple');
+  expect(info.gpuType, 'does not default ambiguous Apple GPUs to discrete').toBe('unknown');
 });

--- a/modules/webgl/test/adapter/helpers/parse-shader-compiler-log.node.spec.ts
+++ b/modules/webgl/test/adapter/helpers/parse-shader-compiler-log.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerParseShaderCompilerLogTests} from 'test/utils/parse-shader-compiler-log.spec.shared';
 
-registerParseShaderCompilerLogTests(test);
+registerParseShaderCompilerLogTests();

--- a/modules/webgl/test/adapter/helpers/parse-shader-compiler-log.spec.ts
+++ b/modules/webgl/test/adapter/helpers/parse-shader-compiler-log.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerParseShaderCompilerLogTests} from 'test/utils/parse-shader-compiler-log.spec.shared';
 
-registerParseShaderCompilerLogTests(test);
+registerParseShaderCompilerLogTests();

--- a/modules/webgl/test/adapter/helpers/webgl-texture-table.spec.ts
+++ b/modules/webgl/test/adapter/helpers/webgl-texture-table.spec.ts
@@ -2,16 +2,14 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 import {GL} from '@luma.gl/webgl/constants';
 import {WEBGL_TEXTURE_FORMATS} from '../../../src/adapter/converters/webgl-texture-table';
 
-test('WEBGL_TEXTURE_FORMATS maps ASTC 10x5 formats correctly', t => {
-  t.equal(WEBGL_TEXTURE_FORMATS['astc-10x5-unorm'].gl, GL.COMPRESSED_RGBA_ASTC_10x5_KHR);
-  t.equal(
-    WEBGL_TEXTURE_FORMATS['astc-10x5-unorm-srgb'].gl,
+it('WEBGL_TEXTURE_FORMATS maps ASTC 10x5 formats correctly', () => {
+  expect(WEBGL_TEXTURE_FORMATS['astc-10x5-unorm'].gl).toBe(GL.COMPRESSED_RGBA_ASTC_10x5_KHR);
+  expect(WEBGL_TEXTURE_FORMATS['astc-10x5-unorm-srgb'].gl).toBe(
     GL.COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR
   );
-  t.end();
 });

--- a/modules/webgl/test/adapter/helpers/webgl-topology-utils.node.spec.ts
+++ b/modules/webgl/test/adapter/helpers/webgl-topology-utils.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerWebGLTopologyUtilsTests} from './webgl-topology-utils.spec.shared';
 
-registerWebGLTopologyUtilsTests(test);
+registerWebGLTopologyUtilsTests();

--- a/modules/webgl/test/adapter/helpers/webgl-topology-utils.spec.shared.ts
+++ b/modules/webgl/test/adapter/helpers/webgl-topology-utils.spec.shared.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {GL} from '@luma.gl/webgl/constants';
+import {expect, it} from 'vitest';
 import {
   getGLDrawMode,
   getGLPrimitive,
@@ -10,63 +11,60 @@ import {
   getPrimitiveDrawMode,
   getVertexCount
 } from '@luma.gl/webgl/adapter/helpers/webgl-topology-utils';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
 
-export function registerWebGLTopologyUtilsTests(test: TapeTestFunction): void {
-  test('getPrimitiveDrawMode', t => {
-    t.equals(getPrimitiveDrawMode(GL.POINTS), GL.POINTS, 'point-list');
-    t.equals(getPrimitiveDrawMode(GL.LINES), GL.LINES, 'line-list');
-    t.equals(getPrimitiveDrawMode(GL.LINE_STRIP), GL.LINES, 'line-strip');
-    t.equals(getPrimitiveDrawMode(GL.LINE_LOOP), GL.LINES, 'line-loop');
-    t.equals(getPrimitiveDrawMode(GL.TRIANGLES), GL.TRIANGLES, 'triangle-list');
-    t.equals(getPrimitiveDrawMode(GL.TRIANGLE_STRIP), GL.TRIANGLES, 'triangle-strip');
-    t.equals(getPrimitiveDrawMode(GL.TRIANGLE_FAN), GL.TRIANGLES, 'triangle-fan');
-    t.throws(() => getPrimitiveDrawMode(-1 as any), 'invalid');
-    t.end();
+export function registerWebGLTopologyUtilsTests(): void {
+  it('getPrimitiveDrawMode', () => {
+    expect(getPrimitiveDrawMode(GL.POINTS), 'point-list').toBe(GL.POINTS);
+    expect(getPrimitiveDrawMode(GL.LINES), 'line-list').toBe(GL.LINES);
+    expect(getPrimitiveDrawMode(GL.LINE_STRIP), 'line-strip').toBe(GL.LINES);
+    expect(getPrimitiveDrawMode(GL.LINE_LOOP), 'line-loop').toBe(GL.LINES);
+    expect(getPrimitiveDrawMode(GL.TRIANGLES), 'triangle-list').toBe(GL.TRIANGLES);
+    expect(getPrimitiveDrawMode(GL.TRIANGLE_STRIP), 'triangle-strip').toBe(GL.TRIANGLES);
+    expect(getPrimitiveDrawMode(GL.TRIANGLE_FAN), 'triangle-fan').toBe(GL.TRIANGLES);
+    expect(() => getPrimitiveDrawMode(-1 as any)).toThrow();
   });
 
-  test('getPrimitiveCount', t => {
-    t.equals(getPrimitiveCount({drawMode: GL.POINTS, vertexCount: 12}), 12, 'point-list');
-    t.equals(getPrimitiveCount({drawMode: GL.LINE_LOOP, vertexCount: 12}), 12, 'line-loop');
-    t.equals(getPrimitiveCount({drawMode: GL.LINES, vertexCount: 12}), 6, 'line-list');
-    t.equals(getPrimitiveCount({drawMode: GL.LINE_STRIP, vertexCount: 12}), 11, 'line-strip');
-    t.equals(getPrimitiveCount({drawMode: GL.TRIANGLES, vertexCount: 12}), 4, 'triangle-list');
-    t.equals(
+  it('getPrimitiveCount', () => {
+    expect(getPrimitiveCount({drawMode: GL.POINTS, vertexCount: 12}), 'point-list').toBe(12);
+    expect(getPrimitiveCount({drawMode: GL.LINE_LOOP, vertexCount: 12}), 'line-loop').toBe(12);
+    expect(getPrimitiveCount({drawMode: GL.LINES, vertexCount: 12}), 'line-list').toBe(6);
+    expect(getPrimitiveCount({drawMode: GL.LINE_STRIP, vertexCount: 12}), 'line-strip').toBe(11);
+    expect(getPrimitiveCount({drawMode: GL.TRIANGLES, vertexCount: 12}), 'triangle-list').toBe(4);
+    expect(
       getPrimitiveCount({drawMode: GL.TRIANGLE_STRIP, vertexCount: 12}),
-      10,
       'triangle-strip'
+    ).toBe(10);
+    expect(getPrimitiveCount({drawMode: GL.TRIANGLE_FAN, vertexCount: 12}), 'triangle-fan').toBe(
+      10
     );
-    t.equals(getPrimitiveCount({drawMode: GL.TRIANGLE_FAN, vertexCount: 12}), 10, 'triangle-fan');
-    t.throws(() => getPrimitiveCount({drawMode: -1 as any, vertexCount: 12}), 'invalid');
-    t.end();
+    expect(() => getPrimitiveCount({drawMode: -1 as any, vertexCount: 12})).toThrow();
   });
 
-  test('getVertexCount', t => {
-    t.equals(getVertexCount({drawMode: GL.POINTS, vertexCount: 12}), 12, 'point-list');
-    t.equals(getVertexCount({drawMode: GL.LINE_STRIP, vertexCount: 12}), 22, 'line-strip');
-    t.equals(getVertexCount({drawMode: GL.TRIANGLE_STRIP, vertexCount: 12}), 30, 'triangle-strip');
-    t.equals(getVertexCount({drawMode: GL.TRIANGLE_FAN, vertexCount: 12}), 30, 'triangle-fan');
-    t.throws(() => getVertexCount({drawMode: -1 as any, vertexCount: 12}), 'invalid');
-    t.end();
+  it('getVertexCount', () => {
+    expect(getVertexCount({drawMode: GL.POINTS, vertexCount: 12}), 'point-list').toBe(12);
+    expect(getVertexCount({drawMode: GL.LINE_STRIP, vertexCount: 12}), 'line-strip').toBe(22);
+    expect(getVertexCount({drawMode: GL.TRIANGLE_STRIP, vertexCount: 12}), 'triangle-strip').toBe(
+      30
+    );
+    expect(getVertexCount({drawMode: GL.TRIANGLE_FAN, vertexCount: 12}), 'triangle-fan').toBe(30);
+    expect(() => getVertexCount({drawMode: -1 as any, vertexCount: 12})).toThrow();
   });
 
-  test('getGLDrawMode', t => {
-    t.equals(getGLDrawMode('point-list'), GL.POINTS, 'point-list');
-    t.equals(getGLDrawMode('line-list'), GL.LINES, 'line-list');
-    t.equals(getGLDrawMode('line-strip'), GL.LINE_STRIP, 'line-strip');
-    t.equals(getGLDrawMode('triangle-list'), GL.TRIANGLES, 'triangle-list');
-    t.equals(getGLDrawMode('triangle-strip'), GL.TRIANGLE_STRIP, 'triangle-strip');
-    t.throws(() => getGLDrawMode('quad-list' as any), 'invalid');
-    t.end();
+  it('getGLDrawMode', () => {
+    expect(getGLDrawMode('point-list'), 'point-list').toBe(GL.POINTS);
+    expect(getGLDrawMode('line-list'), 'line-list').toBe(GL.LINES);
+    expect(getGLDrawMode('line-strip'), 'line-strip').toBe(GL.LINE_STRIP);
+    expect(getGLDrawMode('triangle-list'), 'triangle-list').toBe(GL.TRIANGLES);
+    expect(getGLDrawMode('triangle-strip'), 'triangle-strip').toBe(GL.TRIANGLE_STRIP);
+    expect(() => getGLDrawMode('quad-list' as any)).toThrow();
   });
 
-  test('getGLPrimitive', t => {
-    t.equals(getGLPrimitive('point-list'), GL.POINTS, 'point-list');
-    t.equals(getGLPrimitive('line-list'), GL.LINES, 'line-list');
-    t.equals(getGLPrimitive('line-strip'), GL.LINES, 'line-strip');
-    t.equals(getGLPrimitive('triangle-list'), GL.TRIANGLES, 'triangle-list');
-    t.equals(getGLPrimitive('triangle-strip'), GL.TRIANGLES, 'triangle-strip');
-    t.throws(() => getGLPrimitive('quad-list' as any), 'invalid');
-    t.end();
+  it('getGLPrimitive', () => {
+    expect(getGLPrimitive('point-list'), 'point-list').toBe(GL.POINTS);
+    expect(getGLPrimitive('line-list'), 'line-list').toBe(GL.LINES);
+    expect(getGLPrimitive('line-strip'), 'line-strip').toBe(GL.LINES);
+    expect(getGLPrimitive('triangle-list'), 'triangle-list').toBe(GL.TRIANGLES);
+    expect(getGLPrimitive('triangle-strip'), 'triangle-strip').toBe(GL.TRIANGLES);
+    expect(() => getGLPrimitive('quad-list' as any)).toThrow();
   });
 }

--- a/modules/webgl/test/adapter/helpers/webgl-topology-utils.spec.ts
+++ b/modules/webgl/test/adapter/helpers/webgl-topology-utils.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerWebGLTopologyUtilsTests} from './webgl-topology-utils.spec.shared';
 
-registerWebGLTopologyUtilsTests(test);
+registerWebGLTopologyUtilsTests();

--- a/modules/webgl/test/adapter/webgl-adapter.spec.ts
+++ b/modules/webgl/test/adapter/webgl-adapter.spec.ts
@@ -2,15 +2,13 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('WebGLAdapter imports from the ESM package entry without circular init errors', async t => {
-  t.plan(2);
-
+it('WebGLAdapter imports from the ESM package entry without circular init errors', async () => {
   // Import the local entry file directly to avoid workspace alias resolution mixing src/dist modules.
   // This regression is about entry-module initialization, not package alias behavior.
   const webglModule = await import('../../src/index');
 
-  t.equal(webglModule.webgl2Adapter.type, 'webgl', 'exports a WebGL adapter instance');
-  t.equal(webglModule.WebGLDevice.name, 'WebGLDevice', 'exports the WebGL device class');
+  expect(webglModule.webgl2Adapter.type, 'exports a WebGL adapter instance').toBe('webgl');
+  expect(webglModule.WebGLDevice.name, 'exports the WebGL device class').toBe('WebGLDevice');
 });

--- a/modules/webgl/test/adapter/webgl-device.spec.ts
+++ b/modules/webgl/test/adapter/webgl-device.spec.ts
@@ -2,19 +2,18 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {webgl2Adapter} from '@luma.gl/webgl';
+import {expect, it} from 'vitest';
 
 // TODO - duplicates core spec?
-test('WebGLDevice#lost (Promise)', async t => {
+it('WebGLDevice#lost (Promise)', async () => {
   const device = await webgl2Adapter.create({createCanvasContext: true, debug: false});
 
   // Wrap in a promise to make sure tape waits for us
   await new Promise<void>(resolve => {
     setTimeout(() => {
       void device.lost.then(cause => {
-        t.equal(cause.reason, 'destroyed', `Context lost: ${cause.message}`);
-        t.end();
+        expect(cause.reason, `Context lost: ${cause.message}`).toBe('destroyed');
         resolve();
       });
     }, 0);
@@ -24,11 +23,10 @@ test('WebGLDevice#lost (Promise)', async t => {
   device.destroy();
 });
 
-test('WebGLDevice#destroy marks the device lost', async t => {
+it('WebGLDevice#destroy marks the device lost', async () => {
   const device = await webgl2Adapter.create({createCanvasContext: true, debug: false});
 
-  t.equal(device.isLost, false, 'device starts active');
+  expect(device.isLost, 'device starts active').toBe(false);
   device.destroy();
-  t.equal(device.isLost, true, 'destroy synchronously marks the device lost');
-  t.end();
+  expect(device.isLost, 'destroy synchronously marks the device lost').toBe(true);
 });

--- a/modules/webgl/test/context/debug-bundle.node.spec.ts
+++ b/modules/webgl/test/context/debug-bundle.node.spec.ts
@@ -4,9 +4,9 @@
 
 import {resolve} from 'node:path';
 import esbuild from 'esbuild';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('WebGL debug tools stay outside the normal adapter bundle', async t => {
+it('WebGL debug tools stay outside the normal adapter bundle', async () => {
   const sourceAliases = {
     name: 'webgl-source-alias',
     setup(build: esbuild.PluginBuild): void {
@@ -31,17 +31,16 @@ test('WebGL debug tools stay outside the normal adapter bundle', async t => {
   });
   const bundledInputs = Object.keys(buildResult.metafile.inputs);
 
-  t.notOk(
+  expect(
     bundledInputs.some(path => path.endsWith('/webgl-developer-tools.ts')),
     'adapter bundle excludes WebGLDeveloperTools'
-  );
-  t.notOk(
+  ).toBe(false);
+  expect(
     bundledInputs.some(path => path.endsWith('/spector.ts')),
     'adapter bundle excludes Spector integration'
-  );
-  t.ok(
+  ).toBe(false);
+  expect(
     bundledInputs.some(path => path.endsWith('/debug-hooks.ts')),
     'adapter bundle retains only lightweight registration hooks'
-  );
-  t.end();
+  ).toBe(true);
 });

--- a/modules/webgl/test/context/state-tracker/deep-array-equal.spec.ts
+++ b/modules/webgl/test/context/state-tracker/deep-array-equal.spec.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {deepArrayEqual} from '@luma.gl/webgl/context/state-tracker/deep-array-equal';
+import {expect, it} from 'vitest';
 
-test('WebGLState#deepArrayEqual', t => {
+it('WebGLState#deepArrayEqual', () => {
   const ARRAY = [0, 1, 2];
 
   const TEST_CASES = [
@@ -24,7 +24,6 @@ test('WebGLState#deepArrayEqual', t => {
   ];
 
   for (const tc of TEST_CASES) {
-    t.equals(deepArrayEqual(tc.x, tc.y), tc.result, tc.title);
+    expect(deepArrayEqual(tc.x, tc.y), tc.title).toBe(tc.result);
   }
-  t.end();
 });

--- a/modules/webgl/test/utils/fill-array.spec.ts
+++ b/modules/webgl/test/utils/fill-array.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {fillArray} from '@luma.gl/webgl/utils/fill-array';
 
 const FILL_ARRAY_TEST_CASES = [
@@ -13,15 +13,15 @@ const FILL_ARRAY_TEST_CASES = [
   }
 ];
 
-test('fillArray#import', t => {
-  t.ok(typeof fillArray === 'function', 'fillArray imported OK');
-  t.end();
+it('fillArray#import', () => {
+  expect(typeof fillArray, 'fillArray imported OK').toBe('function');
 });
 
-test('fillArray#tests', t => {
+it('fillArray#tests', () => {
   for (const tc of FILL_ARRAY_TEST_CASES) {
     const result = fillArray(tc.arguments);
-    t.deepEqual(result, tc.result, `fillArray ${tc.title} returned expected result`);
+    expect(result, `fillArray ${tc.title} returned expected result`).toEqual(
+      new Float32Array(tc.result)
+    );
   }
-  t.end();
 });

--- a/test/utils/parse-shader-compiler-log.spec.shared.ts
+++ b/test/utils/parse-shader-compiler-log.spec.shared.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
 import {parseShaderCompilerLog} from '@luma.gl/webgl/adapter/helpers/parse-shader-compiler-log';
+import {expect, it} from 'vitest';
 
 const ERROR_LOG = `\
 WARNING: 0:264: '/' : Zero divided by zero during constant folding generated NaN
@@ -151,29 +151,26 @@ const EXPECTED_MESSAGES = [
   }
 ];
 
-export function registerParseShaderCompilerLogTests(test: TapeTestFunction): void {
-  test('parseShaderCompilerLog', t => {
+export function registerParseShaderCompilerLogTests(): void {
+  it('parseShaderCompilerLog', () => {
     const messages = parseShaderCompilerLog(ERROR_LOG);
-    t.deepEqual(messages, EXPECTED_MESSAGES, 'parseShaderCompilerLog generated correct messages');
+    expect(messages, 'parseShaderCompilerLog generated correct messages').toEqual(
+      EXPECTED_MESSAGES
+    );
 
-    t.deepEqual(
+    expect(
       parseShaderCompilerLog('ERROR: unsupported shader version'),
-      [{message: 'unsupported shader version', type: 'error', lineNum: 0, linePos: 0}],
       'two-segment messages are parsed without line info'
-    );
+    ).toEqual([{message: 'unsupported shader version', type: 'error', lineNum: 0, linePos: 0}]);
 
-    t.deepEqual(
+    expect(
       parseShaderCompilerLog('INFO::invalid'),
-      [{message: ':invalid', type: 'info', lineNum: 0, linePos: 0}],
       'malformed segmented messages fall back to line 0'
-    );
+    ).toEqual([{message: ':invalid', type: 'info', lineNum: 0, linePos: 0}]);
 
-    t.deepEqual(
+    expect(
       parseShaderCompilerLog('\nWARNING: 2:NaN: malformed position'),
-      [{message: 'malformed position', type: 'warning', lineNum: 0, linePos: 2}],
       'blank lines are ignored and NaN line numbers are normalized'
-    );
-
-    t.end();
+    ).toEqual([{message: 'malformed position', type: 'warning', lineNum: 0, linePos: 2}]);
   });
 }


### PR DESCRIPTION
## Summary

This PR continues the monorepo-wide migration from the Tape compatibility layer to native Vitest syntax, stacked on the reviewed glTF migration in #3155.

### This batch
- Migrates `GroupNode` construction, hierarchy mutation, traversal, depth sorting, and bounds coverage to native `it`/`expect`.
- Migrates `ScenegraphNode` and `ModelNode` behavior, including matrix updates and transformed instance bounds.
- Migrates skin-joint palette updates and verifies storage reuse, inverse bind defaults, and animated updates.
- Migrates morph-target blending coverage, including normal renormalization and tangent handedness.
- Migrates animation clip timing/paused-clip behavior and load-file URL resolution.

### Verification
- `nvm use` (Node 22.22.1)
- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn test-node` — 402 files passed, 3,188 tests passed, 1 skipped
- `yarn test` — Node suite passed; headless suite retains four known baseline failures in splats and experimental rendering/math tests

This branch includes the previously reviewed migration history through #3155; the engine batch adds seven more converted suites while preserving the existing coverage assertions.