### PR TITLE
test: migrate GPGPU core suites to Vitest

### DIFF
--- a/modules/constants/test/webgl-constants.spec.ts
+++ b/modules/constants/test/webgl-constants.spec.ts
@@ -2,34 +2,29 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 
 import {GL} from '@luma.gl/constants';
 
-test('@luma.gl/constants', t => {
-  t.equal(typeof GL, 'object', '@luma.gl/constants is an object');
-  t.end();
+it('@luma.gl/constants', () => {
+  expect(typeof GL, '@luma.gl/constants is an object').toBe('object');
 });
 
-test('@luma.gl/constants#WebGL2RenderingContext comparison', async t => {
+it('@luma.gl/constants#WebGL2RenderingContext comparison', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   for (const device of [webglDevice]) {
     // @ts-ignore
     const gl = device.gl;
-    let count = 0;
     for (const key in gl) {
       const value = gl[key];
       if (Number.isFinite(value) && key.toUpperCase() === key && GL[key] !== undefined) {
         // Avoid generating too much test log
         if (GL[key] !== value) {
-          t.equals(GL[key], value, `GL.${key} is equal to gl.${key}`);
+          expect(GL[key], `GL.${key} is equal to gl.${key}`).toBe(value);
         }
-        count++;
       }
     }
-    t.comment(`Checked ${count} GL constants against platform WebGL2 context`);
   }
-  t.end();
 });

--- a/modules/core/test/adapter-utils/buffer-layout-utils.spec.ts
+++ b/modules/core/test/adapter-utils/buffer-layout-utils.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {
   type BufferLayout,
   type ShaderLayout,
@@ -21,7 +21,7 @@ const shaderLayout: ShaderLayout = {
   ]
 };
 
-test('resolveLogicalAttributeMappings resolves interleaved, shorthand, and default mappings', t => {
+it('resolveLogicalAttributeMappings resolves interleaved, shorthand, and default mappings', () => {
   const bufferLayout: BufferLayout[] = [
     {
       name: 'particles',
@@ -33,7 +33,7 @@ test('resolveLogicalAttributeMappings resolves interleaved, shorthand, and defau
     {name: 'vertexPositions', format: 'float32x3'}
   ];
 
-  t.deepEqual(resolveLogicalAttributeMappings(shaderLayout, bufferLayout), [
+  expect(resolveLogicalAttributeMappings(shaderLayout, bufferLayout)).toEqual([
     {
       attributeName: 'instancePositions',
       bufferName: 'particles',
@@ -71,29 +71,25 @@ test('resolveLogicalAttributeMappings resolves interleaved, shorthand, and defau
       stepMode: 'vertex'
     }
   ]);
-  t.end();
 });
 
-test('resolveLogicalAttributeMappings distinguishes zero from omitted stride', t => {
+it('resolveLogicalAttributeMappings distinguishes zero from omitted stride', () => {
   const mappings = resolveLogicalAttributeMappings(shaderLayout, [
     {name: 'vertexPositions', format: 'float32x3', byteStride: 0},
     {name: 'colors', format: 'float32x4'}
   ]);
 
-  t.equal(
+  expect(
     mappings.find(mapping => mapping.attributeName === 'vertexPositions')?.byteStride,
-    0,
     'preserves an explicit zero stride'
-  );
-  t.equal(
+  ).toBe(0);
+  expect(
     mappings.find(mapping => mapping.attributeName === 'colors')?.byteStride,
-    16,
     'resolves an omitted stride to the packed format size'
-  );
-  t.end();
+  ).toBe(16);
 });
 
-test('getLogicalBufferSlots keeps logical layout order and appends unmapped shader attributes', t => {
+it('getLogicalBufferSlots keeps logical layout order and appends unmapped shader attributes', () => {
   const bufferLayout: BufferLayout[] = [
     {name: 'vertexPositions', format: 'float32x3'},
     {
@@ -102,16 +98,15 @@ test('getLogicalBufferSlots keeps logical layout order and appends unmapped shad
     }
   ];
 
-  t.deepEqual(getLogicalBufferSlots(shaderLayout, bufferLayout), {
+  expect(getLogicalBufferSlots(shaderLayout, bufferLayout)).toEqual({
     vertexPositions: 0,
     particles: 1,
     instanceVelocities: 2,
     colors: 3
   });
-  t.end();
 });
 
-test('getBufferLayoutMinAttributeLocation returns the first referenced shader location', t => {
+it('getBufferLayoutMinAttributeLocation returns the first referenced shader location', () => {
   const bufferLayout: BufferLayout = {
     name: 'particles',
     attributes: [
@@ -120,10 +115,8 @@ test('getBufferLayoutMinAttributeLocation returns the first referenced shader lo
     ]
   };
 
-  t.equal(
+  expect(
     getBufferLayoutMinAttributeLocation(bufferLayout, shaderLayout),
-    0,
     'minimum shader location is derived from the referenced attributes'
-  );
-  t.end();
+  ).toBe(0);
 });

--- a/modules/core/test/adapter-utils/format-compiler-log.node.spec.ts
+++ b/modules/core/test/adapter-utils/format-compiler-log.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerFormatCompilerLogTests} from './format-compiler-log.spec.shared';
 
-registerFormatCompilerLogTests(test);
+registerFormatCompilerLogTests();

--- a/modules/core/test/adapter-utils/format-compiler-log.spec.shared.ts
+++ b/modules/core/test/adapter-utils/format-compiler-log.spec.shared.ts
@@ -4,7 +4,7 @@
 
 import type {CompilerMessage} from '@luma.gl/core';
 import {formatCompilerLog} from '@luma.gl/core/adapter-utils/format-compiler-log';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 const ERROR_LOG: CompilerMessage[] = [
   {
@@ -146,52 +146,58 @@ void main() {
 }
 `;
 
-export function registerFormatCompilerLogTests(test: TapeTestFunction): void {
-  test('formatCompilerLog', t => {
+export function registerFormatCompilerLogTests(): void {
+  it('formatCompilerLog', () => {
     const formatted = formatCompilerLog(ERROR_LOG, SHADER_SOURCE);
-    t.ok(
+    expect(
       formatted.includes("ERROR: 'project_scale' : no matching overloaded function found"),
       'default formatting includes error messages'
-    );
-    t.ok(!formatted.includes(' 264:'), 'default formatting omits source lines');
+    ).toBe(true);
+    expect(!formatted.includes(' 264:'), 'default formatting omits source lines').toBe(true);
 
     const withIssues = formatCompilerLog(
       [{type: 'error', linePos: 2, lineNum: 10, message: 'broken shader'}],
       SHADER_SOURCE,
       {showSourceCode: 'issues'}
     );
-    t.ok(withIssues.includes('  10:'), 'issues view includes numbered source lines');
-    t.ok(withIssues.includes('^^^'), 'issues view includes a position indicator');
+    expect(withIssues.includes('  10:'), 'issues view includes numbered source lines').toBe(true);
+    expect(withIssues.includes('^^^'), 'issues view includes a position indicator').toBe(true);
 
     const withAllSource = formatCompilerLog(
       [{type: 'warning', linePos: 0, lineNum: 4, message: 'watch this'}],
       SHADER_SOURCE,
       {showSourceCode: 'all'}
     );
-    t.ok(withAllSource.includes('#define AMD_GPU'), 'all view includes the full source body');
-    t.ok(withAllSource.includes('WARNING: watch this'), 'all view includes inline warnings');
+    expect(
+      withAllSource.includes('#define AMD_GPU'),
+      'all view includes the full source body'
+    ).toBe(true);
+    expect(withAllSource.includes('WARNING: watch this'), 'all view includes inline warnings').toBe(
+      true
+    );
 
     const htmlFormatted = formatCompilerLog(
       [{type: 'error', linePos: 1, lineNum: 6, message: 'html error'}],
       SHADER_SOURCE,
       {showSourceCode: 'all', html: true}
     );
-    t.ok(
+    expect(
       htmlFormatted.includes('luma-compiler-log-error'),
       'html formatting renders wrapped messages'
-    );
-    t.ok(htmlFormatted.includes('style="color:red;"'), 'html formatting applies the error color');
+    ).toBe(true);
+    expect(
+      htmlFormatted.includes('style="color:red;"'),
+      'html formatting applies the error color'
+    ).toBe(true);
 
     const trailingMessage = formatCompilerLog(
       [{type: 'error', linePos: 0, lineNum: 999, message: 'late error'}],
       'void main() {}',
       {showSourceCode: 'all'}
     );
-    t.ok(
+    expect(
       trailingMessage.includes('ERROR: late error'),
       'messages after the source are still reported'
-    );
-
-    t.end();
+    ).toBe(true);
   });
 }

--- a/modules/core/test/adapter-utils/format-compiler-log.spec.ts
+++ b/modules/core/test/adapter-utils/format-compiler-log.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerFormatCompilerLogTests} from './format-compiler-log.spec.shared';
 
-registerFormatCompilerLogTests(test);
+registerFormatCompilerLogTests();

--- a/modules/core/test/adapter-utils/get-attribute-from-layout.spec.ts
+++ b/modules/core/test/adapter-utils/get-attribute-from-layout.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {
   ShaderLayout,
   getAttributeInfosFromLayouts,
@@ -190,15 +190,12 @@ const resolvedLayout: Record<string, AttributeInfo> = {
   }
 };
 
-test('getAttributeInfosFromLayouts', t => {
+it('getAttributeInfosFromLayouts', () => {
   const result = getAttributeInfosFromLayouts(shaderLayout, bufferLayout);
   for (const key of Object.keys(resolvedLayout)) {
-    t.deepEqual(
-      result[key],
-      resolvedLayout[key],
-      `Interleaved attribute info for ${key} are correct`
+    expect(result[key], `Interleaved attribute info for ${key} are correct`).toEqual(
+      resolvedLayout[key]
     );
     // t.comment(JSON.stringify(result[key], null, 2));
   }
-  t.end();
 });

--- a/modules/core/test/adapter-utils/is-uniform-value.spec.ts
+++ b/modules/core/test/adapter-utils/is-uniform-value.spec.ts
@@ -4,23 +4,26 @@
 
 import {isUniformValue} from '@luma.gl/core/adapter-utils/is-uniform-value';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('isUniformValue', async t => {
+it('isUniformValue', async () => {
   const device = await getWebGLTestDevice();
 
-  t.ok(isUniformValue(3), 'Number is uniform value');
-  t.ok(isUniformValue(3.412), 'Number is uniform value');
-  t.ok(isUniformValue(0), 'Number is uniform value');
-  t.ok(isUniformValue(false), 'Boolean is uniform value');
-  t.ok(isUniformValue(true), 'Boolean is uniform value');
-  t.ok(isUniformValue([1, 2, 3, 4]), 'Number array is uniform value');
-  t.ok(isUniformValue(new Float32Array([1, 2, 3, 4])), 'Number array is uniform value');
+  expect(isUniformValue(3), 'Number is uniform value').toBe(true);
+  expect(isUniformValue(3.412), 'Number is uniform value').toBe(true);
+  expect(isUniformValue(0), 'Number is uniform value').toBe(true);
+  expect(isUniformValue(false), 'Boolean is uniform value').toBe(true);
+  expect(isUniformValue(true), 'Boolean is uniform value').toBe(true);
+  expect(isUniformValue([1, 2, 3, 4]), 'Number array is uniform value').toBe(true);
+  expect(isUniformValue(new Float32Array([1, 2, 3, 4])), 'Number array is uniform value').toBe(
+    true
+  );
 
-  t.notOk(
+  expect(
     isUniformValue(device.createTexture({width: 1, height: 1})),
     'WEBGLTexture is not a uniform value'
+  ).toBe(false);
+  expect(isUniformValue(device.createSampler({})), 'WEBGLSampler is not a uniform value').toBe(
+    false
   );
-  t.notOk(isUniformValue(device.createSampler({})), 'WEBGLSampler is not a uniform value');
-  t.end();
 });

--- a/modules/core/test/adapter/helpers/parse-shader-compiler-log.spec.ts
+++ b/modules/core/test/adapter/helpers/parse-shader-compiler-log.spec.ts
@@ -4,7 +4,6 @@
 
 /* eslint-disable quotes */
 
-import test from 'test/utils/vitest-tape';
 import {registerParseShaderCompilerLogTests} from 'test/utils/parse-shader-compiler-log.spec.shared';
 
-registerParseShaderCompilerLogTests(test);
+registerParseShaderCompilerLogTests();

--- a/modules/engine/test/animation/animator.spec.ts
+++ b/modules/engine/test/animation/animator.spec.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {AnimationClipController, Animator} from '@luma.gl/engine';
+import {expect, it} from 'vitest';
 
 class TestClip extends AnimationClipController {
   localTimes: number[] = [];
@@ -13,27 +13,23 @@ class TestClip extends AnimationClipController {
   }
 }
 
-test('Animation#Animator clip controllers resolve local clip time from wall-clock ms', t => {
+it('Animation#Animator clip controllers resolve local clip time from wall-clock ms', () => {
   const clip = new TestClip({name: 'test-clip', startTime: 0.5, speed: 2});
 
   clip.setTime(1250);
 
-  t.deepEqual(clip.localTimes, [1.5], 'clip converts milliseconds to local seconds');
-  t.equal(clip.name, 'test-clip', 'clip exposes configured name');
-
-  t.end();
+  expect(clip.localTimes, 'clip converts milliseconds to local seconds').toEqual([1.5]);
+  expect(clip.name, 'clip exposes configured name').toBe('test-clip');
 });
 
-test('Animation#Animator skips paused clips and exposes compatibility aliases', t => {
+it('Animation#Animator skips paused clips and exposes compatibility aliases', () => {
   const activeClip = new TestClip({name: 'active'});
   const pausedClip = new TestClip({name: 'paused', playing: false});
   const animator = new Animator([activeClip, pausedClip]);
 
   animator.setTime(500);
 
-  t.deepEqual(activeClip.localTimes, [0.5], 'active clip advances');
-  t.deepEqual(pausedClip.localTimes, [], 'paused clip does not advance');
-  t.equal(animator.animations, animator.getAnimations(), 'animations alias matches clip list');
-
-  t.end();
+  expect(activeClip.localTimes, 'active clip advances').toEqual([0.5]);
+  expect(pausedClip.localTimes, 'paused clip does not advance').toEqual([]);
+  expect(animator.animations, 'animations alias matches clip list').toBe(animator.getAnimations());
 });

--- a/modules/engine/test/animation/morph-targets.spec.ts
+++ b/modules/engine/test/animation/morph-targets.spec.ts
@@ -3,9 +3,9 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {applyMorphTargets} from '@luma.gl/engine';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('Animation#applyMorphTargets preserves immutable bases and combines all target weights', t => {
+it('Animation#applyMorphTargets preserves immutable bases and combines all target weights', () => {
   const positions = new Float32Array([1, 2, 3, 4, 5, 6]);
   const normals = new Float32Array([0, 0, 1, 0, 1, 0]);
   const tangents = new Float32Array([1, 0, 0, -1, 0, 1, 0, 1]);
@@ -22,28 +22,24 @@ test('Animation#applyMorphTargets preserves immutable bases and combines all tar
     [0.5, 0.25]
   );
 
-  t.deepEqual(Array.from(positions), [1, 2, 3, 4, 5, 6], 'leaves source positions untouched');
-  t.deepEqual(
-    Array.from(morphed.POSITION || []),
-    [2, 3, 3, 4, 6, 7],
-    'combines weighted positions'
-  );
-  t.ok(
+  expect(Array.from(positions), 'leaves source positions untouched').toEqual([1, 2, 3, 4, 5, 6]);
+  expect(Array.from(morphed.POSITION || []), 'combines weighted positions').toEqual([
+    2, 3, 3, 4, 6, 7
+  ]);
+  expect(
     Math.abs(Math.hypot(...Array.from(morphed.NORMAL?.slice(0, 3) || [])) - 1) < 1e-6,
     'renormalizes morphed normals'
-  );
-  t.equal(morphed.TANGENT?.[3], -1, 'preserves tangent handedness');
-  t.equal(morphed.TANGENT?.[7], 1, 'preserves every tangent handedness component');
-  t.end();
+  ).toBe(true);
+  expect(morphed.TANGENT?.[3], 'preserves tangent handedness').toBe(-1);
+  expect(morphed.TANGENT?.[7], 'preserves every tangent handedness component').toBe(1);
 });
 
-test('Animation#applyMorphTargets handles more than four independent target weights', t => {
+it('Animation#applyMorphTargets handles more than four independent target weights', () => {
   const targets = Array.from({length: 8}, (_, index) => ({
     POSITION: new Float32Array([index + 1, 0, 0])
   }));
   const weights = Array.from({length: 8}, () => 0.25);
   const morphed = applyMorphTargets({POSITION: new Float32Array([0, 0, 0])}, targets, weights);
 
-  t.equal(morphed.POSITION?.[0], 9, 'applies the complete MorphStressTest-sized target set');
-  t.end();
+  expect(morphed.POSITION?.[0], 'applies the complete MorphStressTest-sized target set').toBe(9);
 });

--- a/modules/engine/test/animation/skin.node.spec.ts
+++ b/modules/engine/test/animation/skin.node.spec.ts
@@ -4,9 +4,9 @@
 
 import {GroupNode, updateSkinJointMatrices} from '@luma.gl/engine';
 import {Matrix4} from '@math.gl/core';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('Animation#updateSkinJointMatrices evaluates shared joints in mesh-local space', testContext => {
+it('Animation#updateSkinJointMatrices evaluates shared joints in mesh-local space', () => {
   const meshNode = new GroupNode({id: 'mesh'});
   const firstJoint = new GroupNode({id: 'first-joint'});
   const secondJoint = new GroupNode({id: 'second-joint'});
@@ -29,9 +29,9 @@ test('Animation#updateSkinJointMatrices evaluates shared joints in mesh-local sp
     target
   });
 
-  testContext.equal(jointMatrices, target, 'reuses adapter-owned output storage');
-  testContext.equal(jointMatrices[12], 1, 'evaluates the first joint relative to the skinned mesh');
-  testContext.equal(jointMatrices[16 + 13], 2, 'applies authored inverse bind transforms');
+  expect(jointMatrices, 'reuses adapter-owned output storage').toBe(target);
+  expect(jointMatrices[12], 'evaluates the first joint relative to the skinned mesh').toBe(1);
+  expect(jointMatrices[16 + 13], 'applies authored inverse bind transforms').toBe(2);
 
   worldMatrices.set(secondJoint, new Matrix4().translate([10, 7, 0]));
   updateSkinJointMatrices({
@@ -42,18 +42,16 @@ test('Animation#updateSkinJointMatrices evaluates shared joints in mesh-local sp
     target
   });
 
-  testContext.equal(jointMatrices[16 + 13], 5, 'updates animated joints without reallocating');
-  testContext.end();
+  expect(jointMatrices[16 + 13], 'updates animated joints without reallocating').toBe(5);
 });
 
-test('Animation#updateSkinJointMatrices defaults missing inverse bind matrices', testContext => {
+it('Animation#updateSkinJointMatrices defaults missing inverse bind matrices', () => {
   const joint = new GroupNode({id: 'joint', position: [0, 3, 0]});
   const matrices = updateSkinJointMatrices({
     joints: [joint],
     worldMatrices: new Map([[joint, new Matrix4().translate([0, 3, 0])]])
   });
 
-  testContext.equal(matrices.length, 16, 'allocates only the authored joint palette');
-  testContext.equal(matrices[13], 3, 'uses an identity inverse bind transform by default');
-  testContext.end();
+  expect(matrices.length, 'allocates only the authored joint palette').toBe(16);
+  expect(matrices[13], 'uses an identity inverse bind transform by default').toBe(3);
 });

--- a/modules/engine/test/application-utils/load-file.spec.ts
+++ b/modules/engine/test/application-utils/load-file.spec.ts
@@ -2,45 +2,42 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {_resolveLoadFileUrl, setPathPrefix} from '@luma.gl/engine';
+import {expect, it} from 'vitest';
 
-test('load-file resolves only bare relative asset URLs against the configured prefix', t => {
+it('load-file resolves only bare relative asset URLs against the configured prefix', () => {
   setPathPrefix(
     'https://raw.githubusercontent.com/visgl/luma.gl/master/examples/showcase/water-globe/'
   );
 
-  t.equal(
+  expect(
     _resolveLoadFileUrl('earth.jpg'),
-    'https://raw.githubusercontent.com/visgl/luma.gl/master/examples/showcase/water-globe/earth.jpg',
     'bare relative asset paths use the configured prefix'
+  ).toBe(
+    'https://raw.githubusercontent.com/visgl/luma.gl/master/examples/showcase/water-globe/earth.jpg'
   );
-  t.equal(
+  expect(
     _resolveLoadFileUrl('./assets/images/earth.jpg'),
-    'https://raw.githubusercontent.com/visgl/luma.gl/master/examples/showcase/water-globe/./assets/images/earth.jpg',
     'dot-relative asset paths use the configured prefix'
+  ).toBe(
+    'https://raw.githubusercontent.com/visgl/luma.gl/master/examples/showcase/water-globe/./assets/images/earth.jpg'
   );
-  t.equal(
+  expect(
     _resolveLoadFileUrl('/assets/images/earth.jpg'),
-    '/assets/images/earth.jpg',
     'root-relative asset paths do not use the configured prefix'
-  );
-  t.equal(
+  ).toBe('/assets/images/earth.jpg');
+  expect(
     _resolveLoadFileUrl('https://example.com/earth.jpg'),
-    'https://example.com/earth.jpg',
     'absolute http urls do not use the configured prefix'
-  );
-  t.equal(
+  ).toBe('https://example.com/earth.jpg');
+  expect(
     _resolveLoadFileUrl('blob:https://example.com/earth'),
-    'blob:https://example.com/earth',
     'blob urls do not use the configured prefix'
-  );
-  t.equal(
+  ).toBe('blob:https://example.com/earth');
+  expect(
     _resolveLoadFileUrl('data:image/png;base64,abc'),
-    'data:image/png;base64,abc',
     'data urls do not use the configured prefix'
-  );
+  ).toBe('data:image/png;base64,abc');
 
   setPathPrefix('');
-  t.end();
 });

--- a/modules/engine/test/compute/buffer-transform.spec.ts
+++ b/modules/engine/test/compute/buffer-transform.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 import {BufferTransform} from '@luma.gl/engine';
 import {Buffer, Device} from '@luma.gl/core';
@@ -21,14 +21,13 @@ out vec4 fragColor;
 void main() { fragColor.x = dst; }
 `;
 
-test('BufferTransform#constructor', async t => {
+it('BufferTransform#constructor', async () => {
   const webglDevice = await getWebGLTestDevice();
 
-  t.ok(createBufferTransform(webglDevice), 'WebGL succeeds');
-  t.end();
+  expect(createBufferTransform(webglDevice), 'WebGL succeeds').toBeTruthy();
 });
 
-test('BufferTransform#run', async t => {
+it('BufferTransform#run', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   const SRC_ARRAY = new Float32Array([0, 1, 2, 3, 4, 5]);
@@ -43,9 +42,7 @@ test('BufferTransform#run', async t => {
 
   const bytes = await transform.readAsync('dst');
   const array = new Float32Array(bytes.buffer, bytes.byteOffset, elementCount);
-  t.deepEqual(array, DST_ARRAY, 'output transformed');
-
-  t.end();
+  expect(array, 'output transformed').toEqual(DST_ARRAY);
 });
 
 function createBufferTransform(

--- a/modules/engine/test/compute/swap.spec.ts
+++ b/modules/engine/test/compute/swap.spec.ts
@@ -1,126 +1,117 @@
-import test from 'test/utils/vitest-tape';
+import {describe, expect, it} from 'vitest';
 import {Swap, SwapFramebuffers} from '../../src/compute/swap';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 
 // TODO - these tests could run on NullDevice
 
-test('Swap#constructor', async t => {
-  const webglDevice = await getWebGLTestDevice();
+describe('Swap', () => {
+  it('constructor', async () => {
+    const webglDevice = await getWebGLTestDevice();
 
-  const current = webglDevice.createBuffer({byteLength: 1});
-  const next = webglDevice.createBuffer({byteLength: 1});
-  const swap = new Swap({current, next});
+    const current = webglDevice.createBuffer({byteLength: 1});
+    const next = webglDevice.createBuffer({byteLength: 1});
+    const swap = new Swap({current, next});
 
-  t.equal(swap.current, current, 'should set the current resource correctly');
-  t.equal(swap.next, next, 'should set the next resource correctly');
-
-  t.end();
-});
-
-test('Swap#destroy', async t => {
-  const webglDevice = await getWebGLTestDevice();
-
-  const current = webglDevice.createBuffer({byteLength: 1});
-  const next = webglDevice.createBuffer({byteLength: 1});
-  const swap = new Swap({current, next});
-
-  t.equal(swap.current.destroyed, false, 'should not yet have destroyed the current resource');
-  t.equal(swap.next.destroyed, false, 'should not yet have destroyed the next resource');
-
-  swap.destroy();
-
-  t.equal(swap.current.destroyed, true, 'should destroy the current resource');
-  t.equal(swap.next.destroyed, true, 'should destroy the next resource');
-
-  t.end();
-});
-
-test('Swap#swap', async t => {
-  const webglDevice = await getWebGLTestDevice();
-
-  const current = webglDevice.createBuffer({byteLength: 1});
-  const next = webglDevice.createBuffer({byteLength: 1});
-  const swap = new Swap({current, next});
-
-  swap.swap();
-
-  t.equal(swap.current, next, 'should make the next resource the current resource');
-  t.equal(swap.next, current, 'should reuse the current resource as the next resource');
-
-  t.end();
-});
-
-test('SwapFramebuffers#resize', async t => {
-  const webglDevice = await getWebGLTestDevice();
-
-  const swap = new SwapFramebuffers(webglDevice, {
-    colorAttachments: ['rgba8unorm'],
-    width: 4,
-    height: 4
+    expect(swap.current, 'should set the current resource correctly').toBe(current);
+    expect(swap.next, 'should set the next resource correctly').toBe(next);
   });
 
-  const currentTexture = swap.current.colorAttachments[0].texture;
-  const nextTexture = swap.next.colorAttachments[0].texture;
+  it('destroy', async () => {
+    const webglDevice = await getWebGLTestDevice();
 
-  let resized = swap.resize({width: 4, height: 4});
-  t.equal(resized, false, 'resize with same size returns false');
-  t.equal(
-    swap.current.colorAttachments[0].texture,
-    currentTexture,
-    'current framebuffer texture unchanged'
-  );
-  t.equal(swap.next.colorAttachments[0].texture, nextTexture, 'next framebuffer texture unchanged');
+    const current = webglDevice.createBuffer({byteLength: 1});
+    const next = webglDevice.createBuffer({byteLength: 1});
+    const swap = new Swap({current, next});
 
-  resized = swap.resize({width: 8, height: 8});
-  t.equal(resized, true, 'resize with new size returns true');
-  t.equal(currentTexture.destroyed, true, 'resize destroys the previous current texture');
-  t.equal(nextTexture.destroyed, true, 'resize destroys the previous next texture');
-  t.equal(swap.current.width, 8, 'current framebuffer width updated');
-  t.equal(swap.current.height, 8, 'current framebuffer height updated');
-  t.notEqual(
-    swap.current.colorAttachments[0].texture,
-    currentTexture,
-    'current framebuffer texture replaced after resize'
-  );
+    expect(swap.current.destroyed, 'should not yet have destroyed the current resource').toBe(
+      false
+    );
+    expect(swap.next.destroyed, 'should not yet have destroyed the next resource').toBe(false);
 
-  const newCurrent = swap.current.colorAttachments[0].texture;
-  const newNext = swap.next.colorAttachments[0].texture;
-  resized = swap.resize({width: 8, height: 8});
-  t.equal(resized, false, 'resize with same size again returns false');
-  t.equal(
-    swap.current.colorAttachments[0].texture,
-    newCurrent,
-    'current framebuffer texture unchanged after no-op'
-  );
-  t.equal(
-    swap.next.colorAttachments[0].texture,
-    newNext,
-    'next framebuffer texture unchanged after no-op'
-  );
+    swap.destroy();
 
-  swap.destroy();
-  t.equal(newCurrent.destroyed, true, 'destroy releases the current framebuffer texture');
-  t.equal(newNext.destroyed, true, 'destroy releases the next framebuffer texture');
-
-  t.end();
-});
-
-test('SwapFramebuffers preserves borrowed attachment ownership', async t => {
-  const webglDevice = await getWebGLTestDevice();
-  const borrowedTexture = webglDevice.createTexture({
-    format: 'rgba8unorm',
-    width: 4,
-    height: 4
-  });
-  const swap = new SwapFramebuffers(webglDevice, {
-    colorAttachments: [borrowedTexture],
-    width: 4,
-    height: 4
+    expect(swap.current.destroyed, 'should destroy the current resource').toBe(true);
+    expect(swap.next.destroyed, 'should destroy the next resource').toBe(true);
   });
 
-  swap.destroy();
-  t.equal(borrowedTexture.destroyed, false, 'destroy does not release a borrowed texture');
-  borrowedTexture.destroy();
+  it('swap', async () => {
+    const webglDevice = await getWebGLTestDevice();
 
-  t.end();
+    const current = webglDevice.createBuffer({byteLength: 1});
+    const next = webglDevice.createBuffer({byteLength: 1});
+    const swap = new Swap({current, next});
+
+    swap.swap();
+
+    expect(swap.current, 'should make the next resource the current resource').toBe(next);
+    expect(swap.next, 'should reuse the current resource as the next resource').toBe(current);
+  });
+
+  it('SwapFramebuffers#resize', async () => {
+    const webglDevice = await getWebGLTestDevice();
+
+    const swap = new SwapFramebuffers(webglDevice, {
+      colorAttachments: ['rgba8unorm'],
+      width: 4,
+      height: 4
+    });
+
+    const currentTexture = swap.current.colorAttachments[0].texture;
+    const nextTexture = swap.next.colorAttachments[0].texture;
+
+    let resized = swap.resize({width: 4, height: 4});
+    expect(resized, 'resize with same size returns false').toBe(false);
+    expect(swap.current.colorAttachments[0].texture, 'current framebuffer texture unchanged').toBe(
+      currentTexture
+    );
+    expect(swap.next.colorAttachments[0].texture, 'next framebuffer texture unchanged').toBe(
+      nextTexture
+    );
+
+    resized = swap.resize({width: 8, height: 8});
+    expect(resized, 'resize with new size returns true').toBe(true);
+    expect(currentTexture.destroyed, 'resize destroys the previous current texture').toBe(true);
+    expect(nextTexture.destroyed, 'resize destroys the previous next texture').toBe(true);
+    expect(swap.current.width, 'current framebuffer width updated').toBe(8);
+    expect(swap.current.height, 'current framebuffer height updated').toBe(8);
+    expect(
+      swap.current.colorAttachments[0].texture,
+      'current framebuffer texture replaced after resize'
+    ).not.toBe(currentTexture);
+
+    const newCurrent = swap.current.colorAttachments[0].texture;
+    const newNext = swap.next.colorAttachments[0].texture;
+    resized = swap.resize({width: 8, height: 8});
+    expect(resized, 'resize with same size again returns false').toBe(false);
+    expect(
+      swap.current.colorAttachments[0].texture,
+      'current framebuffer texture unchanged after no-op'
+    ).toBe(newCurrent);
+    expect(
+      swap.next.colorAttachments[0].texture,
+      'next framebuffer texture unchanged after no-op'
+    ).toBe(newNext);
+
+    swap.destroy();
+    expect(newCurrent.destroyed, 'destroy releases the current framebuffer texture').toBe(true);
+    expect(newNext.destroyed, 'destroy releases the next framebuffer texture').toBe(true);
+  });
+
+  it('SwapFramebuffers preserves borrowed attachment ownership', async () => {
+    const webglDevice = await getWebGLTestDevice();
+    const borrowedTexture = webglDevice.createTexture({
+      format: 'rgba8unorm',
+      width: 4,
+      height: 4
+    });
+    const swap = new SwapFramebuffers(webglDevice, {
+      colorAttachments: [borrowedTexture],
+      width: 4,
+      height: 4
+    });
+
+    swap.destroy();
+    expect(borrowedTexture.destroyed, 'destroy does not release a borrowed texture').toBe(false);
+    borrowedTexture.destroy();
+  });
 });

--- a/modules/engine/test/compute/texture-transform.spec.ts
+++ b/modules/engine/test/compute/texture-transform.spec.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 import {TextureTransform} from '@luma.gl/engine';
 import {Device, Texture} from '@luma.gl/core';
 
 /** Creates a minimal, no-op transform. */
-test('TextureTransform#constructor', async t => {
+it('TextureTransform#constructor', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   const targetTexture = webglDevice.createTexture({
@@ -25,13 +25,11 @@ test('TextureTransform#constructor', async t => {
     targetTextureVarying: 'vSrc',
     vertexCount: 1
   });
-  t.ok(transform, 'creates transform');
-
-  t.end();
+  expect(transform, 'creates transform').toBeTruthy();
 });
 
 /** Computes a sum over vertex attribute values by writing to framebuffer. */
-test('TextureTransform#attribute', async t => {
+it('TextureTransform#attribute', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   const src = webglDevice.createBuffer({data: new Float32Array([10, 20, 30, 70, 80, 90])});
@@ -65,15 +63,13 @@ test('TextureTransform#attribute', async t => {
   transform.run({clearColor: [0, 0, 0, 0]});
 
   const sum = await readF32(webglDevice, source, 16);
-  t.is(sum[0], 300, 'computes sum');
+  expect(sum[0], 'computes sum').toBe(300);
 
   transform.destroy();
-
-  t.end();
 });
 
 /** Computes a sum over texture pixels by writing to framebuffer. */
-test('TextureTransform#texture', async t => {
+it('TextureTransform#texture', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   const srcData = new Uint8Array([2, 10, 255, 255]);
@@ -114,18 +110,16 @@ test('TextureTransform#texture', async t => {
   // least mimic its API by accepting a RenderPass in .run().
   transform.run({clearColor: [0, 0, 0, 0]});
   let blend = await readU8(webglDevice, targetTexture, 4);
-  t.deepEqual(Array.from(blend), Array.from(dstData), 'computes blend');
+  expect(Array.from(blend), 'computes blend').toEqual(Array.from(dstData));
 
   const offset = 100 / 255;
   transform.run({clearColor: [offset, offset, offset, 1]});
   blend = await readU8(webglDevice, targetTexture, 4);
-  t.deepEqual(Array.from(blend), Array.from(dstOffsetData), 'computes blend');
+  expect(Array.from(blend), 'computes blend').toEqual(Array.from(dstOffsetData));
 
   transform.destroy();
   inputTexture.destroy();
   targetTexture.destroy();
-
-  t.end();
 });
 
 async function readF32(

--- a/modules/engine/test/geometry/geometries.node.spec.ts
+++ b/modules/engine/test/geometry/geometries.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerGeometriesTests} from './geometries.spec.shared';
 
-registerGeometriesTests(test);
+registerGeometriesTests();

--- a/modules/engine/test/geometry/geometries.spec.shared.ts
+++ b/modules/engine/test/geometry/geometries.spec.shared.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {TypedArrayConstructor} from '@math.gl/types';
+import {expect, it} from 'vitest';
 import {
   ConeGeometry,
   CubeGeometry,
@@ -12,7 +13,6 @@ import {
   SphereGeometry,
   TruncatedConeGeometry
 } from '@luma.gl/engine';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
 
 const GEOMETRY_TESTS = [
   {name: 'ConeGeometry', Geometry: ConeGeometry, props: [{height: 2}, {verticalAxis: 'z'}]},
@@ -53,38 +53,39 @@ function checkAttribute(attribute, type: TypedArrayConstructor[] = [Float32Array
   );
 }
 
-export function registerGeometriesTests(test: TapeTestFunction): void {
-  test('Object#Geometries', t => {
+export function registerGeometriesTests(): void {
+  it('Object#Geometries', () => {
     for (const geometryTest of GEOMETRY_TESTS) {
       const {name, Geometry} = geometryTest;
       const testProps = [undefined].concat(geometryTest.props || []);
 
       for (const props of testProps) {
         if (props?._shouldThrow) {
-          t.throws(() => new Geometry(props), `${name}: should throw`);
+          expect(() => new Geometry(props), `${name}: should throw`).toThrow();
           continue; // eslint-disable-line no-continue
         }
 
         const geometry = new Geometry(props);
 
-        t.is(typeof geometry.topology, 'string', `${name}: .topology is a string`);
-        t.is(typeof geometry.vertexCount, 'number', `${name}: .vertexCount is a number`);
-        t.ok(geometry.vertexCount > 0, `${name}: .vertexCount is positive`);
+        expect(typeof geometry.topology, `${name}: .topology is a string`).toBe('string');
+        expect(typeof geometry.vertexCount, `${name}: .vertexCount is a number`).toBe('number');
+        expect(geometry.vertexCount > 0, `${name}: .vertexCount is positive`).toBe(true);
 
         const attributes = geometry.attributes;
 
-        t.ok(checkAttribute(attributes.POSITION), `${name}: POSITION is Float32Array`);
-        t.ok(checkAttribute(attributes.NORMAL), `${name}: NORMAL is Float32Array`);
-        t.ok(checkAttribute(attributes.TEXCOORD_0), `${name}: TEXCOORD_0 is Float32Array`);
-        t.ok(geometry.bufferLayout.length > 0, `${name}: bufferLayout is populated`);
+        expect(checkAttribute(attributes.POSITION), `${name}: POSITION is Float32Array`).toBe(true);
+        expect(checkAttribute(attributes.NORMAL), `${name}: NORMAL is Float32Array`).toBe(true);
+        expect(checkAttribute(attributes.TEXCOORD_0), `${name}: TEXCOORD_0 is Float32Array`).toBe(
+          true
+        );
+        expect(geometry.bufferLayout.length > 0, `${name}: bufferLayout is populated`).toBe(true);
         if (geometry.indices) {
-          t.ok(
+          expect(
             checkAttribute(geometry.indices, [Uint16Array, Uint32Array]),
             `${name}: indices is Uint{16/32}Array`
-          );
+          ).toBe(true);
         }
       }
     }
-    t.end();
   });
 }

--- a/modules/engine/test/geometry/geometries.spec.ts
+++ b/modules/engine/test/geometry/geometries.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerGeometriesTests} from './geometries.spec.shared';
 
-registerGeometriesTests(test);
+registerGeometriesTests();

--- a/modules/engine/test/geometry/geometry-utils.spec.ts
+++ b/modules/engine/test/geometry/geometry-utils.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {Geometry} from '@luma.gl/engine';
 import {
   makeInterleavedGeometry,
@@ -49,22 +49,18 @@ const TEST_CASES = [
   }
 ];
 
-test('unpackIndexedGeometry', t => {
+it('unpackIndexedGeometry', () => {
   for (const testCase of TEST_CASES) {
     const {attributes} = unpackIndexedGeometry(testCase.input);
     for (const name in testCase.output.attributes) {
-      t.deepEqual(
-        attributes[name],
-        testCase.output.attributes[name],
-        `${testCase.title}: ${name} matches`
+      expect(attributes[name], `${testCase.title}: ${name} matches`).toEqual(
+        testCase.output.attributes[name]
       );
     }
   }
-
-  t.end();
 });
 
-test('makeInterleavedGeometry', t => {
+it('makeInterleavedGeometry', () => {
   const geometry = new Geometry({
     topology: 'triangle-list',
     attributes: {
@@ -76,39 +72,33 @@ test('makeInterleavedGeometry', t => {
 
   const interleavedGeometry = makeInterleavedGeometry(geometry);
 
-  t.ok(interleavedGeometry instanceof Geometry, 'returns a Geometry');
-  t.is(interleavedGeometry.vertexCount, 2, 'vertexCount is preserved');
-  t.deepEqual(
+  expect(interleavedGeometry instanceof Geometry, 'returns a Geometry').toBe(true);
+  expect(interleavedGeometry.vertexCount, 'vertexCount is preserved').toBe(2);
+  expect(
     interleavedGeometry.bufferLayout,
-    [
-      {
-        name: 'geometry',
-        stepMode: 'vertex',
-        byteStride: 32,
-        attributes: [
-          {attribute: 'positions', format: 'float32x3', byteOffset: 0},
-          {attribute: 'normals', format: 'float32x3', byteOffset: 12},
-          {attribute: 'texCoords', format: 'float32x2', byteOffset: 24}
-        ]
-      }
-    ],
     'bufferLayout describes one interleaved geometry buffer'
-  );
-  t.deepEqual(
+  ).toEqual([
+    {
+      name: 'geometry',
+      stepMode: 'vertex',
+      byteStride: 32,
+      attributes: [
+        {attribute: 'positions', format: 'float32x3', byteOffset: 0},
+        {attribute: 'normals', format: 'float32x3', byteOffset: 12},
+        {attribute: 'texCoords', format: 'float32x2', byteOffset: 24}
+      ]
+    }
+  ]);
+  expect(
     Array.from(new Float32Array(interleavedGeometry.attributes.geometry.value.buffer)),
-    [0, 1, 2, 10, 11, 12, 20, 21, 3, 4, 5, 13, 14, 15, 22, 23],
     'attributes are interleaved per vertex'
+  ).toEqual([0, 1, 2, 10, 11, 12, 20, 21, 3, 4, 5, 13, 14, 15, 22, 23]);
+  expect(makeInterleavedGeometry(interleavedGeometry), 'interleaving is idempotent').toBe(
+    interleavedGeometry
   );
-  t.is(
-    makeInterleavedGeometry(interleavedGeometry),
-    interleavedGeometry,
-    'interleaving is idempotent'
-  );
-
-  t.end();
 });
 
-test('makeInterleavedGeometry aligns mixed attribute types', t => {
+it('makeInterleavedGeometry aligns mixed attribute types', () => {
   const geometry = new Geometry({
     topology: 'triangle-list',
     attributes: {
@@ -120,24 +110,21 @@ test('makeInterleavedGeometry aligns mixed attribute types', t => {
   const interleavedGeometry = makeInterleavedGeometry(geometry);
   const bytes = interleavedGeometry.attributes.geometry.value;
 
-  t.ok(interleavedGeometry instanceof Geometry, 'returns a Geometry');
-  t.deepEqual(
+  expect(interleavedGeometry instanceof Geometry, 'returns a Geometry').toBe(true);
+  expect(
     interleavedGeometry.bufferLayout,
-    [
-      {
-        name: 'geometry',
-        stepMode: 'vertex',
-        byteStride: 16,
-        attributes: [
-          {attribute: 'positions', format: 'float32x3', byteOffset: 0},
-          {attribute: 'colors', format: 'unorm8x4', byteOffset: 12}
-        ]
-      }
-    ],
     'mixed typed attributes are packed into a four-byte-aligned layout'
-  );
-  t.deepEqual(Array.from(bytes.slice(12, 16)), [1, 2, 3, 4], 'first color is aligned');
-  t.deepEqual(Array.from(bytes.slice(28, 32)), [5, 6, 7, 8], 'second color is aligned');
-
-  t.end();
+  ).toEqual([
+    {
+      name: 'geometry',
+      stepMode: 'vertex',
+      byteStride: 16,
+      attributes: [
+        {attribute: 'positions', format: 'float32x3', byteOffset: 0},
+        {attribute: 'colors', format: 'unorm8x4', byteOffset: 12}
+      ]
+    }
+  ]);
+  expect(Array.from(bytes.slice(12, 16)), 'first color is aligned').toEqual([1, 2, 3, 4]);
+  expect(Array.from(bytes.slice(28, 32)), 'second color is aligned').toEqual([5, 6, 7, 8]);
 });

--- a/modules/engine/test/geometry/geometry.spec.ts
+++ b/modules/engine/test/geometry/geometry.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {Geometry, GeometryProps} from '@luma.gl/engine';
 import {TypedArray} from '@math.gl/types';
 
@@ -70,31 +70,25 @@ const TEST_CASES: {title: string; props: GeometryProps; [key: string]: any}[] = 
   }
 ];
 
-test('Geometry#constructor', t => {
+it('Geometry#constructor', () => {
   for (const testCase of TEST_CASES) {
     if (testCase.shouldThrow) {
-      t.throws(() => new Geometry(testCase.props), `${testCase.title}: should throw`);
+      expect(() => new Geometry(testCase.props), `${testCase.title}: should throw`).toThrow();
     } else {
       const geometry = new Geometry(testCase.props);
 
-      t.is(geometry.topology, testCase.topology, `${testCase.title}: topology is correct`);
-      t.is(
-        geometry.getVertexCount(),
-        testCase.vertexCount,
-        `${testCase.title}: vertexCount is correct`
+      expect(geometry.topology, `${testCase.title}: topology is correct`).toBe(testCase.topology);
+      expect(geometry.getVertexCount(), `${testCase.title}: vertexCount is correct`).toBe(
+        testCase.vertexCount
       );
-      t.deepEqual(
-        geometry.bufferLayout,
-        testCase.bufferLayout,
-        `${testCase.title}: bufferLayout is correct`
+      expect(geometry.bufferLayout, `${testCase.title}: bufferLayout is correct`).toEqual(
+        testCase.bufferLayout
       );
     }
   }
-
-  t.end();
 });
 
-test('Geometry#constructor preserves source attribute and explicit layout names', t => {
+it('Geometry#constructor preserves source attribute and explicit layout names', () => {
   const geometry = new Geometry({
     topology: 'triangle-list',
     attributes: {
@@ -103,9 +97,9 @@ test('Geometry#constructor preserves source attribute and explicit layout names'
     bufferLayout: [{name: 'POSITION', format: 'float32x3'}]
   });
 
-  t.ok(geometry.attributes.POSITION, 'semantic attribute name is preserved');
-  t.notOk(geometry.attributes.positions, 'semantic attribute has no shader-name alias');
-  t.deepEqual(geometry.bufferLayout, [{name: 'POSITION', format: 'float32x3'}]);
+  expect(geometry.attributes.POSITION, 'semantic attribute name is preserved').toBeTruthy();
+  expect(geometry.attributes.positions, 'semantic attribute has no shader-name alias').toBeFalsy();
+  expect(geometry.bufferLayout).toEqual([{name: 'POSITION', format: 'float32x3'}]);
 
   const positions = {value: new Float32Array([1, 1, 1]), size: 3};
   const geometryWithShaderNameOverride = new Geometry({
@@ -116,13 +110,14 @@ test('Geometry#constructor preserves source attribute and explicit layout names'
     }
   });
 
-  t.notOk(
+  expect(
     geometryWithShaderNameOverride.attributes.POSITION,
     'shader-name override replaces semantic'
+  ).toBeFalsy();
+  expect(geometryWithShaderNameOverride.attributes.positions, 'shader-name override wins').toBe(
+    positions
   );
-  t.is(geometryWithShaderNameOverride.attributes.positions, positions, 'shader-name override wins');
-  t.deepEqual(geometryWithShaderNameOverride.bufferLayout, [
+  expect(geometryWithShaderNameOverride.bufferLayout).toEqual([
     {name: 'positions', format: 'float32x3'}
   ]);
-  t.end();
 });

--- a/modules/engine/test/geometry/gpu-geometry.spec.ts
+++ b/modules/engine/test/geometry/gpu-geometry.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {
   ConeGeometry,
   CubeGeometry,
@@ -25,57 +25,56 @@ const BUILT_IN_GEOMETRY_TESTS = [
   {name: 'TruncatedConeGeometry', Geometry: TruncatedConeGeometry}
 ];
 
-test('CubeGeometry exposes stable face indices for indexed and non-indexed cubes', t => {
+it('CubeGeometry exposes stable face indices for indexed and non-indexed cubes', () => {
   const indexedCube = new CubeGeometry({indices: true});
   const nonIndexedCube = new CubeGeometry({indices: false});
 
-  t.ok(indexedCube.attributes.faceIndex, 'indexed cube includes faceIndex');
-  t.deepEqual(
+  expect(indexedCube.attributes.faceIndex, 'indexed cube includes faceIndex').toBeTruthy();
+  expect(
     indexedCube.attributes.faceIndex?.value,
-    new Uint32Array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5]),
     'indexed cube stores one semantic face id per duplicated vertex'
+  ).toEqual(
+    new Uint32Array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5])
   );
-  t.ok(nonIndexedCube.attributes.faceIndex, 'non-indexed cube includes faceIndex');
-  t.deepEqual(
+  expect(nonIndexedCube.attributes.faceIndex, 'non-indexed cube includes faceIndex').toBeTruthy();
+  expect(
     nonIndexedCube.attributes.faceIndex?.value,
+    'non-indexed cube preserves semantic face ids across its vertex block order'
+  ).toEqual(
     new Uint32Array([
       3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 2, 2, 2, 2, 2, 2, 5, 5, 5, 5, 5, 5, 0, 0, 0, 0, 0, 0, 1,
       1, 1, 1, 1, 1
-    ]),
-    'non-indexed cube preserves semantic face ids across its vertex block order'
+    ])
   );
-
-  t.end();
 });
 
-test('makeGPUGeometry interleaves built-in geometry attributes', async t => {
+it('makeGPUGeometry interleaves built-in geometry attributes', async () => {
   const device = await getWebGLTestDevice();
 
   for (const {name, Geometry} of BUILT_IN_GEOMETRY_TESTS) {
     const gpuGeometry = makeGPUGeometry(device, new Geometry());
     const bufferLayout = gpuGeometry.bufferLayout[0];
 
-    t.deepEqual(
-      Object.keys(gpuGeometry.attributes),
-      ['geometry'],
-      `${name}: has one vertex buffer`
-    );
-    t.is(gpuGeometry.bufferLayout.length, 1, `${name}: has one buffer layout`);
-    t.is(bufferLayout.name, 'geometry', `${name}: buffer layout is named geometry`);
-    t.ok(bufferLayout.attributes?.length, `${name}: buffer layout maps geometry attributes`);
-    t.ok(gpuGeometry.indices, `${name}: keeps index buffer`);
+    expect(Object.keys(gpuGeometry.attributes), `${name}: has one vertex buffer`).toEqual([
+      'geometry'
+    ]);
+    expect(gpuGeometry.bufferLayout.length, `${name}: has one buffer layout`).toBe(1);
+    expect(bufferLayout.name, `${name}: buffer layout is named geometry`).toBe('geometry');
+    expect(
+      bufferLayout.attributes?.length,
+      `${name}: buffer layout maps geometry attributes`
+    ).toBeTruthy();
+    expect(gpuGeometry.indices, `${name}: keeps index buffer`).toBeTruthy();
 
     gpuGeometry.destroy();
   }
-
-  t.end();
 });
 
-test('makeGPUGeometry interleaves cube geometry into one vertex buffer', async t => {
+it('makeGPUGeometry interleaves cube geometry into one vertex buffer', async () => {
   const device = await getWebGLTestDevice();
   const gpuGeometry = makeGPUGeometry(device, new CubeGeometry({indices: true}));
 
-  t.deepEqual(gpuGeometry.bufferLayout, [
+  expect(gpuGeometry.bufferLayout).toEqual([
     {
       name: 'geometry',
       stepMode: 'vertex',
@@ -88,14 +87,11 @@ test('makeGPUGeometry interleaves cube geometry into one vertex buffer', async t
       ]
     }
   ]);
-  t.is(
-    gpuGeometry.attributes.geometry.byteLength,
-    24 * 36,
-    'cube has one interleaved vertex buffer'
+  expect(gpuGeometry.attributes.geometry.byteLength, 'cube has one interleaved vertex buffer').toBe(
+    24 * 36
   );
-  t.is(gpuGeometry.vertexCount, 36, 'indexed cube draw count is preserved');
-  t.ok(gpuGeometry.indices, 'indexed cube keeps index buffer');
+  expect(gpuGeometry.vertexCount, 'indexed cube draw count is preserved').toBe(36);
+  expect(gpuGeometry.indices, 'indexed cube keeps index buffer').toBeTruthy();
 
   gpuGeometry.destroy();
-  t.end();
 });

--- a/modules/engine/test/scenegraph/group-node.spec.ts
+++ b/modules/engine/test/scenegraph/group-node.spec.ts
@@ -2,32 +2,31 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 import {GroupNode, ScenegraphNode, ModelNode, Model} from '@luma.gl/engine';
 import {Matrix4} from '@math.gl/core';
 import {DUMMY_VS, DUMMY_FS} from './model-node.spec';
+import {expect, it} from 'vitest';
 
-test('GroupNode#construction', async t => {
+it('GroupNode#construction', async () => {
   const grandChild = new ScenegraphNode();
   const child1 = new GroupNode([grandChild]);
   const child2 = new GroupNode();
   const groupNode = new GroupNode({children: [child1, child2]});
   const invalidNode = {id: 'invalidNode'};
 
-  t.ok(child1 instanceof GroupNode, 'construction with array is successful');
-  t.ok(groupNode instanceof GroupNode, 'construction with object is successful');
+  expect(child1 instanceof GroupNode, 'construction with array is successful').toBe(true);
+  expect(groupNode instanceof GroupNode, 'construction with object is successful').toBe(true);
 
   // @ts-expect-error
-  t.throws(() => new GroupNode({children: [invalidNode]}));
+  expect(() => new GroupNode({children: [invalidNode]})).toThrow();
   // @ts-expect-error
-  t.throws(() => new GroupNode({children: [invalidNode, child1]}));
+  expect(() => new GroupNode({children: [invalidNode, child1]})).toThrow();
   // @ts-expect-error
-  t.throws(() => new GroupNode({children: [child1, invalidNode]}));
-  t.end();
+  expect(() => new GroupNode({children: [child1, invalidNode]})).toThrow();
 });
 
-test('GroupNode#add', async t => {
+it('GroupNode#add', async () => {
   const child1 = new GroupNode();
   const child2 = new GroupNode();
   const child3 = new GroupNode();
@@ -36,11 +35,10 @@ test('GroupNode#add', async t => {
   // @ts-expect-error Need to fix nested types
   groupNode.add([child1, [child2, child3]]);
 
-  t.ok(groupNode.children.length === 3, 'add: should unpack nested arrays');
-  t.end();
+  expect(groupNode.children.length === 3, 'add: should unpack nested arrays').toBe(true);
 });
 
-test('GroupNode#remove', async t => {
+it('GroupNode#remove', async () => {
   const child1 = new GroupNode();
   const child2 = new GroupNode();
   const child3 = new GroupNode();
@@ -49,14 +47,13 @@ test('GroupNode#remove', async t => {
   groupNode.add([child1, child2]);
 
   groupNode.remove(child3);
-  t.ok(groupNode.children.length === 2, 'remove: should ignore non child node');
+  expect(groupNode.children.length === 2, 'remove: should ignore non child node').toBe(true);
 
   groupNode.remove(child2);
-  t.ok(groupNode.children.length === 1, 'remove: should remove child');
-  t.end();
+  expect(groupNode.children.length === 1, 'remove: should remove child').toBe(true);
 });
 
-test('GroupNode#removeAll', async t => {
+it('GroupNode#removeAll', async () => {
   const child1 = new GroupNode();
   const child2 = new GroupNode();
   const child3 = new GroupNode();
@@ -65,11 +62,10 @@ test('GroupNode#removeAll', async t => {
 
   groupNode.removeAll();
 
-  t.ok(groupNode.children.length === 0, 'removeAll: should remove all');
-  t.end();
+  expect(groupNode.children.length === 0, 'removeAll: should remove all').toBe(true);
 });
 
-test('GroupNode#destroy', async t => {
+it('GroupNode#destroy', async () => {
   const grandChild = new GroupNode();
   const child1 = new GroupNode([grandChild]);
   const child2 = new GroupNode();
@@ -77,12 +73,11 @@ test('GroupNode#destroy', async t => {
 
   groupNode.destroy();
 
-  t.ok(groupNode.children.length === 0, 'destroy: should remove all');
-  t.ok(child1.children.length === 0, 'destroy: should destroy children');
-  t.end();
+  expect(groupNode.children.length === 0, 'destroy: should remove all').toBe(true);
+  expect(child1.children.length === 0, 'destroy: should destroy children').toBe(true);
 });
 
-test('GroupNode#traverse', async t => {
+it('GroupNode#traverse', async () => {
   const modelMatrices = {};
   const matrix = new Matrix4().identity().scale(2);
 
@@ -97,17 +92,13 @@ test('GroupNode#traverse', async t => {
 
   groupNode.traverse(visitor);
 
-  t.deepEqual(modelMatrices[childSNode.id], matrix, 'should update child matrix');
-  t.deepEqual(
-    modelMatrices[grandChildSNode.id],
-    new Matrix4().identity().scale(4),
-    'should update grand child matrix'
+  expect(modelMatrices[childSNode.id], 'should update child matrix').toEqual(matrix);
+  expect(modelMatrices[grandChildSNode.id], 'should update grand child matrix').toEqual(
+    new Matrix4().identity().scale(4)
   );
-
-  t.end();
 });
 
-test('GroupNode#getBounds', async t => {
+it('GroupNode#getBounds', async () => {
   const device = await getWebGLTestDevice();
 
   const matrix = new Matrix4().translate([0, 0, 1]).scale(2);
@@ -119,7 +110,7 @@ test('GroupNode#getBounds', async t => {
   const child1 = new GroupNode({id: 'child-1', matrix, children: [grandChildSNode]});
   const groupNode = new GroupNode({id: 'parent', matrix, children: [child1, childSNode]});
 
-  t.deepEqual(groupNode.getBounds(), null, 'child bounds are not defined');
+  expect(groupNode.getBounds(), 'child bounds are not defined').toBeNull();
 
   childSNode.bounds = [
     [0, 0, 0],
@@ -130,18 +121,13 @@ test('GroupNode#getBounds', async t => {
     [0, 0, 0]
   ];
 
-  t.deepEqual(
-    groupNode.getBounds(),
-    [
-      [-4, -4, -1],
-      [2, 2, 3]
-    ],
-    'bounds calculated'
-  );
-  t.end();
+  expect(groupNode.getBounds(), 'bounds calculated').toEqual([
+    [-4, -4, -1],
+    [2, 2, 3]
+  ]);
 });
 
-test('GroupNode#getBounds applies leaf transforms and rotated box corners', async t => {
+it('GroupNode#getBounds applies leaf transforms and rotated box corners', async () => {
   const device = await getWebGLTestDevice();
   const model = new Model(device, {vs: DUMMY_VS, fs: DUMMY_FS});
   const node = new ModelNode({
@@ -159,23 +145,22 @@ test('GroupNode#getBounds applies leaf transforms and rotated box corners', asyn
   const bounds = group.getBounds();
   const rotatedHalfExtent = 3 / Math.sqrt(2);
 
-  t.ok(bounds, 'transformed model contributes bounds');
-  t.ok(
+  expect(bounds, 'transformed model contributes bounds').toBeTruthy();
+  expect(
     Math.abs(bounds![0][0] - (3 - rotatedHalfExtent)) < 0.000001 &&
       Math.abs(bounds![1][0] - (3 + rotatedHalfExtent)) < 0.000001,
     'all rotated horizontal corners contribute to the aggregate bounds'
-  );
-  t.ok(
+  ).toBe(true);
+  expect(
     Math.abs(bounds![0][1] - (2 - rotatedHalfExtent)) < 0.000001 &&
       Math.abs(bounds![1][1] - (2 + rotatedHalfExtent)) < 0.000001,
     'leaf and parent transforms are included in world-space bounds'
-  );
+  ).toBe(true);
 
   group.destroy();
-  t.end();
 });
 
-test('GroupNode#traverseDepthSorted orders transformed leaf bounds by camera depth', async t => {
+it('GroupNode#traverseDepthSorted orders transformed leaf bounds by camera depth', async () => {
   const nearNode = new ScenegraphNode({
     id: 'near',
     matrix: new Matrix4().translate([0, 0, -2])
@@ -214,29 +199,26 @@ test('GroupNode#traverseDepthSorted orders transformed leaf bounds by camera dep
     {viewMatrix: new Matrix4()}
   );
 
-  t.deepEqual(
-    backToFrontIds,
-    ['far', 'middle', 'near'],
-    'default traversal visits far nodes first'
-  );
-  t.deepEqual(depths, [9, 5, 2], 'nested and leaf transforms contribute to camera depth');
+  expect(backToFrontIds, 'default traversal visits far nodes first').toEqual([
+    'far',
+    'middle',
+    'near'
+  ]);
+  expect(depths, 'nested and leaf transforms contribute to camera depth').toEqual([9, 5, 2]);
 
   const frontToBackIds: string[] = [];
   group.traverseDepthSorted((node: ScenegraphNode) => frontToBackIds.push(node.id), {
     viewMatrix: new Matrix4(),
     order: 'front-to-back'
   });
-  t.deepEqual(frontToBackIds, ['near', 'middle', 'far'], 'front-to-back traversal is available');
+  expect(frontToBackIds, 'front-to-back traversal is available').toEqual(['near', 'middle', 'far']);
 
   const reverseViewIds: string[] = [];
   group.traverseDepthSorted((node: ScenegraphNode) => reverseViewIds.push(node.id), {
     viewMatrix: new Matrix4().lookAt({eye: [0, 0, -20], center: [0, 0, 0], up: [0, 1, 0]})
   });
-  t.deepEqual(
+  expect(
     reverseViewIds,
-    ['near', 'middle', 'far'],
     'camera direction determines ordering instead of fixed world-space depth'
-  );
-
-  t.end();
+  ).toEqual(['near', 'middle', 'far']);
 });

--- a/modules/engine/test/scenegraph/model-node.spec.ts
+++ b/modules/engine/test/scenegraph/model-node.spec.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 // import {makeSpy} from '@probe.gl/test-utils';
 import {Model, ModelNode} from '@luma.gl/engine';
 import {Matrix4} from '@math.gl/core';
+import {expect, it} from 'vitest';
 
 export const DUMMY_VS = `\
 #version 300 es
@@ -20,34 +20,29 @@ out vec4 fragmentColor;
 void main() { fragmentColor = vec4(1.0); }
 `;
 
-test('ModelNode#constructor', async t => {
+it('ModelNode#constructor', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   for (const device of [webglDevice]) {
     const model = new Model(device, {vs: DUMMY_VS, fs: DUMMY_FS});
 
     const mNode1 = new ModelNode({model});
-    t.ok(mNode1.model instanceof Model, 'should get constructed with model');
+    expect(mNode1.model instanceof Model, 'should get constructed with model').toBe(true);
   }
-  t.end();
 });
 
-test('ModelNode#setProps', async t => {
+it('ModelNode#setProps', async () => {
   const webglDevice = await getWebGLTestDevice();
   const model = new Model(webglDevice, {vs: DUMMY_VS, fs: DUMMY_FS});
   const modelNode = new ModelNode({model});
 
   modelNode.setProps({position: [1, 2, 3]});
-  t.deepEqual(
-    Array.from(modelNode.position),
-    [1, 2, 3],
-    'setProps updates position on scenegraph node'
-  );
-
-  t.end();
+  expect(Array.from(modelNode.position), 'setProps updates position on scenegraph node').toEqual([
+    1, 2, 3
+  ]);
 });
 
-test('ModelNode#getBounds combines transformed instance bounds', async t => {
+it('ModelNode#getBounds combines transformed instance bounds', async () => {
   const device = await getWebGLTestDevice();
   const model = new Model(device, {vs: DUMMY_VS, fs: DUMMY_FS});
   const node = new ModelNode({
@@ -62,14 +57,13 @@ test('ModelNode#getBounds combines transformed instance bounds', async t => {
     ]
   });
 
-  t.deepEqual(
+  expect(
     node.getBounds(),
-    [
-      [-3, -2, -4],
-      [3.5, 2, 2]
-    ],
     'one model node exposes aggregate bounds for every transformed instance'
-  );
+  ).toEqual([
+    [-3, -2, -4],
+    [3.5, 2, 2]
+  ]);
 
   const emptyNode = new ModelNode({
     model: new Model(device, {vs: DUMMY_VS, fs: DUMMY_FS}),
@@ -79,9 +73,8 @@ test('ModelNode#getBounds combines transformed instance bounds', async t => {
     ],
     instanceMatrices: []
   });
-  t.equal(emptyNode.getBounds(), null, 'an empty instanced model has no visible bounds');
+  expect(emptyNode.getBounds(), 'an empty instanced model has no visible bounds').toBeNull();
 
   node.destroy();
   emptyNode.destroy();
-  t.end();
 });

--- a/modules/engine/test/scenegraph/scenegraph-node.spec.ts
+++ b/modules/engine/test/scenegraph/scenegraph-node.spec.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {ScenegraphNode} from '@luma.gl/engine';
 import {Matrix4, Vector3} from '@math.gl/core';
+import {expect, it} from 'vitest';
 
 const PROPS = {
   display: true,
@@ -14,101 +14,90 @@ const PROPS = {
   matrix: new Matrix4().scale(4)
 };
 
-test('ScenegraphNode#constructor', t => {
+it('ScenegraphNode#constructor', () => {
   const sgNode = new ScenegraphNode(PROPS);
-  t.ok(sgNode instanceof ScenegraphNode, 'should construct the object');
+  expect(sgNode instanceof ScenegraphNode, 'should construct the object').toBe(true);
   for (const key in PROPS) {
-    t.deepEqual(sgNode.props[key], PROPS[key], `prop: ${key} should get set on the object.props`);
-    t.deepEqual(sgNode[key], PROPS[key], `prop: ${key} should get set on the object`);
+    expect(sgNode.props[key], `prop: ${key} should get set on the object.props`).toEqual(
+      PROPS[key]
+    );
+    expect(sgNode[key], `prop: ${key} should get set on the object`).toEqual(PROPS[key]);
   }
-  t.end();
 });
 
-test('ScenegraphNode#delete', t => {
+it('ScenegraphNode#delete', () => {
   const sgNode = new ScenegraphNode();
-  t.doesNotThrow(() => sgNode.destroy(), 'delete should work');
-
-  t.end();
+  expect(() => sgNode.destroy(), 'delete should work').not.toThrow();
 });
 
-test('ScenegraphNode#setProps', t => {
+it('ScenegraphNode#setProps', () => {
   const sgNode = new ScenegraphNode();
   sgNode.setProps(PROPS);
   for (const key in PROPS) {
-    t.deepEqual(sgNode.props[key], PROPS[key], `prop: ${key} should get set on the object.props`);
-    t.deepEqual(sgNode[key], PROPS[key], `prop: ${key} should get set on the object`);
+    expect(sgNode.props[key], `prop: ${key} should get set on the object.props`).toEqual(
+      PROPS[key]
+    );
+    expect(sgNode[key], `prop: ${key} should get set on the object`).toEqual(PROPS[key]);
   }
-  t.end();
 });
 
-test('ScenegraphNode#toString', t => {
+it('ScenegraphNode#toString', () => {
   const sgNode = new ScenegraphNode();
-  t.doesNotThrow(() => sgNode.toString(), 'delete should work');
-
-  t.end();
+  expect(() => sgNode.toString(), 'delete should work').not.toThrow();
 });
 
-test('ScenegraphNode#setMatrix', t => {
+it('ScenegraphNode#setMatrix', () => {
   const sgNode = new ScenegraphNode();
   const matrix = new Matrix4().scale(1.5);
 
   sgNode.setMatrix(matrix);
-  t.deepEqual(sgNode.matrix, matrix, 'should copy the matrix');
+  expect(sgNode.matrix, 'should copy the matrix').toEqual(matrix);
 
   sgNode.setMatrix(matrix, false);
-  t.equal(sgNode.matrix, matrix, 'should asign the matrix');
-
-  t.end();
+  expect(sgNode.matrix, 'should asign the matrix').toBe(matrix);
 });
 
-test('ScenegraphNode#setMatrixComponents', t => {
+it('ScenegraphNode#setMatrixComponents', () => {
   const sgNode = new ScenegraphNode();
   const position = new Vector3(1, 1, 1);
   const rotation = new Vector3(2, 2, 2);
   const scale = new Vector3(3, 3, 3);
 
   sgNode.setMatrixComponents({update: false});
-  t.deepEqual(sgNode.matrix, new Matrix4(), 'should not update the matrix');
+  expect(sgNode.matrix, 'should not update the matrix').toEqual(new Matrix4());
 
   sgNode.setMatrixComponents({position, rotation, scale});
-  t.deepEqual(
-    sgNode.matrix,
-    new Matrix4().translate(position).rotateXYZ(rotation).scale(scale),
-    'should update the matrix'
+  expect(sgNode.matrix, 'should update the matrix').toEqual(
+    new Matrix4().translate(position).rotateXYZ(rotation).scale(scale)
   );
-
-  t.end();
 });
 
-test('ScenegraphNode#update', t => {
+it('ScenegraphNode#update', () => {
   const sgNode = new ScenegraphNode();
   const position = new Vector3(1, 1, 1);
   const rotation = new Vector3(2, 2, 2);
   const scale = new Vector3(3, 3, 3);
 
   sgNode.update();
-  t.deepEqual(sgNode.matrix, new Matrix4(), 'should update the matrix');
+  expect(sgNode.matrix, 'should update the matrix').toEqual(new Matrix4());
 
   sgNode.update({position, rotation, scale});
-  t.deepEqual(
-    sgNode.matrix,
-    new Matrix4().translate(position).rotateXYZ(rotation).scale(scale),
-    'should update the matrix'
+  expect(sgNode.matrix, 'should update the matrix').toEqual(
+    new Matrix4().translate(position).rotateXYZ(rotation).scale(scale)
   );
-
-  t.end();
 });
 
-test('ScenegraphNode#getCoordinateUniforms', t => {
+it('ScenegraphNode#getCoordinateUniforms', () => {
   const sgNode = new ScenegraphNode();
 
   const uniforms = sgNode.getCoordinateUniforms(new Matrix4());
-  t.ok(uniforms.viewMatrix, 'should return viewMatrix');
-  t.ok(uniforms.modelMatrix, 'should return modelMatrix');
-  t.ok(uniforms.objectMatrix, 'should return objectMatrix');
-  t.ok(uniforms.worldMatrix, 'should return worldMatrix');
-  t.ok(uniforms.worldInverseMatrix, 'should return worldInverseMatrix');
-  t.ok(uniforms.worldInverseTransposeMatrix, 'should return worldInverseTransposeMatrix');
-
-  t.end();
+  expect(uniforms.viewMatrix, 'should return viewMatrix').toBeTruthy();
+  expect(uniforms.modelMatrix, 'should return modelMatrix').toBeTruthy();
+  expect(uniforms.objectMatrix, 'should return objectMatrix').toBeTruthy();
+  expect(uniforms.worldMatrix, 'should return worldMatrix').toBeTruthy();
+  expect(uniforms.worldInverseMatrix, 'should return worldInverseMatrix').toBeTruthy();
+  expect(
+    uniforms.worldInverseTransposeMatrix,
+    'should return worldInverseTransposeMatrix'
+  ).toBeTruthy();
 });

--- a/modules/engine/test/utils/buffer-layout-order.spec.ts
+++ b/modules/engine/test/utils/buffer-layout-order.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {type ShaderLayout, type BufferLayout} from '@luma.gl/core';
 import {sortedBufferLayoutByShaderSourceLocations} from '@luma.gl/engine/utils/buffer-layout-order';
 
@@ -134,11 +134,9 @@ const sortedBufferLayout = [
   }
 ];
 
-test('sortedBufferLayoutByShaderSourceLocations', t => {
+it('sortedBufferLayoutByShaderSourceLocations', () => {
   const result = sortedBufferLayoutByShaderSourceLocations(shaderLayout, bufferLayout);
   for (let i = 0; i < sortedBufferLayout.length; i++) {
-    t.deepEqual(result[i], sortedBufferLayout[i], `Buffer layout order is correct`);
-    // t.comment(JSON.stringify(result[i], null, 2));
+    expect(result[i], 'Buffer layout order is correct').toEqual(sortedBufferLayout[i]);
   }
-  t.end();
 });

--- a/modules/engine/test/utils/deep-equal.node.spec.ts
+++ b/modules/engine/test/utils/deep-equal.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerDeepEqualTests} from './deep-equal.spec.shared';
 
-registerDeepEqualTests(test);
+registerDeepEqualTests();

--- a/modules/engine/test/utils/deep-equal.spec.shared.ts
+++ b/modules/engine/test/utils/deep-equal.spec.shared.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
 import {deepEqual} from '@luma.gl/engine/utils/deep-equal';
+import {expect, it} from 'vitest';
 
 const obj = {longitude: -70, latitude: 40.7, zoom: 12};
 const TEST_CASES = [
@@ -66,13 +66,11 @@ const TEST_CASES = [
   {a: {x: 1}, b: null, depth: 1, output: false}
 ];
 
-export function registerDeepEqualTests(test: TapeTestFunction): void {
-  test('utils#deepEqual', t => {
+export function registerDeepEqualTests(): void {
+  it('utils#deepEqual', () => {
     TEST_CASES.forEach(({a, b, depth, output}) => {
       const result = deepEqual(a, b, depth as number);
-      t.is(result, output, `should ${output ? '' : 'not '}be equal`);
+      expect(result, `should ${output ? '' : 'not '}be equal`).toBe(output);
     });
-
-    t.end();
   });
 }

--- a/modules/engine/test/utils/deep-equal.spec.ts
+++ b/modules/engine/test/utils/deep-equal.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerDeepEqualTests} from './deep-equal.spec.shared';
 
-registerDeepEqualTests(test);
+registerDeepEqualTests();

--- a/modules/engine/test/utils/shader-module-utils.spec.ts
+++ b/modules/engine/test/utils/shader-module-utils.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import type {ShaderLayout} from '../../../core/src';
 import type {ShaderModule} from '../../../shadertools/src';
 import {lighting, pbrMaterial} from '../../../shadertools/src';
@@ -11,13 +11,12 @@ import {
   mergeShaderModuleBindingsIntoLayout
 } from '../../src/utils/shader-module-utils';
 
-test('mergeShaderModuleBindingsIntoLayout does not create placeholder layouts', t => {
+it('mergeShaderModuleBindingsIntoLayout does not create placeholder layouts', () => {
   const shaderLayout = mergeShaderModuleBindingsIntoLayout<ShaderLayout | null>(null, [lighting]);
-  t.equal(shaderLayout, null, 'null shader layouts stay null until a real layout is inferred');
-  t.end();
+  expect(shaderLayout, 'null shader layouts stay null until a real layout is inferred').toBeNull();
 });
 
-test('mergeShaderModuleBindingsIntoLayout remaps companion sampler bindings', t => {
+it('mergeShaderModuleBindingsIntoLayout remaps companion sampler bindings', () => {
   const shaderLayout: ShaderLayout = {
     bindings: [
       {name: 'pbr_baseColorSampler', location: 1, group: 0},
@@ -28,21 +27,17 @@ test('mergeShaderModuleBindingsIntoLayout remaps companion sampler bindings', t 
 
   const mergedLayout = mergeShaderModuleBindingsIntoLayout(shaderLayout, [pbrMaterial]);
 
-  t.equal(
+  expect(
     mergedLayout?.bindings.find(binding => binding.name === 'pbr_baseColorSampler')?.group,
-    3,
     'texture binding group is remapped'
-  );
-  t.equal(
+  ).toBe(3);
+  expect(
     mergedLayout?.bindings.find(binding => binding.name === 'pbr_baseColorSamplerSampler')?.group,
-    3,
     'companion sampler binding group is remapped'
-  );
-
-  t.end();
+  ).toBe(3);
 });
 
-test('mergeInferredShaderLayout merges compatible attributes and rejects conflicts', t => {
+it('mergeInferredShaderLayout merges compatible attributes and rejects conflicts', () => {
   const explicitLayout: ShaderLayout = {
     attributes: [{name: 'positions', location: 0, type: 'vec2<f32>', stepMode: 'instance'}],
     bindings: []
@@ -56,44 +51,36 @@ test('mergeInferredShaderLayout merges compatible attributes and rejects conflic
   };
   const mergedLayout = mergeInferredShaderLayout(explicitLayout, inferredLayout, ['filterValues']);
 
-  t.deepEqual(
+  expect(
     mergedLayout?.attributes,
-    [
-      {name: 'positions', location: 0, type: 'vec2<f32>', stepMode: 'instance'},
-      {name: 'filterValues', location: 1, type: 'f32'}
-    ],
     'explicit metadata wins and inferred plugin attributes are appended'
-  );
-  t.throws(
-    () =>
-      mergeInferredShaderLayout(
-        explicitLayout,
-        {
-          attributes: [{name: 'filterValues', location: 0, type: 'f32'}],
-          bindings: []
-        },
-        ['filterValues']
-      ),
-    /both use location 0/,
-    'different names cannot share a location'
-  );
-  t.throws(
-    () =>
-      mergeInferredShaderLayout(
-        explicitLayout,
-        {
-          attributes: [{name: 'positions', location: 0, type: 'vec3<f32>'}],
-          bindings: []
-        },
-        ['positions']
-      ),
-    /conflicts with its inferred type or location/,
-    'same-name declarations must have compatible types and locations'
-  );
-  t.end();
+  ).toEqual([
+    {name: 'positions', location: 0, type: 'vec2<f32>', stepMode: 'instance'},
+    {name: 'filterValues', location: 1, type: 'f32'}
+  ]);
+  expect(() =>
+    mergeInferredShaderLayout(
+      explicitLayout,
+      {
+        attributes: [{name: 'filterValues', location: 0, type: 'f32'}],
+        bindings: []
+      },
+      ['filterValues']
+    )
+  ).toThrow(/both use location 0/);
+  expect(() =>
+    mergeInferredShaderLayout(
+      explicitLayout,
+      {
+        attributes: [{name: 'positions', location: 0, type: 'vec3<f32>'}],
+        bindings: []
+      },
+      ['positions']
+    )
+  ).toThrow(/conflicts with its inferred type or location/);
 });
 
-test('mergeShaderModuleBindingsIntoLayout merges binding visibility', t => {
+it('mergeShaderModuleBindingsIntoLayout merges binding visibility', () => {
   const shaderLayout: ShaderLayout = {
     bindings: [{type: 'storage', name: 'fragments', location: 1, group: 0}],
     attributes: []
@@ -105,10 +92,8 @@ test('mergeShaderModuleBindingsIntoLayout merges binding visibility', t => {
 
   const mergedLayout = mergeShaderModuleBindingsIntoLayout(shaderLayout, [fragmentStorageModule]);
 
-  t.equal(
+  expect(
     mergedLayout?.bindings.find(binding => binding.name === 'fragments')?.visibility,
-    0x2,
     'module binding visibility is merged into inferred bindings'
-  );
-  t.end();
+  ).toBe(0x2);
 });

--- a/modules/engine/test/utils/split-uniforms-and-bindings.node.spec.ts
+++ b/modules/engine/test/utils/split-uniforms-and-bindings.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerSplitUniformsAndBindingsTests} from './split-uniforms-and-bindings.spec.shared';
 
-registerSplitUniformsAndBindingsTests(test);
+registerSplitUniformsAndBindingsTests();

--- a/modules/engine/test/utils/split-uniforms-and-bindings.spec.shared.ts
+++ b/modules/engine/test/utils/split-uniforms-and-bindings.spec.shared.ts
@@ -3,10 +3,10 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {splitUniformsAndBindings} from '@luma.gl/engine/model/split-uniforms-and-bindings';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-export function registerSplitUniformsAndBindingsTests(test: TapeTestFunction): void {
-  test('splitUniformsAndBindings', t => {
+export function registerSplitUniformsAndBindingsTests(): void {
+  it('splitUniformsAndBindings', () => {
     const mixed: Parameters<typeof splitUniformsAndBindings>[0] = {
       array: [1, 2, 3, 4],
       boolean: true,
@@ -15,16 +15,15 @@ export function registerSplitUniformsAndBindingsTests(test: TapeTestFunction): v
       texture: {texture: true} as any
     };
     const {bindings, uniforms} = splitUniformsAndBindings(mixed);
-    t.deepEquals(Object.keys(bindings), ['sampler', 'texture'], 'bindings correctly extracted');
-    t.deepEquals(
-      Object.keys(uniforms),
-      ['array', 'boolean', 'number'],
-      'bindings correctly extracted'
-    );
-    t.end();
+    expect(Object.keys(bindings), 'bindings correctly extracted').toEqual(['sampler', 'texture']);
+    expect(Object.keys(uniforms), 'uniforms correctly extracted').toEqual([
+      'array',
+      'boolean',
+      'number'
+    ]);
   });
 
-  test('splitUniformsAndBindings respects declared struct uniforms', t => {
+  it('splitUniformsAndBindings respects declared struct uniforms', () => {
     const mixed = {
       light: {
         position: [1, 2, 3],
@@ -41,18 +40,16 @@ export function registerSplitUniformsAndBindingsTests(test: TapeTestFunction): v
       }
     });
 
-    t.deepEquals(Object.keys(uniforms), ['light'], 'struct uniform preserved');
-    t.deepEquals(Object.keys(bindings), ['sampler', 'texture'], 'bindings remain bindings');
-    t.deepEqual(uniforms.light, mixed.light, 'struct uniform value retained');
-    t.end();
+    expect(Object.keys(uniforms), 'struct uniform preserved').toEqual(['light']);
+    expect(Object.keys(bindings), 'bindings remain bindings').toEqual(['sampler', 'texture']);
+    expect(uniforms.light, 'struct uniform value retained').toEqual(mixed.light);
   });
 
-  test('splitUniformsAndBindings treats undeclared objects as bindings', t => {
+  it('splitUniformsAndBindings treats undeclared objects as bindings', () => {
     const nestedUniform = {thresholds: [1, 2, 3], metadata: {enabled: true}};
     const {bindings, uniforms} = splitUniformsAndBindings({config: nestedUniform});
 
-    t.deepEquals(uniforms, {}, 'undeclared objects are not treated as uniforms');
-    t.deepEqual(bindings.config, nestedUniform as any, 'undeclared objects fall back to bindings');
-    t.end();
+    expect(uniforms, 'undeclared objects are not treated as uniforms').toEqual({});
+    expect(bindings.config, 'undeclared objects fall back to bindings').toEqual(nestedUniform);
   });
 }

--- a/modules/engine/test/utils/split-uniforms-and-bindings.spec.ts
+++ b/modules/engine/test/utils/split-uniforms-and-bindings.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerSplitUniformsAndBindingsTests} from './split-uniforms-and-bindings.spec.shared';
 
-registerSplitUniformsAndBindingsTests(test);
+registerSplitUniformsAndBindingsTests();

--- a/modules/gltf/test/gltf/gltf-extension-support.spec.ts
+++ b/modules/gltf/test/gltf/gltf-extension-support.spec.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import type {GLTFPostprocessed} from '@loaders.gl/gltf';
 import type {TextureFormat} from '@luma.gl/core';
 import {NullDevice} from '@luma.gl/test-utils';
+import {expect, it} from 'vitest';
 
 import {
   assertSupportedGLTFExtensions,
@@ -26,7 +26,7 @@ type GLTFPostprocessedWithRemovedExtensions = GLTFPostprocessed & {
   lights?: unknown[];
 };
 
-test('gltf#getGLTFExtensionSupport collects and annotates used extensions', t => {
+it('gltf#getGLTFExtensionSupport collects and annotates used extensions', () => {
   const gltf: GLTFPostprocessedWithRemovedExtensions = {
     id: 'test-gltf',
     extensionsUsed: ['KHR_texture_transform', 'KHR_materials_specular', 'CUSTOM_unknown_extension'],
@@ -51,44 +51,37 @@ test('gltf#getGLTFExtensionSupport collects and annotates used extensions', t =>
 
   const extensionSupport = getGLTFExtensionSupport(gltf);
 
-  t.deepEqual(
+  expect(
     Array.from(extensionSupport.keys()),
-    [
-      'CUSTOM_unknown_extension',
-      'KHR_animation_pointer',
-      'KHR_draco_mesh_compression',
-      'KHR_lights_punctual',
-      'KHR_materials_specular',
-      'KHR_materials_unlit',
-      'KHR_texture_transform'
-    ],
     'used, required, removed, and inferred extensions are included'
-  );
-  t.equal(
+  ).toEqual([
+    'CUSTOM_unknown_extension',
+    'KHR_animation_pointer',
+    'KHR_draco_mesh_compression',
+    'KHR_lights_punctual',
+    'KHR_materials_specular',
+    'KHR_materials_unlit',
+    'KHR_texture_transform'
+  ]);
+  expect(
     extensionSupport.get('KHR_draco_mesh_compression')?.supported,
-    true,
     'built-in extension is marked as supported'
-  );
-  t.equal(
+  ).toBe(true);
+  expect(
     extensionSupport.get('KHR_animation_pointer')?.supported,
-    true,
     'parsed-and-wired extension is marked as supported'
-  );
-  t.equal(
+  ).toBe(true);
+  expect(
     extensionSupport.get('KHR_materials_specular')?.supported,
-    true,
     'stock-shader material extensions are reported as built-in support'
-  );
-  t.equal(
+  ).toBe(true);
+  expect(
     extensionSupport.get('CUSTOM_unknown_extension')?.comment,
-    'Not currently listed in the luma.gl glTF extension support registry.',
     'unknown extensions get a fallback note'
-  );
-
-  t.end();
+  ).toBe('Not currently listed in the luma.gl glTF extension support registry.');
 });
 
-test('gltf#getGLTFExtensionSupport distinguishes actual loader implementations', t => {
+it('gltf#getGLTFExtensionSupport distinguishes actual loader implementations', () => {
   const extensionNames = [
     'EXT_mesh_features',
     'EXT_meshopt_compression',
@@ -104,41 +97,33 @@ test('gltf#getGLTFExtensionSupport distinguishes actual loader implementations',
   } as GLTFPostprocessed;
   const support = getGLTFExtensionSupport(gltf);
 
-  t.equal(
+  expect(
     support.get('EXT_meshopt_compression')?.supportLevel,
-    'built-in',
     'the installed loaders.gl decoder handles EXT meshopt buffer views'
-  );
-  t.equal(
+  ).toBe('built-in');
+  expect(
     support.get('KHR_meshopt_compression')?.supportLevel,
-    'built-in',
     'the loaders.gl v5 decoder handles KHR meshopt buffer views'
-  );
-  t.equal(
+  ).toBe('built-in');
+  expect(
     support.get('EXT_mesh_features')?.supportLevel,
-    'loader-only',
     'feature identifiers are decoded but have no automatic luma.gl runtime'
-  );
-  t.equal(
+  ).toBe('loader-only');
+  expect(
     support.get('EXT_structural_metadata')?.supportLevel,
-    'loader-only',
     'structural metadata is decoded but remains application-owned'
-  );
-  t.equal(
+  ).toBe('loader-only');
+  expect(
     support.get('EXT_texture_webp')?.supportLevel,
-    'loader-only',
     'WebP source selection is conditional on browser image support'
-  );
-  t.equal(
+  ).toBe('loader-only');
+  expect(
     support.get('EXT_texture_avif')?.supportLevel,
-    'none',
     'generic AVIF image decoding does not imply glTF extension source selection'
-  );
-
-  t.end();
+  ).toBe('none');
 });
 
-test('gltf#getGLTFExtensionSupport applies BasisU device format capabilities', t => {
+it('gltf#getGLTFExtensionSupport applies BasisU device format capabilities', () => {
   const gltf = {
     extensionsUsed: ['KHR_texture_basisu'],
     extensionsRequired: ['KHR_texture_basisu'],
@@ -168,68 +153,59 @@ test('gltf#getGLTFExtensionSupport applies BasisU device format capabilities', t
   const unsupported = getGLTFExtensionSupport(gltf, unsupportedDevice).get('KHR_texture_basisu');
   const supported = getGLTFExtensionSupport(gltf, supportedDevice).get('KHR_texture_basisu');
 
-  t.equal(unsupported?.supported, false, 'unsupported transcode format is reported truthfully');
-  t.equal(unsupported?.supportLevel, 'none', 'device gap fails strict extension support');
-  t.match(unsupported?.comment || '', /does not support.*bc7-rgba-unorm/);
-  t.equal(supported?.supported, true, 'supported transcode format retains built-in support');
-  t.throws(
+  expect(unsupported?.supported, 'unsupported transcode format is reported truthfully').toBe(false);
+  expect(unsupported?.supportLevel, 'device gap fails strict extension support').toBe('none');
+  expect(unsupported?.comment || '').toMatch(/does not support.*bc7-rgba-unorm/);
+  expect(supported?.supported, 'supported transcode format retains built-in support').toBe(true);
+  expect(
     () => assertSupportedGLTFExtensions(gltf, unsupportedDevice),
-    /KHR_texture_basisu/,
     'required BasisU rejects an unsupported selected GPU format'
-  );
-  t.throws(
+  ).toThrow(/KHR_texture_basisu/);
+  expect(
     () => createScenegraphsFromGLTF(unsupportedDevice, gltf, {strictExtensions: true}),
-    /KHR_texture_basisu/,
     'strict scenegraph creation checks the active device before allocating resources'
-  );
-  t.doesNotThrow(
+  ).toThrow(/KHR_texture_basisu/);
+  expect(
     () => assertSupportedGLTFExtensions(gltf, supportedDevice),
     'required BasisU accepts a selected GPU format supported by the device'
-  );
+  ).not.toThrow();
 
   unsupportedDevice.destroy();
   supportedDevice.destroy();
-  t.end();
 });
 
-test('gltf#getRegisteredGLTFExtensions exposes generated support and maturity summaries', t => {
+it('gltf#getRegisteredGLTFExtensions exposes generated support and maturity summaries', () => {
   const extensions = getRegisteredGLTFExtensions();
   const summary = getGLTFExtensionSupportSummary();
 
-  t.deepEqual(
+  expect(
     extensions.map(extension => extension.extensionName),
-    [...extensions.map(extension => extension.extensionName)].sort(),
     'registry entries are returned in stable extension-name order'
-  );
-  t.deepEqual(
+  ).toEqual([...extensions.map(extension => extension.extensionName)].sort());
+  expect(
     summary,
-    {
-      total: 35,
-      supported: 26,
-      bySupportLevel: {'built-in': 20, 'parsed-and-wired': 6, 'loader-only': 4, none: 5},
-      byStandardStatus: {
-        ratified: 26,
-        'release-candidate': 2,
-        'multi-vendor': 2,
-        vendor: 1,
-        draft: 2,
-        archived: 2,
-        unknown: 0
-      }
-    },
     'summary is derived from the registry rather than copied into documentation'
-  );
-  t.equal(
+  ).toEqual({
+    total: 35,
+    supported: 26,
+    bySupportLevel: {'built-in': 20, 'parsed-and-wired': 6, 'loader-only': 4, none: 5},
+    byStandardStatus: {
+      ratified: 26,
+      'release-candidate': 2,
+      'multi-vendor': 2,
+      vendor: 1,
+      draft: 2,
+      archived: 2,
+      unknown: 0
+    }
+  });
+  expect(
     extensions.find(extension => extension.extensionName === 'KHR_meshopt_compression')
       ?.standardStatus,
-    'release-candidate',
     'a KHR prefix does not imply ratification'
-  );
-  t.equal(
+  ).toBe('release-candidate');
+  expect(
     extensions.find(extension => extension.extensionName === 'MSFT_lod')?.standardStatus,
-    'vendor',
     'vendor extensions retain their source maturity'
-  );
-
-  t.end();
+  ).toBe('vendor');
 });

--- a/modules/gltf/test/gltf/gltf-native-extensions.spec.ts
+++ b/modules/gltf/test/gltf/gltf-native-extensions.spec.ts
@@ -9,9 +9,9 @@ import {ModelNode} from '@luma.gl/engine';
 import {createScenegraphsFromGLTF} from '@luma.gl/gltf';
 import {getTestDevices} from '@luma.gl/test-utils';
 import {Matrix4} from '@math.gl/core';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('glTF renders official EXT_mesh_gpu_instancing through one real draw on available backends', async testCase => {
+it('glTF renders official EXT_mesh_gpu_instancing through one real draw on available backends', async () => {
   const source = postProcessGLTF(
     await load(new URL('../data/SimpleInstancing.glb', import.meta.url).href, GLTFLoader, {
       gltf: {loadImages: false}
@@ -47,7 +47,7 @@ test('glTF renders official EXT_mesh_gpu_instancing through one real draw on ava
         }
       });
 
-      testCase.ok(modelNode, `${device.type} creates one instanced primitive`);
+      expect(modelNode, `${device.type} creates one instanced primitive`).toBeTruthy();
       if (modelNode) {
         const identity = Array.from(new Matrix4());
         modelNode.model.shaderInputs.setProps({
@@ -63,15 +63,18 @@ test('glTF renders official EXT_mesh_gpu_instancing through one real draw on ava
           clearColor: [0, 0, 0, 0],
           clearDepth: 1
         });
-        testCase.ok(modelNode.model.draw(renderPass), `${device.type} executes an instanced draw`);
+        expect(
+          modelNode.model.draw(renderPass),
+          `${device.type} executes an instanced draw`
+        ).toBeTruthy();
         renderPass.end();
         device.submit();
 
-        testCase.ok(modelNode.model.isInstanced, `${device.type} enables GPU instancing`);
-        testCase.ok(
+        expect(modelNode.model.isInstanced, `${device.type} enables GPU instancing`).toBeTruthy();
+        expect(
           modelNode.model.instanceCount > 1,
           `${device.type} submits every authored source instance`
-        );
+        ).toBe(true);
       }
     } finally {
       for (const scene of scenegraphs.scenes) {
@@ -82,6 +85,4 @@ test('glTF renders official EXT_mesh_gpu_instancing through one real draw on ava
       depthTexture.destroy();
     }
   }
-
-  testCase.end();
 });

--- a/modules/gltf/test/gltf/gltf-production-animation.node.spec.ts
+++ b/modules/gltf/test/gltf/gltf-production-animation.node.spec.ts
@@ -13,7 +13,7 @@ import {
   GLTFSkinController
 } from '@luma.gl/gltf';
 import {NullDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 async function loadSimpleSkin() {
   const asset = await readFile(
@@ -22,43 +22,44 @@ async function loadSimpleSkin() {
   return postProcessGLTF(await parse(asset, GLTFLoader, {gltf: {loadImages: false}}));
 }
 
-test('glTF SimpleSkin automatically binds and animates existing primitive joint palettes', async testContext => {
+it('glTF SimpleSkin automatically binds and animates existing primitive joint palettes', async () => {
   const source = await loadSimpleSkin();
   const device = new NullDevice({});
   const scenegraphs = createScenegraphsFromGLTF(device, source);
   const binding = scenegraphs.skins.getBinding(0);
 
-  testContext.ok(scenegraphs.skins instanceof GLTFSkinController, 'exposes source-owned skins');
-  testContext.equal(scenegraphs.skins.bindings.length, 1, 'binds the authored skinned node');
-  testContext.equal(binding?.skinIndex, 0, 'resolves a postprocessed source skin');
-  testContext.equal(binding?.joints.length, 2, 'preserves both authored joints');
-  testContext.equal(binding?.models.length, 1, 'binds the existing primitive model');
-  testContext.equal(binding?.jointMatrices.length, 32, 'allocates only authored joint matrices');
+  expect(scenegraphs.skins instanceof GLTFSkinController, 'exposes source-owned skins').toBe(true);
+  expect(scenegraphs.skins.bindings.length, 'binds the authored skinned node').toBe(1);
+  expect(binding?.skinIndex, 'resolves a postprocessed source skin').toBe(0);
+  expect(binding?.joints.length, 'preserves both authored joints').toBe(2);
+  expect(binding?.models.length, 'binds the existing primitive model').toBe(1);
+  expect(binding?.jointMatrices.length, 'allocates only authored joint matrices').toBe(32);
 
   if (binding) {
     const startingPalette = Array.from(binding.jointMatrices);
     const storage = binding.jointMatrices;
     scenegraphs.animator.setTime(500);
 
-    testContext.equal(binding.jointMatrices, storage, 'reuses the same palette every frame');
-    testContext.notDeepEqual(
+    expect(binding.jointMatrices, 'reuses the same palette every frame').toBe(storage);
+    expect(
       Array.from(binding.jointMatrices),
-      startingPalette,
       'the existing imported clip updates its joint transforms'
-    );
+    ).not.toEqual(startingPalette);
 
     const uniforms = binding.models[0].model.shaderInputs.getUniformValues();
-    testContext.ok(uniforms['skin'], 'the existing skin shader receives the automatic palette');
+    expect(
+      uniforms['skin'],
+      'the existing skin shader receives the automatic palette'
+    ).toBeTruthy();
   }
 
   for (const scene of scenegraphs.scenes) {
     scene.destroy();
   }
   device.destroy();
-  testContext.end();
 });
 
-test('GLTFSkinController preserves independent skins and mesh-local transforms', testContext => {
+it('GLTFSkinController preserves independent skins and mesh-local transforms', () => {
   const firstMeshNode = new GroupNode({id: 'mesh-node-a', position: [10, 0, 0]});
   const secondMeshNode = new GroupNode({id: 'mesh-node-b', position: [20, 0, 0]});
   const firstJoint = new GroupNode({id: 'joint-a', position: [12, 0, 0]});
@@ -92,25 +93,19 @@ test('GLTFSkinController preserves independent skins and mesh-local transforms',
     ])
   });
 
-  testContext.equal(controller.bindings.length, 2, 'keeps both authored skins independent');
-  testContext.equal(controller.getBinding(0)?.jointMatrices[12], 2, 'localizes the first skin');
-  testContext.equal(
+  expect(controller.bindings.length, 'keeps both authored skins independent').toBe(2);
+  expect(controller.getBinding(0)?.jointMatrices[12], 'localizes the first skin').toBe(2);
+  expect(
     controller.getBinding(secondMeshNode)?.jointMatrices[12],
-    5,
     'localizes the second skin'
-  );
+  ).toBe(5);
 
   secondJoint.setPosition([28, 0, 0]).updateMatrix();
   controller.update();
-  testContext.equal(
-    controller.getBinding(1)?.jointMatrices[12],
-    8,
-    'updates only authored transforms'
-  );
-  testContext.end();
+  expect(controller.getBinding(1)?.jointMatrices[12], 'updates only authored transforms').toBe(8);
 });
 
-test('GLTFAnimator advances wall-clock crossfades and supports explicit clip selection', testContext => {
+it('GLTFAnimator advances wall-clock crossfades and supports explicit clip selection', () => {
   const node = new GroupNode({id: 'animated'});
   let updateCount = 0;
   const makeAnimation = (name: string, position: number): GLTFAnimation => ({
@@ -138,23 +133,18 @@ test('GLTFAnimator advances wall-clock crossfades and supports explicit clip sel
     onUpdate: () => updateCount++
   });
 
-  testContext.equal(animator.activeClip, 'walk', 'initially selects the first authored clip');
-  testContext.false(animator.clips[1].action.playing, 'does not blend unrelated authored clips');
+  expect(animator.activeClip, 'initially selects the first authored clip').toBe('walk');
+  expect(animator.clips[1].action.playing, 'does not blend unrelated authored clips').toBe(false);
   animator.setTime(0);
   animator.selectClip('run', {crossFadeDuration: 1});
   animator.setTime(500);
 
-  testContext.equal(animator.activeClip, 'run', 'exposes the newly selected authored clip');
-  testContext.equal(
-    node.position[0],
-    5,
-    'legacy millisecond playback advances both crossfade weights'
-  );
-  testContext.equal(updateCount, 2, 'runs dependent skin updates once per animation frame');
+  expect(animator.activeClip, 'exposes the newly selected authored clip').toBe('run');
+  expect(node.position[0], 'legacy millisecond playback advances both crossfade weights').toBe(5);
+  expect(updateCount, 'runs dependent skin updates once per animation frame').toBe(2);
 
   animator.setTime(1000);
-  testContext.equal(node.position[0], 10, 'crossfades finish at the incoming clip');
-  testContext.equal(updateCount, 3, 'does not evaluate dependent skins twice');
-  testContext.throws(() => animator.selectClip('missing'), 'unknown clip names remain explicit');
-  testContext.end();
+  expect(node.position[0], 'crossfades finish at the incoming clip').toBe(10);
+  expect(updateCount, 'does not evaluate dependent skins twice').toBe(3);
+  expect(() => animator.selectClip('missing'), 'unknown clip names remain explicit').toThrow();
 });

--- a/modules/gltf/test/gltf/lights.spec.ts
+++ b/modules/gltf/test/gltf/lights.spec.ts
@@ -1,8 +1,8 @@
-import test from 'test/utils/vitest-tape';
 import {parseGLTFLights} from '@luma.gl/gltf/parsers/parse-gltf-lights';
 import type {GLTFPostprocessed} from '@loaders.gl/gltf';
+import {expect, it} from 'vitest';
 
-test('gltf#parseGLTFLights - directional', t => {
+it('gltf#parseGLTFLights - directional', () => {
   const gltf: GLTFPostprocessed = {
     nodes: [
       {
@@ -26,18 +26,19 @@ test('gltf#parseGLTFLights - directional', t => {
   } as any;
 
   const lights = parseGLTFLights(gltf);
-  t.equal(lights.length, 1, 'one light parsed');
+  expect(lights.length, 'one light parsed').toBe(1);
   const light = lights[0] as any;
-  t.equals(light.type, 'directional');
-  t.deepEquals(light.color, [51, 76.5, 102], 'glTF colors are normalized to luma light range');
-  t.equals(light.intensity, 2);
+  expect(light.type).toBe('directional');
+  expect(light.color, 'glTF colors are normalized to luma light range').toEqual([51, 76.5, 102]);
+  expect(light.intensity).toBe(2);
 
   const floatLights = parseGLTFLights(gltf, {useByteColors: false});
-  t.deepEquals((floatLights[0] as any).color, [0.2, 0.3, 0.4], 'float mode preserves glTF colors');
-  t.end();
+  expect((floatLights[0] as any).color, 'float mode preserves glTF colors').toEqual([
+    0.2, 0.3, 0.4
+  ]);
 });
 
-test('gltf#parseGLTFLights - point', t => {
+it('gltf#parseGLTFLights - point', () => {
   const gltf: GLTFPostprocessed = {
     nodes: [
       {
@@ -60,16 +61,15 @@ test('gltf#parseGLTFLights - point', t => {
     }
   } as any;
   const lights = parseGLTFLights(gltf);
-  t.equal(lights.length, 1, 'one light parsed');
+  expect(lights.length, 'one light parsed').toBe(1);
   const light = lights[0] as any;
-  t.equals(light.type, 'point');
-  t.deepEquals(light.position, [1, 2, 3]);
-  t.equals(light.intensity, 5);
-  t.equals(light.attenuation[2], 1 / 100);
-  t.end();
+  expect(light.type).toBe('point');
+  expect(light.position).toEqual([1, 2, 3]);
+  expect(light.intensity).toBe(5);
+  expect(light.attenuation[2]).toBe(1 / 100);
 });
 
-test('gltf#parseGLTFLights - spot', t => {
+it('gltf#parseGLTFLights - spot', () => {
   const gltf: GLTFPostprocessed = {
     nodes: [
       {
@@ -99,30 +99,28 @@ test('gltf#parseGLTFLights - spot', t => {
   } as any;
 
   const lights = parseGLTFLights(gltf);
-  t.equal(lights.length, 1, 'one spot light parsed');
+  expect(lights.length, 'one spot light parsed').toBe(1);
   const light = lights[0] as any;
-  t.equals(light.type, 'spot');
-  t.deepEquals(light.position, [1, 2, 3]);
-  t.deepEquals(light.direction, [0, 0, -1]);
-  t.deepEquals(light.color, [51, 76.5, 102], 'glTF colors are normalized to luma light range');
-  t.equals(light.intensity, 7);
-  t.equals(light.innerConeAngle, 0.1);
-  t.equals(light.outerConeAngle, 0.5);
-  t.equals(light.attenuation[2], 1 / 400);
-  t.end();
+  expect(light.type).toBe('spot');
+  expect(light.position).toEqual([1, 2, 3]);
+  expect(light.direction).toEqual([0, 0, -1]);
+  expect(light.color, 'glTF colors are normalized to luma light range').toEqual([51, 76.5, 102]);
+  expect(light.intensity).toBe(7);
+  expect(light.innerConeAngle).toBe(0.1);
+  expect(light.outerConeAngle).toBe(0.5);
+  expect(light.attenuation[2]).toBe(1 / 400);
 });
 
-test('gltf#parseGLTFLights - missing extension', t => {
+it('gltf#parseGLTFLights - missing extension', () => {
   const gltf: GLTFPostprocessed = {
     nodes: [],
     scenes: []
   } as any;
   const lights = parseGLTFLights(gltf);
-  t.equal(lights.length, 0, 'no lights parsed');
-  t.end();
+  expect(lights.length, 'no lights parsed').toBe(0);
 });
 
-test('gltf#parseGLTFLights - postprocessed lights with node matrix', t => {
+it('gltf#parseGLTFLights - postprocessed lights with node matrix', () => {
   const gltf: GLTFPostprocessed = {
     nodes: [
       {
@@ -141,15 +139,14 @@ test('gltf#parseGLTFLights - postprocessed lights with node matrix', t => {
   } as any;
 
   const lights = parseGLTFLights(gltf);
-  t.equal(lights.length, 1, 'one postprocessed light parsed');
+  expect(lights.length, 'one postprocessed light parsed').toBe(1);
   const light = lights[0] as any;
-  t.equals(light.type, 'point');
-  t.deepEquals(light.position, [4, 5, 6]);
-  t.equals(light.intensity, 3);
-  t.end();
+  expect(light.type).toBe('point');
+  expect(light.position).toEqual([4, 5, 6]);
+  expect(light.intensity).toBe(3);
 });
 
-test('gltf#parseGLTFLights - nested node transforms are resolved in world space', t => {
+it('gltf#parseGLTFLights - nested node transforms are resolved in world space', () => {
   const gltf: GLTFPostprocessed = {
     nodes: [
       {
@@ -179,12 +176,11 @@ test('gltf#parseGLTFLights - nested node transforms are resolved in world space'
   } as any;
 
   const lights = parseGLTFLights(gltf);
-  t.equal(lights.length, 1, 'one nested light parsed');
+  expect(lights.length, 'one nested light parsed').toBe(1);
   const light = lights[0] as any;
-  t.equals(light.type, 'spot');
-  t.deepEquals(light.position, [9, 2, -3], 'position includes parent rotation and translation');
-  t.deepEquals(light.direction, [0, 0, 1], 'direction includes parent rotation');
-  t.deepEquals(light.color, [255, 255, 255], 'white glTF light is normalized to 255');
-  t.equals(light.intensity, 4);
-  t.end();
+  expect(light.type).toBe('spot');
+  expect(light.position, 'position includes parent rotation and translation').toEqual([9, 2, -3]);
+  expect(light.direction, 'direction includes parent rotation').toEqual([0, 0, 1]);
+  expect(light.color, 'white glTF light is normalized to 255').toEqual([255, 255, 255]);
+  expect(light.intensity).toBe(4);
 });

--- a/modules/gltf/test/parsers/parse-pbr-sampler.node.spec.ts
+++ b/modules/gltf/test/parsers/parse-pbr-sampler.node.spec.ts
@@ -1,8 +1,8 @@
 import {parsePBRMaterial} from '@luma.gl/gltf';
 import {NullDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('glTF PBR parser preserves authored postprocessed sampler parameters', testContext => {
+it('glTF PBR parser preserves authored postprocessed sampler parameters', () => {
   const device = new NullDevice({});
   const parsedMaterial = parsePBRMaterial(
     device,
@@ -42,15 +42,14 @@ test('glTF PBR parser preserves authored postprocessed sampler parameters', test
   );
 
   const sampler = parsedMaterial.bindings.pbr_baseColorSampler?.sampler.props;
-  testContext.equal(sampler?.addressModeU, 'clamp-to-edge', 'horizontal wrapping remains authored');
-  testContext.equal(sampler?.addressModeV, 'mirror-repeat', 'vertical wrapping remains authored');
-  testContext.equal(sampler?.magFilter, 'nearest', 'magnification filtering remains authored');
-  testContext.equal(sampler?.minFilter, 'nearest', 'minification filtering remains authored');
-  testContext.equal(sampler?.mipmapFilter, 'linear', 'mipmap filtering remains authored');
+  expect(sampler?.addressModeU, 'horizontal wrapping remains authored').toBe('clamp-to-edge');
+  expect(sampler?.addressModeV, 'vertical wrapping remains authored').toBe('mirror-repeat');
+  expect(sampler?.magFilter, 'magnification filtering remains authored').toBe('nearest');
+  expect(sampler?.minFilter, 'minification filtering remains authored').toBe('nearest');
+  expect(sampler?.mipmapFilter, 'mipmap filtering remains authored').toBe('linear');
 
   for (const texture of parsedMaterial.generatedTextures) {
     texture.destroy();
   }
   device.destroy();
-  testContext.end();
 });

--- a/modules/gltf/test/parsers/parse-pbr-sampler.spec.ts
+++ b/modules/gltf/test/parsers/parse-pbr-sampler.spec.ts
@@ -5,9 +5,9 @@
 import {Buffer} from '@luma.gl/core';
 import {createGLTFTexture} from '@luma.gl/gltf';
 import {getWebGLTestDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('gltf#createGLTFTexture generates authored mipmaps on WebGL and WebGPU', async testContext => {
+it('gltf#createGLTFTexture generates authored mipmaps on WebGL and WebGPU', async () => {
   const image = await createImageBitmap(
     new ImageData(
       new Uint8ClampedArray([0, 0, 0, 255, 4, 0, 0, 255, 8, 0, 0, 255, 12, 0, 0, 255]),
@@ -40,17 +40,15 @@ test('gltf#createGLTFTexture generates authored mipmaps on WebGL and WebGPU', as
       });
 
       try {
-        testContext.equal(texture.mipLevels, 2, `${device.type} allocates the full mip chain`);
-        testContext.equal(
-          texture.format,
-          colorSpace === 'srgb' ? 'rgba8unorm-srgb' : 'rgba8unorm',
-          `${device.type} decodes ${colorSpace} textures exactly once`
+        expect(texture.mipLevels, `${device.type} allocates the full mip chain`).toBe(2);
+        expect(texture.format, `${device.type} decodes ${colorSpace} textures exactly once`).toBe(
+          colorSpace === 'srgb' ? 'rgba8unorm-srgb' : 'rgba8unorm'
         );
 
         texture.readBuffer({mipLevel: 1, width: 1, height: 1}, buffer);
         const mipLevel = new Uint8Array(await buffer.readAsync(0, layout.byteLength));
-        testContext.ok(mipLevel[0] > 0, `${device.type} generates ${colorSpace} mip texels`);
-        testContext.equal(mipLevel[3], 255, `${device.type} preserves authored mip opacity`);
+        expect(mipLevel[0] > 0, `${device.type} generates ${colorSpace} mip texels`).toBe(true);
+        expect(mipLevel[3], `${device.type} preserves authored mip opacity`).toBe(255);
       } finally {
         buffer.destroy();
         texture.destroy();
@@ -59,5 +57,4 @@ test('gltf#createGLTFTexture generates authored mipmaps on WebGL and WebGPU', as
   }
 
   image.close();
-  testContext.end();
 });

--- a/modules/gltf/test/webgl-to-webgpu/convert-webgl-sampler.node.spec.ts
+++ b/modules/gltf/test/webgl-to-webgpu/convert-webgl-sampler.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerConvertWebGLSamplerTests} from './convert-webgl-sampler.spec.shared';
 
-registerConvertWebGLSamplerTests(test);
+registerConvertWebGLSamplerTests();

--- a/modules/gltf/test/webgl-to-webgpu/convert-webgl-sampler.spec.shared.ts
+++ b/modules/gltf/test/webgl-to-webgpu/convert-webgl-sampler.spec.shared.ts
@@ -8,10 +8,10 @@ import {
 } from '@luma.gl/gltf/webgl-to-webgpu/convert-webgl-sampler';
 import {GLEnum} from '@luma.gl/gltf/webgl-to-webgpu/gltf-webgl-constants';
 import {convertSamplerParametersToWebGL} from '@luma.gl/webgl/adapter/converters/sampler-parameters';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-export function registerConvertWebGLSamplerTests(test: TapeTestFunction): void {
-  test('pbr#convertSampler#minFilter', async t => {
+export function registerConvertWebGLSamplerTests(): void {
+  it('pbr#convertSampler#minFilter', () => {
     [
       GLEnum.NEAREST,
       GLEnum.LINEAR,
@@ -24,37 +24,33 @@ export function registerConvertWebGLSamplerTests(test: TapeTestFunction): void {
       const gl = convertSamplerParametersToWebGL(props);
       const glValues = Object.values(gl);
 
-      t.equals(glValues.length, 1, 'Should return 1 value');
-      t.equals(glValues[0], minFilter, 'Value matches minFilter');
+      expect(glValues.length, 'Should return 1 value').toBe(1);
+      expect(glValues[0], 'Value matches minFilter').toBe(minFilter);
     });
 
-    t.deepEqual(convertSampler({}), {}, 'undefined sampler values are omitted');
-
-    t.end();
+    expect(convertSampler({}), 'undefined sampler values are omitted').toEqual({});
   });
 
-  test('pbr#convertSampler#magFilter', async t => {
+  it('pbr#convertSampler#magFilter', () => {
     [GLEnum.NEAREST, GLEnum.LINEAR].forEach(magFilter => {
       const props = convertSampler({magFilter});
       const gl = convertSamplerParametersToWebGL(props);
       const glValues = Object.values(gl);
 
-      t.equals(glValues.length, 1, 'Should return 1 value');
-      t.equals(glValues[0], magFilter, 'Value matches magFilter');
+      expect(glValues.length, 'Should return 1 value').toBe(1);
+      expect(glValues[0], 'Value matches magFilter').toBe(magFilter);
     });
-
-    t.end();
   });
 
-  test('pbr#convertSampler#wrap', async t => {
+  it('pbr#convertSampler#wrap', () => {
     [GLEnum.CLAMP_TO_EDGE, GLEnum.REPEAT, GLEnum.MIRRORED_REPEAT].forEach(wrap => {
       const props = convertSampler({wrapS: wrap, wrapT: wrap});
       const gl = convertSamplerParametersToWebGL(props);
       const glValues = Object.values(gl);
 
-      t.equals(glValues.length, 2, 'Should return 2 values');
-      t.equals(glValues[0], wrap, 'Value matches wrapT');
-      t.equals(glValues[1], wrap, 'Value matches wrapS');
+      expect(glValues.length, 'Should return 2 values').toBe(2);
+      expect(glValues[0], 'Value matches wrapT').toBe(wrap);
+      expect(glValues[1], 'Value matches wrapS').toBe(wrap);
     });
 
     const mixed = convertSampler({
@@ -63,22 +59,16 @@ export function registerConvertWebGLSamplerTests(test: TapeTestFunction): void {
       minFilter: GLEnum.LINEAR_MIPMAP_LINEAR,
       magFilter: GLEnum.LINEAR
     });
-    t.deepEqual(
-      mixed,
-      {
-        addressModeU: 'repeat',
-        addressModeV: 'clamp-to-edge',
-        minFilter: 'linear',
-        mipmapFilter: 'linear',
-        magFilter: 'linear'
-      },
-      'mixed sampler props are converted without dropping fields'
-    );
-
-    t.end();
+    expect(mixed, 'mixed sampler props are converted without dropping fields').toEqual({
+      addressModeU: 'repeat',
+      addressModeV: 'clamp-to-edge',
+      minFilter: 'linear',
+      mipmapFilter: 'linear',
+      magFilter: 'linear'
+    });
   });
 
-  test('pbr#convertSampler preserves postprocessed loaders.gl sampler parameters', async t => {
+  it('pbr#convertSampler preserves postprocessed loaders.gl sampler parameters', () => {
     const sampler = convertSampler({
       parameters: {
         [GLEnum.TEXTURE_WRAP_S]: GLEnum.CLAMP_TO_EDGE,
@@ -88,29 +78,26 @@ export function registerConvertWebGLSamplerTests(test: TapeTestFunction): void {
       }
     });
 
-    t.deepEqual(
+    expect(
       sampler,
-      {
-        addressModeU: 'clamp-to-edge',
-        addressModeV: 'mirror-repeat',
-        magFilter: 'nearest',
-        minFilter: 'nearest',
-        mipmapFilter: 'linear'
-      },
       'numeric postprocessed WebGL parameter keys preserve filtering and wrapping'
-    );
-    t.deepEqual(
+    ).toEqual({
+      addressModeU: 'clamp-to-edge',
+      addressModeV: 'mirror-repeat',
+      magFilter: 'nearest',
+      minFilter: 'nearest',
+      mipmapFilter: 'linear'
+    });
+    expect(
       convertSampler({
         wrapS: GLEnum.REPEAT,
         parameters: {[GLEnum.TEXTURE_WRAP_S]: GLEnum.CLAMP_TO_EDGE}
       }),
-      {addressModeU: 'repeat'},
       'explicit source glTF fields override postprocessed fallback values'
-    );
-    t.end();
+    ).toEqual({addressModeU: 'repeat'});
   });
 
-  test('pbr#convertSamplerToGLTF preserves every minification and mipmap combination', async t => {
+  it('pbr#convertSamplerToGLTF preserves every minification and mipmap combination', () => {
     for (const minFilter of [
       GLEnum.NEAREST,
       GLEnum.LINEAR,
@@ -119,14 +106,13 @@ export function registerConvertWebGLSamplerTests(test: TapeTestFunction): void {
       GLEnum.NEAREST_MIPMAP_LINEAR,
       GLEnum.LINEAR_MIPMAP_LINEAR
     ]) {
-      t.equal(
+      expect(
         convertSamplerToGLTF(convertSampler({minFilter})).minFilter,
-        minFilter,
         'glTF filtering round-trips through canonical portable sampler props'
-      );
+      ).toBe(minFilter);
     }
 
-    t.deepEqual(
+    expect(
       convertSamplerToGLTF({
         addressModeU: 'clamp-to-edge',
         addressModeV: 'mirror-repeat',
@@ -134,14 +120,12 @@ export function registerConvertWebGLSamplerTests(test: TapeTestFunction): void {
         minFilter: 'linear',
         mipmapFilter: 'nearest'
       }),
-      {
-        wrapS: GLEnum.CLAMP_TO_EDGE,
-        wrapT: GLEnum.MIRRORED_REPEAT,
-        magFilter: GLEnum.NEAREST,
-        minFilter: GLEnum.LINEAR_MIPMAP_NEAREST
-      },
       'authored portable sampler settings serialize into glTF WebGL enums'
-    );
-    t.end();
+    ).toEqual({
+      wrapS: GLEnum.CLAMP_TO_EDGE,
+      wrapT: GLEnum.MIRRORED_REPEAT,
+      magFilter: GLEnum.NEAREST,
+      minFilter: GLEnum.LINEAR_MIPMAP_NEAREST
+    });
   });
 }

--- a/modules/gltf/test/webgl-to-webgpu/convert-webgl-sampler.spec.ts
+++ b/modules/gltf/test/webgl-to-webgpu/convert-webgl-sampler.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerConvertWebGLSamplerTests} from './convert-webgl-sampler.spec.shared';
 
-registerConvertWebGLSamplerTests(test);
+registerConvertWebGLSamplerTests();

--- a/modules/gpgpu/test/gpu-core/gpu-batch-hash-index.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-batch-hash-index.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {
   GPUBatchHashIndex,
@@ -14,11 +14,9 @@ import {
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
-test('GPUBatchHashIndex preserves nullable batches, earliest duplicates, and source offsets', async testCase => {
+it('GPUBatchHashIndex preserves nullable batches, earliest duplicates, and source offsets', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
@@ -31,33 +29,39 @@ test('GPUBatchHashIndex preserves nullable batches, earliest duplicates, and sou
     encodingCount: 2
   });
 
-  testCase.deepEqual(
+  expect(
     result.values,
-    [40, 41, GPU_HASH_INDEX_EMPTY_KEY, 503, GPU_HASH_INDEX_EMPTY_KEY, GPU_HASH_INDEX_EMPTY_KEY],
     'generated values retain discontinuous batch offsets and globally earliest duplicates'
-  );
-  testCase.deepEqual(result.found, [1, 1, 0, 1, 0, 0], 'nullable keys are excluded from lookups');
-  testCase.deepEqual(
+  ).toEqual([
+    40,
+    41,
+    GPU_HASH_INDEX_EMPTY_KEY,
+    503,
+    GPU_HASH_INDEX_EMPTY_KEY,
+    GPU_HASH_INDEX_EMPTY_KEY
+  ]);
+  expect(result.found, 'nullable keys are excluded from lookups').toEqual([1, 1, 0, 1, 0, 0]);
+  expect(
     result.buildStatistics.slice(0, 4),
-    [3, 1, 0, 1],
     'counts valid duplicates and reserved keys while silently skipping invalid/null rows'
-  );
-  testCase.equal(
+  ).toEqual([3, 1, 0, 1]);
+  expect(
     result.tableKeys.filter(key => key !== GPU_HASH_INDEX_EMPTY_KEY).length,
-    3,
     'one shared table slot is retained per distinct valid key'
+  ).toBe(3);
+  expect(
+    Boolean(result.buildStatistics[4] >= 4),
+    'cumulative probes include every non-null valid row'
+  ).toBe(true);
+  expect(Boolean(result.buildStatistics[5] <= 8), 'all chunks obey the common probe bound').toBe(
+    true
   );
-  testCase.ok(result.buildStatistics[4] >= 4, 'cumulative probes include every non-null valid row');
-  testCase.ok(result.buildStatistics[5] <= 8, 'all chunks obey the common probe bound');
-  testCase.deepEqual(result.queryStatistics.slice(0, 2), [3, 3], 're-encoding resets diagnostics');
-  testCase.end();
+  expect(result.queryStatistics.slice(0, 2), 're-encoding resets diagnostics').toEqual([3, 3]);
 });
 
-test('GPUBatchHashIndex resolves explicit payloads across offset chunk views', async testCase => {
+it('GPUBatchHashIndex resolves explicit payloads across offset chunk views', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
@@ -69,25 +73,17 @@ test('GPUBatchHashIndex resolves explicit payloads across offset chunk views', a
     sourceByteOffset: 8
   });
 
-  testCase.deepEqual(
+  expect(
     result.values,
-    [500, 800, 1300, 2100],
     'later duplicate chunks cannot overwrite the globally first explicit payload'
-  );
-  testCase.deepEqual(result.found, [1, 1, 1, 1], 'finds keys originating in distinct GPU buffers');
-  testCase.deepEqual(
-    result.buildStatistics.slice(0, 4),
-    [4, 1, 0, 0],
-    'accumulates chunk statistics'
-  );
-  testCase.end();
+  ).toEqual([500, 800, 1300, 2100]);
+  expect(result.found, 'finds keys originating in distinct GPU buffers').toEqual([1, 1, 1, 1]);
+  expect(result.buildStatistics.slice(0, 4), 'accumulates chunk statistics').toEqual([4, 1, 0, 0]);
 });
 
-test('GPUBatchHashIndex accumulates bounded overflow without resetting between chunks', async testCase => {
+it('GPUBatchHashIndex accumulates bounded overflow without resetting between chunks', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
@@ -98,48 +94,36 @@ test('GPUBatchHashIndex accumulates bounded overflow without resetting between c
     capacity: 2
   });
 
-  testCase.deepEqual(
+  expect(
     result.buildStatistics.slice(0, 4),
-    [2, 0, 2, 0],
     'later distinct keys report fixed-capacity overflow without clearing earlier rows'
-  );
-  testCase.deepEqual(result.found, [1, 1, 0, 0], 'only first-batch keys remain available');
-  testCase.deepEqual(
-    result.values,
-    [10, 11, GPU_HASH_INDEX_EMPTY_KEY, GPU_HASH_INDEX_EMPTY_KEY],
-    'surviving keys preserve original first-source offsets'
-  );
-  testCase.end();
+  ).toEqual([2, 0, 2, 0]);
+  expect(result.found, 'only first-batch keys remain available').toEqual([1, 1, 0, 0]);
+  expect(result.values, 'surviving keys preserve original first-source offsets').toEqual([
+    10,
+    11,
+    GPU_HASH_INDEX_EMPTY_KEY,
+    GPU_HASH_INDEX_EMPTY_KEY
+  ]);
 });
 
-test('GPUBatchHashIndex clears zero-chunk and empty-chunk index topologies', async testCase => {
+it('GPUBatchHashIndex clears zero-chunk and empty-chunk index topologies', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
   for (const keys of [[], [[], []]] as readonly (readonly number[])[][]) {
     const result = await runBatchHashIndex(device, {keys, queryKeys: [1], capacity: 4});
-    testCase.deepEqual(
-      result.tableKeys,
-      [
-        GPU_HASH_INDEX_EMPTY_KEY,
-        GPU_HASH_INDEX_EMPTY_KEY,
-        GPU_HASH_INDEX_EMPTY_KEY,
-        GPU_HASH_INDEX_EMPTY_KEY
-      ],
-      'empty source topologies initialize every shared table slot'
-    );
-    testCase.deepEqual(
-      result.buildStatistics,
-      [0, 0, 0, 0, 0, 0],
-      'empty chunks add no statistics'
-    );
-    testCase.deepEqual(result.found, [0], 'empty tables do not publish matches');
+    expect(result.tableKeys, 'empty source topologies initialize every shared table slot').toEqual([
+      GPU_HASH_INDEX_EMPTY_KEY,
+      GPU_HASH_INDEX_EMPTY_KEY,
+      GPU_HASH_INDEX_EMPTY_KEY,
+      GPU_HASH_INDEX_EMPTY_KEY
+    ]);
+    expect(result.buildStatistics, 'empty chunks add no statistics').toEqual([0, 0, 0, 0, 0, 0]);
+    expect(result.found, 'empty tables do not publish matches').toEqual([0]);
   }
-  testCase.end();
 });
 
 type BatchHashIndexFixture = {

--- a/modules/gpgpu/test/gpu-core/gpu-batch-hash-join.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-batch-hash-join.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {
   GPUBatchHashJoin,
@@ -12,11 +12,9 @@ import {
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
-test('GPUBatchHashJoin preserves uneven and empty batch boundaries', async t => {
+it('GPUBatchHashJoin preserves uneven and empty batch boundaries', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -26,40 +24,36 @@ test('GPUBatchHashJoin preserves uneven and empty batch boundaries', async t => 
     firstLeftRow: 100
   });
 
-  t.deepEqual(result.counts, [1, 0, 3], 'each batch reports its own required match count');
-  t.deepEqual(result.overflows, [0, 0, 1], 'only the truncated batch overflows');
-  t.deepEqual(
-    result.leftRows,
-    [[100, 0], [], [102, 103]],
-    'global IDs advance across preserved chunks'
-  );
-  t.deepEqual(
-    result.rightRows,
-    [[700, 0], [], [200, 700]],
-    'pairs cannot spill between batch capacities'
-  );
-  t.deepEqual(
-    result.found,
-    [[1, 0], [], [1, 1, 1]],
-    'aligned match masks preserve source topology'
-  );
-  t.deepEqual(
+  expect(result.counts, 'each batch reports its own required match count').toEqual([1, 0, 3]);
+  expect(result.overflows, 'only the truncated batch overflows').toEqual([0, 0, 1]);
+  expect(result.leftRows, 'global IDs advance across preserved chunks').toEqual([
+    [100, 0],
+    [],
+    [102, 103]
+  ]);
+  expect(result.rightRows, 'pairs cannot spill between batch capacities').toEqual([
+    [700, 0],
+    [],
+    [200, 700]
+  ]);
+  expect(result.found, 'aligned match masks preserve source topology').toEqual([
+    [1, 0],
+    [],
+    [1, 1, 1]
+  ]);
+  expect(
     result.statistics.map(block => block.slice(0, 2)),
-    [
-      [1, 1],
-      [0, 0],
-      [3, 0]
-    ],
     'query statistics stay batch-addressable'
-  );
-  t.end();
+  ).toEqual([
+    [1, 1],
+    [0, 0],
+    [3, 0]
+  ]);
 });
 
-test('GPUBatchHashJoin preserves explicit IDs and propagates source overflow per batch', async t => {
+it('GPUBatchHashJoin preserves explicit IDs and propagates source overflow per batch', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -72,27 +66,26 @@ test('GPUBatchHashJoin preserves explicit IDs and propagates source overflow per
     outputCapacities: [1, 2]
   });
 
-  t.deepEqual(result.overflows, [1, 1], 'an incomplete shared index marks every batch incomplete');
+  expect(result.overflows, 'an incomplete shared index marks every batch incomplete').toEqual([
+    1, 1
+  ]);
   for (let batchIndex = 0; batchIndex < result.leftRows.length; batchIndex++) {
     for (
       let outputIndex = 0;
       outputIndex < Math.min(result.counts[batchIndex], result.leftRows[batchIndex].length);
       outputIndex++
     ) {
-      t.ok(
-        [900, 800, 700].includes(result.leftRows[batchIndex][outputIndex]),
+      expect(
+        Boolean([900, 800, 700].includes(result.leftRows[batchIndex][outputIndex])),
         'retained matches use explicit left IDs'
-      );
+      ).toBe(true);
     }
   }
-  t.end();
 });
 
-test('GPUBatchHashJoin reports matches for nonempty zero-capacity batches', async t => {
+it('GPUBatchHashJoin reports matches for nonempty zero-capacity batches', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -101,19 +94,16 @@ test('GPUBatchHashJoin reports matches for nonempty zero-capacity batches', asyn
     outputCapacities: [0, 0]
   });
 
-  t.deepEqual(result.leftRows, [[], []], 'zero-capacity output chunks retain their topology');
-  t.deepEqual(result.rightRows, [[], []]);
-  t.deepEqual(result.counts, [2, 0], 'required counts remain exact without output bindings');
-  t.deepEqual(result.overflows, [1, 0], 'only a nonempty required result overflows');
-  t.deepEqual(result.found, [[1, 1], [0]], 'source-aligned lookup masks remain available');
-  t.end();
+  expect(result.leftRows, 'zero-capacity output chunks retain their topology').toEqual([[], []]);
+  expect(result.rightRows).toEqual([[], []]);
+  expect(result.counts, 'required counts remain exact without output bindings').toEqual([2, 0]);
+  expect(result.overflows, 'only a nonempty required result overflows').toEqual([1, 0]);
+  expect(result.found, 'source-aligned lookup masks remain available').toEqual([[1, 1], [0]]);
 });
 
-test('GPUBatchHashJoin validates partition and output topology', async t => {
+it('GPUBatchHashJoin validates partition and output topology', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -132,7 +122,7 @@ test('GPUBatchHashJoin validates partition and output topology', async t => {
     maxProbeCount: 4
   };
 
-  t.throws(
+  expect(
     () =>
       new GPUBatchHashJoin({
         index,
@@ -143,10 +133,9 @@ test('GPUBatchHashJoin validates partition and output topology', async t => {
         overflows: importView(graph, 'overflows', overflows, 2),
         statistics: importView(graph, 'statistics', statistics, 8)
       }),
-    /one capacity chunk per input batch/,
     'every input batch requires an output partition'
-  );
-  t.throws(
+  ).toThrow(/one capacity chunk per input batch/);
+  expect(
     () =>
       new GPUBatchHashJoin({
         index,
@@ -157,9 +146,8 @@ test('GPUBatchHashJoin validates partition and output topology', async t => {
         overflows: importView(graph, 'overflows-alias', overflows, 2),
         statistics: importView(graph, 'statistics-alias', statistics, 8)
       }),
-    /output views must not overlap/,
     'pair outputs cannot alias'
-  );
+  ).toThrow(/output views must not overlap/);
 
   destroyBuffers([
     ...keys.buffers,
@@ -171,7 +159,6 @@ test('GPUBatchHashJoin validates partition and output topology', async t => {
     overflows,
     statistics
   ]);
-  t.end();
 });
 
 type BatchJoinProps = {

--- a/modules/gpgpu/test/gpu-core/gpu-bvh-query.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-bvh-query.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {
   GPUBVH,
@@ -13,11 +13,9 @@ import {
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
-test('GPUBVHQuery traverses 2D bounds and clears reusable result masks', async t => {
+it('GPUBVHQuery traverses 2D bounds and clears reusable result masks', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -33,25 +31,22 @@ test('GPUBVHQuery traverses 2D bounds and clears reusable result masks', async t
   });
   encode(device, fixture.compiled);
 
-  t.deepEqual(await readSortedOutput(fixture), [0, 1], 'bounds query matches the CPU oracle');
-  t.deepEqual(await readUint32(fixture.outputMask, 4), [1, 1, 0, 0]);
-  t.deepEqual(await readUint32(fixture.overflow, 1), [0]);
-  t.deepEqual(await readUint32(fixture.visitedCount, 1), [5], 'the disjoint subtree is pruned');
+  expect(await readSortedOutput(fixture), 'bounds query matches the CPU oracle').toEqual([0, 1]);
+  expect(await readUint32(fixture.outputMask, 4)).toEqual([1, 1, 0, 0]);
+  expect(await readUint32(fixture.overflow, 1)).toEqual([0]);
+  expect(await readUint32(fixture.visitedCount, 1), 'the disjoint subtree is pruned').toEqual([5]);
 
   fixture.query.write(Float32Array.from([11.5, 9.5, 13.5, 11.5]));
   encode(device, fixture.compiled);
-  t.deepEqual(await readSortedOutput(fixture), [3], 'the same graph accepts a new query');
-  t.deepEqual(await readUint32(fixture.outputMask, 4), [0, 0, 0, 1], 'old mask bits clear');
+  expect(await readSortedOutput(fixture), 'the same graph accepts a new query').toEqual([3]);
+  expect(await readUint32(fixture.outputMask, 4), 'old mask bits clear').toEqual([0, 0, 0, 1]);
 
   destroyFixture(fixture);
-  t.end();
 });
 
-test('GPUBVHQuery traverses 3D points and reports bounded-output overflow', async t => {
+it('GPUBVHQuery traverses 3D points and reports bounded-output overflow', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -67,37 +62,36 @@ test('GPUBVHQuery traverses 3D points and reports bounded-output overflow', asyn
   });
   encode(device, fixture.compiled);
 
-  t.deepEqual(await readUint32(fixture.count, 1), [2], 'count is the complete CPU-oracle result');
-  t.deepEqual(
-    await readUint32(fixture.overflow, 1),
-    [1],
-    'source or output truncation is explicit'
-  );
+  expect(await readUint32(fixture.count, 1), 'count is the complete CPU-oracle result').toEqual([
+    2
+  ]);
+  expect(await readUint32(fixture.overflow, 1), 'source or output truncation is explicit').toEqual([
+    1
+  ]);
   const storedOutput = await readUint32(fixture.output, 1);
-  t.ok(storedOutput[0] === 0 || storedOutput[0] === 1, 'one matching stable ID is stored');
+  expect(
+    Boolean(storedOutput[0] === 0 || storedOutput[0] === 1),
+    'one matching stable ID is stored'
+  ).toBe(true);
   const outputMask = await readUint32(fixture.outputMask, 4);
-  t.equal(
+  expect(
     outputMask.reduce((sum, value) => sum + value, 0),
-    1,
     'mask describes stored output'
-  );
-  t.equal(outputMask[storedOutput[0]], 1);
+  ).toBe(1);
+  expect(outputMask[storedOutput[0]]).toBe(1);
 
   fixture.query.write(Float32Array.from([Number.NaN, 0, 0]));
   encode(device, fixture.compiled);
-  t.deepEqual(await readUint32(fixture.count, 1), [0], 'non-finite queries match nothing');
-  t.deepEqual(await readUint32(fixture.overflow, 1), [1], 'source BVH overflow is propagated');
-  t.deepEqual(await readUint32(fixture.outputMask, 4), [0, 0, 0, 0]);
+  expect(await readUint32(fixture.count, 1), 'non-finite queries match nothing').toEqual([0]);
+  expect(await readUint32(fixture.overflow, 1), 'source BVH overflow is propagated').toEqual([1]);
+  expect(await readUint32(fixture.outputMask, 4)).toEqual([0, 0, 0, 0]);
 
   destroyFixture(fixture);
-  t.end();
 });
 
-test('GPUBVHQuery preserves maximum stable IDs and rejects overlapping views', async t => {
+it('GPUBVHQuery preserves maximum stable IDs and rejects overlapping views', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -113,11 +107,13 @@ test('GPUBVHQuery preserves maximum stable IDs and rejects overlapping views', a
     maskLength: 2
   });
   encode(device, fixture.compiled);
-  t.deepEqual(await readSortedOutput(fixture), [0xffffffff], 'the full uint32 ID range survives');
-  t.deepEqual(await readUint32(fixture.count, 1), [1], 'invalid empty leaves remain excluded');
+  expect(await readSortedOutput(fixture), 'the full uint32 ID range survives').toEqual([
+    0xffffffff
+  ]);
+  expect(await readUint32(fixture.count, 1), 'invalid empty leaves remain excluded').toEqual([1]);
 
   const query = fixture.workflow;
-  t.throws(
+  expect(
     () =>
       new GPUBVHQuery({
         bvh: query.bvh,
@@ -127,10 +123,9 @@ test('GPUBVHQuery preserves maximum stable IDs and rejects overlapping views', a
         count: query.count,
         overflow: query.overflow
       }),
-    /must not overlap query or BVH inputs/,
     'stable leaf IDs cannot alias writable output'
-  );
-  t.throws(
+  ).toThrow(/must not overlap query or BVH inputs/);
+  expect(
     () =>
       new GPUBVHQuery({
         bvh: query.bvh,
@@ -140,12 +135,10 @@ test('GPUBVHQuery preserves maximum stable IDs and rejects overlapping views', a
         count: query.count,
         overflow: query.count
       }),
-    /must not overlap one another/,
     'count and overflow require independent writable storage'
-  );
+  ).toThrow(/must not overlap one another/);
 
   destroyFixture(fixture);
-  t.end();
 });
 
 type Fixture = {

--- a/modules/gpgpu/test/gpu-core/gpu-bvh.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-bvh.node.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import type {GPUCommandGraph, GraphDataView} from '../../src/gpu-core/gpu-command-graph';
 import {GPUBVH, type GPUBVHStrategy} from '../../src/gpu-core/gpu-bvh';
 
@@ -15,27 +15,24 @@ type MockGraph = GPUCommandGraph & {
   recordedNodes: RecordedGraphNode[];
 };
 
-test('GPUBVH automatically fuses portable small hierarchies into one graph node', testCase => {
+it('GPUBVH automatically fuses portable small hierarchies into one graph node', () => {
   const graph = makeGraph();
   const hierarchy = makeHierarchy(graph, {dimension: 3, leafCapacity: 128, sourceCount: 87});
   hierarchy.addToGraph(graph);
 
-  testCase.equal(hierarchy.strategy, 'auto');
-  testCase.equal(hierarchy.resolvedStrategy, 'fused');
-  testCase.deepEqual(
+  expect(hierarchy.strategy).toBe('auto');
+  expect(hierarchy.resolvedStrategy).toBe('fused');
+  expect(
     graph.recordedNodes.map(node => node.id),
-    ['test-bvh-fused-refit'],
     'all eight parent levels are synchronized within one graph node'
-  );
-  testCase.equal(
+  ).toEqual(['test-bvh-fused-refit']);
+  expect(
     graph.recordedNodes[0].resources.length,
-    8,
     'generated source IDs preserve the default CORE storage-buffer limit'
-  );
-  testCase.end();
+  ).toBe(8);
 });
 
-test('GPUBVH preserves explicit source IDs in the fused graph contributor', testCase => {
+it('GPUBVH preserves explicit source IDs in the fused graph contributor', () => {
   const graph = makeGraph();
   const hierarchy = makeHierarchy(graph, {
     dimension: 2,
@@ -45,36 +42,26 @@ test('GPUBVH preserves explicit source IDs in the fused graph contributor', test
   });
   hierarchy.addToGraph(graph);
 
-  testCase.equal(hierarchy.resolvedStrategy, 'fused');
-  testCase.deepEqual(
+  expect(hierarchy.resolvedStrategy).toBe('fused');
+  expect(
     graph.recordedNodes.map(node => node.id),
-    ['test-bvh-fused-refit', 'test-bvh-remap-source-ids'],
     'stable source IDs are remapped after the complete fused hierarchy is published'
-  );
-  testCase.equal(
+  ).toEqual(['test-bvh-fused-refit', 'test-bvh-remap-source-ids']);
+  expect(
     graph.recordedNodes[0].resources.length,
-    8,
     'explicit IDs do not exceed the default CORE storage-buffer limit'
+  ).toBe(8);
+  expect(graph.recordedNodes[1].resources.length, 'identity remapping needs two buffers').toBe(2);
+  expect(graph.recordedNodes[1].resources[0].usage, 'stable source IDs are never overwritten').toBe(
+    'storage-read'
   );
-  testCase.equal(
-    graph.recordedNodes[1].resources.length,
-    2,
-    'identity remapping needs two buffers'
-  );
-  testCase.equal(
-    graph.recordedNodes[1].resources[0].usage,
-    'storage-read',
-    'stable source IDs are never overwritten'
-  );
-  testCase.equal(
+  expect(
     graph.recordedNodes[1].resources[1].usage,
-    'storage-read-write',
     'remapping waits for published leaf identities and preserves empty leaf slots'
-  );
-  testCase.end();
+  ).toBe('storage-read-write');
 });
 
-test('GPUBVH remaps explicit source IDs after per-level hierarchy publication', testCase => {
+it('GPUBVH remaps explicit source IDs after per-level hierarchy publication', () => {
   const graph = makeGraph();
   const hierarchy = makeHierarchy(graph, {
     dimension: 3,
@@ -85,40 +72,31 @@ test('GPUBVH remaps explicit source IDs after per-level hierarchy publication', 
   });
   hierarchy.addToGraph(graph);
 
-  testCase.equal(hierarchy.resolvedStrategy, 'level');
-  testCase.deepEqual(
-    graph.recordedNodes.map(node => node.id),
-    [
-      'test-bvh-load-leaves',
-      'test-bvh-refit-depth-1',
-      'test-bvh-refit-depth-0',
-      'test-bvh-remap-source-ids'
-    ]
-  );
-  testCase.equal(
+  expect(hierarchy.resolvedStrategy).toBe('level');
+  expect(graph.recordedNodes.map(node => node.id)).toEqual([
+    'test-bvh-load-leaves',
+    'test-bvh-refit-depth-1',
+    'test-bvh-refit-depth-0',
+    'test-bvh-remap-source-ids'
+  ]);
+  expect(
     Math.max(...graph.recordedNodes.map(node => node.resources.length)),
-    8,
     'every level and source-ID remapping pass remains within CORE storage-buffer limits'
-  );
-  testCase.end();
+  ).toBe(8);
 });
 
-test('GPUBVH fuses empty and singleton hierarchies without requiring a parent level', testCase => {
+it('GPUBVH fuses empty and singleton hierarchies without requiring a parent level', () => {
   const graph = makeGraph();
   const hierarchy = makeHierarchy(graph, {dimension: 2, leafCapacity: 1, sourceCount: 0});
   hierarchy.addToGraph(graph);
 
-  testCase.equal(hierarchy.resolvedStrategy, 'fused');
-  testCase.equal(hierarchy.internalNodeCount, 0);
-  testCase.equal(hierarchy.levelCount, 1);
-  testCase.deepEqual(
-    graph.recordedNodes.map(node => node.id),
-    ['test-bvh-fused-refit']
-  );
-  testCase.end();
+  expect(hierarchy.resolvedStrategy).toBe('fused');
+  expect(hierarchy.internalNodeCount).toBe(0);
+  expect(hierarchy.levelCount).toBe(1);
+  expect(graph.recordedNodes.map(node => node.id)).toEqual(['test-bvh-fused-refit']);
 });
 
-test('GPUBVH retains forced and automatic multi-pass hierarchy construction', testCase => {
+it('GPUBVH retains forced and automatic multi-pass hierarchy construction', () => {
   const forcedGraph = makeGraph();
   const forcedHierarchy = makeHierarchy(forcedGraph, {
     dimension: 2,
@@ -128,11 +106,12 @@ test('GPUBVH retains forced and automatic multi-pass hierarchy construction', te
   });
   forcedHierarchy.addToGraph(forcedGraph);
 
-  testCase.equal(forcedHierarchy.resolvedStrategy, 'level');
-  testCase.deepEqual(
-    forcedGraph.recordedNodes.map(node => node.id),
-    ['test-bvh-load-leaves', 'test-bvh-refit-depth-1', 'test-bvh-refit-depth-0']
-  );
+  expect(forcedHierarchy.resolvedStrategy).toBe('level');
+  expect(forcedGraph.recordedNodes.map(node => node.id)).toEqual([
+    'test-bvh-load-leaves',
+    'test-bvh-refit-depth-1',
+    'test-bvh-refit-depth-0'
+  ]);
 
   const largeGraph = makeGraph();
   const largeHierarchy = makeHierarchy(largeGraph, {
@@ -142,19 +121,18 @@ test('GPUBVH retains forced and automatic multi-pass hierarchy construction', te
   });
   largeHierarchy.addToGraph(largeGraph);
 
-  testCase.equal(largeHierarchy.resolvedStrategy, 'level');
-  testCase.equal(largeGraph.recordedNodes.length, 9, 'one leaf load precedes eight tree levels');
-  testCase.end();
+  expect(largeHierarchy.resolvedStrategy).toBe('level');
+  expect(largeGraph.recordedNodes.length, 'one leaf load precedes eight tree levels').toBe(9);
 });
 
-test('GPUBVH checks workgroup capacity and rejects unsupported forced fusion', testCase => {
+it('GPUBVH checks workgroup capacity and rejects unsupported forced fusion', () => {
   const restrictedInvocations = makeGraph({maxComputeInvocationsPerWorkgroup: 32});
   const invocationHierarchy = makeHierarchy(restrictedInvocations, {
     dimension: 2,
     leafCapacity: 64,
     sourceCount: 17
   });
-  testCase.equal(invocationHierarchy.resolvedStrategy, 'level');
+  expect(invocationHierarchy.resolvedStrategy).toBe('level');
 
   const restrictedStorage = makeGraph({maxComputeWorkgroupStorageSize: 1024});
   const storageHierarchy = makeHierarchy(restrictedStorage, {
@@ -162,18 +140,15 @@ test('GPUBVH checks workgroup capacity and rejects unsupported forced fusion', t
     leafCapacity: 32,
     sourceCount: 17
   });
-  testCase.equal(storageHierarchy.resolvedStrategy, 'level');
-  testCase.throws(
-    () =>
-      makeHierarchy(restrictedStorage, {
-        dimension: 3,
-        leafCapacity: 32,
-        sourceCount: 17,
-        strategy: 'fused'
-      }),
-    /fused strategy exceeds portable single-workgroup limits/
-  );
-  testCase.end();
+  expect(storageHierarchy.resolvedStrategy).toBe('level');
+  expect(() =>
+    makeHierarchy(restrictedStorage, {
+      dimension: 3,
+      leafCapacity: 32,
+      sourceCount: 17,
+      strategy: 'fused'
+    })
+  ).toThrow(/fused strategy exceeds portable single-workgroup limits/);
 });
 
 function makeGraph(limitOverrides: Record<string, number> = {}): MockGraph {

--- a/modules/gpgpu/test/gpu-core/gpu-bvh.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-bvh.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {
   GPUBVH,
@@ -13,20 +13,16 @@ import {
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import {getGPUBVHDispatchLayout} from '../../src/gpu-core/gpu-bvh';
 
-test('GPUBVH plans multidimensional leaf-loading dispatches', t => {
-  t.deepEqual(
+it('GPUBVH plans multidimensional leaf-loading dispatches', () => {
+  expect(
     getGPUBVHDispatchLayout(2 ** 24 - 1, 65535),
-    {x: 65535, y: 2, z: 1},
     'the largest standard-binding 2D tree does not exceed the per-dimension limit'
-  );
-  t.end();
+  ).toEqual({x: 65535, y: 2, z: 1});
 });
 
-test('GPUBVH builds deterministic 2D topology and bounds', async t => {
+it('GPUBVH builds deterministic 2D topology and bounds', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -38,28 +34,28 @@ test('GPUBVH builds deterministic 2D topology and bounds', async t => {
   });
   encode(device, fixture.compiled);
 
-  t.deepEqual(
-    await readUint32(fixture.children, 14),
-    [
-      1, 2, 3, 4, 5, 6, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-      0xffffffff, 0xffffffff
-    ]
+  expect(await readUint32(fixture.children, 14)).toEqual([
+    1, 2, 3, 4, 5, 6, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+    0xffffffff, 0xffffffff
+  ]);
+  expect(await readUint32(fixture.leafIds, 4)).toEqual([0, 1, 2, 0xffffffff]);
+  expect(await readFloat32(fixture.nodeMinima, 2), 'root contains every valid leaf').toEqual([
+    -2, 0
+  ]);
+  expect(await readFloat32(fixture.nodeMaxima, 2)).toEqual([5, 6]);
+  expect(await readUint32(fixture.count, 1)).toEqual([3]);
+  expect(await readUint32(fixture.overflow, 1)).toEqual([0]);
+  expect(fixture.bvh.topology).toBe('complete-binary');
+  expect(fixture.bvh.updatePolicy).toBe('refit');
+  expect(fixture.bvh.strategy, 'small hierarchies select their strategy automatically').toBe(
+    'auto'
   );
-  t.deepEqual(await readUint32(fixture.leafIds, 4), [0, 1, 2, 0xffffffff]);
-  t.deepEqual(await readFloat32(fixture.nodeMinima, 2), [-2, 0], 'root contains every valid leaf');
-  t.deepEqual(await readFloat32(fixture.nodeMaxima, 2), [5, 6]);
-  t.deepEqual(await readUint32(fixture.count, 1), [3]);
-  t.deepEqual(await readUint32(fixture.overflow, 1), [0]);
-  t.equal(fixture.bvh.topology, 'complete-binary');
-  t.equal(fixture.bvh.updatePolicy, 'refit');
-  t.equal(fixture.bvh.strategy, 'auto', 'small hierarchies select their strategy automatically');
-  t.equal(fixture.bvh.resolvedStrategy, 'fused', 'small hierarchies use one workgroup');
-  t.deepEqual(
+  expect(fixture.bvh.resolvedStrategy, 'small hierarchies use one workgroup').toBe('fused');
+  expect(
     fixture.compiled.stats.nodeOrder,
-    ['test-bvh-fused-refit'],
     'leaf loading and every parent level execute in one graph node'
-  );
-  t.deepEqual(fixture.bvh.stats, {
+  ).toEqual(['test-bvh-fused-refit']);
+  expect(fixture.bvh.stats).toEqual({
     dimension: 2,
     leafCapacity: 4,
     internalNodeCount: 3,
@@ -69,21 +65,17 @@ test('GPUBVH builds deterministic 2D topology and bounds', async t => {
   });
 
   destroyFixture(fixture);
-  t.end();
 });
 
-test('GPUBVH refits 3D bounds while preserving stable IDs and reports capacity overflow', async t => {
+it('GPUBVH refits 3D bounds while preserving stable IDs and reports capacity overflow', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
-  t.equal(
+  expect(
     device.limits.maxStorageBuffersPerShaderStage,
-    8,
     'explicit stable IDs work within the default WebGPU CORE storage-buffer limit'
-  );
+  ).toBe(8);
 
   const fixture = createFixture(device, {
     dimension: 3,
@@ -96,41 +88,36 @@ test('GPUBVH refits 3D bounds while preserving stable IDs and reports capacity o
   });
   encode(device, fixture.compiled);
 
-  t.deepEqual(await readFloat32(fixture.nodeMinima, 3), [-1, -2, 0]);
-  t.deepEqual(await readFloat32(fixture.nodeMaxima, 3), [6, 5, 7]);
-  t.deepEqual(
+  expect(await readFloat32(fixture.nodeMinima, 3)).toEqual([-1, -2, 0]);
+  expect(await readFloat32(fixture.nodeMaxima, 3)).toEqual([6, 5, 7]);
+  expect(
     await readUint32(fixture.leafIds, 6),
-    [0, 0, 10, 0xffffffff, 30, 40],
     'source and destination offsets preserve surrounding storage and the maximum stable ID'
-  );
-  t.deepEqual(await readUint32(fixture.count, 1), [5], 'count reports required leaf capacity');
-  t.deepEqual(await readUint32(fixture.overflow, 1), [1], 'the fifth leaf is not written');
+  ).toEqual([0, 0, 10, 0xffffffff, 30, 40]);
+  expect(await readUint32(fixture.count, 1), 'count reports required leaf capacity').toEqual([5]);
+  expect(await readUint32(fixture.overflow, 1), 'the fifth leaf is not written').toEqual([1]);
 
   fixture.minima.write(Float32Array.from([8, 8, 8, 2, 2, 2, -1, 3, 1, 4, -2, 0, 100, 100, 100]));
   fixture.maxima.write(Float32Array.from([9, 9, 9, 3, 4, 5, 0, 5, 2, 6, 0, 7, 101, 101, 101]));
   encode(device, fixture.compiled);
-  t.deepEqual(await readFloat32(fixture.nodeMinima, 3), [-1, -2, 0]);
-  t.deepEqual(await readFloat32(fixture.nodeMaxima, 3), [9, 9, 9], 'root refits updated leaves');
-  t.deepEqual(
+  expect(await readFloat32(fixture.nodeMinima, 3)).toEqual([-1, -2, 0]);
+  expect(await readFloat32(fixture.nodeMaxima, 3), 'root refits updated leaves').toEqual([9, 9, 9]);
+  expect(
     await readUint32(fixture.leafIds, 4, fixture.leafIdsByteOffset),
-    [10, 0xffffffff, 30, 40],
     'identity is stable across repeated encoding'
-  );
-  t.equal(fixture.bvh.resolvedStrategy, 'fused', 'explicit source IDs preserve fused refits');
-  t.deepEqual(fixture.compiled.stats.nodeOrder, [
+  ).toEqual([10, 0xffffffff, 30, 40]);
+  expect(fixture.bvh.resolvedStrategy, 'explicit source IDs preserve fused refits').toBe('fused');
+  expect(fixture.compiled.stats.nodeOrder).toEqual([
     'test-bvh-fused-refit',
     'test-bvh-remap-source-ids'
   ]);
 
   destroyFixture(fixture);
-  t.end();
 });
 
-test('GPUBVH fused and per-level strategies publish identical invalid and padded bounds', async t => {
+it('GPUBVH fused and per-level strategies publish identical invalid and padded bounds', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -147,61 +134,53 @@ test('GPUBVH fused and per-level strategies publish identical invalid and padded
   encode(device, perLevel.compiled);
 
   const nodeCount = bounds.leafCapacity * 2 - 1;
-  t.equal(fused.bvh.resolvedStrategy, 'fused');
-  t.equal(perLevel.bvh.resolvedStrategy, 'level');
-  t.equal(
+  expect(fused.bvh.resolvedStrategy).toBe('fused');
+  expect(perLevel.bvh.resolvedStrategy).toBe('level');
+  expect(
     fused.compiled.stats.nodeOrder.length,
-    2,
     'fused construction adds only the CORE-compatible source-ID remapping node'
-  );
-  t.equal(
+  ).toBe(2);
+  expect(
     perLevel.compiled.stats.nodeOrder.length,
-    5,
     'per-level construction adds only the CORE-compatible source-ID remapping node'
-  );
-  t.ok(
-    perLevel.compiled.stats.nodeOrder.indexOf('test-bvh-load-leaves') <
-      perLevel.compiled.stats.nodeOrder.indexOf('test-bvh-remap-source-ids'),
+  ).toBe(5);
+  expect(
+    Boolean(
+      perLevel.compiled.stats.nodeOrder.indexOf('test-bvh-load-leaves') <
+        perLevel.compiled.stats.nodeOrder.indexOf('test-bvh-remap-source-ids')
+    ),
     'the graph remaps explicit IDs only after their implicit leaf slots have been published'
-  );
-  t.deepEqual(
+  ).toBe(true);
+  expect(
     await readFloat32(fused.nodeMinima, nodeCount * bounds.dimension),
-    await readFloat32(perLevel.nodeMinima, nodeCount * bounds.dimension),
     'invalid and padded leaf minima reduce identically'
-  );
-  t.deepEqual(
+  ).toEqual(await readFloat32(perLevel.nodeMinima, nodeCount * bounds.dimension));
+  expect(
     await readFloat32(fused.nodeMaxima, nodeCount * bounds.dimension),
-    await readFloat32(perLevel.nodeMaxima, nodeCount * bounds.dimension),
     'invalid and padded leaf maxima reduce identically'
-  );
-  t.deepEqual(
+  ).toEqual(await readFloat32(perLevel.nodeMaxima, nodeCount * bounds.dimension));
+  expect(
     await readUint32(fused.children, nodeCount * 2),
-    await readUint32(perLevel.children, nodeCount * 2),
     'both strategies publish the same complete-binary child topology'
-  );
-  t.deepEqual(
+  ).toEqual(await readUint32(perLevel.children, nodeCount * 2));
+  expect(
     await readUint32(fused.leafIds, bounds.leafCapacity),
-    [91, 71, 63, 47, 35, 0xffffffff, 0xffffffff, 0xffffffff],
     'invalid bounds retain their explicit identities while padded leaves stay invalid'
-  );
-  t.deepEqual(
+  ).toEqual([91, 71, 63, 47, 35, 0xffffffff, 0xffffffff, 0xffffffff]);
+  expect(
     await readUint32(fused.leafIds, bounds.leafCapacity),
-    await readUint32(perLevel.leafIds, bounds.leafCapacity),
     'both strategies remap explicit source identities identically'
-  );
-  t.deepEqual(await readUint32(fused.count, 1), await readUint32(perLevel.count, 1));
-  t.deepEqual(await readUint32(fused.overflow, 1), await readUint32(perLevel.overflow, 1));
+  ).toEqual(await readUint32(perLevel.leafIds, bounds.leafCapacity));
+  expect(await readUint32(fused.count, 1)).toEqual(await readUint32(perLevel.count, 1));
+  expect(await readUint32(fused.overflow, 1)).toEqual(await readUint32(perLevel.overflow, 1));
 
   destroyFixture(fused);
   destroyFixture(perLevel);
-  t.end();
 });
 
-test('GPUBVH fuses empty singleton roots and the maximum portable small hierarchy', async t => {
+it('GPUBVH fuses empty singleton roots and the maximum portable small hierarchy', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -213,11 +192,11 @@ test('GPUBVH fuses empty singleton roots and the maximum portable small hierarch
   });
   encode(device, empty.compiled);
 
-  t.equal(empty.bvh.resolvedStrategy, 'fused');
-  t.deepEqual(await readUint32(empty.children, 2), [0xffffffff, 0xffffffff]);
-  t.deepEqual(await readUint32(empty.leafIds, 1), [0xffffffff]);
-  t.deepEqual(await readUint32(empty.count, 1), [0]);
-  t.deepEqual(await readUint32(empty.overflow, 1), [0]);
+  expect(empty.bvh.resolvedStrategy).toBe('fused');
+  expect(await readUint32(empty.children, 2)).toEqual([0xffffffff, 0xffffffff]);
+  expect(await readUint32(empty.leafIds, 1)).toEqual([0xffffffff]);
+  expect(await readUint32(empty.count, 1)).toEqual([0]);
+  expect(await readUint32(empty.overflow, 1)).toEqual([0]);
 
   const boundary = createFixture(device, {
     dimension: 2,
@@ -227,22 +206,19 @@ test('GPUBVH fuses empty singleton roots and the maximum portable small hierarch
   });
   encode(device, boundary.compiled);
 
-  t.equal(boundary.bvh.resolvedStrategy, 'fused');
-  t.deepEqual(boundary.compiled.stats.nodeOrder, ['test-bvh-fused-refit']);
-  t.deepEqual(await readFloat32(boundary.nodeMinima, 2), [-4, -2]);
-  t.deepEqual(await readFloat32(boundary.nodeMaxima, 2), [5, 9]);
-  t.deepEqual(await readUint32(boundary.count, 1), [3]);
+  expect(boundary.bvh.resolvedStrategy).toBe('fused');
+  expect(boundary.compiled.stats.nodeOrder).toEqual(['test-bvh-fused-refit']);
+  expect(await readFloat32(boundary.nodeMinima, 2)).toEqual([-4, -2]);
+  expect(await readFloat32(boundary.nodeMaxima, 2)).toEqual([5, 9]);
+  expect(await readUint32(boundary.count, 1)).toEqual([3]);
 
   destroyFixture(empty);
   destroyFixture(boundary);
-  t.end();
 });
 
-test('GPUBVH retains per-level construction when one workgroup cannot contain every leaf', async t => {
+it('GPUBVH retains per-level construction when one workgroup cannot contain every leaf', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -254,22 +230,19 @@ test('GPUBVH retains per-level construction when one workgroup cannot contain ev
   });
   encode(device, fixture.compiled);
 
-  t.equal(fixture.bvh.strategy, 'auto');
-  t.equal(
-    fixture.bvh.resolvedStrategy,
-    'level',
-    'large hierarchies avoid cross-workgroup barriers'
+  expect(fixture.bvh.strategy).toBe('auto');
+  expect(fixture.bvh.resolvedStrategy, 'large hierarchies avoid cross-workgroup barriers').toBe(
+    'level'
   );
-  t.equal(fixture.compiled.stats.nodeOrder.length, 9, 'one load and eight refit passes remain');
-  t.equal(fixture.compiled.stats.nodeOrder[0], 'test-bvh-load-leaves');
-  t.equal(fixture.compiled.stats.nodeOrder[8], 'test-bvh-refit-depth-0');
-  t.deepEqual(await readFloat32(fixture.nodeMinima, 2), [-3, -2]);
-  t.deepEqual(await readFloat32(fixture.nodeMaxima, 2), [6, 7]);
-  t.deepEqual(await readUint32(fixture.count, 1), [3]);
-  t.deepEqual(await readUint32(fixture.overflow, 1), [0]);
+  expect(fixture.compiled.stats.nodeOrder.length, 'one load and eight refit passes remain').toBe(9);
+  expect(fixture.compiled.stats.nodeOrder[0]).toBe('test-bvh-load-leaves');
+  expect(fixture.compiled.stats.nodeOrder[8]).toBe('test-bvh-refit-depth-0');
+  expect(await readFloat32(fixture.nodeMinima, 2)).toEqual([-3, -2]);
+  expect(await readFloat32(fixture.nodeMaxima, 2)).toEqual([6, 7]);
+  expect(await readUint32(fixture.count, 1)).toEqual([3]);
+  expect(await readUint32(fixture.overflow, 1)).toEqual([0]);
 
   destroyFixture(fixture);
-  t.end();
 });
 
 type Fixture = {

--- a/modules/gpgpu/test/gpu-core/gpu-chunked-indexed-scatter.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-chunked-indexed-scatter.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -6,15 +7,12 @@ import {Buffer, type Device} from '@luma.gl/core';
 import {GPUChunkedIndexedScatter, GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
 import {GPUData} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
 
 const INVALID_ROUTE = 0xffffffff;
 
-test('GPUChunkedIndexedScatter routes compacted IDs into indirect-ready chunk ranges', async t => {
+it('GPUChunkedIndexedScatter routes compacted IDs into indirect-ready chunk ranges', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -71,29 +69,25 @@ test('GPUChunkedIndexedScatter routes compacted IDs into indirect-ready chunk ra
   try {
     await encodeAndSubmit(device, compiled, 'chunked-scatter-first');
     const firstOutput = await readUint32(outputBuffer, 6);
-    t.deepEqual(
+    expect(
       firstOutput.slice(0, 2).sort((a, b) => a - b),
-      [2, 9],
       'chunk zero jobs'
-    );
-    t.deepEqual(
+    ).toEqual([2, 9]);
+    expect(
       firstOutput.slice(2, 4).sort((a, b) => a - b),
-      [3, 10],
       'chunk one jobs'
-    );
-    t.deepEqual(
+    ).toEqual([3, 10]);
+    expect(
       firstOutput.slice(4, 6).sort((a, b) => a - b),
-      [8, 11],
       'chunk two jobs'
-    );
+    ).toEqual([8, 11]);
 
     sourceCountBuffer.write(Uint32Array.from([1]));
     await encodeAndSubmit(device, compiled, 'chunked-scatter-updated');
-    t.deepEqual(
+    expect(
       (await readUint32(outputBuffer, 2)).sort((a, b) => a - b),
-      [10, 11],
       'GPU-resident counts update routed work without recompilation'
-    );
+    ).toEqual([10, 11]);
   } finally {
     compiled.destroy();
     sourceIdsBuffer.destroy();
@@ -101,8 +95,6 @@ test('GPUChunkedIndexedScatter routes compacted IDs into indirect-ready chunk ra
     routesBuffer.destroy();
     outputBuffer.destroy();
   }
-
-  t.end();
 });
 
 async function encodeAndSubmit(

--- a/modules/gpgpu/test/gpu-core/gpu-command-graph-autotuner.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-command-graph-autotuner.node.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -8,7 +9,6 @@ import {
   type GPUCommandGraphPreflightReport,
   type GPUCommandGraphTimingReport
 } from '@luma.gl/gpgpu/gpu-core';
-import test from 'test/utils/vitest-tape';
 
 const ADAPTER: GPUCommandGraphAdapterIdentity = Object.freeze({
   key: 'test-adapter',
@@ -25,13 +25,13 @@ const ADAPTER: GPUCommandGraphAdapterIdentity = Object.freeze({
 
 const CANDIDATES = [{id: 'portable'}, {id: 'subgroups'}] as const;
 
-test('GPUCommandGraphAutotuner explores then selects the measured faster kernel', t => {
+it('GPUCommandGraphAutotuner explores then selects the measured faster kernel', () => {
   const autotuner = new GPUCommandGraphAutotuner({adapter: ADAPTER});
   const request = {operation: 'GPUScan', candidates: CANDIDATES, workloadSize: 1_000_000};
 
   const first = autotuner.selectKernel(request);
-  t.equal(first.variant, 'portable', 'explores the first supported variant');
-  t.equal(first.reason, 'exploration', 'reports exploration explicitly');
+  expect(first.variant, 'explores the first supported variant').toBe('portable');
+  expect(first.reason, 'reports exploration explicitly').toBe('exploration');
   autotuner.observeKernel({
     operation: 'GPUScan',
     variant: 'portable',
@@ -40,7 +40,7 @@ test('GPUCommandGraphAutotuner explores then selects the measured faster kernel'
   });
 
   const second = autotuner.selectKernel(request);
-  t.equal(second.variant, 'subgroups', 'explores the remaining unmeasured variant');
+  expect(second.variant, 'explores the remaining unmeasured variant').toBe('subgroups');
   autotuner.observeKernel({
     operation: 'GPUScan',
     variant: 'subgroups',
@@ -49,13 +49,12 @@ test('GPUCommandGraphAutotuner explores then selects the measured faster kernel'
   });
 
   const selected = autotuner.selectKernel(request);
-  t.equal(selected.variant, 'subgroups', 'selects the faster calibrated implementation');
-  t.equal(selected.reason, 'calibrated', 'distinguishes an empirical decision');
-  t.equal(selected.estimatedDurationMilliseconds, 1, 'reports the expected duration');
-  t.end();
+  expect(selected.variant, 'selects the faster calibrated implementation').toBe('subgroups');
+  expect(selected.reason, 'distinguishes an empirical decision').toBe('calibrated');
+  expect(selected.estimatedDurationMilliseconds, 'reports the expected duration').toBe(1);
 });
 
-test('GPUCommandGraphAutotuner respects support and persists adapter-local calibration', t => {
+it('GPUCommandGraphAutotuner respects support and persists adapter-local calibration', () => {
   const autotuner = new GPUCommandGraphAutotuner({adapter: ADAPTER, explorationEnabled: false});
   autotuner.observeKernel({
     operation: 'GPUHistogram',
@@ -75,43 +74,39 @@ test('GPUCommandGraphAutotuner respects support and persists adapter-local calib
     profile,
     explorationEnabled: false
   });
-  t.equal(
+  expect(
     restored.selectKernel({
       operation: 'GPUHistogram',
       candidates: CANDIDATES,
       workloadSize: 1024
     }).variant,
-    'subgroups',
     'restores calibration for the matching adapter'
-  );
-  t.equal(
+  ).toBe('subgroups');
+  expect(
     restored.selectKernel({
       operation: 'GPUHistogram',
       candidates: [{id: 'portable'}, {id: 'subgroups', supported: false}],
       workloadSize: 1024
     }).variant,
-    'portable',
     'never selects an unsupported candidate'
-  );
+  ).toBe('portable');
 
   const mismatched = new GPUCommandGraphAutotuner({
     adapter: {...ADAPTER, key: 'another-adapter'},
     profile,
     explorationEnabled: false
   });
-  t.equal(
+  expect(
     mismatched.selectKernel({
       operation: 'GPUHistogram',
       candidates: CANDIDATES,
       workloadSize: 1024
     }).reason,
-    'fallback',
     'ignores measurements captured on another adapter'
-  );
-  t.end();
+  ).toBe('fallback');
 });
 
-test('GPUCommandGraphAutotuner consumes annotated graph GPU timings', t => {
+it('GPUCommandGraphAutotuner consumes annotated graph GPU timings', () => {
   const autotuner = new GPUCommandGraphAutotuner({adapter: ADAPTER});
   const preflight: GPUCommandGraphPreflightReport = {
     nodes: [
@@ -170,16 +165,13 @@ test('GPUCommandGraphAutotuner consumes annotated graph GPU timings', t => {
     ]
   };
 
-  t.equal(
+  expect(
     autotuner.observeTimingReport(timingReport, preflight),
-    1,
     'records only nodes with operation and variant annotations'
-  );
-  t.equal(autotuner.exportProfile().calibrations.length, 1, 'publishes one calibration entry');
-  t.equal(
+  ).toBe(1);
+  expect(autotuner.exportProfile().calibrations.length, 'publishes one calibration entry').toBe(1);
+  expect(
     autotuner.exportProfile().calibrations[0].meanWorkloadSize,
-    1024,
     'uses the node invocation bound as the workload size'
-  );
-  t.end();
+  ).toBe(1024);
 });

--- a/modules/gpgpu/test/gpu-core/gpu-command-graph-history.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-command-graph-history.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -6,15 +7,12 @@ import {Buffer, Texture, type Device} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {GPUCommandGraph, GPUTextureHistory} from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
 
 const HISTORY_TEXTURE_USAGE = Texture.SAMPLE | Texture.STORAGE | Texture.COPY_SRC;
 
-test('GPUTextureHistory preserves GPU results across copy-free CORE WebGPU frame rotation', async testCase => {
+it('GPUTextureHistory preserves GPU results across copy-free CORE WebGPU frame rotation', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
@@ -112,30 +110,23 @@ fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
 
   try {
     const rejectedEncoder = device.createCommandEncoder({id: 'rejected-history-alias'});
-    testCase.throws(
+    expect(
       () =>
         compiled.encode(rejectedEncoder, {
           parameters: undefined,
           textures: {previous: history.previousTexture, current: history.previousTexture}
         }),
-      /previous.*current.*same physical texture/i,
       'read/write aliases fail before any CORE GPU work is recorded'
-    );
+    ).toThrow(/previous.*current.*same physical texture/i);
     rejectedEncoder.destroy();
-    testCase.equal(
-      history.previousTexture,
-      initialPreviousTexture,
-      'a failed encoding leaves the previous role unchanged'
+    expect(history.previousTexture, 'a failed encoding leaves the previous role unchanged').toBe(
+      initialPreviousTexture
     );
-    testCase.equal(
-      history.currentTexture,
-      initialCurrentTexture,
-      'a failed encoding leaves the current role unchanged'
+    expect(history.currentTexture, 'a failed encoding leaves the current role unchanged').toBe(
+      initialCurrentTexture
     );
-    testCase.equal(
-      textureViewStats.count,
-      initialTextureViewCount,
-      'rejected aliases do not allocate concrete texture views'
+    expect(textureViewStats.count, 'rejected aliases do not allocate concrete texture views').toBe(
+      initialTextureViewCount
     );
 
     for (let frameIndex = 0; frameIndex < 3; frameIndex++) {
@@ -145,45 +136,45 @@ fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
         parameters: undefined,
         textures: history.getBindings('previous', 'current')
       });
-      testCase.equal(encoding.stats.nodeCount, 1, 'history graph encodes only the compute node');
-      testCase.equal(encoding.stats.computePassCount, 1, 'the graph opens one CORE compute pass');
+      expect(encoding.stats.nodeCount, 'history graph encodes only the compute node').toBe(1);
+      expect(encoding.stats.computePassCount, 'the graph opens one CORE compute pass').toBe(1);
       device.submit(commandEncoder.finish());
       const pixel = await readHistoryPixel(device, outputTexture);
-      testCase.equal(
-        pixel[0],
-        Math.round((frameIndex + 1) * 0.2 * 255),
-        'the next frame reads the retained previous GPU output'
+      expect(pixel[0], 'the next frame reads the retained previous GPU output').toBe(
+        Math.round((frameIndex + 1) * 0.2 * 255)
       );
       history.advance();
     }
 
-    testCase.equal(
+    expect(
       textureViewStats.count,
-      initialTextureViewCount + 4,
       'repeated role swaps retain only two concrete views per logical graph role'
-    );
+    ).toBe(initialTextureViewCount + 4);
     compiled.destroy();
-    testCase.equal(
-      textureViewStats.count,
-      initialTextureViewCount,
-      'destroying the graph releases its cached views'
+    expect(textureViewStats.count, 'destroying the graph releases its cached views').toBe(
+      initialTextureViewCount
     );
-    testCase.notOk(
-      initialPreviousTexture.destroyed,
+    expect(
+      Boolean(initialPreviousTexture.destroyed),
       'the first history texture stays caller-owned'
-    );
-    testCase.notOk(
-      initialCurrentTexture.destroyed,
+    ).toBe(false);
+    expect(
+      Boolean(initialCurrentTexture.destroyed),
       'the second history texture stays caller-owned'
-    );
+    ).toBe(false);
   } finally {
     compiled.destroy();
     history.destroy();
   }
 
-  testCase.ok(initialPreviousTexture.destroyed, 'history destruction releases the first texture');
-  testCase.ok(initialCurrentTexture.destroyed, 'history destruction releases the second texture');
-  testCase.end();
+  expect(
+    Boolean(initialPreviousTexture.destroyed),
+    'history destruction releases the first texture'
+  ).toBe(true);
+  expect(
+    Boolean(initialCurrentTexture.destroyed),
+    'history destruction releases the second texture'
+  ).toBe(true);
 });
 
 async function readHistoryPixel(device: Device, texture: Texture): Promise<Uint8Array> {

--- a/modules/gpgpu/test/gpu-core/gpu-command-graph-inspector.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-command-graph-inspector.node.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import type {CommandEncoder} from '@luma.gl/core';
 import {
   GPUCommandGraphInspector,
@@ -61,7 +61,7 @@ const GRAPH_CAPABILITIES: GPUCommandGraphCapabilities = {
   maxComputeWorkgroupsPerDimension: 65_535
 };
 
-test('GPUCommandGraphInspector summarizes bounded CPU and GPU samples', async testCase => {
+it('GPUCommandGraphInspector summarizes bounded CPU and GPU samples', async () => {
   const inspector = new GPUCommandGraphInspector({
     maxSamples: 2,
     getNodeGroup: node => (node.id === 'render' ? 'drawing' : 'query')
@@ -80,79 +80,77 @@ test('GPUCommandGraphInspector summarizes bounded CPU and GPU samples', async te
 
   const snapshot = inspector.getSnapshot();
   const graph = snapshot.graphs[0];
-  testCase.equal(graph.encodingCount, 3, 'counts every synchronous encoding');
-  testCase.deepEqual(
-    graph.totals.cpu,
-    {sampleCount: 2, latestMilliseconds: 30, p50Milliseconds: 20, p95Milliseconds: 30},
-    'bounds and summarizes whole-graph CPU samples'
-  );
-  testCase.deepEqual(
-    graph.totals.gpu,
-    {sampleCount: 2, latestMilliseconds: 300, p50Milliseconds: 200, p95Milliseconds: 300},
-    'bounds and summarizes whole-graph GPU samples'
-  );
-  testCase.deepEqual(
+  expect(graph.encodingCount, 'counts every synchronous encoding').toBe(3);
+  expect(graph.totals.cpu, 'bounds and summarizes whole-graph CPU samples').toEqual({
+    sampleCount: 2,
+    latestMilliseconds: 30,
+    p50Milliseconds: 20,
+    p95Milliseconds: 30
+  });
+  expect(graph.totals.gpu, 'bounds and summarizes whole-graph GPU samples').toEqual({
+    sampleCount: 2,
+    latestMilliseconds: 300,
+    p50Milliseconds: 200,
+    p95Milliseconds: 300
+  });
+  expect(
     graph.nodes.map(node => [node.id, node.type, node.group]),
-    [
-      ['prepare', 'compute', 'query'],
-      ['render', 'render', 'drawing']
-    ],
     'preserves compiled node order and semantic groups'
-  );
-  testCase.deepEqual(
-    graph.nodes[0].cpu,
-    {sampleCount: 2, latestMilliseconds: 6, p50Milliseconds: 4, p95Milliseconds: 6},
-    'summarizes per-node CPU samples'
-  );
-  testCase.deepEqual(
-    graph.nodes[1].gpu,
-    {sampleCount: 2, latestMilliseconds: 90, p50Milliseconds: 60, p95Milliseconds: 90},
-    'summarizes per-node GPU samples'
-  );
-  testCase.end();
+  ).toEqual([
+    ['prepare', 'compute', 'query'],
+    ['render', 'render', 'drawing']
+  ]);
+  expect(graph.nodes[0].cpu, 'summarizes per-node CPU samples').toEqual({
+    sampleCount: 2,
+    latestMilliseconds: 6,
+    p50Milliseconds: 4,
+    p95Milliseconds: 6
+  });
+  expect(graph.nodes[1].gpu, 'summarizes per-node GPU samples').toEqual({
+    sampleCount: 2,
+    latestMilliseconds: 90,
+    p50Milliseconds: 60,
+    p95Milliseconds: 90
+  });
 });
 
-test('GPUCommandGraphInspector summarizes bounded scalar counters', testCase => {
+it('GPUCommandGraphInspector summarizes bounded scalar counters', () => {
   const inspector = new GPUCommandGraphInspector({maxSamples: 2});
   inspector.registerGraph(makeGraph('counters'));
   inspector.recordCounters('counters', {candidates: 30, intersectedCells: 3});
   inspector.recordCounters('counters', {candidates: 10, intersectedCells: 1});
   inspector.recordCounters('counters', {candidates: 20, intersectedCells: 2});
 
-  testCase.deepEqual(
+  expect(
     inspector.getSnapshot().graphs[0].counters,
-    [
-      {
-        id: 'candidates',
-        sampleCount: 2,
-        latestValue: 20,
-        p50Value: 10,
-        p95Value: 20
-      },
-      {
-        id: 'intersectedCells',
-        sampleCount: 2,
-        latestValue: 2,
-        p50Value: 1,
-        p95Value: 2
-      }
-    ],
     'retains bounded samples and preserves first-observed counter order'
-  );
-  testCase.throws(
+  ).toEqual([
+    {
+      id: 'candidates',
+      sampleCount: 2,
+      latestValue: 20,
+      p50Value: 10,
+      p95Value: 20
+    },
+    {
+      id: 'intersectedCells',
+      sampleCount: 2,
+      latestValue: 2,
+      p50Value: 1,
+      p95Value: 2
+    }
+  ]);
+  expect(
     () => inspector.recordCounters('counters', {valid: 1, invalid: Number.NaN}),
-    /finite, non-negative value/,
     'rejects invalid counter batches'
-  );
-  testCase.equal(
+  ).toThrow(/finite, non-negative value/);
+  expect(
     inspector.getSnapshot().graphs[0].counters.length,
-    2,
     'validates the complete batch before recording any sample'
-  );
-  testCase.end();
+  ).toBe(2);
 });
 
-test('GPUCommandGraphInspector returns immutable snapshots and copied graph metadata', testCase => {
+it('GPUCommandGraphInspector returns immutable snapshots and copied graph metadata', () => {
   const stats = {...GRAPH_STATS, nodeOrder: [...GRAPH_STATS.nodeOrder]};
   const capabilities = {...GRAPH_CAPABILITIES};
   const graph: GPUCommandGraphInspectorGraph = {id: 'immutable', stats, capabilities};
@@ -165,23 +163,29 @@ test('GPUCommandGraphInspector returns immutable snapshots and copied graph meta
   capabilities.timestampQueries = false;
   const snapshot = inspector.getSnapshot();
   const graphSnapshot = snapshot.graphs[0];
-  testCase.deepEqual(graphSnapshot.stats.nodeOrder, ['prepare', 'render'], 'copies node order');
-  testCase.equal(graphSnapshot.capabilities.timestampQueries, true, 'copies adapter capabilities');
-  testCase.ok(Object.isFrozen(snapshot), 'freezes the root snapshot');
-  testCase.ok(Object.isFrozen(snapshot.graphs), 'freezes the graph list');
-  testCase.ok(Object.isFrozen(graphSnapshot), 'freezes each graph');
-  testCase.ok(Object.isFrozen(graphSnapshot.stats), 'freezes compile statistics');
-  testCase.ok(Object.isFrozen(graphSnapshot.stats.nodeOrder), 'freezes compiled node order');
-  testCase.ok(Object.isFrozen(graphSnapshot.totals), 'freezes graph totals');
-  testCase.ok(Object.isFrozen(graphSnapshot.totals.cpu), 'freezes duration summaries');
-  testCase.ok(Object.isFrozen(graphSnapshot.counters), 'freezes the counter list');
-  testCase.ok(Object.isFrozen(graphSnapshot.counters[0]), 'freezes each counter summary');
-  testCase.ok(Object.isFrozen(graphSnapshot.nodes), 'freezes the node list');
-  testCase.ok(Object.isFrozen(graphSnapshot.nodes[0]), 'freezes each node summary');
-  testCase.end();
+  expect(graphSnapshot.stats.nodeOrder, 'copies node order').toEqual(['prepare', 'render']);
+  expect(graphSnapshot.capabilities.timestampQueries, 'copies adapter capabilities').toBe(true);
+  expect(Boolean(Object.isFrozen(snapshot)), 'freezes the root snapshot').toBe(true);
+  expect(Boolean(Object.isFrozen(snapshot.graphs)), 'freezes the graph list').toBe(true);
+  expect(Boolean(Object.isFrozen(graphSnapshot)), 'freezes each graph').toBe(true);
+  expect(Boolean(Object.isFrozen(graphSnapshot.stats)), 'freezes compile statistics').toBe(true);
+  expect(
+    Boolean(Object.isFrozen(graphSnapshot.stats.nodeOrder)),
+    'freezes compiled node order'
+  ).toBe(true);
+  expect(Boolean(Object.isFrozen(graphSnapshot.totals)), 'freezes graph totals').toBe(true);
+  expect(Boolean(Object.isFrozen(graphSnapshot.totals.cpu)), 'freezes duration summaries').toBe(
+    true
+  );
+  expect(Boolean(Object.isFrozen(graphSnapshot.counters)), 'freezes the counter list').toBe(true);
+  expect(Boolean(Object.isFrozen(graphSnapshot.counters[0])), 'freezes each counter summary').toBe(
+    true
+  );
+  expect(Boolean(Object.isFrozen(graphSnapshot.nodes)), 'freezes the node list').toBe(true);
+  expect(Boolean(Object.isFrozen(graphSnapshot.nodes[0])), 'freezes each node summary').toBe(true);
 });
 
-test('GPUCommandGraphInspector observes encode and post-submit timing lifecycles', async testCase => {
+it('GPUCommandGraphInspector observes encode and post-submit timing lifecycles', async () => {
   const inspector = new GPUCommandGraphInspector();
   const graph = makeObservableGraph('observed');
   const observation = inspector.observeGraph(graph);
@@ -191,30 +195,29 @@ test('GPUCommandGraphInspector observes encode and post-submit timing lifecycles
   await observation.recordGPUTimings(encoding);
 
   const graphSnapshot = inspector.getSnapshot().graphs[0];
-  testCase.equal(observation.graph, graph, 'exposes the observed graph without wrapping ownership');
-  testCase.ok(Object.isFrozen(observation), 'returns an immutable observation handle');
-  testCase.equal(graphSnapshot.encodingCount, 1, 'records CPU stats while delegating encode');
-  testCase.equal(graphSnapshot.totals.cpu.latestMilliseconds, 8, 'records delegated CPU time');
-  testCase.equal(
-    graphSnapshot.totals.gpu.latestMilliseconds,
-    80,
-    'records explicit post-submit GPU time without a repeated graph id'
+  expect(observation.graph, 'exposes the observed graph without wrapping ownership').toBe(graph);
+  expect(Boolean(Object.isFrozen(observation)), 'returns an immutable observation handle').toBe(
+    true
   );
+  expect(graphSnapshot.encodingCount, 'records CPU stats while delegating encode').toBe(1);
+  expect(graphSnapshot.totals.cpu.latestMilliseconds, 'records delegated CPU time').toBe(8);
+  expect(
+    graphSnapshot.totals.gpu.latestMilliseconds,
+    'records explicit post-submit GPU time without a repeated graph id'
+  ).toBe(80);
 
   observation.detach();
   observation.detach();
   observation.encode(COMMAND_ENCODER, {
     parameters: {cpuTimeMilliseconds: 16, gpuTimeMilliseconds: 160}
   });
-  testCase.deepEqual(
+  expect(
     inspector.getSnapshot().graphs,
-    [],
     'detach is idempotent and stops observation without disabling graph encoding'
-  );
-  testCase.end();
+  ).toEqual([]);
 });
 
-test('GPUCommandGraphInspector observations isolate same-id replacement lifecycles', async testCase => {
+it('GPUCommandGraphInspector observations isolate same-id replacement lifecycles', async () => {
   const inspector = new GPUCommandGraphInspector();
   const oldObservation = inspector.observeGraph(makeObservableGraph('replaceable'));
   const oldEncoding = oldObservation.encode(COMMAND_ENCODER, {
@@ -234,29 +237,22 @@ test('GPUCommandGraphInspector observations isolate same-id replacement lifecycl
   currentObservation.recordCounters({candidates: 7});
 
   const graph = inspector.getSnapshot().graphs[0];
-  testCase.equal(graph.encodingCount, 1, 'an old handle cannot record into its replacement');
-  testCase.equal(graph.totals.cpu.latestMilliseconds, 7, 'keeps only the current observation');
-  testCase.equal(
+  expect(graph.encodingCount, 'an old handle cannot record into its replacement').toBe(1);
+  expect(graph.totals.cpu.latestMilliseconds, 'keeps only the current observation').toBe(7);
+  expect(
     graph.totals.gpu.sampleCount,
-    0,
     'an old handle cannot attach pending timings to its replacement'
-  );
-  testCase.equal(
+  ).toBe(0);
+  expect(
     graph.counters[0].latestValue,
-    7,
     'an old handle cannot publish delayed counters into its replacement'
-  );
+  ).toBe(7);
   currentObservation.detach();
   currentObservation.recordCounters({candidates: 70});
-  testCase.deepEqual(
-    inspector.getSnapshot().graphs,
-    [],
-    'the current handle owns its registration'
-  );
-  testCase.end();
+  expect(inspector.getSnapshot().graphs, 'the current handle owns its registration').toEqual([]);
 });
 
-test('GPUCommandGraphInspector observations reject foreign encodings', async testCase => {
+it('GPUCommandGraphInspector observations reject foreign encodings', async () => {
   const inspector = new GPUCommandGraphInspector();
   const firstObservation = inspector.observeGraph(makeObservableGraph('first'));
   const secondObservation = inspector.observeGraph(makeObservableGraph('second'));
@@ -265,23 +261,20 @@ test('GPUCommandGraphInspector observations reject foreign encodings', async tes
   });
 
   await secondObservation.recordGPUTimings(firstEncoding);
-  testCase.deepEqual(
+  expect(
     inspector.getSnapshot().graphs.map(graph => graph.totals.gpu.sampleCount),
-    [0, 0],
     "does not attribute another observation's timing report to the current graph"
-  );
+  ).toEqual([0, 0]);
   await firstObservation.recordGPUTimings(firstEncoding);
-  testCase.equal(
+  expect(
     inspector.getSnapshot().graphs[0].totals.gpu.latestMilliseconds,
-    40,
     'the originating observation can read its own encoding'
-  );
+  ).toBe(40);
   firstObservation.detach();
   secondObservation.detach();
-  testCase.end();
 });
 
-test('GPUCommandGraphInspector observations coalesce repeated timing reads', async testCase => {
+it('GPUCommandGraphInspector observations coalesce repeated timing reads', async () => {
   const inspector = new GPUCommandGraphInspector();
   let timingReadCount = 0;
   let resolveTiming: ((report: GPUCommandGraphTimingReport) => void) | undefined;
@@ -305,19 +298,18 @@ test('GPUCommandGraphInspector observations coalesce repeated timing reads', asy
 
   const firstRead = observation.recordGPUTimings(encoding);
   const secondRead = observation.recordGPUTimings(encoding);
-  testCase.equal(timingReadCount, 1, 'starts only one timing read for concurrent calls');
+  expect(timingReadCount, 'starts only one timing read for concurrent calls').toBe(1);
   resolveTiming?.(makeTimingReport(6, 60, 10, 20));
   await Promise.all([firstRead, secondRead]);
   await observation.recordGPUTimings(encoding);
 
   const graphSnapshot = inspector.getSnapshot().graphs[0];
-  testCase.equal(timingReadCount, 1, 'reuses the completed timing read');
-  testCase.equal(graphSnapshot.totals.gpu.sampleCount, 1, 'records one GPU sample per encoding');
+  expect(timingReadCount, 'reuses the completed timing read').toBe(1);
+  expect(graphSnapshot.totals.gpu.sampleCount, 'records one GPU sample per encoding').toBe(1);
   observation.detach();
-  testCase.end();
 });
 
-test('GPUCommandGraphInspector resets replacements and isolates asynchronous timing reads', async testCase => {
+it('GPUCommandGraphInspector resets replacements and isolates asynchronous timing reads', async () => {
   const inspector = new GPUCommandGraphInspector();
   inspector.registerGraph(makeGraph('replaceable'));
   const queuedEncoding = makeEncoding(12, 3, 4, 130, 30, 40);
@@ -347,17 +339,14 @@ test('GPUCommandGraphInspector resets replacements and isolates asynchronous tim
   });
   await inspector.recordGPUTimings('replaceable', failingEncoding);
   const graph = inspector.getSnapshot().graphs[0];
-  testCase.equal(graph.encodingCount, 0, 'replacement resets encoding history');
-  testCase.equal(graph.totals.gpu.sampleCount, 0, 'discards timing from the old registration');
-  testCase.equal(graph.timingReadFailureCount, 1, 'counts timing read failures without throwing');
-  testCase.equal(
-    graph.capabilities.timestampQueries,
-    false,
-    'publishes metadata from the replacement graph'
+  expect(graph.encodingCount, 'replacement resets encoding history').toBe(0);
+  expect(graph.totals.gpu.sampleCount, 'discards timing from the old registration').toBe(0);
+  expect(graph.timingReadFailureCount, 'counts timing read failures without throwing').toBe(1);
+  expect(graph.capabilities.timestampQueries, 'publishes metadata from the replacement graph').toBe(
+    false
   );
   inspector.clear();
-  testCase.deepEqual(inspector.getSnapshot().graphs, [], 'clear removes every registration');
-  testCase.end();
+  expect(inspector.getSnapshot().graphs, 'clear removes every registration').toEqual([]);
 });
 
 function makeGraph(id: string, timestampQueries = true): GPUCommandGraphInspectorGraph {

--- a/modules/gpgpu/test/gpu-core/gpu-command-graph-planning.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-command-graph-planning.node.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -8,7 +9,6 @@ import {
   type GPUCommandGraphExecutionPlanStep,
   type GPUCommandGraphNodePreflight
 } from '@luma.gl/gpgpu/gpu-core';
-import test from 'test/utils/vitest-tape';
 
 function makeNode(
   id: string,
@@ -30,7 +30,7 @@ function makeNode(
   };
 }
 
-test('GPUCommandGraph execution planning respects multidimensional budgets', t => {
+it('GPUCommandGraph execution planning respects multidimensional budgets', () => {
   const plan = getGPUCommandGraphExecutionPlan(
     {
       nodes: [
@@ -54,53 +54,51 @@ test('GPUCommandGraph execution planning respects multidimensional budgets', t =
     }
   );
 
-  t.equal(plan.stepCount, 3, 'plans three queue submissions');
-  t.equal(plan.nodeCount, 5, 'retains every scheduled node');
-  t.equal(plan.maximumInvocationCount, 1600, 'reports complete invocation bounds');
-  t.equal(plan.conditionalNodeCount, 1, 'retains conservative conditional-node bounds');
-  t.equal(plan.steps[0].conditionalNodeCount, 1, 'reports conditions per submission step');
-  t.equal(plan.readByteLength, 6400, 'reports complete read bounds');
-  t.deepEqual(
+  expect(plan.stepCount, 'plans three queue submissions').toBe(3);
+  expect(plan.nodeCount, 'retains every scheduled node').toBe(5);
+  expect(plan.maximumInvocationCount, 'reports complete invocation bounds').toBe(1600);
+  expect(plan.conditionalNodeCount, 'retains conservative conditional-node bounds').toBe(1);
+  expect(plan.steps[0].conditionalNodeCount, 'reports conditions per submission step').toBe(1);
+  expect(plan.readByteLength, 'reports complete read bounds').toBe(6400);
+  expect(
     plan.steps.map(step => [step.firstNodeIndex, step.nextNodeIndex]),
-    [
-      [0, 3],
-      [3, 4],
-      [4, 5]
-    ],
     'keeps dependency order while packing bounded ranges'
-  );
-  t.equal(plan.steps[0].commandCount, 2, 'packs commands up to the budget');
-  t.ok(plan.steps[1].exceedsBudget, 'allows one indivisible oversized node to make progress');
-  t.equal(plan.oversizedStepCount, 1, 'summarizes oversized work before execution');
-  t.ok(Object.isFrozen(plan), 'freezes the plan');
-  t.ok(Object.isFrozen(plan.steps), 'freezes the step list');
-  t.ok(Object.isFrozen(plan.steps[0]), 'freezes individual steps');
-  t.end();
+  ).toEqual([
+    [0, 3],
+    [3, 4],
+    [4, 5]
+  ]);
+  expect(plan.steps[0].commandCount, 'packs commands up to the budget').toBe(2);
+  expect(
+    Boolean(plan.steps[1].exceedsBudget),
+    'allows one indivisible oversized node to make progress'
+  ).toBe(true);
+  expect(plan.oversizedStepCount, 'summarizes oversized work before execution').toBe(1);
+  expect(Boolean(Object.isFrozen(plan)), 'freezes the plan').toBe(true);
+  expect(Boolean(Object.isFrozen(plan.steps)), 'freezes the step list').toBe(true);
+  expect(Boolean(Object.isFrozen(plan.steps[0])), 'freezes individual steps').toBe(true);
 });
 
-test('GPUCommandGraph execution planning rejects invalid budgets', t => {
+it('GPUCommandGraph execution planning rejects invalid budgets', () => {
   const preflight = {nodes: [makeNode('partition', 1)], annotatedNodeCount: 1};
-  t.throws(
+  expect(
     () =>
       getGPUCommandGraphExecutionPlan(preflight, {
         maximumInvocationCount: 0
       }),
-    /maximumInvocationCount must be a positive safe integer/,
     'rejects a zero invocation budget'
-  );
-  t.throws(
+  ).toThrow(/maximumInvocationCount must be a positive safe integer/);
+  expect(
     () =>
       getGPUCommandGraphExecutionPlan(preflight, {
         maximumInvocationCount: 1,
         maximumReadByteLength: Number.POSITIVE_INFINITY
       }),
-    /maximumReadByteLength must be a positive safe integer/,
     'rejects a non-finite byte budget'
-  );
-  t.end();
+  ).toThrow(/maximumReadByteLength must be a positive safe integer/);
 });
 
-test('GPUCommandGraph execution planning controls coherent partial publication', t => {
+it('GPUCommandGraph execution planning controls coherent partial publication', () => {
   const preflight = {
     nodes: [
       makeNode('summary-work', 300),
@@ -115,34 +113,36 @@ test('GPUCommandGraph execution planning controls coherent partial publication',
   const atomicPlan = getGPUCommandGraphExecutionPlan(preflight, budget, {
     latencyPriority: 'background'
   });
-  t.equal(atomicPlan.stepCount, 1, 'keeps intermediate results private by default');
-  t.equal(atomicPlan.publicationCount, 0, 'does not surface undeclared application publication');
-  t.equal(atomicPlan.latencyPriority, 'background', 'retains explicit scheduling urgency');
-  t.ok(atomicPlan.steps[0].publishable, 'always publishes the completed graph');
+  expect(atomicPlan.stepCount, 'keeps intermediate results private by default').toBe(1);
+  expect(atomicPlan.publicationCount, 'does not surface undeclared application publication').toBe(
+    0
+  );
+  expect(atomicPlan.latencyPriority, 'retains explicit scheduling urgency').toBe('background');
+  expect(Boolean(atomicPlan.steps[0].publishable), 'always publishes the completed graph').toBe(
+    true
+  );
 
   const progressivePlan = getGPUCommandGraphExecutionPlan(preflight, budget, {
     latencyPriority: 'interactive',
     publicationPolicy: 'progressive'
   });
-  t.equal(progressivePlan.stepCount, 3, 'ends steps at coherent intermediate boundaries');
-  t.equal(progressivePlan.publicationCount, 2, 'reports every surfaced intermediate result');
-  t.deepEqual(
+  expect(progressivePlan.stepCount, 'ends steps at coherent intermediate boundaries').toBe(3);
+  expect(progressivePlan.publicationCount, 'reports every surfaced intermediate result').toBe(2);
+  expect(
     progressivePlan.steps.map(step => step.publications.map(publication => publication.id)),
-    [['summary'], ['histogram'], []],
     'identifies exactly which result became safe after each queue completion'
-  );
-  t.ok(
-    progressivePlan.steps.every(step => step.publishable),
+  ).toEqual([['summary'], ['histogram'], []]);
+  expect(
+    Boolean(progressivePlan.steps.every(step => step.publishable)),
     'marks intermediate boundaries and final completion as publishable'
-  );
-  t.ok(
-    progressivePlan.steps.every(step => step.latencyPriority === 'interactive'),
+  ).toBe(true);
+  expect(
+    Boolean(progressivePlan.steps.every(step => step.latencyPriority === 'interactive')),
     'propagates latency priority to every scheduler-visible step'
-  );
-  t.end();
+  ).toBe(true);
 });
 
-test('GPUCommandGraph execution budget controller learns from saturated measured steps', t => {
+it('GPUCommandGraph execution budget controller learns from saturated measured steps', () => {
   const controller = new GPUCommandGraphExecutionBudgetController({
     initialBudget: {
       maximumInvocationCount: 1000,
@@ -174,28 +174,27 @@ test('GPUCommandGraph execution budget controller learns from saturated measured
   });
 
   const slowObservation = controller.observeStep(makeStep(1000, 10, 4000), 20);
-  t.equal(slowObservation.scale, 0.5, 'halves the future envelope after a saturated slow step');
-  t.equal(
+  expect(slowObservation.scale, 'halves the future envelope after a saturated slow step').toBe(0.5);
+  expect(
     controller.budget.maximumInvocationCount,
-    500,
     'scales invocation limits for the next execution'
+  ).toBe(500);
+  expect(controller.budget.maximumReadByteLength, 'scales memory-traffic limits coherently').toBe(
+    2000
   );
-  t.equal(controller.budget.maximumReadByteLength, 2000, 'scales memory-traffic limits coherently');
 
   const fastObservation = controller.observeStep(makeStep(500, 5, 2000), 2.5);
-  t.equal(fastObservation.scale, 1, 'recovers conservatively after a saturated fast step');
+  expect(fastObservation.scale, 'recovers conservatively after a saturated fast step').toBe(1);
   controller.reset();
   const partialObservation = controller.observeStep(makeStep(250, 2, 1000), 2.5);
-  t.equal(
+  expect(
     partialObservation.scale,
-    1,
     'does not inflate the budget from a proportionally fast partial tail step'
-  );
-  t.equal(controller.sampleCount, 1, 'reset clears prior empirical samples');
-  t.end();
+  ).toBe(1);
+  expect(controller.sampleCount, 'reset clears prior empirical samples').toBe(1);
 });
 
-test('GPUCommandGraph execution latency priorities select queue-time targets', t => {
+it('GPUCommandGraph execution latency priorities select queue-time targets', () => {
   const makeController = (
     latencyPriority: 'interactive' | 'normal' | 'background'
   ): GPUCommandGraphExecutionBudgetController =>
@@ -203,8 +202,9 @@ test('GPUCommandGraph execution latency priorities select queue-time targets', t
       initialBudget: {maximumInvocationCount: 1000},
       latencyPriority
     });
-  t.equal(makeController('interactive').targetStepMilliseconds, 4, 'prioritizes low latency');
-  t.equal(makeController('normal').targetStepMilliseconds, 8, 'uses the balanced default');
-  t.equal(makeController('background').targetStepMilliseconds, 16, 'favors background throughput');
-  t.end();
+  expect(makeController('interactive').targetStepMilliseconds, 'prioritizes low latency').toBe(4);
+  expect(makeController('normal').targetStepMilliseconds, 'uses the balanced default').toBe(8);
+  expect(makeController('background').targetStepMilliseconds, 'favors background throughput').toBe(
+    16
+  );
 });

--- a/modules/gpgpu/test/gpu-core/gpu-command-graph-textures.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-command-graph-textures.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {
   Buffer,
   ExternalTexture,
@@ -41,15 +41,13 @@ class TestExternalTexture extends ExternalTexture {
   }
 }
 
-test('GPUCommandGraph validates texture descriptors, views, and imports', async t => {
+it('GPUCommandGraph validates texture descriptors, views, and imports', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const graph = new GPUCommandGraph(device, {id: 'texture-validation'});
-  t.throws(
+  expect(
     () =>
       graph.createTransientTexture({
         id: 'invalid-size',
@@ -58,9 +56,8 @@ test('GPUCommandGraph validates texture descriptors, views, and imports', async 
         height: 4,
         usage: Texture.RENDER
       }),
-    /positive safe integer/,
     'zero texture extent is rejected'
-  );
+  ).toThrow(/positive safe integer/);
   const mipTexture = graph.createTransientTexture({
     id: 'mips',
     format: 'rgba8unorm',
@@ -73,23 +70,21 @@ test('GPUCommandGraph validates texture descriptors, views, and imports', async 
     baseMipLevel: 2,
     mipLevelCount: 1
   });
-  t.equal(mipTwo.width, 2, 'view width reflects base mip');
-  t.equal(mipTwo.height, 2, 'view height reflects base mip');
-  t.throws(
+  expect(mipTwo.width, 'view width reflects base mip').toBe(2);
+  expect(mipTwo.height, 'view height reflects base mip').toBe(2);
+  expect(
     () => graph.createTextureView(mipTexture, {baseMipLevel: 4, mipLevelCount: 1}),
-    /exceeds.*mip levels/,
     'view outside mip range is rejected'
-  );
-  t.throws(
+  ).toThrow(/exceeds.*mip levels/);
+  expect(
     () =>
       graph.addComputePass({
         id: 'wrong-usage',
         resources: [{texture: mipTwo, usage: 'render-attachment'}],
         compile: () => ({encode: () => {}})
       }),
-    /does not declare usage/,
     'node texture role must be declared by the descriptor'
-  );
+  ).toThrow(/does not declare usage/);
 
   const importedTexture = device.createTexture({
     id: 'imported-texture',
@@ -119,23 +114,22 @@ test('GPUCommandGraph validates texture descriptors, views, and imports', async 
     })
   });
   const compiled = importGraph.compile();
-  t.equal(compiled.stats.importedTextureCount, 1, 'imported texture count is reported');
-  t.equal(compiled.stats.importedTextureBytes, 64, 'imported texture bytes are estimated');
-  t.equal(compiled.stats.logicalTextureCount, 1, 'logical texture count includes imports');
-  t.equal(compiled.stats.logicalTextureBytes, 64, 'logical texture bytes include imports');
-  t.equal(compiled.stats.logicalResourceBytes, 64, 'logical resource bytes include textures');
-  t.equal(
+  expect(compiled.stats.importedTextureCount, 'imported texture count is reported').toBe(1);
+  expect(compiled.stats.importedTextureBytes, 'imported texture bytes are estimated').toBe(64);
+  expect(compiled.stats.logicalTextureCount, 'logical texture count includes imports').toBe(1);
+  expect(compiled.stats.logicalTextureBytes, 'logical texture bytes include imports').toBe(64);
+  expect(compiled.stats.logicalResourceBytes, 'logical resource bytes include textures').toBe(64);
+  expect(
     compiled.stats.physicalTransientResourceBytes,
-    0,
     'imported textures are excluded from owned transient memory'
-  );
+  ).toBe(0);
   compiled.encode(device.createCommandEncoder({id: 'texture-import-first'}), {
     parameters: undefined
   });
   compiled.encode(device.createCommandEncoder({id: 'texture-import-second'}), {
     parameters: undefined
   });
-  t.equal(resolvedViews[0], resolvedViews[1], 'concrete texture view is cached across encodes');
+  expect(resolvedViews[0], 'concrete texture view is cached across encodes').toBe(resolvedViews[1]);
   const replacement = device.createTexture({
     id: 'replacement-texture',
     width: 4,
@@ -147,7 +141,9 @@ test('GPUCommandGraph validates texture descriptors, views, and imports', async 
     parameters: undefined,
     textures: {imported: replacement}
   });
-  t.notEqual(resolvedViews[1], resolvedViews[2], 'replacement texture resolves a distinct view');
+  expect(resolvedViews[1], 'replacement texture resolves a distinct view').not.toBe(
+    resolvedViews[2]
+  );
   const wrongSize = device.createTexture({
     id: 'wrong-size-texture',
     width: 8,
@@ -155,28 +151,26 @@ test('GPUCommandGraph validates texture descriptors, views, and imports', async 
     format: 'rgba8unorm',
     usage: Texture.SAMPLE
   });
-  t.throws(
+  expect(
     () =>
       compiled.encode(device.createCommandEncoder({id: 'texture-import-invalid'}), {
         parameters: undefined,
         textures: {imported: wrongSize}
       }),
-    /incompatible width/,
     'fixed-size import rejects resized replacement'
-  );
+  ).toThrow(/incompatible width/);
   compiled.destroy();
-  t.notOk(importedTexture.destroyed, 'compiled graph leaves imported texture alive');
+  expect(Boolean(importedTexture.destroyed), 'compiled graph leaves imported texture alive').toBe(
+    false
+  );
   importedTexture.destroy();
   replacement.destroy();
   wrongSize.destroy();
-  t.end();
 });
 
-test('GPUCommandGraph resolves multisampled color attachments', async t => {
+it('GPUCommandGraph resolves multisampled color attachments', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const resolvedTexture = device.createTexture({
@@ -221,12 +215,12 @@ test('GPUCommandGraph resolves multisampled color attachments', async t => {
   compiled.encode(commandEncoder, {parameters: undefined});
   device.submit(commandEncoder.finish());
   const pixels = await readPixels(resolvedTexture, 4, 4);
-  t.ok(
-    pixels[0] > 240 && pixels[1] < 10 && pixels[2] < 10,
+  expect(
+    Boolean(pixels[0] > 240 && pixels[1] < 10 && pixels[2] < 10),
     'multisampled clear resolves into the declared single-sample target'
-  );
+  ).toBe(true);
   compiled.destroy();
-  t.notOk(resolvedTexture.destroyed, 'resolve target remains caller-owned');
+  expect(Boolean(resolvedTexture.destroyed), 'resolve target remains caller-owned').toBe(false);
   resolvedTexture.destroy();
 
   const invalidGraph = new GPUCommandGraph(device, {id: 'invalid-resolve'});
@@ -244,7 +238,7 @@ test('GPUCommandGraph resolves multisampled color attachments', async t => {
     height: 4,
     usage: Texture.RENDER
   });
-  t.throws(
+  expect(
     () =>
       invalidGraph.addRenderPass({
         id: 'invalid-resolve-pass',
@@ -254,17 +248,13 @@ test('GPUCommandGraph resolves multisampled color attachments', async t => {
         },
         compile: () => ({encode: () => {}})
       }),
-    /match a multisampled source and be single-sampled/,
     'single-sample sources cannot declare resolve targets'
-  );
-  t.end();
+  ).toThrow(/match a multisampled source and be single-sampled/);
 });
 
-test('GPUCommandGraph redirects reusable render passes to caller-owned framebuffers', async t => {
+it('GPUCommandGraph redirects reusable render passes to caller-owned framebuffers', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -332,18 +322,16 @@ test('GPUCommandGraph redirects reusable render passes to caller-owned framebuff
   });
   device.submit(secondEncoder.finish());
 
-  t.deepEqual(
+  expect(
     Array.from((await readPixels(firstTexture, 4, 4)).subarray(0, 4)),
-    [255, 0, 0, 255],
     'the first offscreen framebuffer receives only its own render pass'
-  );
-  t.deepEqual(
+  ).toEqual([255, 0, 0, 255]);
+  expect(
     Array.from((await readPixels(secondTexture, 4, 4)).subarray(0, 4)),
-    [0, 255, 0, 255],
     'the next encoding can target a different caller-owned framebuffer'
-  );
-  t.equal(compilationCount, 1, 'changing the target does not recompile the render executable');
-  t.equal(encodingCount, 2, 'the same compiled render executable records both frames');
+  ).toEqual([0, 255, 0, 255]);
+  expect(compilationCount, 'changing the target does not recompile the render executable').toBe(1);
+  expect(encodingCount, 'the same compiled render executable records both frames').toBe(2);
 
   const conflictingGraph = new GPUCommandGraph(device, {id: 'conflicting-framebuffer'});
   const managedColor = conflictingGraph.importTexture(
@@ -365,33 +353,40 @@ test('GPUCommandGraph redirects reusable render passes to caller-owned framebuff
     })
   });
   const conflictingCompiled = conflictingGraph.compile();
-  t.throws(
+  expect(
     () =>
       conflictingCompiled.encode(device.createCommandEncoder({id: 'conflicting-encoding'}), {
         parameters: undefined
       }),
-    /cannot supply framebuffer with graph attachments/,
     'graph-managed attachments cannot be replaced by a callback-supplied framebuffer'
-  );
+  ).toThrow(/cannot supply framebuffer with graph attachments/);
 
   conflictingCompiled.destroy();
   compiled.destroy();
-  t.notOk(firstFramebuffer.destroyed, 'the first framebuffer remains caller-owned');
-  t.notOk(secondFramebuffer.destroyed, 'the replacement framebuffer remains caller-owned');
-  t.notOk(firstTexture.destroyed, 'the first framebuffer texture remains caller-owned');
-  t.notOk(secondTexture.destroyed, 'the replacement framebuffer texture remains caller-owned');
+  expect(Boolean(firstFramebuffer.destroyed), 'the first framebuffer remains caller-owned').toBe(
+    false
+  );
+  expect(
+    Boolean(secondFramebuffer.destroyed),
+    'the replacement framebuffer remains caller-owned'
+  ).toBe(false);
+  expect(
+    Boolean(firstTexture.destroyed),
+    'the first framebuffer texture remains caller-owned'
+  ).toBe(false);
+  expect(
+    Boolean(secondTexture.destroyed),
+    'the replacement framebuffer texture remains caller-owned'
+  ).toBe(false);
   firstFramebuffer.destroy();
   secondFramebuffer.destroy();
   firstTexture.destroy();
   secondTexture.destroy();
-  t.end();
 });
 
-test('GPUCommandGraph enforces frame-scoped texture bindings', async t => {
+it('GPUCommandGraph enforces frame-scoped texture bindings', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const firstTexture = device.createTexture({
@@ -450,14 +445,13 @@ test('GPUCommandGraph enforces frame-scoped texture bindings', async t => {
   const resourceStats = device.statsManager.getStats('Resource Counts');
   const baselineFramebufferCount = resourceStats.get('Framebuffers Active').count;
   const baselineTextureViewCount = resourceStats.get('TextureViews Active').count;
-  t.throws(
+  expect(
     () =>
       compiled.encode(device.createCommandEncoder({id: 'missing-frame'}), {
         parameters: undefined
       }),
-    /frame texture "frame-color" is required/,
     'frame-scoped imports have no persistent default'
-  );
+  ).toThrow(/frame texture "frame-color" is required/);
   const firstEncoder = device.createCommandEncoder({id: 'frame-0'});
   compiled.encode(firstEncoder, {
     parameters: undefined,
@@ -467,17 +461,15 @@ test('GPUCommandGraph enforces frame-scoped texture bindings', async t => {
     }
   });
   device.submit(firstEncoder.finish());
-  t.equal(
+  expect(
     resourceStats.get('Framebuffers Active').count,
-    baselineFramebufferCount + 1,
     'the first frame owns one cached framebuffer'
-  );
-  t.equal(
+  ).toBe(baselineFramebufferCount + 1);
+  expect(
     resourceStats.get('TextureViews Active').count,
-    baselineTextureViewCount + 1,
     'the first frame owns one non-default attachment view'
-  );
-  t.throws(
+  ).toBe(baselineTextureViewCount + 1);
+  expect(
     () =>
       compiled.encode(device.createCommandEncoder({id: 'stale-frame'}), {
         parameters: undefined,
@@ -486,10 +478,9 @@ test('GPUCommandGraph enforces frame-scoped texture bindings', async t => {
           ['frame-auxiliary']: {texture: auxiliaryTexture, frameId: 0}
         }
       }),
-    /frameId 0 is stale/,
     'a consumed frame ID cannot be reused'
-  );
-  t.throws(
+  ).toThrow(/frameId 0 is stale/);
+  expect(
     () =>
       compiled.encode(device.createCommandEncoder({id: 'mixed-frame'}), {
         parameters: undefined,
@@ -498,9 +489,8 @@ test('GPUCommandGraph enforces frame-scoped texture bindings', async t => {
           ['frame-auxiliary']: {texture: auxiliaryTexture, frameId: 2}
         }
       }),
-    /must share one frameId/,
     'all frame-scoped imports in one encoding share a coherent frame ID'
-  );
+  ).toThrow(/must share one frameId/);
   const secondEncoder = device.createCommandEncoder({id: 'frame-1'});
   compiled.encode(secondEncoder, {
     parameters: undefined,
@@ -510,35 +500,31 @@ test('GPUCommandGraph enforces frame-scoped texture bindings', async t => {
     }
   });
   device.submit(secondEncoder.finish());
-  t.equal(
+  expect(
     resourceStats.get('Framebuffers Active').count,
-    baselineFramebufferCount + 1,
     'refreshing a frame view retires its stale framebuffer'
-  );
-  t.equal(
+  ).toBe(baselineFramebufferCount + 1);
+  expect(
     resourceStats.get('TextureViews Active').count,
-    baselineTextureViewCount + 1,
     'refreshing a frame view retires its stale texture view'
-  );
+  ).toBe(baselineTextureViewCount + 1);
   compiled.destroy();
-  t.equal(
+  expect(
     resourceStats.get('Framebuffers Active').count,
-    baselineFramebufferCount,
     'destroy releases the final cached framebuffer'
+  ).toBe(baselineFramebufferCount);
+  expect(Boolean(firstTexture.destroyed), 'first frame texture remains caller-owned').toBe(false);
+  expect(Boolean(secondTexture.destroyed), 'replacement frame texture remains caller-owned').toBe(
+    false
   );
-  t.notOk(firstTexture.destroyed, 'first frame texture remains caller-owned');
-  t.notOk(secondTexture.destroyed, 'replacement frame texture remains caller-owned');
   firstTexture.destroy();
   secondTexture.destroy();
   auxiliaryTexture.destroy();
-  t.end();
 });
 
-test('GPUCommandGraph enforces sampled-only external texture frames', async t => {
+it('GPUCommandGraph enforces sampled-only external texture frames', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const externalTextureSampler = device.createSampler({id: 'external-texture-test-sampler'});
@@ -556,11 +542,10 @@ test('GPUCommandGraph enforces sampled-only external texture frames', async t =>
     usage: Texture.RENDER
   });
   const graph = new GPUCommandGraph(device, {id: 'external-texture'});
-  t.throws(
+  expect(
     () => graph.importExternalTexture({id: 'invalid-video', width: 0, height: 4}),
-    /positive safe integer/,
     'external texture descriptors require positive fixed dimensions'
-  );
+  ).toThrow(/positive safe integer/);
   const externalTexture = graph.importExternalTexture({id: 'video', width: 4, height: 4});
   const frameTextureHandle = graph.importFrameTexture({
     id: 'color',
@@ -571,16 +556,15 @@ test('GPUCommandGraph enforces sampled-only external texture frames', async t =>
   });
   const frameTextureView = graph.createTextureView(frameTextureHandle);
   const resolvedExternalTextures: unknown[] = [];
-  t.throws(
+  expect(
     () =>
       graph.addComputePass({
         id: 'invalid-external-compute',
         resources: [{externalTexture, usage: 'sampled'}],
         compile: () => ({encode: () => {}})
       }),
-    /only by render nodes/,
     'external texture bindings cannot leak into incompatible pass types'
-  );
+  ).toThrow(/only by render nodes/);
   graph.addRenderPass({
     id: 'sample-video',
     attachments: {colorAttachments: [frameTextureView]},
@@ -592,27 +576,25 @@ test('GPUCommandGraph enforces sampled-only external texture frames', async t =>
   });
   const compiled = graph.compile();
   const missingFrameEncoder = device.createCommandEncoder({id: 'missing-external-frame'});
-  t.throws(
+  expect(
     () =>
       compiled.encode(missingFrameEncoder, {
         parameters: undefined,
         frameTextures: {color: {texture: frameTexture, frameId: 0}}
       }),
-    /external texture "video" is required/,
     'external texture imports have no persistent default'
-  );
+  ).toThrow(/external texture "video" is required/);
   missingFrameEncoder.destroy();
   const wrongSizeEncoder = device.createCommandEncoder({id: 'wrong-size-external-frame'});
-  t.throws(
+  expect(
     () =>
       compiled.encode(wrongSizeEncoder, {
         parameters: undefined,
         frameTextures: {color: {texture: frameTexture, frameId: 0}},
         externalTextures: {video: {texture: wrongSizeExternalTexture, frameId: 0}}
       }),
-    /incompatible dimensions/,
     'external frame dimensions must match the compiled contract'
-  );
+  ).toThrow(/incompatible dimensions/);
   wrongSizeEncoder.destroy();
   const firstFrameEncoder = device.createCommandEncoder({id: 'external-frame-0'});
   compiled.encode(firstFrameEncoder, {
@@ -621,30 +603,30 @@ test('GPUCommandGraph enforces sampled-only external texture frames', async t =>
     externalTextures: {video: {texture: firstExternalTexture, frameId: 0}}
   });
   firstFrameEncoder.destroy();
-  t.equal(resolvedExternalTextures[0], firstExternalTexture, 'first frame resolves its snapshot');
+  expect(resolvedExternalTextures[0], 'first frame resolves its snapshot').toBe(
+    firstExternalTexture
+  );
   const reusedFrameEncoder = device.createCommandEncoder({id: 'reused-external-frame'});
-  t.throws(
+  expect(
     () =>
       compiled.encode(reusedFrameEncoder, {
         parameters: undefined,
         frameTextures: {color: {texture: frameTexture, frameId: 1}},
         externalTextures: {video: {texture: firstExternalTexture, frameId: 1}}
       }),
-    /requires a fresh binding/,
     'the same opaque external binding cannot cross frame boundaries'
-  );
+  ).toThrow(/requires a fresh binding/);
   reusedFrameEncoder.destroy();
   const mixedFrameEncoder = device.createCommandEncoder({id: 'mixed-external-frame'});
-  t.throws(
+  expect(
     () =>
       compiled.encode(mixedFrameEncoder, {
         parameters: undefined,
         frameTextures: {color: {texture: frameTexture, frameId: 1}},
         externalTextures: {video: {texture: secondExternalTexture, frameId: 2}}
       }),
-    /must share one frameId/,
     'ordinary and external frame imports share one coherent frame ID'
-  );
+  ).toThrow(/must share one frameId/);
   mixedFrameEncoder.destroy();
   const secondFrameEncoder = device.createCommandEncoder({id: 'external-frame-1'});
   compiled.encode(secondFrameEncoder, {
@@ -653,41 +635,41 @@ test('GPUCommandGraph enforces sampled-only external texture frames', async t =>
     externalTextures: {video: {texture: secondExternalTexture, frameId: 1}}
   });
   secondFrameEncoder.destroy();
-  t.equal(
-    resolvedExternalTextures[1],
-    secondExternalTexture,
-    'the next frame resolves a fresh binding'
+  expect(resolvedExternalTextures[1], 'the next frame resolves a fresh binding').toBe(
+    secondExternalTexture
   );
   const nonconsecutiveReuseEncoder = device.createCommandEncoder({
     id: 'nonconsecutive-reused-external-frame'
   });
-  t.throws(
+  expect(
     () =>
       compiled.encode(nonconsecutiveReuseEncoder, {
         parameters: undefined,
         frameTextures: {color: {texture: frameTexture, frameId: 2}},
         externalTextures: {video: {texture: firstExternalTexture, frameId: 2}}
       }),
-    /requires a fresh binding/,
     'an expired binding cannot be reused after an intervening frame'
-  );
+  ).toThrow(/requires a fresh binding/);
   nonconsecutiveReuseEncoder.destroy();
   compiled.destroy();
-  t.notOk(firstExternalTexture.destroyed, 'compiled graph leaves external bindings caller-owned');
-  t.notOk(secondExternalTexture.destroyed, 'replacement external binding remains caller-owned');
+  expect(
+    Boolean(firstExternalTexture.destroyed),
+    'compiled graph leaves external bindings caller-owned'
+  ).toBe(false);
+  expect(
+    Boolean(secondExternalTexture.destroyed),
+    'replacement external binding remains caller-owned'
+  ).toBe(false);
   firstExternalTexture.destroy();
   secondExternalTexture.destroy();
   wrongSizeExternalTexture.destroy();
   frameTexture.destroy();
   externalTextureSampler.destroy();
-  t.end();
 });
 
-test('GPUCommandGraph tracks texture subresources and reuses compatible transients', async t => {
+it('GPUCommandGraph tracks texture subresources and reuses compatible transients', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const disjointGraph = new GPUCommandGraph(device, {id: 'disjoint-subresources'});
@@ -719,11 +701,10 @@ test('GPUCommandGraph tracks texture subresources and reuses compatible transien
     compile: () => ({encode: () => {}})
   });
   const disjointCompiled = disjointGraph.compile();
-  t.deepEqual(
+  expect(
     disjointCompiled.stats.nodeOrder,
-    ['write-mip-zero', 'read-mip-one'],
     'disjoint subresources do not create a reverse hazard cycle'
-  );
+  ).toEqual(['write-mip-zero', 'read-mip-one']);
   disjointCompiled.destroy();
 
   const overlapGraph = new GPUCommandGraph(device, {id: 'overlap-subresources'});
@@ -750,7 +731,9 @@ test('GPUCommandGraph tracks texture subresources and reuses compatible transien
     resources: [{texture: overlapMip, usage: 'storage-write'}],
     compile: () => ({encode: () => {}})
   });
-  t.throws(() => overlapGraph.compile(), /dependency cycle/, 'overlapping view hazard is detected');
+  expect(() => overlapGraph.compile(), 'overlapping view hazard is detected').toThrow(
+    /dependency cycle/
+  );
 
   const reuseGraph = new GPUCommandGraph(device, {id: 'texture-reuse'});
   const first = reuseGraph.createTransientTexture({
@@ -789,25 +772,28 @@ test('GPUCommandGraph tracks texture subresources and reuses compatible transien
     compile: () => ({encode: () => {}})
   });
   const reused = reuseGraph.compile();
-  t.equal(reused.stats.logicalTransientTextureCount, 2, 'two logical textures are tracked');
-  t.equal(reused.stats.physicalTransientTextureCount, 1, 'compatible lifetimes share texture');
-  t.equal(reused.stats.logicalTextureCount, 2, 'logical texture count includes both transients');
-  t.equal(reused.stats.logicalTextureBytes, 512, 'logical texture bytes include both transients');
-  t.equal(
-    reused.stats.physicalTransientResourceBytes,
-    256,
-    'owned transient memory reflects physical texture reuse'
+  expect(reused.stats.logicalTransientTextureCount, 'two logical textures are tracked').toBe(2);
+  expect(reused.stats.physicalTransientTextureCount, 'compatible lifetimes share texture').toBe(1);
+  expect(reused.stats.logicalTextureCount, 'logical texture count includes both transients').toBe(
+    2
   );
-  t.ok(reused.stats.reusedTransientTextureBytes > 0, 'texture reuse reports saved bytes');
+  expect(reused.stats.logicalTextureBytes, 'logical texture bytes include both transients').toBe(
+    512
+  );
+  expect(
+    reused.stats.physicalTransientResourceBytes,
+    'owned transient memory reflects physical texture reuse'
+  ).toBe(256);
+  expect(
+    Boolean(reused.stats.reusedTransientTextureBytes > 0),
+    'texture reuse reports saved bytes'
+  ).toBe(true);
   reused.destroy();
-  t.end();
 });
 
-test('GPUCommandGraph composes storage texture output with sampled rendering', async t => {
+it('GPUCommandGraph composes storage texture output with sampled rendering', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const graph = new GPUCommandGraph(device, {id: 'storage-sampled'});
@@ -913,18 +899,20 @@ test('GPUCommandGraph composes storage texture output with sampled rendering', a
   compiled.encode(commandEncoder, {parameters: undefined});
   device.submit(commandEncoder.finish());
   const pixels = await readPixels(outputTexture, 4, 4);
-  t.ok(pixels[0] > 240 && pixels[1] > 50, 'sampled render observes storage texture writes');
+  expect(
+    Boolean(pixels[0] > 240 && pixels[1] > 50),
+    'sampled render observes storage texture writes'
+  ).toBe(true);
   compiled.destroy();
-  t.notOk(outputTexture.destroyed, 'imported output texture remains caller-owned');
+  expect(Boolean(outputTexture.destroyed), 'imported output texture remains caller-owned').toBe(
+    false
+  );
   outputTexture.destroy();
-  t.end();
 });
 
-test('GPUIndexPickingTarget renders stable integer IDs and copies dynamic pixels', async t => {
+it('GPUIndexPickingTarget renders stable integer IDs and copies dynamic pixels', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const defaultReadback = makePickingReadbackBuffer(device, 'picking-readback-default');
@@ -975,46 +963,42 @@ test('GPUIndexPickingTarget renders stable integer IDs and copies dynamic pixels
   target.addReadbackPass({after: 'pick-render', getPixel: parameters => parameters.pixel});
   const compiled = graph.compile();
   await encodePick(device, compiled, [0, 0]);
-  t.deepEqual(
+  expect(
     decodeGPUIndexPickInfo(await defaultReadback.readAsync(0, 8)),
-    {objectIndex: 7, batchIndex: null},
     'left pixel preserves a stable object without a batch ID'
-  );
+  ).toEqual({objectIndex: 7, batchIndex: null});
   const replacementReadback = makePickingReadbackBuffer(device, 'picking-readback-replacement');
   await encodePick(device, compiled, [3, 0], replacementReadback, target.readback.id);
-  t.deepEqual(
+  expect(
     decodeGPUIndexPickInfo(await replacementReadback.readAsync(0, 8)),
-    {objectIndex: 9, batchIndex: 3},
     'per-encoding staging override returns second stable ID'
-  );
+  ).toEqual({objectIndex: 9, batchIndex: 3});
   const backgroundReadback = makePickingReadbackBuffer(device, 'picking-readback-background');
   await encodePick(device, compiled, [1, 3], backgroundReadback, target.readback.id);
-  t.deepEqual(
+  expect(
     decodeGPUIndexPickInfo(await backgroundReadback.readAsync(0, 8)),
-    {objectIndex: null, batchIndex: null},
     'cleared background decodes to no pick'
-  );
-  t.throws(
+  ).toEqual({objectIndex: null, batchIndex: null});
+  expect(
     () =>
       compiled.encode(device.createCommandEncoder({id: 'picking-out-of-range'}), {
         parameters: {pixel: [4, 0]}
       }),
-    /outside 4x4 target/,
     'out-of-range dynamic pixel is rejected'
-  );
+  ).toThrow(/outside 4x4 target/);
   compiled.destroy();
-  t.notOk(defaultReadback.destroyed, 'compiled graph preserves caller-owned staging buffer');
+  expect(
+    Boolean(defaultReadback.destroyed),
+    'compiled graph preserves caller-owned staging buffer'
+  ).toBe(false);
   defaultReadback.destroy();
   replacementReadback.destroy();
   backgroundReadback.destroy();
-  t.end();
 });
 
-test('GPUIndexPickingTarget reduces regions through a reusable readback ring', async t => {
+it('GPUIndexPickingTarget reduces regions through a reusable readback ring', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const capacity = 6;
@@ -1095,12 +1079,15 @@ test('GPUIndexPickingTarget reduces regions through a reusable readback ring', a
 
   const firstTicket = ring.tryAcquire();
   const reservedTicket = ring.tryAcquire();
-  t.ok(firstTicket && reservedTicket, 'all configured staging slots can be reserved');
-  t.equal(ring.tryAcquire(), null, 'tryAcquire exposes drop-on-pressure policy');
+  expect(
+    Boolean(firstTicket && reservedTicket),
+    'all configured staging slots can be reserved'
+  ).toBe(true);
+  expect(ring.tryAcquire(), 'tryAcquire exposes drop-on-pressure policy').toBe(null);
   const waitingTicketPromise = ring.acquire();
   reservedTicket?.cancel();
   const waitingTicket = await waitingTicketPromise;
-  t.ok(waitingTicket, 'acquire waits for the next released slot');
+  expect(Boolean(waitingTicket), 'acquire waits for the next released slot').toBe(true);
   waitingTicket.cancel();
 
   const firstEncoder = device.createCommandEncoder({id: 'pick-region-first'});
@@ -1108,17 +1095,19 @@ test('GPUIndexPickingTarget reduces regions through a reusable readback ring', a
   firstTicket?.copyFrom(firstEncoder, resultBuffer);
   device.submit(firstEncoder.finish());
   const firstResult = decodeGPUIndexPickRegion(await firstTicket!.read());
-  t.equal(firstResult.count, 12, 'count includes every non-background covered pixel');
-  t.equal(firstResult.picks.length, capacity, 'stored pairs stop at caller capacity');
-  t.ok(firstResult.overflow, 'overflow reports truncated results');
-  t.ok(
-    firstResult.picks.every(
-      pick =>
-        (pick.objectIndex === 7 && pick.batchIndex === null) ||
-        (pick.objectIndex === 9 && pick.batchIndex === 3)
+  expect(firstResult.count, 'count includes every non-background covered pixel').toBe(12);
+  expect(firstResult.picks.length, 'stored pairs stop at caller capacity').toBe(capacity);
+  expect(Boolean(firstResult.overflow), 'overflow reports truncated results').toBe(true);
+  expect(
+    Boolean(
+      firstResult.picks.every(
+        pick =>
+          (pick.objectIndex === 7 && pick.batchIndex === null) ||
+          (pick.objectIndex === 9 && pick.batchIndex === 3)
+      )
     ),
     'stable object IDs survive collection with optional batch IDs'
-  );
+  ).toBe(true);
 
   regionBuffer.write(new Uint32Array([0, 0, 2, 3]));
   const exactTicket = ring.tryAcquire();
@@ -1127,9 +1116,9 @@ test('GPUIndexPickingTarget reduces regions through a reusable readback ring', a
   exactTicket?.copyFrom(exactEncoder, resultBuffer);
   device.submit(exactEncoder.finish());
   const exactResult = decodeGPUIndexPickRegion(await exactTicket!.read());
-  t.equal(exactResult.count, capacity, 'exact-capacity selection reports the complete count');
-  t.equal(exactResult.picks.length, capacity, 'exact-capacity selection stores every pair');
-  t.notOk(exactResult.overflow, 'exact capacity does not report overflow');
+  expect(exactResult.count, 'exact-capacity selection reports the complete count').toBe(capacity);
+  expect(exactResult.picks.length, 'exact-capacity selection stores every pair').toBe(capacity);
+  expect(Boolean(exactResult.overflow), 'exact capacity does not report overflow').toBe(false);
 
   regionBuffer.write(new Uint32Array([0, 0, 0, 3]));
   const emptyTicket = ring.tryAcquire();
@@ -1137,24 +1126,22 @@ test('GPUIndexPickingTarget reduces regions through a reusable readback ring', a
   compiled.encode(emptyEncoder, {parameters: undefined});
   emptyTicket?.copyFrom(emptyEncoder, resultBuffer);
   device.submit(emptyEncoder.finish());
-  t.deepEqual(
+  expect(
     decodeGPUIndexPickRegion(await emptyTicket!.read()),
-    {picks: [], count: 0, overflow: false},
     'empty rectangles clear prior results'
-  );
+  ).toEqual({picks: [], count: 0, overflow: false});
 
   regionBuffer.write(new Uint32Array([0, 0, 1, 1]));
   const secondTicket = ring.tryAcquire();
-  t.ok(secondTicket, 'mapped slot is reusable after read completion');
+  expect(Boolean(secondTicket), 'mapped slot is reusable after read completion').toBe(true);
   const secondEncoder = device.createCommandEncoder({id: 'pick-region-second'});
   compiled.encode(secondEncoder, {parameters: undefined});
   secondTicket?.copyFrom(secondEncoder, resultBuffer);
   device.submit(secondEncoder.finish());
-  t.deepEqual(
+  expect(
     decodeGPUIndexPickRegion(await secondTicket!.read()),
-    {picks: [{objectIndex: 7, batchIndex: null}], count: 1, overflow: false},
     'GPU-resident rectangle updates produce exact results without rebuilding the graph'
-  );
+  ).toEqual({picks: [{objectIndex: 7, batchIndex: null}], count: 1, overflow: false});
 
   const heldTicket = ring.tryAcquire();
   const cancelledTicket = ring.tryAcquire();
@@ -1167,18 +1154,15 @@ test('GPUIndexPickingTarget reduces regions through a reusable readback ring', a
     error => String(error)
   );
   cancelledTicket?.cancel();
-  t.match(
-    await cancelledRead,
-    /cancelled/,
-    'in-progress cancellation drains and discards its slot'
+  expect(await cancelledRead, 'in-progress cancellation drains and discards its slot').toMatch(
+    /cancelled/
   );
-  t.equal(
+  expect(
     ring.availableSlotCount,
-    1,
     'a later ticket can complete while an earlier encoded ticket remains reserved'
-  );
+  ).toBe(1);
   await heldTicket?.read();
-  t.equal(ring.availableSlotCount, 2, 'out-of-order completion eventually releases every slot');
+  expect(ring.availableSlotCount, 'out-of-order completion eventually releases every slot').toBe(2);
 
   const pendingTicket = ring.tryAcquire();
   const secondPendingTicket = ring.tryAcquire();
@@ -1188,13 +1172,14 @@ test('GPUIndexPickingTarget reduces regions through a reusable readback ring', a
     error => String(error)
   );
   ring.destroy();
-  t.match(await rejectionMessage, /destroyed/, 'destroy rejects pending backpressure waiters');
+  expect(await rejectionMessage, 'destroy rejects pending backpressure waiters').toMatch(
+    /destroyed/
+  );
   pendingTicket?.cancel();
   secondPendingTicket?.cancel();
   compiled.destroy();
   regionBuffer.destroy();
   resultBuffer.destroy();
-  t.end();
 });
 
 function makePickingReadbackBuffer(device: Device, id: string): Buffer {
@@ -1246,11 +1231,9 @@ async function readPixels(texture: Texture, width: number, height: number): Prom
   }
 }
 
-test('GPUCommandGraph rejects texture imports from another device', async t => {
+it('GPUCommandGraph rejects texture imports from another device', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const nullDevice = await getNullTestDevice();
@@ -1261,7 +1244,7 @@ test('GPUCommandGraph rejects texture imports from another device', async t => {
     usage: Texture.SAMPLE
   });
   const graph = new GPUCommandGraph(device);
-  t.throws(
+  expect(
     () =>
       graph.importTexture(
         {
@@ -1273,9 +1256,7 @@ test('GPUCommandGraph rejects texture imports from another device', async t => {
         },
         wrongDeviceTexture
       ),
-    /another device/,
     'wrong-device texture import is rejected'
-  );
+  ).toThrow(/another device/);
   wrongDeviceTexture.destroy();
-  t.end();
 });

--- a/modules/gpgpu/test/gpu-core/gpu-command-graph.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-command-graph.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -18,7 +19,6 @@ import {
 } from '@luma.gl/gpgpu/gpu-core';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getNullTestDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
 import {
   getBoundedDispatchLayout,
   getBoundedInvocationIndexSource
@@ -31,11 +31,9 @@ import {
   getGPUScanStrategy
 } from '../../src/gpu-core/gpu-scan';
 
-test('GPUCommandGraph compiles dependencies and reuses transient buffers', async t => {
+it('GPUCommandGraph compiles dependencies and reuses transient buffers', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -77,56 +75,51 @@ test('GPUCommandGraph compiles dependencies and reuses transient buffers', async
   const compiled = graph.compile();
   const debugString =
     'CompiledGPUCommandGraph:"graph-scheduling-test":3 nodes:128B transient:active';
-  t.equal(
-    Object.prototype.toString.call(compiled),
-    '[object CompiledGPUCommandGraph]',
-    'exposes a compact object-inspection tag'
+  expect(Object.prototype.toString.call(compiled), 'exposes a compact object-inspection tag').toBe(
+    '[object CompiledGPUCommandGraph]'
   );
-  t.equal(compiled.toString(), debugString, 'summarizes graph identity, size, and lifecycle');
-  t.equal(compiled.toJSON(), debugString, 'serializes without recursive resource graphs');
-  t.equal(JSON.stringify(compiled), JSON.stringify(debugString), 'keeps JSON logs compact');
-  t.deepEqual(
-    compiled.stats.nodeOrder,
-    ['write-first', 'write-second', 'read-second'],
-    'stable order includes inferred dependency'
+  expect(compiled.toString(), 'summarizes graph identity, size, and lifecycle').toBe(debugString);
+  expect(compiled.toJSON(), 'serializes without recursive resource graphs').toBe(debugString);
+  expect(JSON.stringify(compiled), 'keeps JSON logs compact').toBe(JSON.stringify(debugString));
+  expect(compiled.stats.nodeOrder, 'stable order includes inferred dependency').toEqual([
+    'write-first',
+    'write-second',
+    'read-second'
+  ]);
+  expect(compiled.stats.logicalTransientBufferCount, 'tracks two logical buffers').toBe(2);
+  expect(compiled.stats.logicalBufferCount, 'reports all logical buffers').toBe(2);
+  expect(compiled.stats.importedBufferCount, 'reports no imported buffers').toBe(0);
+  expect(compiled.stats.physicalTransientBufferCount, 'reuses one physical allocation').toBe(1);
+  expect(compiled.stats.logicalTransientBytes, 'reports logical bytes').toBe(192);
+  expect(compiled.stats.logicalBufferBytes, 'reports total logical buffer bytes').toBe(192);
+  expect(compiled.stats.physicalTransientBytes, 'reports physical bytes').toBe(128);
+  expect(compiled.stats.logicalResourceBytes, 'reports total logical resource bytes').toBe(192);
+  expect(compiled.stats.physicalTransientResourceBytes, 'reports total owned transient bytes').toBe(
+    128
   );
-  t.equal(compiled.stats.logicalTransientBufferCount, 2, 'tracks two logical buffers');
-  t.equal(compiled.stats.logicalBufferCount, 2, 'reports all logical buffers');
-  t.equal(compiled.stats.importedBufferCount, 0, 'reports no imported buffers');
-  t.equal(compiled.stats.physicalTransientBufferCount, 1, 'reuses one physical allocation');
-  t.equal(compiled.stats.logicalTransientBytes, 192, 'reports logical bytes');
-  t.equal(compiled.stats.logicalBufferBytes, 192, 'reports total logical buffer bytes');
-  t.equal(compiled.stats.physicalTransientBytes, 128, 'reports physical bytes');
-  t.equal(compiled.stats.logicalResourceBytes, 192, 'reports total logical resource bytes');
-  t.equal(
-    compiled.stats.physicalTransientResourceBytes,
-    128,
-    'reports total owned transient bytes'
-  );
-  t.equal(compiled.preflight.commandCount, 1, 'aggregates annotated commands');
-  t.equal(compiled.preflight.annotatedNodeCount, 1, 'reports workload-estimate coverage');
-  t.equal(compiled.preflight.maximumWorkgroupCount, 2, 'aggregates annotated workgroups');
-  t.equal(compiled.preflight.maximumInvocationCount, 512, 'aggregates annotated invocations');
-  t.equal(compiled.preflight.readByteLength, 16, 'aggregates annotated reads');
-  t.equal(compiled.preflight.writeByteLength, 64, 'aggregates annotated writes');
-  t.equal(compiled.preflight.largestBufferByteLength, 128, 'reports the largest buffer');
-  t.equal(compiled.preflight.nodes[0].operation, 'TestFill', 'preserves operation identity');
-  t.equal(compiled.preflight.fitsDeviceLimits, true, 'reports valid declared resources');
+  expect(compiled.preflight.commandCount, 'aggregates annotated commands').toBe(1);
+  expect(compiled.preflight.annotatedNodeCount, 'reports workload-estimate coverage').toBe(1);
+  expect(compiled.preflight.maximumWorkgroupCount, 'aggregates annotated workgroups').toBe(2);
+  expect(compiled.preflight.maximumInvocationCount, 'aggregates annotated invocations').toBe(512);
+  expect(compiled.preflight.readByteLength, 'aggregates annotated reads').toBe(16);
+  expect(compiled.preflight.writeByteLength, 'aggregates annotated writes').toBe(64);
+  expect(compiled.preflight.largestBufferByteLength, 'reports the largest buffer').toBe(128);
+  expect(compiled.preflight.nodes[0].operation, 'preserves operation identity').toBe('TestFill');
+  expect(compiled.preflight.fitsDeviceLimits, 'reports valid declared resources').toBe(true);
   const commandEncoder = device.createCommandEncoder({id: 'graph-scheduling-encoding'});
   const encoding = compiled.encode(commandEncoder, {parameters: undefined});
-  t.equal(encoding.stats.computePassCount, 1, 'coalesces consecutive graph compute nodes');
-  t.equal(encoding.stats.coalescedComputeNodeCount, 2, 'reports nodes sharing the physical pass');
+  expect(encoding.stats.computePassCount, 'coalesces consecutive graph compute nodes').toBe(1);
+  expect(encoding.stats.coalescedComputeNodeCount, 'reports nodes sharing the physical pass').toBe(
+    2
+  );
   commandEncoder.destroy();
   compiled.destroy();
-  t.match(compiled.toString(), /:destroyed$/, 'reports destroyed graph state compactly');
-  t.end();
+  expect(compiled.toString(), 'reports destroyed graph state compactly').toMatch(/:destroyed$/);
 });
 
-test('GPUCommandGraph reports adapter capabilities and explicit encoding timings', async t => {
+it('GPUCommandGraph reports adapter capabilities and explicit encoding timings', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -152,46 +145,43 @@ test('GPUCommandGraph reports adapter capabilities and explicit encoding timings
   });
   const compiled = graph.compile();
 
-  t.equal(compiled.stats.importedBufferCount, 1, 'counts imported buffers');
-  t.equal(compiled.stats.importedBufferBytes, 32, 'reports imported buffer capacity');
-  t.equal(compiled.stats.logicalBufferBytes, 32, 'includes imports in logical memory');
-  t.equal(
-    compiled.capabilities.timestampQueries,
-    device.features.has('timestamp-query'),
-    'reports timestamp-query support'
+  expect(compiled.stats.importedBufferCount, 'counts imported buffers').toBe(1);
+  expect(compiled.stats.importedBufferBytes, 'reports imported buffer capacity').toBe(32);
+  expect(compiled.stats.logicalBufferBytes, 'includes imports in logical memory').toBe(32);
+  expect(compiled.capabilities.timestampQueries, 'reports timestamp-query support').toBe(
+    device.features.has('timestamp-query')
   );
-  t.equal(
-    compiled.capabilities.subgroups,
-    device.features.has('subgroups'),
-    'reports subgroup device support'
+  expect(compiled.capabilities.subgroups, 'reports subgroup device support').toBe(
+    device.features.has('subgroups')
   );
-  t.equal(
-    compiled.capabilities.subgroupId,
-    device.wgslLanguageFeatures.has('subgroup_id'),
-    'reports subgroup_id WGSL language support'
+  expect(compiled.capabilities.subgroupId, 'reports subgroup_id WGSL language support').toBe(
+    device.wgslLanguageFeatures.has('subgroup_id')
   );
-  t.equal(
-    compiled.capabilities.maxBufferByteLength,
-    device.limits.maxBufferSize,
-    'reports the device buffer limit'
+  expect(compiled.capabilities.maxBufferByteLength, 'reports the device buffer limit').toBe(
+    device.limits.maxBufferSize
   );
 
   const commandEncoder = device.createCommandEncoder({id: 'graph-diagnostics-encoding'});
   const encoding = compiled.encode(commandEncoder, {parameters: undefined});
-  t.equal(encoding.stats.nodeCount, 2, 'reports every encoded node');
-  t.equal(encoding.stats.computePassCount, 1, 'reports the number of physical compute passes');
-  t.equal(encoding.stats.coalescedComputeNodeCount, 0, 'reports no merged standalone node');
-  t.equal(encoding.stats.timestampedNodeCount, 0, 'does not invent GPU timestamps');
-  t.notOk(encoding.canReadGPUTimings, 'plain encoders do not expose GPU timing readback');
-  t.ok(encoding.stats.cpuEncodeTimeMilliseconds >= 0, 'reports total CPU encoding time');
-  t.deepEqual(
+  expect(encoding.stats.nodeCount, 'reports every encoded node').toBe(2);
+  expect(encoding.stats.computePassCount, 'reports the number of physical compute passes').toBe(1);
+  expect(encoding.stats.coalescedComputeNodeCount, 'reports no merged standalone node').toBe(0);
+  expect(encoding.stats.timestampedNodeCount, 'does not invent GPU timestamps').toBe(0);
+  expect(
+    Boolean(encoding.canReadGPUTimings),
+    'plain encoders do not expose GPU timing readback'
+  ).toBe(false);
+  expect(
+    Boolean(encoding.stats.cpuEncodeTimeMilliseconds >= 0),
+    'reports total CPU encoding time'
+  ).toBe(true);
+  expect(
     encoding.stats.nodes.map(node => [node.id, node.type, node.hasGPUTimestamps]),
-    [
-      ['observe-import', 'compute', false],
-      ['cpu-only-copy', 'copy', false]
-    ],
     'reports stable per-node encoding metadata'
-  );
+  ).toEqual([
+    ['observe-import', 'compute', false],
+    ['cpu-only-copy', 'copy', false]
+  ]);
   commandEncoder.destroy();
 
   if (device.features.has('timestamp-query')) {
@@ -208,30 +198,34 @@ test('GPUCommandGraph reports adapter capabilities and explicit encoding timings
     const commandBuffer = timestampEncoder.finish();
     device.submit(commandBuffer);
     const report = await timestampEncoding.readTimings();
-    t.equal(
+    expect(
       timestampEncoding.stats.timestampedNodeCount,
-      1,
       'timestamps render and compute passes'
-    );
-    t.ok(timestampEncoding.canReadGPUTimings, 'exposes explicit timing readback capability');
-    t.ok(report.gpuTimeMilliseconds !== undefined, 'reads a total GPU duration after submission');
-    t.ok(report.nodes[0].gpuTimeMilliseconds !== undefined, 'reads the compute node GPU duration');
-    t.equal(report.nodes[1].gpuTimeMilliseconds, undefined, 'copy nodes remain CPU-timed');
+    ).toBe(1);
+    expect(
+      Boolean(timestampEncoding.canReadGPUTimings),
+      'exposes explicit timing readback capability'
+    ).toBe(true);
+    expect(
+      Boolean(report.gpuTimeMilliseconds !== undefined),
+      'reads a total GPU duration after submission'
+    ).toBe(true);
+    expect(
+      Boolean(report.nodes[0].gpuTimeMilliseconds !== undefined),
+      'reads the compute node GPU duration'
+    ).toBe(true);
+    expect(report.nodes[1].gpuTimeMilliseconds, 'copy nodes remain CPU-timed').toBe(undefined);
     querySet.destroy();
   } else {
-    t.comment('Timestamp queries are unavailable on this adapter');
   }
 
   compiled.destroy();
   importedBuffer.destroy();
-  t.end();
 });
 
-test('GPUCommandGraph spreads workload-annotated nodes across bounded execution steps', async t => {
+it('GPUCommandGraph spreads workload-annotated nodes across bounded execution steps', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -264,60 +258,61 @@ test('GPUCommandGraph spreads workload-annotated nodes across bounded execution 
     maximumWriteByteLength: 1400
   };
   const plan = compiled.getExecutionPlan(executionBudget);
-  t.equal(plan.stepCount, 3, 'plans three bounded queue submissions');
-  t.equal(plan.maximumInvocationCount, 1600, 'reports complete invocation bounds');
-  t.equal(plan.readByteLength, 6400, 'reports complete read bounds');
-  t.equal(plan.steps[0].commandCount, 2, 'packs commands up to the multidimensional budget');
-  t.equal(plan.steps[0].readByteLength, 2800, 'packs reads up to the byte budget');
-  t.ok(plan.steps[1].exceedsBudget, 'identifies an indivisible oversized partition');
-  t.equal(plan.oversizedStepCount, 1, 'summarizes oversized steps before encoding');
+  expect(plan.stepCount, 'plans three bounded queue submissions').toBe(3);
+  expect(plan.maximumInvocationCount, 'reports complete invocation bounds').toBe(1600);
+  expect(plan.readByteLength, 'reports complete read bounds').toBe(6400);
+  expect(plan.steps[0].commandCount, 'packs commands up to the multidimensional budget').toBe(2);
+  expect(plan.steps[0].readByteLength, 'packs reads up to the byte budget').toBe(2800);
+  expect(
+    Boolean(plan.steps[1].exceedsBudget),
+    'identifies an indivisible oversized partition'
+  ).toBe(true);
+  expect(plan.oversizedStepCount, 'summarizes oversized steps before encoding').toBe(1);
   const execution = compiled.createExecution(executionBudget);
-  t.deepEqual(execution.plan, plan, 'execution exposes an equivalent immutable plan');
+  expect(execution.plan, 'execution exposes an equivalent immutable plan').toEqual(plan);
 
   const firstEncoder = device.createCommandEncoder({id: 'bounded-execution-step-0'});
   const firstStep = execution.encodeNext(firstEncoder, {parameters: undefined});
-  t.deepEqual(
-    encodedNodeIds,
-    ['initialize', 'partition-0', 'partition-1'],
-    'first step packs dependency-ordered nodes up to the budget'
-  );
-  t.equal(firstStep.maximumInvocationCount, 700, 'reports the first step invocation bound');
-  t.equal(firstStep.stepIndex, 0, 'reports the encoded plan step');
-  t.equal(firstStep.progress, 1 / 3, 'reports planned-submission progress');
-  t.equal(firstStep.publishedProgress, 0, 'keeps incomplete results private by default');
-  t.notOk(firstStep.completed, 'execution remains resumable');
+  expect(encodedNodeIds, 'first step packs dependency-ordered nodes up to the budget').toEqual([
+    'initialize',
+    'partition-0',
+    'partition-1'
+  ]);
+  expect(firstStep.maximumInvocationCount, 'reports the first step invocation bound').toBe(700);
+  expect(firstStep.stepIndex, 'reports the encoded plan step').toBe(0);
+  expect(firstStep.progress, 'reports planned-submission progress').toBe(1 / 3);
+  expect(firstStep.publishedProgress, 'keeps incomplete results private by default').toBe(0);
+  expect(Boolean(firstStep.completed), 'execution remains resumable').toBe(false);
   firstEncoder.destroy();
 
   const secondEncoder = device.createCommandEncoder({id: 'bounded-execution-step-1'});
   const secondStep = execution.encodeNext(secondEncoder, {parameters: undefined});
-  t.deepEqual(
-    encodedNodeIds,
-    ['initialize', 'partition-0', 'partition-1', 'oversized-partition'],
-    'one oversized node still makes forward progress'
-  );
-  t.equal(secondStep.maximumInvocationCount, 900, 'reports an indivisible oversized node');
-  t.ok(secondStep.exceedsBudget, 'propagates the oversized-step diagnostic');
-  t.equal(secondStep.publishedProgress, 0, 'does not expose an unsafe intermediate state');
-  t.notOk(secondStep.completed, 'trailing finalization remains pending');
+  expect(encodedNodeIds, 'one oversized node still makes forward progress').toEqual([
+    'initialize',
+    'partition-0',
+    'partition-1',
+    'oversized-partition'
+  ]);
+  expect(secondStep.maximumInvocationCount, 'reports an indivisible oversized node').toBe(900);
+  expect(Boolean(secondStep.exceedsBudget), 'propagates the oversized-step diagnostic').toBe(true);
+  expect(secondStep.publishedProgress, 'does not expose an unsafe intermediate state').toBe(0);
+  expect(Boolean(secondStep.completed), 'trailing finalization remains pending').toBe(false);
   secondEncoder.destroy();
 
   const thirdEncoder = device.createCommandEncoder({id: 'bounded-execution-step-2'});
   const thirdStep = execution.encodeNext(thirdEncoder, {parameters: undefined});
-  t.deepEqual(encodedNodeIds.at(-1), 'finalize', 'finalization is encoded last');
-  t.ok(thirdStep.completed, 'final step completes the execution');
-  t.equal(thirdStep.progress, 1, 'completed execution reports full progress');
-  t.equal(thirdStep.publishedProgress, 1, 'publishes the atomically completed graph');
+  expect(encodedNodeIds.at(-1), 'finalization is encoded last').toEqual('finalize');
+  expect(Boolean(thirdStep.completed), 'final step completes the execution').toBe(true);
+  expect(thirdStep.progress, 'completed execution reports full progress').toBe(1);
+  expect(thirdStep.publishedProgress, 'publishes the atomically completed graph').toBe(1);
   thirdEncoder.destroy();
 
   compiled.destroy();
-  t.end();
 });
 
-test('GPUCommandGraph rejects explicit dependency cycles', async t => {
+it('GPUCommandGraph rejects explicit dependency cycles', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const graph = new GPUCommandGraph(device, {id: 'cycle-test'});
@@ -331,15 +326,12 @@ test('GPUCommandGraph rejects explicit dependency cycles', async t => {
     dependsOn: ['left'],
     compile: () => ({encode: () => {}})
   });
-  t.throws(() => graph.compile(), /dependency cycle/, 'cycle is rejected');
-  t.end();
+  expect(() => graph.compile(), 'cycle is rejected').toThrow(/dependency cycle/);
 });
 
-test('GPUCommandGraph preserves fixed-width GPUVector chunks and borrowed ownership', async t => {
+it('GPUCommandGraph preserves fixed-width GPUVector chunks and borrowed ownership', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -375,21 +367,23 @@ test('GPUCommandGraph preserves fixed-width GPUVector chunks and borrowed owners
   const firstView = graph.importGPUData('first-data', firstChunk);
   const vectorView = graph.importGPUVector('values', vector);
 
-  t.equal(firstView.format, 'uint32', 'GPUData format is preserved');
-  t.equal(firstView.length, 2, 'GPUData length is preserved');
-  t.equal(firstView.byteOffset, 0, 'GPUData byte offset is preserved');
-  t.equal(firstView.byteStride, 4, 'GPUData byte stride is preserved');
-  t.equal(vectorView.name, 'values', 'GPUVector name is preserved');
-  t.equal(vectorView.length, 6, 'GPUVector row count is preserved');
-  t.equal(vectorView.data.length, 3, 'GPUVector chunk count is preserved');
-  t.equal(vectorView.data[0].buffer, firstView.buffer, 'reuses an already imported table buffer');
-  t.equal(vectorView.data[0].buffer, vectorView.data[1].buffer, 'shared chunks share one handle');
-  t.notEqual(
-    vectorView.data[1].buffer,
-    vectorView.data[2].buffer,
-    'distinct buffers stay distinct'
+  expect(firstView.format, 'GPUData format is preserved').toBe('uint32');
+  expect(firstView.length, 'GPUData length is preserved').toBe(2);
+  expect(firstView.byteOffset, 'GPUData byte offset is preserved').toBe(0);
+  expect(firstView.byteStride, 'GPUData byte stride is preserved').toBe(4);
+  expect(vectorView.name, 'GPUVector name is preserved').toBe('values');
+  expect(vectorView.length, 'GPUVector row count is preserved').toBe(6);
+  expect(vectorView.data.length, 'GPUVector chunk count is preserved').toBe(3);
+  expect(vectorView.data[0].buffer, 'reuses an already imported table buffer').toBe(
+    firstView.buffer
   );
-  t.equal(vectorView.data[1].byteOffset, 8, 'per-chunk byte offsets are preserved');
+  expect(vectorView.data[0].buffer, 'shared chunks share one handle').toBe(
+    vectorView.data[1].buffer
+  );
+  expect(vectorView.data[1].buffer, 'distinct buffers stay distinct').not.toBe(
+    vectorView.data[2].buffer
+  );
+  expect(vectorView.data[1].byteOffset, 'per-chunk byte offsets are preserved').toBe(8);
 
   graph.addCopyPass({
     id: 'read-first-chunk',
@@ -404,26 +398,30 @@ test('GPUCommandGraph preserves fixed-width GPUVector chunks and borrowed owners
   });
   graph.addCopyPass({id: 'gate', compile: () => ({encode: () => {}})});
   const compiled = graph.compile();
-  t.deepEqual(
+  expect(
     compiled.stats.nodeOrder,
-    ['gate', 'read-first-chunk', 'write-second-chunk'],
     'hazards are inferred through the shared physical buffer handle'
-  );
+  ).toEqual(['gate', 'read-first-chunk', 'write-second-chunk']);
 
   compiled.destroy();
-  t.notOk(sharedBuffer.destroyed, 'compiled graph does not destroy borrowed shared storage');
-  t.notOk(trailingBuffer.destroyed, 'compiled graph does not destroy borrowed trailing storage');
+  expect(
+    Boolean(sharedBuffer.destroyed),
+    'compiled graph does not destroy borrowed shared storage'
+  ).toBe(false);
+  expect(
+    Boolean(trailingBuffer.destroyed),
+    'compiled graph does not destroy borrowed trailing storage'
+  ).toBe(false);
   vector.destroy();
-  t.ok(sharedBuffer.destroyed, 'GPUVector retains shared-buffer ownership');
-  t.ok(trailingBuffer.destroyed, 'GPUVector retains trailing-buffer ownership');
-  t.end();
+  expect(Boolean(sharedBuffer.destroyed), 'GPUVector retains shared-buffer ownership').toBe(true);
+  expect(Boolean(trailingBuffer.destroyed), 'GPUVector retains trailing-buffer ownership').toBe(
+    true
+  );
 });
 
-test('GPUCommandGraph rejects interleaved and variable-length GPUVector imports', async t => {
+it('GPUCommandGraph rejects interleaved and variable-length GPUVector imports', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -453,27 +451,22 @@ test('GPUCommandGraph rejects interleaved and variable-length GPUVector imports'
   });
   const graph = new GPUCommandGraph(device);
 
-  t.throws(
+  expect(
     () => graph.importGPUVector('interleaved', interleaved),
-    /does not accept interleaved/,
     'interleaved vectors require an explicit attribute adapter'
-  );
-  t.throws(
+  ).toThrow(/does not accept interleaved/);
+  expect(
     () => graph.importGPUVector('variable-length', variableLength),
-    /fixed-width GPUVector format/,
     'variable-length vectors require an explicit topology adapter'
-  );
+  ).toThrow(/fixed-width GPUVector format/);
 
   interleaved.destroy();
   variableLength.destroy();
-  t.end();
 });
 
-test('GPUCommandGraph exposes safe extension-library helpers', async t => {
+it('GPUCommandGraph exposes safe extension-library helpers', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -492,39 +485,34 @@ test('GPUCommandGraph exposes safe extension-library helpers', async t => {
     }
   };
   contributor.addToGraph(graph);
-  t.equal(
-    contributorOutputUsage,
-    Buffer.STORAGE | Buffer.INDIRECT,
-    'contributors can request additional transient usage flags'
+  expect(contributorOutputUsage, 'contributors can request additional transient usage flags').toBe(
+    Buffer.STORAGE | Buffer.INDIRECT
   );
 
-  t.throws(
+  expect(
     () => createTransientView(graph, 'invalid-length', 'uint32', -1),
-    /non-negative safe integer/,
     'negative transient lengths are rejected before graph allocation'
-  );
-  t.doesNotThrow(
+  ).toThrow(/non-negative safe integer/);
+  expect(
     () => createTransientView(graph, 'invalid-length', 'uint32', 0),
     'a rejected transient does not reserve its graph resource id'
-  );
-  t.throws(
+  ).not.toThrow();
+  expect(
     () => createTransientView(graph, 'missing-storage', 'uint32', 1, Buffer.INDIRECT),
-    /must include Buffer.STORAGE/,
     'typed transient views retain storage binding usage'
-  );
+  ).toThrow(/must include Buffer.STORAGE/);
   for (const [format, id] of [
     ['vertex-list<float32x3>', 'vertex-list-transient'],
     ['value-list<uint32>', 'value-list-transient']
   ] as const) {
-    t.throws(
+    expect(
       () => Reflect.apply(createTransientView, undefined, [graph, id, format, 2]),
-      /requires a fixed-width GPUVector format/,
       `${format} requires an explicit variable-length adapter`
-    );
-    t.doesNotThrow(
+    ).toThrow(/requires a fixed-width GPUVector format/);
+    expect(
       () => createTransientView(graph, id, 'float32x3', 2),
       `${format} is rejected before reserving its graph resource id`
-    );
+    ).not.toThrow();
   }
 
   const bindingBuffer = device.createBuffer({byteLength: 512, usage: Buffer.STORAGE});
@@ -538,55 +526,49 @@ test('GPUCommandGraph exposes safe extension-library helpers', async t => {
     byteOffset: 260
   });
   const binding = getViewBinding(bindingView, () => bindingBuffer);
-  t.equal(binding.offset, 256, 'storage binding starts at an aligned byte offset');
-  t.equal(binding.size, 8, 'storage binding includes the view prefix and row');
-  t.equal(getViewElementOffset(bindingView), 1, 'shader element offset addresses the view row');
+  expect(binding.offset, 'storage binding starts at an aligned byte offset').toBe(256);
+  expect(binding.size, 'storage binding includes the view prefix and row').toBe(8);
+  expect(getViewElementOffset(bindingView), 'shader element offset addresses the view row').toBe(1);
 
   const misalignedView = graph.createDataView(bindingHandle, {
     format: 'uint32',
     length: 1,
     byteOffset: 261
   });
-  t.throws(
+  expect(
     () => getViewElementOffset(misalignedView),
-    /must be uint32-aligned/,
     'fractional shader element offsets are rejected'
-  );
+  ).toThrow(/must be uint32-aligned/);
   const emptyEndView = graph.createDataView(bindingHandle, {
     format: 'uint32',
     length: 0,
     byteOffset: bindingHandle.byteLength
   });
-  t.throws(
+  expect(
     () => getViewBinding(emptyEndView, () => bindingBuffer),
-    /exceeds its logical buffer/,
     'empty views still require one bindable row inside the logical buffer'
-  );
+  ).toThrow(/exceeds its logical buffer/);
 
   bindingBuffer.destroy();
-  t.end();
 });
 
-test('GPUCommandGraph validates resources and overlapping lifetimes', async t => {
+it('GPUCommandGraph validates resources and overlapping lifetimes', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
   const nullDevice = await getNullTestDevice();
   const wrongDeviceBuffer = nullDevice.createBuffer({byteLength: 16, usage: Buffer.STORAGE});
   const wrongDeviceGraph = new GPUCommandGraph(device);
-  t.throws(
+  expect(
     () =>
       wrongDeviceGraph.importBuffer(
         {id: 'wrong-device', byteLength: 16, usage: Buffer.STORAGE},
         wrongDeviceBuffer
       ),
-    /another device/,
     'wrong-device imports are rejected'
-  );
+  ).toThrow(/another device/);
 
   const validationGraph = new GPUCommandGraph(device);
   const copyOnly = validationGraph.createTransientBuffer({
@@ -594,56 +576,51 @@ test('GPUCommandGraph validates resources and overlapping lifetimes', async t =>
     byteLength: 16,
     usage: Buffer.COPY_DST
   });
-  t.throws(
+  expect(
     () =>
       validationGraph.addComputePass({
         id: 'invalid-use',
         resources: [{buffer: copyOnly, usage: 'storage-read'}],
         compile: () => ({encode: () => {}})
       }),
-    /does not declare usage/,
     'node uses must be compatible with descriptors'
-  );
+  ).toThrow(/does not declare usage/);
   const unaligned = validationGraph.createDataView(copyOnly, {
     format: 'uint32',
     length: 1,
     byteOffset: 2
   });
-  t.throws(
+  expect(
     () => new GPUScan({input: unaligned, output: unaligned}),
-    /uint32-aligned/,
     'uint32 algorithms reject misaligned views'
-  );
-  t.throws(
+  ).toThrow(/uint32-aligned/);
+  expect(
     () =>
       validationGraph.createDataView(copyOnly, {
         format: 'uint32',
         length: 4,
         byteOffset: 4
       }),
-    /exceeds buffer/,
     'views cannot exceed logical capacity'
-  );
-  t.throws(
+  ).toThrow(/exceeds buffer/);
+  expect(
     () =>
       validationGraph.createDataView(copyOnly, {
         format: 'uint32',
         length: 1,
         byteOffset: Number.MAX_SAFE_INTEGER
       }),
-    /safe integer precision/,
     'view byte ranges cannot overflow safe integer precision'
-  );
-  t.throws(
+  ).toThrow(/safe integer precision/);
+  expect(
     () =>
       validationGraph.createTransientBuffer({
         id: 'oversized-buffer',
         byteLength: device.limits.maxBufferSize + 1,
         usage: Buffer.STORAGE
       }),
-    /device buffer limit/,
     'logical buffers cannot exceed the adapter allocation limit'
-  );
+  ).toThrow(/device buffer limit/);
   const aliasingBuffer = validationGraph.createTransientBuffer({
     id: 'aliasing-storage',
     byteLength: 512,
@@ -658,7 +635,7 @@ test('GPUCommandGraph validates resources and overlapping lifetimes', async t =>
     length: 16,
     byteOffset: 64
   });
-  t.throws(
+  expect(
     () =>
       validationGraph.addComputePass({
         id: 'writable-storage-alias',
@@ -668,9 +645,8 @@ test('GPUCommandGraph validates resources and overlapping lifetimes', async t =>
         ],
         compile: () => ({encode: () => {}})
       }),
-    /overlapping writable storage bindings.*aliasing-storage.*0–64 bytes.*0–128 bytes/,
     'aligned WebGPU binding ranges are validated before shader compilation'
-  );
+  ).toThrow(/overlapping writable storage bindings.*aliasing-storage.*0–64 bytes.*0–128 bytes/);
   const alignedStorageView = validationGraph.createDataView(aliasingBuffer, {
     format: 'uint32',
     length: 16,
@@ -684,7 +660,7 @@ test('GPUCommandGraph validates resources and overlapping lifetimes', async t =>
     ],
     compile: () => ({encode: () => {}})
   });
-  t.throws(
+  expect(
     () =>
       validationGraph.createTransientTexture({
         id: 'oversized-texture',
@@ -693,9 +669,8 @@ test('GPUCommandGraph validates resources and overlapping lifetimes', async t =>
         height: 1,
         usage: Texture.RENDER
       }),
-    /device dimension limits/,
     'logical textures cannot exceed adapter dimension limits'
-  );
+  ).toThrow(/device dimension limits/);
 
   const overlapGraph = new GPUCommandGraph(device);
   const first = overlapGraph.createTransientBuffer({
@@ -727,21 +702,17 @@ test('GPUCommandGraph validates resources and overlapping lifetimes', async t =>
     compile: () => ({encode: () => {}})
   });
   const overlapping = overlapGraph.compile();
-  t.equal(
+  expect(
     overlapping.stats.physicalTransientBufferCount,
-    2,
     'overlapping transient lifetimes use separate allocations'
-  );
+  ).toBe(2);
   overlapping.destroy();
   wrongDeviceBuffer.destroy();
-  t.end();
 });
 
-test('CompiledGPUCommandGraph rejects encoding after device loss', async t => {
+it('CompiledGPUCommandGraph rejects encoding after device loss', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -752,11 +723,10 @@ test('CompiledGPUCommandGraph rejects encoding after device loss', async t => {
   const existingDescriptor = Object.getOwnPropertyDescriptor(device, 'isLost');
   Object.defineProperty(device, 'isLost', {configurable: true, value: true});
   try {
-    t.throws(
+    expect(
       () => compiled.encode(commandEncoder, {parameters: undefined}),
-      /after device loss/,
       'device loss fails before resource resolution or command recording'
-    );
+    ).toThrow(/after device loss/);
   } finally {
     if (existingDescriptor) {
       Object.defineProperty(device, 'isLost', existingDescriptor);
@@ -766,14 +736,11 @@ test('CompiledGPUCommandGraph rejects encoding after device loss', async t => {
   }
   commandEncoder.destroy();
   compiled.destroy();
-  t.end();
 });
 
-test('CompiledGPUCommandGraph resolves DynamicBuffer replacements and preserves imports', async t => {
+it('CompiledGPUCommandGraph resolves DynamicBuffer replacements and preserves imports', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const dynamicBuffer = new DynamicBuffer(device, {
@@ -798,134 +765,124 @@ test('CompiledGPUCommandGraph resolves DynamicBuffer replacements and preserves 
   dynamicBuffer.resize({byteLength: 32});
   const secondBackingBuffer = dynamicBuffer.buffer;
   compiled.encode(device.createCommandEncoder({id: 'dynamic-second'}), {parameters: undefined});
-  t.equal(resolvedBuffers[0], firstBackingBuffer, 'first encoding resolves initial backing buffer');
-  t.equal(
-    resolvedBuffers[1],
-    secondBackingBuffer,
-    'second encoding resolves replacement backing buffer'
+  expect(resolvedBuffers[0], 'first encoding resolves initial backing buffer').toBe(
+    firstBackingBuffer
+  );
+  expect(resolvedBuffers[1], 'second encoding resolves replacement backing buffer').toBe(
+    secondBackingBuffer
   );
   compiled.destroy();
-  t.notOk(secondBackingBuffer.destroyed, 'destroying graph leaves imported buffer alive');
+  expect(
+    Boolean(secondBackingBuffer.destroyed),
+    'destroying graph leaves imported buffer alive'
+  ).toBe(false);
   dynamicBuffer.destroy();
 
   const missingGraph = new GPUCommandGraph(device);
   missingGraph.importBuffer({id: 'required', byteLength: 16, usage: Buffer.STORAGE});
   const missingCompiled = missingGraph.compile();
-  t.throws(
+  expect(
     () =>
       missingCompiled.encode(device.createCommandEncoder({id: 'missing-import'}), {
         parameters: undefined
       }),
-    /is required/,
     'encoding rejects a missing import'
-  );
+  ).toThrow(/is required/);
   const undersized = device.createBuffer({byteLength: 4, usage: Buffer.STORAGE});
-  t.throws(
+  expect(
     () =>
       missingCompiled.encode(device.createCommandEncoder({id: 'undersized-import'}), {
         parameters: undefined,
         buffers: {required: undersized}
       }),
-    /smaller than compiled capacity/,
     'encoding rejects an undersized override'
-  );
+  ).toThrow(/smaller than compiled capacity/);
   missingCompiled.destroy();
   undersized.destroy();
-  t.end();
 });
 
-test('GPUScan plans bounded multidimensional direct dispatches', t => {
+it('GPUScan plans bounded multidimensional direct dispatches', () => {
   const maximum = 65_535;
   const oneDimensionalRowCapacity = maximum * 256;
 
-  t.deepEqual(getGPUScanDispatchLayout(0, maximum), {x: 1, y: 1, z: 1});
-  t.deepEqual(getGPUScanDispatchLayout(oneDimensionalRowCapacity, maximum), {
+  expect(getGPUScanDispatchLayout(0, maximum)).toEqual({x: 1, y: 1, z: 1});
+  expect(getGPUScanDispatchLayout(oneDimensionalRowCapacity, maximum)).toEqual({
     x: maximum,
     y: 1,
     z: 1
   });
-  t.deepEqual(getGPUScanDispatchLayout(oneDimensionalRowCapacity + 1, maximum), {
+  expect(getGPUScanDispatchLayout(oneDimensionalRowCapacity + 1, maximum)).toEqual({
     x: maximum,
     y: 2,
     z: 1
   });
-  t.deepEqual(
+  expect(
     getGPUScanDispatchLayout(4 * 256 + 1, 2),
-    {x: 2, y: 2, z: 2},
     'a small synthetic limit exercises the third dispatch dimension'
-  );
-  t.throws(() => getGPUScanDispatchLayout(8 * 256 + 1, 2), /exceeding the 3D dispatch limit/);
-  t.throws(
+  ).toEqual({x: 2, y: 2, z: 2});
+  expect(() => getGPUScanDispatchLayout(8 * 256 + 1, 2)).toThrow(/exceeding the 3D dispatch limit/);
+  expect(
     () => getBoundedDispatchLayout('GPUScan', 1024, 3, maximum),
-    /power of two greater than one/,
     'the shared uint32 guard rejects workgroup sizes that can wrap padded lanes'
-  );
-  t.throws(
+  ).toThrow(/power of two greater than one/);
+  expect(
     () => getBoundedInvocationIndexSource({x: 1, y: 1, z: 1}, 1),
-    /power of two greater than one/,
     'the source helper never emits an unrepresentable 2^32 guard literal'
-  );
+  ).toThrow(/power of two greater than one/);
 
   const source = getGPUScanInvocationIndexSource({x: 3, y: 2, z: 2});
-  t.match(source, /workgroupId\.z \* 2u \+ workgroupId\.y/);
-  t.match(source, /\* 3u \+ workgroupId\.x/);
-  t.match(
-    source,
-    /workgroupIndex >= 16777216u/,
-    'padded workgroups cannot wrap the uint32 invocation index'
+  expect(source).toMatch(/workgroupId\.z \* 2u \+ workgroupId\.y/);
+  expect(source).toMatch(/\* 3u \+ workgroupId\.x/);
+  expect(source, 'padded workgroups cannot wrap the uint32 invocation index').toMatch(
+    /workgroupIndex >= 16777216u/
   );
-  t.ok(
-    source.indexOf('workgroupIndex >= 16777216u') <
-      source.indexOf('workgroupIndex * 256u + localInvocationIndex'),
+  expect(
+    Boolean(
+      source.indexOf('workgroupIndex >= 16777216u') <
+        source.indexOf('workgroupIndex * 256u + localInvocationIndex')
+    ),
     'the uint32 guard executes before invocation-index multiplication'
-  );
-  t.end();
+  ).toBe(true);
 });
 
-test('GPUScan selects subgroups only when device and WGSL capabilities are both available', t => {
+it('GPUScan selects subgroups only when device and WGSL capabilities are both available', () => {
   const makeDevice = (subgroups: boolean, subgroupId: boolean) =>
     ({
       features: {has: (feature: string) => feature === 'subgroups' && subgroups},
       wgslLanguageFeatures: new Set(subgroupId ? ['subgroup_id'] : [])
     }) as Device;
 
-  t.equal(getGPUScanStrategy(makeDevice(true, true)), 'subgroups', 'selects the fast path');
-  t.equal(
+  expect(getGPUScanStrategy(makeDevice(true, true)), 'selects the fast path').toBe('subgroups');
+  expect(
     getGPUScanStrategy(makeDevice(true, false)),
-    'portable',
     'requires the subgroup_id language extension'
+  ).toBe('portable');
+  expect(getGPUScanStrategy(makeDevice(false, true)), 'requires the subgroup device feature').toBe(
+    'portable'
   );
-  t.equal(
-    getGPUScanStrategy(makeDevice(false, true)),
-    'portable',
-    'requires the subgroup device feature'
-  );
-  t.equal(
+  expect(
     getGPUScanStrategy(makeDevice(true, true), true),
-    'portable',
     'keeps segmented scans on the portable path'
-  );
-  t.end();
+  ).toBe('portable');
 });
 
-test('GPUReduction selects subgroups only when device and WGSL capabilities are available', t => {
+it('GPUReduction selects subgroups only when device and WGSL capabilities are available', () => {
   const makeDevice = (subgroups: boolean, subgroupId: boolean) =>
     ({
       features: {has: (feature: string) => feature === 'subgroups' && subgroups},
       wgslLanguageFeatures: new Set(subgroupId ? ['subgroup_id'] : [])
     }) as Device;
 
-  t.equal(getGPUReductionStrategy(makeDevice(true, true)), 'subgroups', 'selects subgroups');
-  t.equal(getGPUReductionStrategy(makeDevice(true, false)), 'portable', 'requires subgroup_id');
-  t.equal(getGPUReductionStrategy(makeDevice(false, true)), 'portable', 'requires device feature');
-  t.end();
+  expect(getGPUReductionStrategy(makeDevice(true, true)), 'selects subgroups').toBe('subgroups');
+  expect(getGPUReductionStrategy(makeDevice(true, false)), 'requires subgroup_id').toBe('portable');
+  expect(getGPUReductionStrategy(makeDevice(false, true)), 'requires device feature').toBe(
+    'portable'
+  );
 });
 
-test('GPUScan executes multidimensional block and offset dispatches', async t => {
+it('GPUScan executes multidimensional block and offset dispatches', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -941,19 +898,15 @@ test('GPUScan executes multidimensional block and offset dispatches', async t =>
     maxComputeWorkgroupsPerDimension: 2
   });
 
-  t.deepEqual(
+  expect(
     result,
-    getExpectedScan(values, 'exclusive', segmentFlags),
     'five block scans and their offset pass execute through a padded 2x2x2 layout'
-  );
-  t.end();
+  ).toEqual(getExpectedScan(values, 'exclusive', segmentFlags));
 });
 
-test('GPUScan preserves vector segments and carries through multidimensional passes', async t => {
+it('GPUScan preserves vector segments and carries through multidimensional passes', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -970,20 +923,17 @@ test('GPUScan preserves vector segments and carries through multidimensional pas
     maxComputeWorkgroupsPerDimension: 2
   });
 
-  t.deepEqual(result.chunks[0], [0], 'the first chunk starts the vector-wide prefix');
-  t.equal(result.chunks[1][0], 10, 'the preceding chunk carry reaches the 3D-dispatched chunk');
-  t.equal(result.chunks[1][699], 709, 'the carry survives x-to-y workgroup boundaries');
-  t.equal(result.chunks[1][700], 0, 'the interior segment start resets the carried prefix');
-  t.equal(result.chunks[1][1024], 324, 'the reset segment survives the padded z workgroup');
-  t.deepEqual(result.chunks[2], [325], 'the final chunk receives the last segment total');
-  t.end();
+  expect(result.chunks[0], 'the first chunk starts the vector-wide prefix').toEqual([0]);
+  expect(result.chunks[1][0], 'the preceding chunk carry reaches the 3D-dispatched chunk').toBe(10);
+  expect(result.chunks[1][699], 'the carry survives x-to-y workgroup boundaries').toBe(709);
+  expect(result.chunks[1][700], 'the interior segment start resets the carried prefix').toBe(0);
+  expect(result.chunks[1][1024], 'the reset segment survives the padded z workgroup').toBe(324);
+  expect(result.chunks[2], 'the final chunk receives the last segment total').toEqual([325]);
 });
 
-test('GPUScan computes exclusive uint32 prefixes', async t => {
+it('GPUScan computes exclusive uint32 prefixes', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -1037,19 +987,16 @@ test('GPUScan computes exclusive uint32 prefixes', async t => {
       matches &&= result[index] === expected;
       expected += inputValues[index];
     }
-    t.ok(matches, `exclusive scan matches for ${length} values`);
+    expect(Boolean(matches), `exclusive scan matches for ${length} values`).toBe(true);
     compiled.destroy();
     inputBuffer.destroy();
     outputBuffer.destroy();
   }
-  t.end();
 });
 
-test('GPUScan propagates carries across GPUVector chunks without changing topology', async t => {
+it('GPUScan propagates carries across GPUVector chunks without changing topology', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -1059,23 +1006,26 @@ test('GPUScan propagates carries across GPUVector chunks without changing topolo
     Uint32Array.from([7, 8])
   ];
   const result = await runVectorScan(device, chunks);
-  t.equal(result.chunks.length, 3, 'output preserves all source chunks');
-  t.equal(result.chunks[0].length, 300, 'first chunk length is preserved');
-  t.deepEqual(result.chunks[1], [], 'empty middle chunk is preserved');
-  t.equal(result.chunks[0][299], 299, 'hierarchical local scan completes within the first chunk');
-  t.deepEqual(result.chunks[2], [300, 307], 'later chunks receive the sum of all preceding chunks');
-  t.notOk(
-    result.nodeOrder.some(id => id.includes('clear-chunk-totals') || id.endsWith('-total')),
-    'final local scan levels write compact chunk totals without separate passes'
+  expect(result.chunks.length, 'output preserves all source chunks').toBe(3);
+  expect(result.chunks[0].length, 'first chunk length is preserved').toBe(300);
+  expect(result.chunks[1], 'empty middle chunk is preserved').toEqual([]);
+  expect(result.chunks[0][299], 'hierarchical local scan completes within the first chunk').toBe(
+    299
   );
-  t.end();
+  expect(result.chunks[2], 'later chunks receive the sum of all preceding chunks').toEqual([
+    300, 307
+  ]);
+  expect(
+    Boolean(
+      result.nodeOrder.some(id => id.includes('clear-chunk-totals') || id.endsWith('-total'))
+    ),
+    'final local scan levels write compact chunk totals without separate passes'
+  ).toBe(false);
 });
 
-test('GPUScan computes inclusive and segmented uint32 prefixes across block boundaries', async t => {
+it('GPUScan computes inclusive and segmented uint32 prefixes across block boundaries', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -1090,35 +1040,28 @@ test('GPUScan computes inclusive and segmented uint32 prefixes across block boun
 
   for (const mode of ['exclusive', 'inclusive'] as const) {
     const result = await runScan(device, values, {mode, segmentFlags});
-    t.deepEqual(
-      result,
-      getExpectedScan(values, mode, segmentFlags),
-      `${mode} segmented scan matches the CPU oracle`
+    expect(result, `${mode} segmented scan matches the CPU oracle`).toEqual(
+      getExpectedScan(values, mode, segmentFlags)
     );
   }
 
   const inclusive = await runScan(device, values, {mode: 'inclusive'});
-  t.deepEqual(
+  expect(
     inclusive,
-    getExpectedScan(values, 'inclusive'),
     'inclusive unsegmented scan matches the CPU oracle and wraps modulo 2^32'
-  );
-  t.deepEqual(
+  ).toEqual(getExpectedScan(values, 'inclusive'));
+  expect(
     await runScan(device, new Uint32Array(0), {
       mode: 'inclusive',
       segmentFlags: new Uint32Array(0)
     }),
-    [],
     'empty segmented scans add no work'
-  );
-  t.end();
+  ).toEqual([]);
 });
 
-test('GPUScan preserves segments and carries across GPUVector chunk boundaries', async t => {
+it('GPUScan preserves segments and carries across GPUVector chunk boundaries', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -1139,21 +1082,21 @@ test('GPUScan preserves segments and carries across GPUVector chunk boundaries',
     segmentFlagChunks,
     mode: 'exclusive'
   });
-  t.deepEqual(
+  expect(
     exclusive.chunks,
-    [[0, 2], [], [5, 0, 7], [18]],
     'exclusive segments continue across chunks and reset at flagged rows'
-  );
+  ).toEqual([[0, 2], [], [5, 0, 7], [18]]);
 
   const inclusive = await runVectorScan(device, valueChunks, {
     segmentFlagChunks,
     mode: 'inclusive'
   });
-  t.deepEqual(
-    inclusive.chunks,
-    [[2, 5], [], [10, 7, 18], [31]],
-    'inclusive segments preserve the same chunk topology'
-  );
+  expect(inclusive.chunks, 'inclusive segments preserve the same chunk topology').toEqual([
+    [2, 5],
+    [],
+    [10, 7, 18],
+    [31]
+  ]);
 
   const longChunkValues = [Uint32Array.from([10]), Uint32Array.from({length: 512}, () => 1)];
   const longChunkSegmentFlags = [new Uint32Array(1), new Uint32Array(512)];
@@ -1162,21 +1105,17 @@ test('GPUScan preserves segments and carries across GPUVector chunk boundaries',
     segmentFlagChunks: longChunkSegmentFlags,
     mode: 'exclusive'
   });
-  t.equal(longChunkResult.chunks[1][99], 109, 'carry reaches rows before the segment start');
-  t.equal(longChunkResult.chunks[1][100], 0, 'the segment start discards the preceding carry');
-  t.equal(
+  expect(longChunkResult.chunks[1][99], 'carry reaches rows before the segment start').toBe(109);
+  expect(longChunkResult.chunks[1][100], 'the segment start discards the preceding carry').toBe(0);
+  expect(
     longChunkResult.chunks[1][256],
-    156,
     'the discarded carry stays removed in later workgroups'
-  );
-  t.end();
+  ).toBe(156);
 });
 
-test('GPUCompaction preserves selected order and writes indirect instance count', async t => {
+it('GPUCompaction preserves selected order and writes indirect instance count', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const values = new Uint32Array([11, 22, 33, 44, 55, 66, 77]);
@@ -1236,27 +1175,24 @@ test('GPUCompaction preserves selected order and writes indirect instance count'
 
   const outputBytes = await outputBuffer.readAsync();
   const output = new Uint32Array(outputBytes.buffer, outputBytes.byteOffset, values.length);
-  t.deepEqual(Array.from(output.slice(0, 4)), [22, 33, 55, 77], 'selected values stay ordered');
+  expect(Array.from(output.slice(0, 4)), 'selected values stay ordered').toEqual([22, 33, 55, 77]);
   const countBytes = await drawCommands.buffer.readAsync(
     drawCommands.getInstanceCountByteOffset(0),
     Uint32Array.BYTES_PER_ELEMENT
   );
   const count = new Uint32Array(countBytes.buffer, countBytes.byteOffset, 1)[0];
-  t.equal(count, 4, 'compaction writes indirect instance count');
+  expect(count, 'compaction writes indirect instance count').toBe(4);
 
   compiled.destroy();
   valuesBuffer.destroy();
   flagsBuffer.destroy();
   outputBuffer.destroy();
   drawCommands.destroy();
-  t.end();
 });
 
-test('GPUTextSelection gathers selected row-indexed glyph records and indirect count', async t => {
+it('GPUTextSelection gathers selected row-indexed glyph records and indirect count', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const records = new Uint32Array([10, 100, 2, 11, 101, 0, 12, 102, 1, 13, 103, 2, 14, 104, 0]);
@@ -1332,26 +1268,23 @@ test('GPUTextSelection gathers selected row-indexed glyph records and indirect c
   device.submit(commandEncoder.finish());
 
   const selectedIdBytes = await selectedIdBuffer.readAsync();
-  t.deepEqual(
+  expect(
     Array.from(new Uint32Array(selectedIdBytes.buffer, selectedIdBytes.byteOffset, 4)),
-    [0, 1, 3, 4],
     'selection preserves original glyph order'
-  );
+  ).toEqual([0, 1, 3, 4]);
   const selectedRecordBytes = await selectedRecordBuffer.readAsync();
-  t.deepEqual(
+  expect(
     Array.from(new Uint32Array(selectedRecordBytes.buffer, selectedRecordBytes.byteOffset, 12)),
-    [10, 100, 2, 11, 101, 0, 13, 103, 2, 14, 104, 0],
     'selected compact records retain original row ids'
-  );
+  ).toEqual([10, 100, 2, 11, 101, 0, 13, 103, 2, 14, 104, 0]);
   const countBytes = await drawCommands.buffer.readAsync(
     drawCommands.getInstanceCountByteOffset(0),
     Uint32Array.BYTES_PER_ELEMENT
   );
-  t.equal(
+  expect(
     new Uint32Array(countBytes.buffer, countBytes.byteOffset, 1)[0],
-    4,
     'selection writes exact indirect glyph count'
-  );
+  ).toBe(4);
 
   compiled.destroy();
   recordBuffer.destroy();
@@ -1359,14 +1292,11 @@ test('GPUTextSelection gathers selected row-indexed glyph records and indirect c
   selectedIdBuffer.destroy();
   selectedRecordBuffer.destroy();
   drawCommands.destroy();
-  t.end();
 });
 
-test('GPUCompaction handles empty, none, all, alternating, and random masks', async t => {
+it('GPUCompaction handles empty, none, all, alternating, and random masks', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const randomValues = Uint32Array.from({length: 71}, (_, index) => index * 17 + 3);
@@ -1390,17 +1320,14 @@ test('GPUCompaction handles empty, none, all, alternating, and random masks', as
   for (const scenario of scenarios) {
     const result = await runCompaction(device, scenario.values, scenario.flags, scenario.name);
     const expected = Array.from(scenario.values).filter((_, index) => scenario.flags[index] !== 0);
-    t.equal(result.count, expected.length, `${scenario.name} mask writes exact count`);
-    t.deepEqual(result.values, expected, `${scenario.name} mask preserves stable order`);
+    expect(result.count, `${scenario.name} mask writes exact count`).toBe(expected.length);
+    expect(result.values, `${scenario.name} mask preserves stable order`).toEqual(expected);
   }
-  t.end();
 });
 
-test('GPUCompaction preserves GPUVector topology while selecting across chunks', async t => {
+it('GPUCompaction preserves GPUVector topology while selecting across chunks', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -1419,31 +1346,26 @@ test('GPUCompaction preserves GPUVector topology while selecting across chunks',
       Uint32Array.from([1, 1, 0])
     ]
   );
-  t.equal(result.count, 4, 'count spans the complete logical vector');
-  t.deepEqual(
+  expect(result.count, 'count spans the complete logical vector').toBe(4);
+  expect(
     result.chunks.map(chunk => chunk.length),
-    [3, 0, 0, 3],
     'output chunk boundaries remain intact'
-  );
-  t.deepEqual(result.chunks[0], [10, 12, 20], 'selection crosses into the first output chunk');
-  t.equal(result.chunks[3][0], 21, 'selection continues in the next non-empty output chunk');
-  t.notOk(
-    result.nodeOrder.some(id => id.endsWith('-write-count')),
+  ).toEqual([3, 0, 0, 3]);
+  expect(result.chunks[0], 'selection crosses into the first output chunk').toEqual([10, 12, 20]);
+  expect(result.chunks[3][0], 'selection continues in the next non-empty output chunk').toBe(21);
+  expect(
+    Boolean(result.nodeOrder.some(id => id.endsWith('-write-count'))),
     'the final scatter writes the vector-wide count without a separate pass'
-  );
-  t.equal(
+  ).toBe(false);
+  expect(
     result.logicalTransientBufferCount,
-    5,
     'zero-length offset chunks share one transient backing view'
-  );
-  t.end();
+  ).toBe(5);
 });
 
-test('DrawCommandBuffer replays an indirect draw through a render bundle', async t => {
+it('DrawCommandBuffer replays an indirect draw through a render bundle', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const colorTexture = device.createTexture({
@@ -1492,20 +1414,17 @@ test('DrawCommandBuffer replays an indirect draw through a render bundle', async
   renderPass.end();
   device.submit(commandEncoder.finish());
   const pixels = await readPixels(framebuffer.colorAttachments[0].texture, 4, 4);
-  t.ok(pixels[0] > 200, 'render bundle replays GPU indirect vertex count');
+  expect(Boolean(pixels[0] > 200), 'render bundle replays GPU indirect vertex count').toBe(true);
   bundle.destroy();
   drawCommands.destroy();
   model.destroy();
   framebuffer.destroy();
   colorTexture.destroy();
-  t.end();
 });
 
-test('DispatchCommandBuffer stores typed GPU-writable dispatch records', async t => {
+it('DispatchCommandBuffer stores typed GPU-writable dispatch records', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const dispatchCommands = new DispatchCommandBuffer(device, {
@@ -1514,25 +1433,19 @@ test('DispatchCommandBuffer stores typed GPU-writable dispatch records', async t
   });
   const bytes = await dispatchCommands.buffer.readAsync();
   const values = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4);
-  t.deepEqual(
-    Array.from(values),
-    [2, 1, 1, 3, 4, 5, 0, 0, 0],
-    'records preserve WebGPU x/y/z layout and zero-fill capacity'
+  expect(Array.from(values), 'records preserve WebGPU x/y/z layout and zero-fill capacity').toEqual(
+    [2, 1, 1, 3, 4, 5, 0, 0, 0]
   );
   const secondCommand = dispatchCommands.getCommandData(1);
-  t.equal(secondCommand.length, 3, 'borrowed command data contains three uint32 rows');
-  t.equal(
-    secondCommand.byteOffset,
-    DispatchCommandBuffer.recordByteLength,
-    'borrowed command data points at the selected record'
+  expect(secondCommand.length, 'borrowed command data contains three uint32 rows').toBe(3);
+  expect(secondCommand.byteOffset, 'borrowed command data points at the selected record').toBe(
+    DispatchCommandBuffer.recordByteLength
   );
-  t.throws(
+  expect(
     () => dispatchCommands.getCommandByteOffset(3),
-    /out of range/,
     'command index is bounded by capacity'
-  );
+  ).toThrow(/out of range/);
   dispatchCommands.destroy();
-  t.end();
 });
 
 async function readPixels(texture: Texture, width: number, height: number): Promise<Uint8Array> {

--- a/modules/gpgpu/test/gpu-core/gpu-convolution.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-convolution.node.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -10,7 +11,6 @@ import {
   GPU_CONVOLUTION_AUTO_DIRECT_KERNEL_AREA,
   makeGPUConvolutionStats
 } from '@luma.gl/gpgpu/gpu-core';
-import test from 'test/utils/vitest-tape';
 import {WgslReflect} from 'wgsl_reflect';
 import {
   getGPUConvolutionDirectShaderSource,
@@ -18,32 +18,31 @@ import {
   getGPUConvolutionPackShaderSource
 } from '../../src/gpu-core/gpu-convolution';
 
-test('GPUConvolution publishes direct and padded FFT workload plans', testCase => {
-  testCase.deepEqual(
+it('GPUConvolution publishes direct and padded FFT workload plans', () => {
+  expect(
     makeGPUConvolutionStats({
       width: 8,
       height: 6,
       kernelWidth: 3,
       kernelHeight: 3
-    }),
-    {
-      width: 8,
-      height: 6,
-      kernelWidth: 3,
-      kernelHeight: 3,
-      boundary: 'zero',
-      elementCount: 48,
-      kernelElementCount: 9,
-      directMultiplyAddCount: 432,
-      fftWidth: 16,
-      fftHeight: 8,
-      fftElementCount: 128,
-      fftTransformPassCount: 9,
-      fftDispatchCount: 30,
-      fftComplexBufferByteLength: 1024,
-      fftLogicalTransientByteLength: 9216
-    }
-  );
+    })
+  ).toEqual({
+    width: 8,
+    height: 6,
+    kernelWidth: 3,
+    kernelHeight: 3,
+    boundary: 'zero',
+    elementCount: 48,
+    kernelElementCount: 9,
+    directMultiplyAddCount: 432,
+    fftWidth: 16,
+    fftHeight: 8,
+    fftElementCount: 128,
+    fftTransformPassCount: 9,
+    fftDispatchCount: 30,
+    fftComplexBufferByteLength: 1024,
+    fftLogicalTransientByteLength: 9216
+  });
   const wrap = makeGPUConvolutionStats({
     width: 8,
     height: 8,
@@ -51,37 +50,33 @@ test('GPUConvolution publishes direct and padded FFT workload plans', testCase =
     kernelHeight: 3,
     boundary: 'wrap'
   });
-  testCase.equal(wrap.fftWidth, 8);
-  testCase.equal(wrap.fftHeight, 8);
-  testCase.equal(wrap.fftTransformPassCount, 8);
-  testCase.equal(GPU_CONVOLUTION_AUTO_DIRECT_KERNEL_AREA, 4096);
-  testCase.throws(
-    () => makeGPUConvolutionStats({width: 8, height: 8, kernelWidth: 4, kernelHeight: 3}),
-    /must be odd/
-  );
-  testCase.end();
+  expect(wrap.fftWidth).toBe(8);
+  expect(wrap.fftHeight).toBe(8);
+  expect(wrap.fftTransformPassCount).toBe(8);
+  expect(GPU_CONVOLUTION_AUTO_DIRECT_KERNEL_AREA).toBe(4096);
+  expect(() =>
+    makeGPUConvolutionStats({width: 8, height: 8, kernelWidth: 4, kernelHeight: 3})
+  ).toThrow(/must be odd/);
 });
 
-test('GPUConvolution support exposes the automatic crossover and FFT constraints', testCase => {
+it('GPUConvolution support exposes the automatic crossover and FFT constraints', () => {
   const device = makeSupportDevice();
-  testCase.equal(
+  expect(
     getGPUConvolutionSupport(device, {
       width: 64,
       height: 32,
       kernelWidth: 3,
       kernelHeight: 3
-    }).strategy,
-    'direct'
-  );
-  testCase.equal(
+    }).strategy
+  ).toBe('direct');
+  expect(
     getGPUConvolutionSupport(device, {
       width: 64,
       height: 32,
       kernelWidth: 65,
       kernelHeight: 65
-    }).strategy,
-    'fft'
-  );
+    }).strategy
+  ).toBe('fft');
   const automaticFallback = getGPUConvolutionSupport(device, {
     width: 60,
     height: 30,
@@ -89,8 +84,8 @@ test('GPUConvolution support exposes the automatic crossover and FFT constraints
     kernelHeight: 11,
     boundary: 'wrap'
   });
-  testCase.equal(automaticFallback.supported, true);
-  testCase.equal(automaticFallback.strategy, 'direct');
+  expect(automaticFallback.supported).toBe(true);
+  expect(automaticFallback.strategy).toBe('direct');
   const explicitUnsupported = getGPUConvolutionSupport(device, {
     width: 60,
     height: 30,
@@ -99,17 +94,16 @@ test('GPUConvolution support exposes the automatic crossover and FFT constraints
     boundary: 'wrap',
     strategy: 'fft'
   });
-  testCase.equal(explicitUnsupported.supported, false);
-  testCase.match(explicitUnsupported.reason || '', /power-of-two/);
-  testCase.end();
+  expect(explicitUnsupported.supported).toBe(false);
+  expect(explicitUnsupported.reason || '').toMatch(/power-of-two/);
 });
 
-test('GPUConvolution validates views, capacity, aliasing, and graph ownership', testCase => {
+it('GPUConvolution validates views, capacity, aliasing, and graph ownership', () => {
   const graph = new GPUCommandGraph(makeSupportDevice());
   const input = makeView(graph, 'input', 64);
   const kernel = makeView(graph, 'kernel', 9);
   const output = makeView(graph, 'output', 64);
-  testCase.doesNotThrow(
+  expect(
     () =>
       new GPUConvolution({
         input,
@@ -120,8 +114,8 @@ test('GPUConvolution validates views, capacity, aliasing, and graph ownership', 
         kernelWidth: 3,
         kernelHeight: 3
       })
-  );
-  testCase.throws(
+  ).not.toThrow();
+  expect(
     () =>
       new GPUConvolution({
         input,
@@ -131,11 +125,10 @@ test('GPUConvolution validates views, capacity, aliasing, and graph ownership', 
         height: 8,
         kernelWidth: 3,
         kernelHeight: 3
-      }),
-    /output must contain at least/
-  );
+      })
+  ).toThrow(/output must contain at least/);
   const aliasedOutput = graph.createDataView(input.buffer, {format: 'float32', length: 64});
-  testCase.throws(
+  expect(
     () =>
       new GPUConvolution({
         input,
@@ -145,28 +138,24 @@ test('GPUConvolution validates views, capacity, aliasing, and graph ownership', 
         height: 8,
         kernelWidth: 3,
         kernelHeight: 3
-      }),
-    /separate buffer/
-  );
+      })
+  ).toThrow(/separate buffer/);
   const otherGraph = new GPUCommandGraph(makeSupportDevice());
   const otherOutput = makeView(otherGraph, 'other-output', 64);
-  testCase.throws(
-    () =>
-      new GPUConvolution({
-        input,
-        kernel,
-        output: otherOutput,
-        width: 8,
-        height: 8,
-        kernelWidth: 3,
-        kernelHeight: 3
-      }).addToGraph(graph),
-    /different GPUCommandGraph/
-  );
-  testCase.end();
+  expect(() =>
+    new GPUConvolution({
+      input,
+      kernel,
+      output: otherOutput,
+      width: 8,
+      height: 8,
+      kernelWidth: 3,
+      kernelHeight: 3
+    }).addToGraph(graph)
+  ).toThrow(/different GPUCommandGraph/);
 });
 
-test('GPUConvolution generated direct, packing, and FFT shaders reflect', testCase => {
+it('GPUConvolution generated direct, packing, and FFT shaders reflect', () => {
   const graph = new GPUCommandGraph(makeSupportDevice());
   const input = makeView(graph, 'input', 64);
   const kernel = makeView(graph, 'kernel', 9);
@@ -199,15 +188,11 @@ test('GPUConvolution generated direct, packing, and FFT shaders reflect', testCa
     {x: 1, y: 1, z: 1}
   );
   for (const source of [direct, pack, fft]) {
-    testCase.deepEqual(
-      new WgslReflect(source).entry.compute.map(entry => entry.name),
-      ['main']
-    );
+    expect(new WgslReflect(source).entry.compute.map(entry => entry.name)).toEqual(['main']);
   }
-  testCase.match(direct, /wrappedX/, 'direct wrap boundary is explicit');
-  testCase.match(pack, /packedKernel/, 'FFT path centers the kernel in the padded field');
-  testCase.match(fft, /multiplyComplex/, 'FFT path consumes shared complex arithmetic');
-  testCase.end();
+  expect(direct, 'direct wrap boundary is explicit').toMatch(/wrappedX/);
+  expect(pack, 'FFT path centers the kernel in the padded field').toMatch(/packedKernel/);
+  expect(fft, 'FFT path consumes shared complex arithmetic').toMatch(/multiplyComplex/);
 });
 
 function makeView(graph: GPUCommandGraph, id: string, length: number) {

--- a/modules/gpgpu/test/gpu-core/gpu-convolution.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-convolution.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -11,13 +12,10 @@ import {
   type GPUConvolutionStrategy
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
 
-test('GPUConvolution direct path matches CPU convolution for zero and wrap boundaries', async testCase => {
+it('GPUConvolution direct path matches CPU convolution for zero and wrap boundaries', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
   const width = 7;
@@ -47,17 +45,14 @@ test('GPUConvolution direct path matches CPU convolution for zero and wrap bound
       kernelHeight,
       boundary
     );
-    assertClose(testCase, result.values, expected, 0.00001, `direct ${boundary}`);
-    testCase.equal(result.logicalTransientBufferCount, 0, `${boundary} direct path has no scratch`);
+    assertClose(result.values, expected, 0.00001, `direct ${boundary}`);
+    expect(result.logicalTransientBufferCount, `${boundary} direct path has no scratch`).toBe(0);
   }
-  testCase.end();
 });
 
-test('GPUConvolution FFT path agrees with direct and CPU results', async testCase => {
+it('GPUConvolution FFT path agrees with direct and CPU results', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
   for (const dimensions of [
@@ -102,22 +97,19 @@ test('GPUConvolution FFT path agrees with direct and CPU results', async testCas
       kernelHeight,
       dimensions.boundary
     );
-    assertClose(testCase, fft.values, direct.values, 0.001, `FFT/direct ${dimensions.boundary}`);
-    assertClose(testCase, fft.values, expected, 0.001, `FFT/CPU ${dimensions.boundary}`);
-    testCase.equal(fft.logicalTransientBufferCount, 9, 'FFT scratch is explicit in graph stats');
-    testCase.ok(
-      fft.physicalTransientBufferCount < fft.logicalTransientBufferCount,
+    assertClose(fft.values, direct.values, 0.001, `FFT/direct ${dimensions.boundary}`);
+    assertClose(fft.values, expected, 0.001, `FFT/CPU ${dimensions.boundary}`);
+    expect(fft.logicalTransientBufferCount, 'FFT scratch is explicit in graph stats').toBe(9);
+    expect(
+      Boolean(fft.physicalTransientBufferCount < fft.logicalTransientBufferCount),
       'non-overlapping FFT fields alias physical scratch'
-    );
+    ).toBe(true);
   }
-  testCase.end();
 });
 
-test('GPUConvolution benchmark compares available direct and FFT paths', async testCase => {
+it('GPUConvolution benchmark compares available direct and FFT paths', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
   const report = await runGPUConvolutionBenchmark(device, {
@@ -130,21 +122,21 @@ test('GPUConvolution benchmark compares available direct and FFT paths', async t
     warmupIterations: 1,
     measuredIterations: 2
   });
-  testCase.equal(report.cases.length, 2);
-  testCase.deepEqual(
-    report.cases.map(benchmarkCase => benchmarkCase.paths.map(path => path.strategy)),
+  expect(report.cases.length).toBe(2);
+  expect(report.cases.map(benchmarkCase => benchmarkCase.paths.map(path => path.strategy))).toEqual(
     [
       ['direct', 'fft'],
       ['direct', 'fft']
     ]
   );
-  testCase.ok(
-    report.cases.every(benchmarkCase =>
-      benchmarkCase.paths.every(path => Number.isFinite(path.cpuEncodeTimeMilliseconds.median))
+  expect(
+    Boolean(
+      report.cases.every(benchmarkCase =>
+        benchmarkCase.paths.every(path => Number.isFinite(path.cpuEncodeTimeMilliseconds.median))
+      )
     ),
     'each strategy reports a finite timing distribution'
-  );
-  testCase.end();
+  ).toBe(true);
 });
 
 async function runGPUConvolution(
@@ -253,17 +245,16 @@ function makeCPUConvolution(
 }
 
 function assertClose(
-  testCase: {ok: (value: unknown, message?: string) => void},
   actual: readonly number[],
   expected: readonly number[],
   tolerance: number,
   label: string
 ): void {
-  testCase.ok(actual.length === expected.length, `${label} length matches`);
+  expect(Boolean(actual.length === expected.length), `${label} length matches`).toBe(true);
   for (let index = 0; index < actual.length; index++) {
-    testCase.ok(
-      Math.abs(actual[index] - expected[index]) <= tolerance,
+    expect(
+      Boolean(Math.abs(actual[index] - expected[index]) <= tolerance),
       `${label} value ${index}: ${actual[index]} ~= ${expected[index]}`
-    );
+    ).toBe(true);
   }
 }

--- a/modules/gpgpu/test/gpu-core/gpu-data-analysis.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-data-analysis.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {
   GPUCommandGraph,
@@ -19,120 +19,108 @@ import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import {GPUData, GPUVector, type GPUVectorFormat} from '@luma.gl/gpgpu/gpu-data';
 import {getGPUGroupAggregationDispatchLayout} from '../../src/gpu-core/gpu-group-aggregation';
 
-test('GPUReduction handles operations, formats, hierarchy, and invalid floats', async t => {
+it('GPUReduction handles operations, formats, hierarchy, and invalid floats', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
-  t.deepEqual(await runReduction(device, Uint32Array.from([0xffffffff, 2]), 'uint32', 'sum'), [1]);
-  t.deepEqual(await runReduction(device, Uint32Array.from([7, 3, 9, 3]), 'uint32', 'min'), [3]);
-  t.deepEqual(await runReduction(device, Uint32Array.from([7, 3, 9, 3]), 'uint32', 'max'), [9]);
-  t.deepEqual(
-    await runReduction(device, Uint32Array.from([7, 3, 9, 3]), 'uint32', 'extent'),
-    [3, 9]
-  );
-  t.deepEqual(await runReduction(device, Int32Array.from([-7, 3, -2]), 'sint32', 'sum'), [-6]);
-  t.deepEqual(await runReduction(device, Int32Array.from([-7, 3, -2]), 'sint32', 'min'), [-7]);
-  t.deepEqual(await runReduction(device, Int32Array.from([-7, 3, -2]), 'sint32', 'max'), [3]);
-  t.deepEqual(
-    await runReduction(device, Int32Array.from([-7, 3, -2]), 'sint32', 'extent'),
-    [-7, 3]
-  );
+  expect(await runReduction(device, Uint32Array.from([0xffffffff, 2]), 'uint32', 'sum')).toEqual([
+    1
+  ]);
+  expect(await runReduction(device, Uint32Array.from([7, 3, 9, 3]), 'uint32', 'min')).toEqual([3]);
+  expect(await runReduction(device, Uint32Array.from([7, 3, 9, 3]), 'uint32', 'max')).toEqual([9]);
+  expect(await runReduction(device, Uint32Array.from([7, 3, 9, 3]), 'uint32', 'extent')).toEqual([
+    3, 9
+  ]);
+  expect(await runReduction(device, Int32Array.from([-7, 3, -2]), 'sint32', 'sum')).toEqual([-6]);
+  expect(await runReduction(device, Int32Array.from([-7, 3, -2]), 'sint32', 'min')).toEqual([-7]);
+  expect(await runReduction(device, Int32Array.from([-7, 3, -2]), 'sint32', 'max')).toEqual([3]);
+  expect(await runReduction(device, Int32Array.from([-7, 3, -2]), 'sint32', 'extent')).toEqual([
+    -7, 3
+  ]);
   const hierarchical = Uint32Array.from({length: 513}, (_, index) => index % 11);
-  t.deepEqual(await runReduction(device, hierarchical, 'uint32', 'sum'), [2551]);
+  expect(await runReduction(device, hierarchical, 'uint32', 'sum')).toEqual([2551]);
 
   const invalidFloats = Float32Array.from([Number.NaN, 4, Number.POSITIVE_INFINITY, -2]);
   const floatSum = await runReduction(device, Float32Array.from([0.1, 0.2, 0.3]), 'float32', 'sum');
-  t.ok(Math.abs(floatSum[0] - 0.6) < 1e-6, 'float sum remains numerically accurate');
-  t.deepEqual(await runReduction(device, invalidFloats, 'float32', 'min'), [-2]);
-  t.deepEqual(await runReduction(device, invalidFloats, 'float32', 'max'), [4]);
-  t.deepEqual(await runReduction(device, invalidFloats, 'float32', 'extent'), [-2, 4]);
-  t.deepEqual(
+  expect(
+    Boolean(Math.abs(floatSum[0] - 0.6) < 1e-6),
+    'float sum remains numerically accurate'
+  ).toBe(true);
+  expect(await runReduction(device, invalidFloats, 'float32', 'min')).toEqual([-2]);
+  expect(await runReduction(device, invalidFloats, 'float32', 'max')).toEqual([4]);
+  expect(await runReduction(device, invalidFloats, 'float32', 'extent')).toEqual([-2, 4]);
+  expect(
     await runReduction(
       device,
       Float32Array.from([Number.NaN, Number.NEGATIVE_INFINITY]),
       'float32',
       'min'
-    ),
-    [0]
-  );
-  t.deepEqual(await runReduction(device, new Float32Array(0), 'float32', 'extent'), [0, 0]);
-  t.end();
+    )
+  ).toEqual([0]);
+  expect(await runReduction(device, new Float32Array(0), 'float32', 'extent')).toEqual([0, 0]);
 });
 
-test('GPUReduction combines fixed-width GPUVector chunks', async t => {
+it('GPUReduction combines fixed-width GPUVector chunks', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
-  t.deepEqual(
+  expect(
     await runVectorReduction(
       device,
       [Uint32Array.from([7, 3]), new Uint32Array(0), Uint32Array.from([9, 4])],
       'uint32',
       'sum'
     ),
-    [23],
     'sum combines non-empty chunks and skips empty chunks'
-  );
-  t.deepEqual(
+  ).toEqual([23]);
+  expect(
     await runVectorReduction(
       device,
       [Uint32Array.from([7, 3]), Uint32Array.from([9, 4])],
       'uint32',
       'extent'
     ),
-    [3, 9],
     'extent combines per-chunk minima and maxima'
-  );
-  t.deepEqual(
+  ).toEqual([3, 9]);
+  expect(
     await runVectorReduction(
       device,
       [Float32Array.from([Number.NaN, Number.POSITIVE_INFINITY]), Float32Array.from([4, -2])],
       'float32',
       'min'
     ),
-    [-2],
     'invalid-only chunks do not inject zero into a valid floating reduction'
-  );
-  t.deepEqual(
+  ).toEqual([-2]);
+  expect(
     await runVectorReduction(
       device,
       [Float32Array.from([Number.NaN]), Float32Array.from([Number.NEGATIVE_INFINITY])],
       'float32',
       'max'
     ),
-    [0],
     'all-invalid floating chunks produce zero'
-  );
-  t.deepEqual(
+  ).toEqual([0]);
+  expect(
     await runVectorReduction(device, [new Int32Array(0), new Int32Array(0)], 'sint32', 'extent'),
-    [0, 0],
     'an all-empty vector produces zero'
-  );
-  t.end();
+  ).toEqual([0, 0]);
 });
 
-test('GPUHistogram supports literal, GPU, and automatic domains', async t => {
+it('GPUHistogram supports literal, GPU, and automatic domains', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
-  t.deepEqual(
+  expect(
     await runHistogram(device, Uint32Array.from([0, 1, 2, 3, 4, 4, 5]), 'uint32', 4, [0, 4]),
-    [1, 1, 1, 3],
     'literal uint32 domain includes exact maximum in final bin'
-  );
-  t.deepEqual(
+  ).toEqual([1, 1, 1, 3]);
+  expect(
     await runHistogram(
       device,
       Uint32Array.from([0, 0x7fffffff, 0x80000000, 0xffffffff]),
@@ -140,10 +128,9 @@ test('GPUHistogram supports literal, GPU, and automatic domains', async t => {
       2,
       [0, 0xffffffff]
     ),
-    [2, 2],
     'full-range uint32 bin boundaries stay in integer space'
-  );
-  t.deepEqual(
+  ).toEqual([2, 2]);
+  expect(
     await runHistogram(
       device,
       Int32Array.from([-0x80000000, -1, 0, 0x7fffffff]),
@@ -151,9 +138,8 @@ test('GPUHistogram supports literal, GPU, and automatic domains', async t => {
       2,
       [-0x80000000, 0x7fffffff]
     ),
-    [2, 2],
     'full-range sint32 bin boundaries stay in integer space'
-  );
+  ).toEqual([2, 2]);
   let randomState = 0x1234abcd;
   const fullRangeValues = Uint32Array.from({length: 1025}, (_, index) => {
     randomState = (Math.imul(randomState, 1664525) + 1013904223) >>> 0;
@@ -168,17 +154,15 @@ test('GPUHistogram supports literal, GPU, and automatic domains', async t => {
         : Number((BigInt(value) * BigInt(fullRangeBinCount)) / 0xffffffffn);
     expectedFullRangeCounts[binIndex]++;
   }
-  t.deepEqual(
+  expect(
     await runHistogram(device, fullRangeValues, 'uint32', fullRangeBinCount, [0, 0xffffffff]),
-    expectedFullRangeCounts,
     'wide integer multiply/divide matches an exact BigInt reference above 256 bins'
-  );
-  t.deepEqual(
+  ).toEqual(expectedFullRangeCounts);
+  expect(
     await runHistogram(device, Int32Array.from([-2, -1, 0, 1, 2]), 'sint32', 2, [-2, 2], true),
-    [2, 3],
     'GPU sint32 domain is accepted'
-  );
-  t.deepEqual(
+  ).toEqual([2, 3]);
+  expect(
     await runHistogram(
       device,
       Float32Array.from([Number.NaN, -1, 0, 1, Number.POSITIVE_INFINITY]),
@@ -186,37 +170,30 @@ test('GPUHistogram supports literal, GPU, and automatic domains', async t => {
       2,
       'auto'
     ),
-    [1, 2],
     'automatic float domain ignores non-finite values'
-  );
-  t.deepEqual(
+  ).toEqual([1, 2]);
+  expect(
     await runHistogram(device, Uint32Array.from([7, 7, 8]), 'uint32', 3, [7, 7]),
-    [2, 0, 0],
     'degenerate domain counts matching values in bin zero'
-  );
-  t.deepEqual(
+  ).toEqual([2, 0, 0]);
+  expect(
     await runHistogram(device, new Float32Array(0), 'float32', 4, 'auto'),
-    [0, 0, 0, 0],
     'empty automatic histogram is cleared'
-  );
+  ).toEqual([0, 0, 0, 0]);
   const globalValues = Uint32Array.from({length: 300}, (_, index) => index);
-  t.deepEqual(
+  expect(
     await runHistogram(device, globalValues, 'uint32', 300, [0, 299]),
-    Array.from({length: 300}, () => 1),
     'more than 256 bins uses the global atomic path'
-  );
-  t.end();
+  ).toEqual(Array.from({length: 300}, () => 1));
 });
 
-test('GPUHistogram supports irregular literal and GPU-resident edges', async t => {
+it('GPUHistogram supports irregular literal and GPU-resident edges', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
-  t.deepEqual(
+  expect(
     await runIrregularHistogram(
       device,
       Float32Array.from([
@@ -235,30 +212,27 @@ test('GPUHistogram supports irregular literal and GPU-resident edges', async t =
       'float32',
       [0, 1, 10, 100]
     ),
-    [2, 2, 3],
     'literal edges use half-open intervals and include the final edge'
-  );
-  t.deepEqual(
+  ).toEqual([2, 2, 3]);
+  expect(
     await runIrregularHistogram(
       device,
       Float32Array.from([0, 1e21, 2e21]),
       'float32',
       [0, 1e21, 2e21]
     ),
-    [1, 2],
     'exponential float edges generate valid WGSL literals'
-  );
-  t.deepEqual(
+  ).toEqual([1, 2]);
+  expect(
     await runIrregularHistogram(
       device,
       Uint32Array.from([0, 1, 9, 10, 99, 100]),
       'uint32',
       [0, 10, 100]
     ),
-    [3, 3],
     'integer edge comparisons remain exact'
-  );
-  t.deepEqual(
+  ).toEqual([3, 3]);
+  expect(
     await runIrregularHistogram(
       device,
       Int32Array.from([-10, -1, 0, 9, 10]),
@@ -266,10 +240,9 @@ test('GPUHistogram supports irregular literal and GPU-resident edges', async t =
       [-10, 0, 10],
       true
     ),
-    [2, 3],
     'GPU-resident signed edges are accepted'
-  );
-  t.deepEqual(
+  ).toEqual([2, 3]);
+  expect(
     await runIrregularHistogram(
       device,
       Uint32Array.from([0, 1, 5, 10, 100]),
@@ -277,10 +250,9 @@ test('GPUHistogram supports irregular literal and GPU-resident edges', async t =
       [0, 10, 5, 100],
       true
     ),
-    [0, 0, 0],
     'unordered GPU-resident edges suppress accumulation without a readback'
-  );
-  t.deepEqual(
+  ).toEqual([0, 0, 0]);
+  expect(
     await runIrregularHistogram(
       device,
       Uint32Array.from([1, 3, 4, 7]),
@@ -289,30 +261,24 @@ test('GPUHistogram supports irregular literal and GPU-resident edges', async t =
       true,
       [0, 2, 10]
     ),
-    [1, 3],
     'rewriting GPU edges changes bins without recompiling the graph'
-  );
-  t.deepEqual(
+  ).toEqual([1, 3]);
+  expect(
     await runIrregularHistogram(device, new Float32Array(0), 'float32', [0, 1, 10]),
-    [0, 0],
     'an empty irregular histogram is cleared'
-  );
+  ).toEqual([0, 0]);
 
   const globalEdges = Uint32Array.from({length: 301}, (_, index) => index);
   const globalValues = Uint32Array.from({length: 301}, (_, index) => index);
-  t.deepEqual(
+  expect(
     await runIrregularHistogram(device, globalValues, 'uint32', globalEdges, true),
-    [...Array.from({length: 299}, () => 1), 2],
     'GPU edges support more than 256 bins through the global atomic path'
-  );
-  t.end();
+  ).toEqual([...Array.from({length: 299}, () => 1), 2]);
 });
 
-test('GPUHistogram reads interleaved scalar columns with explicit edges', async t => {
+it('GPUHistogram reads interleaved scalar columns with explicit edges', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -344,18 +310,15 @@ test('GPUHistogram reads interleaved scalar columns with explicit edges', async 
   compiled.encode(commandEncoder, {parameters: undefined});
   device.submit(commandEncoder.finish());
 
-  t.deepEqual(await readUint32(outputBuffer, 3), [1, 2, 1]);
+  expect(await readUint32(outputBuffer, 3)).toEqual([1, 2, 1]);
   compiled.destroy();
   inputBuffer.destroy();
   outputBuffer.destroy();
-  t.end();
 });
 
-test('GPUHistogram accumulates fixed-width GPUVector chunks after one clear', async t => {
+it('GPUHistogram accumulates fixed-width GPUVector chunks after one clear', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -366,17 +329,15 @@ test('GPUHistogram accumulates fixed-width GPUVector chunks after one clear', as
     4,
     [0, 3]
   );
-  t.deepEqual(literal.counts, [1, 1, 1, 2], 'every non-empty chunk contributes counts');
-  t.deepEqual(
+  expect(literal.counts, 'every non-empty chunk contributes counts').toEqual([1, 1, 1, 2]);
+  expect(
     literal.nodeOrder,
-    ['gpu-histogram-clear', 'gpu-histogram-chunk-0-local', 'gpu-histogram-chunk-2-local'],
     'one clear precedes ordered per-chunk accumulation and empty chunks keep their source index'
-  );
-  t.equal(
+  ).toEqual(['gpu-histogram-clear', 'gpu-histogram-chunk-0-local', 'gpu-histogram-chunk-2-local']);
+  expect(
     literal.logicalTransientBufferCount,
-    0,
     'a literal-domain histogram does not pack or concatenate input chunks'
-  );
+  ).toBe(0);
 
   const automatic = await runVectorHistogram(
     device,
@@ -389,30 +350,24 @@ test('GPUHistogram accumulates fixed-width GPUVector chunks after one clear', as
     4,
     'auto'
   );
-  t.deepEqual(
+  expect(
     automatic.counts,
-    [1, 1, 0, 2],
     'automatic domain reduction spans all chunks and ignores non-finite values'
-  );
+  ).toEqual([1, 1, 0, 2]);
 
   const globalValues = [
     Uint32Array.from({length: 150}, (_, index) => index),
     Uint32Array.from({length: 150}, (_, index) => index + 150)
   ];
   const global = await runVectorHistogram(device, globalValues, 'uint32', 300, [0, 299]);
-  t.deepEqual(
-    global.counts,
-    Array.from({length: 300}, () => 1),
-    'the global atomic path accumulates every chunk'
+  expect(global.counts, 'the global atomic path accumulates every chunk').toEqual(
+    Array.from({length: 300}, () => 1)
   );
-  t.end();
 });
 
-test('GPUHistogram preserves vector chunks with irregular edges', async t => {
+it('GPUHistogram preserves vector chunks with irregular edges', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -422,30 +377,25 @@ test('GPUHistogram preserves vector chunks with irregular edges', async t => {
     'float32',
     [0, 1, 10, 100]
   );
-  t.deepEqual(result.counts, [2, 2, 2], 'every non-empty source chunk contributes counts');
-  t.deepEqual(
+  expect(result.counts, 'every non-empty source chunk contributes counts').toEqual([2, 2, 2]);
+  expect(
     result.nodeOrder,
-    [
-      'gpu-histogram-validate-edges',
-      'gpu-histogram-clear',
-      'gpu-histogram-chunk-0-edges-local',
-      'gpu-histogram-chunk-2-edges-local'
-    ],
     'edge validation and one clear precede ordered per-chunk accumulation'
-  );
-  t.equal(
+  ).toEqual([
+    'gpu-histogram-validate-edges',
+    'gpu-histogram-clear',
+    'gpu-histogram-chunk-0-edges-local',
+    'gpu-histogram-chunk-2-edges-local'
+  ]);
+  expect(
     result.logicalTransientBufferCount,
-    1,
     'GPU edges use only one graph-owned ordering flag'
-  );
-  t.end();
+  ).toBe(1);
 });
 
-test('GPUHistogram clears counts for every graph encoding and composes with reduction', async t => {
+it('GPUHistogram clears counts for every graph encoding and composes with reduction', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const values = Uint32Array.from([0, 1, 1, 2, 3, 3, 3]);
@@ -463,37 +413,32 @@ test('GPUHistogram clears counts for every graph encoding and composes with redu
   compiled.encode(commandEncoder, {parameters: undefined});
   compiled.encode(commandEncoder, {parameters: undefined});
   device.submit(commandEncoder.finish());
-  t.deepEqual(await readUint32(countsBuffer, 4), [1, 2, 1, 3], 'second encoding resets output');
-  t.deepEqual(await readUint32(totalBuffer, 1), [7], 'reduced count equals accepted rows');
+  expect(await readUint32(countsBuffer, 4), 'second encoding resets output').toEqual([1, 2, 1, 3]);
+  expect(await readUint32(totalBuffer, 1), 'reduced count equals accepted rows').toEqual([7]);
   compiled.destroy();
-  t.notOk(inputBuffer.destroyed, 'compiled graph preserves imported input');
-  t.notOk(countsBuffer.destroyed, 'compiled graph preserves imported output');
+  expect(Boolean(inputBuffer.destroyed), 'compiled graph preserves imported input').toBe(false);
+  expect(Boolean(countsBuffer.destroyed), 'compiled graph preserves imported output').toBe(false);
   inputBuffer.destroy();
   countsBuffer.destroy();
   totalBuffer.destroy();
-  t.end();
 });
 
-test('GPUGroupAggregation counts dense keys with optional dynamic selection', async t => {
+it('GPUGroupAggregation counts dense keys with optional dynamic selection', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
   const keys = Uint32Array.from([0, 1, 3, 4, 0xffffffff, 1, 0]);
-  t.deepEqual(
+  expect(
     await runGroupAggregation(device, keys, 4),
-    [2, 2, 0, 1],
     'dense keys count into output rows and out-of-range keys are ignored'
-  );
-  t.deepEqual(
+  ).toEqual([2, 2, 0, 1]);
+  expect(
     await runGroupAggregation(device, keys, 4, Uint32Array.from([7, 0, 1, 1, 1, 1, 0])),
-    [1, 1, 0, 1],
     'nonzero mask rows contribute to their groups'
-  );
-  t.deepEqual(
+  ).toEqual([1, 1, 0, 1]);
+  expect(
     await runGroupAggregation(
       device,
       keys,
@@ -501,48 +446,38 @@ test('GPUGroupAggregation counts dense keys with optional dynamic selection', as
       Uint32Array.from([7, 0, 1, 1, 1, 1, 0]),
       Uint32Array.from({length: keys.length}, () => 1)
     ),
-    [2, 2, 0, 1],
     'rewriting the selection changes counts without recompiling the graph'
-  );
-  t.deepEqual(
+  ).toEqual([2, 2, 0, 1]);
+  expect(
     await runGroupAggregation(device, new Uint32Array(0), 3),
-    [0, 0, 0],
     'empty input still clears every group'
-  );
+  ).toEqual([0, 0, 0]);
 
   const globalKeys = Uint32Array.from({length: 301}, (_, index) => index);
-  t.deepEqual(
+  expect(
     await runGroupAggregation(device, globalKeys, 300),
-    Array.from({length: 300}, () => 1),
     'more than 256 groups uses global atomics and ignores key 300'
-  );
-  t.end();
+  ).toEqual(Array.from({length: 300}, () => 1));
 });
 
-test('GPUGroupAggregation plans bounded multidimensional dispatches', t => {
-  t.deepEqual(
+it('GPUGroupAggregation plans bounded multidimensional dispatches', () => {
+  expect(
     getGPUGroupAggregationDispatchLayout(5 * 256, 4),
-    {x: 4, y: 2, z: 1},
     'workgroups spill from x into y at the device limit'
-  );
-  t.deepEqual(
+  ).toEqual({x: 4, y: 2, z: 1});
+  expect(
     getGPUGroupAggregationDispatchLayout(20 * 256, 4),
-    {x: 4, y: 4, z: 2},
     'larger chunks spill into the third dimension'
-  );
-  t.throws(
+  ).toEqual({x: 4, y: 4, z: 2});
+  expect(
     () => getGPUGroupAggregationDispatchLayout((4 * 4 * 4 + 1) * 256, 4),
-    /exceeding the 3D dispatch limit/,
     'chunks beyond the full 3D device limit are rejected before encoding'
-  );
-  t.end();
+  ).toThrow(/exceeding the 3D dispatch limit/);
 });
 
-test('GPUGroupAggregation computes filtered floating-point group statistics', async t => {
+it('GPUGroupAggregation computes filtered floating-point group statistics', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -556,13 +491,21 @@ test('GPUGroupAggregation computes filtered floating-point group statistics', as
   const maximum = await run('max');
   const mean = await run('mean');
 
-  t.deepEqual(sum, [3, 5, -3, 0], 'sum accepts finite selected values with valid keys');
-  t.deepEqual(minimum.slice(0, 3), [-2, 1, -3], 'minimum retains each smallest value');
-  t.ok(Number.isNaN(minimum[3]), 'minimum marks a group with no finite values as NaN');
-  t.deepEqual(maximum.slice(0, 3), [5, 4, -3], 'maximum retains each largest value');
-  t.ok(Number.isNaN(maximum[3]), 'maximum marks a group with no finite values as NaN');
-  t.deepEqual(mean.slice(0, 3), [1.5, 2.5, -3], 'mean divides sums by accepted values');
-  t.ok(Number.isNaN(mean[3]), 'mean marks a group with no finite values as NaN');
+  expect(sum, 'sum accepts finite selected values with valid keys').toEqual([3, 5, -3, 0]);
+  expect(minimum.slice(0, 3), 'minimum retains each smallest value').toEqual([-2, 1, -3]);
+  expect(
+    Boolean(Number.isNaN(minimum[3])),
+    'minimum marks a group with no finite values as NaN'
+  ).toBe(true);
+  expect(maximum.slice(0, 3), 'maximum retains each largest value').toEqual([5, 4, -3]);
+  expect(
+    Boolean(Number.isNaN(maximum[3])),
+    'maximum marks a group with no finite values as NaN'
+  ).toBe(true);
+  expect(mean.slice(0, 3), 'mean divides sums by accepted values').toEqual([1.5, 2.5, -3]);
+  expect(Boolean(Number.isNaN(mean[3])), 'mean marks a group with no finite values as NaN').toBe(
+    true
+  );
 
   const emptyMean = await runGroupStatistic(
     device,
@@ -571,7 +514,9 @@ test('GPUGroupAggregation computes filtered floating-point group statistics', as
     3,
     'mean'
   );
-  t.ok(emptyMean.every(Number.isNaN), 'empty means finalize every group to NaN');
+  expect(Boolean(emptyMean.every(Number.isNaN)), 'empty means finalize every group to NaN').toBe(
+    true
+  );
   const minimumZero = await runGroupStatistic(
     device,
     Uint32Array.from([0, 0]),
@@ -586,16 +531,19 @@ test('GPUGroupAggregation computes filtered floating-point group statistics', as
     1,
     'max'
   );
-  t.ok(Object.is(minimumZero[0], -0), 'minimum preserves the ordered-float signed-zero contract');
-  t.ok(Object.is(maximumZero[0], 0), 'maximum preserves the ordered-float signed-zero contract');
-  t.end();
+  expect(
+    Boolean(Object.is(minimumZero[0], -0)),
+    'minimum preserves the ordered-float signed-zero contract'
+  ).toBe(true);
+  expect(
+    Boolean(Object.is(maximumZero[0], 0)),
+    'maximum preserves the ordered-float signed-zero contract'
+  ).toBe(true);
 });
 
-test('GPUGroupAggregation preserves aligned vector chunks', async t => {
+it('GPUGroupAggregation preserves aligned vector chunks', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -605,21 +553,16 @@ test('GPUGroupAggregation preserves aligned vector chunks', async t => {
     [Uint32Array.from([1, 0]), new Uint32Array(0), Uint32Array.from([1, 1, 1])],
     4
   );
-  t.deepEqual(result.counts, [1, 1, 0, 1], 'aligned non-empty chunks share dense counts');
-  t.deepEqual(
-    result.nodeOrder,
-    [
-      'gpu-group-aggregation-clear',
-      'gpu-group-aggregation-chunk-0-local',
-      'gpu-group-aggregation-chunk-2-local'
-    ],
-    'one clear precedes ordered per-chunk accumulation'
-  );
-  t.equal(
+  expect(result.counts, 'aligned non-empty chunks share dense counts').toEqual([1, 1, 0, 1]);
+  expect(result.nodeOrder, 'one clear precedes ordered per-chunk accumulation').toEqual([
+    'gpu-group-aggregation-clear',
+    'gpu-group-aggregation-chunk-0-local',
+    'gpu-group-aggregation-chunk-2-local'
+  ]);
+  expect(
     result.logicalTransientBufferCount,
-    0,
     'group counting does not pack chunks or allocate scratch storage'
-  );
+  ).toBe(0);
 
   const mean = await runVectorGroupStatistic(
     device,
@@ -629,39 +572,33 @@ test('GPUGroupAggregation preserves aligned vector chunks', async t => {
     2,
     'mean'
   );
-  t.deepEqual(mean.values, [3, 7], 'weighted groups combine aligned selected chunks');
-  t.deepEqual(
+  expect(mean.values, 'weighted groups combine aligned selected chunks').toEqual([3, 7]);
+  expect(
     mean.nodeOrder,
-    [
-      'gpu-group-aggregation-initialize',
-      'gpu-group-aggregation-chunk-0-mean',
-      'gpu-group-aggregation-chunk-2-mean',
-      'gpu-group-aggregation-finalize'
-    ],
     'weighted vector aggregation initializes and finalizes once around non-empty chunks'
-  );
-  t.equal(mean.logicalTransientBufferCount, 1, 'mean owns one transient group-count buffer');
-  t.end();
+  ).toEqual([
+    'gpu-group-aggregation-initialize',
+    'gpu-group-aggregation-chunk-0-mean',
+    'gpu-group-aggregation-chunk-2-mean',
+    'gpu-group-aggregation-finalize'
+  ]);
+  expect(mean.logicalTransientBufferCount, 'mean owns one transient group-count buffer').toBe(1);
 });
 
-test('GPUGridBinning handles literal/GPU bounds, boundaries, and both atomic paths', async t => {
+it('GPUGridBinning handles literal/GPU bounds, boundaries, and both atomic paths', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const positions = Float32Array.from([0, 0, 1, 0, 0, 1, 2, 2, 2, 2, -1, 0, Number.NaN, 1]);
-  t.deepEqual(
+  expect(
     await runGrid(device, positions, [2, 2], [0, 0, 2, 2]),
-    [1, 1, 1, 2],
     'row-major cells include exact maximum boundaries'
-  );
-  t.deepEqual(
+  ).toEqual([1, 1, 1, 2]);
+  expect(
     await runGrid(device, positions, [2, 2], [0, 0, 2, 2], true),
-    [1, 1, 1, 2],
     'GPU bounds view is accepted'
-  );
+  ).toEqual([1, 1, 1, 2]);
   const globalPositions = new Float32Array(17 * 17 * 2);
   for (let row = 0; row < 17; row++) {
     for (let column = 0; column < 17; column++) {
@@ -670,24 +607,19 @@ test('GPUGridBinning handles literal/GPU bounds, boundaries, and both atomic pat
       globalPositions[index * 2 + 1] = row;
     }
   }
-  t.deepEqual(
+  expect(
     await runGrid(device, globalPositions, [17, 17], [0, 0, 16, 16]),
-    Array.from({length: 289}, () => 1),
     'more than 256 cells uses the global atomic path'
-  );
-  t.deepEqual(
+  ).toEqual(Array.from({length: 289}, () => 1));
+  expect(
     await runGrid(device, new Float32Array(0), [2, 2], [0, 0, 1, 1]),
-    [0, 0, 0, 0],
     'empty grid is cleared'
-  );
-  t.end();
+  ).toEqual([0, 0, 0, 0]);
 });
 
-test('GPUGridBinning clears once and accumulates GPUVector chunks in order', async t => {
+it('GPUGridBinning clears once and accumulates GPUVector chunks in order', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -697,37 +629,37 @@ test('GPUGridBinning clears once and accumulates GPUVector chunks in order', asy
     [2, 2],
     [0, 0, 2, 2]
   );
-  t.deepEqual(result.counts, [1, 1, 1, 2], 'every non-empty position chunk contributes');
-  t.deepEqual(
+  expect(result.counts, 'every non-empty position chunk contributes').toEqual([1, 1, 1, 2]);
+  expect(
     result.nodeOrder,
-    ['gpu-grid-binning-clear', 'gpu-grid-binning-chunk-0-local', 'gpu-grid-binning-chunk-2-local'],
     'one clear precedes ordered accumulation and empty chunks keep their source index'
+  ).toEqual([
+    'gpu-grid-binning-clear',
+    'gpu-grid-binning-chunk-0-local',
+    'gpu-grid-binning-chunk-2-local'
+  ]);
+  expect(result.logicalTransientBufferCount, 'position chunks are not packed or concatenated').toBe(
+    0
   );
-  t.equal(result.logicalTransientBufferCount, 0, 'position chunks are not packed or concatenated');
-  t.end();
 });
 
-test('GPUGridAggregation sums finite weights with float32 atomics', async t => {
+it('GPUGridAggregation sums finite weights with float32 atomics', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
   const positions = Float32Array.from([0, 0, 1, 0, 0, 1, 2, 2, 2, 2, -1, 0, Number.NaN, 1, 1, 1]);
   const weights = Float32Array.from([1.5, -2, 3, 4, 0.25, 100, 100, Number.POSITIVE_INFINITY]);
-  t.deepEqual(
+  expect(
     await runGridAggregation(device, positions, weights, [2, 2], [0, 0, 2, 2]),
-    [1.5, -2, 3, 4.25],
     'finite in-bounds weights contribute to row-major cell sums'
-  );
-  t.deepEqual(
+  ).toEqual([1.5, -2, 3, 4.25]);
+  expect(
     await runGridAggregation(device, positions, weights, [2, 2], [0, 0, 2, 2], true),
-    [1.5, -2, 3, 4.25],
     'GPU-resident bounds preserve weighted sums'
-  );
-  t.deepEqual(
+  ).toEqual([1.5, -2, 3, 4.25]);
+  expect(
     await runGridAggregation(
       device,
       new Float32Array(0),
@@ -735,10 +667,9 @@ test('GPUGridAggregation sums finite weights with float32 atomics', async t => {
       [2, 2],
       [0, 0, 1, 1]
     ),
-    [0, 0, 0, 0],
     'empty inputs still clear every sum'
-  );
-  t.deepEqual(
+  ).toEqual([0, 0, 0, 0]);
+  expect(
     await runGridAggregation(
       device,
       Float32Array.from([0, 0, 0, 0]),
@@ -746,17 +677,13 @@ test('GPUGridAggregation sums finite weights with float32 atomics', async t => {
       [1, 1],
       [0, 0, 0, 0]
     ),
-    [Number.POSITIVE_INFINITY],
     'finite contributions may overflow their float32 cell sum'
-  );
-  t.end();
+  ).toEqual([Number.POSITIVE_INFINITY]);
 });
 
-test('GPUGridAggregation computes minimum, maximum, and mean cell statistics', async t => {
+it('GPUGridAggregation computes minimum, maximum, and mean cell statistics', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -768,12 +695,12 @@ test('GPUGridAggregation computes minimum, maximum, and mean cell statistics', a
   const minimum = await run('min');
   const maximum = await run('max');
 
-  t.deepEqual(minimum.slice(0, 3), [-2, 4, -3], 'minimum retains the smallest finite weight');
-  t.ok(Number.isNaN(minimum[3]), 'minimum marks an empty cell with NaN');
-  t.deepEqual(maximum.slice(0, 3), [5, 4, -3], 'maximum retains the largest finite weight');
-  t.ok(Number.isNaN(maximum[3]), 'maximum marks an empty cell with NaN');
-  t.deepEqual(mean.slice(0, 3), [1.5, 4, -3], 'mean divides the float32 sum by accepted rows');
-  t.ok(Number.isNaN(mean[3]), 'mean marks an empty cell with NaN');
+  expect(minimum.slice(0, 3), 'minimum retains the smallest finite weight').toEqual([-2, 4, -3]);
+  expect(Boolean(Number.isNaN(minimum[3])), 'minimum marks an empty cell with NaN').toBe(true);
+  expect(maximum.slice(0, 3), 'maximum retains the largest finite weight').toEqual([5, 4, -3]);
+  expect(Boolean(Number.isNaN(maximum[3])), 'maximum marks an empty cell with NaN').toBe(true);
+  expect(mean.slice(0, 3), 'mean divides the float32 sum by accepted rows').toEqual([1.5, 4, -3]);
+  expect(Boolean(Number.isNaN(mean[3])), 'mean marks an empty cell with NaN').toBe(true);
 
   const emptyMean = await runGridAggregation(
     device,
@@ -784,7 +711,10 @@ test('GPUGridAggregation computes minimum, maximum, and mean cell statistics', a
     false,
     'mean'
   );
-  t.ok(emptyMean.every(Number.isNaN), 'an empty mean aggregation finalizes every cell to NaN');
+  expect(
+    Boolean(emptyMean.every(Number.isNaN)),
+    'an empty mean aggregation finalizes every cell to NaN'
+  ).toBe(true);
 
   const zeroPositions = Float32Array.from([0, 0, 0, 0]);
   const zeroWeights = Float32Array.from([0, -0]);
@@ -806,16 +736,19 @@ test('GPUGridAggregation computes minimum, maximum, and mean cell statistics', a
     false,
     'max'
   );
-  t.ok(Object.is(minimumZero[0], -0), 'minimum uses the ordered-float signed-zero contract');
-  t.ok(Object.is(maximumZero[0], 0), 'maximum uses the ordered-float signed-zero contract');
-  t.end();
+  expect(
+    Boolean(Object.is(minimumZero[0], -0)),
+    'minimum uses the ordered-float signed-zero contract'
+  ).toBe(true);
+  expect(
+    Boolean(Object.is(maximumZero[0], 0)),
+    'maximum uses the ordered-float signed-zero contract'
+  ).toBe(true);
 });
 
-test('GPUGridAggregation preserves paired GPUVector chunk topology', async t => {
+it('GPUGridAggregation preserves paired GPUVector chunk topology', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -826,17 +759,15 @@ test('GPUGridAggregation preserves paired GPUVector chunk topology', async t => 
     [2, 2],
     [0, 0, 2, 2]
   );
-  t.deepEqual(result.values, [1.25, 2.5, -3, 4.75], 'aligned chunks accumulate in source order');
-  t.deepEqual(
-    result.nodeOrder,
-    [
-      'gpu-grid-aggregation-clear',
-      'gpu-grid-aggregation-chunk-0-sum',
-      'gpu-grid-aggregation-chunk-2-sum'
-    ],
-    'one clear precedes each non-empty aligned chunk'
+  expect(result.values, 'aligned chunks accumulate in source order').toEqual([1.25, 2.5, -3, 4.75]);
+  expect(result.nodeOrder, 'one clear precedes each non-empty aligned chunk').toEqual([
+    'gpu-grid-aggregation-clear',
+    'gpu-grid-aggregation-chunk-0-sum',
+    'gpu-grid-aggregation-chunk-2-sum'
+  ]);
+  expect(result.logicalTransientBufferCount, 'paired chunks are not packed or concatenated').toBe(
+    0
   );
-  t.equal(result.logicalTransientBufferCount, 0, 'paired chunks are not packed or concatenated');
 
   const mean = await runVectorGridAggregation(
     device,
@@ -846,26 +777,22 @@ test('GPUGridAggregation preserves paired GPUVector chunk topology', async t => 
     [0, 0, 0, 0],
     'mean'
   );
-  t.deepEqual(mean.values, [3], 'mean combines sums and counts across aligned chunks');
-  t.deepEqual(
+  expect(mean.values, 'mean combines sums and counts across aligned chunks').toEqual([3]);
+  expect(
     mean.nodeOrder,
-    [
-      'gpu-grid-aggregation-initialize',
-      'gpu-grid-aggregation-chunk-0-mean',
-      'gpu-grid-aggregation-chunk-2-mean',
-      'gpu-grid-aggregation-finalize'
-    ],
     'mean initializes once, accumulates every non-empty chunk, and finalizes once'
-  );
-  t.equal(mean.logicalTransientBufferCount, 1, 'mean owns one transient cell-count buffer');
-  t.end();
+  ).toEqual([
+    'gpu-grid-aggregation-initialize',
+    'gpu-grid-aggregation-chunk-0-mean',
+    'gpu-grid-aggregation-chunk-2-mean',
+    'gpu-grid-aggregation-finalize'
+  ]);
+  expect(mean.logicalTransientBufferCount, 'mean owns one transient cell-count buffer').toBe(1);
 });
 
-test('GPU data analysis primitives validate layouts and ownership', async t => {
+it('GPU data analysis primitives validate layouts and ownership', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const graph = new GPUCommandGraph(device);
@@ -882,82 +809,72 @@ test('GPU data analysis primitives validate layouts and ownership', async t => {
   const input = graph.createDataView(inputHandle, {format: 'uint32', length: 4});
   const one = graph.createDataView(outputHandle, {format: 'uint32', length: 1});
   const two = graph.createDataView(outputHandle, {format: 'uint32', length: 2});
-  t.throws(
+  expect(
     () => new GPUReduction({input, output: two, operation: 'sum'}),
-    /must contain 1 row/,
     'scalar reduction requires one output row'
-  );
-  t.throws(
+  ).toThrow(/must contain 1 row/);
+  expect(
     () => new GPUReduction({input, output: one, operation: 'extent'}),
-    /must contain 2 row/,
     'extent requires two output rows'
-  );
-  t.throws(
+  ).toThrow(/must contain 2 row/);
+  expect(
     () => new GPUHistogram({input, output: two, domain: [2, 1]}),
-    /finite \[min, max\]/,
     'inverted literal histogram domain is rejected'
-  );
-  t.throws(
+  ).toThrow(/finite \[min, max\]/);
+  expect(
     () => new GPUHistogram({input, output: two, edges: [0, 1]}),
-    /output.length \+ 1/,
     'literal histogram edges must match the output size'
-  );
-  t.throws(
+  ).toThrow(/output.length \+ 1/);
+  expect(
     () => new GPUHistogram({input, output: two, edges: [0, 1, 1]}),
-    /strictly increasing/,
     'literal histogram edges must be strictly increasing'
-  );
+  ).toThrow(/strictly increasing/);
   const floatInput = graph.createDataView(inputHandle, {format: 'float32', length: 4});
-  t.throws(
+  expect(
     () =>
       new GPUHistogram({
         input: floatInput,
         output: two,
         edges: [16_777_216, 16_777_217, 16_777_218]
       }),
-    /strictly increasing/,
     'literal histogram edges must remain ordered after float32 conversion'
-  );
-  t.throws(
+  ).toThrow(/strictly increasing/);
+  expect(
     () =>
       new GPUGroupAggregation({
         keys: input,
         output: two,
         operation: 'median' as GPUGroupAggregationOperation
       }),
-    /operation must be count/,
     'unsupported group statistics are rejected'
-  );
-  t.throws(
+  ).toThrow(/operation must be count/);
+  expect(
     () =>
       new GPUGroupAggregation({
         keys: input,
         mask: graph.createDataView(inputHandle, {format: 'uint32', length: 3}),
         output: two
       }),
-    /lengths must match/,
     'group keys and masks require row alignment'
-  );
-  t.throws(
+  ).toThrow(/lengths must match/);
+  expect(
     () =>
       new GPUGroupAggregation({
         keys: input,
         output: graph.createDataView(outputHandle, {format: 'uint32', length: 0})
       }),
-    /at least one group/,
     'group output must define a nonempty key range'
-  );
-  t.throws(
+  ).toThrow(/at least one group/);
+  expect(
     () =>
       new GPUGroupAggregation({
         keys: input,
         output: graph.createDataView(inputHandle, {format: 'uint32', length: 2})
       }),
-    /separate buffers/,
     'group output cannot alias its keys'
-  );
+  ).toThrow(/separate buffers/);
   const floatGroupOutput = graph.createDataView(outputHandle, {format: 'float32', length: 2});
-  t.throws(
+  expect(
     () =>
       new GPUGroupAggregation({
         keys: input,
@@ -965,28 +882,25 @@ test('GPU data analysis primitives validate layouts and ownership', async t => {
         output: floatGroupOutput,
         operation: 'sum'
       }),
-    /lengths must match/,
     'group keys and floating-point values require row alignment'
-  );
-  t.throws(
+  ).toThrow(/lengths must match/);
+  expect(
     () =>
       new GPUGroupAggregation({
         keys: input,
         output: floatGroupOutput,
         operation: 'mean'
       } as never),
-    /requires values/,
     'weighted group statistics require an aligned value input'
-  );
+  ).toThrow(/requires values/);
   const positions = graph.createDataView(inputHandle, {format: 'float32x2', length: 4});
-  t.throws(
+  expect(
     () => new GPUGridBinning({positions, output: two, gridSize: [2, 2], bounds: [0, 0, 1, 1]}),
-    /output.length/,
     'grid output layout is validated'
-  );
+  ).toThrow(/output.length/);
   const weights = graph.createDataView(inputHandle, {format: 'float32', length: 3});
   const floatOutput = graph.createDataView(outputHandle, {format: 'float32', length: 4});
-  t.throws(
+  expect(
     () =>
       new GPUGridAggregation({
         positions,
@@ -995,10 +909,9 @@ test('GPU data analysis primitives validate layouts and ownership', async t => {
         gridSize: [2, 2],
         bounds: [0, 0, 1, 1]
       }),
-    /same number of rows/,
     'weighted grid inputs require row alignment'
-  );
-  t.throws(
+  ).toThrow(/same number of rows/);
+  expect(
     () =>
       new GPUGridAggregation({
         positions,
@@ -1008,10 +921,8 @@ test('GPU data analysis primitives validate layouts and ownership', async t => {
         gridSize: [2, 2],
         bounds: [0, 0, 1, 1]
       }),
-    /operation must be sum, min, max, or mean/,
-    'unsupported grid statistics are rejected'
-  );
-  t.end();
+    'weighted grid operations only support sum'
+  ).toThrow(/operation must be sum/);
 });
 
 type ScalarFormat = 'uint32' | 'sint32' | 'float32';

--- a/modules/gpgpu/test/gpu-core/gpu-fft1d.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-fft1d.node.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -12,13 +13,12 @@ import {
   GPU_FFT1D_MIN_LENGTH,
   makeGPUFFT1DStats
 } from '@luma.gl/gpgpu/gpu-core';
-import test from 'test/utils/vitest-tape';
 import {WgslReflect} from 'wgsl_reflect';
 import {getGPUFFT1DShaderSource} from '../../src/gpu-core/gpu-fft1d';
 import {GPU_FFT2D_SHADER} from '../../src/gpu-core/gpu-fft2d-shaders';
 
-test('GPUFFT1D publishes bounded batched radix-2 plans', testCase => {
-  testCase.deepEqual(makeGPUFFT1DStats(8, 3), {
+it('GPUFFT1D publishes bounded batched radix-2 plans', () => {
+  expect(makeGPUFFT1DStats(8, 3)).toEqual({
     length: 8,
     batchCount: 3,
     elementCount: 24,
@@ -29,53 +29,49 @@ test('GPUFFT1D publishes bounded batched radix-2 plans', testCase => {
     scratchBufferByteLength: 192,
     workgroupSize: 256
   });
-  testCase.equal(GPU_FFT1D_MIN_LENGTH, 2, 'minimum length is explicit');
-  testCase.equal(GPU_FFT1D_MAX_LENGTH, 2048, 'maximum length is explicit');
-  testCase.equal(makeGPUFFT1DStats(2).passCount, 2, 'minimum plan has one butterfly');
-  testCase.equal(makeGPUFFT1DStats(2048).passCount, 12, 'maximum plan has eleven butterflies');
-  testCase.throws(() => makeGPUFFT1DStats(1), /from 2 through 2048/);
-  testCase.throws(() => makeGPUFFT1DStats(12), /power of two/);
-  testCase.throws(() => makeGPUFFT1DStats(8, 0), /positive integer/);
-  testCase.end();
+  expect(GPU_FFT1D_MIN_LENGTH, 'minimum length is explicit').toBe(2);
+  expect(GPU_FFT1D_MAX_LENGTH, 'maximum length is explicit').toBe(2048);
+  expect(makeGPUFFT1DStats(2).passCount, 'minimum plan has one butterfly').toBe(2);
+  expect(makeGPUFFT1DStats(2048).passCount, 'maximum plan has eleven butterflies').toBe(12);
+  expect(() => makeGPUFFT1DStats(1)).toThrow(/from 2 through 2048/);
+  expect(() => makeGPUFFT1DStats(12)).toThrow(/power of two/);
+  expect(() => makeGPUFFT1DStats(8, 0)).toThrow(/positive integer/);
 });
 
-test('GPUFFT1D support selects portable and subgroup strategies explicitly', testCase => {
+it('GPUFFT1D support selects portable and subgroup strategies explicitly', () => {
   const portableDevice = makeSupportDevice();
   const portableSupport = getGPUFFT1DSupport(portableDevice, {length: 256, batchCount: 4});
-  testCase.equal(portableSupport.supported, true);
-  testCase.equal(portableSupport.strategy, 'portable');
-  testCase.equal(portableSupport.subgroupStageCount, 0);
+  expect(portableSupport.supported).toBe(true);
+  expect(portableSupport.strategy).toBe('portable');
+  expect(portableSupport.subgroupStageCount).toBe(0);
 
   const subgroupDevice = makeSupportDevice({subgroups: true, subgroupMinSize: 32});
   const subgroupSupport = getGPUFFT1DSupport(subgroupDevice, {
     length: 256,
     batchCount: 4
   });
-  testCase.equal(subgroupSupport.strategy, 'subgroups');
-  testCase.equal(subgroupSupport.subgroupStageCount, 5, 'spans through 32 use subgroup shuffles');
-  testCase.equal(
+  expect(subgroupSupport.strategy).toBe('subgroups');
+  expect(subgroupSupport.subgroupStageCount, 'spans through 32 use subgroup shuffles').toBe(5);
+  expect(
     getGPUFFT1DStrategy(subgroupDevice, 'portable'),
-    'portable',
     'portable can be forced for benchmarking'
-  );
-  testCase.throws(() => getGPUFFT1DStrategy(portableDevice, 'subgroups'), /not supported/);
+  ).toBe('portable');
+  expect(() => getGPUFFT1DStrategy(portableDevice, 'subgroups')).toThrow(/not supported/);
 
   const smallStorageDevice = makeSupportDevice({maxStorageBufferBindingSize: 1024});
   const smallStorageSupport = getGPUFFT1DSupport(smallStorageDevice, {
     length: 256,
     batchCount: 1
   });
-  testCase.equal(smallStorageSupport.supported, false);
-  testCase.match(smallStorageSupport.reason || '', /maxStorageBufferBindingSize/);
-  testCase.equal(
+  expect(smallStorageSupport.supported).toBe(false);
+  expect(smallStorageSupport.reason || '').toMatch(/maxStorageBufferBindingSize/);
+  expect(
     getGPUFFT1DSupport(portableDevice, {length: 7}).stats,
-    undefined,
     'invalid radix-2 lengths do not publish a plan'
-  );
-  testCase.end();
+  ).toBe(undefined);
 });
 
-test('GPUFFT1D validates packed complex views, capacity, aliasing, and ownership', testCase => {
+it('GPUFFT1D validates packed complex views, capacity, aliasing, and ownership', () => {
   const graph = new GPUCommandGraph(makeSupportDevice());
   const inputHandle = graph.importBuffer({
     id: 'input',
@@ -89,13 +85,12 @@ test('GPUFFT1D validates packed complex views, capacity, aliasing, and ownership
   });
   const input = graph.createDataView(inputHandle, {format: 'float32x2', length: 8});
   const output = graph.createDataView(outputHandle, {format: 'float32x2', length: 8});
-  testCase.doesNotThrow(
+  expect(
     () => new GPUFFT1D({input, output, length: 4, batchCount: 2}),
     'packed batched views are accepted'
-  );
+  ).not.toThrow();
   const shortOutput = graph.createDataView(outputHandle, {format: 'float32x2', length: 7});
-  testCase.throws(
-    () => new GPUFFT1D({input, output: shortOutput, length: 4, batchCount: 2}),
+  expect(() => new GPUFFT1D({input, output: shortOutput, length: 4, batchCount: 2})).toThrow(
     /output must contain at least/
   );
   const stridedInput = graph.createDataView(inputHandle, {
@@ -103,12 +98,9 @@ test('GPUFFT1D validates packed complex views, capacity, aliasing, and ownership
     length: 4,
     byteStride: 16
   });
-  testCase.throws(() => new GPUFFT1D({input: stridedInput, output, length: 4}), /must be packed/);
+  expect(() => new GPUFFT1D({input: stridedInput, output, length: 4})).toThrow(/must be packed/);
   const aliasedOutput = graph.createDataView(inputHandle, {format: 'float32x2', length: 8});
-  testCase.throws(
-    () => new GPUFFT1D({input, output: aliasedOutput, length: 8}),
-    /separate buffers/
-  );
+  expect(() => new GPUFFT1D({input, output: aliasedOutput, length: 8})).toThrow(/separate buffers/);
 
   const otherGraph = new GPUCommandGraph(makeSupportDevice());
   const otherHandle = otherGraph.importBuffer({
@@ -117,14 +109,12 @@ test('GPUFFT1D validates packed complex views, capacity, aliasing, and ownership
     usage: Buffer.STORAGE
   });
   const otherOutput = otherGraph.createDataView(otherHandle, {format: 'float32x2', length: 8});
-  testCase.throws(
-    () => new GPUFFT1D({input, output: otherOutput, length: 8}).addToGraph(graph),
+  expect(() => new GPUFFT1D({input, output: otherOutput, length: 8}).addToGraph(graph)).toThrow(
     /different GPUCommandGraph/
   );
-  testCase.end();
 });
 
-test('GPUFFT1D shaders share FFT helpers and expose portable and subgroup butterflies', testCase => {
+it('GPUFFT1D shaders share FFT helpers and expose portable and subgroup butterflies', () => {
   const graph = new GPUCommandGraph(makeSupportDevice());
   const inputHandle = graph.importBuffer({
     id: 'input',
@@ -156,16 +146,12 @@ test('GPUFFT1D shaders share FFT helpers and expose portable and subgroup butter
     {...baseProps, pass: {kind: 'butterfly', stage: 2}, useSubgroups: true},
     {x: 1, y: 1, z: 1}
   );
-  testCase.deepEqual(
-    new WgslReflect(portableSource).entry.compute.map(entry => entry.name),
-    ['main']
-  );
-  testCase.match(portableSource, /multiplyComplex/, 'portable shader uses shared complex math');
-  testCase.match(subgroupSource, /enable subgroups/, 'subgroup extension is capability-gated');
-  testCase.match(subgroupSource, /subgroupShuffleXor/, 'eligible butterflies shuffle partners');
-  testCase.match(subgroupSource, /subgroupMappingMatches/, 'unexpected lane mappings fall back');
-  testCase.match(GPU_FFT2D_SHADER, /GPU_FFT_PI/, 'GPUFFT2D consumes the same shared helpers');
-  testCase.end();
+  expect(new WgslReflect(portableSource).entry.compute.map(entry => entry.name)).toEqual(['main']);
+  expect(portableSource, 'portable shader uses shared complex math').toMatch(/multiplyComplex/);
+  expect(subgroupSource, 'subgroup extension is capability-gated').toMatch(/enable subgroups/);
+  expect(subgroupSource, 'eligible butterflies shuffle partners').toMatch(/subgroupShuffleXor/);
+  expect(subgroupSource, 'unexpected lane mappings fall back').toMatch(/subgroupMappingMatches/);
+  expect(GPU_FFT2D_SHADER, 'GPUFFT2D consumes the same shared helpers').toMatch(/GPU_FFT_PI/);
 });
 
 function makeSupportDevice(

--- a/modules/gpgpu/test/gpu-core/gpu-fft1d.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-fft1d.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -11,13 +12,10 @@ import {
   type GPUFFT1DStrategy
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
 
-test('GPUFFT1D matches a CPU DFT for independent packed batches', async testCase => {
+it('GPUFFT1D matches a CPU DFT for independent packed batches', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
   const length = 8;
@@ -33,32 +31,18 @@ test('GPUFFT1D matches a CPU DFT for independent packed batches', async testCase
     );
   }
   const result = await runGPUFFT1D(device, inputValues, length, batchCount, 'portable');
-  assertClose(testCase, result.forward, expectedValues, 0.0005, 'batched forward transform');
-  assertClose(
-    testCase,
-    result.inverse,
-    Array.from(inputValues),
-    0.0005,
-    'batched inverse round trip'
-  );
-  testCase.equal(
-    result.logicalTransientBufferCount,
-    2,
-    'each transform declares inspectable scratch'
-  );
-  testCase.equal(
+  assertClose(result.forward, expectedValues, 0.0005, 'batched forward transform');
+  assertClose(result.inverse, Array.from(inputValues), 0.0005, 'batched inverse round trip');
+  expect(result.logicalTransientBufferCount, 'each transform declares inspectable scratch').toBe(2);
+  expect(
     result.physicalTransientBufferCount,
-    1,
     'disjoint forward and inverse scratch lifetimes alias physically'
-  );
-  testCase.end();
+  ).toBe(1);
 });
 
-test('GPUFFT1D benchmark correctness-gates available strategies', async testCase => {
+it('GPUFFT1D benchmark correctness-gates available strategies', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
   const report = await runGPUFFT1DBenchmark(device, {
@@ -67,23 +51,20 @@ test('GPUFFT1D benchmark correctness-gates available strategies', async testCase
     warmupIterations: 1,
     measuredIterations: 2
   });
-  testCase.equal(report.length, 16);
-  testCase.equal(report.batchCount, 3);
-  testCase.equal(report.passCount, 5);
-  testCase.equal(report.paths[0].strategy, 'portable');
-  testCase.equal(report.paths.length, report.subgroupAvailable ? 2 : 1);
-  testCase.ok(
-    report.paths.every(path => Number.isFinite(path.cpuEncodeTimeMilliseconds.median)),
+  expect(report.length).toBe(16);
+  expect(report.batchCount).toBe(3);
+  expect(report.passCount).toBe(5);
+  expect(report.paths[0].strategy).toBe('portable');
+  expect(report.paths.length).toBe(report.subgroupAvailable ? 2 : 1);
+  expect(
+    Boolean(report.paths.every(path => Number.isFinite(path.cpuEncodeTimeMilliseconds.median))),
     'each available path reports a finite timing distribution'
-  );
-  testCase.end();
+  ).toBe(true);
 });
 
-test('GPUFFT1D auto strategy preserves portable numerical results', async testCase => {
+it('GPUFFT1D auto strategy preserves portable numerical results', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
   const length = 32;
@@ -92,18 +73,16 @@ test('GPUFFT1D auto strategy preserves portable numerical results', async testCa
   const portable = await runGPUFFT1D(device, inputValues, length, batchCount, 'portable');
   const automatic = await runGPUFFT1D(device, inputValues, length, batchCount, 'auto');
   assertClose(
-    testCase,
     automatic.forward,
     portable.forward,
     0.0005,
     'automatic subgroup selection matches portable output'
   );
   const support = getGPUFFT1DSupport(device, {length, batchCount});
-  testCase.ok(
-    support.strategy === 'portable' || support.subgroupStageCount! > 0,
+  expect(
+    Boolean(support.strategy === 'portable' || support.subgroupStageCount! > 0),
     'support exposes whether subgroup butterflies were eligible'
-  );
-  testCase.end();
+  ).toBe(true);
 });
 
 async function runGPUFFT1D(
@@ -219,17 +198,16 @@ async function readFloat32(buffer: Buffer, length: number): Promise<number[]> {
 }
 
 function assertClose(
-  testCase: {ok: (value: unknown, message?: string) => void},
   actual: readonly number[],
   expected: readonly number[],
   tolerance: number,
   label: string
 ): void {
-  testCase.ok(actual.length === expected.length, `${label} length matches`);
+  expect(Boolean(actual.length === expected.length), `${label} length matches`).toBe(true);
   for (let index = 0; index < actual.length; index++) {
-    testCase.ok(
-      Math.abs(actual[index] - expected[index]) <= tolerance,
+    expect(
+      Boolean(Math.abs(actual[index] - expected[index]) <= tolerance),
       `${label} component ${index}: ${actual[index]} ~= ${expected[index]}`
-    );
+    ).toBe(true);
   }
 }

--- a/modules/gpgpu/test/gpu-core/gpu-fft2d.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-fft2d.node.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import type {Device} from '@luma.gl/core';
 import {
   getGPUFFT2DSupport,
@@ -17,112 +17,105 @@ import {
   GPU_FFT2D_WORKGROUP_DIMENSION
 } from '../../src/gpu-core/gpu-fft2d-shaders';
 
-test('GPUFFT2D publishes a bounded immutable radix-2 plan', testCase => {
+it('GPUFFT2D publishes a bounded immutable radix-2 plan', () => {
   const stats = makeGPUFFT2DStats(8, 4);
 
-  testCase.deepEqual(
+  expect(
     stats,
-    {
-      width: 8,
-      height: 4,
-      elementCount: 32,
-      complexBufferByteLength: 256,
-      horizontalStageCount: 3,
-      verticalStageCount: 2,
-      passCount: 7,
-      dispatchCountPerEncode: 7,
-      workgroupSize: [8, 8, 1],
-      workgroupCount: [1, 1, 1],
-      scratchBufferByteLength: 256,
-      parameterBufferCount: 14,
-      parameterBufferByteLength: 448
-    },
     'stats account for two bit reversals, five butterfly stages, and both directions'
-  );
-  testCase.ok(Object.isFrozen(stats), 'stats are immutable');
-  testCase.ok(Object.isFrozen(stats.workgroupSize), 'workgroup size is immutable');
-  testCase.ok(Object.isFrozen(stats.workgroupCount), 'workgroup count is immutable');
-  testCase.equal(GPU_FFT2D_MIN_DIMENSION, 2, 'minimum dimension is explicit');
-  testCase.equal(GPU_FFT2D_MAX_DIMENSION, 2048, 'maximum dimension is explicit');
-  testCase.end();
+  ).toEqual({
+    width: 8,
+    height: 4,
+    elementCount: 32,
+    complexBufferByteLength: 256,
+    horizontalStageCount: 3,
+    verticalStageCount: 2,
+    passCount: 7,
+    dispatchCountPerEncode: 7,
+    workgroupSize: [8, 8, 1],
+    workgroupCount: [1, 1, 1],
+    scratchBufferByteLength: 256,
+    parameterBufferCount: 14,
+    parameterBufferByteLength: 448
+  });
+  expect(Boolean(Object.isFrozen(stats)), 'stats are immutable').toBe(true);
+  expect(Boolean(Object.isFrozen(stats.workgroupSize)), 'workgroup size is immutable').toBe(true);
+  expect(Boolean(Object.isFrozen(stats.workgroupCount)), 'workgroup count is immutable').toBe(true);
+  expect(GPU_FFT2D_MIN_DIMENSION, 'minimum dimension is explicit').toBe(2);
+  expect(GPU_FFT2D_MAX_DIMENSION, 'maximum dimension is explicit').toBe(2048);
 });
 
-test('GPUFFT2D validates both transform dimensions before allocation', testCase => {
-  testCase.throws(() => makeGPUFFT2DStats(3, 4), /width must be a power of two/);
-  testCase.throws(() => makeGPUFFT2DStats(4, 7), /height must be a power of two/);
-  testCase.throws(() => makeGPUFFT2DStats(1, 4), /width must be from 2 through 2048/);
-  testCase.throws(() => makeGPUFFT2DStats(4, 4096), /height must be from 2 through 2048/);
-  testCase.throws(() => makeGPUFFT2DStats(4.5, 8), /width must be an integer/);
-  testCase.throws(() => makeGPUFFT2DStats(4, 8, 0), /batchCount must be a positive integer/);
-  testCase.end();
+it('GPUFFT2D validates both transform dimensions before allocation', () => {
+  expect(() => makeGPUFFT2DStats(3, 4)).toThrow(/width must be a power of two/);
+  expect(() => makeGPUFFT2DStats(4, 7)).toThrow(/height must be a power of two/);
+  expect(() => makeGPUFFT2DStats(1, 4)).toThrow(/width must be from 2 through 2048/);
+  expect(() => makeGPUFFT2DStats(4, 4096)).toThrow(/height must be from 2 through 2048/);
+  expect(() => makeGPUFFT2DStats(4.5, 8)).toThrow(/width must be an integer/);
+  expect(() => makeGPUFFT2DStats(4, 8, 0)).toThrow(/batchCount must be a positive integer/);
 });
 
-test('GPUFFT2D batches independent packed transforms in the dispatch depth dimension', testCase => {
+it('GPUFFT2D batches independent packed transforms in the dispatch depth dimension', () => {
   const stats = makeGPUFFT2DStats(8, 4, 3);
 
-  testCase.equal(stats.batchCount, 3, 'the plan exposes the independent transform count');
-  testCase.equal(stats.elementCount, 32, 'each transform retains its own spatial element count');
-  testCase.equal(stats.complexBufferByteLength, 768, 'buffers contain all three packed transforms');
-  testCase.deepEqual(stats.workgroupCount, [1, 1, 3], 'the batch index uses dispatch depth');
-  testCase.equal(stats.dispatchCountPerEncode, 7, 'batching does not add FFT stage dispatches');
-  testCase.end();
+  expect(stats.batchCount, 'the plan exposes the independent transform count').toBe(3);
+  expect(stats.elementCount, 'each transform retains its own spatial element count').toBe(32);
+  expect(stats.complexBufferByteLength, 'buffers contain all three packed transforms').toBe(768);
+  expect(stats.workgroupCount, 'the batch index uses dispatch depth').toEqual([1, 1, 3]);
+  expect(stats.dispatchCountPerEncode, 'batching does not add FFT stage dispatches').toBe(7);
 });
 
-test('getGPUFFT2DSupport reports backend and resource-limit failures', testCase => {
+it('getGPUFFT2DSupport reports backend and resource-limit failures', () => {
   const supportedDevice = makeSupportDevice();
   const supported = getGPUFFT2DSupport(supportedDevice, {width: 256, height: 128});
-  testCase.equal(supported.supported, true, 'representative WebGPU limits are supported');
-  testCase.equal(supported.stats?.passCount, 17, 'support query includes the pass plan');
+  expect(supported.supported, 'representative WebGPU limits are supported').toBe(true);
+  expect(supported.stats?.passCount, 'support query includes the pass plan').toBe(17);
 
   const webglDevice = makeSupportDevice({type: 'webgl'});
   const webglSupport = getGPUFFT2DSupport(webglDevice, {width: 8, height: 8});
-  testCase.equal(webglSupport.supported, false, 'WebGL is rejected');
-  testCase.match(webglSupport.reason || '', /requires WebGPU/);
+  expect(webglSupport.supported, 'WebGL is rejected').toBe(false);
+  expect(webglSupport.reason || '').toMatch(/requires WebGPU/);
 
   const smallStorageDevice = makeSupportDevice({maxStorageBufferBindingSize: 1024});
   const smallStorageSupport = getGPUFFT2DSupport(smallStorageDevice, {
     width: 32,
     height: 32
   });
-  testCase.equal(smallStorageSupport.supported, false, 'storage binding capacity is checked');
-  testCase.match(smallStorageSupport.reason || '', /maxStorageBufferBindingSize/);
+  expect(smallStorageSupport.supported, 'storage binding capacity is checked').toBe(false);
+  expect(smallStorageSupport.reason || '').toMatch(/maxStorageBufferBindingSize/);
 
   const smallWorkgroupDevice = makeSupportDevice({maxComputeInvocationsPerWorkgroup: 32});
   const smallWorkgroupSupport = getGPUFFT2DSupport(smallWorkgroupDevice, {width: 8, height: 8});
-  testCase.equal(smallWorkgroupSupport.supported, false, 'workgroup capacity is checked');
-  testCase.match(smallWorkgroupSupport.reason || '', /8 by 8/);
+  expect(smallWorkgroupSupport.supported, 'workgroup capacity is checked').toBe(false);
+  expect(smallWorkgroupSupport.reason || '').toMatch(/8 by 8/);
 
   const invalidDimensions = getGPUFFT2DSupport(supportedDevice, {width: 12, height: 8});
-  testCase.equal(invalidDimensions.supported, false, 'non-radix-2 dimensions are rejected');
-  testCase.equal(invalidDimensions.stats, undefined, 'invalid dimensions do not publish a plan');
-  testCase.end();
+  expect(invalidDimensions.supported, 'non-radix-2 dimensions are rejected').toBe(false);
+  expect(invalidDimensions.stats, 'invalid dimensions do not publish a plan').toBe(undefined);
 });
 
-test('GPUFFT2D shader exposes one bounded storage-buffer compute pass', testCase => {
+it('GPUFFT2D shader exposes one bounded storage-buffer compute pass', () => {
   const reflection = new WgslReflect(GPU_FFT2D_SHADER);
 
-  testCase.deepEqual(
+  expect(
     reflection.entry.compute.map(entry => entry.name),
-    ['main'],
     'shader has one compute entry point'
-  );
-  testCase.ok(
-    reflection.storage.some(storage => storage.name === 'inputValues'),
+  ).toEqual(['main']);
+  expect(
+    Boolean(reflection.storage.some(storage => storage.name === 'inputValues')),
     'shader reads packed complex input storage'
-  );
-  testCase.ok(
-    reflection.storage.some(storage => storage.name === 'outputValues'),
+  ).toBe(true);
+  expect(
+    Boolean(reflection.storage.some(storage => storage.name === 'outputValues')),
     'shader writes packed complex output storage'
-  );
-  testCase.ok(
-    reflection.uniforms.some(uniform => uniform.name === 'parameters'),
+  ).toBe(true);
+  expect(
+    Boolean(reflection.uniforms.some(uniform => uniform.name === 'parameters')),
     'shader consumes immutable pass parameters'
-  );
-  testCase.equal(GPU_FFT2D_WORKGROUP_DIMENSION, 8, 'workgroup dimension is stable');
-  testCase.equal(GPU_FFT2D_PARAMETER_BYTE_LENGTH, 32, 'uniform block remains 32 bytes');
-  testCase.match(GPU_FFT2D_SHADER, /reverseLowBits/, 'shader explicitly performs bit reversal');
-  testCase.match(GPU_FFT2D_SHADER, /multiplyComplex/, 'shader performs complex butterflies');
-  testCase.end();
+  ).toBe(true);
+  expect(GPU_FFT2D_WORKGROUP_DIMENSION, 'workgroup dimension is stable').toBe(8);
+  expect(GPU_FFT2D_PARAMETER_BYTE_LENGTH, 'uniform block remains 32 bytes').toBe(32);
+  expect(GPU_FFT2D_SHADER, 'shader explicitly performs bit reversal').toMatch(/reverseLowBits/);
+  expect(GPU_FFT2D_SHADER, 'shader performs complex butterflies').toMatch(/multiplyComplex/);
 });
 
 function makeSupportDevice(overrides: Record<string, unknown> = {}): Device {

--- a/modules/gpgpu/test/gpu-core/gpu-fft2d.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-fft2d.spec.ts
@@ -1,18 +1,16 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {GPUFFT2D} from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
-test('GPUFFT2D matches a CPU DFT and composes forward/inverse passes in one encoder', async t => {
+it('GPUFFT2D matches a CPU DFT and composes forward/inverse passes in one encoder', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -31,15 +29,14 @@ test('GPUFFT2D matches a CPU DFT and composes forward/inverse passes in one enco
 
   try {
     const commandEncoder = device.createCommandEncoder({id: 'gpu-fft2d-roundtrip'});
-    t.equal(
+    expect(
       transform.encode(commandEncoder, {
         inputBuffer,
         outputBuffer: forwardBuffer,
         direction: 'forward'
       }),
-      forwardBuffer,
       'forward encode returns the caller-owned output'
-    );
+    ).toBe(forwardBuffer);
     transform.encode(commandEncoder, {
       inputBuffer: forwardBuffer,
       outputBuffer: inverseBuffer,
@@ -49,13 +46,11 @@ test('GPUFFT2D matches a CPU DFT and composes forward/inverse passes in one enco
 
     const forwardValues = await readFloat32(forwardBuffer, inputValues.length);
     const inverseValues = await readFloat32(inverseBuffer, inputValues.length);
-    assertClose(t, forwardValues, expectedForward, 0.0005, 'forward transform');
-    assertClose(t, inverseValues, Array.from(inputValues), 0.0005, 'inverse round trip');
-    t.equal(transform.stats.passCount, 7, 'rectangular transform reports every dispatch');
-    t.equal(
-      transform.stats.scratchBufferByteLength,
-      inputValues.byteLength,
-      'one complex field of scratch is owned'
+    assertClose(forwardValues, expectedForward, 0.0005, 'forward transform');
+    assertClose(inverseValues, Array.from(inputValues), 0.0005, 'inverse round trip');
+    expect(transform.stats.passCount, 'rectangular transform reports every dispatch').toBe(7);
+    expect(transform.stats.scratchBufferByteLength, 'one complex field of scratch is owned').toBe(
+      inputValues.byteLength
     );
   } finally {
     transform.destroy();
@@ -64,14 +59,11 @@ test('GPUFFT2D matches a CPU DFT and composes forward/inverse passes in one enco
     forwardBuffer.destroy();
     inverseBuffer.destroy();
   }
-  t.end();
 });
 
-test('GPUFFT2D transforms packed RGB fields in one batched dispatch sequence', async testCase => {
+it('GPUFFT2D transforms packed RGB fields in one batched dispatch sequence', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
@@ -99,31 +91,18 @@ test('GPUFFT2D transforms packed RGB fields in one batched dispatch sequence', a
     transform.encode(commandEncoder, {inputBuffer, outputBuffer});
     device.submit(commandEncoder.finish());
     const actualValues = await readFloat32(outputBuffer, inputValues.length);
-    assertClose(
-      testCase,
-      actualValues,
-      expectedValues,
-      0.002,
-      'independent batched RGB transforms'
-    );
-    testCase.equal(
-      transform.stats.dispatchCountPerEncode,
-      6,
-      'batching preserves one FFT schedule'
-    );
+    assertClose(actualValues, expectedValues, 0.002, 'independent batched RGB transforms');
+    expect(transform.stats.dispatchCountPerEncode, 'batching preserves one FFT schedule').toBe(6);
   } finally {
     transform.destroy();
     inputBuffer.destroy();
     outputBuffer.destroy();
   }
-  testCase.end();
 });
 
-test('GPUFFT2D rejects aliased and incompatible caller buffers', async t => {
+it('GPUFFT2D rejects aliased and incompatible caller buffers', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -144,52 +123,47 @@ test('GPUFFT2D rejects aliased and incompatible caller buffers', async t => {
   });
 
   try {
-    t.throws(
+    expect(
       () =>
         transform.encode(device.commandEncoder, {
           inputBuffer: validBuffer,
           outputBuffer: validBuffer
         }),
-      /must be separate/,
       'in-place aliasing is rejected'
-    );
-    t.throws(
+    ).toThrow(/must be separate/);
+    expect(
       () =>
         transform.encode(device.commandEncoder, {
           inputBuffer: validBuffer,
           outputBuffer: aliasBuffer
         }),
-      /must be separate/,
       'distinct Buffer wrappers cannot alias the same GPU allocation'
-    );
-    t.throws(
+    ).toThrow(/must be separate/);
+    expect(
       () =>
         transform.encode(device.commandEncoder, {
           inputBuffer: shortBuffer,
           outputBuffer: validBuffer
         }),
-      /at least 32 bytes/,
       'short complex fields are rejected'
-    );
-    t.throws(
+    ).toThrow(/at least 32 bytes/);
+    expect(
       () =>
         transform.encode(device.commandEncoder, {
           inputBuffer: copyOnlyBuffer,
           outputBuffer: validBuffer
         }),
-      /Buffer.STORAGE/,
       'buffers without storage usage are rejected'
-    );
+    ).toThrow(/Buffer.STORAGE/);
     transform.destroy();
-    t.throws(
+    expect(
       () =>
         transform.encode(device.commandEncoder, {
           inputBuffer: validBuffer,
           outputBuffer: shortBuffer
         }),
-      /destroyed/,
       'destroyed transforms reject new work'
-    );
+    ).toThrow(/destroyed/);
   } finally {
     transform.destroy();
     aliasBuffer.destroy();
@@ -197,14 +171,11 @@ test('GPUFFT2D rejects aliased and incompatible caller buffers', async t => {
     shortBuffer.destroy();
     copyOnlyBuffer.destroy();
   }
-  t.end();
 });
 
-test('GPUFFT2D construction unwinds partial GPU allocations', async t => {
+it('GPUFFT2D construction unwinds partial GPU allocations', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -232,28 +203,27 @@ test('GPUFFT2D construction unwinds partial GPU allocations', async t => {
   };
 
   try {
-    t.throws(
+    expect(
       () => new GPUFFT2D(device, {id, width: 4, height: 4}),
-      /injected GPUFFT2D allocation failure/,
       'the original allocation error is preserved'
-    );
+    ).toThrow(/injected GPUFFT2D allocation failure/);
   } finally {
     device.createBuffer = originalCreateBuffer;
     Computation.prototype.destroy = originalComputationDestroy;
   }
 
-  t.equal(allocatedBuffers.length, 4, 'scratch and completed parameter allocations were observed');
-  t.ok(
-    allocatedBuffers.every(buffer => buffer.destroyed),
+  expect(allocatedBuffers.length, 'scratch and completed parameter allocations were observed').toBe(
+    4
+  );
+  expect(
+    Boolean(allocatedBuffers.every(buffer => buffer.destroyed)),
     'every buffer allocated before the failure is destroyed'
-  );
-  t.equal(computationDestroyCount, 1, 'the partially initialized computation is destroyed');
-  t.equal(
+  ).toBe(true);
+  expect(computationDestroyCount, 'the partially initialized computation is destroyed').toBe(1);
+  expect(
     getResourceCount(device, 'Buffers'),
-    activeBufferCount,
     'active buffer accounting returns to its baseline'
-  );
-  t.end();
+  ).toBe(activeBufferCount);
 });
 
 function makeOutputBuffer(device: Device, id: string, byteLength: number): Buffer {
@@ -321,16 +291,13 @@ function makeCPUDFT2D(
   return output;
 }
 
-function assertClose(
-  t: {ok(value: unknown, message?: string): void},
-  actual: number[],
-  expected: number[],
-  tolerance: number,
-  label: string
-): void {
+function assertClose(actual: number[], expected: number[], tolerance: number, label: string): void {
   let maximumError = 0;
   for (let valueIndex = 0; valueIndex < expected.length; valueIndex++) {
     maximumError = Math.max(maximumError, Math.abs(actual[valueIndex] - expected[valueIndex]));
   }
-  t.ok(maximumError <= tolerance, `${label} maximum error ${maximumError} is within ${tolerance}`);
+  expect(
+    Boolean(maximumError <= tolerance),
+    `${label} maximum error ${maximumError} is within ${tolerance}`
+  ).toBe(true);
 }

--- a/modules/gpgpu/test/gpu-core/gpu-finite-difference-2d.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-finite-difference-2d.node.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -8,54 +9,47 @@ import {
   GPUFiniteDifference2D,
   makeGPUFiniteDifference2DStats
 } from '@luma.gl/gpgpu/gpu-core';
-import test from 'test/utils/vitest-tape';
 import {WgslReflect} from 'wgsl_reflect';
 import {getGPUFiniteDifference2DShaderSource} from '../../src/gpu-core/gpu-finite-difference-2d';
 
-test('GPUFiniteDifference2D plans explicit second-order numerical policies', t => {
-  t.deepEqual(
+it('GPUFiniteDifference2D plans explicit second-order numerical policies', () => {
+  expect(
     makeGPUFiniteDifference2DStats({
       width: 12,
       height: 8,
       spacing: [0.25, 0.5],
       operator: 'gradient'
-    }),
-    {
-      width: 12,
+    })
+  ).toEqual({
+    width: 12,
+    height: 8,
+    elementCount: 96,
+    spacing: [0.25, 0.5],
+    operator: 'gradient',
+    boundary: 'one-sided',
+    stencilOrder: 2,
+    inputComponentCount: 1,
+    outputComponentCount: 2
+  });
+  expect(() =>
+    makeGPUFiniteDifference2DStats({
+      width: 3,
       height: 8,
-      elementCount: 96,
-      spacing: [0.25, 0.5],
-      operator: 'gradient',
-      boundary: 'one-sided',
-      stencilOrder: 2,
-      inputComponentCount: 1,
-      outputComponentCount: 2
-    }
-  );
-  t.throws(
-    () =>
-      makeGPUFiniteDifference2DStats({
-        width: 3,
-        height: 8,
-        spacing: [1, 1],
-        operator: 'curl'
-      }),
-    /at least 4/
-  );
-  t.throws(
-    () =>
-      makeGPUFiniteDifference2DStats({
-        width: 8,
-        height: 8,
-        spacing: [0, 1],
-        operator: 'laplacian'
-      }),
-    /positive finite/
-  );
-  t.end();
+      spacing: [1, 1],
+      operator: 'curl'
+    })
+  ).toThrow(/at least 4/);
+  expect(() =>
+    makeGPUFiniteDifference2DStats({
+      width: 8,
+      height: 8,
+      spacing: [0, 1],
+      operator: 'laplacian'
+    })
+  ).toThrow(/positive finite/);
 });
 
-test('GPUFiniteDifference2D validates topology and generated WGSL', t => {
+it('GPUFiniteDifference2D validates topology and generated WGSL', () => {
   const graph = new GPUCommandGraph(makeSupportDevice());
   const scalarInput = makeView(graph, 'scalar-input', 'float32', 64);
   const scalarOutput = makeView(graph, 'scalar-output', 'float32', 64);
@@ -84,21 +78,16 @@ test('GPUFiniteDifference2D validates topology and generated WGSL', t => {
   });
   for (const operation of [gradient, curl]) {
     const source = getGPUFiniteDifference2DShaderSource(operation, {x: 1, y: 1, z: 1});
-    t.deepEqual(
-      new WgslReflect(source).entry.compute.map(entry => entry.name),
-      ['main']
-    );
+    expect(new WgslReflect(source).entry.compute.map(entry => entry.name)).toEqual(['main']);
   }
-  t.match(
+  expect(
     getGPUFiniteDifference2DShaderSource(gradient, {x: 1, y: 1, z: 1}),
-    /-3\.0 \* sampleField/,
     'one-sided first derivative is explicit'
-  );
-  t.match(
+  ).toMatch(/-3\.0 \* sampleField/);
+  expect(
     getGPUFiniteDifference2DShaderSource(curl, {x: 1, y: 1, z: 1}),
-    /% i32\(WIDTH\)/,
     'periodic wrapping is explicit'
-  );
+  ).toMatch(/% i32\(WIDTH\)/);
   const offsetGradient = new GPUFiniteDifference2D({
     input: offsetScalarInput,
     output: offsetVectorOutput,
@@ -117,10 +106,10 @@ test('GPUFiniteDifference2D validates topology and generated WGSL', t => {
   });
   for (const operation of [offsetGradient, offsetCurl]) {
     const source = getGPUFiniteDifference2DShaderSource(operation, {x: 1, y: 1, z: 1});
-    t.match(source, /INPUT_OFFSET: u32 = 1u/, 'input offset uses WGSL array elements');
-    t.match(source, /OUTPUT_OFFSET: u32 = 1u/, 'output offset uses WGSL array elements');
+    expect(source, 'input offset uses WGSL array elements').toMatch(/INPUT_OFFSET: u32 = 1u/);
+    expect(source, 'output offset uses WGSL array elements').toMatch(/OUTPUT_OFFSET: u32 = 1u/);
   }
-  t.throws(
+  expect(
     () =>
       new GPUFiniteDifference2D({
         input: scalarInput,
@@ -129,10 +118,8 @@ test('GPUFiniteDifference2D validates topology and generated WGSL', t => {
         height: 8,
         spacing: [1, 1],
         operator: 'gradient'
-      }),
-    /output/
-  );
-  t.end();
+      })
+  ).toThrow(/output/);
 });
 
 function makeView(

--- a/modules/gpgpu/test/gpu-core/gpu-finite-difference-2d.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-finite-difference-2d.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -9,18 +10,15 @@ import {
   type GPUFiniteDifference2DOperator
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
 
 const WIDTH = 9;
 const HEIGHT = 7;
 const DX = 0.25;
 const DY = 0.4;
 
-test('GPUFiniteDifference2D matches analytic scalar derivatives including boundaries', async t => {
+it('GPUFiniteDifference2D matches analytic scalar derivatives including boundaries', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const scalar = sampleScalar((x, y) => 2 + 3 * x - 4 * y + 0.5 * x * x + 2 * y * y);
@@ -29,28 +27,24 @@ test('GPUFiniteDifference2D matches analytic scalar derivatives including bounda
   for (let index = 0; index < WIDTH * HEIGHT; index++) {
     const x = (index % WIDTH) * DX;
     const y = Math.floor(index / WIDTH) * DY;
-    close(t, gradient[index * 2], 3 + x, 0.0001, `gradient x ${index}`);
-    close(t, gradient[index * 2 + 1], -4 + 4 * y, 0.0001, `gradient y ${index}`);
-    close(t, laplacian[index], 5, 0.0002, `laplacian ${index}`);
+    close(gradient[index * 2], 3 + x, 0.0001, `gradient x ${index}`);
+    close(gradient[index * 2 + 1], -4 + 4 * y, 0.0001, `gradient y ${index}`);
+    close(laplacian[index], 5, 0.0002, `laplacian ${index}`);
   }
-  t.end();
 });
 
-test('GPUFiniteDifference2D matches rotational divergence and curl identities', async t => {
+it('GPUFiniteDifference2D matches rotational divergence and curl identities', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const vector = sampleVector((x, y) => [-2 * y + 0.25 * x, 2 * x - 0.25 * y]);
   const divergence = await runOperator(device, 'divergence', vector);
   const curl = await runOperator(device, 'curl', vector);
   for (let index = 0; index < WIDTH * HEIGHT; index++) {
-    close(t, divergence[index], 0, 0.00002, `divergence ${index}`);
-    close(t, curl[index], 4, 0.00002, `curl ${index}`);
+    close(divergence[index], 0, 0.00002, `divergence ${index}`);
+    close(curl[index], 4, 0.00002, `curl ${index}`);
   }
-  t.end();
 });
 
 async function runOperator(
@@ -119,12 +113,9 @@ function sampleVector(sample: (x: number, y: number) => readonly [number, number
   return values;
 }
 
-function close(
-  t: {ok(value: unknown, message?: string): void},
-  actual: number,
-  expected: number,
-  epsilon: number,
-  label: string
-): void {
-  t.ok(Math.abs(actual - expected) <= epsilon, `${label}: ${actual} ~= ${expected}`);
+function close(actual: number, expected: number, epsilon: number, label: string): void {
+  expect(
+    Boolean(Math.abs(actual - expected) <= epsilon),
+    `${label}: ${actual} ~= ${expected}`
+  ).toBe(true);
 }

--- a/modules/gpgpu/test/gpu-core/gpu-finite-difference-3d.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-finite-difference-3d.node.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -8,47 +9,42 @@ import {
   GPUFiniteDifference3D,
   makeGPUFiniteDifference3DStats
 } from '@luma.gl/gpgpu/gpu-core';
-import test from 'test/utils/vitest-tape';
 import {WgslReflect} from 'wgsl_reflect';
 import {getGPUFiniteDifference3DShaderSource} from '../../src/gpu-core/gpu-finite-difference-3d';
 
-test('GPUFiniteDifference3D plans explicit volumetric numerical policies', t => {
-  t.deepEqual(
+it('GPUFiniteDifference3D plans explicit volumetric numerical policies', () => {
+  expect(
     makeGPUFiniteDifference3DStats({
       width: 8,
       height: 7,
       depth: 6,
       spacing: [0.25, 0.5, 0.75],
       operator: 'curl'
-    }),
-    {
+    })
+  ).toEqual({
+    width: 8,
+    height: 7,
+    depth: 6,
+    elementCount: 336,
+    spacing: [0.25, 0.5, 0.75],
+    operator: 'curl',
+    boundary: 'one-sided',
+    stencilOrder: 2,
+    inputComponentCount: 4,
+    outputComponentCount: 4
+  });
+  expect(() =>
+    makeGPUFiniteDifference3DStats({
       width: 8,
-      height: 7,
+      height: 3,
       depth: 6,
-      elementCount: 336,
-      spacing: [0.25, 0.5, 0.75],
-      operator: 'curl',
-      boundary: 'one-sided',
-      stencilOrder: 2,
-      inputComponentCount: 4,
-      outputComponentCount: 4
-    }
-  );
-  t.throws(
-    () =>
-      makeGPUFiniteDifference3DStats({
-        width: 8,
-        height: 3,
-        depth: 6,
-        spacing: [1, 1, 1],
-        operator: 'gradient'
-      }),
-    /at least 4/
-  );
-  t.end();
+      spacing: [1, 1, 1],
+      operator: 'gradient'
+    })
+  ).toThrow(/at least 4/);
 });
 
-test('GPUFiniteDifference3D generates valid scalar and vector kernels', t => {
+it('GPUFiniteDifference3D generates valid scalar and vector kernels', () => {
   const graph = new GPUCommandGraph(makeSupportDevice());
   const scalar = makeView(graph, 'scalar', 'float32', 64);
   const vector = makeView(graph, 'vector', 'float32x4', 64);
@@ -73,16 +69,11 @@ test('GPUFiniteDifference3D generates valid scalar and vector kernels', t => {
   });
   for (const operation of [gradient, curl]) {
     const source = getGPUFiniteDifference3DShaderSource(operation, {x: 1, y: 1, z: 1});
-    t.deepEqual(
-      new WgslReflect(source).entry.compute.map(entry => entry.name),
-      ['main']
-    );
+    expect(new WgslReflect(source).entry.compute.map(entry => entry.name)).toEqual(['main']);
   }
-  t.match(
-    getGPUFiniteDifference3DShaderSource(curl, {x: 1, y: 1, z: 1}),
+  expect(getGPUFiniteDifference3DShaderSource(curl, {x: 1, y: 1, z: 1})).toMatch(
     /OUTPUT_OFFSET: u32 = 1u/
   );
-  t.end();
 });
 
 function makeView(

--- a/modules/gpgpu/test/gpu-core/gpu-finite-difference-3d.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-finite-difference-3d.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -9,16 +10,13 @@ import {
   type GPUFiniteDifference3DOperator
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
 
 const RESOLUTION = 5;
 const SPACING = 0.4;
 
-test('GPUFiniteDifference3D matches analytic gradient and Laplacian', async t => {
+it('GPUFiniteDifference3D matches analytic gradient and Laplacian', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const values = Float32Array.from({length: RESOLUTION ** 3}, (_, index) => {
@@ -29,19 +27,16 @@ test('GPUFiniteDifference3D matches analytic gradient and Laplacian', async t =>
   const laplacian = await runOperator(device, 'laplacian', values);
   for (let index = 0; index < RESOLUTION ** 3; index++) {
     const [x, y, z] = getCoordinates(index);
-    close(t, gradient[index * 4], 2 + 2 * x, 0.0002);
-    close(t, gradient[index * 4 + 1], -3 + 3 * y, 0.0002);
-    close(t, gradient[index * 4 + 2], 4 + 4 * z, 0.0002);
-    close(t, laplacian[index], 9, 0.0004);
+    close(gradient[index * 4], 2 + 2 * x, 0.0002);
+    close(gradient[index * 4 + 1], -3 + 3 * y, 0.0002);
+    close(gradient[index * 4 + 2], 4 + 4 * z, 0.0002);
+    close(laplacian[index], 9, 0.0004);
   }
-  t.end();
 });
 
-test('GPUFiniteDifference3D matches divergence and curl identities', async t => {
+it('GPUFiniteDifference3D matches divergence and curl identities', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const values = new Float32Array(RESOLUTION ** 3 * 4);
@@ -52,12 +47,11 @@ test('GPUFiniteDifference3D matches divergence and curl identities', async t => 
   const divergence = await runOperator(device, 'divergence', values);
   const curl = await runOperator(device, 'curl', values);
   for (let index = 0; index < RESOLUTION ** 3; index++) {
-    close(t, divergence[index], 0.5, 0.0001);
-    close(t, curl[index * 4], 0, 0.0001);
-    close(t, curl[index * 4 + 1], 0, 0.0001);
-    close(t, curl[index * 4 + 2], 2, 0.0001);
+    close(divergence[index], 0.5, 0.0001);
+    close(curl[index * 4], 0, 0.0001);
+    close(curl[index * 4 + 1], 0, 0.0001);
+    close(curl[index * 4 + 2], 2, 0.0001);
   }
-  t.end();
 });
 
 async function runOperator(
@@ -119,11 +113,6 @@ function getCoordinates(index: number): [number, number, number] {
   ];
 }
 
-function close(
-  t: {ok(value: unknown, message?: string): void},
-  actual: number,
-  expected: number,
-  epsilon: number
-): void {
-  t.ok(Math.abs(actual - expected) <= epsilon, `${actual} ~= ${expected}`);
+function close(actual: number, expected: number, epsilon: number): void {
+  expect(Boolean(Math.abs(actual - expected) <= epsilon), `${actual} ~= ${expected}`).toBe(true);
 }

--- a/modules/gpgpu/test/gpu-core/gpu-galloping-search.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-galloping-search.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {
   GPUGallopingSearch,
@@ -15,11 +15,9 @@ import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
 const BUFFER_USAGE = Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC;
 
-test('GPUGallopingSearch matches segmented lower bounds and recovers from unsorted queries', async t => {
+it('GPUGallopingSearch matches segmented lower bounds and recovers from unsorted queries', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -44,7 +42,7 @@ test('GPUGallopingSearch matches segmented lower bounds and recovers from unsort
     output: output.view,
     validationErrors: validationErrors.view
   });
-  t.deepEqual(search.stats, {
+  expect(search.stats).toEqual({
     orderedValueCount: 10,
     indirect: false,
     segmentCount: 2,
@@ -58,25 +56,21 @@ test('GPUGallopingSearch matches segmented lower bounds and recovers from unsort
   compiled.encode(encoder, {parameters: undefined});
   device.submit(encoder.finish());
 
-  t.deepEqual(await readUint32(output.buffer), [0, 1, 3, 5, 6, 8, 6, 9]);
-  t.equal(
+  expect(await readUint32(output.buffer)).toEqual([0, 1, 3, 5, 6, 8, 6, 9]);
+  expect(
     (await readUint32(validationErrors.buffer))[0],
-    GPU_GALLOPING_SEARCH_UNSORTED_QUERIES,
     'decreasing queries are reported while falling back to a correct lower bound'
-  );
+  ).toBe(GPU_GALLOPING_SEARCH_UNSORTED_QUERIES);
 
   compiled.destroy();
   for (const resource of [values, queries, segments, output, validationErrors]) {
     resource.buffer.destroy();
   }
-  t.end();
 });
 
-test('GPUGallopingSearch follows a sorted index over strided canonical values', async t => {
+it('GPUGallopingSearch follows a sorted index over strided canonical values', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -106,7 +100,7 @@ test('GPUGallopingSearch follows a sorted index over strided canonical values', 
     output: output.view,
     validationErrors: validationErrors.view
   });
-  t.deepEqual(search.stats, {
+  expect(search.stats).toEqual({
     orderedValueCount: 5,
     indirect: true,
     segmentCount: 1,
@@ -120,22 +114,19 @@ test('GPUGallopingSearch follows a sorted index over strided canonical values', 
   compiled.encode(encoder, {parameters: undefined});
   device.submit(encoder.finish());
 
-  t.deepEqual(await readUint32(output.buffer), [0, 1, 2, 4, 5]);
-  t.deepEqual(await readUint32(validationErrors.buffer), [0]);
+  expect(await readUint32(output.buffer)).toEqual([0, 1, 2, 4, 5]);
+  expect(await readUint32(validationErrors.buffer)).toEqual([0]);
 
   compiled.destroy();
   sourceBuffer.destroy();
   for (const resource of [valueOrder, queries, segments, output, validationErrors]) {
     resource.buffer.destroy();
   }
-  t.end();
 });
 
-test('GPUGallopingSearch supports uint32 values, empty segments, and offset views', async t => {
+it('GPUGallopingSearch supports uint32 values, empty segments, and offset views', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -158,14 +149,13 @@ test('GPUGallopingSearch supports uint32 values, empty segments, and offset view
   compiled.encode(encoder, {parameters: undefined});
   device.submit(encoder.finish());
 
-  t.deepEqual(await readUint32(output.buffer), [99, 0, 1, 3, 5, 99]);
-  t.deepEqual(await readUint32(validationErrors.buffer), [0]);
+  expect(await readUint32(output.buffer)).toEqual([99, 0, 1, 3, 5, 99]);
+  expect(await readUint32(validationErrors.buffer)).toEqual([0]);
 
   compiled.destroy();
   for (const resource of [values, queries, segments, output, validationErrors]) {
     resource.buffer.destroy();
   }
-  t.end();
 });
 
 function makeView<Format extends GPUGallopingSearchFormat | 'uint32'>(

--- a/modules/gpgpu/test/gpu-core/gpu-graph-traversal.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-graph-traversal.node.spec.ts
@@ -1,70 +1,63 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {
   getGPUGraphTraversalDispatchLayout,
   getGPUGraphTraversalInvocationIndexSource
 } from '../../src/gpu-core/gpu-graph-traversal';
 
-test('GPUGraphTraversal plans bounded multidimensional dispatches', testCase => {
+it('GPUGraphTraversal plans bounded multidimensional dispatches', () => {
   const maximumWorkgroupsPerDimension = 65_535;
   const maximumOneDimensionalRowCount = maximumWorkgroupsPerDimension * 256;
 
-  testCase.deepEqual(getGPUGraphTraversalDispatchLayout(0, maximumWorkgroupsPerDimension), {
+  expect(getGPUGraphTraversalDispatchLayout(0, maximumWorkgroupsPerDimension)).toEqual({
     x: 1,
     y: 1,
     z: 1
   });
-  testCase.deepEqual(
+  expect(
     getGPUGraphTraversalDispatchLayout(
       maximumOneDimensionalRowCount,
       maximumWorkgroupsPerDimension
     ),
-    {x: maximumWorkgroupsPerDimension, y: 1, z: 1},
     'the largest single-dimensional dispatch exactly reaches its final row'
-  );
-  testCase.deepEqual(
+  ).toEqual({x: maximumWorkgroupsPerDimension, y: 1, z: 1});
+  expect(
     getGPUGraphTraversalDispatchLayout(
       maximumOneDimensionalRowCount + 1,
       maximumWorkgroupsPerDimension
     ),
-    {x: maximumWorkgroupsPerDimension, y: 2, z: 1},
     'one additional row expands into the second dispatch dimension'
-  );
-  testCase.deepEqual(
+  ).toEqual({x: maximumWorkgroupsPerDimension, y: 2, z: 1});
+  expect(
     getGPUGraphTraversalDispatchLayout(4 * 256 + 1, 2),
-    {x: 2, y: 2, z: 2},
     'a synthetic device limit exercises the third dispatch dimension'
-  );
-  testCase.throws(
+  ).toEqual({x: 2, y: 2, z: 2});
+  expect(
     () => getGPUGraphTraversalDispatchLayout(8 * 256 + 1, 2),
-    /exceeding the 3D dispatch limit/,
     'dispatches exceeding every available dimension fail explicitly'
-  );
-  testCase.throws(
+  ).toThrow(/exceeding the 3D dispatch limit/);
+  expect(
     () => getGPUGraphTraversalDispatchLayout(0x1_0000_0000, maximumWorkgroupsPerDimension),
-    /non-negative uint32/,
     'row identifiers remain bounded unsigned 32-bit values'
-  );
-  testCase.end();
+  ).toThrow(/non-negative uint32/);
 });
 
-test('GPUGraphTraversal flattens workgroups before bounded invocation indexing', testCase => {
+it('GPUGraphTraversal flattens workgroups before bounded invocation indexing', () => {
   const source = getGPUGraphTraversalInvocationIndexSource({x: 3, y: 2, z: 2});
 
-  testCase.match(source, /workgroupId\.z \* 2u \+ workgroupId\.y/);
-  testCase.match(source, /\* 3u \+ workgroupId\.x/);
-  testCase.match(
-    source,
-    /workgroupIndex >= 16777216u/,
-    'padded workgroups cannot wrap their uint32 invocation index'
+  expect(source).toMatch(/workgroupId\.z \* 2u \+ workgroupId\.y/);
+  expect(source).toMatch(/\* 3u \+ workgroupId\.x/);
+  expect(source, 'padded workgroups cannot wrap their uint32 invocation index').toMatch(
+    /workgroupIndex >= 16777216u/
   );
-  testCase.ok(
-    source.indexOf('workgroupIndex >= 16777216u') <
-      source.indexOf('workgroupIndex * 256u + localInvocationIndex'),
+  expect(
+    Boolean(
+      source.indexOf('workgroupIndex >= 16777216u') <
+        source.indexOf('workgroupIndex * 256u + localInvocationIndex')
+    ),
     'the overflow guard executes before multiplication'
-  );
-  testCase.end();
+  ).toBe(true);
 });

--- a/modules/gpgpu/test/gpu-core/gpu-grid-index-query.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-grid-index-query.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {
   GPUCommandGraph,
@@ -18,11 +18,9 @@ const POSITIONS_2D = Float32Array.from([
   0.25, 0.25, 0.75, 0.75, 1.25, 0.25, 0.25, 1.25, 1.25, 1.25, 1.75, 1.75
 ]);
 
-test('GPUGridIndexQuery selects point cells and refreshes IDs and masks', async t => {
+it('GPUGridIndexQuery selects point cells and refreshes IDs and masks', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -37,30 +35,25 @@ test('GPUGridIndexQuery selects point cells and refreshes IDs and masks', async 
     maskLength: 6
   });
   encode(device, fixture.compiled);
-  t.deepEqual((await readQueryResult(fixture)).ids.sort(sortNumbers), [0, 1]);
-  t.deepEqual(await readUint32(fixture.outputMask!, 6), [1, 1, 0, 0, 0, 0]);
+  expect((await readQueryResult(fixture)).ids.sort(sortNumbers)).toEqual([0, 1]);
+  expect(await readUint32(fixture.outputMask!, 6)).toEqual([1, 1, 0, 0, 0, 0]);
 
   fixture.query.write(Float32Array.from([1, 0.5]));
   encode(device, fixture.compiled);
-  t.deepEqual(
+  expect(
     await readQueryResult(fixture),
-    {ids: [2], count: 1, overflow: 0},
     'an internal boundary selects the same upper cell used by index construction'
-  );
-  t.deepEqual(
+  ).toEqual({ids: [2], count: 1, overflow: 0});
+  expect(
     await readUint32(fixture.outputMask!, 6),
-    [0, 0, 1, 0, 0, 0],
     'each encoding clears the previous source-aligned mask'
-  );
+  ).toEqual([0, 0, 1, 0, 0, 0]);
   destroyFixture(fixture);
-  t.end();
 });
 
-test('GPUGridIndexQuery returns conservative bounds and radius candidates', async t => {
+it('GPUGridIndexQuery returns conservative bounds and radius candidates', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -74,11 +67,10 @@ test('GPUGridIndexQuery returns conservative bounds and radius candidates', asyn
     outputCapacity: 6
   });
   encode(device, boundsFixture.compiled);
-  t.deepEqual(
+  expect(
     (await readQueryResult(boundsFixture)).ids.sort(sortNumbers),
-    [0, 1],
     'bounds return the containing-cell candidates, including a documented false positive'
-  );
+  ).toEqual([0, 1]);
   destroyFixture(boundsFixture);
 
   const radiusFixture = createQueryFixture(device, {
@@ -91,20 +83,16 @@ test('GPUGridIndexQuery returns conservative bounds and radius candidates', asyn
     outputCapacity: 6
   });
   encode(device, radiusFixture.compiled);
-  t.deepEqual(
+  expect(
     (await readQueryResult(radiusFixture)).ids.sort(sortNumbers),
-    [0, 1, 2, 3],
     'radius rejects a diagonally distant cell while preserving intersecting candidates'
-  );
+  ).toEqual([0, 1, 2, 3]);
   destroyFixture(radiusFixture);
-  t.end();
 });
 
-test('GPUGridIndexQuery reports query and source-index overflow independently', async t => {
+it('GPUGridIndexQuery reports query and source-index overflow independently', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -119,9 +107,9 @@ test('GPUGridIndexQuery reports query and source-index overflow independently', 
   });
   encode(device, outputOverflow.compiled);
   const outputResult = await readQueryResult(outputOverflow);
-  t.equal(outputResult.count, 6, 'candidate count reports required output capacity');
-  t.equal(outputResult.ids.length, 2, 'candidate storage remains bounded');
-  t.equal(outputResult.overflow, 1, 'candidate truncation sets overflow');
+  expect(outputResult.count, 'candidate count reports required output capacity').toBe(6);
+  expect(outputResult.ids.length, 'candidate storage remains bounded').toBe(2);
+  expect(outputResult.overflow, 'candidate truncation sets overflow').toBe(1);
   destroyFixture(outputOverflow);
 
   const indexOverflow = createQueryFixture(device, {
@@ -135,20 +123,16 @@ test('GPUGridIndexQuery reports query and source-index overflow independently', 
     outputCapacity: 6
   });
   encode(device, indexOverflow.compiled);
-  t.deepEqual(
+  expect(
     await readQueryResult(indexOverflow),
-    {ids: [], count: 0, overflow: 1},
     'an overflowed source index marks even an otherwise empty stored-prefix result incomplete'
-  );
+  ).toEqual({ids: [], count: 0, overflow: 1});
   destroyFixture(indexOverflow);
-  t.end();
 });
 
-test('GPUGridIndexQuery selects 3D point cells', async t => {
+it('GPUGridIndexQuery selects 3D point cells', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -162,16 +146,13 @@ test('GPUGridIndexQuery selects 3D point cells', async t => {
     outputCapacity: 3
   });
   encode(device, fixture.compiled);
-  t.deepEqual(await readQueryResult(fixture), {ids: [2], count: 1, overflow: 0});
+  expect(await readQueryResult(fixture)).toEqual({ids: [2], count: 1, overflow: 0});
   destroyFixture(fixture);
-  t.end();
 });
 
-test('GPUGridIndexQuery handles extreme domains and exponential WGSL literals', async t => {
+it('GPUGridIndexQuery handles extreme domains and exponential WGSL literals', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -185,11 +166,10 @@ test('GPUGridIndexQuery handles extreme domains and exponential WGSL literals', 
     outputCapacity: 1
   });
   encode(device, pointFixture.compiled);
-  t.deepEqual(
+  expect(
     await readQueryResult(pointFixture),
-    {ids: [0], count: 1, overflow: 0},
     'cross-zero normalization agrees with index construction'
-  );
+  ).toEqual({ids: [0], count: 1, overflow: 0});
   destroyFixture(pointFixture);
 
   const radiusFixture = createQueryFixture(device, {
@@ -202,20 +182,16 @@ test('GPUGridIndexQuery handles extreme domains and exponential WGSL literals', 
     outputCapacity: 2
   });
   encode(device, radiusFixture.compiled);
-  t.deepEqual(
+  expect(
     (await readQueryResult(radiusFixture)).ids.sort(sortNumbers),
-    [0, 1],
     'overflow-safe cell boundaries preserve both cells touching the query radius'
-  );
+  ).toEqual([0, 1]);
   destroyFixture(radiusFixture);
-  t.end();
 });
 
-test('GPUGridIndexQuery rejects overlapping inputs and writable results', async t => {
+it('GPUGridIndexQuery rejects overlapping inputs and writable results', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -238,7 +214,7 @@ test('GPUGridIndexQuery rejects overlapping inputs and writable results', async 
   const query = view('float32', 2, 40);
   const overflow = view('uint32', 1, 60);
 
-  t.throws(
+  expect(
     () =>
       new GPUGridIndexQuery({
         index,
@@ -248,10 +224,9 @@ test('GPUGridIndexQuery rejects overlapping inputs and writable results', async 
         count: view('uint32', 1, 56),
         overflow
       }),
-    /output and index objectIds must not overlap/,
     'query writes cannot alias live index reads'
-  );
-  t.throws(
+  ).toThrow(/output and index objectIds must not overlap/);
+  expect(
     () =>
       new GPUGridIndexQuery({
         index,
@@ -261,12 +236,10 @@ test('GPUGridIndexQuery rejects overlapping inputs and writable results', async 
         count: view('uint32', 1, 68),
         overflow
       }),
-    /count and output must not overlap/,
     'writable result views cannot race each other'
-  );
+  ).toThrow(/count and output must not overlap/);
 
   buffer.destroy();
-  t.end();
 });
 
 type QueryFixture = {

--- a/modules/gpgpu/test/gpu-core/gpu-grid-index.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-grid-index.spec.ts
@@ -12,57 +12,54 @@ import {
 } from '@luma.gl/gpgpu/gpu-core';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {
   addGPUGridIndexToGraphWithDispatchLimit,
   getGPUGridIndexDispatchLayout,
   getGPUGridIndexInvocationIndexSource
 } from '../../src/gpu-core/gpu-grid-index-internals';
 
-test('GPUGridIndex plans bounded multidimensional direct dispatches', t => {
+it('GPUGridIndex plans bounded multidimensional direct dispatches', () => {
   const maximum = 65_535;
   const oneDimensionalRowCapacity = maximum * 256;
 
-  t.deepEqual(getGPUGridIndexDispatchLayout(0, maximum), {x: 1, y: 1, z: 1});
-  t.deepEqual(getGPUGridIndexDispatchLayout(oneDimensionalRowCapacity, maximum), {
+  expect(getGPUGridIndexDispatchLayout(0, maximum)).toEqual({x: 1, y: 1, z: 1});
+  expect(getGPUGridIndexDispatchLayout(oneDimensionalRowCapacity, maximum)).toEqual({
     x: maximum,
     y: 1,
     z: 1
   });
-  t.deepEqual(getGPUGridIndexDispatchLayout(oneDimensionalRowCapacity + 1, maximum), {
+  expect(getGPUGridIndexDispatchLayout(oneDimensionalRowCapacity + 1, maximum)).toEqual({
     x: maximum,
     y: 2,
     z: 1
   });
-  t.deepEqual(
+  expect(
     getGPUGridIndexDispatchLayout(4 * 256 + 1, 2),
-    {x: 2, y: 2, z: 2},
     'a small synthetic limit exercises the third dispatch dimension'
+  ).toEqual({x: 2, y: 2, z: 2});
+  expect(() => getGPUGridIndexDispatchLayout(8 * 256 + 1, 2)).toThrow(
+    /exceeding the 3D dispatch limit/
   );
-  t.throws(() => getGPUGridIndexDispatchLayout(8 * 256 + 1, 2), /exceeding the 3D dispatch limit/);
 
   const source = getGPUGridIndexInvocationIndexSource({x: 3, y: 2, z: 2});
-  t.match(source, /workgroupId\.z \* 2u \+ workgroupId\.y/);
-  t.match(source, /\* 3u \+ workgroupId\.x/);
-  t.match(
-    source,
-    /workgroupIndex >= 16777216u/,
-    'padded workgroups cannot wrap the uint32 invocation index'
+  expect(source).toMatch(/workgroupId\.z \* 2u \+ workgroupId\.y/);
+  expect(source).toMatch(/\* 3u \+ workgroupId\.x/);
+  expect(source, 'padded workgroups cannot wrap the uint32 invocation index').toMatch(
+    /workgroupIndex >= 16777216u/
   );
-  t.ok(
-    source.indexOf('workgroupIndex >= 16777216u') <
-      source.indexOf('workgroupIndex * 256u + localInvocationIndex'),
+  expect(
+    Boolean(
+      source.indexOf('workgroupIndex >= 16777216u') <
+        source.indexOf('workgroupIndex * 256u + localInvocationIndex')
+    ),
     'the uint32 guard executes before invocation-index multiplication'
-  );
-  t.end();
+  ).toBe(true);
 });
 
-test('GPUGridIndex executes a small three-dimensional dispatch layout', async t => {
+it('GPUGridIndex executes a small three-dimensional dispatch layout', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -81,26 +78,21 @@ test('GPUGridIndex executes a small three-dimensional dispatch layout', async t 
     }
   );
 
-  t.deepEqual(
-    result.cellOffsets,
-    [0, positionCount],
-    'every multidimensional invocation is counted'
-  );
-  t.equal(result.count, positionCount, 'the padded dispatch does not add phantom rows');
-  t.equal(result.overflow, 0, 'the exact-capacity result does not overflow');
-  t.deepEqual(
+  expect(result.cellOffsets, 'every multidimensional invocation is counted').toEqual([
+    0,
+    positionCount
+  ]);
+  expect(result.count, 'the padded dispatch does not add phantom rows').toBe(positionCount);
+  expect(result.overflow, 'the exact-capacity result does not overflow').toBe(0);
+  expect(
     result.objectIds.sort((left, right) => left - right),
-    Array.from({length: positionCount}, (_, index) => index),
     'scatter visits every source row exactly once'
-  );
-  t.end();
+  ).toEqual(Array.from({length: positionCount}, (_, index) => index));
 });
 
-test('GPUGridIndex scans cell offsets through a multidimensional dispatch', async t => {
+it('GPUGridIndex scans cell offsets through a multidimensional dispatch', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -132,27 +124,22 @@ test('GPUGridIndex scans cell offsets through a multidimensional dispatch', asyn
     return 3;
   });
 
-  t.deepEqual(
+  expect(
     result.cellOffsets,
-    expectedOffsets,
     'the five-block cell-count scan and offset pass preserve every empty cell'
-  );
-  t.deepEqual(
+  ).toEqual(expectedOffsets);
+  expect(
     scanDispatch?.slice(1),
-    [2, 2, 2],
     'the GridIndex synthetic device limit reaches its nested scan dispatch'
-  );
-  t.deepEqual(result.objectIds, [0, 1, 2], 'widely separated cells retain their source rows');
-  t.equal(result.count, 3, 'the complete index count survives the multidimensional scan');
-  t.equal(result.overflow, 0, 'the exact-capacity index does not overflow');
-  t.end();
+  ).toEqual([2, 2, 2]);
+  expect(result.objectIds, 'widely separated cells retain their source rows').toEqual([0, 1, 2]);
+  expect(result.count, 'the complete index count survives the multidimensional scan').toBe(3);
+  expect(result.overflow, 'the exact-capacity index does not overflow').toBe(0);
 });
 
-test('GPUGridIndex builds bounded 2D cells with stable logical IDs', async t => {
+it('GPUGridIndex builds bounded 2D cells with stable logical IDs', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -161,24 +148,22 @@ test('GPUGridIndex builds bounded 2D cells with stable logical IDs', async t => 
     firstSourceIndex: 10
   });
 
-  t.deepEqual(result.cellOffsets, [0, 1, 2, 3, 5], 'exclusive offsets delimit row-major cells');
-  t.equal(result.count, 5, 'only finite in-domain positions are indexed');
-  t.equal(result.overflow, 0, 'exact capacity does not overflow');
-  t.deepEqual(result.objectIds.slice(0, 3), [10, 11, 12], 'single-entry cells preserve source IDs');
-  t.deepEqual(
+  expect(result.cellOffsets, 'exclusive offsets delimit row-major cells').toEqual([0, 1, 2, 3, 5]);
+  expect(result.count, 'only finite in-domain positions are indexed').toBe(5);
+  expect(result.overflow, 'exact capacity does not overflow').toBe(0);
+  expect(result.objectIds.slice(0, 3), 'single-entry cells preserve source IDs').toEqual([
+    10, 11, 12
+  ]);
+  expect(
     result.objectIds.slice(3).sort((left, right) => left - right),
-    [13, 14],
     'clustered cell contains both stable source IDs regardless of atomic order'
-  );
-  t.equal(result.updatePolicy, 'rebuild', 'the initial update contract is explicit');
-  t.end();
+  ).toEqual([13, 14]);
+  expect(result.updatePolicy, 'the initial update contract is explicit').toBe('rebuild');
 });
 
-test('GPUGridIndex normalizes bounds whose full span exceeds float32', async t => {
+it('GPUGridIndex normalizes bounds whose full span exceeds float32', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -190,16 +175,13 @@ test('GPUGridIndex normalizes bounds whose full span exceeds float32', async t =
     [-3e38, 0, 3e38, 1],
     1
   );
-  t.deepEqual(result.cellOffsets, [0, 0, 1, 1], 'zero maps to the middle of extreme bounds');
-  t.deepEqual(result.objectIds, [0], 'the accepted point keeps its logical ID');
-  t.end();
+  expect(result.cellOffsets, 'zero maps to the middle of extreme bounds').toEqual([0, 0, 1, 1]);
+  expect(result.objectIds, 'the accepted point keeps its logical ID').toEqual([0]);
 });
 
-test('GPUGridIndex rejects overlapping scatter inputs and output', async t => {
+it('GPUGridIndex rejects overlapping scatter inputs and output', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -221,7 +203,7 @@ test('GPUGridIndex rejects overlapping scatter inputs and output', async t => {
   const outputs = createIndexOutputs(device, 1, 2);
   const importedOutputs = importIndexOutputs(graph, outputs, 1, 2);
 
-  t.throws(
+  expect(
     () =>
       new GPUGridIndex({
         positions,
@@ -230,9 +212,8 @@ test('GPUGridIndex rejects overlapping scatter inputs and output', async t => {
         ...importedOutputs,
         objectIds: overlappingObjectIds
       }),
-    /positions and objectIds must not overlap/,
     'position reads cannot alias object ID writes'
-  );
+  ).toThrow(/positions and objectIds must not overlap/);
 
   const separatePositionsBuffer = createInputBuffer(device, Float32Array.from([0, 0, 1, 1]));
   const separatePositions = importView(
@@ -247,7 +228,7 @@ test('GPUGridIndex rejects overlapping scatter inputs and output', async t => {
     length: 2,
     byteOffset: 4
   });
-  t.throws(
+  expect(
     () =>
       new GPUGridIndex({
         positions: separatePositions,
@@ -257,31 +238,30 @@ test('GPUGridIndex rejects overlapping scatter inputs and output', async t => {
         ...importedOutputs,
         objectIds: overlappingObjectIds
       }),
-    /sourceIds and objectIds must not overlap/,
     'source ID reads cannot alias object ID writes'
-  );
+  ).toThrow(/sourceIds and objectIds must not overlap/);
 
   sharedBuffer.destroy();
   separatePositionsBuffer.destroy();
   for (const buffer of Object.values(outputs)) buffer.destroy();
-  t.end();
 });
 
-test('GPUGridIndex reports capacity overflow without corrupting offsets', async t => {
+it('GPUGridIndex reports capacity overflow without corrupting offsets', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
   const positions = Float32Array.from([0, 0, 1, 0, 0, 1, 2, 2, 2, 2]);
   const result = await runGridIndex(device, positions, 'float32x2', [2, 2], [0, 0, 2, 2], 4);
-  t.deepEqual(result.cellOffsets, [0, 1, 2, 3, 5], 'offsets describe the untruncated index');
-  t.equal(result.count, 5, 'count reports required capacity');
-  t.equal(result.overflow, 1, 'overflow reports truncated object ID storage');
-  t.deepEqual(result.objectIds.slice(0, 3), [0, 1, 2], 'complete cells remain addressable');
-  t.ok(result.objectIds[3] === 3 || result.objectIds[3] === 4, 'bounded tail stores one valid ID');
+  expect(result.cellOffsets, 'offsets describe the untruncated index').toEqual([0, 1, 2, 3, 5]);
+  expect(result.count, 'count reports required capacity').toBe(5);
+  expect(result.overflow, 'overflow reports truncated object ID storage').toBe(1);
+  expect(result.objectIds.slice(0, 3), 'complete cells remain addressable').toEqual([0, 1, 2]);
+  expect(
+    Boolean(result.objectIds[3] === 3 || result.objectIds[3] === 4),
+    'bounded tail stores one valid ID'
+  ).toBe(true);
 
   const zeroCapacity = await runGridIndex(
     device,
@@ -291,18 +271,15 @@ test('GPUGridIndex reports capacity overflow without corrupting offsets', async 
     [0, 0, 1, 1],
     0
   );
-  t.deepEqual(zeroCapacity.cellOffsets, [0, 1], 'zero capacity still publishes exact offsets');
-  t.deepEqual(zeroCapacity.objectIds, [], 'zero capacity performs no object-ID writes');
-  t.equal(zeroCapacity.count, 1, 'zero capacity reports the required row count');
-  t.equal(zeroCapacity.overflow, 1, 'zero capacity reports overflow for accepted input');
-  t.end();
+  expect(zeroCapacity.cellOffsets, 'zero capacity still publishes exact offsets').toEqual([0, 1]);
+  expect(zeroCapacity.objectIds, 'zero capacity performs no object-ID writes').toEqual([]);
+  expect(zeroCapacity.count, 'zero capacity reports the required row count').toBe(1);
+  expect(zeroCapacity.overflow, 'zero capacity reports overflow for accepted input').toBe(1);
 });
 
-test('GPUGridIndex builds 3D cells and preserves explicit source IDs', async t => {
+it('GPUGridIndex builds 3D cells and preserves explicit source IDs', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -315,18 +292,15 @@ test('GPUGridIndex builds 3D cells and preserves explicit source IDs', async t =
     4,
     {sourceIds: Uint32Array.from([90, 80, 70, 60, 50])}
   );
-  t.deepEqual(result.cellOffsets, [0, 1, 2, 3, 4], 'layer-major 3D cells have exact offsets');
-  t.deepEqual(result.objectIds, [90, 80, 70, 60], 'explicit IDs replace generated row IDs');
-  t.equal(result.count, 4, 'out-of-domain 3D positions are ignored');
-  t.equal(result.overflow, 0, 'accepted 3D positions fit capacity');
-  t.end();
+  expect(result.cellOffsets, 'layer-major 3D cells have exact offsets').toEqual([0, 1, 2, 3, 4]);
+  expect(result.objectIds, 'explicit IDs replace generated row IDs').toEqual([90, 80, 70, 60]);
+  expect(result.count, 'out-of-domain 3D positions are ignored').toBe(4);
+  expect(result.overflow, 'accepted 3D positions fit capacity').toBe(0);
 });
 
-test('GPUGridIndex preserves vector chunks and rebuilds after input updates', async t => {
+it('GPUGridIndex preserves vector chunks and rebuilds after input updates', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -363,30 +337,26 @@ test('GPUGridIndex preserves vector chunks and rebuilds after input updates', as
   const compiled = graph.compile();
 
   encode(device, compiled);
-  t.deepEqual(await readUint32(outputs.cellOffsets, 5), [0, 1, 2, 3, 4]);
-  t.deepEqual(
+  expect(await readUint32(outputs.cellOffsets, 5)).toEqual([0, 1, 2, 3, 4]);
+  expect(
     compiled.stats.nodeOrder.filter(id => id.includes('-count-')),
-    ['gpu-grid-index-count-0', 'gpu-grid-index-count-2'],
     'empty chunks retain identity without adding count work'
-  );
+  ).toEqual(['gpu-grid-index-count-0', 'gpu-grid-index-count-2']);
 
   buffers[2].write(Float32Array.from([0, 0, 0, 0]));
   encode(device, compiled);
-  t.deepEqual(
+  expect(
     await readUint32(outputs.cellOffsets, 5),
-    [0, 3, 4, 4, 4],
     'rewriting one source chunk causes the next encoding to rebuild the complete compact index'
-  );
-  t.equal(
+  ).toEqual([0, 3, 4, 4, 4]);
+  expect(
     compiled.stats.logicalTransientBufferCount,
-    3,
     'build scratch is graph-owned and visible'
-  );
+  ).toBe(3);
 
   compiled.destroy();
   vector.destroy();
   for (const buffer of [...buffers, ...Object.values(outputs)]) buffer.destroy();
-  t.end();
 });
 
 type IndexOutputs = {

--- a/modules/gpgpu/test/gpu-core/gpu-hash-index.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-hash-index.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {
   GPUCommandGraph,
@@ -12,11 +12,9 @@ import {
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
-test('GPUHashIndex builds and queries deterministic first-row values', async t => {
+it('GPUHashIndex builds and queries deterministic first-row values', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -28,65 +26,57 @@ test('GPUHashIndex builds and queries deterministic first-row values', async t =
     8
   );
 
-  t.deepEqual(
-    result.values,
-    [70, 30, 190, 110, GPU_HASH_INDEX_EMPTY_KEY, GPU_HASH_INDEX_EMPTY_KEY],
-    'lookups return the lowest-source-row value'
-  );
-  t.deepEqual(result.found, [1, 1, 1, 1, 0, 0], 'lookups publish an explicit found mask');
-  t.deepEqual(
+  expect(result.values, 'lookups return the lowest-source-row value').toEqual([
+    70,
+    30,
+    190,
+    110,
+    GPU_HASH_INDEX_EMPTY_KEY,
+    GPU_HASH_INDEX_EMPTY_KEY
+  ]);
+  expect(result.found, 'lookups publish an explicit found mask').toEqual([1, 1, 1, 1, 0, 0]);
+  expect(
     result.buildStatistics.slice(0, 4),
-    [4, 1, 0, 1],
     'build distinguishes unique, duplicate, overflow, and invalid rows'
-  );
-  t.deepEqual(result.queryStatistics.slice(0, 2), [4, 2], 'query counts found and missing keys');
-  t.ok(
-    result.probes.every(probeCount => probeCount <= 8),
+  ).toEqual([4, 1, 0, 1]);
+  expect(result.queryStatistics.slice(0, 2), 'query counts found and missing keys').toEqual([4, 2]);
+  expect(
+    Boolean(result.probes.every(probeCount => probeCount <= 8)),
     'every lookup obeys the probe bound'
-  );
-  t.equal(
+  ).toBe(true);
+  expect(
     result.tableKeys.filter(key => key !== GPU_HASH_INDEX_EMPTY_KEY).length,
-    4,
     'one table slot is occupied per distinct valid key'
-  );
-  t.end();
+  ).toBe(4);
 });
 
-test('GPUHashIndex reports fixed-capacity overflow and generated row IDs', async t => {
+it('GPUHashIndex reports fixed-capacity overflow and generated row IDs', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
   const keys = Uint32Array.from([1, 2, 3, 4, 5, 6]);
   const result = await runHashIndex(device, keys, undefined, keys, 4, {firstValue: 100});
 
-  t.deepEqual(
+  expect(
     result.buildStatistics.slice(0, 4),
-    [4, 0, 2, 0],
     'a full table reports the exact overflow row count'
-  );
-  t.equal(result.queryStatistics[0], 4, 'exactly the retained keys are found');
-  t.equal(result.queryStatistics[1], 2, 'overflowed keys are reported missing');
+  ).toEqual([4, 0, 2, 0]);
+  expect(result.queryStatistics[0], 'exactly the retained keys are found').toBe(4);
+  expect(result.queryStatistics[1], 'overflowed keys are reported missing').toBe(2);
   for (let row = 0; row < keys.length; row++) {
     if (result.found[row]) {
-      t.equal(
-        result.values[row],
-        100 + row,
-        `retained key ${keys[row]} maps to its generated row ID`
+      expect(result.values[row], `retained key ${keys[row]} maps to its generated row ID`).toBe(
+        100 + row
       );
     }
   }
-  t.end();
 });
 
-test('GPUHashIndex validates capacity, probe bounds, and aliasing', async t => {
+it('GPUHashIndex validates capacity, probe bounds, and aliasing', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -103,7 +93,7 @@ test('GPUHashIndex validates capacity, probe bounds, and aliasing', async t => {
   });
   const statisticsView = importView(graph, 'statistics', statistics, 6);
 
-  t.throws(
+  expect(
     () =>
       new GPUHashIndex({
         keys,
@@ -111,10 +101,9 @@ test('GPUHashIndex validates capacity, probe bounds, and aliasing', async t => {
         tableValues: overlappingTableValues,
         statistics: statisticsView
       }),
-    /output views must not overlap/,
     'table outputs cannot alias'
-  );
-  t.throws(
+  ).toThrow(/output views must not overlap/);
+  expect(
     () =>
       new GPUHashIndex({
         keys,
@@ -126,10 +115,9 @@ test('GPUHashIndex validates capacity, probe bounds, and aliasing', async t => {
         }),
         statistics: statisticsView
       }),
-    /positive power of two/,
     'capacity must be a power of two'
-  );
-  t.throws(
+  ).toThrow(/positive power of two/);
+  expect(
     () =>
       new GPUHashIndex({
         keys,
@@ -138,21 +126,17 @@ test('GPUHashIndex validates capacity, probe bounds, and aliasing', async t => {
         statistics: statisticsView,
         maxProbeCount: 5
       }),
-    /one through capacity/,
     'probe work cannot exceed capacity'
-  );
+  ).toThrow(/one through capacity/);
 
   input.destroy();
   table.destroy();
   statistics.destroy();
-  t.end();
 });
 
-test('GPUHashIndex accepts empty explicit-value views at the end of their buffers', async t => {
+it('GPUHashIndex accepts empty explicit-value views at the end of their buffers', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -183,11 +167,10 @@ test('GPUHashIndex accepts empty explicit-value views at the end of their buffer
   device.submit(commandEncoder.finish());
 
   const tableBytes = await tableKeysBuffer.readAsync();
-  t.deepEqual(
+  expect(
     Array.from(new Uint32Array(tableBytes.buffer, tableBytes.byteOffset, 4)),
-    Array.from({length: 4}, () => GPU_HASH_INDEX_EMPTY_KEY),
     'an empty rebuild clears every table slot without binding empty source values'
-  );
+  ).toEqual(Array.from({length: 4}, () => GPU_HASH_INDEX_EMPTY_KEY));
 
   compiled.destroy();
   for (const buffer of [
@@ -199,7 +182,6 @@ test('GPUHashIndex accepts empty explicit-value views at the end of their buffer
   ]) {
     buffer.destroy();
   }
-  t.end();
 });
 
 async function runHashIndex(

--- a/modules/gpgpu/test/gpu-core/gpu-hash-join.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-hash-join.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {
   GPUCommandGraph,
@@ -12,11 +12,9 @@ import {
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
-test('GPUHashJoin stably publishes sparse row pairs', async t => {
+it('GPUHashJoin stably publishes sparse row pairs', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -28,36 +26,25 @@ test('GPUHashJoin stably publishes sparse row pairs', async t => {
     outputCapacity: 6
   });
 
-  t.deepEqual(
-    result.leftRows.slice(0, 4),
-    [100, 102, 103, 105],
-    'matching left rows retain source order'
-  );
-  t.deepEqual(
-    result.rightRows.slice(0, 4),
-    [700, 200, 700, 400],
-    'right rows align with stable left rows'
-  );
-  t.equal(result.count, 4, 'count reports all inner-join matches');
-  t.equal(result.overflow, 0, 'sufficient output capacity does not overflow');
-  t.deepEqual(
-    result.found,
-    [1, 0, 1, 1, 0, 1],
-    'optional found mask exposes aligned left-join semantics'
-  );
-  t.deepEqual(
-    result.statistics.slice(0, 2),
-    [4, 2],
-    'lookup statistics report found and missing rows'
-  );
-  t.end();
+  expect(result.leftRows.slice(0, 4), 'matching left rows retain source order').toEqual([
+    100, 102, 103, 105
+  ]);
+  expect(result.rightRows.slice(0, 4), 'right rows align with stable left rows').toEqual([
+    700, 200, 700, 400
+  ]);
+  expect(result.count, 'count reports all inner-join matches').toBe(4);
+  expect(result.overflow, 'sufficient output capacity does not overflow').toBe(0);
+  expect(result.found, 'optional found mask exposes aligned left-join semantics').toEqual([
+    1, 0, 1, 1, 0, 1
+  ]);
+  expect(result.statistics.slice(0, 2), 'lookup statistics report found and missing rows').toEqual([
+    4, 2
+  ]);
 });
 
-test('GPUHashJoin preserves explicit left IDs and reports required capacity', async t => {
+it('GPUHashJoin preserves explicit left IDs and reports required capacity', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -69,22 +56,17 @@ test('GPUHashJoin preserves explicit left IDs and reports required capacity', as
     outputCapacity: 2
   });
 
-  t.deepEqual(
-    result.leftRows,
-    [500, 502],
-    'bounded publication retains the stable matching prefix'
-  );
-  t.deepEqual(result.rightRows, [700, 200], 'truncated right rows remain pair-aligned');
-  t.equal(result.count, 4, 'count reports required rather than stored capacity');
-  t.equal(result.overflow, 1, 'truncation is explicit');
-  t.end();
+  expect(result.leftRows, 'bounded publication retains the stable matching prefix').toEqual([
+    500, 502
+  ]);
+  expect(result.rightRows, 'truncated right rows remain pair-aligned').toEqual([700, 200]);
+  expect(result.count, 'count reports required rather than stored capacity').toBe(4);
+  expect(result.overflow, 'truncation is explicit').toBe(1);
 });
 
-test('GPUHashJoin clears empty results and validates output ownership', async t => {
+it('GPUHashJoin clears empty results and validates output ownership', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -94,9 +76,9 @@ test('GPUHashJoin clears empty results and validates output ownership', async t 
     leftKeys: new Uint32Array(0),
     outputCapacity: 1
   });
-  t.equal(empty.count, 0, 'empty input writes a zero required count');
-  t.equal(empty.overflow, 0, 'empty input clears overflow');
-  t.deepEqual(empty.statistics, [0, 0, 0, 0], 'empty lookup clears query statistics');
+  expect(empty.count, 'empty input writes a zero required count').toBe(0);
+  expect(empty.overflow, 'empty input clears overflow').toBe(0);
+  expect(empty.statistics, 'empty lookup clears query statistics').toEqual([0, 0, 0, 0]);
 
   const sourceOverflow = await runHashJoin(device, {
     rightKeys: Uint32Array.from([1, 2, 3]),
@@ -105,7 +87,7 @@ test('GPUHashJoin clears empty results and validates output ownership', async t 
     tableCapacity: 2,
     outputCapacity: 1
   });
-  t.equal(sourceOverflow.overflow, 1, 'an incomplete source index propagates overflow');
+  expect(sourceOverflow.overflow, 'an incomplete source index propagates overflow').toBe(1);
 
   const graph = new GPUCommandGraph(device);
   const tableKeysBuffer = createOutputBuffer(device, 4);
@@ -123,7 +105,7 @@ test('GPUHashJoin clears empty results and validates output ownership', async t 
     {id: 'scalars', byteLength: scalarBuffer.byteLength, usage: scalarBuffer.usage},
     scalarBuffer
   );
-  t.throws(
+  expect(
     () =>
       new GPUHashJoin({
         index,
@@ -142,16 +124,14 @@ test('GPUHashJoin clears empty results and validates output ownership', async t 
           byteOffset: 8
         })
       }),
-    /output views must not overlap/,
     'join outputs cannot alias'
-  );
+  ).toThrow(/output views must not overlap/);
 
   tableKeysBuffer.destroy();
   tableValuesBuffer.destroy();
   keysBuffer.destroy();
   sharedOutputBuffer.destroy();
   scalarBuffer.destroy();
-  t.end();
 });
 
 type JoinFixtureProps = {

--- a/modules/gpgpu/test/gpu-core/gpu-histogram-mask.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-histogram-mask.node.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {
   GPUHistogram,
   GraphBufferHandle,
@@ -13,7 +13,7 @@ import {
 
 type ScalarFormat = 'float32' | 'uint32';
 
-test('GPUHistogram accepts aligned masks and preserves public selection metadata', testCase => {
+it('GPUHistogram accepts aligned masks and preserves public selection metadata', () => {
   const input = createView('input', 'float32', 4);
   const output = createView('output', 'uint32', 4);
   const mask: GPUHistogramMask = createView('mask', 'uint32', 4, {
@@ -21,12 +21,11 @@ test('GPUHistogram accepts aligned masks and preserves public selection metadata
   });
   const histogram = new GPUHistogram({input, output, mask, domain: [0, 3]});
 
-  testCase.equal(histogram.mask, mask, 'retains the caller-owned public selection mask');
-  testCase.equal(mask.byteOffset, 4, 'accepts packed uint32-aligned nonzero view offsets');
-  testCase.end();
+  expect(histogram.mask, 'retains the caller-owned public selection mask').toBe(mask);
+  expect(mask.byteOffset, 'accepts packed uint32-aligned nonzero view offsets').toBe(4);
 });
 
-test('GPUHistogram rejects invalid atomic mask formats, layouts, lengths, and aliases', testCase => {
+it('GPUHistogram rejects invalid atomic mask formats, layouts, lengths, and aliases', () => {
   const input = createView('input', 'float32', 4);
   const output = createView('output', 'uint32', 4);
   const shortMask = createView('short-mask', 'uint32', 3);
@@ -34,35 +33,29 @@ test('GPUHistogram rejects invalid atomic mask formats, layouts, lengths, and al
   const stridedMask = createView('strided-mask', 'uint32', 4, {byteStride: 8});
   const unalignedMask = createView('unaligned-mask', 'uint32', 4, {byteOffset: 2});
 
-  testCase.throws(
+  expect(
     () => new GPUHistogram({input, output, mask: shortMask, domain: [0, 3]}),
-    /input and mask lengths must match/,
     'atomic masks require one source-aligned row per input value'
-  );
-  testCase.throws(
+  ).toThrow(/input and mask lengths must match/);
+  expect(
     () => new GPUHistogram({input, output, mask: floatMask as never, domain: [0, 3]}),
-    /packed, uint32-aligned uint32/,
     'floating-point masks cannot be reinterpreted as selection flags'
-  );
-  testCase.throws(
+  ).toThrow(/packed, uint32-aligned uint32/);
+  expect(
     () => new GPUHistogram({input, output, mask: stridedMask, domain: [0, 3]}),
-    /packed, uint32-aligned uint32/,
     'strided selections cannot be consumed by packed mask shaders'
-  );
-  testCase.throws(
+  ).toThrow(/packed, uint32-aligned uint32/);
+  expect(
     () => new GPUHistogram({input, output, mask: unalignedMask, domain: [0, 3]}),
-    /packed, uint32-aligned uint32/,
     'selection views must start at uint32-aligned byte offsets'
-  );
-  testCase.throws(
+  ).toThrow(/packed, uint32-aligned uint32/);
+  expect(
     () => new GPUHistogram({input, output, mask: output, domain: [0, 3]}),
-    /mask and output must use separate buffers/,
     'selection flags cannot alias the cleared and accumulated output'
-  );
-  testCase.end();
+  ).toThrow(/mask and output must use separate buffers/);
 });
 
-test('GPUHistogram requires identical mask view kind and ordered vector topology', testCase => {
+it('GPUHistogram requires identical mask view kind and ordered vector topology', () => {
   const input = createVector('input', 'float32', [2, 0, 3]);
   const matchingMask = createVector('matching-mask', 'uint32', [2, 0, 3]);
   const mismatchedMask = createVector('mismatched-mask', 'uint32', [1, 0, 4]);
@@ -71,23 +64,19 @@ test('GPUHistogram requires identical mask view kind and ordered vector topology
   const output = createView('output', 'uint32', 4);
 
   const histogram = new GPUHistogram({input, output, mask: matchingMask, domain: [0, 4]});
-  testCase.equal(histogram.mask, matchingMask, 'accepts empty chunks at matching source indices');
-  testCase.throws(
+  expect(histogram.mask, 'accepts empty chunks at matching source indices').toBe(matchingMask);
+  expect(
     () => new GPUHistogram({input, output, mask: atomicMask, domain: [0, 4]}),
-    /same view kind/,
     'vector inputs cannot silently concatenate an atomic selection'
-  );
-  testCase.throws(
+  ).toThrow(/same view kind/);
+  expect(
     () => new GPUHistogram({input, output, mask: mismatchedMask, domain: [0, 4]}),
-    /same chunk topology/,
     'equal total row counts do not permit different ordered chunk sizes'
-  );
-  testCase.throws(
+  ).toThrow(/same chunk topology/);
+  expect(
     () => new GPUHistogram({input, output, mask: differentChunkCountMask, domain: [0, 4]}),
-    /same chunk topology/,
     'vector masks must preserve the complete source chunk count'
-  );
-  testCase.end();
+  ).toThrow(/same chunk topology/);
 });
 
 function createView<T extends ScalarFormat>(

--- a/modules/gpgpu/test/gpu-core/gpu-histogram-mask.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-histogram-mask.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {
   GPUCommandGraph,
@@ -24,11 +24,9 @@ type VectorFixture<T extends ScalarFormat> = {
   buffers: Buffer[];
 };
 
-test('GPUHistogram filters equal-width bins with reusable GPU-resident masks', async testCase => {
+it('GPUHistogram filters equal-width bins with reusable GPU-resident masks', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
@@ -41,21 +39,17 @@ test('GPUHistogram filters equal-width bins with reusable GPU-resident masks', a
     binCount: 4,
     options: {domain: [0, 4]}
   });
-  testCase.deepEqual(
-    local.counts,
-    [1, 0, 1, 2],
-    'the local atomic path accepts every nonzero in-range mask row'
-  );
-  testCase.deepEqual(
+  expect(local.counts, 'the local atomic path accepts every nonzero in-range mask row').toEqual([
+    1, 0, 1, 2
+  ]);
+  expect(
     local.updatedCounts,
-    [0, 1, 0, 1],
     'rewriting the mask updates counts without recompiling the graph'
-  );
-  testCase.deepEqual(
-    local.nodeOrder,
-    ['gpu-histogram-clear', 'gpu-histogram-local'],
-    'masking does not introduce extra dispatches'
-  );
+  ).toEqual([0, 1, 0, 1]);
+  expect(local.nodeOrder, 'masking does not introduce extra dispatches').toEqual([
+    'gpu-histogram-clear',
+    'gpu-histogram-local'
+  ]);
 
   const globalValues = Uint32Array.from({length: 301}, (_, index) => index);
   const globalMask = Uint32Array.from(globalValues, value => Number(value % 2 === 0));
@@ -67,10 +61,8 @@ test('GPUHistogram filters equal-width bins with reusable GPU-resident masks', a
     binCount: 300,
     options: {domain: [0, 299]}
   });
-  testCase.deepEqual(
-    global.counts,
-    Array.from({length: 300}, (_, index) => Number(index % 2 === 0)),
-    'the global atomic path ignores rejected and out-of-domain rows'
+  expect(global.counts, 'the global atomic path ignores rejected and out-of-domain rows').toEqual(
+    Array.from({length: 300}, (_, index) => Number(index % 2 === 0))
   );
 
   const automatic = await runMaskedHistogram({
@@ -81,19 +73,14 @@ test('GPUHistogram filters equal-width bins with reusable GPU-resident masks', a
     binCount: 2,
     options: {domain: 'auto'}
   });
-  testCase.deepEqual(
-    automatic.counts,
-    [0, 1],
-    'automatic domains retain the full unfiltered input extent'
-  );
-  testCase.end();
+  expect(automatic.counts, 'automatic domains retain the full unfiltered input extent').toEqual([
+    0, 1
+  ]);
 });
 
-test('GPUHistogram filters irregular literal and GPU-resident edges', async testCase => {
+it('GPUHistogram filters irregular literal and GPU-resident edges', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
@@ -105,11 +92,9 @@ test('GPUHistogram filters irregular literal and GPU-resident edges', async test
     binCount: 3,
     options: {edges: [0, 1, 10, 100]}
   });
-  testCase.deepEqual(
-    local.counts,
-    [1, 1, 2],
-    'literal-edge local accumulation applies the source-aligned mask'
-  );
+  expect(local.counts, 'literal-edge local accumulation applies the source-aligned mask').toEqual([
+    1, 1, 2
+  ]);
 
   const globalValues = Uint32Array.from({length: 301}, (_, index) => index);
   const global = await runMaskedHistogram({
@@ -123,24 +108,19 @@ test('GPUHistogram filters irregular literal and GPU-resident edges', async test
       gpuEdges: true
     }
   });
-  testCase.deepEqual(
+  expect(
     global.counts,
-    Array.from({length: 300}, (_, index) => Number(index % 3 === 0 || index === 299)),
     'GPU-edge global accumulation includes only selected rows and the exact final edge'
-  );
-  testCase.deepEqual(
+  ).toEqual(Array.from({length: 300}, (_, index) => Number(index % 3 === 0 || index === 299)));
+  expect(
     global.nodeOrder,
-    ['gpu-histogram-validate-edges', 'gpu-histogram-clear', 'gpu-histogram-edges-global'],
     'GPU edge validation remains upstream of masked global accumulation'
-  );
-  testCase.end();
+  ).toEqual(['gpu-histogram-validate-edges', 'gpu-histogram-clear', 'gpu-histogram-edges-global']);
 });
 
-test('GPUHistogram preserves source-aligned masked vector chunks', async testCase => {
+it('GPUHistogram preserves source-aligned masked vector chunks', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
@@ -161,30 +141,26 @@ test('GPUHistogram preserves source-aligned masked vector chunks', async testCas
   const compiled = graph.compile();
 
   submitGraph(device, compiled, 'masked-vector-histogram-initial');
-  testCase.deepEqual(
+  expect(
     await readUint32(outputBuffer, 4),
-    [1, 0, 0, 2],
     'each nonempty source chunk uses its matching mask chunk'
-  );
-  testCase.deepEqual(
+  ).toEqual([1, 0, 0, 2]);
+  expect(
     compiled.stats.nodeOrder,
-    ['gpu-histogram-clear', 'gpu-histogram-chunk-0-local', 'gpu-histogram-chunk-2-local'],
     'empty aligned chunks retain their index without a dispatch'
-  );
-  testCase.equal(
+  ).toEqual(['gpu-histogram-clear', 'gpu-histogram-chunk-0-local', 'gpu-histogram-chunk-2-local']);
+  expect(
     compiled.stats.logicalTransientBufferCount,
-    0,
     'masked vector accumulation does not concatenate chunks or allocate scratch buffers'
-  );
+  ).toBe(0);
 
   masks.buffers[0].write(Uint32Array.from([0, 1]));
   masks.buffers[2].write(Uint32Array.from([1, 0, 0]));
   submitGraph(device, compiled, 'masked-vector-histogram-updated');
-  testCase.deepEqual(
+  expect(
     await readUint32(outputBuffer, 4),
-    [0, 1, 1, 0],
     'updating individual mask chunks changes one reusable graph encoding'
-  );
+  ).toEqual([0, 1, 1, 0]);
 
   compiled.destroy();
 
@@ -200,33 +176,28 @@ test('GPUHistogram preserves source-aligned masked vector chunks', async testCas
   }).addToGraph(irregularGraph);
   const irregularCompiled = irregularGraph.compile();
   submitGraph(device, irregularCompiled, 'masked-irregular-vector-histogram');
-  testCase.deepEqual(
+  expect(
     await readUint32(outputBuffer, 3),
-    [0, 2, 0],
     'irregular-edge accumulation preserves the same updated mask chunk boundaries'
-  );
-  testCase.deepEqual(
+  ).toEqual([0, 2, 0]);
+  expect(
     irregularCompiled.stats.nodeOrder,
-    [
-      'gpu-histogram-clear',
-      'gpu-histogram-chunk-0-edges-local',
-      'gpu-histogram-chunk-2-edges-local'
-    ],
     'irregular-edge vector passes skip empty aligned chunks'
-  );
+  ).toEqual([
+    'gpu-histogram-clear',
+    'gpu-histogram-chunk-0-edges-local',
+    'gpu-histogram-chunk-2-edges-local'
+  ]);
   irregularCompiled.destroy();
 
   destroyVectorFixture(values);
   destroyVectorFixture(masks);
   outputBuffer.destroy();
-  testCase.end();
 });
 
-test('GPUHistogram shares offset selection views across independently binned outputs', async testCase => {
+it('GPUHistogram shares offset selection views across independently binned outputs', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
@@ -265,30 +236,25 @@ test('GPUHistogram shares offset selection views across independently binned out
   const compiled = graph.compile();
   submitGraph(device, compiled, 'offset-masked-histograms');
 
-  testCase.deepEqual(
+  expect(
     await readUint32(regularOutputBuffer, 4),
-    [0, 1, 0, 1],
     'equal-width accumulation reads from the logical selection byte offset'
-  );
-  testCase.deepEqual(
+  ).toEqual([0, 1, 0, 1]);
+  expect(
     await readUint32(irregularOutputBuffer, 3),
-    [0, 1, 1],
     'irregular accumulation reuses the same offset GPU selection without readback'
-  );
+  ).toEqual([0, 1, 1]);
 
   compiled.destroy();
   inputBuffer.destroy();
   maskBuffer.destroy();
   regularOutputBuffer.destroy();
   irregularOutputBuffer.destroy();
-  testCase.end();
 });
 
-test('GPUHistogram validates mask layout, topology, ownership, and aliases', async testCase => {
+it('GPUHistogram validates mask layout, topology, ownership, and aliases', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
@@ -311,26 +277,22 @@ test('GPUHistogram validates mask layout, topology, ownership, and aliases', asy
   });
   const shortInput = graph.createDataView(input.buffer, {format: 'float32', length: 2});
 
-  testCase.throws(
+  expect(
     () => new GPUHistogram({input, mask: shortMask, output, domain: [0, 3]}),
-    /input and mask lengths must match/,
     'atomic masks require one selection row per input value'
-  );
-  testCase.throws(
+  ).toThrow(/input and mask lengths must match/);
+  expect(
     () => new GPUHistogram({input, mask: floatMask as never, output, domain: [0, 3]}),
-    /must be packed, uint32-aligned uint32 GPU data/,
     'mask rows must use packed uint32 storage'
-  );
-  testCase.throws(
+  ).toThrow(/must be packed, uint32-aligned uint32 GPU data/);
+  expect(
     () => new GPUHistogram({input: shortInput, mask: stridedMask, output, domain: [0, 3]}),
-    /must be packed, uint32-aligned uint32 GPU data/,
     'interleaved selection rows cannot be consumed as packed histogram masks'
-  );
-  testCase.throws(
+  ).toThrow(/must be packed, uint32-aligned uint32 GPU data/);
+  expect(
     () => new GPUHistogram({input, mask: output, output, domain: [0, 3]}),
-    /mask and output must use separate buffers/,
     'selection masks cannot alias histogram counts'
-  );
+  ).toThrow(/mask and output must use separate buffers/);
 
   const vectorValues = createVectorFixture(device, 'vector-values', 'float32', [
     Float32Array.from([0, 1]),
@@ -342,31 +304,27 @@ test('GPUHistogram validates mask layout, topology, ownership, and aliases', asy
   ]);
   const vectorInput = graph.importGPUVector('vector-values', vectorValues.vector);
   const vectorMask = graph.importGPUVector('vector-masks', vectorMasks.vector);
-  testCase.throws(
+  expect(
     () => new GPUHistogram({input: vectorInput, mask: shortMask, output, domain: [0, 3]}),
-    /same view kind/,
     'vector input cannot use a single atomic mask view'
-  );
-  testCase.throws(
+  ).toThrow(/same view kind/);
+  expect(
     () => new GPUHistogram({input: vectorInput, mask: vectorMask, output, domain: [0, 3]}),
-    /same chunk topology/,
     'vector masks must preserve every source chunk boundary'
-  );
+  ).toThrow(/same chunk topology/);
 
   const foreignGraph = new GPUCommandGraph(device, {id: 'foreign-histogram-mask'});
   const foreignMask = importView(foreignGraph, 'foreign-mask', maskBuffer, 'uint32', 4);
-  testCase.throws(
+  expect(
     () => new GPUHistogram({input, mask: foreignMask, output, domain: [0, 3]}).addToGraph(graph),
-    /views must belong to the target graph/,
     'mask storage must belong to the encoded command graph'
-  );
+  ).toThrow(/views must belong to the target graph/);
 
   destroyVectorFixture(vectorValues);
   destroyVectorFixture(vectorMasks);
   inputBuffer.destroy();
   maskBuffer.destroy();
   outputBuffer.destroy();
-  testCase.end();
 });
 
 async function runMaskedHistogram(props: {

--- a/modules/gpgpu/test/gpu-core/gpu-partitioned-indexed-range-compaction.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-partitioned-indexed-range-compaction.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -10,13 +11,10 @@ import {
   type GraphDataView
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
 
-test('GPUPartitionedIndexedRangeCompaction keeps visible IDs in bounded chunks', async t => {
+it('GPUPartitionedIndexedRangeCompaction keeps visible IDs in bounded chunks', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -61,26 +59,22 @@ test('GPUPartitionedIndexedRangeCompaction keeps visible IDs in bounded chunks',
 
   try {
     await encodeAndSubmit(device, compiled, 'partitioned-range-compaction-all');
-    t.deepEqual(await readUint32(output.buffers[0], 4), [0, 2, 4, 5], 'first output chunk');
-    t.deepEqual(await readUint32(output.buffers[1], 3), [7, 8, 10], 'second output chunk');
-    t.deepEqual(await readUint32(count.buffer, 1), [7], 'total selected count');
+    expect(await readUint32(output.buffers[0], 4), 'first output chunk').toEqual([0, 2, 4, 5]);
+    expect(await readUint32(output.buffers[1], 3), 'second output chunk').toEqual([7, 8, 10]);
+    expect(await readUint32(count.buffer, 1), 'total selected count').toEqual([7]);
 
     activeRangeIdsResource.buffer.write(Uint32Array.from([1, 3, 2, 0]));
     activeRangeDispatch.buffer.write(Uint32Array.from([1, 2, 1]));
     await encodeAndSubmit(device, compiled, 'partitioned-range-compaction-subset');
-    t.deepEqual(await readUint32(output.buffers[0], 2), [4, 5], 'first candidate partition');
-    t.deepEqual(await readUint32(output.buffers[1], 2), [8, 10], 'second candidate partition');
-    t.deepEqual(
-      await readUint32(count.buffer, 1),
-      [4],
-      'GPU candidate changes avoid recompilation'
-    );
+    expect(await readUint32(output.buffers[0], 2), 'first candidate partition').toEqual([4, 5]);
+    expect(await readUint32(output.buffers[1], 2), 'second candidate partition').toEqual([8, 10]);
+    expect(await readUint32(count.buffer, 1), 'GPU candidate changes avoid recompilation').toEqual([
+      4
+    ]);
   } finally {
     compiled.destroy();
     for (const resource of resources) resource.destroy();
   }
-
-  t.end();
 });
 
 function createImportedVector(

--- a/modules/gpgpu/test/gpu-core/gpu-point-spatial-filter.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-point-spatial-filter.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {
   GPUCommandGraph,
@@ -16,11 +16,9 @@ import {
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
-test('GPUPointSpatialFilter gives indexed and unindexed 2D visibility the same exact result', async t => {
+it('GPUPointSpatialFilter gives indexed and unindexed 2D visibility the same exact result', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -36,37 +34,31 @@ test('GPUPointSpatialFilter gives indexed and unindexed 2D visibility the same e
   });
   encode(device, fixture.compiled);
 
-  t.deepEqual(await readVisible(fixture.indexed), [1], 'grid candidates are refined exactly');
-  t.deepEqual(
+  expect(await readVisible(fixture.indexed), 'grid candidates are refined exactly').toEqual([1]);
+  expect(
     await readVisible(fixture.unindexed),
-    [1],
     'the full scan provides the same exact visibility oracle'
-  );
-  t.deepEqual(
+  ).toEqual([1]);
+  expect(
     await readUint32(fixture.candidateCount, 1),
-    [2],
     'the broad phase visits only points in intersecting cells'
-  );
-  t.deepEqual(await readUint32(fixture.indexed.overflow, 1), [0]);
+  ).toEqual([2]);
+  expect(await readUint32(fixture.indexed.overflow, 1)).toEqual([0]);
 
   fixture.query.write(Float32Array.from([1.5, 1.5, 0.6]));
   encode(device, fixture.compiled);
-  t.deepEqual((await readVisible(fixture.indexed)).sort(sortNumbers), [5, 6]);
-  t.deepEqual(
+  expect((await readVisible(fixture.indexed)).sort(sortNumbers)).toEqual([5, 6]);
+  expect(
     (await readVisible(fixture.unindexed)).sort(sortNumbers),
-    [5, 6],
     'query updates preserve indexed/unindexed equivalence without recompiling'
-  );
+  ).toEqual([5, 6]);
 
   destroyFixture(fixture);
-  t.end();
 });
 
-test('GPUPointSpatialFilter composes 3D bounds candidates with selection visibility', async t => {
+it('GPUPointSpatialFilter composes 3D bounds candidates with selection visibility', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -83,23 +75,21 @@ test('GPUPointSpatialFilter composes 3D bounds candidates with selection visibil
   });
   encode(device, fixture.compiled);
 
-  t.deepEqual(await readVisible(fixture.indexed), [0], 'selection intersects exact spatial mask');
-  t.deepEqual(await readVisible(fixture.unindexed), [0], '3D indexed and scan paths agree');
-  t.deepEqual(
+  expect(await readVisible(fixture.indexed), 'selection intersects exact spatial mask').toEqual([
+    0
+  ]);
+  expect(await readVisible(fixture.unindexed), '3D indexed and scan paths agree').toEqual([0]);
+  expect(
     await readUint32(fixture.indexed.mask, 6),
-    [1, 0, 0, 0, 0, 0],
     'visibility publishes the composed canonical mask'
-  );
+  ).toEqual([1, 0, 0, 0, 0, 0]);
 
   destroyFixture(fixture);
-  t.end();
 });
 
-test('GPUPointSpatialFilter compares large radii without squared-distance overflow', async t => {
+it('GPUPointSpatialFilter compares large radii without squared-distance overflow', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -113,19 +103,16 @@ test('GPUPointSpatialFilter compares large radii without squared-distance overfl
   });
   encode(device, fixture.compiled);
 
-  t.deepEqual(
+  expect(
     await readVisible(fixture.indexed),
-    [],
     'indexed refinement rejects the distant point'
-  );
-  t.deepEqual(
+  ).toEqual([]);
+  expect(
     await readVisible(fixture.unindexed),
-    [],
     'the exact full scan rejects inf-squared false positives'
-  );
+  ).toEqual([]);
 
   destroyFixture(fixture);
-  t.end();
 });
 
 type ResultBuffers = {

--- a/modules/gpgpu/test/gpu-core/gpu-reduction-mask.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-reduction-mask.node.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {
   GPUReduction,
   GraphBufferHandle,
@@ -13,18 +13,17 @@ import {
 
 type ScalarFormat = 'float32' | 'sint32' | 'uint32';
 
-test('GPUReduction accepts packed, source-aligned optional selection masks', testCase => {
+it('GPUReduction accepts packed, source-aligned optional selection masks', () => {
   const input = createView('input', 'float32', 4);
   const output = createView('output', 'float32', 2);
   const mask: GPUReductionMask = createView('mask', 'uint32', 4, {byteOffset: 4});
   const reduction = new GPUReduction({input, output, mask, operation: 'extent'});
 
-  testCase.equal(reduction.mask, mask, 'retains the caller-owned public selection mask');
-  testCase.equal(mask.byteOffset, 4, 'accepts packed uint32-aligned nonzero view offsets');
-  testCase.end();
+  expect(reduction.mask, 'retains the caller-owned public selection mask').toBe(mask);
+  expect(mask.byteOffset, 'accepts packed uint32-aligned nonzero view offsets').toBe(4);
 });
 
-test('GPUReduction rejects invalid selection mask formats, layouts, lengths, and aliases', testCase => {
+it('GPUReduction rejects invalid selection mask formats, layouts, lengths, and aliases', () => {
   const input = createView('input', 'uint32', 4);
   const output = createView('output', 'uint32', 1);
   const shortMask = createView('short-mask', 'uint32', 3);
@@ -32,35 +31,29 @@ test('GPUReduction rejects invalid selection mask formats, layouts, lengths, and
   const stridedMask = createView('strided-mask', 'uint32', 4, {byteStride: 8});
   const unalignedMask = createView('unaligned-mask', 'uint32', 4, {byteOffset: 2});
 
-  testCase.throws(
+  expect(
     () => new GPUReduction({input, output, mask: shortMask, operation: 'sum'}),
-    /input and mask lengths must match/,
     'scalar masks require one selection row per input value'
-  );
-  testCase.throws(
+  ).toThrow(/input and mask lengths must match/);
+  expect(
     () => new GPUReduction({input, output, mask: floatMask as never, operation: 'sum'}),
-    /packed, uint32-aligned uint32/,
     'floating-point views cannot be consumed as selection flags'
-  );
-  testCase.throws(
+  ).toThrow(/packed, uint32-aligned uint32/);
+  expect(
     () => new GPUReduction({input, output, mask: stridedMask, operation: 'sum'}),
-    /packed, uint32-aligned uint32/,
     'interleaved selections cannot be consumed by packed shaders'
-  );
-  testCase.throws(
+  ).toThrow(/packed, uint32-aligned uint32/);
+  expect(
     () => new GPUReduction({input, output, mask: unalignedMask, operation: 'sum'}),
-    /packed, uint32-aligned uint32/,
     'selection views must begin at a uint32-aligned byte offset'
-  );
-  testCase.throws(
+  ).toThrow(/packed, uint32-aligned uint32/);
+  expect(
     () => new GPUReduction({input, output, mask: output, operation: 'sum'}),
-    /mask and output must use separate buffers/,
     'selection flags cannot alias the caller-owned output'
-  );
-  testCase.end();
+  ).toThrow(/mask and output must use separate buffers/);
 });
 
-test('GPUReduction requires selection masks to preserve ordered vector topology', testCase => {
+it('GPUReduction requires selection masks to preserve ordered vector topology', () => {
   const input = createVector('input', 'sint32', [2, 0, 3]);
   const matchingMask = createVector('matching-mask', 'uint32', [2, 0, 3]);
   const mismatchedMask = createVector('mismatched-mask', 'uint32', [1, 0, 4]);
@@ -69,23 +62,19 @@ test('GPUReduction requires selection masks to preserve ordered vector topology'
   const output = createView('output', 'sint32', 1);
 
   const reduction = new GPUReduction({input, output, mask: matchingMask, operation: 'min'});
-  testCase.equal(reduction.mask, matchingMask, 'preserves empty chunks at their source positions');
-  testCase.throws(
+  expect(reduction.mask, 'preserves empty chunks at their source positions').toBe(matchingMask);
+  expect(
     () => new GPUReduction({input, output, mask: atomicMask, operation: 'min'}),
-    /same view kind/,
     'vector inputs cannot silently concatenate an atomic selection'
-  );
-  testCase.throws(
+  ).toThrow(/same view kind/);
+  expect(
     () => new GPUReduction({input, output, mask: mismatchedMask, operation: 'min'}),
-    /same chunk topology/,
     'equal total row counts cannot replace matching ordered chunk sizes'
-  );
-  testCase.throws(
+  ).toThrow(/same chunk topology/);
+  expect(
     () => new GPUReduction({input, output, mask: differentChunkCountMask, operation: 'min'}),
-    /same chunk topology/,
     'vector selections must preserve the complete source chunk count'
-  );
-  testCase.end();
+  ).toThrow(/same chunk topology/);
 });
 
 function createView<T extends ScalarFormat>(

--- a/modules/gpgpu/test/gpu-core/gpu-reduction-mask.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-reduction-mask.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {
   GPUCommandGraph,
@@ -16,56 +16,47 @@ import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 type ScalarFormat = 'uint32' | 'sint32' | 'float32';
 type ScalarArray = Uint32Array | Int32Array | Float32Array;
 
-test('GPUReduction filters sums and extrema across every scalar format', async testCase => {
+it('GPUReduction filters sums and extrema across every scalar format', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
   const unsignedValues = Uint32Array.from([0xffffffff, 5, 7, 2]);
   const selection = Uint32Array.from([0, 1, 3, 0]);
-  testCase.deepEqual(
+  expect(
     await runMaskedReduction(device, unsignedValues, selection, 'uint32', 'sum'),
-    [12],
     'unsigned sums accept every nonzero selection and ignore excluded rows'
-  );
-  testCase.deepEqual(
+  ).toEqual([12]);
+  expect(
     await runMaskedReduction(device, unsignedValues, selection, 'uint32', 'min'),
-    [5],
     'unsigned minima do not treat excluded rows as zeros'
-  );
-  testCase.deepEqual(
+  ).toEqual([5]);
+  expect(
     await runMaskedReduction(device, unsignedValues, selection, 'uint32', 'max'),
-    [7],
     'unsigned maxima omit excluded high values'
-  );
-  testCase.deepEqual(
+  ).toEqual([7]);
+  expect(
     await runMaskedReduction(device, unsignedValues, selection, 'uint32', 'extent'),
-    [5, 7],
     'unsigned extents span selected values only'
-  );
+  ).toEqual([5, 7]);
 
   const signedValues = Int32Array.from([-30, -9, -4, 90]);
-  testCase.deepEqual(
+  expect(
     await runMaskedReduction(device, signedValues, selection, 'sint32', 'sum'),
-    [-13],
     'signed sums preserve negative selected values'
-  );
-  testCase.deepEqual(
+  ).toEqual([-13]);
+  expect(
     await runMaskedReduction(device, signedValues, selection, 'sint32', 'extent'),
-    [-9, -4],
     'signed extrema do not inject excluded zero values'
-  );
+  ).toEqual([-9, -4]);
 
   const floatingValues = Float32Array.from([Number.NaN, -1.5, 4.5, Number.POSITIVE_INFINITY]);
-  testCase.deepEqual(
+  expect(
     await runMaskedReduction(device, floatingValues, selection, 'float32', 'sum'),
-    [3],
     'excluded floating NaN and infinities cannot contaminate selected sums'
-  );
-  testCase.deepEqual(
+  ).toEqual([3]);
+  expect(
     await runMaskedReduction(
       device,
       Float32Array.from([Number.NaN, Number.POSITIVE_INFINITY, 2]),
@@ -73,60 +64,49 @@ test('GPUReduction filters sums and extrema across every scalar format', async t
       'float32',
       'sum'
     ),
-    [2],
     'masked floating sums also ignore selected non-finite samples'
-  );
-  testCase.deepEqual(
+  ).toEqual([2]);
+  expect(
     await runMaskedReduction(device, floatingValues, selection, 'float32', 'extent'),
-    [-1.5, 4.5],
     'floating extrema combine source selection with finite-value filtering'
-  );
-  testCase.end();
+  ).toEqual([-1.5, 4.5]);
 });
 
-test('GPUReduction returns zero for fully excluded rows and preserves hierarchical validity', async testCase => {
+it('GPUReduction returns zero for fully excluded rows and preserves hierarchical validity', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
   const values = Uint32Array.from([9, 13, 21]);
   const excluded = new Uint32Array(values.length);
   for (const operation of ['sum', 'min', 'max', 'extent'] as const) {
-    testCase.deepEqual(
+    expect(
       await runMaskedReduction(device, values, excluded, 'uint32', operation),
-      operation === 'extent' ? [0, 0] : [0],
       `fully excluded unsigned ${operation} results use the documented zero sentinel`
-    );
+    ).toEqual(operation === 'extent' ? [0, 0] : [0]);
   }
 
   const hierarchicalValues = Int32Array.from({length: 769}, (_, index) => index - 900);
   const hierarchicalSelection = new Uint32Array(hierarchicalValues.length);
   hierarchicalSelection[512] = 1;
   hierarchicalSelection[768] = 9;
-  testCase.deepEqual(
+  expect(
     await runMaskedReduction(device, hierarchicalValues, hierarchicalSelection, 'sint32', 'extent'),
-    [-388, -132],
     'invalid workgroups cannot inject zeros while merging later selected negative values'
-  );
+  ).toEqual([-388, -132]);
 
   const floatingValues = Float32Array.from([Number.NaN, Number.POSITIVE_INFINITY, 12]);
   const floatingSelection = Uint32Array.from([1, 1, 0]);
-  testCase.deepEqual(
+  expect(
     await runMaskedReduction(device, floatingValues, floatingSelection, 'float32', 'max'),
-    [0],
     'selected nonfinite floating values do not produce valid extrema'
-  );
-  testCase.end();
+  ).toEqual([0]);
 });
 
-test('GPUReduction preserves aligned masks across empty and fully excluded vector chunks', async testCase => {
+it('GPUReduction preserves aligned masks across empty and fully excluded vector chunks', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
@@ -136,38 +116,32 @@ test('GPUReduction preserves aligned masks across empty and fully excluded vecto
     Int32Array.from([-8, -3, -1])
   ];
   const maskChunks = [Uint32Array.from([0, 0]), new Uint32Array(0), Uint32Array.from([1, 7, 0])];
-  testCase.deepEqual(
+  expect(
     await runMaskedVectorReduction(device, signedChunks, maskChunks, 'sint32', 'sum'),
-    [-11],
     'masked chunk sums preserve source positions across empty chunks'
-  );
-  testCase.deepEqual(
+  ).toEqual([-11]);
+  expect(
     await runMaskedVectorReduction(device, signedChunks, maskChunks, 'sint32', 'min'),
-    [-8],
     'fully excluded first chunks do not introduce zero minima'
-  );
-  testCase.deepEqual(
+  ).toEqual([-8]);
+  expect(
     await runMaskedVectorReduction(device, signedChunks, maskChunks, 'sint32', 'max'),
-    [-3],
     'fully excluded first chunks do not introduce zero maxima'
-  );
-  testCase.deepEqual(
+  ).toEqual([-3]);
+  expect(
     await runMaskedVectorReduction(device, signedChunks, maskChunks, 'sint32', 'extent'),
-    [-8, -3],
     'chunk validity propagates through the final signed extent merge'
-  );
+  ).toEqual([-8, -3]);
 
   const floatingChunks = [
     Float32Array.from([Number.NaN, Number.POSITIVE_INFINITY]),
     Float32Array.from([3.5, -2.5])
   ];
   const floatingMasks = [Uint32Array.from([1, 1]), Uint32Array.from([0, 1])];
-  testCase.deepEqual(
+  expect(
     await runMaskedVectorReduction(device, floatingChunks, floatingMasks, 'float32', 'extent'),
-    [-2.5, -2.5],
     'invalid-only floating chunks preserve the selected finite chunk extent'
-  );
-  testCase.end();
+  ).toEqual([-2.5, -2.5]);
 });
 
 async function runMaskedReduction(

--- a/modules/gpgpu/test/gpu-core/gpu-scene-draw-generation.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-scene-draw-generation.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {
   CompiledGPUCommandGraph,
@@ -18,11 +18,9 @@ import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 const STORAGE_USAGE = Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC;
 const BOUNDS = {minimum: [0, 0, 0], maximum: [1, 1, 1]} as const;
 
-test('GPUSceneDrawGeneration publishes deterministic bounded commands and re-encodes visibility', async t => {
+it('GPUSceneDrawGeneration publishes deterministic bounded commands and re-encodes visibility', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -65,7 +63,7 @@ test('GPUSceneDrawGeneration publishes deterministic bounded commands and re-enc
     overflow: overflow.view
   });
   generation.addToGraph(graph);
-  t.deepEqual(generation.stats, {
+  expect(generation.stats).toEqual({
     recordCount: 6,
     recordCapacity: 6,
     commandCapacity: 4,
@@ -76,25 +74,24 @@ test('GPUSceneDrawGeneration publishes deterministic bounded commands and re-enc
 
   const compiled = graph.compile();
   await encodeAndSubmit(device, compiled);
-  t.deepEqual(
+  expect(
     await readDrawWords(commands),
-    [3, 1, 10, 1, 4, 0, 20, 0, 5, 1, 30, 0, 6, 0, 40, 0],
     'the lowest scene row owns collisions and static geometry fields remain unchanged'
-  );
-  t.deepEqual(
+  ).toEqual([3, 1, 10, 1, 4, 0, 20, 0, 5, 1, 30, 0, 6, 0, 40, 0]);
+  expect(
     await readDiagnostics(required.buffer, published.buffer, overflow.buffer),
-    [4, 2, 1],
     'out-of-range and colliding requests report required, published, and overflow state'
-  );
+  ).toEqual([4, 2, 1]);
 
   visibilityBuffer.write(new Uint32Array([0, 0, 1, 0, 1, 1]));
   await encodeAndSubmit(device, compiled);
-  t.deepEqual(
+  expect(
     await readDrawWords(commands),
-    [3, 0, 10, 0, 4, 1, 20, 5, 5, 1, 30, 2, 6, 0, 40, 0],
     'parameter-only visibility changes clear and republish the same compiled graph'
-  );
-  t.deepEqual(await readDiagnostics(required.buffer, published.buffer, overflow.buffer), [2, 2, 0]);
+  ).toEqual([3, 0, 10, 0, 4, 1, 20, 5, 5, 1, 30, 2, 6, 0, 40, 0]);
+  expect(await readDiagnostics(required.buffer, published.buffer, overflow.buffer)).toEqual([
+    2, 2, 0
+  ]);
 
   compiled.destroy();
   scene.destroy();
@@ -103,14 +100,11 @@ test('GPUSceneDrawGeneration publishes deterministic bounded commands and re-enc
   required.buffer.destroy();
   published.buffer.destroy();
   overflow.buffer.destroy();
-  t.end();
 });
 
-test('GPUSceneDrawGeneration supports indexed commands, inactive rows, and validation', async t => {
+it('GPUSceneDrawGeneration supports indexed commands, inactive rows, and validation', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -138,23 +132,25 @@ test('GPUSceneDrawGeneration supports indexed commands, inactive rows, and valid
   const compiled = graph.compile();
 
   await encodeAndSubmit(device, compiled);
-  t.deepEqual(
+  expect(
     await readDrawWords(commands),
-    [36, 1, 2, 0xffffffff, 0],
     'indexed geometry fields and signed baseVertex bits survive publication'
-  );
-  t.deepEqual(await readDiagnostics(required.buffer, published.buffer, overflow.buffer), [1, 1, 0]);
+  ).toEqual([36, 1, 2, 0xffffffff, 0]);
+  expect(await readDiagnostics(required.buffer, published.buffer, overflow.buffer)).toEqual([
+    1, 1, 0
+  ]);
 
   scene.mutate({remove: [20]});
   await encodeAndSubmit(device, compiled);
-  t.deepEqual(
+  expect(
     await readDrawWords(commands),
-    [36, 0, 2, 0xffffffff, 0],
     'inactive rows clear their prior command without CPU draw selection'
-  );
-  t.deepEqual(await readDiagnostics(required.buffer, published.buffer, overflow.buffer), [0, 0, 0]);
+  ).toEqual([36, 0, 2, 0xffffffff, 0]);
+  expect(await readDiagnostics(required.buffer, published.buffer, overflow.buffer)).toEqual([
+    0, 0, 0
+  ]);
 
-  t.throws(
+  expect(
     () =>
       new GPUSceneDrawGeneration({
         scene: sceneView,
@@ -163,9 +159,8 @@ test('GPUSceneDrawGeneration supports indexed commands, inactive rows, and valid
         publishedCount: published.view,
         overflow: overflow.view
       }),
-    /outputs cannot overlap/,
     'diagnostics cannot alias writable indirect commands'
-  );
+  ).toThrow(/outputs cannot overlap/);
 
   compiled.destroy();
   scene.destroy();
@@ -173,14 +168,11 @@ test('GPUSceneDrawGeneration supports indexed commands, inactive rows, and valid
   required.buffer.destroy();
   published.buffer.destroy();
   overflow.buffer.destroy();
-  t.end();
 });
 
-test('GPUSceneDrawGeneration discovers inserted records across the full scene capacity', async t => {
+it('GPUSceneDrawGeneration discovers inserted records across the full scene capacity', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -206,12 +198,14 @@ test('GPUSceneDrawGeneration discovers inserted records across the full scene ca
     overflow: overflow.view
   });
   generation.addToGraph(graph);
-  t.equal(generation.stats.recordCount, 0, 'the imported active prefix starts empty');
-  t.equal(generation.stats.recordCapacity, 2, 'dispatch spans the reserved record capacity');
+  expect(generation.stats.recordCount, 'the imported active prefix starts empty').toBe(0);
+  expect(generation.stats.recordCapacity, 'dispatch spans the reserved record capacity').toBe(2);
 
   const compiled = graph.compile();
   await encodeAndSubmit(device, compiled);
-  t.deepEqual(await readDiagnostics(required.buffer, published.buffer, overflow.buffer), [0, 0, 0]);
+  expect(await readDiagnostics(required.buffer, published.buffer, overflow.buffer)).toEqual([
+    0, 0, 0
+  ]);
 
   scene.mutate({
     insert: [
@@ -220,8 +214,10 @@ test('GPUSceneDrawGeneration discovers inserted records across the full scene ca
     ]
   });
   await encodeAndSubmit(device, compiled);
-  t.deepEqual(await readDrawWords(commands), [3, 1, 0, 0, 4, 1, 0, 1]);
-  t.deepEqual(await readDiagnostics(required.buffer, published.buffer, overflow.buffer), [2, 2, 0]);
+  expect(await readDrawWords(commands)).toEqual([3, 1, 0, 0, 4, 1, 0, 1]);
+  expect(await readDiagnostics(required.buffer, published.buffer, overflow.buffer)).toEqual([
+    2, 2, 0
+  ]);
 
   compiled.destroy();
   scene.destroy();
@@ -229,14 +225,11 @@ test('GPUSceneDrawGeneration discovers inserted records across the full scene ca
   required.buffer.destroy();
   published.buffer.destroy();
   overflow.buffer.destroy();
-  t.end();
 });
 
-test('GPUSceneDrawGeneration rejects devices without indirect-first-instance', async t => {
+it('GPUSceneDrawGeneration rejects devices without indirect-first-instance', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device || device.features.has('indirect-first-instance')) {
-    t.comment('A WebGPU device without indirect-first-instance is not available');
-    t.end();
     return;
   }
 
@@ -257,18 +250,16 @@ test('GPUSceneDrawGeneration rejects devices without indirect-first-instance', a
     overflow: overflow.view
   });
 
-  t.throws(
+  expect(
     () => generation.addToGraph(graph),
-    /indirect-first-instance/,
     'nonzero first-instance publication requires the optional WebGPU feature'
-  );
+  ).toThrow(/indirect-first-instance/);
 
   scene.destroy();
   commands.destroy();
   required.buffer.destroy();
   published.buffer.destroy();
   overflow.buffer.destroy();
-  t.end();
 });
 
 function makeScalar(

--- a/modules/gpgpu/test/gpu-core/gpu-scene-resource-groups.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-scene-resource-groups.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {
   DrawCommandBuffer,
@@ -20,36 +20,29 @@ const STORAGE_USAGE = Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC;
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 const BOUNDS = {minimum: [0, 0, 0], maximum: [1, 1, 1]} as const;
 
-test('GPUSceneResourceGroups plans bounded multidimensional command dispatches', t => {
-  t.deepEqual(getGPUSceneResourceGroupDispatchLayout(0, 4), {x: 1, y: 1, z: 1});
-  t.deepEqual(
+it('GPUSceneResourceGroups plans bounded multidimensional command dispatches', () => {
+  expect(getGPUSceneResourceGroupDispatchLayout(0, 4)).toEqual({x: 1, y: 1, z: 1});
+  expect(
     getGPUSceneResourceGroupDispatchLayout(4 * 256, 4),
-    {x: 4, y: 1, z: 1},
     'one-dimensional dispatch remains valid at its exact limit'
-  );
-  t.deepEqual(
+  ).toEqual({x: 4, y: 1, z: 1});
+  expect(
     getGPUSceneResourceGroupDispatchLayout(4 * 256 + 1, 4),
-    {x: 4, y: 2, z: 1},
     'commands beyond the X workgroup limit spill into Y'
-  );
-  t.deepEqual(
+  ).toEqual({x: 4, y: 2, z: 1});
+  expect(
     getGPUSceneResourceGroupDispatchLayout(4 * 4 * 256 + 1, 4),
-    {x: 4, y: 4, z: 2},
     'commands beyond the XY workgroup limit spill into Z'
-  );
-  t.throws(
+  ).toEqual({x: 4, y: 4, z: 2});
+  expect(
     () => getGPUSceneResourceGroupDispatchLayout((4 * 4 * 4 + 1) * 256, 4),
-    /dispatch limit/,
     'capacities beyond all three supported dimensions fail before encoding'
-  );
-  t.end();
+  ).toThrow(/dispatch limit/);
 });
 
-test('GPUSceneResourceGroups preserves binding order and classifies regrouped commands', async t => {
+it('GPUSceneResourceGroups preserves binding order and classifies regrouped commands', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -105,7 +98,7 @@ test('GPUSceneResourceGroups preserves binding order and classifies regrouped co
     overflows: overflows.view,
     overflow: overflow.view
   });
-  t.deepEqual(groups.stats, {
+  expect(groups.stats).toEqual({
     groupCount: 3,
     commandCapacity: 5,
     maximumGroupCommandCount: 2,
@@ -115,17 +108,15 @@ test('GPUSceneResourceGroups preserves binding order and classifies regrouped co
   const compiled = graph.compile();
 
   encode(device, compiled);
-  t.deepEqual(
+  expect(
     await readUint32(counts.buffer, 3),
-    [2, 1, 0],
     'renderer-authored group order is stable and empty groups remain present'
-  );
-  t.deepEqual(
+  ).toEqual([2, 1, 0]);
+  expect(
     await readUint32(overflows.buffer, 3),
-    [0, 0, 1],
     'an active command targeting a zero-capacity group is reported on that group'
-  );
-  t.deepEqual(await readUint32(overflow.buffer, 1), [1], 'unknown groups remain observable');
+  ).toEqual([0, 0, 1]);
+  expect(await readUint32(overflow.buffer, 1), 'unknown groups remain observable').toEqual([1]);
 
   scene.mutate({
     remove: [13],
@@ -136,27 +127,27 @@ test('GPUSceneResourceGroups preserves binding order and classifies regrouped co
     ]
   });
   encode(device, compiled);
-  t.deepEqual(
+  expect(
     await readUint32(counts.buffer, 3),
-    [1, 2, 0],
     'changed group ownership reclassifies commands without rebuilding the compiled graph'
-  );
-  t.deepEqual(
+  ).toEqual([1, 2, 0]);
+  expect(
     await readUint32(overflows.buffer, 3),
-    [1, 0, 0],
     'geometry/resource mismatches are attributed to the owning group'
-  );
+  ).toEqual([1, 0, 0]);
 
   scene.mutate({update: [{id: 12, geometryId: 20}]});
   encode(device, compiled);
-  t.deepEqual(await readUint32(counts.buffer, 3), [2, 2, 0]);
-  t.deepEqual(await readUint32(overflows.buffer, 3), [0, 0, 0]);
-  t.deepEqual(await readUint32(overflow.buffer, 1), [0], 'overflow clears after regrouping');
+  expect(await readUint32(counts.buffer, 3)).toEqual([2, 2, 0]);
+  expect(await readUint32(overflows.buffer, 3)).toEqual([0, 0, 0]);
+  expect(await readUint32(overflow.buffer, 1), 'overflow clears after regrouping').toEqual([0]);
 
   visibilityBuffer.write(new Uint32Array(5));
   encode(device, compiled);
-  t.deepEqual(await readUint32(counts.buffer, 3), [0, 0, 0], 'all groups clear when draws vanish');
-  t.deepEqual(await readUint32(overflow.buffer, 1), [0]);
+  expect(await readUint32(counts.buffer, 3), 'all groups clear when draws vanish').toEqual([
+    0, 0, 0
+  ]);
+  expect(await readUint32(overflow.buffer, 1)).toEqual([0]);
 
   compiled.destroy();
   scene.destroy();
@@ -165,14 +156,11 @@ test('GPUSceneResourceGroups preserves binding order and classifies regrouped co
   for (const output of [required, published, drawOverflow, counts, overflows, overflow]) {
     output.buffer.destroy();
   }
-  t.end();
 });
 
-test('GPUSceneResourceGroups rejects ambiguous windows and aliased diagnostics', async t => {
+it('GPUSceneResourceGroups rejects ambiguous windows and aliased diagnostics', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -197,7 +185,7 @@ test('GPUSceneResourceGroups rejects ambiguous windows and aliased diagnostics',
     overflow: overflow.view
   };
 
-  t.throws(
+  expect(
     () =>
       new GPUSceneResourceGroups({
         ...shared,
@@ -206,10 +194,9 @@ test('GPUSceneResourceGroups rejects ambiguous windows and aliased diagnostics',
           {id: 1, firstCommand: 1, commandCount: 1}
         ]
       }),
-    /unique IDs/,
     'one resource identity cannot have ambiguous binding groups'
-  );
-  t.throws(
+  ).toThrow(/unique IDs/);
+  expect(
     () =>
       new GPUSceneResourceGroups({
         ...shared,
@@ -218,42 +205,36 @@ test('GPUSceneResourceGroups rejects ambiguous windows and aliased diagnostics',
           {id: 2, firstCommand: 1, commandCount: 1}
         ]
       }),
-    /must not overlap/,
     'binding-group command windows must remain disjoint'
-  );
-  t.throws(
+  ).toThrow(/must not overlap/);
+  expect(
     () =>
       new GPUSceneResourceGroups({
         ...shared,
         groups: [{id: 1, firstCommand: 1, commandCount: 2}]
       }),
-    /bounded slot windows/,
     'renderer-owned windows cannot exceed command capacity'
-  );
-  t.throws(
+  ).toThrow(/bounded slot windows/);
+  expect(
     () =>
       new GPUSceneResourceGroups({
         ...shared,
         groups: [{id: 1, firstCommand: 0, commandCount: 1}],
         overflow: counts.view
       }),
-    /cannot overlap one another/,
     'global and per-group diagnostics cannot alias'
-  );
+  ).toThrow(/cannot overlap one another/);
 
   scene.destroy();
   commands.destroy();
   counts.buffer.destroy();
   overflows.buffer.destroy();
   overflow.buffer.destroy();
-  t.end();
 });
 
-test('GPUSceneResourceGroups classifies records inserted after graph compilation', async t => {
+it('GPUSceneResourceGroups classifies records inserted after graph compilation', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -290,7 +271,7 @@ test('GPUSceneResourceGroups classifies records inserted after graph compilation
 
   const compiled = graph.compile();
   encode(device, compiled);
-  t.deepEqual(await readUint32(counts.buffer, 1), [0]);
+  expect(await readUint32(counts.buffer, 1)).toEqual([0]);
 
   scene.mutate({
     insert: [
@@ -299,9 +280,9 @@ test('GPUSceneResourceGroups classifies records inserted after graph compilation
     ]
   });
   encode(device, compiled);
-  t.deepEqual(await readUint32(counts.buffer, 1), [2]);
-  t.deepEqual(await readUint32(overflows.buffer, 1), [0]);
-  t.deepEqual(await readUint32(overflow.buffer, 1), [0]);
+  expect(await readUint32(counts.buffer, 1)).toEqual([2]);
+  expect(await readUint32(overflows.buffer, 1)).toEqual([0]);
+  expect(await readUint32(overflow.buffer, 1)).toEqual([0]);
 
   compiled.destroy();
   scene.destroy();
@@ -309,7 +290,6 @@ test('GPUSceneResourceGroups classifies records inserted after graph compilation
   for (const output of [required, published, drawOverflow, counts, overflows, overflow]) {
     output.buffer.destroy();
   }
-  t.end();
 });
 
 function makeOutput(

--- a/modules/gpgpu/test/gpu-core/gpu-scene.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-scene.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer} from '@luma.gl/core';
 import {
   GPUCommandGraph,
@@ -15,11 +15,9 @@ import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
 const REQUIRED_USAGE = Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC;
 
-test('GPUScene stores fixed-layout records and publishes graph views', async t => {
+it('GPUScene stores fixed-layout records and publishes graph views', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -43,34 +41,31 @@ test('GPUScene stores fixed-layout records and publishes graph views', async t =
   const records = new DataView(recordBytes.buffer, recordBytes.byteOffset, recordBytes.byteLength);
   const second = GPU_SCENE_RECORD_BYTE_LENGTH;
 
-  t.equal(records.getUint32(0, true), 10, 'stable object ID is stored');
-  t.equal(records.getUint32(4, true), GPU_SCENE_ACTIVE_FLAG, 'initial records are active');
-  t.equal(records.getUint32(8, true), GPU_SCENE_INVALID_REFERENCE, 'references default to invalid');
-  t.deepEqual(
-    [records.getFloat32(32, true), records.getFloat32(36, true), records.getFloat32(40, true)],
-    [-1, -2, -3],
-    'bounds occupy fixed field offsets'
+  expect(records.getUint32(0, true), 'stable object ID is stored').toBe(10);
+  expect(records.getUint32(4, true), 'initial records are active').toBe(GPU_SCENE_ACTIVE_FLAG);
+  expect(records.getUint32(8, true), 'references default to invalid').toBe(
+    GPU_SCENE_INVALID_REFERENCE
   );
-  t.equal(records.getFloat32(64, true), 1, 'the default transform is identity');
-  t.equal(records.getFloat32(84, true), 1, 'the second identity diagonal is present');
-  t.deepEqual(
+  expect(
+    [records.getFloat32(32, true), records.getFloat32(36, true), records.getFloat32(40, true)],
+    'bounds occupy fixed field offsets'
+  ).toEqual([-1, -2, -3]);
+  expect(records.getFloat32(64, true), 'the default transform is identity').toBe(1);
+  expect(records.getFloat32(84, true), 'the second identity diagonal is present').toBe(1);
+  expect(
     [
       records.getUint32(second + 8, true),
       records.getUint32(second + 12, true),
       records.getUint32(second + 16, true)
     ],
-    [2, 3, 4],
     'group, geometry, and command references are explicit'
-  );
-  t.equal(records.getFloat32(second + 112, true), 13, 'custom transforms are column-major');
+  ).toEqual([2, 3, 4]);
+  expect(records.getFloat32(second + 112, true), 'custom transforms are column-major').toBe(13);
   const stateBytes = await scene.stateBuffer.readAsync();
-  t.deepEqual(
-    Array.from(
-      new Uint32Array(stateBytes.buffer, stateBytes.byteOffset, stateBytes.byteLength / 4)
-    ),
-    [2, 2, 0, 0]
-  );
-  t.deepEqual(scene.stats, {
+  expect(
+    Array.from(new Uint32Array(stateBytes.buffer, stateBytes.byteOffset, stateBytes.byteLength / 4))
+  ).toEqual([2, 2, 0, 0]);
+  expect(scene.stats).toEqual({
     capacity: 3,
     recordCount: 2,
     activeCount: 2,
@@ -79,32 +74,32 @@ test('GPUScene stores fixed-layout records and publishes graph views', async t =
     stateBufferByteLength: 16,
     outputByteLength: 400
   });
-  t.equal(scene.getRecordByteOffset(2), 256);
-  t.throws(() => scene.getRecordByteOffset(3), /out of range/);
+  expect(scene.getRecordByteOffset(2)).toBe(256);
+  expect(() => scene.getRecordByteOffset(3)).toThrow(/out of range/);
 
   const graph = new GPUCommandGraph(device, {id: 'scene-graph'});
   const view = scene.importToGraph(graph);
-  t.equal(view.objectIds.format, 'uint32');
-  t.equal(view.objectIds.byteStride, 128);
-  t.equal(view.boundsMinimum.byteOffset, 32);
-  t.deepEqual(
+  expect(view.objectIds.format).toBe('uint32');
+  expect(view.objectIds.byteStride).toBe(128);
+  expect(view.boundsMinimum.byteOffset).toBe(32);
+  expect(
     view.transformColumns.map(column => column.byteOffset),
-    [64, 80, 96, 112],
     'all transform columns are addressable without repacking'
-  );
+  ).toEqual([64, 80, 96, 112]);
   graph.compile().destroy();
-  t.notOk(scene.recordBuffer.destroyed, 'compiled graphs only borrow scene storage');
+  expect(Boolean(scene.recordBuffer.destroyed), 'compiled graphs only borrow scene storage').toBe(
+    false
+  );
   scene.destroy();
-  t.ok(scene.recordBuffer.destroyed, 'owned buffers are destroyed with the scene');
+  expect(Boolean(scene.recordBuffer.destroyed), 'owned buffers are destroyed with the scene').toBe(
+    true
+  );
   scene.destroy();
-  t.end();
 });
 
-test('GPUScene validates identity, layout, and borrowed ownership', async t => {
+it('GPUScene validates identity, layout, and borrowed ownership', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -116,11 +111,13 @@ test('GPUScene validates identity, layout, and borrowed ownership', async t => {
     buffers: {records: recordBuffer, state: stateBuffer}
   });
   scene.destroy();
-  t.notOk(recordBuffer.destroyed, 'borrowed record storage remains caller-owned');
-  t.notOk(stateBuffer.destroyed, 'borrowed state storage remains caller-owned');
+  expect(Boolean(recordBuffer.destroyed), 'borrowed record storage remains caller-owned').toBe(
+    false
+  );
+  expect(Boolean(stateBuffer.destroyed), 'borrowed state storage remains caller-owned').toBe(false);
 
   const bounds = {minimum: [0, 0, 0], maximum: [1, 1, 1]} as const;
-  t.throws(
+  expect(
     () =>
       new GPUScene(device, {
         records: [
@@ -128,64 +125,54 @@ test('GPUScene validates identity, layout, and borrowed ownership', async t => {
           {id: 1, bounds}
         ]
       }),
-    /duplicated/,
     'stable IDs are unique'
-  );
-  t.throws(
+  ).toThrow(/duplicated/);
+  expect(
     () =>
       new GPUScene(device, {
         records: [{id: 1, bounds: {minimum: [2, 0, 0], maximum: [1, 1, 1]}}]
       }),
-    /ordered minima/,
     'bounds are ordered'
-  );
-  t.throws(
+  ).toThrow(/ordered minima/);
+  expect(
     () => new GPUScene(device, {records: [{id: 1, bounds, transform: [1, 2]}]}),
-    /16 finite values/,
     'transforms have a fixed layout'
-  );
-  t.throws(
+  ).toThrow(/16 finite values/);
+  expect(
     () => new GPUScene(device, {capacity: 1, recordCount: 1}),
-    /requires records or pre-populated buffers/,
     'an active prefix cannot be declared over newly allocated empty storage'
-  );
-  t.throws(
+  ).toThrow(/requires records or pre-populated buffers/);
+  expect(
     () =>
       new GPUScene(device, {
         records: [{id: 1, bounds: {minimum: [0, 0, 0], maximum: [1e100, 1, 1]}}]
       }),
-    /finite ordered minima/,
     'finite JavaScript bounds that overflow float32 are rejected'
-  );
-  t.throws(
+  ).toThrow(/finite ordered minima/);
+  expect(
     () =>
       new GPUScene(device, {
         records: [{id: 1, bounds, transform: Array.from({length: 16}, () => 1e100)}]
       }),
-    /16 finite values/,
     'finite JavaScript transforms that overflow float32 are rejected'
-  );
-  t.throws(
+  ).toThrow(/16 finite values/);
+  expect(
     () =>
       new GPUScene(device, {
         capacity: 3,
         recordCount: 0,
         buffers: {records: recordBuffer, state: stateBuffer}
       }),
-    /smaller than/,
     'borrowed buffers cover the declared capacity'
-  );
+  ).toThrow(/smaller than/);
 
   recordBuffer.destroy();
   stateBuffer.destroy();
-  t.end();
 });
 
-test('GPUScene mutates holes, reports overflow, and compacts in stable slot order', async t => {
+it('GPUScene mutates holes, reports overflow, and compacts in stable slot order', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -207,7 +194,7 @@ test('GPUScene mutates holes, reports overflow, and compacts in stable slot orde
       {id: 60, bounds}
     ]
   });
-  t.deepEqual(mutation, {
+  expect(mutation).toEqual({
     insertedIds: [40, 50],
     updatedIds: [30],
     removedIds: [20],
@@ -218,22 +205,22 @@ test('GPUScene mutates holes, reports overflow, and compacts in stable slot orde
     recordCount: 4,
     activeCount: 4
   });
-  t.deepEqual(await readSceneIds(scene, 4), [10, 40, 30, 50], 'the lowest hole is reused first');
-  t.deepEqual(await readSceneState(scene), [4, 4, 1, 0], 'overflow is published to graph state');
-  t.equal(scene.getRecordIndex(40), 1);
+  expect(await readSceneIds(scene, 4), 'the lowest hole is reused first').toEqual([10, 40, 30, 50]);
+  expect(await readSceneState(scene), 'overflow is published to graph state').toEqual([4, 4, 1, 0]);
+  expect(scene.getRecordIndex(40)).toBe(1);
 
   const compacted = scene.mutate({remove: [10, 40], compact: true});
-  t.deepEqual(compacted.moves, [
+  expect(compacted.moves).toEqual([
     {id: 30, from: 2, to: 0},
     {id: 50, from: 3, to: 1}
   ]);
-  t.equal(compacted.uploadedByteLength, 528, 'compaction reports its bounded prefix upload');
-  t.equal(compacted.writeCount, 2, 'one record-prefix write and one state write are issued');
-  t.deepEqual(await readSceneIds(scene, 4), [30, 50, 0, 0]);
-  t.deepEqual(await readSceneState(scene), [2, 2, 0, 0]);
-  t.equal(scene.getRecordIndex(30), 0);
-  t.equal(scene.getRecordIndex(50), 1);
-  t.deepEqual(scene.stats, {
+  expect(compacted.uploadedByteLength, 'compaction reports its bounded prefix upload').toBe(528);
+  expect(compacted.writeCount, 'one record-prefix write and one state write are issued').toBe(2);
+  expect(await readSceneIds(scene, 4)).toEqual([30, 50, 0, 0]);
+  expect(await readSceneState(scene)).toEqual([2, 2, 0, 0]);
+  expect(scene.getRecordIndex(30)).toBe(0);
+  expect(scene.getRecordIndex(50)).toBe(1);
+  expect(scene.stats).toEqual({
     capacity: 4,
     recordCount: 2,
     activeCount: 2,
@@ -244,28 +231,24 @@ test('GPUScene mutates holes, reports overflow, and compacts in stable slot orde
   });
 
   const denseUpdate = scene.mutate({update: [{id: 30, geometryId: 17}], compact: true});
-  t.equal(denseUpdate.writeCount, 2, 'dense compacting updates upload their changed records');
-  t.equal(denseUpdate.uploadedByteLength, 272);
+  expect(denseUpdate.writeCount, 'dense compacting updates upload their changed records').toBe(2);
+  expect(denseUpdate.uploadedByteLength).toBe(272);
   const updatedBytes = await scene.recordBuffer.readAsync();
-  t.equal(
+  expect(
     new DataView(updatedBytes.buffer, updatedBytes.byteOffset).getUint32(12, true),
-    17,
     'the GPU record reflects the dense compacting update'
-  );
+  ).toBe(17);
 
   const denseInsertion = scene.mutate({insert: [{id: 60, bounds}], compact: true});
-  t.equal(denseInsertion.writeCount, 2, 'dense compacting insertions upload their new tail');
-  t.deepEqual(await readSceneIds(scene, 3), [30, 50, 60]);
+  expect(denseInsertion.writeCount, 'dense compacting insertions upload their new tail').toBe(2);
+  expect(await readSceneIds(scene, 3)).toEqual([30, 50, 60]);
 
   scene.destroy();
-  t.end();
 });
 
-test('GPUScene validates complete transactions before changing CPU metadata', async t => {
+it('GPUScene validates complete transactions before changing CPU metadata', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -277,16 +260,14 @@ test('GPUScene validates complete transactions before changing CPU metadata', as
       {id: 2, bounds}
     ]
   });
-  t.throws(
-    () =>
-      scene.mutate({
-        remove: [1],
-        update: [{id: 2, bounds: {minimum: [2, 0, 0], maximum: [1, 1, 1]}}]
-      }),
-    /ordered minima/
-  );
-  t.equal(scene.activeCount, 2, 'a rejected transaction removes nothing');
-  t.equal(scene.getRecordIndex(1), 0, 'stable ID metadata remains unchanged');
+  expect(() =>
+    scene.mutate({
+      remove: [1],
+      update: [{id: 2, bounds: {minimum: [2, 0, 0], maximum: [1, 1, 1]}}]
+    })
+  ).toThrow(/ordered minima/);
+  expect(scene.activeCount, 'a rejected transaction removes nothing').toBe(2);
+  expect(scene.getRecordIndex(1), 'stable ID metadata remains unchanged').toBe(0);
 
   const recordBuffer = device.createBuffer({byteLength: 128, usage: REQUIRED_USAGE});
   const stateBuffer = device.createBuffer({byteLength: 16, usage: REQUIRED_USAGE});
@@ -295,14 +276,15 @@ test('GPUScene validates complete transactions before changing CPU metadata', as
     recordCount: 1,
     buffers: {records: recordBuffer, state: stateBuffer}
   });
-  t.notOk(opaqueScene.mutable, 'opaque borrowed storage does not claim CPU-known IDs');
-  t.throws(() => opaqueScene.compact(), /CPU-known initial records/);
+  expect(Boolean(opaqueScene.mutable), 'opaque borrowed storage does not claim CPU-known IDs').toBe(
+    false
+  );
+  expect(() => opaqueScene.compact()).toThrow(/CPU-known initial records/);
 
   scene.destroy();
   opaqueScene.destroy();
   recordBuffer.destroy();
   stateBuffer.destroy();
-  t.end();
 });
 
 async function readSceneIds(scene: GPUScene, count: number): Promise<number[]> {

--- a/modules/gpgpu/test/gpu-core/gpu-segmented-bvh.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-segmented-bvh.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {
@@ -13,7 +12,7 @@ import {
   type GraphDataView
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {addGPUSegmentedBVHToGraphWithDispatchLimit} from '../../src/gpu-core/gpu-segmented-bvh';
 
 const SOURCE_GAP = -123_456;
@@ -22,15 +21,13 @@ const OUTPUT_GAP = 0xdeadbeef;
 const INVALID_NODE = 0xffffffff;
 const MAXIMUM_FLOAT32 = new Float32Array([3.402823466e38])[0];
 
-test('GPUSegmentedBVH refits mixed packed 2D and 3D hierarchies within CORE limits', async t => {
+it('GPUSegmentedBVH refits mixed packed 2D and 3D hierarchies within CORE limits', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
-  t.equal(device.limits.maxStorageBuffersPerShaderStage, 8, 'uses the standard CORE limit');
+  expect(device.limits.maxStorageBuffersPerShaderStage, 'uses the standard CORE limit').toBe(8);
   const capacities = [1, 1, 2, 4, 8, 16, 32, 64, 128];
   const sourceCounts = [0, 1, 3, 3, 5, 9, 17, 33, 65];
 
@@ -40,32 +37,28 @@ test('GPUSegmentedBVH refits mixed packed 2D and 3D hierarchies within CORE limi
 
     try {
       encodeFixture(device, compiled);
-      await assertFixture(t, fixture, `${dimension}D`);
-      t.deepEqual(
+      await assertFixture(fixture, `${dimension}D`);
+      expect(
         compiled.stats.nodeOrder,
+        `${dimension}D mixed independent trees use at most eight CORE graph nodes`
+      ).toEqual(
         [1, 2, 4, 8, 16, 32, 64, 128].map(
           leafCapacity => `segmented-bvh-fused-refit-${leafCapacity}`
-        ),
-        `${dimension}D mixed independent trees use at most eight CORE graph nodes`
+        )
       );
-      t.equal(
+      expect(
         compiled.stats.logicalTransientBufferCount,
-        0,
         `${dimension}D hierarchy descriptors allocate no GPU scratch`
-      );
+      ).toBe(0);
     } finally {
       destroyFixture(fixture, compiled);
     }
   }
-
-  t.end();
 });
 
-test('GPUSegmentedBVH refits 96 independent four-leaf trees in one eight-binding dispatch', async t => {
+it('GPUSegmentedBVH refits 96 independent four-leaf trees in one eight-binding dispatch', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -80,31 +73,31 @@ test('GPUSegmentedBVH refits 96 independent four-leaf trees in one eight-binding
 
   try {
     encodeFixture(device, compiled);
-    await assertFixture(t, fixture, '96-tree');
+    await assertFixture(fixture, '96-tree');
     const source = dispatch.mock.instances.at(-1)?.source ?? '';
 
-    t.deepEqual(compiled.stats.nodeOrder, ['segmented-bvh-fused-refit-4']);
-    t.equal(dispatch.mock.calls.length, 1, 'all 96 independent hierarchies require one dispatch');
-    t.deepEqual(dispatch.mock.calls[0].slice(1), [96, 1, 1], 'one workgroup handles each tree');
-    t.ok(source.includes('@workgroup_size(4)'), 'only four lanes wake for each four-leaf tree');
-    t.equal(
-      (source.match(/@group\(0\) @binding\(/g) ?? []).length,
-      8,
-      'the batched hierarchy consumes exactly the CORE storage-buffer limit'
+    expect(compiled.stats.nodeOrder).toEqual(['segmented-bvh-fused-refit-4']);
+    expect(dispatch.mock.calls.length, 'all 96 independent hierarchies require one dispatch').toBe(
+      1
     );
+    expect(dispatch.mock.calls[0].slice(1), 'one workgroup handles each tree').toEqual([96, 1, 1]);
+    expect(
+      Boolean(source.includes('@workgroup_size(4)')),
+      'only four lanes wake for each four-leaf tree'
+    ).toBe(true);
+    expect(
+      (source.match(/@group\(0\) @binding\(/g) ?? []).length,
+      'the batched hierarchy consumes exactly the CORE storage-buffer limit'
+    ).toBe(8);
   } finally {
     dispatch.mockRestore();
     destroyFixture(fixture, compiled);
   }
-
-  t.end();
 });
 
-test('GPUSegmentedBVH bounds singleton hierarchy workgroups across all three dispatch dimensions', async t => {
+it('GPUSegmentedBVH bounds singleton hierarchy workgroups across all three dispatch dimensions', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -115,29 +108,29 @@ test('GPUSegmentedBVH bounds singleton hierarchy workgroups across all three dis
 
   try {
     encodeFixture(device, compiled);
-    await assertFixture(t, fixture, 'bounded singleton');
-    t.deepEqual(dispatch.mock.calls[0].slice(1), [2, 2, 2], 'workgroups span three dimensions');
-    t.ok(
-      (dispatch.mock.instances.at(-1)?.source ?? '').includes('@workgroup_size(1)'),
+    await assertFixture(fixture, 'bounded singleton');
+    expect(dispatch.mock.calls[0].slice(1), 'workgroups span three dimensions').toEqual([2, 2, 2]);
+    expect(
+      Boolean((dispatch.mock.instances.at(-1)?.source ?? '').includes('@workgroup_size(1)')),
       'singleton roots use exactly one invocation per workgroup'
-    );
-    t.ok(
-      (dispatch.mock.instances.at(-1)?.source ?? '').includes('if (segmentIndex >= SEGMENT_COUNT)'),
+    ).toBe(true);
+    expect(
+      Boolean(
+        (dispatch.mock.instances.at(-1)?.source ?? '').includes(
+          'if (segmentIndex >= SEGMENT_COUNT)'
+        )
+      ),
       'surplus padded workgroups do not touch caller-owned output gaps'
-    );
+    ).toBe(true);
   } finally {
     dispatch.mockRestore();
     destroyFixture(fixture, compiled);
   }
-
-  t.end();
 });
 
-test('GPUSegmentedBVH refits caller-owned source changes without rebuilding the graph', async t => {
+it('GPUSegmentedBVH refits caller-owned source changes without rebuilding the graph', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -146,7 +139,7 @@ test('GPUSegmentedBVH refits caller-owned source changes without rebuilding the 
 
   try {
     encodeFixture(device, compiled);
-    await assertFixture(t, fixture, 'initial refit');
+    await assertFixture(fixture, 'initial refit');
 
     const segment = fixture.segments[1];
     const minimumIndex = (fixture.minimaPrefix + segment.sourceOffset) * fixture.dimension;
@@ -158,22 +151,19 @@ test('GPUSegmentedBVH refits caller-owned source changes without rebuilding the 
     updateExpectedOutputs(fixture);
 
     encodeFixture(device, compiled);
-    await assertFixture(t, fixture, 'updated refit');
-    t.deepEqual(
+    await assertFixture(fixture, 'updated refit');
+    expect(
       Array.from(
         fixture.expectedNodeMinima.subarray(
           (fixture.nodeMinimaPrefix + segment.nodeOffset) * fixture.dimension,
           (fixture.nodeMinimaPrefix + segment.nodeOffset + 1) * fixture.dimension
         )
       ),
-      [-800, -700, -600],
       'the unchanged graph updates the corresponding independent hierarchy root'
-    );
+    ).toEqual([-800, -700, -600]);
   } finally {
     destroyFixture(fixture, compiled);
   }
-
-  t.end();
 });
 
 type SegmentedBVHFixture = {
@@ -505,11 +495,7 @@ function encodeFixture(device: Device, compiled: CompiledGPUCommandGraph): void 
   device.submit(commandEncoder.finish());
 }
 
-async function assertFixture(
-  testCase: Parameters<Parameters<typeof test>[1]>[0],
-  fixture: SegmentedBVHFixture,
-  label: string
-): Promise<void> {
+async function assertFixture(fixture: SegmentedBVHFixture, label: string): Promise<void> {
   const [minima, maxima, children, leafIds, counts, overflows] = await Promise.all([
     readFloat32(fixture.nodeMinimaBuffer),
     readFloat32(fixture.nodeMaximaBuffer),
@@ -518,35 +504,25 @@ async function assertFixture(
     readUint32(fixture.countsBuffer),
     readUint32(fixture.overflowsBuffer)
   ]);
-  testCase.deepEqual(
+  expect(
     minima,
-    Array.from(fixture.expectedNodeMinima),
     `${label} packed minima preserve gaps, invalid leaves, and independent roots`
-  );
-  testCase.deepEqual(
+  ).toEqual(Array.from(fixture.expectedNodeMinima));
+  expect(
     maxima,
-    Array.from(fixture.expectedNodeMaxima),
     `${label} packed maxima preserve gaps, invalid leaves, and independent roots`
+  ).toEqual(Array.from(fixture.expectedNodeMaxima));
+  expect(children, `${label} complete-binary children stay local to each packed hierarchy`).toEqual(
+    Array.from(fixture.expectedNodeChildren)
   );
-  testCase.deepEqual(
-    children,
-    Array.from(fixture.expectedNodeChildren),
-    `${label} complete-binary children stay local to each packed hierarchy`
+  expect(leafIds, `${label} padded leaves are invalid and populated identities are local`).toEqual(
+    Array.from(fixture.expectedLeafIds)
   );
-  testCase.deepEqual(
-    leafIds,
-    Array.from(fixture.expectedLeafIds),
-    `${label} padded leaves are invalid and populated identities are local`
+  expect(counts, `${label} metadata publishes the full count and preserves every gap`).toEqual(
+    Array.from(fixture.expectedCounts)
   );
-  testCase.deepEqual(
-    counts,
-    Array.from(fixture.expectedCounts),
-    `${label} metadata publishes the full count and preserves every gap`
-  );
-  testCase.deepEqual(
-    overflows,
-    Array.from(fixture.expectedOverflows),
-    `${label} independent overflow flags preserve every gap`
+  expect(overflows, `${label} independent overflow flags preserve every gap`).toEqual(
+    Array.from(fixture.expectedOverflows)
   );
 }
 

--- a/modules/gpgpu/test/gpu-core/gpu-segmented-sort.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-segmented-sort.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {
@@ -14,21 +13,22 @@ import {
   type GPUSortSegment
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {addGPUSegmentedSortToGraphWithDispatchLimit} from '../../src/gpu-core/gpu-segmented-sort';
 
 const UNSORTED_GAP = 0xcafef00d;
 const OUTPUT_GAP = 0xdeadbeef;
 
-test('GPUSegmentedSort stably sorts mixed packed domains and preserves every gap on CORE WebGPU', async t => {
+it('GPUSegmentedSort stably sorts mixed packed domains and preserves every gap on CORE WebGPU', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
-  t.equal(device.limits.maxStorageBuffersPerShaderStage, 8, 'uses the standard CORE storage limit');
+  expect(
+    device.limits.maxStorageBuffersPerShaderStage,
+    'uses the standard CORE storage limit'
+  ).toBe(8);
   const lengths = [0, 1, 2, 3, 5, 9, 17, 33, 65, 129, 255, 256];
 
   for (const direction of ['ascending', 'descending'] as const) {
@@ -39,49 +39,39 @@ test('GPUSegmentedSort stably sorts mixed packed domains and preserves every gap
       encodeFixture(device, compiled);
       const [keys, values, outputKeys, outputValues] = await readFixtureBuffers(fixture);
 
-      t.deepEqual(
-        keys,
-        Array.from(fixture.keyData),
-        `${direction} source key storage is unchanged`
+      expect(keys, `${direction} source key storage is unchanged`).toEqual(
+        Array.from(fixture.keyData)
       );
-      t.deepEqual(
-        values,
-        Array.from(fixture.valueData),
-        `${direction} source payload storage is unchanged`
+      expect(values, `${direction} source payload storage is unchanged`).toEqual(
+        Array.from(fixture.valueData)
       );
-      t.deepEqual(
+      expect(
         outputKeys,
-        Array.from(fixture.expectedOutputKeys),
         `${direction} sorted keys preserve padding, parent offsets, and every gap`
-      );
-      t.deepEqual(
+      ).toEqual(Array.from(fixture.expectedOutputKeys));
+      expect(
         outputValues,
-        Array.from(fixture.expectedOutputValues),
         `${direction} equal-key payloads retain independent source order`
-      );
-      t.deepEqual(
+      ).toEqual(Array.from(fixture.expectedOutputValues));
+      expect(
         compiled.stats.nodeOrder,
-        [2, 4, 8, 16, 32, 64, 128, 256].map(width => `segmented-sort-bitonic-local-${width}`),
         `${direction} independent domains need only one graph node per workgroup width`
+      ).toEqual(
+        [2, 4, 8, 16, 32, 64, 128, 256].map(width => `segmented-sort-bitonic-local-${width}`)
       );
-      t.equal(
+      expect(
         compiled.stats.logicalTransientBufferCount,
-        0,
         'segment descriptors and workgroup-local sorting allocate no GPU scratch buffers'
-      );
+      ).toBe(0);
     } finally {
       destroyFixture(fixture, compiled);
     }
   }
-
-  t.end();
 });
 
-test('GPUSegmentedSort batches many workgroups into one four-binding CORE dispatch', async t => {
+it('GPUSegmentedSort batches many workgroups into one four-binding CORE dispatch', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -98,46 +88,41 @@ test('GPUSegmentedSort batches many workgroups into one four-binding CORE dispat
     const [, , outputKeys, outputValues] = await readFixtureBuffers(fixture);
     const source = dispatch.mock.instances.at(-1)?.source ?? '';
 
-    t.deepEqual(
-      outputKeys,
-      Array.from(fixture.expectedOutputKeys),
-      'all 96 sort domains are correct'
+    expect(outputKeys, 'all 96 sort domains are correct').toEqual(
+      Array.from(fixture.expectedOutputKeys)
     );
-    t.deepEqual(
-      outputValues,
-      Array.from(fixture.expectedOutputValues),
-      'all 96 domains preserve paired values and stable equal keys'
+    expect(outputValues, 'all 96 domains preserve paired values and stable equal keys').toEqual(
+      Array.from(fixture.expectedOutputValues)
     );
-    t.deepEqual(
+    expect(
       compiled.stats.nodeOrder,
-      ['segmented-sort-bitonic-local-4'],
       '96 independent three-row sorts require one graph node'
-    );
-    t.equal(dispatch.mock.calls.length, 1, 'the graph encodes exactly one GPU dispatch');
-    t.deepEqual(dispatch.mock.calls[0].slice(1), [96, 1, 1], 'one workgroup handles each domain');
-    t.ok(source.includes('@workgroup_size(4)'), 'only four lanes wake for each three-row domain');
-    t.ok(
-      source.includes('var<workgroup> cachedKeys: array<u32, 4>'),
+    ).toEqual(['segmented-sort-bitonic-local-4']);
+    expect(dispatch.mock.calls.length, 'the graph encodes exactly one GPU dispatch').toBe(1);
+    expect(dispatch.mock.calls[0].slice(1), 'one workgroup handles each domain').toEqual([
+      96, 1, 1
+    ]);
+    expect(
+      Boolean(source.includes('@workgroup_size(4)')),
+      'only four lanes wake for each three-row domain'
+    ).toBe(true);
+    expect(
+      Boolean(source.includes('var<workgroup> cachedKeys: array<u32, 4>')),
       'source keys are cached once in workgroup storage'
-    );
-    t.equal(
+    ).toBe(true);
+    expect(
       (source.match(/@group\(0\) @binding\(/g) ?? []).length,
-      4,
       'the portable batched shader uses exactly four storage bindings'
-    );
+    ).toBe(4);
   } finally {
     dispatch.mockRestore();
     destroyFixture(fixture, compiled);
   }
-
-  t.end();
 });
 
-test('GPUSegmentedSort bounds segment workgroups across all three dispatch dimensions', async t => {
+it('GPUSegmentedSort bounds segment workgroups across all three dispatch dimensions', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -150,34 +135,33 @@ test('GPUSegmentedSort bounds segment workgroups across all three dispatch dimen
     encodeFixture(device, compiled);
     const [, , outputKeys, outputValues] = await readFixtureBuffers(fixture);
 
-    t.deepEqual(
-      outputKeys,
-      Array.from(fixture.expectedOutputKeys),
-      'all bounded workgroups sort keys'
+    expect(outputKeys, 'all bounded workgroups sort keys').toEqual(
+      Array.from(fixture.expectedOutputKeys)
     );
-    t.deepEqual(
+    expect(
       outputValues,
-      Array.from(fixture.expectedOutputValues),
       'out-of-range padded workgroups leave caller-owned gaps untouched'
-    );
-    t.deepEqual(dispatch.mock.calls[0].slice(1), [2, 2, 2], 'workgroups span all three dimensions');
-    t.ok(
-      (dispatch.mock.instances.at(-1)?.source ?? '').includes('if (segmentIndex >= SEGMENT_COUNT)'),
+    ).toEqual(Array.from(fixture.expectedOutputValues));
+    expect(dispatch.mock.calls[0].slice(1), 'workgroups span all three dimensions').toEqual([
+      2, 2, 2
+    ]);
+    expect(
+      Boolean(
+        (dispatch.mock.instances.at(-1)?.source ?? '').includes(
+          'if (segmentIndex >= SEGMENT_COUNT)'
+        )
+      ),
       'surplus multidimensional workgroups are rejected before descriptor access'
-    );
+    ).toBe(true);
   } finally {
     dispatch.mockRestore();
     destroyFixture(fixture, compiled);
   }
-
-  t.end();
 });
 
-test('GPUSegmentedSort reuses one compiled graph after caller-owned source data changes', async t => {
+it('GPUSegmentedSort reuses one compiled graph after caller-owned source data changes', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -187,10 +171,8 @@ test('GPUSegmentedSort reuses one compiled graph after caller-owned source data 
   try {
     encodeFixture(device, compiled);
     const firstOutput = await readBuffer(fixture.outputKeysBuffer);
-    t.deepEqual(
-      firstOutput,
-      Array.from(fixture.expectedOutputKeys),
-      'initial graph encoding sorts'
+    expect(firstOutput, 'initial graph encoding sorts').toEqual(
+      Array.from(fixture.expectedOutputKeys)
     );
 
     const firstSegment = fixture.segments[0];
@@ -201,21 +183,15 @@ test('GPUSegmentedSort reuses one compiled graph after caller-owned source data 
 
     encodeFixture(device, compiled);
     const [, , outputKeys, outputValues] = await readFixtureBuffers(fixture);
-    t.deepEqual(
-      outputKeys,
-      Array.from(fixture.expectedOutputKeys),
-      're-encoding sees updated keys'
+    expect(outputKeys, 're-encoding sees updated keys').toEqual(
+      Array.from(fixture.expectedOutputKeys)
     );
-    t.deepEqual(
-      outputValues,
-      Array.from(fixture.expectedOutputValues),
-      're-encoding preserves stable duplicate payloads'
+    expect(outputValues, 're-encoding preserves stable duplicate payloads').toEqual(
+      Array.from(fixture.expectedOutputValues)
     );
   } finally {
     destroyFixture(fixture, compiled);
   }
-
-  t.end();
 });
 
 type SegmentedSortFixture = {

--- a/modules/gpgpu/test/gpu-core/gpu-sort.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-sort.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {
@@ -15,14 +14,12 @@ import {
 } from '@luma.gl/gpgpu/gpu-core';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {addGPUSortToGraphWithDispatchLimit} from '../../src/gpu-core/gpu-sort';
 
-test('GPUSort bitonic stably sorts paired uint32 values in both directions', async t => {
+it('GPUSort bitonic stably sorts paired uint32 values in both directions', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const keys = Uint32Array.from([9, 4, 6, 2, 4, 1, 7, 0xffffffff, 1]);
@@ -30,23 +27,19 @@ test('GPUSort bitonic stably sorts paired uint32 values in both directions', asy
   for (const direction of ['ascending', 'descending'] as const) {
     const result = await runSort(device, keys, values, 'bitonic', direction);
     const expected = getStableSortedPairs(keys, values, direction);
-    t.deepEqual(result.keys, expected.keys, `${direction} bitonic keys match`);
-    t.deepEqual(result.values, expected.values, `${direction} bitonic values remain stable`);
-    t.equal(result.resolvedAlgorithm, 'bitonic', 'forced bitonic is reported');
-    t.deepEqual(
+    expect(result.keys, `${direction} bitonic keys match`).toEqual(expected.keys);
+    expect(result.values, `${direction} bitonic values remain stable`).toEqual(expected.values);
+    expect(result.resolvedAlgorithm, 'forced bitonic is reported').toBe('bitonic');
+    expect(
       result.nodeOrder,
-      ['sort-bitonic-local'],
       'one workgroup executes the complete stable bitonic network in a single pass'
-    );
+    ).toEqual(['sort-bitonic-local']);
   }
-  t.end();
 });
 
-test('GPUSort fuses irregular workgroup-local networks on CORE WebGPU devices', async t => {
+it('GPUSort fuses irregular workgroup-local networks on CORE WebGPU devices', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -63,44 +56,35 @@ test('GPUSort fuses irregular workgroup-local networks on CORE WebGPU devices', 
         const paddedLength = 2 ** Math.ceil(Math.log2(length));
         const source = dispatchSpy.mock.instances.at(-1)?.source ?? '';
 
-        t.deepEqual(result.keys, expected.keys, `${length}-row ${direction} local keys match`);
-        t.deepEqual(
-          result.values,
-          expected.values,
-          `${length}-row ${direction} local sort is stable`
+        expect(result.keys, `${length}-row ${direction} local keys match`).toEqual(expected.keys);
+        expect(result.values, `${length}-row ${direction} local sort is stable`).toEqual(
+          expected.values
         );
-        t.deepEqual(
-          result.nodeOrder,
-          ['sort-bitonic-local'],
-          'one workgroup uses exactly one pass'
-        );
-        t.ok(
-          source.includes(`@workgroup_size(${paddedLength})`),
+        expect(result.nodeOrder, 'one workgroup uses exactly one pass').toEqual([
+          'sort-bitonic-local'
+        ]);
+        expect(
+          Boolean(source.includes(`@workgroup_size(${paddedLength})`)),
           `${length}-row workgroups contain only their ${paddedLength} padded lanes`
-        );
-        t.ok(
-          source.includes(`var<workgroup> cachedKeys: array<u32, ${paddedLength}>`),
+        ).toBe(true);
+        expect(
+          Boolean(source.includes(`var<workgroup> cachedKeys: array<u32, ${paddedLength}>`)),
           'each source key is cached in workgroup storage'
-        );
-        t.equal(
+        ).toBe(true);
+        expect(
           (source.match(/keys\[KEYS_OFFSET \+ localInvocationIndex\]/g) ?? []).length,
-          1,
           'the complete sorting network reads each source key from global storage only once'
-        );
+        ).toBe(1);
       }
     }
   } finally {
     dispatchSpy.mockRestore();
   }
-
-  t.end();
 });
 
-test('GPUSort radix stably sorts paired uint32 values in both directions', async t => {
+it('GPUSort radix stably sorts paired uint32 values in both directions', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   let randomState = 0x1234abcd;
@@ -112,19 +96,19 @@ test('GPUSort radix stably sorts paired uint32 values in both directions', async
   for (const direction of ['ascending', 'descending'] as const) {
     const result = await runSort(device, keys, values, 'radix', direction);
     const expected = getStableSortedPairs(keys, values, direction);
-    t.deepEqual(result.keys, expected.keys, `${direction} radix keys match`);
-    t.deepEqual(result.values, expected.values, `${direction} radix values remain stable`);
-    t.equal(result.resolvedAlgorithm, 'radix', 'forced radix is reported');
-    t.ok(result.logicalTransientCount > result.physicalTransientCount, 'radix scratch is reused');
+    expect(result.keys, `${direction} radix keys match`).toEqual(expected.keys);
+    expect(result.values, `${direction} radix values remain stable`).toEqual(expected.values);
+    expect(result.resolvedAlgorithm, 'forced radix is reported').toBe('radix');
+    expect(
+      Boolean(result.logicalTransientCount > result.physicalTransientCount),
+      'radix scratch is reused'
+    ).toBe(true);
   }
-  t.end();
 });
 
-test('GPUSort four-bit radix preserves cross-workgroup stability on CORE WebGPU', async t => {
+it('GPUSort four-bit radix preserves cross-workgroup stability on CORE WebGPU', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -137,24 +121,20 @@ test('GPUSort four-bit radix preserves cross-workgroup stability on CORE WebGPU'
   for (const direction of ['ascending', 'descending'] as const) {
     const result = await runSort(device, keys, values, 'auto', direction);
     const expected = getStableSortedPairs(keys, values, direction);
-    t.deepEqual(result.keys, expected.keys, `${direction} four-bit radix keys match`);
-    t.deepEqual(
-      result.values,
-      expected.values,
-      `${direction} equal keys retain global input order`
+    expect(result.keys, `${direction} four-bit radix keys match`).toEqual(expected.keys);
+    expect(result.values, `${direction} equal keys retain global input order`).toEqual(
+      expected.values
     );
-    t.equal(result.resolvedAlgorithm, 'radix', 'multi-workgroup inputs choose four-bit radix');
-    t.equal(result.nodeOrder.length, 24, 'eight digits each require histogram, scan, and scatter');
+    expect(result.resolvedAlgorithm, 'multi-workgroup inputs choose four-bit radix').toBe('radix');
+    expect(result.nodeOrder.length, 'eight digits each require histogram, scan, and scatter').toBe(
+      24
+    );
   }
-
-  t.end();
 });
 
-test('GPUSort radix scans digit histograms across multiple workgroups on CORE WebGPU', async t => {
+it('GPUSort radix scans digit histograms across multiple workgroups on CORE WebGPU', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -168,27 +148,22 @@ test('GPUSort radix scans digit histograms across multiple workgroups on CORE We
     const result = await runSort(device, keys, values, 'auto', direction);
     const expected = getStableSortedPairs(keys, values, direction);
 
-    t.deepEqual(result.keys, expected.keys, `${direction} multi-workgroup histogram keys match`);
-    t.deepEqual(
+    expect(result.keys, `${direction} multi-workgroup histogram keys match`).toEqual(expected.keys);
+    expect(
       result.values,
-      expected.values,
       `${direction} equal keys retain stable order across histogram scan carries`
-    );
-    t.ok(
-      result.nodeOrder.includes('sort-radix-digit-0-scan-level-0-add-offsets'),
+    ).toEqual(expected.values);
+    expect(
+      Boolean(result.nodeOrder.includes('sort-radix-digit-0-scan-level-0-add-offsets')),
       'digit histograms larger than one scan workgroup propagate scanned block offsets'
-    );
-    t.equal(result.nodeOrder.length, 40, 'eight digits use five graph nodes each');
+    ).toBe(true);
+    expect(result.nodeOrder.length, 'eight digits use five graph nodes each').toBe(40);
   }
-
-  t.end();
 });
 
-test('GPUSort radix processes only the requested significant key bits', async t => {
+it('GPUSort radix processes only the requested significant key bits', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -197,24 +172,22 @@ test('GPUSort radix processes only the requested significant key bits', async t 
   for (const keyBits of [15, 16]) {
     const result = await runSort(device, keys, values, 'radix', 'ascending', keyBits);
     const expected = getStableSortedPairs(keys, values, 'ascending');
-    t.deepEqual(result.keys, expected.keys, `${keyBits}-bit radix sorts every key`);
-    t.deepEqual(result.values, expected.values, `${keyBits}-bit radix remains stable`);
-    t.equal(
+    expect(result.keys, `${keyBits}-bit radix sorts every key`).toEqual(expected.keys);
+    expect(result.values, `${keyBits}-bit radix remains stable`).toEqual(expected.values);
+    expect(
       result.nodeOrder.filter(identifier => identifier.endsWith('-histogram')).length,
-      Math.ceil(keyBits / 4),
       `${keyBits}-bit radix emits only the required four-bit histogram passes`
-    );
-    t.notOk(result.nodeOrder.includes('sort-radix-final-copy'), 'final digits write directly');
+    ).toBe(Math.ceil(keyBits / 4));
+    expect(
+      Boolean(result.nodeOrder.includes('sort-radix-final-copy')),
+      'final digits write directly'
+    ).toBe(false);
   }
-
-  t.end();
 });
 
-test('GPUSort radix ignores insignificant bits and stably handles partial final digits', async t => {
+it('GPUSort radix ignores insignificant bits and stably handles partial final digits', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -237,32 +210,25 @@ test('GPUSort radix ignores insignificant bits and stably handles partial final 
           return comparison || left.index - right.index;
         }
       );
-      t.deepEqual(
+      expect(
         result.keys,
-        expected.map(pair => pair.key),
         `${keyBits}-bit ${direction} radix ignores insignificant high bits`
-      );
-      t.deepEqual(
+      ).toEqual(expected.map(pair => pair.key));
+      expect(
         result.values,
-        expected.map(pair => pair.value),
         `${keyBits}-bit ${direction} radix preserves equal-significant-key order`
-      );
-      t.equal(
+      ).toEqual(expected.map(pair => pair.value));
+      expect(
         result.nodeOrder.filter(identifier => identifier.endsWith('-histogram')).length,
-        Math.ceil(keyBits / 4),
         'only significant four-bit digits contribute graph work'
-      );
+      ).toBe(Math.ceil(keyBits / 4));
     }
   }
-
-  t.end();
 });
 
-test('GPUSort bounds bitonic and radix stages across all three dispatch dimensions', async t => {
+it('GPUSort bounds bitonic and radix stages across all three dispatch dimensions', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -281,12 +247,11 @@ test('GPUSort bounds bitonic and radix stages across all three dispatch dimensio
     try {
       const result = await runSort(device, keys, values, algorithm, direction, undefined, 2);
       const expected = getStableSortedPairs(keys, values, direction);
-      t.deepEqual(result.keys, expected.keys, `${algorithm} sorts every multidimensional key`);
-      t.deepEqual(
+      expect(result.keys, `${algorithm} sorts every multidimensional key`).toEqual(expected.keys);
+      expect(
         result.values,
-        expected.values,
         `${algorithm} preserves duplicate-key payload order across workgroups`
-      );
+      ).toEqual(expected.values);
 
       const dispatches = dispatchSpy.mock.instances.map((computation, index) => ({
         id: (computation as Computation).id,
@@ -308,11 +273,10 @@ test('GPUSort bounds bitonic and radix stages across all three dispatch dimensio
             ];
 
       for (const [identifier, expectedDimensions] of expectedPasses) {
-        t.deepEqual(
+        expect(
           dispatches.find(dispatch => dispatch.id === identifier)?.dimensions,
-          expectedDimensions,
           `${identifier} respects the synthetic per-dimension dispatch limit`
-        );
+        ).toEqual(expectedDimensions);
       }
     } finally {
       dispatchSpy.mockRestore();
@@ -324,29 +288,26 @@ test('GPUSort bounds bitonic and radix stages across all three dispatch dimensio
   try {
     const result = await runSort(device, limitedKeys, values, 'radix', 'ascending', 15, 2);
     const expected = getStableSortedPairs(limitedKeys, values, 'ascending');
-    t.deepEqual(result.keys, expected.keys, 'odd-width multidimensional radix keys match');
-    t.deepEqual(result.values, expected.values, 'odd-width multidimensional radix remains stable');
+    expect(result.keys, 'odd-width multidimensional radix keys match').toEqual(expected.keys);
+    expect(result.values, 'odd-width multidimensional radix remains stable').toEqual(
+      expected.values
+    );
 
     const finalScatterDispatchIndex = dispatchSpy.mock.instances.findIndex(
       computation => (computation as Computation).id === 'sort-radix-digit-12-scatter'
     );
-    t.deepEqual(
+    expect(
       dispatchSpy.mock.calls[finalScatterDispatchIndex]?.slice(1),
-      [2, 2, 2],
       'partial final radix digits respect the synthetic per-dimension dispatch limit'
-    );
+    ).toEqual([2, 2, 2]);
   } finally {
     dispatchSpy.mockRestore();
   }
-
-  t.end();
 });
 
-test('GPUSort honors offset storage views for local bitonic and multi-workgroup radix', async t => {
+it('GPUSort honors offset storage views for local bitonic and multi-workgroup radix', async () => {
   const device = await getWebGPUTestDevice('core');
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -408,17 +369,15 @@ test('GPUSort honors offset storage views for local bitonic and multi-workgroup 
       const words = Array.from(
         new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4)
       );
-      t.deepEqual(
+      expect(
         words.slice(0, output.paddingLength),
-        Array.from({length: output.paddingLength}, () => paddingValue),
         `${algorithm} preserves ${label} prefix padding`
-      );
-      t.deepEqual(
+      ).toEqual(Array.from({length: output.paddingLength}, () => paddingValue));
+      expect(
         words.slice(output.paddingLength, output.paddingLength + length),
-        expectedValues,
         `${algorithm} sorts ${label} through its offset view`
-      );
-      t.equal(words.at(-1), paddingValue, `${algorithm} preserves ${label} suffix padding`);
+      ).toEqual(expectedValues);
+      expect(words.at(-1), `${algorithm} preserves ${label} suffix padding`).toBe(paddingValue);
     }
 
     compiled.destroy();
@@ -426,21 +385,17 @@ test('GPUSort honors offset storage views for local bitonic and multi-workgroup 
       buffer.destroy();
     }
   }
-
-  t.end();
 });
 
-test('GPUSort handles empty and single-row inputs', async t => {
+it('GPUSort handles empty and single-row inputs', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const empty = await runSort(device, new Uint32Array(0), new Uint32Array(0), 'auto', 'ascending');
-  t.deepEqual(empty.keys, [], 'empty sort has no keys');
-  t.deepEqual(empty.values, [], 'empty sort has no values');
-  t.deepEqual(empty.nodeOrder, [], 'empty sort records no graph nodes');
+  expect(empty.keys, 'empty sort has no keys').toEqual([]);
+  expect(empty.values, 'empty sort has no values').toEqual([]);
+  expect(empty.nodeOrder, 'empty sort records no graph nodes').toEqual([]);
 
   const single = await runSort(
     device,
@@ -449,17 +404,14 @@ test('GPUSort handles empty and single-row inputs', async t => {
     'auto',
     'descending'
   );
-  t.deepEqual(single.keys, [42], 'single key is copied');
-  t.deepEqual(single.values, [99], 'single value is copied');
-  t.deepEqual(single.nodeOrder, ['sort-copy-pair'], 'single row uses one copy pass');
-  t.end();
+  expect(single.keys, 'single key is copied').toEqual([42]);
+  expect(single.values, 'single value is copied').toEqual([99]);
+  expect(single.nodeOrder, 'single row uses one copy pass').toEqual(['sort-copy-pair']);
 });
 
-test('GPUBatchSort stably sorts each vector chunk without changing boundaries', async t => {
+it('GPUBatchSort stably sorts each vector chunk without changing boundaries', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const keyChunks = [
@@ -480,38 +432,32 @@ test('GPUBatchSort stably sorts each vector chunk without changing boundaries', 
     const expected = keyChunks.map((keys, chunkIndex) =>
       getStableSortedPairs(keys, valueChunks[chunkIndex], direction)
     );
-    t.deepEqual(
-      result.keyChunks,
-      expected.map(chunk => chunk.keys),
-      `${direction} keys remain in their source chunks`
+    expect(result.keyChunks, `${direction} keys remain in their source chunks`).toEqual(
+      expected.map(chunk => chunk.keys)
     );
-    t.deepEqual(
-      result.valueChunks,
-      expected.map(chunk => chunk.values),
-      `${direction} payloads remain stable within each chunk`
+    expect(result.valueChunks, `${direction} payloads remain stable within each chunk`).toEqual(
+      expected.map(chunk => chunk.values)
     );
-    t.deepEqual(
-      result.resolvedAlgorithms,
-      ['bitonic', 'bitonic', 'bitonic', 'bitonic'],
-      'auto selection is reported in chunk order'
-    );
-    t.ok(
-      result.nodeOrder.some(id => id === 'batch-sort-chunk-2-copy-pair'),
+    expect(result.resolvedAlgorithms, 'auto selection is reported in chunk order').toEqual([
+      'bitonic',
+      'bitonic',
+      'bitonic',
+      'bitonic'
+    ]);
+    expect(
+      Boolean(result.nodeOrder.some(id => id === 'batch-sort-chunk-2-copy-pair')),
       'single-row chunks retain the copy fast path'
-    );
-    t.notOk(
-      result.nodeOrder.some(id => id.startsWith('batch-sort-chunk-1-')),
+    ).toBe(true);
+    expect(
+      Boolean(result.nodeOrder.some(id => id.startsWith('batch-sort-chunk-1-'))),
       'empty chunks add no graph nodes'
-    );
+    ).toBe(false);
   }
-  t.end();
 });
 
-test('GPUBatchSort resolves algorithms per chunk and validates vector topology', async t => {
+it('GPUBatchSort resolves algorithms per chunk and validates vector topology', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const graph = new GPUCommandGraph(device, {id: 'batch-sort-validation'});
@@ -520,13 +466,12 @@ test('GPUBatchSort resolves algorithms per chunk and validates vector topology',
   const outputKeys = makeGraphVector(graph, 'output-keys', [256, 257]);
   const outputValues = makeGraphVector(graph, 'output-values', [256, 257]);
   const sort = new GPUBatchSort({keys, values, outputKeys, outputValues});
-  t.deepEqual(
-    sort.resolvedAlgorithms,
-    ['bitonic', 'radix'],
-    'auto chooses independently from each chunk length'
-  );
+  expect(sort.resolvedAlgorithms, 'auto chooses independently from each chunk length').toEqual([
+    'bitonic',
+    'radix'
+  ]);
 
-  t.throws(
+  expect(
     () =>
       new GPUBatchSort({
         keys,
@@ -534,14 +479,12 @@ test('GPUBatchSort resolves algorithms per chunk and validates vector topology',
         outputKeys,
         outputValues
       }),
-    /same chunk topology/,
     'aligned inputs must preserve every chunk length'
-  );
-  t.throws(
+  ).toThrow(/same chunk topology/);
+  expect(
     () => new GPUBatchSort({keys, values, outputKeys: keys, outputValues}),
-    /separate buffers/,
     'outputs cannot alias any input chunk'
-  );
+  ).toThrow(/separate buffers/);
   const sharedOutputBuffer = graph.createTransientBuffer({
     id: 'shared-output-keys',
     byteLength: 16,
@@ -569,7 +512,7 @@ test('GPUBatchSort resolves algorithms per chunk and validates vector topology',
   const twoChunkKeys = makeGraphVector(graph, 'two-chunk-keys', [2, 2]);
   const twoChunkValues = makeGraphVector(graph, 'two-chunk-values', [2, 2]);
   const twoChunkOutputValues = makeGraphVector(graph, 'two-chunk-output-values', [2, 2]);
-  t.throws(
+  expect(
     () =>
       new GPUBatchSort({
         keys: twoChunkKeys,
@@ -577,10 +520,9 @@ test('GPUBatchSort resolves algorithms per chunk and validates vector topology',
         outputKeys: makeSharedOutputKeys(4),
         outputValues: twoChunkOutputValues
       }),
-    /output keys chunks must not overlap/,
     'writable chunks cannot overlap within one output vector'
-  );
-  t.doesNotThrow(
+  ).toThrow(/output keys chunks must not overlap/);
+  expect(
     () =>
       new GPUBatchSort({
         keys: twoChunkKeys,
@@ -589,8 +531,8 @@ test('GPUBatchSort resolves algorithms per chunk and validates vector topology',
         outputValues: twoChunkOutputValues
       }),
     'disjoint output chunks may share one logical buffer'
-  );
-  t.throws(
+  ).not.toThrow();
+  expect(
     () =>
       new GPUBatchSort({
         keys: makeGraphVector(graph, 'empty-keys', []),
@@ -599,34 +541,29 @@ test('GPUBatchSort resolves algorithms per chunk and validates vector topology',
         outputValues: makeGraphVector(graph, 'empty-output-values', []),
         algorithm: 'merge' as never
       }),
-    /algorithm must be/,
     'empty vector sorts still validate options'
-  );
-  t.end();
+  ).toThrow(/algorithm must be/);
 });
 
-test('GPUSort auto selection switches beyond one 256-row workgroup', async t => {
+it('GPUSort auto selection switches beyond one 256-row workgroup', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
-  t.equal(makeUncompiledSort(device, 256).resolvedAlgorithm, 'bitonic', 'one workgroup is bitonic');
-  t.equal(makeUncompiledSort(device, 257).resolvedAlgorithm, 'radix', 'above threshold is radix');
-  t.equal(
-    makeUncompiledSort(device, 3, 'radix').resolvedAlgorithm,
-    'radix',
-    'explicit override wins'
+  expect(makeUncompiledSort(device, 256).resolvedAlgorithm, 'one workgroup is bitonic').toBe(
+    'bitonic'
   );
-  t.end();
+  expect(makeUncompiledSort(device, 257).resolvedAlgorithm, 'above threshold is radix').toBe(
+    'radix'
+  );
+  expect(makeUncompiledSort(device, 3, 'radix').resolvedAlgorithm, 'explicit override wins').toBe(
+    'radix'
+  );
 });
 
-test('GPUSort validates layouts, lengths, graph ownership, and output buffers', async t => {
+it('GPUSort validates layouts, lengths, graph ownership, and output buffers', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const graph = new GPUCommandGraph(device, {id: 'sort-validation'});
@@ -655,7 +592,7 @@ test('GPUSort validates layouts, lengths, graph ownership, and output buffers', 
   const outputKeys = graph.createDataView(outputKeysHandle, {format: 'uint32', length: 4});
   const outputValues = graph.createDataView(outputValuesHandle, {format: 'uint32', length: 4});
 
-  t.throws(
+  expect(
     () =>
       new GPUSort({
         keys,
@@ -663,43 +600,36 @@ test('GPUSort validates layouts, lengths, graph ownership, and output buffers', 
         outputKeys,
         outputValues
       }),
-    /lengths must match/,
     'length mismatch is rejected'
-  );
-  t.throws(
+  ).toThrow(/lengths must match/);
+  expect(
     () => new GPUSort({keys, values, outputKeys: keys, outputValues}),
-    /separate buffers/,
     'input/output alias is rejected'
-  );
+  ).toThrow(/separate buffers/);
   for (const keyBits of [0, 33, 1.5, Number.NaN]) {
-    t.throws(
+    expect(
       () => new GPUSort({keys, values, outputKeys, outputValues, keyBits}),
-      /keyBits must be an integer from 1 to 32/,
       `invalid key width ${keyBits} is rejected`
-    );
+    ).toThrow(/keyBits must be an integer from 1 to 32/);
   }
   const unaligned = graph.createDataView(outputKeysHandle, {
     format: 'uint32',
     length: 1,
     byteOffset: 2
   });
-  t.throws(
+  expect(
     () => new GPUSort({keys: unaligned, values, outputKeys, outputValues}),
-    /uint32-aligned/,
     'unaligned keys are rejected'
-  );
+  ).toThrow(/uint32-aligned/);
 
   const otherGraph = new GPUCommandGraph(device, {id: 'other-sort-graph'});
   const sort = new GPUSort({keys, values, outputKeys, outputValues});
-  t.throws(() => sort.addToGraph(otherGraph), /target graph/, 'foreign graph is rejected');
-  t.end();
+  expect(() => sort.addToGraph(otherGraph), 'foreign graph is rejected').toThrow(/target graph/);
 });
 
-test('GPUSort rejects borrowed physical-buffer aliases before encoding either algorithm', async t => {
+it('GPUSort rejects borrowed physical-buffer aliases before encoding either algorithm', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -728,17 +658,15 @@ test('GPUSort rejects borrowed physical-buffer aliases before encoding either al
     const compiled = graph.compile();
     const rejectedEncoder = device.createCommandEncoder({id: `${algorithm}-rejected-alias`});
 
-    t.throws(
+    expect(
       () => compiled.encode(rejectedEncoder, {parameters: undefined}),
-      /keys.*output-keys.*same physical buffer/i,
       `${algorithm} rejects distinct borrowed wrappers resolving to one physical GPUBuffer`
-    );
+    ).toThrow(/keys.*output-keys.*same physical buffer/i);
     rejectedEncoder.destroy();
-    t.deepEqual(
+    expect(
       await readUint32SortBuffer(keysBuffer, 4),
-      [4, 1, 3, 2],
       `${algorithm} leaves caller-owned input unchanged`
-    );
+    ).toEqual([4, 1, 3, 2]);
 
     const validEncoder = device.createCommandEncoder({id: `${algorithm}-valid-sort`});
     compiled.encode(validEncoder, {
@@ -750,8 +678,10 @@ test('GPUSort rejects borrowed physical-buffer aliases before encoding either al
       readUint32SortBuffer(outputKeysBuffer, 4),
       readUint32SortBuffer(outputValuesBuffer, 4)
     ]);
-    t.deepEqual(sortedKeys, [1, 2, 3, 4], `${algorithm} accepts a later distinct output override`);
-    t.deepEqual(sortedValues, [10, 20, 30, 40], `${algorithm} preserves paired payload values`);
+    expect(sortedKeys, `${algorithm} accepts a later distinct output override`).toEqual([
+      1, 2, 3, 4
+    ]);
+    expect(sortedValues, `${algorithm} preserves paired payload values`).toEqual([10, 20, 30, 40]);
 
     compiled.destroy();
     const importedBuffers = [
@@ -763,24 +693,19 @@ test('GPUSort rejects borrowed physical-buffer aliases before encoding either al
     ];
     tAssertImportedBuffersAlive(importedBuffers);
     borrowedKeysBuffer.destroy();
-    t.deepEqual(
+    expect(
       await readUint32SortBuffer(keysBuffer, 4),
-      [4, 1, 3, 2],
       `${algorithm} borrowed-wrapper destruction leaves the physical GPUBuffer intact`
-    );
+    ).toEqual([4, 1, 3, 2]);
     for (const buffer of [keysBuffer, valuesBuffer, outputKeysBuffer, outputValuesBuffer]) {
       buffer.destroy();
     }
   }
-
-  t.end();
 });
 
-test('GPUBatchSort rejects physically aliased output overrides before encoding', async t => {
+it('GPUBatchSort rejects physically aliased output overrides before encoding', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -800,21 +725,19 @@ test('GPUBatchSort rejects physically aliased output overrides before encoding',
   const compiled = graph.compile();
   const rejectedEncoder = device.createCommandEncoder({id: 'batch-sort-rejected-alias'});
 
-  t.throws(
+  expect(
     () =>
       compiled.encode(rejectedEncoder, {
         parameters: undefined,
         buffers: {'batch-output-keys': keysBuffer}
       }),
-    /batch-keys.*batch-output-keys.*same physical buffer/i,
     'rejects an encoding-time output override that aliases an active input chunk'
-  );
+  ).toThrow(/batch-keys.*batch-output-keys.*same physical buffer/i);
   rejectedEncoder.destroy();
-  t.deepEqual(
+  expect(
     await readUint32SortBuffer(keysBuffer, 3),
-    [3, 1, 2],
     'rejected batch encoding leaves its caller-owned input chunk unchanged'
-  );
+  ).toEqual([3, 1, 2]);
 
   const validEncoder = device.createCommandEncoder({id: 'batch-sort-valid-encoding'});
   compiled.encode(validEncoder, {parameters: undefined});
@@ -823,14 +746,13 @@ test('GPUBatchSort rejects physically aliased output overrides before encoding',
     readUint32SortBuffer(outputKeysBuffer, 3),
     readUint32SortBuffer(outputValuesBuffer, 3)
   ]);
-  t.deepEqual(sortedKeys, [1, 2, 3], 'batch graph accepts its original distinct output buffer');
-  t.deepEqual(sortedValues, [10, 20, 30], 'batch retry preserves paired chunk payload values');
+  expect(sortedKeys, 'batch graph accepts its original distinct output buffer').toEqual([1, 2, 3]);
+  expect(sortedValues, 'batch retry preserves paired chunk payload values').toEqual([10, 20, 30]);
 
   compiled.destroy();
   const importedBuffers = [keysBuffer, valuesBuffer, outputKeysBuffer, outputValuesBuffer];
   tAssertImportedBuffersAlive(importedBuffers);
   for (const buffer of importedBuffers) buffer.destroy();
-  t.end();
 });
 
 type SortResult = {

--- a/modules/gpgpu/test/gpu-core/gpu-spatial-query-benchmark.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-spatial-query-benchmark.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {
   GPUCommandGraph,
   runGPUSpatialQueryBenchmark,
@@ -13,26 +13,22 @@ import {
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
-test('summarizeGPUSpatialBenchmarkSamples reports nearest-rank distributions', t => {
-  t.deepEqual(summarizeGPUSpatialBenchmarkSamples([4, 1, 3, 2]), {
+it('summarizeGPUSpatialBenchmarkSamples reports nearest-rank distributions', () => {
+  expect(summarizeGPUSpatialBenchmarkSamples([4, 1, 3, 2])).toEqual({
     minimum: 1,
     median: 2,
     percentile95: 4,
     maximum: 4
   });
-  t.throws(
+  expect(
     () => summarizeGPUSpatialBenchmarkSamples([1, Number.NaN]),
-    /finite non-negative/,
     'invalid samples cannot produce misleading reports'
-  );
-  t.end();
+  ).toThrow(/finite non-negative/);
 });
 
-test('runGPUSpatialQueryBenchmark applies one oracle to scan, grid, and BVH paths', async t => {
+it('runGPUSpatialQueryBenchmark applies one oracle to scan, grid, and BVH paths', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const compiledGraphs: CompiledGPUCommandGraph<void>[] = [];
@@ -65,12 +61,14 @@ test('runGPUSpatialQueryBenchmark applies one oracle to scan, grid, and BVH path
     reuseCounts: [1, 4]
   });
 
-  t.equal(report.expectedResultCount, 2);
-  t.equal(report.paths.length, 3);
-  t.equal(report.paths[1].candidateCount, 4, 'grid candidate work is retained');
-  t.equal(report.paths[2].visitedCount, 7, 'BVH traversal work is retained');
-  t.deepEqual(report.paths[0].amortizedGPUTime, [], 'GPU costs require timestamped phases');
-  t.ok(report.paths.every(path => path.cpuEncodeTimeMilliseconds.minimum >= 0));
+  expect(report.expectedResultCount).toBe(2);
+  expect(report.paths.length).toBe(3);
+  expect(report.paths[1].candidateCount, 'grid candidate work is retained').toBe(4);
+  expect(report.paths[2].visitedCount, 'BVH traversal work is retained').toBe(7);
+  expect(report.paths[0].amortizedGPUTime, 'GPU costs require timestamped phases').toEqual([]);
+  expect(Boolean(report.paths.every(path => path.cpuEncodeTimeMilliseconds.minimum >= 0))).toBe(
+    true
+  );
 
   let mismatchError: unknown;
   try {
@@ -83,7 +81,9 @@ test('runGPUSpatialQueryBenchmark applies one oracle to scan, grid, and BVH path
   } catch (error) {
     mismatchError = error;
   }
-  t.match(String(mismatchError), /shared CPU oracle/, 'incorrect paths cannot report timings');
+  expect(String(mismatchError), 'incorrect paths cannot report timings').toMatch(
+    /shared CPU oracle/
+  );
 
   const resourceCounts = device.statsManager.getStats('Resource Counts');
   const activeCommandEncodersBeforeFailure = resourceCounts.get('CommandEncoders Active').count;
@@ -113,13 +113,11 @@ test('runGPUSpatialQueryBenchmark applies one oracle to scan, grid, and BVH path
   } catch (error) {
     encodingError = error;
   }
-  t.match(String(encodingError), /intentional measured encoding failure/);
-  t.equal(
+  expect(String(encodingError)).toMatch(/intentional measured encoding failure/);
+  expect(
     resourceCounts.get('CommandEncoders Active').count,
-    activeCommandEncodersBeforeFailure,
     'a failed measured encoding releases its command encoder'
-  );
+  ).toBe(activeCommandEncodersBeforeFailure);
 
   for (const compiled of compiledGraphs) compiled.destroy();
-  t.end();
 });

--- a/modules/gpgpu/test/gpu-core/gpu-trace-manipulation.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-trace-manipulation.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {
@@ -16,54 +15,43 @@ import {
 } from '@luma.gl/gpgpu/gpu-core';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {addGPUGraphTraversalToGraphWithDispatchLimit} from '../../src/gpu-core/gpu-graph-traversal';
 
-test('GPUMask composes canonical GPU selection masks', async t => {
+it('GPUMask composes canonical GPU selection masks', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
   const first = Uint32Array.from([0, 1, 2, 0, 9, 1]);
   const second = Uint32Array.from([0, 1, 0, 8, 3, 0]);
   const third = Uint32Array.from([0, 0, 1, 1, 7, 1]);
-  t.deepEqual(
+  expect(
     await runMask(device, [first, second], 'and'),
-    [0, 1, 0, 0, 1, 0],
     'intersection treats every nonzero input as true'
-  );
-  t.deepEqual(
+  ).toEqual([0, 1, 0, 0, 1, 0]);
+  expect(
     await runMask(device, [first, second], 'or'),
-    [0, 1, 1, 1, 1, 1],
     'union writes canonical zero and one values'
-  );
-  t.deepEqual(
+  ).toEqual([0, 1, 1, 1, 1, 1]);
+  expect(
     await runMask(device, [first, second, third], 'xor'),
-    [0, 0, 0, 0, 1, 0],
     'exclusive union supports more than two masks'
-  );
-  t.deepEqual(
+  ).toEqual([0, 0, 0, 0, 1, 0]);
+  expect(
     await runMask(device, [first, second, third], 'difference'),
-    [0, 0, 0, 0, 0, 0],
     'difference excludes every later matching input'
-  );
-  t.deepEqual(
-    await runMask(device, [first], 'not'),
-    [1, 0, 0, 1, 0, 0],
-    'inversion canonicalizes nonzero values'
-  );
-  t.deepEqual(await runMask(device, [new Uint32Array(0)], 'and'), [], 'empty masks add no work');
-  t.end();
+  ).toEqual([0, 0, 0, 0, 0, 0]);
+  expect(await runMask(device, [first], 'not'), 'inversion canonicalizes nonzero values').toEqual([
+    1, 0, 0, 1, 0, 0
+  ]);
+  expect(await runMask(device, [new Uint32Array(0)], 'and'), 'empty masks add no work').toEqual([]);
 });
 
-test('GPUMask preserves imported GPUVector chunk boundaries', async t => {
+it('GPUMask preserves imported GPUVector chunk boundaries', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -79,128 +67,103 @@ test('GPUMask preserves imported GPUVector chunk boundaries', async t => {
   new GPUMask({inputs: [firstView, secondView], output: outputView}).addToGraph(graph);
   const compiled = graph.compile();
   submitGraph(device, compiled, 'chunked-mask');
-  t.deepEqual(
+  expect(
     await Promise.all(
       output.buffers.map((buffer, index) => readUint32(buffer, firstChunks[index].length))
     ),
-    [[1, 0, 0], [], [0, 1]],
     'each existing chunk receives only its source-aligned selected rows'
-  );
-  t.deepEqual(
+  ).toEqual([[1, 0, 0], [], [0, 1]]);
+  expect(
     compiled.stats.nodeOrder,
-    ['gpu-mask-chunk-0', 'gpu-mask-chunk-2'],
     'empty chunks preserve their identity without generating a dispatch'
-  );
+  ).toEqual(['gpu-mask-chunk-0', 'gpu-mask-chunk-2']);
   compiled.destroy();
   destroyVectorFixture(first);
   destroyVectorFixture(second);
   destroyVectorFixture(output);
-  t.end();
 });
 
-test('GPUHierarchyLayout scans live parent and child expansion states', async t => {
+it('GPUHierarchyLayout scans live parent and child expansion states', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
-  t.deepEqual(
+  expect(
     await runHierarchyLayout(device, Uint32Array.from([1, 0]), Uint32Array.from([1, 0, 1, 1]), 2),
-    {heights: [4, 1, 1, 0], offsets: [0, 4, 5, 6]},
     'expanded children and collapsed parent summaries receive stable scanned row offsets'
-  );
-  t.deepEqual(
+  ).toEqual({heights: [4, 1, 1, 0], offsets: [0, 4, 5, 6]});
+  expect(
     await runHierarchyLayout(device, Uint32Array.from([1, 1]), Uint32Array.from([1, 0, 0, 1]), 2),
-    {heights: [4, 1, 1, 4], offsets: [0, 4, 5, 6]},
     'individually collapsed children retain one row while expanded children retain four'
-  );
-  t.deepEqual(
+  ).toEqual({heights: [4, 1, 1, 4], offsets: [0, 4, 5, 6]});
+  expect(
     await runHierarchyLayout(device, new Uint32Array(0), new Uint32Array(0), 2),
-    {heights: [], offsets: []},
     'an empty hierarchy adds no scan or dispatch'
-  );
-  t.end();
+  ).toEqual({heights: [], offsets: []});
 });
 
-test('GPUHierarchyLayout preserves uneven parent and child partitions', async t => {
+it('GPUHierarchyLayout preserves uneven parent and child partitions', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
   const result = await runPartitionedHierarchyLayout(device);
-  t.deepEqual(
+  expect(
     result.heights,
-    [[4, 1, 1], [], [0, 1, 4]],
     'global parent IDs remain correct when one child chunk crosses parent chunk boundaries'
-  );
-  t.deepEqual(
-    result.offsets,
-    [[0, 4, 5], [], [6, 6, 7]],
-    'the vector-wide scan preserves empty and uneven output chunks'
-  );
-  t.ok(
-    result.nodeOrder.includes('partitioned-hierarchy-heights-child-0-parent-2'),
+  ).toEqual([[4, 1, 1], [], [0, 1, 4]]);
+  expect(result.offsets, 'the vector-wide scan preserves empty and uneven output chunks').toEqual([
+    [0, 4, 5],
+    [],
+    [6, 6, 7]
+  ]);
+  expect(
+    Boolean(result.nodeOrder.includes('partitioned-hierarchy-heights-child-0-parent-2')),
     'the crossing child chunk is split against the relevant parent partition'
-  );
-  t.deepEqual(
+  ).toBe(true);
+  expect(
     result.updatedOffsets,
-    [[0, 4, 5], [], [6, 6, 10]],
     'replacing one child batch updates the vector-wide layout without recompiling the graph'
-  );
-  t.end();
+  ).toEqual([[0, 4, 5], [], [6, 6, 10]]);
 });
 
-test('GPUGraphTraversal expands outgoing, incoming, and bidirectional frontiers', async t => {
+it('GPUGraphTraversal expands outgoing, incoming, and bidirectional frontiers', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
-  t.deepEqual(
+  expect(
     await runTraversal(device, {seeds: [0], maxDepth: 0}),
-    [1, 0, 0, 0, 0, 0],
     'zero-hop traversal preserves the selected seed'
-  );
-  t.deepEqual(
+  ).toEqual([1, 0, 0, 0, 0, 0]);
+  expect(
     await runTraversal(device, {seeds: [0], maxDepth: 1}),
-    [1, 1, 1, 0, 0, 0],
     'one-hop traversal returns direct outgoing neighbors'
-  );
-  t.deepEqual(
+  ).toEqual([1, 1, 1, 0, 0, 0]);
+  expect(
     await runTraversal(device, {seeds: [0], maxDepth: 3}),
-    [1, 1, 1, 1, 1, 0],
     'multi-hop traversal handles cycles and shared descendants'
-  );
-  t.deepEqual(
+  ).toEqual([1, 1, 1, 1, 1, 0]);
+  expect(
     await runTraversal(device, {seeds: [3], maxDepth: 1, direction: 'incoming'}),
-    [0, 1, 1, 1, 0, 0],
     'reverse CSR returns direct incoming dependencies'
-  );
-  t.deepEqual(
+  ).toEqual([0, 1, 1, 1, 0, 0]);
+  expect(
     await runTraversal(device, {seeds: [1], maxDepth: 1, direction: 'both'}),
-    [1, 1, 1, 1, 0, 0],
     'bidirectional traversal combines parents and children in the same frontier'
-  );
-  t.deepEqual(
+  ).toEqual([1, 1, 1, 1, 0, 0]);
+  expect(
     await runTraversal(device, {seeds: [0, 99, 5], maxDepth: 1}),
-    [1, 1, 1, 0, 0, 1],
     'multiple seeds are retained while out-of-range references are ignored'
-  );
-  t.end();
+  ).toEqual([1, 1, 1, 0, 0, 1]);
 });
 
-test('GPUGraphTraversal executes packed initialization, seeds, and expansion in three dimensions', async t => {
+it('GPUGraphTraversal executes packed initialization, seeds, and expansion in three dimensions', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -239,21 +202,19 @@ test('GPUGraphTraversal executes packed initialization, seeds, and expansion in 
       expectedOutput[sourceNode] = 1;
       expectedOutput[sourceNode + 1] = 1;
     }
-    t.deepEqual(
+    expect(
       await readUint32(buffers.output, nodeCount),
-      Array.from(expectedOutput),
       'initialization, seed publication, and outgoing expansion cover x, y, and z workgroups'
-    );
+    ).toEqual(Array.from(expectedOutput));
 
     for (const passName of ['initialize', 'seed', 'depth-0-clear', 'depth-0-outgoing']) {
       const dispatchIndex = dispatchSpy.mock.instances.findIndex(
         computation => (computation as Computation).id === `packed-bounded-traversal-${passName}`
       );
-      t.deepEqual(
+      expect(
         dispatchSpy.mock.calls[dispatchIndex]?.slice(1),
-        [2, 2, 2],
         `${passName} respects the synthetic two-workgroup limit in every dimension`
-      );
+      ).toEqual([2, 2, 2]);
     }
   } finally {
     dispatchSpy.mockRestore();
@@ -262,67 +223,57 @@ test('GPUGraphTraversal executes packed initialization, seeds, and expansion in 
       buffer.destroy();
     }
   }
-  t.end();
 });
 
-test('GPUGraphTraversal reads dynamic seed counts and traversal depth', async t => {
+it('GPUGraphTraversal reads dynamic seed counts and traversal depth', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
-  t.deepEqual(
+  expect(
     await runTraversal(device, {
       seeds: [0, 5],
       activeSeedCount: 1,
       maxDepth: 3,
       activeDepth: 1
     }),
-    [1, 1, 1, 0, 0, 0],
     'GPU-resident counts restrict both seed selection and traversal depth'
-  );
-  t.deepEqual(
+  ).toEqual([1, 1, 1, 0, 0, 0]);
+  expect(
     await runTraversal(device, {
       seeds: [0, 5],
       activeSeedCount: 0,
       maxDepth: 3,
       activeDepth: 2
     }),
-    [0, 0, 0, 0, 0, 0],
     'zero active seeds clear every previously selected node'
-  );
-  t.end();
+  ).toEqual([0, 0, 0, 0, 0, 0]);
 });
 
-test('GPUGraphTraversal follows global IDs across local CSR partitions', async t => {
+it('GPUGraphTraversal follows global IDs across local CSR partitions', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
   const result = await runPartitionedTraversal(device);
-  t.deepEqual(
+  expect(
     result.output,
-    [[1, 1], [], [1, 1], [1, 0]],
     'cross-partition edges match the packed traversal while preserving output topology'
-  );
-  t.ok(
-    result.nodeOrder.includes('partitioned-traversal-depth-0-outgoing-source-0-target-2') &&
-      result.nodeOrder.includes('partitioned-traversal-depth-1-outgoing-source-2-target-3'),
+  ).toEqual([[1, 1], [], [1, 1], [1, 0]]);
+  expect(
+    Boolean(
+      result.nodeOrder.includes('partitioned-traversal-depth-0-outgoing-source-0-target-2') &&
+        result.nodeOrder.includes('partitioned-traversal-depth-1-outgoing-source-2-target-3')
+    ),
     'source-to-target partition pairs make cross-partition routing explicit'
-  );
-  t.end();
+  ).toBe(true);
 });
 
-test('GPUGraphTraversal routes large seed and output partitions through three-dimensional dispatches', async t => {
+it('GPUGraphTraversal routes large seed and output partitions through three-dimensional dispatches', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -383,11 +334,10 @@ test('GPUGraphTraversal routes large seed and output partitions through three-di
         1;
       expectedLastPartition[sourceNode] = 1;
     }
-    t.deepEqual(
+    expect(
       await readVectorFixture(output),
-      [Array.from(expectedFirstPartition), [], Array.from(expectedLastPartition)],
       'large chunks preserve their empty partition while following global IDs in both directions'
-    );
+    ).toEqual([Array.from(expectedFirstPartition), [], Array.from(expectedLastPartition)]);
 
     for (const passName of [
       'partition-0-initialize',
@@ -403,11 +353,10 @@ test('GPUGraphTraversal routes large seed and output partitions through three-di
         computation =>
           (computation as Computation).id === `partitioned-bounded-traversal-${passName}`
       );
-      t.deepEqual(
+      expect(
         dispatchSpy.mock.calls[dispatchIndex]?.slice(1),
-        [2, 2, 2],
         `${passName} preserves the bounded three-dimensional dispatch`
-      );
+      ).toEqual([2, 2, 2]);
     }
   } finally {
     dispatchSpy.mockRestore();
@@ -416,61 +365,51 @@ test('GPUGraphTraversal routes large seed and output partitions through three-di
       destroyVectorFixture(fixture);
     }
   }
-  t.end();
 });
 
-test('GPUAncestorProjection reconnects visible nodes across hidden parent chains', async t => {
+it('GPUAncestorProjection reconnects visible nodes across hidden parent chains', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
   const invalid = 0xffffffff;
-  t.deepEqual(
+  expect(
     await runAncestorProjection(
       device,
       Uint32Array.from([invalid, 0, 1, 2, 3, 4]),
       Uint32Array.from([1, 0, 1, 0, 0, 1]),
       8
     ),
-    [0, 0, 2, 2, 2, 5],
     'visible records project to themselves and filtered records select the nearest visible parent'
-  );
-  t.deepEqual(
+  ).toEqual([0, 0, 2, 2, 2, 5]);
+  expect(
     await runAncestorProjection(
       device,
       Uint32Array.from([invalid, 0, 1, 2, 3, 4]),
       Uint32Array.from([1, 0, 1, 0, 0, 1]),
       1
     ),
-    [0, 0, 2, 2, invalid, 5],
     'depth-bounded projection rejects unresolved hidden-parent chains'
-  );
-  t.deepEqual(
+  ).toEqual([0, 0, 2, 2, invalid, 5]);
+  expect(
     await runAncestorProjection(
       device,
       Uint32Array.from([1, 0, 99]),
       Uint32Array.from([0, 0, 0]),
       6
     ),
-    [invalid, invalid, invalid],
     'cycles and out-of-range parents resolve to the sentinel'
-  );
-  t.deepEqual(
+  ).toEqual([invalid, invalid, invalid]);
+  expect(
     await runAncestorProjection(device, new Uint32Array(0), new Uint32Array(0), 4),
-    [],
     'empty parent mappings do not dispatch'
-  );
-  t.end();
+  ).toEqual([]);
 });
 
-test('GPU trace-manipulation primitives reject incompatible views', async t => {
+it('GPU trace-manipulation primitives reject incompatible views', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -488,27 +427,23 @@ test('GPU trace-manipulation primitives reject incompatible views', async t => {
   const first = graph.createDataView(firstHandle, {format: 'uint32', length: 4});
   const second = graph.createDataView(secondHandle, {format: 'uint32', length: 4});
   const short = graph.createDataView(secondHandle, {format: 'uint32', length: 2});
-  t.throws(
+  expect(
     () => new GPUMask({inputs: [], output: second}),
-    /at least one input/,
     'mask composition requires an input'
-  );
-  t.throws(
+  ).toThrow(/at least one input/);
+  expect(
     () => new GPUMask({inputs: [first, first], output: second, operation: 'not'}),
-    /exactly one input/,
     'inversion rejects ambiguous source masks'
-  );
-  t.throws(
+  ).toThrow(/exactly one input/);
+  expect(
     () => new GPUMask({inputs: [first], output: first}),
-    /separate buffers/,
     'read-write mask aliases are rejected'
-  );
-  t.throws(
+  ).toThrow(/separate buffers/);
+  expect(
     () => new GPUMask({inputs: [first], output: short}),
-    /length/,
     'mask composition requires matching row counts'
-  );
-  t.throws(
+  ).toThrow(/length/);
+  expect(
     () =>
       new GPUHierarchyLayout({
         parentStates: short,
@@ -517,10 +452,9 @@ test('GPU trace-manipulation primitives reject incompatible views', async t => {
         offsets: first,
         childrenPerParent: 0
       }),
-    /positive/,
     'hierarchy layout requires a positive child grouping'
-  );
-  t.throws(
+  ).toThrow(/positive/);
+  expect(
     () =>
       new GPUHierarchyLayout({
         parentStates: short,
@@ -529,16 +463,14 @@ test('GPU trace-manipulation primitives reject incompatible views', async t => {
         offsets: first,
         childrenPerParent: 3
       }),
-    /parent count/,
     'hierarchy layout requires complete source-aligned child groups'
-  );
-  t.throws(
+  ).toThrow(/parent count/);
+  expect(
     () => new GPUGraphTraversal({offsets: short, neighbors: first, seeds: first, output: second}),
-    /one more row/,
     'CSR offsets must describe every output node'
-  );
+  ).toThrow(/one more row/);
   const offsets = graph.createDataView(firstHandle, {format: 'uint32', length: 5});
-  t.throws(
+  expect(
     () =>
       new GPUGraphTraversal({
         offsets,
@@ -547,10 +479,9 @@ test('GPU trace-manipulation primitives reject incompatible views', async t => {
         output: second,
         direction: 'both'
       }),
-    /reverse adjacency/,
     'bidirectional traversal requires reverse CSR'
-  );
-  t.throws(
+  ).toThrow(/reverse adjacency/);
+  expect(
     () =>
       new GPUGraphTraversal({
         offsets,
@@ -559,10 +490,9 @@ test('GPU trace-manipulation primitives reject incompatible views', async t => {
         output: second,
         maxDepth: -1
       }),
-    /nonnegative/,
     'negative traversal depth is rejected'
-  );
-  t.throws(
+  ).toThrow(/nonnegative/);
+  expect(
     () =>
       new GPUGraphTraversal({
         offsets,
@@ -571,10 +501,9 @@ test('GPU trace-manipulation primitives reject incompatible views', async t => {
         output: second,
         maxDepth: 1025
       }),
-    /at most 1024/,
     'traversal depth is bounded before graph-node expansion'
-  );
-  t.throws(
+  ).toThrow(/at most 1024/);
+  expect(
     () =>
       new GPUGraphTraversal({
         offsets,
@@ -583,26 +512,22 @@ test('GPU trace-manipulation primitives reject incompatible views', async t => {
         output: second,
         maxDepth: 0x100000000
       }),
-    /at most 1024/,
     'traversal depth cannot reach an unrepresentable WGSL literal'
-  );
-  t.throws(
+  ).toThrow(/at most 1024/);
+  expect(
     () => new GPUAncestorProjection({parents: first, visibility: short, output: second}),
-    /matching lengths/,
     'ancestor projection requires source-aligned masks'
-  );
-  t.throws(
+  ).toThrow(/matching lengths/);
+  expect(
     () => new GPUAncestorProjection({parents: first, visibility: second, output: second}),
-    /separate buffer/,
     'ancestor projection rejects writable input aliases'
-  );
-  t.throws(
+  ).toThrow(/separate buffer/);
+  expect(
     () =>
       new GPUAncestorProjection({parents: first, visibility: first, output: second, maxDepth: -1}),
-    /nonnegative/,
     'ancestor projection rejects negative depth'
-  );
-  t.throws(
+  ).toThrow(/nonnegative/);
+  expect(
     () =>
       new GPUAncestorProjection({
         parents: first,
@@ -610,10 +535,8 @@ test('GPU trace-manipulation primitives reject incompatible views', async t => {
         output: second,
         maxDepth: 0x100000000
       }),
-    /uint32/,
     'ancestor projection rejects depth constants that WGSL cannot represent'
-  );
-  t.end();
+  ).toThrow(/uint32/);
 });
 
 async function runHierarchyLayout(

--- a/modules/gpgpu/test/gpu-core/gpu-transpose.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-transpose.node.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -9,13 +10,12 @@ import {
   GPU_TRANSPOSE_TILE_SIZE,
   makeGPUTransposeStats
 } from '@luma.gl/gpgpu/gpu-core';
-import test from 'test/utils/vitest-tape';
 import {WgslReflect} from 'wgsl_reflect';
 import {getGPUTransposeShaderSource} from '../../src/gpu-core/gpu-transpose';
 
-test('GPUTranspose publishes a rectangular tiled plan', testCase => {
+it('GPUTranspose publishes a rectangular tiled plan', () => {
   const stats = makeGPUTransposeStats(17, 35);
-  testCase.deepEqual(stats, {
+  expect(stats).toEqual({
     rows: 17,
     columns: 35,
     elementCount: 595,
@@ -24,29 +24,24 @@ test('GPUTranspose publishes a rectangular tiled plan', testCase => {
     tileCount: 6,
     workgroupSize: [16, 16, 1]
   });
-  testCase.ok(Object.isFrozen(stats), 'stats are immutable');
-  testCase.ok(Object.isFrozen(stats.workgroupSize), 'workgroup size is immutable');
-  testCase.equal(GPU_TRANSPOSE_TILE_SIZE, 16, 'tile dimension is explicit');
-  testCase.deepEqual(
-    makeGPUTransposeStats(0, 23),
-    {
-      rows: 0,
-      columns: 23,
-      elementCount: 0,
-      tileRowCount: 0,
-      tileColumnCount: 2,
-      tileCount: 0,
-      workgroupSize: [16, 16, 1]
-    },
-    'zero rows produce an empty plan'
-  );
-  testCase.throws(() => makeGPUTransposeStats(-1, 2), /rows must be a non-negative/);
-  testCase.throws(() => makeGPUTransposeStats(2.5, 2), /rows must be a non-negative/);
-  testCase.throws(() => makeGPUTransposeStats(0x100000000, 2), /uint32 index range/);
-  testCase.end();
+  expect(Boolean(Object.isFrozen(stats)), 'stats are immutable').toBe(true);
+  expect(Boolean(Object.isFrozen(stats.workgroupSize)), 'workgroup size is immutable').toBe(true);
+  expect(GPU_TRANSPOSE_TILE_SIZE, 'tile dimension is explicit').toBe(16);
+  expect(makeGPUTransposeStats(0, 23), 'zero rows produce an empty plan').toEqual({
+    rows: 0,
+    columns: 23,
+    elementCount: 0,
+    tileRowCount: 0,
+    tileColumnCount: 2,
+    tileCount: 0,
+    workgroupSize: [16, 16, 1]
+  });
+  expect(() => makeGPUTransposeStats(-1, 2)).toThrow(/rows must be a non-negative/);
+  expect(() => makeGPUTransposeStats(2.5, 2)).toThrow(/rows must be a non-negative/);
+  expect(() => makeGPUTransposeStats(0x100000000, 2)).toThrow(/uint32 index range/);
 });
 
-test('GPUTranspose validates packed capacity, format, aliasing, and graph ownership', testCase => {
+it('GPUTranspose validates packed capacity, format, aliasing, and graph ownership', () => {
   const graph = new GPUCommandGraph(makeSupportDevice());
   const inputHandle = graph.importBuffer({
     id: 'input',
@@ -61,25 +56,22 @@ test('GPUTranspose validates packed capacity, format, aliasing, and graph owners
   const input = graph.createDataView(inputHandle, {format: 'float32', length: 12});
   const output = graph.createDataView(outputHandle, {format: 'float32', length: 12});
   const transpose = new GPUTranspose({input, output, rows: 3, columns: 4});
-  testCase.doesNotThrow(() => transpose.addToGraph(graph), 'valid transpose adds one graph node');
+  expect(() => transpose.addToGraph(graph), 'valid transpose adds one graph node').not.toThrow();
 
   const shortOutput = graph.createDataView(outputHandle, {format: 'float32', length: 11});
-  testCase.throws(
-    () => new GPUTranspose({input, output: shortOutput, rows: 3, columns: 4}),
+  expect(() => new GPUTranspose({input, output: shortOutput, rows: 3, columns: 4})).toThrow(
     /output must contain at least/
   );
   const integerOutput = graph.createDataView(outputHandle, {format: 'uint32', length: 12});
-  testCase.throws(
-    () => new GPUTranspose({input, output: integerOutput as never, rows: 3, columns: 4}),
-    /formats must match/
-  );
+  expect(
+    () => new GPUTranspose({input, output: integerOutput as never, rows: 3, columns: 4})
+  ).toThrow(/formats must match/);
   const stridedInput = graph.createDataView(inputHandle, {
     format: 'float32',
     length: 6,
     byteStride: 8
   });
-  testCase.throws(
-    () => new GPUTranspose({input: stridedInput, output, rows: 2, columns: 3}),
+  expect(() => new GPUTranspose({input: stridedInput, output, rows: 2, columns: 3})).toThrow(
     /must be packed/
   );
   const overlappingOutput = graph.createDataView(inputHandle, {
@@ -87,8 +79,7 @@ test('GPUTranspose validates packed capacity, format, aliasing, and graph owners
     length: 12,
     byteOffset: 4
   });
-  testCase.throws(
-    () => new GPUTranspose({input, output: overlappingOutput, rows: 2, columns: 3}),
+  expect(() => new GPUTranspose({input, output: overlappingOutput, rows: 2, columns: 3})).toThrow(
     /separate buffers/
   );
 
@@ -100,7 +91,7 @@ test('GPUTranspose validates packed capacity, format, aliasing, and graph owners
   });
   const otherOutput = otherGraph.createDataView(otherHandle, {format: 'float32', length: 12});
   const crossGraphTranspose = new GPUTranspose({input, output: otherOutput, rows: 3, columns: 4});
-  testCase.throws(() => crossGraphTranspose.addToGraph(graph), /different GPUCommandGraph/);
+  expect(() => crossGraphTranspose.addToGraph(graph)).toThrow(/different GPUCommandGraph/);
 
   const emptyGraph = new GPUCommandGraph(makeSupportDevice());
   const emptyInputHandle = emptyGraph.importBuffer({
@@ -119,16 +110,11 @@ test('GPUTranspose validates packed capacity, format, aliasing, and graph owners
     emptyGraph
   );
   const compiledEmptyGraph = emptyGraph.compile();
-  testCase.equal(
-    compiledEmptyGraph.stats.nodeOrder.length,
-    0,
-    'empty transpose adds no graph node'
-  );
+  expect(compiledEmptyGraph.stats.nodeOrder.length, 'empty transpose adds no graph node').toBe(0);
   compiledEmptyGraph.destroy();
-  testCase.end();
 });
 
-test('GPUTranspose shader uses padded workgroup tiles and bounded tile indexing', testCase => {
+it('GPUTranspose shader uses padded workgroup tiles and bounded tile indexing', () => {
   const graph = new GPUCommandGraph(makeSupportDevice());
   const inputHandle = graph.importBuffer({
     id: 'input',
@@ -146,20 +132,16 @@ test('GPUTranspose shader uses padded workgroup tiles and bounded tile indexing'
   const source = getGPUTransposeShaderSource(transpose, {x: 6, y: 1, z: 1});
   const reflection = new WgslReflect(source);
 
-  testCase.deepEqual(
+  expect(
     reflection.entry.compute.map(entry => entry.name),
-    ['main'],
     'shader exposes one compute entry point'
+  ).toEqual(['main']);
+  expect(source, 'tile is padded by one column').toMatch(/array<array<i32, 17>, 16>/);
+  expect(source, 'tile load is synchronized before writing').toMatch(/workgroupBarrier/);
+  expect(source, 'partial bounded dispatch workgroups are guarded').toMatch(/tileIndex >= 6u/);
+  expect(source, 'rectangular output stride uses rows').toMatch(
+    /outputRow \* ROWS \+ outputColumn/
   );
-  testCase.match(source, /array<array<i32, 17>, 16>/, 'tile is padded by one column');
-  testCase.match(source, /workgroupBarrier/, 'tile load is synchronized before writing');
-  testCase.match(source, /tileIndex >= 6u/, 'partial bounded dispatch workgroups are guarded');
-  testCase.match(
-    source,
-    /outputRow \* ROWS \+ outputColumn/,
-    'rectangular output stride uses rows'
-  );
-  testCase.end();
 });
 
 function makeSupportDevice(): Device {

--- a/modules/gpgpu/test/gpu-core/gpu-transpose.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-transpose.spec.ts
@@ -1,3 +1,4 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
@@ -10,42 +11,33 @@ import {
   type GPUTransposeFormat
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
 
-test('GPUTranspose transposes square, rectangular, and partial tiles', async testCase => {
+it('GPUTranspose transposes square, rectangular, and partial tiles', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
-  testCase.deepEqual(
+  expect(
     await runTranspose(device, Uint32Array.from([1]), 'uint32', 1, 1),
-    [1],
     'one-element uint32 matrix'
-  );
-  testCase.deepEqual(
+  ).toEqual([1]);
+  expect(
     await runTranspose(device, Int32Array.from([1, -2, 3, -4, 5, -6]), 'sint32', 2, 3),
-    [1, -4, -2, 5, 3, -6],
     'rectangular sint32 matrix'
-  );
+  ).toEqual([1, -4, -2, 5, 3, -6]);
   const rows = 17;
   const columns = 35;
   const values = Float32Array.from({length: rows * columns}, (_, index) => index * 0.25 - 13);
-  testCase.deepEqual(
+  expect(
     await runTranspose(device, values, 'float32', rows, columns),
-    makeCPUTranspose(values, rows, columns),
     'float32 partial edge tiles'
-  );
-  testCase.end();
+  ).toEqual(makeCPUTranspose(values, rows, columns));
 });
 
-test('runGPUTransposeBenchmark compares correctness-gated tiled and reference paths', async t => {
+it('runGPUTransposeBenchmark compares correctness-gated tiled and reference paths', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
   const report = await runGPUTransposeBenchmark(device, {
@@ -54,17 +46,15 @@ test('runGPUTransposeBenchmark compares correctness-gated tiled and reference pa
     warmupIterations: 1,
     measuredIterations: 2
   });
-  t.equal(report.elementCount, 323, 'report preserves rectangular dimensions');
-  t.deepEqual(
+  expect(report.elementCount, 'report preserves rectangular dimensions').toBe(323);
+  expect(
     report.paths.map(path => path.strategy),
-    ['tiled', 'reference'],
     'both implementations are measured'
-  );
-  t.ok(
-    report.paths.every(path => path.cpuEncodeTimeMilliseconds.minimum >= 0),
+  ).toEqual(['tiled', 'reference']);
+  expect(
+    Boolean(report.paths.every(path => path.cpuEncodeTimeMilliseconds.minimum >= 0)),
     'every path reports finite encoding timings'
-  );
-  t.end();
+  ).toBe(true);
 });
 
 type ScalarArray = Uint32Array | Int32Array | Float32Array;

--- a/modules/gpgpu/test/gpu-core/gpu-virtual-geometry-selection.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-virtual-geometry-selection.node.spec.ts
@@ -1,49 +1,46 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {makeGPUVirtualGeometrySelectionPlan} from '@luma.gl/gpgpu/gpu-core';
 
-test('GPU virtual geometry publishes an immutable breadth-level plan', testCase => {
+it('GPU virtual geometry publishes an immutable breadth-level plan', () => {
   const levelOffsets = [0, 2, 6, 10];
   const plan = makeGPUVirtualGeometrySelectionPlan(levelOffsets, 10);
 
-  testCase.deepEqual(plan, {
+  expect(plan).toEqual({
     nodeCount: 10,
     rootCount: 2,
     levelCount: 3,
     traversalPassCount: 3,
     levelOffsets: [0, 2, 6, 10]
   });
-  testCase.ok(Object.isFrozen(plan), 'the plan is immutable');
-  testCase.ok(Object.isFrozen(plan.levelOffsets), 'the copied level offsets are immutable');
+  expect(Boolean(Object.isFrozen(plan)), 'the plan is immutable').toBe(true);
+  expect(
+    Boolean(Object.isFrozen(plan.levelOffsets)),
+    'the copied level offsets are immutable'
+  ).toBe(true);
 
   levelOffsets[1] = 4;
-  testCase.deepEqual(plan.levelOffsets, [0, 2, 6, 10], 'caller mutation cannot change the plan');
-  testCase.end();
+  expect(plan.levelOffsets, 'caller mutation cannot change the plan').toEqual([0, 2, 6, 10]);
 });
 
-test('GPU virtual geometry rejects invalid CPU-known hierarchy layouts', testCase => {
-  testCase.throws(
+it('GPU virtual geometry rejects invalid CPU-known hierarchy layouts', () => {
+  expect(
     () => makeGPUVirtualGeometrySelectionPlan([1, 2], 2),
-    /begin with zero/,
     'the first breadth level begins at node zero'
-  );
-  testCase.throws(
+  ).toThrow(/begin with zero/);
+  expect(
     () => makeGPUVirtualGeometrySelectionPlan([0, 2, 2], 2),
-    /strictly increasing/,
     'empty or overlapping breadth levels are rejected'
-  );
-  testCase.throws(
+  ).toThrow(/strictly increasing/);
+  expect(
     () => makeGPUVirtualGeometrySelectionPlan([0, 2, 5], 6),
-    /end at nodeCount/,
     'the final level must cover every node'
-  );
-  testCase.throws(
+  ).toThrow(/end at nodeCount/);
+  expect(
     () => makeGPUVirtualGeometrySelectionPlan([0, 1], 0),
-    /positive safe integer/,
     'empty hierarchies are rejected'
-  );
-  testCase.end();
+  ).toThrow(/positive safe integer/);
 });

--- a/modules/gpgpu/test/gpu-core/gpu-virtual-geometry-selection.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-virtual-geometry-selection.spec.ts
@@ -1,8 +1,8 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {
   DrawCommandBuffer,
@@ -14,124 +14,98 @@ import {
 import type {GPUVectorFormat} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
-test('GPUVirtualGeometrySelection publishes a stable bounded indirect frontier', async testCase => {
+it('GPUVirtualGeometrySelection publishes a stable bounded indirect frontier', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
   const fixture = createFixture(device, 2);
   encode(device, fixture.compiled);
-  testCase.deepEqual(
+  expect(
     await readUint32(fixture.output, 2),
-    [101, 200],
     'stable node order retains the coarse second root before refined first-root children'
-  );
-  testCase.equal(
-    await readDrawCount(fixture.drawCommands),
-    2,
-    'indirect count is capacity-clamped'
-  );
-  testCase.deepEqual(
-    await readUint32(fixture.totalCount, 1),
-    [3],
-    'full frontier count is explicit'
-  );
-  testCase.deepEqual(await readUint32(fixture.overflow, 1), [1], 'truncation sets overflow');
+  ).toEqual([101, 200]);
+  expect(await readDrawCount(fixture.drawCommands), 'indirect count is capacity-clamped').toBe(2);
+  expect(await readUint32(fixture.totalCount, 1), 'full frontier count is explicit').toEqual([3]);
+  expect(await readUint32(fixture.overflow, 1), 'truncation sets overflow').toEqual([1]);
 
   fixture.maximumScreenSpaceError.write(Float32Array.of(200));
   encode(device, fixture.compiled);
-  testCase.deepEqual(
+  expect(
     await readUint32(fixture.output, 2),
-    [100, 101],
     'a larger error tolerance selects both coarse roots'
-  );
-  testCase.equal(
-    await readDrawCount(fixture.drawCommands),
-    2,
-    'the indirect slot resets each encode'
-  );
-  testCase.deepEqual(await readUint32(fixture.totalCount, 1), [2]);
-  testCase.deepEqual(
-    await readUint32(fixture.overflow, 1),
-    [0],
-    'overflow clears when capacity fits'
-  );
+  ).toEqual([100, 101]);
+  expect(await readDrawCount(fixture.drawCommands), 'the indirect slot resets each encode').toBe(2);
+  expect(await readUint32(fixture.totalCount, 1)).toEqual([2]);
+  expect(await readUint32(fixture.overflow, 1), 'overflow clears when capacity fits').toEqual([0]);
 
   fixture.cameraPosition.write(Float32Array.of(8, 0, 30));
   fixture.maximumScreenSpaceError.write(Float32Array.of(100_000));
   encode(device, fixture.compiled);
-  testCase.deepEqual(
+  expect(
     await readUint32(fixture.output, 2),
-    [100, 300],
     'camera-inside selection refines conservatively despite a large threshold'
-  );
-  testCase.deepEqual(await readUint32(fixture.totalCount, 1), [3]);
+  ).toEqual([100, 300]);
+  expect(await readUint32(fixture.totalCount, 1)).toEqual([3]);
 
-  testCase.ok(
-    fixture.compiled.stats.nodeOrder.includes('virtual-geometry-level-0') &&
-      fixture.compiled.stats.nodeOrder.includes('virtual-geometry-level-1'),
+  expect(
+    Boolean(
+      fixture.compiled.stats.nodeOrder.includes('virtual-geometry-level-0') &&
+        fixture.compiled.stats.nodeOrder.includes('virtual-geometry-level-1')
+    ),
     'the compiled graph exposes one ordered pass per breadth level'
-  );
-  testCase.ok(
-    fixture.compiled.stats.nodeOrder.some(id =>
-      id.startsWith('virtual-geometry-visibility-compact')
+  ).toBe(true);
+  expect(
+    Boolean(
+      fixture.compiled.stats.nodeOrder.some(id =>
+        id.startsWith('virtual-geometry-visibility-compact')
+      )
     ),
     'frontier publication reuses stable visibility compaction'
-  );
+  ).toBe(true);
 
-  testCase.equal(
+  expect(
     await destroyFixture(fixture),
-    2,
     'idempotent selector destruction leaves borrowed indirect-count storage alive'
-  );
-  testCase.end();
+  ).toBe(2);
 });
 
-test('GPUVirtualGeometrySelection culls roots and deduplicates convergent activation', async testCase => {
+it('GPUVirtualGeometrySelection culls roots and deduplicates convergent activation', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    testCase.comment('WebGPU is not available');
-    testCase.end();
     return;
   }
 
   const fixture = createFixture(device, 6);
   fixture.frustumPlanes.write(makeBoxFrustum(0, 100));
   encode(device, fixture.compiled);
-  testCase.deepEqual(
+  expect(
     await readSelectedIds(fixture),
-    [200, 201],
     'a rejected root activates no children while the visible root refines'
-  );
+  ).toEqual([200, 201]);
 
   fixture.frustumPlanes.write(makeBoxFrustum(100, 100));
   fixture.maximumScreenSpaceError.write(Float32Array.of(0));
   fixture.children.write(Uint32Array.from([2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0]));
   encode(device, fixture.compiled);
-  testCase.deepEqual(
+  expect(
     await readSelectedIds(fixture),
-    [200, 201],
     'node-aligned activity prevents duplicate IDs across multiple roots'
-  );
-  testCase.deepEqual(await readUint32(fixture.overflow, 1), [0]);
+  ).toEqual([200, 201]);
+  expect(await readUint32(fixture.overflow, 1)).toEqual([0]);
 
   fixture.maximumScreenSpaceError.write(Float32Array.of(50));
   encode(device, fixture.compiled);
-  testCase.deepEqual(
+  expect(
     await readSelectedIds(fixture),
-    [101],
     'a coarse shared parent suppresses children requested by another refining parent'
-  );
+  ).toEqual([101]);
 
-  testCase.equal(
+  expect(
     await destroyFixture(fixture),
-    1,
     'destroying selector-owned storage does not destroy the draw command'
-  );
-  testCase.end();
+  ).toBe(1);
 });
 
 type Fixture = {

--- a/modules/gpgpu/test/gpu-core/gpu-visibility-workflow.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-visibility-workflow.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {
@@ -13,14 +12,12 @@ import {
 } from '@luma.gl/gpgpu/gpu-core';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {addGPUVisibilityWorkflowToGraphWithDispatchLimit} from '../../src/gpu-core/gpu-visibility-workflow';
 
-test('GPUVisibilityWorkflow composes predicates and publishes indirect-ready results', async t => {
+it('GPUVisibilityWorkflow composes predicates and publishes indirect-ready results', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -104,48 +101,49 @@ test('GPUVisibilityWorkflow composes predicates and publishes indirect-ready res
   const compiled = graph.compile();
 
   await encodeAndSubmit(device, compiled, 'visibility-first');
-  t.deepEqual(await readUint32(outputBuffer, 2), [42, 45], 'stable generated IDs preserve order');
-  t.deepEqual(
+  expect(await readUint32(outputBuffer, 2), 'stable generated IDs preserve order').toEqual([
+    42, 45
+  ]);
+  expect(
     await readUint32(outputMaskBuffer, predicateValues.timeRange.length),
-    [0, 0, 1, 0, 0, 1, 0, 0],
     'fused nonzero predicates publish one canonical mask'
+  ).toEqual([0, 0, 1, 0, 0, 1, 0, 0]);
+  expect(await readDrawCount(drawCommands), 'visible count writes the indirect command slot').toBe(
+    2
   );
-  t.equal(await readDrawCount(drawCommands), 2, 'visible count writes the indirect command slot');
 
   predicateBuffers.selection.write(Uint32Array.from({length: 8}, () => 1));
   await encodeAndSubmit(device, compiled, 'visibility-updated');
-  t.deepEqual(
+  expect(
     await readUint32(outputBuffer, 4),
-    [40, 42, 45, 46],
     'predicate data updates without graph recompilation'
+  ).toEqual([40, 42, 45, 46]);
+  expect(await readDrawCount(drawCommands), 'the indirect count updates with the predicates').toBe(
+    4
   );
-  t.equal(await readDrawCount(drawCommands), 4, 'the indirect count updates with the predicates');
-  t.ok(
-    compiled.stats.nodeOrder.some(id => id === 'objects-identity'),
+  expect(
+    Boolean(compiled.stats.nodeOrder.some(id => id === 'objects-identity')),
     'workflow owns stable identity generation'
-  );
-  t.ok(
-    compiled.stats.nodeOrder.some(id => id === 'objects-compose'),
+  ).toBe(true);
+  expect(
+    Boolean(compiled.stats.nodeOrder.some(id => id === 'objects-compose')),
     'workflow owns predicate composition'
-  );
-  t.ok(
-    compiled.stats.nodeOrder.some(id => id.startsWith('objects-compact')),
+  ).toBe(true);
+  expect(
+    Boolean(compiled.stats.nodeOrder.some(id => id.startsWith('objects-compact'))),
     'workflow owns scan and stable compaction'
-  );
+  ).toBe(true);
 
   compiled.destroy();
   for (const buffer of Object.values(predicateBuffers)) buffer.destroy();
   outputBuffer.destroy();
   outputMaskBuffer.destroy();
   drawCommands.destroy();
-  t.end();
 });
 
-test('GPUVisibilityWorkflow scales mask, identity, scan, and scatter through bounded 3D dispatches', async t => {
+it('GPUVisibilityWorkflow scales mask, identity, scan, and scatter through bounded 3D dispatches', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -209,21 +207,18 @@ test('GPUVisibilityWorkflow scales mask, identity, scan, and scatter through bou
   try {
     await encodeAndSubmit(device, compiled, 'bounded-visibility-encoding');
 
-    t.deepEqual(
+    expect(
       await readUint32(outputMaskBuffer, rowCount),
-      expectedMask,
       'multidimensional mask composition visits each source row exactly once'
-    );
-    t.deepEqual(
+    ).toEqual(expectedMask);
+    expect(
       await readUint32(outputBuffer, expectedSourceIds.length),
-      expectedSourceIds,
       'bounded identity generation and scatter preserve stable source-row order'
-    );
-    t.deepEqual(
+    ).toEqual(expectedSourceIds);
+    expect(
       await readUint32(countBuffer, 1),
-      [expectedSourceIds.length],
       'padded multidimensional workgroups never inflate the selected count'
-    );
+    ).toEqual([expectedSourceIds.length]);
 
     const dispatches = dispatchSpy.mock.instances.map((computation, index) => ({
       id: (computation as Computation).id,
@@ -236,11 +231,10 @@ test('GPUVisibilityWorkflow scales mask, identity, scan, and scatter through bou
       'bounded-visibility-compact-scan-level-0-add-offsets',
       'bounded-visibility-compact-scatter'
     ]) {
-      t.deepEqual(
+      expect(
         dispatches.find(dispatch => dispatch.id === passId)?.dimensions,
-        [2, 2, 2],
         `${passId} inherits the same bounded three-dimensional dispatch limit`
-      );
+      ).toEqual([2, 2, 2]);
     }
   } finally {
     dispatchSpy.mockRestore();
@@ -251,15 +245,11 @@ test('GPUVisibilityWorkflow scales mask, identity, scan, and scatter through bou
     outputBuffer.destroy();
     countBuffer.destroy();
   }
-
-  t.end();
 });
 
-test('GPUVisibilityWorkflow preserves chunk topology while generating global IDs', async t => {
+it('GPUVisibilityWorkflow preserves chunk topology while generating global IDs', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -293,35 +283,29 @@ test('GPUVisibilityWorkflow preserves chunk topology while generating global IDs
   const compiled = graph.compile();
   await encodeAndSubmit(device, compiled, 'chunked-visibility');
 
-  t.deepEqual(
+  expect(
     await readVectorFixture(outputFixture),
-    [[0, 2, 3], [], [4, 0xffffffff]],
     'identity generation and compaction preserve global order across chunks'
-  );
-  t.deepEqual(await readUint32(countBuffer, 1), [4], 'one count spans the complete vector');
-  t.deepEqual(
+  ).toEqual([[0, 2, 3], [], [4, 0xffffffff]]);
+  expect(await readUint32(countBuffer, 1), 'one count spans the complete vector').toEqual([4]);
+  expect(
     compiled.stats.nodeOrder.filter(id => id.includes('compose')),
-    ['gpu-visibility-compose-chunk-0', 'gpu-visibility-compose-chunk-2'],
     'one noncanonical predicate is normalized before compaction'
-  );
-  t.deepEqual(
+  ).toEqual(['gpu-visibility-compose-chunk-0', 'gpu-visibility-compose-chunk-2']);
+  expect(
     compiled.stats.nodeOrder.filter(id => id.includes('identity')),
-    ['gpu-visibility-identity-chunk-0', 'gpu-visibility-identity-chunk-2'],
     'empty chunks retain topology without an unnecessary dispatch'
-  );
+  ).toEqual(['gpu-visibility-identity-chunk-0', 'gpu-visibility-identity-chunk-2']);
 
   compiled.destroy();
   destroyVectorFixture(maskFixture);
   destroyVectorFixture(outputFixture);
   countBuffer.destroy();
-  t.end();
 });
 
-test('GPUVisibilityWorkflow rejects incompatible contracts', async t => {
+it('GPUVisibilityWorkflow rejects incompatible contracts', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -341,12 +325,11 @@ test('GPUVisibilityWorkflow rejects incompatible contracts', async t => {
   const output = graph.createDataView(secondBuffer, {format: 'uint32', length: 4});
   const count = graph.createDataView(firstBuffer, {format: 'uint32', length: 1});
 
-  t.throws(
+  expect(
     () => new GPUVisibilityWorkflow({predicates: [], output, count}),
-    /at least one visibility predicate/,
     'at least one fixed-contract predicate is required'
-  );
-  t.throws(
+  ).toThrow(/at least one visibility predicate/);
+  expect(
     () =>
       new GPUVisibilityWorkflow({
         predicates: [
@@ -356,10 +339,9 @@ test('GPUVisibilityWorkflow rejects incompatible contracts', async t => {
         output,
         count
       }),
-    /length must match/,
     'predicate masks remain source aligned'
-  );
-  t.throws(
+  ).toThrow(/length must match/);
+  expect(
     () =>
       new GPUVisibilityWorkflow({
         predicates: [{kind: 'bounds', mask: first}],
@@ -367,10 +349,9 @@ test('GPUVisibilityWorkflow rejects incompatible contracts', async t => {
         count,
         firstSourceIndex: 0xffffffff
       }),
-    /exceed uint32 range/,
     'generated identities cannot overflow uint32'
-  );
-  t.throws(
+  ).toThrow(/exceed uint32 range/);
+  expect(
     () =>
       new GPUVisibilityWorkflow({
         predicates: [{kind: 'bounds', mask: first}],
@@ -379,10 +360,8 @@ test('GPUVisibilityWorkflow rejects incompatible contracts', async t => {
         sourceIds: first,
         firstSourceIndex: 1
       }),
-    /cannot be used with explicit source IDs/,
     'explicit source IDs and generated offsets are mutually exclusive'
-  );
-  t.end();
+  ).toThrow(/cannot be used with explicit source IDs/);
 });
 
 async function encodeAndSubmit(

--- a/modules/gpgpu/test/gpu-core/gpu-workgroup-reduction-benchmark.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-workgroup-reduction-benchmark.spec.ts
@@ -1,16 +1,14 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {runGPUWorkgroupReductionBenchmark} from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
-test('runGPUWorkgroupReductionBenchmark compares graph-owned reductions', async t => {
+it('runGPUWorkgroupReductionBenchmark compares graph-owned reductions', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -21,19 +19,17 @@ test('runGPUWorkgroupReductionBenchmark compares graph-owned reductions', async 
     warmupIterations: 1,
     measuredIterations: 2
   });
-  t.equal(report.paths[0].strategy, 'portable', 'portable path is always measured');
-  t.equal(
+  expect(report.paths[0].strategy, 'portable path is always measured').toBe('portable');
+  expect(
     report.paths.length,
-    report.subgroupAvailable ? 2 : 1,
     'subgroup path is measured only when both capabilities are available'
-  );
-  t.ok(
-    report.paths.every(path => path.checksum === report.paths[0].checksum),
+  ).toBe(report.subgroupAvailable ? 2 : 1);
+  expect(
+    Boolean(report.paths.every(path => path.checksum === report.paths[0].checksum)),
     'every measured path passes the shared checksum oracle'
-  );
-  t.ok(
-    report.paths.every(path => path.cpuEncodeTimeMilliseconds.minimum >= 0),
+  ).toBe(true);
+  expect(
+    Boolean(report.paths.every(path => path.cpuEncodeTimeMilliseconds.minimum >= 0)),
     'per-dispatch CPU encoding distributions are reported'
-  );
-  t.end();
+  ).toBe(true);
 });

--- a/modules/gpgpu/test/gpu-core/gpu-workgroup-scan-benchmark.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-workgroup-scan-benchmark.spec.ts
@@ -1,34 +1,30 @@
+import {expect, it} from 'vitest';
 // luma.gl
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {
   runGPUWorkgroupScanBenchmark,
   summarizeGPUWorkgroupScanBenchmarkSamples
 } from '@luma.gl/gpgpu/gpu-core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
-test('summarizeGPUWorkgroupScanBenchmarkSamples reports nearest-rank distributions', t => {
-  t.deepEqual(summarizeGPUWorkgroupScanBenchmarkSamples([4, 1, 3, 2]), {
+it('summarizeGPUWorkgroupScanBenchmarkSamples reports nearest-rank distributions', () => {
+  expect(summarizeGPUWorkgroupScanBenchmarkSamples([4, 1, 3, 2])).toEqual({
     minimum: 1,
     median: 2,
     percentile95: 4,
     maximum: 4
   });
-  t.throws(
+  expect(
     () => summarizeGPUWorkgroupScanBenchmarkSamples([1, Number.NaN]),
-    /finite and non-negative/,
     'invalid samples cannot produce misleading reports'
-  );
-  t.end();
+  ).toThrow(/finite and non-negative/);
 });
 
-test('runGPUWorkgroupScanBenchmark compares graph-owned scan computations', async t => {
+it('runGPUWorkgroupScanBenchmark compares graph-owned scan computations', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    t.comment('WebGPU is not available');
-    t.end();
     return;
   }
 
@@ -39,25 +35,23 @@ test('runGPUWorkgroupScanBenchmark compares graph-owned scan computations', asyn
     warmupIterations: 1,
     measuredIterations: 2
   });
-  t.equal(report.paths[0].strategy, 'portable', 'portable path is always measured');
-  t.equal(
+  expect(report.paths[0].strategy, 'portable path is always measured').toBe('portable');
+  expect(
     report.paths.length,
-    report.subgroupAvailable ? 2 : 1,
     'subgroup path is measured only when both required capabilities are available'
-  );
-  t.ok(
-    report.paths.every(path => path.checksum === report.paths[0].checksum),
+  ).toBe(report.subgroupAvailable ? 2 : 1);
+  expect(
+    Boolean(report.paths.every(path => path.checksum === report.paths[0].checksum)),
     'every measured path passes the shared checksum oracle'
-  );
-  t.ok(
-    report.paths.every(path => path.cpuEncodeTimeMilliseconds.minimum >= 0),
+  ).toBe(true);
+  expect(
+    Boolean(report.paths.every(path => path.cpuEncodeTimeMilliseconds.minimum >= 0)),
     'per-dispatch CPU encoding distributions are reported'
-  );
+  ).toBe(true);
   if (report.timestampQueries) {
-    t.ok(
-      report.paths.every(path => path.gpuTimeMilliseconds?.minimum !== undefined),
+    expect(
+      Boolean(report.paths.every(path => path.gpuTimeMilliseconds?.minimum !== undefined)),
       'per-dispatch GPU timing distributions are reported'
-    );
+    ).toBe(true);
   }
-  t.end();
 });

--- a/modules/gpgpu/test/gpu-graph/gpu-graph-benchmark.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph-benchmark.spec.ts
@@ -12,8 +12,7 @@ import {
   type GPUGraphBenchmarkReport
 } from '@luma.gl/gpgpu/gpu-graph/benchmarks';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test, {type Test} from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 
 const BENCHMARK_ALGORITHMS: GPUGraphBenchmarkAlgorithm[] = [
   'topology',
@@ -36,11 +35,9 @@ const BENCHMARK_DATASETS: GPUGraphBenchmarkDatasetKind[] = [
 ];
 
 for (const kind of BENCHMARK_DATASETS) {
-  test(`GPU Graph real WebGPU benchmark independently validates the ${kind} graph workload`, async tapeTest => {
+  it(`GPU Graph real WebGPU benchmark independently validates the ${kind} graph workload`, async () => {
     const device = await getWebGPUTestDevice();
     if (!device) {
-      tapeTest.comment('WebGPU is not available');
-      tapeTest.end();
       return;
     }
 
@@ -62,7 +59,7 @@ for (const kind of BENCHMARK_DATASETS) {
         gridSize: [4, 4]
       });
 
-      assertBenchmarkReport(tapeTest, report, device, {
+      assertBenchmarkReport(report, device, {
         kind,
         vertexCount: 12,
         edgeCount: expectedDataset.edgeCount,
@@ -70,31 +67,28 @@ for (const kind of BENCHMARK_DATASETS) {
         theta,
         pageRankIterations: 4
       });
-      tapeTest.ok(
-        submitSpy.mock.calls.length >= 10,
+      expect(
+        Boolean(submitSpy.mock.calls.length >= 10),
         'each real graph workload and independent spatial-index phase submits actual GPU work'
-      );
-      tapeTest.ok(
-        fenceSpy.mock.calls.length >= 10,
+      ).toBe(true);
+      expect(
+        Boolean(fenceSpy.mock.calls.length >= 10),
         'GPU operation and standalone spatial-index timers wait on real completion fences'
-      );
+      ).toBe(true);
       if (theta === 0) {
-        tapeTest.ok(
-          report.approximationMaxAbsoluteError < 2e-4,
+        expect(
+          Boolean(report.approximationMaxAbsoluteError < 2e-4),
           'theta zero retains exact long-range repulsion instead of hiding approximation error'
-        );
+        ).toBe(true);
       }
     } finally {
       fenceSpy.mockRestore();
       submitSpy.mockRestore();
     }
-
-    tapeTest.end();
   });
 }
 
 function assertBenchmarkReport(
-  tapeTest: Test,
   report: GPUGraphBenchmarkReport,
   device: Device,
   expected: {
@@ -106,76 +100,68 @@ function assertBenchmarkReport(
     pageRankIterations: number;
   }
 ): void {
-  tapeTest.equal(
-    report.datasetKind,
-    expected.kind,
-    'CPU and GPU execute the requested graph family'
+  expect(report.datasetKind, 'CPU and GPU execute the requested graph family').toBe(expected.kind);
+  expect(report.vertexCount, 'both paths share the same vertex IDs').toBe(expected.vertexCount);
+  expect(report.edgeCount, 'both paths share every deterministic source edge').toBe(
+    expected.edgeCount
   );
-  tapeTest.equal(report.vertexCount, expected.vertexCount, 'both paths share the same vertex IDs');
-  tapeTest.equal(
-    report.edgeCount,
-    expected.edgeCount,
-    'both paths share every deterministic source edge'
-  );
-  tapeTest.equal(report.warmupIterations, 0, 'warmup cost is excluded from the requested sample');
-  tapeTest.equal(
-    report.measuredIterations,
-    1,
-    'one real measured execution contributes each sample'
-  );
-  tapeTest.ok(
-    Number.isFinite(report.uploadTimeMilliseconds) && report.uploadTimeMilliseconds >= 0,
+  expect(report.warmupIterations, 'warmup cost is excluded from the requested sample').toBe(0);
+  expect(report.measuredIterations, 'one real measured execution contributes each sample').toBe(1);
+  expect(
+    Boolean(Number.isFinite(report.uploadTimeMilliseconds) && report.uploadTimeMilliseconds >= 0),
     'source upload is measured and reported independently'
-  );
-  tapeTest.ok(
-    Number.isFinite(report.compilationTimeMilliseconds) && report.compilationTimeMilliseconds >= 0,
+  ).toBe(true);
+  expect(
+    Boolean(
+      Number.isFinite(report.compilationTimeMilliseconds) && report.compilationTimeMilliseconds >= 0
+    ),
     'graph compilation is measured separately from GPU execution'
-  );
-  tapeTest.ok(
-    Number.isFinite(report.readbackTimeMilliseconds) && report.readbackTimeMilliseconds >= 0,
+  ).toBe(true);
+  expect(
+    Boolean(
+      Number.isFinite(report.readbackTimeMilliseconds) && report.readbackTimeMilliseconds >= 0
+    ),
     'explicit oracle-validation readback is separated from fenced benchmark timing'
-  );
+  ).toBe(true);
   assertDistribution(
-    tapeTest,
     report.spatialIndexBuildTimeMilliseconds,
     'independent GPUGridIndex construction'
   );
-  tapeTest.equal(
+  expect(
     report.indexMemoryBytes,
-    4 * (expected.cellCount + 1) + 4 * expected.vertexCount + 8 * expected.cellCount + 8,
     'index memory reports exclusive offsets, vertex IDs, float32x2 centers, and both statuses'
-  );
-  tapeTest.ok(
-    Number.isFinite(report.approximationMaxAbsoluteError) &&
-      report.approximationMaxAbsoluteError >= 0,
+  ).toBe(4 * (expected.cellCount + 1) + 4 * expected.vertexCount + 8 * expected.cellCount + 8);
+  expect(
+    Boolean(
+      Number.isFinite(report.approximationMaxAbsoluteError) &&
+        report.approximationMaxAbsoluteError >= 0
+    ),
     'spatial accuracy is honestly compared against the independently evaluated exact force result'
-  );
+  ).toBe(true);
 
-  tapeTest.deepEqual(
+  expect(
     report.paths.map(path => path.algorithm),
-    BENCHMARK_ALGORITHMS,
     'nine independently compiled CPU and WebGPU algorithms are actually benchmarked'
-  );
+  ).toEqual(BENCHMARK_ALGORITHMS);
   for (const path of report.paths) {
-    assertDistribution(tapeTest, path.cpuTimeMilliseconds, `${path.algorithm} CPU reference`);
-    assertDistribution(tapeTest, path.cpuEncodeTimeMilliseconds, `${path.algorithm} CPU encoding`);
+    assertDistribution(path.cpuTimeMilliseconds, `${path.algorithm} CPU reference`);
+    assertDistribution(path.cpuEncodeTimeMilliseconds, `${path.algorithm} CPU encoding`);
     assertDistribution(
-      tapeTest,
       path.synchronizedTimeMilliseconds,
       `${path.algorithm} fence-synchronized GPU execution`
     );
-    tapeTest.ok(
-      Number.isSafeInteger(path.importedBufferBytes) && path.importedBufferBytes > 0,
+    expect(
+      Boolean(Number.isSafeInteger(path.importedBufferBytes) && path.importedBufferBytes > 0),
       `${path.algorithm} reports actual caller-owned imported GPU bytes`
-    );
-    tapeTest.ok(
-      Number.isSafeInteger(path.transientBufferBytes) && path.transientBufferBytes >= 0,
+    ).toBe(true);
+    expect(
+      Boolean(Number.isSafeInteger(path.transientBufferBytes) && path.transientBufferBytes >= 0),
       `${path.algorithm} reports actual graph-owned transient GPU bytes`
-    );
-    tapeTest.ok(
-      Number.isFinite(path.maxAbsoluteError) && path.maxAbsoluteError >= 0,
+    ).toBe(true);
+    expect(
+      Boolean(Number.isFinite(path.maxAbsoluteError) && path.maxAbsoluteError >= 0),
       `${path.algorithm} validates GPU results against its independent CPU oracle`
-    );
+    ).toBe(true);
     if (
       path.algorithm === 'topology' ||
       path.algorithm === 'breadth-first-search' ||
@@ -183,111 +169,96 @@ function assertBenchmarkReport(
       path.algorithm === 'connected-components' ||
       path.algorithm === 'label-propagation'
     ) {
-      tapeTest.equal(
+      expect(
         path.maxAbsoluteError,
-        0,
         `${path.algorithm} matches its exact CPU reference outputs`
-      );
+      ).toBe(0);
     } else {
-      tapeTest.ok(
-        path.maxAbsoluteError < 5e-4,
+      expect(
+        Boolean(path.maxAbsoluteError < 5e-4),
         `${path.algorithm} stays within real float32 accuracy`
-      );
+      ).toBe(true);
     }
     if (!report.timestampQueries) {
-      tapeTest.equal(
+      expect(
         path.gpuTimeMilliseconds,
-        undefined,
         `${path.algorithm} never fabricates unavailable GPU timestamp-query timings`
-      );
+      ).toBe(undefined);
     } else if (path.gpuTimeMilliseconds) {
-      assertDistribution(tapeTest, path.gpuTimeMilliseconds, `${path.algorithm} GPU timestamps`);
+      assertDistribution(path.gpuTimeMilliseconds, `${path.algorithm} GPU timestamps`);
     }
 
     if (path.algorithm === 'single-source-shortest-path') {
-      tapeTest.equal(
+      expect(
         path.iterations,
-        expected.vertexCount - 1,
         'weighted shortest paths report their actual bounded GPU relaxation passes'
-      );
-      tapeTest.equal(
+      ).toBe(expected.vertexCount - 1);
+      expect(
         typeof path.converged,
-        'boolean',
         'weighted shortest paths expose the actual final GPU fixed-point status'
-      );
-      tapeTest.equal(path.residual, undefined, 'weighted paths never fabricate a residual');
+      ).toBe('boolean');
+      expect(path.residual, 'weighted paths never fabricate a residual').toBe(undefined);
     } else if (path.algorithm === 'connected-components') {
-      tapeTest.equal(path.iterations, 32, 'weak components report their actual bounded GPU passes');
-      tapeTest.equal(
+      expect(path.iterations, 'weak components report their actual bounded GPU passes').toBe(32);
+      expect(
         path.converged,
-        true,
         'weak components report the real final GPU fixed-point convergence status'
-      );
-      tapeTest.equal(
-        path.residual,
-        undefined,
-        'integer weak components never fabricate a residual'
-      );
+      ).toBe(true);
+      expect(path.residual, 'integer weak components never fabricate a residual').toBe(undefined);
     } else if (path.algorithm === 'label-propagation') {
-      tapeTest.equal(path.iterations, 8, 'community labels report their real bounded vote passes');
-      tapeTest.equal(
+      expect(path.iterations, 'community labels report their real bounded vote passes').toBe(8);
+      expect(
         typeof path.converged,
-        'boolean',
         'community labels expose their actual final GPU fixed-point status'
-      );
-      tapeTest.equal(path.residual, undefined, 'community labels never fabricate a residual');
+      ).toBe('boolean');
+      expect(path.residual, 'community labels never fabricate a residual').toBe(undefined);
     } else if (path.algorithm === 'page-rank') {
-      tapeTest.equal(
+      expect(
         path.iterations,
-        expected.pageRankIterations,
         'PageRank reports its actual independently configured GPU pass count'
-      );
-      tapeTest.ok(
-        typeof path.residual === 'number' &&
-          Number.isFinite(path.residual) &&
-          path.residual >= 0 &&
-          path.residual <= 2,
+      ).toBe(expected.pageRankIterations);
+      expect(
+        Boolean(
+          typeof path.residual === 'number' &&
+            Number.isFinite(path.residual) &&
+            path.residual >= 0 &&
+            path.residual <= 2
+        ),
         'PageRank exposes the real finite, normalized final GPU L1 residual'
-      );
-      tapeTest.equal(path.converged, undefined, 'PageRank never invents a binary convergence flag');
+      ).toBe(true);
+      expect(path.converged, 'PageRank never invents a binary convergence flag').toBe(undefined);
     } else {
-      tapeTest.equal(path.iterations, undefined, `${path.algorithm} omits unrelated pass counts`);
-      tapeTest.equal(path.converged, undefined, `${path.algorithm} omits unrelated convergence`);
-      tapeTest.equal(path.residual, undefined, `${path.algorithm} omits unrelated GPU residuals`);
+      expect(path.iterations, `${path.algorithm} omits unrelated pass counts`).toBe(undefined);
+      expect(path.converged, `${path.algorithm} omits unrelated convergence`).toBe(undefined);
+      expect(path.residual, `${path.algorithm} omits unrelated GPU residuals`).toBe(undefined);
     }
   }
-  tapeTest.equal(
-    typeof report.timestampQueries,
-    'boolean',
-    'optional timestamp support is explicit'
-  );
-  tapeTest.equal(
-    device.type,
-    'webgpu',
-    'reported timings were produced by an actual WebGPU device'
-  );
+  expect(typeof report.timestampQueries, 'optional timestamp support is explicit').toBe('boolean');
+  expect(device.type, 'reported timings were produced by an actual WebGPU device').toBe('webgpu');
 }
 
-function assertDistribution(
-  tapeTest: Test,
-  distribution: GPUGraphBenchmarkDistribution,
-  label: string
-): void {
+function assertDistribution(distribution: GPUGraphBenchmarkDistribution, label: string): void {
   for (const value of [
     distribution.minimum,
     distribution.median,
     distribution.percentile95,
     distribution.maximum
   ]) {
-    tapeTest.ok(Number.isFinite(value) && value >= 0, `${label} publishes finite measured timings`);
+    expect(
+      Boolean(Number.isFinite(value) && value >= 0),
+      `${label} publishes finite measured timings`
+    ).toBe(true);
   }
-  tapeTest.ok(distribution.minimum <= distribution.median, `${label} median follows its minimum`);
-  tapeTest.ok(
-    distribution.median <= distribution.percentile95,
+  expect(
+    Boolean(distribution.minimum <= distribution.median),
+    `${label} median follows its minimum`
+  ).toBe(true);
+  expect(
+    Boolean(distribution.median <= distribution.percentile95),
     `${label} 95th percentile follows its median`
-  );
-  tapeTest.ok(
-    distribution.percentile95 <= distribution.maximum,
+  ).toBe(true);
+  expect(
+    Boolean(distribution.percentile95 <= distribution.maximum),
     `${label} maximum bounds its percentile`
-  );
+  ).toBe(true);
 }

--- a/modules/gpgpu/test/gpu-graph/gpu-graph-breadth-first-search.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph-breadth-first-search.spec.ts
@@ -13,8 +13,7 @@ import {
 } from '@luma.gl/gpgpu/gpu-graph';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test, {type Test} from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {
   addGPUGraphBreadthFirstSearchToGraphWithDispatchLimit,
   getGPUGraphBreadthFirstSearchDispatchLayout
@@ -291,21 +290,18 @@ const searchScenarios: SearchScenario[] = [
   }
 ];
 
-test('GPUGraphBreadthFirstSearch plans bounded three-dimensional seed and vertex dispatch', tapeTest => {
-  tapeTest.deepEqual(getGPUGraphBreadthFirstSearchDispatchLayout(0, 2), {x: 1, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphBreadthFirstSearchDispatchLayout(512, 2), {x: 2, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphBreadthFirstSearchDispatchLayout(513, 2), {x: 2, y: 2, z: 1});
-  tapeTest.deepEqual(getGPUGraphBreadthFirstSearchDispatchLayout(1025, 2), {x: 2, y: 2, z: 2});
-  tapeTest.throws(() => getGPUGraphBreadthFirstSearchDispatchLayout(2049, 2), /3D dispatch limit/);
-  tapeTest.end();
+it('GPUGraphBreadthFirstSearch plans bounded three-dimensional seed and vertex dispatch', () => {
+  expect(getGPUGraphBreadthFirstSearchDispatchLayout(0, 2)).toEqual({x: 1, y: 1, z: 1});
+  expect(getGPUGraphBreadthFirstSearchDispatchLayout(512, 2)).toEqual({x: 2, y: 1, z: 1});
+  expect(getGPUGraphBreadthFirstSearchDispatchLayout(513, 2)).toEqual({x: 2, y: 2, z: 1});
+  expect(getGPUGraphBreadthFirstSearchDispatchLayout(1025, 2)).toEqual({x: 2, y: 2, z: 2});
+  expect(() => getGPUGraphBreadthFirstSearchDispatchLayout(2049, 2)).toThrow(/3D dispatch limit/);
 });
 
 for (const scenario of searchScenarios) {
-  test(`GPUGraphBreadthFirstSearch GPU traversal: ${scenario.name}`, async tapeTest => {
+  it(`GPUGraphBreadthFirstSearch GPU traversal: ${scenario.name}`, async () => {
     const device = await getWebGPUTestDevice();
     if (!device) {
-      tapeTest.comment('WebGPU is not available');
-      tapeTest.end();
       return;
     }
 
@@ -314,32 +310,26 @@ for (const scenario of searchScenarios) {
     try {
       compileSearch(fixture, scenario.maximumWorkgroups);
       executeSearch(fixture);
-      await assertSearch(tapeTest, fixture, expected);
-      tapeTest.deepEqual(
+      await assertSearch(fixture, expected);
+      expect(
         fixture.search.seeds.data.map(chunk => chunk.length),
-        scenario.seedChunks.map(chunk => chunk.length),
         'traversal preserves ordered seed chunks and empty seed batches'
-      );
+      ).toEqual(scenario.seedChunks.map(chunk => chunk.length));
       if (scenario.assertNoScratch) {
-        tapeTest.equal(
+        expect(
           fixture.compiled?.stats.logicalTransientBufferCount,
-          3,
           'shortest-path traversal adds no frontier or scratch buffers beyond CSR construction'
-        );
+        ).toBe(3);
       }
     } finally {
-      destroyExecutionFixture(tapeTest, fixture);
+      destroyExecutionFixture(fixture);
     }
-
-    tapeTest.end();
   });
 }
 
-test('GPUGraphBreadthFirstSearch rereads dynamic seeds, depth, and sources on every encoding', async tapeTest => {
+it('GPUGraphBreadthFirstSearch rereads dynamic seeds, depth, and sources on every encoding', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -365,40 +355,37 @@ test('GPUGraphBreadthFirstSearch rereads dynamic seeds, depth, and sources on ev
 
   try {
     compileSearch(fixture);
-    tapeTest.equal(submitSpy.mock.calls.length, 0, 'topology and search construction never submit');
-    tapeTest.ok(
-      sourceReadbackSpies.every(spy => spy.mock.calls.length === 0),
+    expect(submitSpy.mock.calls.length, 'topology and search construction never submit').toBe(0);
+    expect(
+      Boolean(sourceReadbackSpies.every(spy => spy.mock.calls.length === 0)),
       'graph construction and compilation never read source or seed buffers'
-    );
+    ).toBe(true);
     submitSpy.mockRestore();
     for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
 
     executeSearch(fixture);
-    await assertSearch(tapeTest, fixture, calculateExpectedSearch(original));
+    await assertSearch(fixture, calculateExpectedSearch(original));
 
     (fixture.search.seedCount!.data[0].buffer as Buffer).write(Uint32Array.from([2]));
     (fixture.search.activeDepth!.data[0].buffer as Buffer).write(Uint32Array.from([3]));
     const expanded = {...original, activeSeedCount: 2, activeDepth: 3};
     executeSearch(fixture);
-    await assertSearch(tapeTest, fixture, calculateExpectedSearch(expanded));
+    await assertSearch(fixture, calculateExpectedSearch(expanded));
 
     const sourceBuffer = fixture.graph.sourceVertices.data[0].buffer as Buffer;
     sourceBuffer.write(Uint32Array.from([9, 1]));
     const updated = {...expanded, sourceChunks: [[9, 1], [], [2, 4]]};
     executeSearch(fixture);
-    await assertSearch(tapeTest, fixture, calculateExpectedSearch(updated));
-    tapeTest.equal(
+    await assertSearch(fixture, calculateExpectedSearch(updated));
+    expect(
       fixture.graph.sourceVertices.data[0].buffer,
-      sourceBuffer,
       'source updates retain the original caller-owned GPUData chunk'
-    );
+    ).toBe(sourceBuffer);
   } finally {
     submitSpy.mockRestore();
     for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-
-  tapeTest.end();
 });
 
 /** Builds complete CPU adjacency before applying deterministic multi-source shortest-hop search. */
@@ -757,7 +744,6 @@ function executeSearch(fixture: SearchExecutionFixture): void {
 }
 
 async function assertSearch(
-  tapeTest: Test,
   fixture: SearchExecutionFixture,
   expected: ExpectedSearch
 ): Promise<void> {
@@ -773,38 +759,33 @@ async function assertSearch(
         : Promise.resolve(undefined)
     ]);
 
-  tapeTest.deepEqual(distances, expected.distances, 'shortest-hop distances match the CPU oracle');
-  tapeTest.deepEqual(
+  expect(distances, 'shortest-hop distances match the CPU oracle').toEqual(expected.distances);
+  expect(
     predecessors,
-    expected.predecessors,
     'equal-length paths choose the deterministic lowest stable predecessor ID'
-  );
+  ).toEqual(expected.predecessors);
   if (mask) {
-    tapeTest.deepEqual(mask, expected.mask, 'optional reachability masks stay source aligned');
+    expect(mask, 'optional reachability masks stay source aligned').toEqual(expected.mask);
   }
-  tapeTest.equal(
-    invalidEdgeCount[0],
-    expected.invalidEdgeCount,
-    'invalid graph edges remain excluded'
+  expect(invalidEdgeCount[0], 'invalid graph edges remain excluded').toBe(
+    expected.invalidEdgeCount
   );
-  tapeTest.equal(
-    forwardOverflow[0],
-    Number(expected.forwardOverflow),
-    'forward overflow remains explicit'
+  expect(forwardOverflow[0], 'forward overflow remains explicit').toBe(
+    Number(expected.forwardOverflow)
   );
   if (reverseOverflow) {
-    tapeTest.equal(
-      reverseOverflow[0],
-      Number(expected.reverseOverflow),
-      'reverse overflow remains explicit'
+    expect(reverseOverflow[0], 'reverse overflow remains explicit').toBe(
+      Number(expected.reverseOverflow)
     );
   }
   if (expected.requiredOverflow) {
-    tapeTest.ok(
-      distances.every(distance => distance === UNREACHABLE_VERTEX) &&
-        predecessors.every(predecessor => predecessor === UNREACHABLE_VERTEX),
+    expect(
+      Boolean(
+        distances.every(distance => distance === UNREACHABLE_VERTEX) &&
+          predecessors.every(predecessor => predecessor === UNREACHABLE_VERTEX)
+      ),
       'required adjacency overflow fails closed without exposing misleading partial paths'
-    );
+    ).toBe(true);
   }
 }
 
@@ -818,12 +799,12 @@ async function readUint32Vector(vector: GPUVector<'uint32'>): Promise<number[]> 
   return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, vector.length));
 }
 
-function destroyExecutionFixture(tapeTest: Test, fixture: SearchExecutionFixture): void {
+function destroyExecutionFixture(fixture: SearchExecutionFixture): void {
   fixture.compiled?.destroy();
   for (const vector of fixture.vectors) vector.destroy();
-  tapeTest.ok(
-    fixture.buffers.every(buffer => !buffer.destroyed),
+  expect(
+    Boolean(fixture.buffers.every(buffer => !buffer.destroyed)),
     'destroying a compiled traversal and borrowed vectors preserves every caller-owned buffer'
-  );
+  ).toBe(true);
   for (const buffer of fixture.buffers) buffer.destroy();
 }

--- a/modules/gpgpu/test/gpu-graph/gpu-graph-connected-components.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph-connected-components.spec.ts
@@ -12,8 +12,7 @@ import {
 } from '@luma.gl/gpgpu/gpu-graph';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test, {type Test} from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {
   addGPUGraphConnectedComponentsToGraphWithDispatchLimit,
   getGPUGraphConnectedComponentsDispatchLayout
@@ -199,21 +198,18 @@ const componentsScenarios: ComponentsScenario[] = [
   }
 ];
 
-test('GPUGraphConnectedComponents plans bounded three-dimensional vertex dispatch', tapeTest => {
-  tapeTest.deepEqual(getGPUGraphConnectedComponentsDispatchLayout(0, 2), {x: 1, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphConnectedComponentsDispatchLayout(512, 2), {x: 2, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphConnectedComponentsDispatchLayout(513, 2), {x: 2, y: 2, z: 1});
-  tapeTest.deepEqual(getGPUGraphConnectedComponentsDispatchLayout(1025, 2), {x: 2, y: 2, z: 2});
-  tapeTest.throws(() => getGPUGraphConnectedComponentsDispatchLayout(2049, 2), /3D dispatch limit/);
-  tapeTest.end();
+it('GPUGraphConnectedComponents plans bounded three-dimensional vertex dispatch', () => {
+  expect(getGPUGraphConnectedComponentsDispatchLayout(0, 2)).toEqual({x: 1, y: 1, z: 1});
+  expect(getGPUGraphConnectedComponentsDispatchLayout(512, 2)).toEqual({x: 2, y: 1, z: 1});
+  expect(getGPUGraphConnectedComponentsDispatchLayout(513, 2)).toEqual({x: 2, y: 2, z: 1});
+  expect(getGPUGraphConnectedComponentsDispatchLayout(1025, 2)).toEqual({x: 2, y: 2, z: 2});
+  expect(() => getGPUGraphConnectedComponentsDispatchLayout(2049, 2)).toThrow(/3D dispatch limit/);
 });
 
 for (const scenario of componentsScenarios) {
-  test(`GPUGraphConnectedComponents GPU labeling: ${scenario.name}`, async tapeTest => {
+  it(`GPUGraphConnectedComponents GPU labeling: ${scenario.name}`, async () => {
     const device = await getWebGPUTestDevice();
     if (!device) {
-      tapeTest.comment('WebGPU is not available');
-      tapeTest.end();
       return;
     }
 
@@ -222,32 +218,26 @@ for (const scenario of componentsScenarios) {
     try {
       compileComponents(fixture, scenario.maximumWorkgroups);
       executeComponents(fixture);
-      await assertComponents(tapeTest, fixture, scenario, expected);
-      tapeTest.deepEqual(
+      await assertComponents(fixture, scenario, expected);
+      expect(
         fixture.graph.sourceVertices.data.map(chunk => chunk.length),
-        scenario.sourceChunks.map(chunk => chunk.length),
         'weak-component evaluation preserves every original source chunk'
-      );
+      ).toEqual(scenario.sourceChunks.map(chunk => chunk.length));
       if (scenario.assertNoScratch) {
-        tapeTest.equal(
+        expect(
           fixture.compiled?.stats.logicalTransientBufferCount,
-          3,
           'weak-component hooking allocates no scratch beyond CSR topology construction'
-        );
+        ).toBe(3);
       }
     } finally {
-      destroyExecutionFixture(tapeTest, fixture);
+      destroyExecutionFixture(fixture);
     }
-
-    tapeTest.end();
   });
 }
 
-test('GPUGraphConnectedComponents rebuilds weak labels after source updates without hidden execution', async tapeTest => {
+it('GPUGraphConnectedComponents rebuilds weak labels after source updates without hidden execution', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -267,38 +257,31 @@ test('GPUGraphConnectedComponents rebuilds weak labels after source updates with
 
   try {
     compileComponents(fixture);
-    tapeTest.equal(
-      submitSpy.mock.calls.length,
-      0,
-      'construction and compilation never submit work'
-    );
-    tapeTest.ok(
-      sourceReadbackSpies.every(spy => spy.mock.calls.length === 0),
+    expect(submitSpy.mock.calls.length, 'construction and compilation never submit work').toBe(0);
+    expect(
+      Boolean(sourceReadbackSpies.every(spy => spy.mock.calls.length === 0)),
       'weak connectivity never reads graph source buffers back'
-    );
+    ).toBe(true);
     submitSpy.mockRestore();
     for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
 
     executeComponents(fixture);
-    await assertComponents(tapeTest, fixture, original, calculateExpectedComponents(original));
+    await assertComponents(fixture, original, calculateExpectedComponents(original));
 
     const sourceBuffer = fixture.graph.sourceVertices.data[0].buffer as Buffer;
     sourceBuffer.write(Uint32Array.from([9, 1]));
     const updated = {...original, sourceChunks: [[9, 1], [], [3, 4]]};
     executeComponents(fixture);
-    await assertComponents(tapeTest, fixture, updated, calculateExpectedComponents(updated));
-    tapeTest.equal(
+    await assertComponents(fixture, updated, calculateExpectedComponents(updated));
+    expect(
       fixture.graph.sourceVertices.data[0].buffer,
-      sourceBuffer,
       'source updates retain exact caller-owned chunk identity'
-    );
+    ).toBe(sourceBuffer);
   } finally {
     submitSpy.mockRestore();
     for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-
-  tapeTest.end();
 });
 
 /** Computes weak connected components with minimum stable vertex IDs using CPU union-find. */
@@ -569,7 +552,6 @@ function executeComponents(fixture: ComponentsExecutionFixture): void {
 }
 
 async function assertComponents(
-  tapeTest: Test,
   fixture: ComponentsExecutionFixture,
   scenario: ComponentsScenario,
   expected: ExpectedComponents
@@ -588,47 +570,40 @@ async function assertComponents(
     ]);
 
   if (scenario.allowPartialLabels && !expected.forwardOverflow) {
-    tapeTest.ok(
-      labels.every(
-        (label, vertexIndex) =>
-          label <= vertexIndex && expected.labels[label] === expected.labels[vertexIndex]
+    expect(
+      Boolean(
+        labels.every(
+          (label, vertexIndex) =>
+            label <= vertexIndex && expected.labels[label] === expected.labels[vertexIndex]
+        )
       ),
       'bounded iterations preserve monotone labels inside each true weak component'
-    );
+    ).toBe(true);
   } else {
-    tapeTest.deepEqual(labels, expected.labels, 'component IDs equal each weak component minimum');
+    expect(labels, 'component IDs equal each weak component minimum').toEqual(expected.labels);
   }
 
   if (convergence) {
     const expectedConvergence = Number(!expected.forwardOverflow && !scenario.incomplete);
-    tapeTest.equal(
+    expect(
       convergence[0],
-      expectedConvergence,
       'convergence is proven only when the final iteration makes no changes'
-    );
+    ).toBe(expectedConvergence);
   }
-  tapeTest.equal(
-    invalidEdgeCount[0],
-    expected.invalidEdgeCount,
-    'invalid source edges stay excluded'
-  );
-  tapeTest.equal(
-    forwardOverflow[0],
-    Number(expected.forwardOverflow),
-    'forward adjacency overflow remains explicit'
+  expect(invalidEdgeCount[0], 'invalid source edges stay excluded').toBe(expected.invalidEdgeCount);
+  expect(forwardOverflow[0], 'forward adjacency overflow remains explicit').toBe(
+    Number(expected.forwardOverflow)
   );
   if (reverseOverflow) {
-    tapeTest.equal(
-      reverseOverflow[0],
-      Number(expected.reverseOverflow),
-      'unused reverse overflow does not invalidate weak components'
+    expect(reverseOverflow[0], 'unused reverse overflow does not invalidate weak components').toBe(
+      Number(expected.reverseOverflow)
     );
   }
   if (expected.forwardOverflow) {
-    tapeTest.ok(
-      labels.every(label => label === INVALID_COMPONENT),
+    expect(
+      Boolean(labels.every(label => label === INVALID_COMPONENT)),
       'truncated forward adjacency publishes no misleading partial labels'
-    );
+    ).toBe(true);
   }
 }
 
@@ -642,12 +617,12 @@ async function readUint32Vector(vector: GPUVector<'uint32'>): Promise<number[]> 
   return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, vector.length));
 }
 
-function destroyExecutionFixture(tapeTest: Test, fixture: ComponentsExecutionFixture): void {
+function destroyExecutionFixture(fixture: ComponentsExecutionFixture): void {
   fixture.compiled?.destroy();
   for (const vector of fixture.vectors) vector.destroy();
-  tapeTest.ok(
-    fixture.buffers.every(buffer => !buffer.destroyed),
+  expect(
+    Boolean(fixture.buffers.every(buffer => !buffer.destroyed)),
     'compiled component graphs and borrowed vectors never destroy caller-owned buffers'
-  );
+  ).toBe(true);
   for (const buffer of fixture.buffers) buffer.destroy();
 }

--- a/modules/gpgpu/test/gpu-graph/gpu-graph-core-number.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph-core-number.spec.ts
@@ -12,8 +12,7 @@ import {
 } from '@luma.gl/gpgpu/gpu-graph';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test, {type Test} from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {
   addGPUGraphCoreNumberToGraphWithDispatchLimit,
   getGPUGraphCoreNumberDispatchLayout
@@ -245,20 +244,17 @@ const coreNumberScenarios: CoreNumberScenario[] = [
   }
 ];
 
-test('GPUGraphCoreNumber plans bounded three-dimensional graph dispatch', tapeTest => {
-  tapeTest.deepEqual(getGPUGraphCoreNumberDispatchLayout(0, 2), {x: 1, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphCoreNumberDispatchLayout(513, 2), {x: 2, y: 2, z: 1});
-  tapeTest.deepEqual(getGPUGraphCoreNumberDispatchLayout(1025, 2), {x: 2, y: 2, z: 2});
-  tapeTest.throws(() => getGPUGraphCoreNumberDispatchLayout(2049, 2), /3D dispatch limit/);
-  tapeTest.end();
+it('GPUGraphCoreNumber plans bounded three-dimensional graph dispatch', () => {
+  expect(getGPUGraphCoreNumberDispatchLayout(0, 2)).toEqual({x: 1, y: 1, z: 1});
+  expect(getGPUGraphCoreNumberDispatchLayout(513, 2)).toEqual({x: 2, y: 2, z: 1});
+  expect(getGPUGraphCoreNumberDispatchLayout(1025, 2)).toEqual({x: 2, y: 2, z: 2});
+  expect(() => getGPUGraphCoreNumberDispatchLayout(2049, 2)).toThrow(/3D dispatch limit/);
 });
 
 for (const scenario of coreNumberScenarios) {
-  test(`GPUGraphCoreNumber GPU decomposition: ${scenario.name}`, async tapeTest => {
+  it(`GPUGraphCoreNumber GPU decomposition: ${scenario.name}`, async () => {
     const device = await getWebGPUTestDevice();
     if (!device) {
-      tapeTest.comment('WebGPU is not available');
-      tapeTest.end();
       return;
     }
 
@@ -267,19 +263,16 @@ for (const scenario of coreNumberScenarios) {
     try {
       compileCoreNumber(fixture, scenario.maximumWorkgroups);
       executeCoreNumber(fixture);
-      await assertCoreNumbers(tapeTest, fixture, expected, scenario);
+      await assertCoreNumbers(fixture, expected, scenario);
     } finally {
-      destroyExecutionFixture(tapeTest, fixture);
+      destroyExecutionFixture(fixture);
     }
-    tapeTest.end();
   });
 }
 
-test('GPUGraphCoreNumber rereads caller-owned edge columns on each graph encoding', async tapeTest => {
+it('GPUGraphCoreNumber rereads caller-owned edge columns on each graph encoding', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -294,7 +287,7 @@ test('GPUGraphCoreNumber rereads caller-owned edge columns on each graph encodin
   try {
     compileCoreNumber(fixture);
     executeCoreNumber(fixture);
-    await assertCoreNumbers(tapeTest, fixture, expectedInitial, initial);
+    await assertCoreNumbers(fixture, expectedInitial, initial);
 
     const updated: CoreNumberScenario = {
       ...initial,
@@ -303,18 +296,15 @@ test('GPUGraphCoreNumber rereads caller-owned edge columns on each graph encodin
     };
     (fixture.graph.targetVertices.data[0].buffer as Buffer).write(Uint32Array.from([1, 2, 3]));
     executeCoreNumber(fixture);
-    await assertCoreNumbers(tapeTest, fixture, calculateExpectedCoreNumbers(updated), updated);
+    await assertCoreNumbers(fixture, calculateExpectedCoreNumbers(updated), updated);
   } finally {
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-  tapeTest.end();
 });
 
-test('GPUGraphCoreNumber schedules GPU work without submission or source readback', async tapeTest => {
+it('GPUGraphCoreNumber schedules GPU work without submission or source readback', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -334,19 +324,18 @@ test('GPUGraphCoreNumber schedules GPU work without submission or source readbac
   const readbacks = sourceBuffers.map(chunk => vi.spyOn(chunk.buffer as Buffer, 'readAsync'));
   try {
     compileCoreNumber(fixture);
-    tapeTest.equal(submit.mock.calls.length, 0, 'construction and compilation never submit work');
+    expect(submit.mock.calls.length, 'construction and compilation never submit work').toBe(0);
     executeCoreNumber(fixture);
-    await assertCoreNumbers(tapeTest, fixture, expected, scenario);
-    tapeTest.ok(
-      readbacks.every(readback => readback.mock.calls.length === 0),
+    await assertCoreNumbers(fixture, expected, scenario);
+    expect(
+      Boolean(readbacks.every(readback => readback.mock.calls.length === 0)),
       'source and adjacency data remain resident on the caller-owned device'
-    );
+    ).toBe(true);
   } finally {
     submit.mockRestore();
     for (const readback of readbacks) readback.mockRestore();
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-  tapeTest.end();
 });
 
 /** Independently builds simple weak neighborhoods and compares bounded H-index to exact peeling. */
@@ -671,7 +660,6 @@ function executeCoreNumber(fixture: CoreNumberExecutionFixture): void {
 }
 
 async function assertCoreNumbers(
-  tapeTest: Test,
   fixture: CoreNumberExecutionFixture,
   expected: ExpectedCoreNumbers,
   scenario: CoreNumberScenario
@@ -681,59 +669,38 @@ async function assertCoreNumbers(
     readUint32Vector(fixture.topology.invalidEdgeCount),
     readUint32Vector(fixture.topology.forward.overflow)
   ]);
-  tapeTest.deepEqual(
-    output,
-    expected.output,
-    'bounded GPU core numbers match synchronous H-indices'
-  );
-  tapeTest.equal(
-    invalidEdges[0],
-    expected.invalidEdgeCount,
-    'invalid source endpoints are excluded'
-  );
-  tapeTest.equal(
-    forwardOverflow[0],
-    Number(expected.forwardOverflow),
-    'forward overflow stays explicit'
+  expect(output, 'bounded GPU core numbers match synchronous H-indices').toEqual(expected.output);
+  expect(invalidEdges[0], 'invalid source endpoints are excluded').toBe(expected.invalidEdgeCount);
+  expect(forwardOverflow[0], 'forward overflow stays explicit').toBe(
+    Number(expected.forwardOverflow)
   );
   if (scenario.expectedCoreNumbers) {
-    tapeTest.deepEqual(
+    expect(
       expected.exactCoreNumbers,
-      scenario.expectedCoreNumbers,
       'independent simple-graph peeling produces the documented exact shell numbers'
-    );
+    ).toEqual(scenario.expectedCoreNumbers);
   }
   if (!expected.forwardOverflow && !expected.reverseOverflow) {
-    tapeTest.ok(
-      output.every((value, vertex) => value >= expected.exactCoreNumbers[vertex]),
+    expect(
+      Boolean(output.every((value, vertex) => value >= expected.exactCoreNumbers[vertex])),
       'bounded, unconverged output remains a valid upper bound on exact core numbers'
-    );
+    ).toBe(true);
     if (expected.converged) {
-      tapeTest.deepEqual(
-        output,
-        expected.exactCoreNumbers,
-        'converged H-indices equal exact peeling'
-      );
+      expect(output, 'converged H-indices equal exact peeling').toEqual(expected.exactCoreNumbers);
     }
   }
   if (fixture.operation.converged) {
     const converged = await readUint32Vector(fixture.operation.converged);
-    tapeTest.equal(converged[0], Number(expected.converged), 'fixed-point convergence is truthful');
+    expect(converged[0], 'fixed-point convergence is truthful').toBe(Number(expected.converged));
   }
   if (fixture.operation.degeneracy) {
     const degeneracy = await readUint32Vector(fixture.operation.degeneracy);
-    tapeTest.equal(
-      degeneracy[0],
-      expected.degeneracy,
-      'GPU max reduction reports graph degeneracy'
-    );
+    expect(degeneracy[0], 'GPU max reduction reports graph degeneracy').toBe(expected.degeneracy);
   }
   if (fixture.topology.reverse) {
     const reverseOverflow = await readUint32Vector(fixture.topology.reverse.overflow);
-    tapeTest.equal(
-      reverseOverflow[0],
-      Number(expected.reverseOverflow),
-      'reverse overflow stays explicit'
+    expect(reverseOverflow[0], 'reverse overflow stays explicit').toBe(
+      Number(expected.reverseOverflow)
     );
   }
 }
@@ -748,12 +715,12 @@ async function readUint32Vector(vector: GPUVector<'uint32'>): Promise<number[]> 
   return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, vector.length));
 }
 
-function destroyExecutionFixture(tapeTest: Test, fixture: CoreNumberExecutionFixture): void {
+function destroyExecutionFixture(fixture: CoreNumberExecutionFixture): void {
   fixture.compiled?.destroy();
   for (const vector of fixture.vectors) vector.destroy();
-  tapeTest.ok(
-    fixture.buffers.every(buffer => !buffer.destroyed),
+  expect(
+    Boolean(fixture.buffers.every(buffer => !buffer.destroyed)),
     'destroying graph-owned scratch never destroys caller-owned source or output buffers'
-  );
+  ).toBe(true);
   for (const buffer of fixture.buffers) buffer.destroy();
 }

--- a/modules/gpgpu/test/gpu-graph/gpu-graph-degree.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph-degree.spec.ts
@@ -13,8 +13,7 @@ import {
 } from '@luma.gl/gpgpu/gpu-graph';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test, {type Test} from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {
   addGPUGraphDegreeToGraphWithDispatchLimit,
   getGPUGraphDegreeDispatchLayout
@@ -148,21 +147,18 @@ const degreeScenarios: DegreeScenario[] = [
   }
 ];
 
-test('GPUGraphDegree plans bounded three-dimensional direct dispatch', tapeTest => {
-  tapeTest.deepEqual(getGPUGraphDegreeDispatchLayout(0, 2), {x: 1, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphDegreeDispatchLayout(512, 2), {x: 2, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphDegreeDispatchLayout(513, 2), {x: 2, y: 2, z: 1});
-  tapeTest.deepEqual(getGPUGraphDegreeDispatchLayout(1025, 2), {x: 2, y: 2, z: 2});
-  tapeTest.throws(() => getGPUGraphDegreeDispatchLayout(2049, 2), /3D dispatch limit/);
-  tapeTest.end();
+it('GPUGraphDegree plans bounded three-dimensional direct dispatch', () => {
+  expect(getGPUGraphDegreeDispatchLayout(0, 2)).toEqual({x: 1, y: 1, z: 1});
+  expect(getGPUGraphDegreeDispatchLayout(512, 2)).toEqual({x: 2, y: 1, z: 1});
+  expect(getGPUGraphDegreeDispatchLayout(513, 2)).toEqual({x: 2, y: 2, z: 1});
+  expect(getGPUGraphDegreeDispatchLayout(1025, 2)).toEqual({x: 2, y: 2, z: 2});
+  expect(() => getGPUGraphDegreeDispatchLayout(2049, 2)).toThrow(/3D dispatch limit/);
 });
 
 for (const scenario of degreeScenarios) {
-  test(`GPUGraphDegree GPU metrics: ${scenario.name}`, async tapeTest => {
+  it(`GPUGraphDegree GPU metrics: ${scenario.name}`, async () => {
     const device = await getWebGPUTestDevice();
     if (!device) {
-      tapeTest.comment('WebGPU is not available');
-      tapeTest.end();
       return;
     }
 
@@ -171,25 +167,20 @@ for (const scenario of degreeScenarios) {
     try {
       compileMetrics(fixture, scenario.maximumWorkgroups);
       executeMetrics(fixture);
-      await assertDegrees(tapeTest, fixture, expected);
-      tapeTest.deepEqual(
+      await assertDegrees(fixture, expected);
+      expect(
         fixture.graph.sourceVertices.data.map(chunk => chunk.length),
-        scenario.sourceChunks.map(chunk => chunk.length),
         'degree evaluation preserves original source chunks and empty batches'
-      );
+      ).toEqual(scenario.sourceChunks.map(chunk => chunk.length));
     } finally {
-      destroyExecutionFixture(tapeTest, fixture);
+      destroyExecutionFixture(fixture);
     }
-
-    tapeTest.end();
   });
 }
 
-test('GPUGraphDegree recomputes incoming degrees after source updates without hidden execution', async tapeTest => {
+it('GPUGraphDegree recomputes incoming degrees after source updates without hidden execution', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -212,38 +203,31 @@ test('GPUGraphDegree recomputes incoming degrees after source updates without hi
 
   try {
     compileMetrics(fixture);
-    tapeTest.equal(
-      submitSpy.mock.calls.length,
-      0,
-      'construction and compilation never submit work'
-    );
-    tapeTest.ok(
-      sourceReadbackSpies.every(spy => spy.mock.calls.length === 0),
+    expect(submitSpy.mock.calls.length, 'construction and compilation never submit work').toBe(0);
+    expect(
+      Boolean(sourceReadbackSpies.every(spy => spy.mock.calls.length === 0)),
       'topology and degree construction never read source buffers back'
-    );
+    ).toBe(true);
     submitSpy.mockRestore();
     for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
 
     executeMetrics(fixture);
-    await assertDegrees(tapeTest, fixture, calculateExpectedDegrees(original));
+    await assertDegrees(fixture, calculateExpectedDegrees(original));
 
     const sourceBuffer = fixture.graph.sourceVertices.data[0].buffer as Buffer;
     sourceBuffer.write(Uint32Array.from([9, 9]));
     const updated = {...original, sourceChunks: [[9, 9], [], [2, 3, 4]]};
     executeMetrics(fixture);
-    await assertDegrees(tapeTest, fixture, calculateExpectedDegrees(updated));
-    tapeTest.equal(
+    await assertDegrees(fixture, calculateExpectedDegrees(updated));
+    expect(
       fixture.graph.sourceVertices.data[0].buffer,
-      sourceBuffer,
       'source updates preserve caller-owned source buffer identity'
-    );
+    ).toBe(sourceBuffer);
   } finally {
     submitSpy.mockRestore();
     for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-
-  tapeTest.end();
 });
 
 /** Counts original valid graph edges rather than relying on bounded neighbor storage. */
@@ -480,7 +464,6 @@ function executeMetrics(fixture: DegreeExecutionFixture): void {
 }
 
 async function assertDegrees(
-  tapeTest: Test,
   fixture: DegreeExecutionFixture,
   expected: ExpectedDegrees
 ): Promise<void> {
@@ -494,25 +477,15 @@ async function assertDegrees(
     readUint32Vector(selectedAdjacency.count),
     readUint32Vector(selectedAdjacency.overflow)
   ]);
-  tapeTest.deepEqual(
-    values,
-    expected.values,
-    'vertex degrees match the complete CPU edge reference'
+  expect(values, 'vertex degrees match the complete CPU edge reference').toEqual(expected.values);
+  expect(invalidEdgeCount[0], 'invalid graph endpoints are excluded').toBe(
+    expected.invalidEdgeCount
   );
-  tapeTest.equal(
-    invalidEdgeCount[0],
-    expected.invalidEdgeCount,
-    'invalid graph endpoints are excluded'
+  expect(adjacencyCount[0], 'CSR records the exact edge count').toBe(
+    expected.selectedAdjacencyCount
   );
-  tapeTest.equal(
-    adjacencyCount[0],
-    expected.selectedAdjacencyCount,
-    'CSR records the exact edge count'
-  );
-  tapeTest.equal(
-    overflow[0],
-    Number(expected.selectedAdjacencyCount > selectedAdjacency.neighbors.length),
-    'degree remains exact even when selected neighbor storage overflows'
+  expect(overflow[0], 'degree remains exact even when selected neighbor storage overflows').toBe(
+    Number(expected.selectedAdjacencyCount > selectedAdjacency.neighbors.length)
   );
 }
 
@@ -526,12 +499,12 @@ async function readUint32Vector(vector: GPUVector<'uint32'>): Promise<number[]> 
   return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, vector.length));
 }
 
-function destroyExecutionFixture(tapeTest: Test, fixture: DegreeExecutionFixture): void {
+function destroyExecutionFixture(fixture: DegreeExecutionFixture): void {
   fixture.compiled?.destroy();
   for (const vector of fixture.vectors) vector.destroy();
-  tapeTest.ok(
-    fixture.buffers.every(buffer => !buffer.destroyed),
+  expect(
+    Boolean(fixture.buffers.every(buffer => !buffer.destroyed)),
     'destroying graph-owned scratch and borrowed vectors preserves all caller-owned buffers'
-  );
+  ).toBe(true);
   for (const buffer of fixture.buffers) buffer.destroy();
 }

--- a/modules/gpgpu/test/gpu-graph/gpu-graph-explorer.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph-explorer.spec.ts
@@ -7,8 +7,7 @@ import type {AnimationProps} from '@luma.gl/engine';
 import {decodeGPUIndexPickInfo, INDEX_PICKING_READBACK_BYTE_LENGTH} from '@luma.gl/gpgpu/gpu-core';
 import type {GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import GPUGraphExplorerAnimationLoopTemplate from '../../../../examples/experimental/gpu-graph-explorer/app';
 import {
   GRAPH_EXPLORER_VERTEX_COUNTS,
@@ -45,11 +44,9 @@ type ExplorerDashboardBindings = {
   writeViewUniforms(width: number, height: number): void;
 };
 
-test('GPU Graph explorer constructs actual GPU models and computes source-aligned graph analytics', async tapeTest => {
+it('GPU Graph explorer constructs actual GPU models and computes source-aligned graph analytics', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -57,48 +54,41 @@ test('GPU Graph explorer constructs actual GPU models and computes source-aligne
   let explorer: GPUGraphExplorerAnimationLoopTemplate | undefined;
   try {
     explorer = createExplorer(device);
-    tapeTest.equal(submitSpy.mock.calls.length, 0, 'construction never submits hidden GPU work');
+    expect(submitSpy.mock.calls.length, 'construction never submits hidden GPU work').toBe(0);
     submitSpy.mockRestore();
 
     const dataset = makeGraphExplorerDataset();
-    tapeTest.equal(
-      explorer.graph.vertexCount,
-      dataset.vertexCount,
-      'source vertex identities stay stable'
+    expect(explorer.graph.vertexCount, 'source vertex identities stay stable').toBe(
+      dataset.vertexCount
     );
-    tapeTest.deepEqual(
+    expect(
       explorer.graph.sourceVertices.data.map(chunk => chunk.length),
-      dataset.sourceChunks.map(chunk => chunk.length),
       'source edge vectors retain original nonempty, empty, and nonempty batches'
-    );
-    tapeTest.deepEqual(
+    ).toEqual(dataset.sourceChunks.map(chunk => chunk.length));
+    expect(
       explorer.edgeModels.map(model => model.chunkIndex),
-      [0, 2],
       'each nonempty original edge batch has its own directly bound edge model'
-    );
-    tapeTest.ok(
-      explorer.nodeModel.pipeline,
+    ).toEqual([0, 2]);
+    expect(
+      Boolean(explorer.nodeModel.pipeline),
       'actual WebGPU node shader and vertex pipeline compile'
-    );
-    tapeTest.ok(
-      explorer.pickingModel.pipeline,
+    ).toBe(true);
+    expect(
+      Boolean(explorer.pickingModel.pipeline),
       'actual integer picking shader and pipeline compile'
-    );
-    tapeTest.equal(
+    ).toBe(true);
+    expect(
       explorer.nodeModel.bindings['degrees'],
-      explorer.degree.output.data[0].buffer,
       'node color and sizing consume the actual GPU-computed degree buffer'
-    );
-    tapeTest.equal(
+    ).toBe(explorer.degree.output.data[0].buffer);
+    expect(
       explorer.pickingModel.bindings['degrees'],
-      explorer.degree.output.data[0].buffer,
       'integer picking uses the same degree-dependent radius as visible nodes'
-    );
-    tapeTest.equal(
+    ).toBe(explorer.degree.output.data[0].buffer);
+    expect(
       explorer.layout.positions.data[0].buffer.usage & (Buffer.STORAGE | Buffer.VERTEX),
-      Buffer.STORAGE | Buffer.VERTEX,
       'progressive layout coordinates are the same physical render vertex allocation'
-    );
+    ).toBe(Buffer.STORAGE | Buffer.VERTEX);
 
     executeAnalysis(device, explorer);
     const [
@@ -121,73 +111,51 @@ test('GPU Graph explorer constructs actual GPU models and computes source-aligne
       readUint32Vector(explorer.topology.forward.overflow)
     ]);
 
-    tapeTest.equal(
-      forwardCount[0],
-      explorer.graph.edgeCount,
-      'GPU builds every original directed edge'
+    expect(forwardCount[0], 'GPU builds every original directed edge').toBe(
+      explorer.graph.edgeCount
     );
-    tapeTest.equal(reverseCount[0], explorer.graph.edgeCount, 'GPU builds full reverse adjacency');
-    tapeTest.equal(invalid[0], 0, 'deterministic dataset contains no invalid source identifiers');
-    tapeTest.equal(overflow[0], 0, 'caller-owned graph adjacency has adequate explicit capacity');
-    tapeTest.equal(
+    expect(reverseCount[0], 'GPU builds full reverse adjacency').toBe(explorer.graph.edgeCount);
+    expect(invalid[0], 'deterministic dataset contains no invalid source identifiers').toBe(0);
+    expect(overflow[0], 'caller-owned graph adjacency has adequate explicit capacity').toBe(0);
+    expect(
       degrees.reduce((sum, degree) => sum + degree, 0),
-      explorer.graph.edgeCount,
       'GPU degree outputs exactly account for all original source edges'
-    );
-    tapeTest.equal(degrees[dataset.vertexCount - 1], 0, 'final isolated vertex has degree zero');
-    tapeTest.equal(
-      componentLabels[0],
-      0,
-      'first community retains minimum stable source identifier'
-    );
-    tapeTest.equal(
-      componentLabels[32],
-      0,
-      'one actual bridge joins the first two weak communities'
-    );
-    tapeTest.equal(communityLabels[0], 0, 'GPU label propagation preserves the first community');
-    tapeTest.equal(
+    ).toBe(explorer.graph.edgeCount);
+    expect(degrees[dataset.vertexCount - 1], 'final isolated vertex has degree zero').toBe(0);
+    expect(componentLabels[0], 'first community retains minimum stable source identifier').toBe(0);
+    expect(componentLabels[32], 'one actual bridge joins the first two weak communities').toBe(0);
+    expect(communityLabels[0], 'GPU label propagation preserves the first community').toBe(0);
+    expect(
       communityLabels[32],
-      32,
       'the same bridge leaves the second majority-vote community visibly distinct'
-    );
-    tapeTest.notEqual(
+    ).toBe(32);
+    expect(
       communityLabels[32],
-      componentLabels[32],
       'true GPU community coloring is not a relabeled weak-component result'
-    );
-    tapeTest.equal(componentLabels[64], 64, 'third disconnected community keeps its own component');
-    tapeTest.equal(
-      componentLabels[96],
-      96,
-      'fourth disconnected community keeps its own component'
-    );
-    tapeTest.equal(
+    ).not.toBe(componentLabels[32]);
+    expect(componentLabels[64], 'third disconnected community keeps its own component').toBe(64);
+    expect(componentLabels[96], 'fourth disconnected community keeps its own component').toBe(96);
+    expect(
       componentLabels[dataset.vertexCount - 1],
-      dataset.vertexCount - 1,
       'isolated node retains its own stable component identifier'
-    );
-    tapeTest.ok(
-      importance.every(score => Number.isFinite(score) && score > 0),
+    ).toBe(dataset.vertexCount - 1);
+    expect(
+      Boolean(importance.every(score => Number.isFinite(score) && score > 0)),
       'real dangling-aware PageRank supplies positive node sizing values'
-    );
-    tapeTest.ok(
-      Math.abs(importance.reduce((sum, score) => sum + score, 0) - 1) < 5e-5,
+    ).toBe(true);
+    expect(
+      Boolean(Math.abs(importance.reduce((sum, score) => sum + score, 0) - 1) < 5e-5),
       'GPU node importance remains correctly normalized'
-    );
+    ).toBe(true);
   } finally {
     submitSpy.mockRestore();
     explorer?.onFinalize();
   }
-
-  tapeTest.end();
 });
 
-test('GPU Graph explorer renders original GPU chunks, highlights neighborhoods, pins, and picks stable nodes', async tapeTest => {
+it('GPU Graph explorer renders original GPU chunks, highlights neighborhoods, pins, and picks stable nodes', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -201,11 +169,10 @@ test('GPU Graph explorer renders original GPU chunks, highlights neighborhoods, 
   try {
     explorer = createExplorer(device);
     const bindings = explorer as unknown as ExplorerGraphBindings;
-    tapeTest.deepEqual(
+    expect(
       [bindings.frameWidth, bindings.frameHeight],
-      [320, 240],
       'GPU picking uses real centered device pixels rather than assuming a one-pixel test canvas'
-    );
+    ).toEqual([320, 240]);
     color = device.createTexture({
       id: 'gpu-graph-explorer-test-color',
       format: device.preferredColorFormat,
@@ -255,23 +222,18 @@ test('GPU Graph explorer renders original GPU chunks, highlights neighborhoods, 
     ]);
     const pick = decodeGPUIndexPickInfo(bytes);
 
-    tapeTest.equal(distances[0], 0, 'selected root is highlighted at GPU hop distance zero');
-    tapeTest.ok(
-      distances.some(distance => distance === 1 || distance === 2),
+    expect(distances[0], 'selected root is highlighted at GPU hop distance zero').toBe(0);
+    expect(
+      Boolean(distances.some(distance => distance === 1 || distance === 2)),
       'GPU traversal publishes a bounded multi-hop neighborhood'
-    );
-    tapeTest.equal(mask[0], 1, 'node shader receives the source-aligned GPU selection mask');
-    tapeTest.equal(
+    ).toBe(true);
+    expect(mask[0], 'node shader receives the source-aligned GPU selection mask').toBe(1);
+    expect(
       mask[explorer.graph.vertexCount - 1],
-      0,
       'disconnected isolated nodes remain outside the highlighted component'
-    );
-    tapeTest.equal(pin[0], 1, 'dragged node remains pinned through force integration');
-    tapeTest.equal(
-      pick.objectIndex,
-      0,
-      'integer GPU picking recovers the original stable vertex ID'
-    );
+    ).toBe(0);
+    expect(pin[0], 'dragged node remains pinned through force integration').toBe(1);
+    expect(pick.objectIndex, 'integer GPU picking recovers the original stable vertex ID').toBe(0);
   } finally {
     devicePixelSizeSpy.mockRestore();
     pickingReadback?.destroy();
@@ -279,15 +241,11 @@ test('GPU Graph explorer renders original GPU chunks, highlights neighborhoods, 
     color?.destroy();
     explorer?.onFinalize();
   }
-
-  tapeTest.end();
 });
 
-test('GPU Graph explorer exposes genuine GPU analytics and only expands its own graph inspector', async tapeTest => {
+it('GPU Graph explorer exposes genuine GPU analytics and only expands its own graph inspector', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -317,106 +275,109 @@ test('GPU Graph explorer exposes genuine GPU analytics and only expands its own 
   try {
     explorer = createExplorer(device);
     const dashboard = explorer as unknown as ExplorerDashboardBindings;
-    tapeTest.equal(graphExpansion.mock.calls.length, 1, 'the graph inspector opens exactly once');
-    tapeTest.equal(
+    expect(graphExpansion.mock.calls.length, 'the graph inspector opens exactly once').toBe(1);
+    expect(
       unrelatedExpansion.mock.calls.length,
-      0,
       'unrelated collapsed example inspectors are never opened'
-    );
+    ).toBe(0);
 
     const color = host.querySelector<HTMLSelectElement>('[data-color-mode]');
     const size = host.querySelector<HTMLSelectElement>('[data-node-size]');
     const pause = host.querySelector<HTMLButtonElement>('[data-pause]');
     const edges = host.querySelector<HTMLButtonElement>('[data-edge-toggle]');
     const depth = host.querySelector<HTMLInputElement>('[data-depth]');
-    tapeTest.deepEqual(
+    expect(
       Array.from(color!.options, option => option.value),
-      ['community', 'component', 'degree', 'pagerank', 'distance'],
       'all five available GPU analytics are selectable as node colors'
-    );
-    tapeTest.deepEqual(
+    ).toEqual(['community', 'component', 'degree', 'pagerank', 'distance']);
+    expect(
       Array.from(size!.options, option => option.value),
-      ['pagerank', 'degree', 'uniform'],
       'importance, degree, and uniform node sizing are independently selectable'
-    );
+    ).toEqual(['pagerank', 'degree', 'uniform']);
 
     color!.value = 'degree';
     color!.dispatchEvent(new Event('change', {bubbles: true}));
     size!.value = 'degree';
     size!.dispatchEvent(new Event('change', {bubbles: true}));
-    tapeTest.equal(dashboard.colorMode, 'degree', 'degree coloring updates the real render state');
-    tapeTest.equal(dashboard.nodeSizeMode, 'degree', 'degree sizing updates the real render state');
-    tapeTest.ok(
-      host.querySelector('[data-graph-legend]')?.textContent?.includes('vertex degree'),
+    expect(dashboard.colorMode, 'degree coloring updates the real render state').toBe('degree');
+    expect(dashboard.nodeSizeMode, 'degree sizing updates the real render state').toBe('degree');
+    expect(
+      Boolean(host.querySelector('[data-graph-legend]')?.textContent?.includes('vertex degree')),
       'the visible legend describes the active GPU-computed color metric'
-    );
+    ).toBe(true);
 
     const uniformWrite = vi.spyOn(dashboard.viewUniforms, 'write');
     dashboard.writeViewUniforms(320, 240);
     const uniformBytes = uniformWrite.mock.calls[0][0] as Uint8Array;
-    tapeTest.equal(
+    expect(
       new DataView(uniformBytes.buffer, uniformBytes.byteOffset, uniformBytes.byteLength).getUint32(
         28,
         true
       ),
-      (2 << 1) | (1 << 4),
       'the shared node and picking uniform packs the selected genuine GPU metric modes'
-    );
+    ).toBe((2 << 1) | (1 << 4));
     uniformWrite.mockRestore();
 
     depth!.value = '4';
     depth!.dispatchEvent(new Event('input', {bubbles: true}));
-    tapeTest.equal(
+    expect(
       (await readUint32Vector(explorer.search.activeDepth!))[0],
-      4,
       'the depth slider writes the existing GPU traversal control'
-    );
+    ).toBe(4);
 
     const layoutNode = 'gpu-graph-explorer-layout-initialize';
-    tapeTest.ok(explorer.frameGraph.stats.nodeOrder.includes(layoutNode), 'layout starts active');
+    expect(
+      Boolean(explorer.frameGraph.stats.nodeOrder.includes(layoutNode)),
+      'layout starts active'
+    ).toBe(true);
     pause!.click();
-    tapeTest.equal(dashboard.paused, true, 'pausing changes actual graph execution state');
-    tapeTest.equal(pause!.getAttribute('aria-pressed'), 'true', 'pause state remains accessible');
-    tapeTest.equal(
+    expect(dashboard.paused, 'pausing changes actual graph execution state').toBe(true);
+    expect(pause!.getAttribute('aria-pressed'), 'pause state remains accessible').toBe('true');
+    expect(
       explorer.frameGraph.stats.nodeOrder.includes(layoutNode),
-      false,
       'pausing removes actual force-layout compute from the compiled frame graph'
-    );
-    tapeTest.ok(
-      explorer.frameGraph.stats.nodeOrder.includes('gpu-graph-explorer-neighborhood-initialize'),
+    ).toBe(false);
+    expect(
+      Boolean(
+        explorer.frameGraph.stats.nodeOrder.includes('gpu-graph-explorer-neighborhood-initialize')
+      ),
       'selection and neighborhood traversal remain active while layout is paused'
-    );
+    ).toBe(true);
     pause!.click();
-    tapeTest.ok(
-      explorer.frameGraph.stats.nodeOrder.includes(layoutNode),
+    expect(
+      Boolean(explorer.frameGraph.stats.nodeOrder.includes(layoutNode)),
       'resuming restores real force-layout compute'
-    );
+    ).toBe(true);
 
     edges!.click();
-    tapeTest.equal(dashboard.edgesVisible, false, 'edge visibility changes actual rendering state');
-    tapeTest.equal(edges!.getAttribute('aria-pressed'), 'false', 'edge state remains accessible');
-    tapeTest.ok(host.querySelector('[data-status]')?.textContent?.includes('depth 4'));
-    tapeTest.ok(host.querySelector('[data-graph-adapter]')?.textContent?.includes('GPU adapter:'));
-    tapeTest.ok(host.querySelector('[data-graph-memory]')?.textContent?.includes('KiB resident'));
-    tapeTest.ok(
-      host.querySelector('[data-graph-fps]')?.textContent?.includes('CPU command encoding'),
-      'telemetry identifies CPU encoding honestly instead of inventing GPU execution timings'
+    expect(dashboard.edgesVisible, 'edge visibility changes actual rendering state').toBe(false);
+    expect(edges!.getAttribute('aria-pressed'), 'edge state remains accessible').toBe('false');
+    expect(Boolean(host.querySelector('[data-status]')?.textContent?.includes('depth 4'))).toBe(
+      true
     );
-    tapeTest.equal(graphExpansion.mock.calls.length, 1, 'interaction never reopens the inspector');
+    expect(
+      Boolean(host.querySelector('[data-graph-adapter]')?.textContent?.includes('GPU adapter:'))
+    ).toBe(true);
+    expect(
+      Boolean(host.querySelector('[data-graph-memory]')?.textContent?.includes('KiB resident'))
+    ).toBe(true);
+    expect(
+      Boolean(
+        host.querySelector('[data-graph-fps]')?.textContent?.includes('CPU command encoding')
+      ),
+      'telemetry identifies CPU encoding honestly instead of inventing GPU execution timings'
+    ).toBe(true);
+    expect(graphExpansion.mock.calls.length, 'interaction never reopens the inspector').toBe(1);
   } finally {
     explorer?.onFinalize();
     graphInfoBox.remove();
     unrelatedInfoBox.remove();
   }
-
-  tapeTest.end();
 });
 
-test('GPU Graph native showcase renders every real GPU point while sampling only forces and visible original edges', async tapeTest => {
+it('GPU Graph native showcase renders every real GPU point while sampling only forces and visible original edges', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -430,55 +391,35 @@ test('GPU Graph native showcase renders every real GPU point while sampling only
     .mockReturnValue([65, 49]);
   try {
     explorer = createExplorer(device, 32, 'sampled', {pointMode: true, maxVisibleEdges: 4});
-    tapeTest.equal(
-      explorer.activeLayoutMode,
-      'sampled',
-      'the actual four-sample force path is used'
-    );
-    tapeTest.equal(
+    expect(explorer.activeLayoutMode, 'the actual four-sample force path is used').toBe('sampled');
+    expect(
       explorer.layout.repulsion,
-      0.0015,
       'four-sample repulsion remains positive and independent of population size'
-    );
-    tapeTest.equal(
+    ).toBe(0.0015);
+    expect(
       explorer.layout.gravity,
-      0.005,
       'bounded sampled gravity preserves visible source communities'
-    );
-    tapeTest.equal(explorer.pointMode, true, 'full-population point rendering is enabled');
-    tapeTest.equal(explorer.renderedVertexCount, 32, 'every actual original vertex stays rendered');
-    tapeTest.equal(explorer.renderedEdgeCount, 4, 'only displayed original edges are decimated');
-    tapeTest.ok(explorer.graph.edgeCount > 4, 'full GPU adjacency retains all original edge rows');
-    tapeTest.equal(
-      explorer.spatialLayout,
-      null,
-      'sampled forces do not misrepresent a spatial grid'
-    );
-    tapeTest.deepEqual(
+    ).toBe(0.005);
+    expect(explorer.pointMode, 'full-population point rendering is enabled').toBe(true);
+    expect(explorer.renderedVertexCount, 'every actual original vertex stays rendered').toBe(32);
+    expect(explorer.renderedEdgeCount, 'only displayed original edges are decimated').toBe(4);
+    expect(
+      Boolean(explorer.graph.edgeCount > 4),
+      'full GPU adjacency retains all original edge rows'
+    ).toBe(true);
+    expect(explorer.spatialLayout, 'sampled forces do not misrepresent a spatial grid').toBe(null);
+    expect(
       explorer.edgeModels.map(({model}) => model.instanceCount),
-      [2, 2],
       'edge-only detail remains source-aligned across both nonempty original batches'
+    ).toEqual([2, 2]);
+    expect(explorer.nodeModel.topology, 'nodes use a real GPU point pipeline').toBe('point-list');
+    expect(explorer.nodeModel.vertexCount, 'each source vertex produces one GPU point').toBe(1);
+    expect(explorer.nodeModel.instanceCount, 'point instances cover every graph vertex').toBe(32);
+    expect(explorer.pickingModel.topology, 'integer picking consumes real points').toBe(
+      'point-list'
     );
-    tapeTest.equal(
-      explorer.nodeModel.topology,
-      'point-list',
-      'nodes use a real GPU point pipeline'
-    );
-    tapeTest.equal(explorer.nodeModel.vertexCount, 1, 'each source vertex produces one GPU point');
-    tapeTest.equal(
-      explorer.nodeModel.instanceCount,
-      32,
-      'point instances cover every graph vertex'
-    );
-    tapeTest.equal(
-      explorer.pickingModel.topology,
-      'point-list',
-      'integer picking consumes real points'
-    );
-    tapeTest.equal(
-      explorer.pickingModel.instanceCount,
-      32,
-      'picking preserves every stable source ID'
+    expect(explorer.pickingModel.instanceCount, 'picking preserves every stable source ID').toBe(
+      32
     );
 
     const bindings = explorer as unknown as ExplorerGraphBindings;
@@ -536,24 +477,22 @@ test('GPU Graph native showcase renders every real GPU point while sampling only
         readFloat32Vector(explorer.pageRank.output),
         pickingReadback.readAsync(0, INDEX_PICKING_READBACK_BYTE_LENGTH)
       ]);
-    tapeTest.equal(forward[0], explorer.graph.edgeCount, 'GPU retains every original forward edge');
-    tapeTest.equal(reverse[0], explorer.graph.edgeCount, 'GPU retains every original reverse edge');
-    tapeTest.equal(
+    expect(forward[0], 'GPU retains every original forward edge').toBe(explorer.graph.edgeCount);
+    expect(reverse[0], 'GPU retains every original reverse edge').toBe(explorer.graph.edgeCount);
+    expect(
       degrees.reduce((sum, degree) => sum + degree, 0),
-      explorer.graph.edgeCount,
       'GPU degrees use the complete edge graph instead of its displayed subset'
-    );
-    tapeTest.equal(components[8], 0, 'actual weak components still span the source bridge');
-    tapeTest.equal(communities[8], 8, 'GPU majority-vote communities remain distinct');
-    tapeTest.ok(
-      Math.abs(importance.reduce((sum, score) => sum + score, 0) - 1) < 5e-5,
+    ).toBe(explorer.graph.edgeCount);
+    expect(components[8], 'actual weak components still span the source bridge').toBe(0);
+    expect(communities[8], 'GPU majority-vote communities remain distinct').toBe(8);
+    expect(
+      Boolean(Math.abs(importance.reduce((sum, score) => sum + score, 0) - 1) < 5e-5),
       'full-graph GPU PageRank remains normalized in sampled-force mode'
-    );
-    tapeTest.equal(
+    ).toBe(true);
+    expect(
       decodeGPUIndexPickInfo(bytes).objectIndex,
-      0,
       'actual integer GPU point picking returns the stable original source vertex'
-    );
+    ).toBe(0);
   } finally {
     devicePixelSizeSpy.mockRestore();
     pickingReadback?.destroy();
@@ -561,15 +500,11 @@ test('GPU Graph native showcase renders every real GPU point while sampling only
     color?.destroy();
     explorer?.onFinalize();
   }
-
-  tapeTest.end();
 });
 
-test('GPU Graph explorer waits for the current asynchronous GPU pick before dragging a different node', async tapeTest => {
+it('GPU Graph explorer waits for the current asynchronous GPU pick before dragging a different node', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -634,17 +569,15 @@ test('GPU Graph explorer waits for the current asynchronous GPU pick before drag
       new PointerEvent('pointermove', {pointerId: 11, clientX: 190, clientY: 135})
     );
 
-    tapeTest.equal(pinWriteSpy.mock.calls.length, 0, 'the previously selected node is not pinned');
-    tapeTest.equal(
+    expect(pinWriteSpy.mock.calls.length, 'the previously selected node is not pinned').toBe(0);
+    expect(
       positionWriteSpy.mock.calls.length,
-      0,
       'the previously selected node coordinates are not changed before GPU picking resolves'
-    );
-    tapeTest.equal(
+    ).toBe(0);
+    expect(
       velocityWriteSpy.mock.calls.length,
-      0,
       'the previously selected node velocity is not cleared while picking remains asynchronous'
-    );
+    ).toBe(0);
 
     resolveCurrentPick!(new Uint8Array(Int32Array.of(7, 0).buffer));
     await currentReadback;
@@ -652,25 +585,22 @@ test('GPU Graph explorer waits for the current asynchronous GPU pick before drag
       new PointerEvent('pointermove', {pointerId: 11, clientX: 205, clientY: 145})
     );
 
-    tapeTest.equal(pinWriteSpy.mock.calls.length, 1, 'the resolved current node is pinned once');
-    tapeTest.equal(
+    expect(pinWriteSpy.mock.calls.length, 'the resolved current node is pinned once').toBe(1);
+    expect(
       pinWriteSpy.mock.calls[0][1],
-      7 * Uint32Array.BYTES_PER_ELEMENT,
       'pinning targets the newly picked stable vertex, never the stale selected node'
-    );
-    tapeTest.equal(
+    ).toBe(7 * Uint32Array.BYTES_PER_ELEMENT);
+    expect(
       positionWriteSpy.mock.calls[0][1],
-      7 * 2 * Float32Array.BYTES_PER_ELEMENT,
       'position writes target only the newly picked vertex row'
-    );
-    tapeTest.equal(
+    ).toBe(7 * 2 * Float32Array.BYTES_PER_ELEMENT);
+    expect(
       velocityWriteSpy.mock.calls[0][1],
-      7 * 2 * Float32Array.BYTES_PER_ELEMENT,
       'velocity writes target only the newly picked vertex row'
-    );
+    ).toBe(7 * 2 * Float32Array.BYTES_PER_ELEMENT);
     const pinValues = await readUint32Vector(explorer.layout.pinned!);
-    tapeTest.equal(pinValues[0], 0, 'the old selected vertex remains unpinned on the actual GPU');
-    tapeTest.equal(pinValues[7], 1, 'the resolved drag target is pinned on the actual GPU');
+    expect(pinValues[0], 'the old selected vertex remains unpinned on the actual GPU').toBe(0);
+    expect(pinValues[7], 'the resolved drag target is pinned on the actual GPU').toBe(1);
 
     canvas.dispatchEvent(new PointerEvent('pointerup', {pointerId: 11}));
     canvas.dispatchEvent(
@@ -688,31 +618,22 @@ test('GPU Graph explorer waits for the current asynchronous GPU pick before drag
       new PointerEvent('pointermove', {pointerId: 12, clientX: 235, clientY: 170})
     );
 
-    tapeTest.equal(
+    expect(
       pinWriteSpy.mock.calls.length,
-      1,
       'a GPU pick resolving after pointer release never resurrects a stale drag'
-    );
-    tapeTest.equal(positionWriteSpy.mock.calls.length, 1, 'released pointers never move a node');
-    tapeTest.equal(
-      velocityWriteSpy.mock.calls.length,
-      1,
-      'released pointers never clear velocities'
-    );
+    ).toBe(1);
+    expect(positionWriteSpy.mock.calls.length, 'released pointers never move a node').toBe(1);
+    expect(velocityWriteSpy.mock.calls.length, 'released pointers never clear velocities').toBe(1);
   } finally {
     for (const restore of cleanup.reverse()) restore();
     explorer?.onFinalize();
     canvas.remove();
   }
-
-  tapeTest.end();
 });
 
-test('GPU Graph showcase rebuilds an accessible graph slider with real spatial indexing and community colors', async tapeTest => {
+it('GPU Graph showcase rebuilds an accessible graph slider with real spatial indexing and community colors', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -753,25 +674,25 @@ test('GPU Graph showcase rebuilds an accessible graph slider with real spatial i
   let depth: Texture | undefined;
   try {
     explorer = createExplorer(device, 32, 'spatial');
-    tapeTest.equal(explorer.graph.vertexCount, 32, 'the tiny real-GPU fixture remains injectable');
-    tapeTest.ok(explorer.spatialLayout, 'explicit spatial mode creates a real caller-owned index');
+    expect(explorer.graph.vertexCount, 'the tiny real-GPU fixture remains injectable').toBe(32);
+    expect(
+      Boolean(explorer.spatialLayout),
+      'explicit spatial mode creates a real caller-owned index'
+    ).toBe(true);
     if (!explorer.spatialLayout) throw new Error('The showcase did not create its spatial layout');
-    tapeTest.equal(
+    expect(
       ownExpandSpy.mock.calls.length,
-      1,
       'the native showcase opens its own collapsed graph-inspector controls once'
-    );
-    tapeTest.equal(
+    ).toBe(1);
+    expect(
       expandInfoBox.getAttribute('aria-expanded'),
-      'true',
       'the actual accessible website InfoBox becomes visible immediately'
-    );
-    tapeTest.equal(host.hidden, false, 'the graph-size slider is visible without a hidden InfoBox');
-    tapeTest.equal(
+    ).toBe('true');
+    expect(host.hidden, 'the graph-size slider is visible without a hidden InfoBox').toBe(false);
+    expect(
       unrelatedExpandSpy.mock.calls.length,
-      0,
       'other unrelated website InfoBox controls are never opened'
-    );
+    ).toBe(0);
 
     const slider = host.querySelector<HTMLInputElement>('[data-graph-size]');
     const layoutMode = host.querySelector<HTMLSelectElement>('[data-layout-mode]');
@@ -782,53 +703,62 @@ test('GPU Graph showcase rebuilds an accessible graph slider with real spatial i
     const adapter = host.querySelector<HTMLElement>('[data-graph-adapter]');
     const memory = host.querySelector<HTMLElement>('[data-graph-memory]');
     const status = host.querySelector<HTMLElement>('[role="status"]');
-    tapeTest.ok(slider, 'the native showcase publishes a keyboard-accessible graph-size slider');
-    tapeTest.equal(slider?.type, 'range', 'graph scale is an actual accessible range control');
-    tapeTest.equal(slider?.min, '0', 'the first slider step maps to 128 resident vertices');
-    tapeTest.equal(
+    expect(
+      Boolean(slider),
+      'the native showcase publishes a keyboard-accessible graph-size slider'
+    ).toBe(true);
+    expect(slider?.type, 'graph scale is an actual accessible range control').toBe('range');
+    expect(slider?.min, 'the first slider step maps to 128 resident vertices').toBe('0');
+    expect(
       slider?.max,
-      String(GRAPH_EXPLORER_VERTEX_COUNTS.length - 1),
       'the fourteenth slider step maps to the actual 1,048,576-vertex graph'
-    );
-    tapeTest.equal(
+    ).toBe(String(GRAPH_EXPLORER_VERTEX_COUNTS.length - 1));
+    expect(
       GRAPH_EXPLORER_VERTEX_COUNTS.at(-1),
-      1_048_576,
       'the final scale represents actual original resident vertices'
-    );
-    tapeTest.ok(layoutMode, 'exact, automatic, spatial, and four-sample modes are user-visible');
-    tapeTest.ok(colorMode, 'actual analytic color choices are user-visible');
-    tapeTest.ok(sizeMode, 'GPU PageRank, degree, and uniform sizes are selectable');
-    tapeTest.deepEqual(
+    ).toBe(1_048_576);
+    expect(
+      Boolean(layoutMode),
+      'exact, automatic, spatial, and four-sample modes are user-visible'
+    ).toBe(true);
+    expect(Boolean(colorMode), 'actual analytic color choices are user-visible').toBe(true);
+    expect(Boolean(sizeMode), 'GPU PageRank, degree, and uniform sizes are selectable').toBe(true);
+    expect(
       Array.from(layoutMode?.options ?? [], option => option.value),
-      ['auto', 'exact', 'spatial', 'sampled'],
       'layout choices select real exact, flat-grid, and linear-work GPU contributors'
-    );
-    tapeTest.deepEqual(
+    ).toEqual(['auto', 'exact', 'spatial', 'sampled']);
+    expect(
       Array.from(colorMode?.options ?? [], option => option.value),
-      ['community', 'component', 'degree', 'pagerank', 'distance'],
       'all advertised node colors correspond to real GPU analytics'
-    );
-    tapeTest.deepEqual(
+    ).toEqual(['community', 'component', 'degree', 'pagerank', 'distance']);
+    expect(
       Array.from(sizeMode?.options ?? [], option => option.value),
-      ['pagerank', 'degree', 'uniform'],
       'all advertised node sizes use real resident metrics or a uniform radius'
+    ).toEqual(['pagerank', 'degree', 'uniform']);
+    expect(Boolean(edgeVisibility), 'original source-chunk edges can be hidden accessibly').toBe(
+      true
     );
-    tapeTest.ok(edgeVisibility, 'original source-chunk edges can be hidden accessibly');
-    tapeTest.ok(legend, 'a visible accessible legend describes actual GPU analytic colors');
-    tapeTest.ok(
-      legend?.getAttribute('aria-label'),
+    expect(
+      Boolean(legend),
+      'a visible accessible legend describes actual GPU analytic colors'
+    ).toBe(true);
+    expect(
+      Boolean(legend?.getAttribute('aria-label')),
       'color meaning remains screen-reader accessible'
-    );
-    tapeTest.ok(adapter?.textContent, 'the graph inspector reports real adapter information');
-    tapeTest.ok(
-      memory?.textContent,
+    ).toBe(true);
+    expect(
+      Boolean(adapter?.textContent),
+      'the graph inspector reports real adapter information'
+    ).toBe(true);
+    expect(
+      Boolean(memory?.textContent),
       'the graph inspector reports actual GPU allocation accounting'
-    );
-    tapeTest.ok(
-      /resident|transient/i.test(memory?.textContent ?? ''),
+    ).toBe(true);
+    expect(
+      Boolean(/resident|transient/i.test(memory?.textContent ?? '')),
       'GPU memory statistics distinguish owned graph and transient allocations'
-    );
-    tapeTest.equal(status?.getAttribute('aria-live'), 'polite', 'graph changes announce politely');
+    ).toBe(true);
+    expect(status?.getAttribute('aria-live'), 'graph changes announce politely').toBe('polite');
 
     const firstBindings = explorer as unknown as ExplorerGraphBindings;
     color = device.createTexture({
@@ -853,34 +783,34 @@ test('GPU Graph showcase rebuilds an accessible graph slider with real spatial i
       readUint32Vector(explorer.communities.output),
       readUint32Vector(explorer.components.output)
     ]);
-    tapeTest.equal(initialCount[0], 32, 'the actual GPU grid accepts every original vertex');
-    tapeTest.equal(initialOverflow[0], 0, 'caller-owned vertex-ID capacity does not overflow');
-    tapeTest.equal(initialComponents[8], 0, 'one bridge joins the first two weak components');
-    tapeTest.equal(initialCommunity[8], 8, 'actual majority votes retain a separate community');
+    expect(initialCount[0], 'the actual GPU grid accepts every original vertex').toBe(32);
+    expect(initialOverflow[0], 'caller-owned vertex-ID capacity does not overflow').toBe(0);
+    expect(initialComponents[8], 'one bridge joins the first two weak components').toBe(0);
+    expect(initialCommunity[8], 'actual majority votes retain a separate community').toBe(8);
 
     const previousPositions = explorer.layout.positions.data[0].buffer;
     const previousAnalysis = explorer.analysisGraph;
     if (!slider) throw new Error('The native graph-size control was not mounted');
     slider.value = '0';
     slider.dispatchEvent(new Event('change', {bubbles: true}));
-    tapeTest.equal(explorer.graph.vertexCount, 128, 'a real slider change rebuilds the GPU graph');
-    tapeTest.equal(
+    expect(explorer.graph.vertexCount, 'a real slider change rebuilds the GPU graph').toBe(128);
+    expect(
       ownExpandSpy.mock.calls.length,
-      1,
       'resizing never repeatedly reopens a user-controlled website InfoBox'
-    );
-    tapeTest.notEqual(
+    ).toBe(1);
+    expect(
       explorer.layout.positions.data[0].buffer,
-      previousPositions,
       'new vertex attributes use fresh caller-owned physical storage'
-    );
-    tapeTest.notEqual(explorer.analysisGraph, previousAnalysis, 'analytics graphs are rebuilt');
-    tapeTest.deepEqual(
+    ).not.toBe(previousPositions);
+    expect(explorer.analysisGraph, 'analytics graphs are rebuilt').not.toBe(previousAnalysis);
+    expect(
       explorer.graph.sourceVertices.data.map(chunk => chunk.length === 0),
-      [false, true, false],
       'graph resizing still preserves the original empty source batch'
-    );
-    tapeTest.ok(explorer.spatialLayout, 'the selected spatial mode survives graph resizing');
+    ).toEqual([false, true, false]);
+    expect(
+      Boolean(explorer.spatialLayout),
+      'the selected spatial mode survives graph resizing'
+    ).toBe(true);
     if (!explorer.spatialLayout) throw new Error('The rebuilt showcase lost its spatial layout');
 
     executeShowcaseFrame(device, explorer, color, depth);
@@ -891,14 +821,14 @@ test('GPU Graph showcase rebuilds an accessible graph slider with real spatial i
         readUint32Vector(explorer.communities.output),
         readUint32Vector(explorer.components.output)
       ]);
-    tapeTest.equal(resizedCount[0], 128, 'rebuilt spatial passes index all resized vertices');
-    tapeTest.equal(resizedOverflow[0], 0, 'rebuilt explicit index buffers remain large enough');
-    tapeTest.equal(resizedComponents[32], 0, 'resized weak components still cross the bridge');
-    tapeTest.equal(resizedCommunities[32], 32, 'resized GPU community labels remain distinct');
-    tapeTest.ok(
-      !/GPU\s+(?:frame|execution|duration)\s*[:=]\s*\d/i.test(status?.textContent ?? ''),
+    expect(resizedCount[0], 'rebuilt spatial passes index all resized vertices').toBe(128);
+    expect(resizedOverflow[0], 'rebuilt explicit index buffers remain large enough').toBe(0);
+    expect(resizedComponents[32], 'resized weak components still cross the bridge').toBe(0);
+    expect(resizedCommunities[32], 'resized GPU community labels remain distinct').toBe(32);
+    expect(
+      Boolean(!/GPU\s+(?:frame|execution|duration)\s*[:=]\s*\d/i.test(status?.textContent ?? '')),
       'the live inspector never fabricates GPU execution timings'
-    );
+    ).toBe(true);
   } finally {
     devicePixelSizeSpy.mockRestore();
     ownExpandSpy.mockRestore();
@@ -911,8 +841,6 @@ test('GPU Graph showcase rebuilds an accessible graph slider with real spatial i
     infoBox.remove();
     unrelatedInfoBox.remove();
   }
-
-  tapeTest.end();
 });
 
 function createExplorer(

--- a/modules/gpgpu/test/gpu-graph/gpu-graph-force-layout.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph-force-layout.spec.ts
@@ -12,8 +12,7 @@ import {
 } from '@luma.gl/gpgpu/gpu-graph';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test, {type Test} from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {
   addGPUGraphForceLayoutToGraphWithDispatchLimit,
   getGPUGraphForceLayoutDispatchLayout
@@ -322,21 +321,18 @@ const layoutScenarios: ForceLayoutScenario[] = [
   }
 ];
 
-test('GPUGraphForceLayout plans bounded three-dimensional exact repulsion dispatch', tapeTest => {
-  tapeTest.deepEqual(getGPUGraphForceLayoutDispatchLayout(0, 2), {x: 1, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphForceLayoutDispatchLayout(512, 2), {x: 2, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphForceLayoutDispatchLayout(513, 2), {x: 2, y: 2, z: 1});
-  tapeTest.deepEqual(getGPUGraphForceLayoutDispatchLayout(1025, 2), {x: 2, y: 2, z: 2});
-  tapeTest.throws(() => getGPUGraphForceLayoutDispatchLayout(2049, 2), /3D dispatch limit/);
-  tapeTest.end();
+it('GPUGraphForceLayout plans bounded three-dimensional exact repulsion dispatch', () => {
+  expect(getGPUGraphForceLayoutDispatchLayout(0, 2)).toEqual({x: 1, y: 1, z: 1});
+  expect(getGPUGraphForceLayoutDispatchLayout(512, 2)).toEqual({x: 2, y: 1, z: 1});
+  expect(getGPUGraphForceLayoutDispatchLayout(513, 2)).toEqual({x: 2, y: 2, z: 1});
+  expect(getGPUGraphForceLayoutDispatchLayout(1025, 2)).toEqual({x: 2, y: 2, z: 2});
+  expect(() => getGPUGraphForceLayoutDispatchLayout(2049, 2)).toThrow(/3D dispatch limit/);
 });
 
 for (const scenario of layoutScenarios) {
-  test(`GPUGraphForceLayout exact GPU physics: ${scenario.name}`, async tapeTest => {
+  it(`GPUGraphForceLayout exact GPU physics: ${scenario.name}`, async () => {
     const device = await getWebGPUTestDevice();
     if (!device) {
-      tapeTest.comment('WebGPU is not available');
-      tapeTest.end();
       return;
     }
 
@@ -345,32 +341,26 @@ for (const scenario of layoutScenarios) {
     try {
       compileLayout(fixture, scenario.maximumWorkgroups);
       executeLayout(fixture);
-      await assertForceLayout(tapeTest, fixture, scenario, expected);
-      tapeTest.deepEqual(
+      await assertForceLayout(fixture, scenario, expected);
+      expect(
         fixture.graph.sourceVertices.data.map(chunk => chunk.length),
-        scenario.sourceChunks.map(chunk => chunk.length),
         'exact GPU layout preserves caller-owned source chunks and empty record batches'
-      );
+      ).toEqual(scenario.sourceChunks.map(chunk => chunk.length));
       if (scenario.assertNoScratch) {
-        tapeTest.equal(
+        expect(
           fixture.compiled?.stats.logicalTransientBufferCount,
-          6,
           'exact force and integration passes allocate no scratch beyond forward/reverse CSR'
-        );
+        ).toBe(6);
       }
     } finally {
-      destroyExecutionFixture(tapeTest, fixture);
+      destroyExecutionFixture(fixture);
     }
-
-    tapeTest.end();
   });
 }
 
-test('GPUGraphForceLayout progressively warm-starts and repeats deterministic seeded reset', async tapeTest => {
+it('GPUGraphForceLayout progressively warm-starts and repeats deterministic seeded reset', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -395,16 +385,16 @@ test('GPUGraphForceLayout progressively warm-starts and repeats deterministic se
 
   try {
     compileLayout(fixture);
-    tapeTest.equal(submitSpy.mock.calls.length, 0, 'force layout construction never submits work');
-    tapeTest.ok(
-      sourceReadbackSpies.every(spy => spy.mock.calls.length === 0),
+    expect(submitSpy.mock.calls.length, 'force layout construction never submits work').toBe(0);
+    expect(
+      Boolean(sourceReadbackSpies.every(spy => spy.mock.calls.length === 0)),
       'exact layout never reads graph or render data back to the CPU'
-    );
+    ).toBe(true);
     submitSpy.mockRestore();
     for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
 
     executeLayout(fixture);
-    await assertForceLayout(tapeTest, fixture, initial, expectedInitial);
+    await assertForceLayout(fixture, initial, expectedInitial);
 
     const warmStart = {
       ...initial,
@@ -413,24 +403,21 @@ test('GPUGraphForceLayout progressively warm-starts and repeats deterministic se
       reset: 0
     };
     executeLayout(fixture);
-    await assertForceLayout(tapeTest, fixture, warmStart, calculateExpectedForceLayout(warmStart));
+    await assertForceLayout(fixture, warmStart, calculateExpectedForceLayout(warmStart));
 
     const resetBuffer = fixture.layout.reset!.data[0].buffer as Buffer;
     resetBuffer.write(Uint32Array.from([1]));
     executeLayout(fixture);
-    await assertForceLayout(tapeTest, fixture, initial, expectedInitial);
-    tapeTest.equal(
+    await assertForceLayout(fixture, initial, expectedInitial);
+    expect(
       fixture.layout.positions.data[0].buffer.usage & Buffer.VERTEX,
-      Buffer.VERTEX,
       'the exact caller-owned layout buffer remains directly usable as a render vertex attribute'
-    );
+    ).toBe(Buffer.VERTEX);
   } finally {
     submitSpy.mockRestore();
     for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-
-  tapeTest.end();
 });
 
 /** Evaluates exact all-pairs repulsion and undirected incident-edge attraction on the CPU. */
@@ -845,7 +832,6 @@ function executeLayout(fixture: LayoutExecutionFixture): void {
 }
 
 async function assertForceLayout(
-  tapeTest: Test,
   fixture: LayoutExecutionFixture,
   scenario: ForceLayoutScenario,
   expected: ExpectedForceLayout
@@ -862,92 +848,71 @@ async function assertForceLayout(
         : Promise.resolve(undefined)
     ]);
 
-  tapeTest.equal(
-    positions.length,
-    scenario.vertexCount * 2,
-    'two render coordinates remain per vertex'
+  expect(positions.length, 'two render coordinates remain per vertex').toBe(
+    scenario.vertexCount * 2
   );
   assertCloseCoordinates(
-    tapeTest,
     positions,
     expected.positions,
     'GPU positions match exact CPU force physics'
   );
   assertCloseCoordinates(
-    tapeTest,
     velocities,
     expected.velocities,
     'GPU velocities match damped CPU force and clipping'
   );
-  tapeTest.ok(
-    positions.every(Number.isFinite) && velocities.every(Number.isFinite),
+  expect(
+    Boolean(positions.every(Number.isFinite) && velocities.every(Number.isFinite)),
     'all softened coordinates and velocities remain finite'
+  ).toBe(true);
+  expect(invalidEdgeCount[0], 'invalid graph endpoints are excluded').toBe(
+    expected.invalidEdgeCount
   );
-  tapeTest.equal(
-    invalidEdgeCount[0],
-    expected.invalidEdgeCount,
-    'invalid graph endpoints are excluded'
-  );
-  tapeTest.equal(
-    forwardOverflow[0],
-    Number(expected.forwardOverflow),
-    'forward capacity remains explicit'
+  expect(forwardOverflow[0], 'forward capacity remains explicit').toBe(
+    Number(expected.forwardOverflow)
   );
   if (reverseOverflow) {
-    tapeTest.equal(
-      reverseOverflow[0],
-      Number(expected.reverseOverflow),
-      'reverse capacity remains explicit'
+    expect(reverseOverflow[0], 'reverse capacity remains explicit').toBe(
+      Number(expected.reverseOverflow)
     );
   }
   if (reset)
-    tapeTest.equal(reset[0], 0, 'GPU consumes and clears deterministic initialization control');
+    expect(reset[0], 'GPU consumes and clears deterministic initialization control').toBe(0);
 
   for (const [vertexIndex, pinned] of (scenario.pinned ?? []).entries()) {
     if (pinned) {
-      tapeTest.equal(
-        positions[vertexIndex * 2],
-        scenario.positions[vertexIndex * 2],
-        'pinned x coordinate never moves'
+      expect(positions[vertexIndex * 2], 'pinned x coordinate never moves').toBe(
+        scenario.positions[vertexIndex * 2]
       );
-      tapeTest.equal(
-        positions[vertexIndex * 2 + 1],
-        scenario.positions[vertexIndex * 2 + 1],
-        'pinned y coordinate never moves'
+      expect(positions[vertexIndex * 2 + 1], 'pinned y coordinate never moves').toBe(
+        scenario.positions[vertexIndex * 2 + 1]
       );
-      tapeTest.equal(velocities[vertexIndex * 2], 0, 'pinned horizontal velocity is cleared');
-      tapeTest.equal(velocities[vertexIndex * 2 + 1], 0, 'pinned vertical velocity is cleared');
+      expect(velocities[vertexIndex * 2], 'pinned horizontal velocity is cleared').toBe(0);
+      expect(velocities[vertexIndex * 2 + 1], 'pinned vertical velocity is cleared').toBe(0);
     }
   }
 
   if (expected.failed) {
-    tapeTest.deepEqual(
-      positions,
-      Array.from(new Float32Array(scenario.positions)),
-      'CSR overflow preserves all render positions'
+    expect(positions, 'CSR overflow preserves all render positions').toEqual(
+      Array.from(new Float32Array(scenario.positions))
     );
-    tapeTest.ok(
-      velocities.every(velocity => velocity === 0),
+    expect(
+      Boolean(velocities.every(velocity => velocity === 0)),
       'CSR overflow clears every simulation velocity'
-    );
+    ).toBe(true);
   }
 }
 
-function assertCloseCoordinates(
-  tapeTest: Test,
-  actual: number[],
-  expected: number[],
-  message: string
-): void {
+function assertCloseCoordinates(actual: number[], expected: number[], message: string): void {
   const largestError = actual.reduce(
     (largest, value, coordinateIndex) =>
       Math.max(largest, Math.abs(value - expected[coordinateIndex])),
     0
   );
-  tapeTest.ok(
-    largestError <= PHYSICS_TOLERANCE,
+  expect(
+    Boolean(largestError <= PHYSICS_TOLERANCE),
     `${message} within ${PHYSICS_TOLERANCE}: ${largestError}`
-  );
+  ).toBe(true);
 }
 
 async function readUint32Vector(vector: GPUVector<'uint32'>): Promise<number[]> {
@@ -964,12 +929,12 @@ async function readCoordinateVector(vector: GPUVector<'float32x2'>): Promise<num
   return Array.from(new Float32Array(bytes.buffer, bytes.byteOffset, vector.length * 2));
 }
 
-function destroyExecutionFixture(tapeTest: Test, fixture: LayoutExecutionFixture): void {
+function destroyExecutionFixture(fixture: LayoutExecutionFixture): void {
   fixture.compiled?.destroy();
   for (const vector of fixture.vectors) vector.destroy();
-  tapeTest.ok(
-    fixture.buffers.every(buffer => !buffer.destroyed),
+  expect(
+    Boolean(fixture.buffers.every(buffer => !buffer.destroyed)),
     'destroying borrowed force-layout vectors preserves every caller-owned physical allocation'
-  );
+  ).toBe(true);
   for (const buffer of fixture.buffers) buffer.destroy();
 }

--- a/modules/gpgpu/test/gpu-graph/gpu-graph-label-propagation.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph-label-propagation.spec.ts
@@ -12,8 +12,7 @@ import {
 } from '@luma.gl/gpgpu/gpu-graph';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test, {type Test} from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {
   addGPUGraphLabelPropagationToGraphWithDispatchLimit,
   getGPUGraphLabelPropagationDispatchLayout
@@ -277,21 +276,18 @@ const propagationScenarios: PropagationScenario[] = [
   }
 ];
 
-test('GPUGraphLabelPropagation plans bounded three-dimensional vertex dispatch', tapeTest => {
-  tapeTest.deepEqual(getGPUGraphLabelPropagationDispatchLayout(0, 2), {x: 1, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphLabelPropagationDispatchLayout(512, 2), {x: 2, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphLabelPropagationDispatchLayout(513, 2), {x: 2, y: 2, z: 1});
-  tapeTest.deepEqual(getGPUGraphLabelPropagationDispatchLayout(1025, 2), {x: 2, y: 2, z: 2});
-  tapeTest.throws(() => getGPUGraphLabelPropagationDispatchLayout(2049, 2), /3D dispatch limit/);
-  tapeTest.end();
+it('GPUGraphLabelPropagation plans bounded three-dimensional vertex dispatch', () => {
+  expect(getGPUGraphLabelPropagationDispatchLayout(0, 2)).toEqual({x: 1, y: 1, z: 1});
+  expect(getGPUGraphLabelPropagationDispatchLayout(512, 2)).toEqual({x: 2, y: 1, z: 1});
+  expect(getGPUGraphLabelPropagationDispatchLayout(513, 2)).toEqual({x: 2, y: 2, z: 1});
+  expect(getGPUGraphLabelPropagationDispatchLayout(1025, 2)).toEqual({x: 2, y: 2, z: 2});
+  expect(() => getGPUGraphLabelPropagationDispatchLayout(2049, 2)).toThrow(/3D dispatch limit/);
 });
 
 for (const scenario of propagationScenarios) {
-  test(`GPUGraphLabelPropagation GPU labeling: ${scenario.name}`, async tapeTest => {
+  it(`GPUGraphLabelPropagation GPU labeling: ${scenario.name}`, async () => {
     const device = await getWebGPUTestDevice();
     if (!device) {
-      tapeTest.comment('WebGPU is not available');
-      tapeTest.end();
       return;
     }
 
@@ -300,57 +296,48 @@ for (const scenario of propagationScenarios) {
     try {
       compilePropagation(fixture, scenario.maximumWorkgroups);
       executePropagation(fixture);
-      await assertPropagation(tapeTest, fixture, expected);
-      tapeTest.deepEqual(
+      await assertPropagation(fixture, expected);
+      expect(
         fixture.graph.sourceVertices.data.map(chunk => chunk.length),
-        scenario.sourceChunks.map(chunk => chunk.length),
         'community voting preserves every original source chunk'
-      );
+      ).toEqual(scenario.sourceChunks.map(chunk => chunk.length));
       if (scenario.expectedLabels) {
-        tapeTest.deepEqual(
+        expect(
           expected.labels,
-          scenario.expectedLabels,
           'the independent CPU majority oracle matches the explicit stable-label fixture'
-        );
+        ).toEqual(scenario.expectedLabels);
       }
       if (scenario.expectedConvergence !== undefined) {
-        tapeTest.equal(
+        expect(
           expected.converged,
-          scenario.expectedConvergence,
           'the independent CPU oracle proves convergence only after an unchanged final round'
-        );
+        ).toBe(scenario.expectedConvergence);
       }
       if (scenario.proveSingleWeakComponent) {
-        tapeTest.equal(
+        expect(
           countWeakComponents(scenario),
-          1,
           'both distinct dense community labels belong to one actual weakly connected component'
-        );
+        ).toBe(1);
       }
       if (scenario.assertSnapshotAllocation) {
         const propagationOnlyGraph = new GPUCommandGraph(device);
         fixture.propagation.addToGraph(propagationOnlyGraph);
         const compiledPropagationOnly = propagationOnlyGraph.compile();
-        tapeTest.equal(
+        expect(
           compiledPropagationOnly.stats.logicalTransientBufferCount,
-          scenario.vertexCount > 0 ? 1 : 0,
           'synchronous propagation owns exactly one snapshot only when vertices exist'
-        );
+        ).toBe(scenario.vertexCount > 0 ? 1 : 0);
         compiledPropagationOnly.destroy();
       }
     } finally {
-      destroyExecutionFixture(tapeTest, fixture);
+      destroyExecutionFixture(fixture);
     }
-
-    tapeTest.end();
   });
 }
 
-test('GPUGraphLabelPropagation rebuilds communities after source updates without hidden execution', async tapeTest => {
+it('GPUGraphLabelPropagation rebuilds communities after source updates without hidden execution', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -370,38 +357,31 @@ test('GPUGraphLabelPropagation rebuilds communities after source updates without
 
   try {
     compilePropagation(fixture);
-    tapeTest.equal(
-      submitSpy.mock.calls.length,
-      0,
-      'construction and compilation never submit work'
-    );
-    tapeTest.ok(
-      sourceReadbackSpies.every(spy => spy.mock.calls.length === 0),
+    expect(submitSpy.mock.calls.length, 'construction and compilation never submit work').toBe(0);
+    expect(
+      Boolean(sourceReadbackSpies.every(spy => spy.mock.calls.length === 0)),
       'community propagation never reads graph source buffers back'
-    );
+    ).toBe(true);
     submitSpy.mockRestore();
     for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
 
     executePropagation(fixture);
-    await assertPropagation(tapeTest, fixture, calculateExpectedPropagation(original));
+    await assertPropagation(fixture, calculateExpectedPropagation(original));
 
     const sourceBuffer = fixture.graph.sourceVertices.data[0].buffer as Buffer;
     sourceBuffer.write(Uint32Array.from([9, 1]));
     const updated = {...original, sourceChunks: [[9, 1], [], [3, 4]]};
     executePropagation(fixture);
-    await assertPropagation(tapeTest, fixture, calculateExpectedPropagation(updated));
-    tapeTest.equal(
+    await assertPropagation(fixture, calculateExpectedPropagation(updated));
+    expect(
       fixture.graph.sourceVertices.data[0].buffer,
-      sourceBuffer,
       'source updates retain exact caller-owned chunk identity'
-    );
+    ).toBe(sourceBuffer);
   } finally {
     submitSpy.mockRestore();
     for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-
-  tapeTest.end();
 });
 
 /** Evaluates independent synchronous weak-neighbor majority voting from stable vertex IDs. */
@@ -721,7 +701,6 @@ function executePropagation(fixture: PropagationExecutionFixture): void {
 }
 
 async function assertPropagation(
-  tapeTest: Test,
   fixture: PropagationExecutionFixture,
   expected: ExpectedPropagation
 ): Promise<void> {
@@ -738,41 +717,31 @@ async function assertPropagation(
         : Promise.resolve(undefined)
     ]);
 
-  tapeTest.deepEqual(
+  expect(
     labels,
-    expected.labels,
     'GPU communities exactly match independent synchronous weak-neighbor majority voting'
-  );
+  ).toEqual(expected.labels);
 
   if (convergence) {
-    tapeTest.equal(
+    expect(
       convergence[0],
-      Number(expected.converged),
       'convergence is proven only when the final iteration makes no changes'
-    );
+    ).toBe(Number(expected.converged));
   }
-  tapeTest.equal(
-    invalidEdgeCount[0],
-    expected.invalidEdgeCount,
-    'invalid source edges stay excluded'
-  );
-  tapeTest.equal(
-    forwardOverflow[0],
-    Number(expected.forwardOverflow),
-    'forward adjacency overflow remains explicit'
+  expect(invalidEdgeCount[0], 'invalid source edges stay excluded').toBe(expected.invalidEdgeCount);
+  expect(forwardOverflow[0], 'forward adjacency overflow remains explicit').toBe(
+    Number(expected.forwardOverflow)
   );
   if (reverseOverflow) {
-    tapeTest.equal(
-      reverseOverflow[0],
-      Number(expected.reverseOverflow),
-      'required reverse adjacency overflow remains explicit'
+    expect(reverseOverflow[0], 'required reverse adjacency overflow remains explicit').toBe(
+      Number(expected.reverseOverflow)
     );
   }
   if (expected.forwardOverflow || expected.reverseOverflow) {
-    tapeTest.ok(
-      labels.every(label => label === INVALID_LABEL),
+    expect(
+      Boolean(labels.every(label => label === INVALID_LABEL)),
       'truncated required adjacency publishes no misleading partial community labels'
-    );
+    ).toBe(true);
   }
 }
 
@@ -786,12 +755,12 @@ async function readUint32Vector(vector: GPUVector<'uint32'>): Promise<number[]> 
   return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, vector.length));
 }
 
-function destroyExecutionFixture(tapeTest: Test, fixture: PropagationExecutionFixture): void {
+function destroyExecutionFixture(fixture: PropagationExecutionFixture): void {
   fixture.compiled?.destroy();
   for (const vector of fixture.vectors) vector.destroy();
-  tapeTest.ok(
-    fixture.buffers.every(buffer => !buffer.destroyed),
+  expect(
+    Boolean(fixture.buffers.every(buffer => !buffer.destroyed)),
     'compiled community graphs and borrowed vectors never destroy caller-owned buffers'
-  );
+  ).toBe(true);
   for (const buffer of fixture.buffers) buffer.destroy();
 }

--- a/modules/gpgpu/test/gpu-graph/gpu-graph-local-clustering-coefficient.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph-local-clustering-coefficient.spec.ts
@@ -12,8 +12,7 @@ import {
 } from '@luma.gl/gpgpu/gpu-graph';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test, {type Test} from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {addGPUGraphLocalClusteringCoefficientToGraphWithDispatchLimit} from '../../src/gpu-graph/gpu-graph-local-clustering-coefficient-internals';
 
 const INVALID_TRIANGLE_COUNT = 0xffffffff;
@@ -193,11 +192,9 @@ const clusteringScenarios: ClusteringScenario[] = [
 ];
 
 for (const scenario of clusteringScenarios) {
-  test(`GPUGraphLocalClusteringCoefficient GPU: ${scenario.name}`, async tapeTest => {
+  it(`GPUGraphLocalClusteringCoefficient GPU: ${scenario.name}`, async () => {
     const device = await getWebGPUTestDevice();
     if (!device) {
-      tapeTest.comment('WebGPU is not available');
-      tapeTest.end();
       return;
     }
 
@@ -206,40 +203,34 @@ for (const scenario of clusteringScenarios) {
     try {
       compileClustering(fixture, scenario.maximumWorkgroups);
       executeClustering(fixture);
-      await assertClustering(tapeTest, fixture, expected);
-      tapeTest.deepEqual(
+      await assertClustering(fixture, expected);
+      expect(
         fixture.graph.sourceVertices.data.map(chunk => chunk.length),
-        scenario.sourceChunks.map(chunk => chunk.length),
         'clustering preserves every original source chunk and its physical allocation'
-      );
+      ).toEqual(scenario.sourceChunks.map(chunk => chunk.length));
       if (scenario.expectedCoefficients) {
         for (const [vertexIndex, coefficient] of scenario.expectedCoefficients.entries()) {
-          tapeTest.ok(
-            Math.abs(expected.coefficients[vertexIndex] - coefficient) < 1e-7,
+          expect(
+            Boolean(Math.abs(expected.coefficients[vertexIndex] - coefficient) < 1e-7),
             `independent CPU oracle matches the explicit Graphalytics coefficient at vertex ${vertexIndex}`
-          );
+          ).toBe(true);
         }
       }
       if (scenario.expectedTriangles) {
-        tapeTest.deepEqual(
+        expect(
           expected.triangles,
-          scenario.expectedTriangles,
           'independent oracle matches explicit directed closures or undirected incident triangles'
-        );
+        ).toEqual(scenario.expectedTriangles);
       }
     } finally {
-      destroyExecutionFixture(tapeTest, fixture);
+      destroyExecutionFixture(fixture);
     }
-
-    tapeTest.end();
   });
 }
 
-test('GPUGraphLocalClusteringCoefficient rebuilds exact triangles after source updates', async tapeTest => {
+it('GPUGraphLocalClusteringCoefficient rebuilds exact triangles after source updates', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -258,34 +249,28 @@ test('GPUGraphLocalClusteringCoefficient rebuilds exact triangles after source u
 
   try {
     compileClustering(fixture);
-    tapeTest.equal(
-      submitSpy.mock.calls.length,
-      0,
-      'construction and compilation never submit work'
-    );
-    tapeTest.ok(
-      readbackSpies.every(spy => spy.mock.calls.length === 0),
+    expect(submitSpy.mock.calls.length, 'construction and compilation never submit work').toBe(0);
+    expect(
+      Boolean(readbackSpies.every(spy => spy.mock.calls.length === 0)),
       'exact local clustering never reads graph source buffers back'
-    );
+    ).toBe(true);
     submitSpy.mockRestore();
     for (const readbackSpy of readbackSpies) readbackSpy.mockRestore();
 
     executeClustering(fixture);
-    await assertClustering(tapeTest, fixture, calculateExpectedClustering(original));
+    await assertClustering(fixture, calculateExpectedClustering(original));
 
     const sourceBuffer = fixture.graph.sourceVertices.data[0].buffer as Buffer;
     sourceBuffer.write(Uint32Array.from([3, 1]));
     const updated = {...original, sourceChunks: [[3, 1], [], [2]]};
     executeClustering(fixture);
-    await assertClustering(tapeTest, fixture, calculateExpectedClustering(updated));
-    tapeTest.equal(sourceBuffer, fixture.graph.sourceVertices.data[0].buffer);
+    await assertClustering(fixture, calculateExpectedClustering(updated));
+    expect(sourceBuffer).toBe(fixture.graph.sourceVertices.data[0].buffer);
   } finally {
     submitSpy.mockRestore();
     for (const readbackSpy of readbackSpies) readbackSpy.mockRestore();
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-
-  tapeTest.end();
 });
 
 /** Independently applies the official weak-neighbor, directed-edge Graphalytics definition. */
@@ -565,7 +550,6 @@ function executeClustering(fixture: ClusteringExecutionFixture): void {
 }
 
 async function assertClustering(
-  tapeTest: Test,
   fixture: ClusteringExecutionFixture,
   expected: ExpectedClustering
 ): Promise<void> {
@@ -582,26 +566,26 @@ async function assertClustering(
         : Promise.resolve(undefined)
     ]);
 
-  tapeTest.equal(coefficients.length, expected.coefficients.length);
+  expect(coefficients.length).toBe(expected.coefficients.length);
   for (const [vertexIndex, coefficient] of coefficients.entries()) {
-    tapeTest.ok(
-      Math.abs(coefficient - expected.coefficients[vertexIndex]) < 1e-6,
+    expect(
+      Boolean(Math.abs(coefficient - expected.coefficients[vertexIndex]) < 1e-6),
       `vertex ${vertexIndex} coefficient matches the independent Graphalytics directed-edge oracle`
-    );
+    ).toBe(true);
   }
   if (triangles) {
-    tapeTest.deepEqual(
+    expect(
       triangles,
-      expected.triangles,
       'unsigned counts distinguish directed closures from undirected incident triangles'
-    );
+    ).toEqual(expected.triangles);
   }
-  tapeTest.equal(invalidEdgeCount[0], expected.invalidEdgeCount);
-  tapeTest.equal(forwardOverflow[0], Number(expected.forwardOverflow));
-  if (reverseOverflow) tapeTest.equal(reverseOverflow[0], Number(expected.reverseOverflow));
+  expect(invalidEdgeCount[0]).toBe(expected.invalidEdgeCount);
+  expect(forwardOverflow[0]).toBe(Number(expected.forwardOverflow));
+  if (reverseOverflow) expect(reverseOverflow[0]).toBe(Number(expected.reverseOverflow));
   if (expected.forwardOverflow || expected.reverseOverflow) {
-    tapeTest.ok(coefficients.every(coefficient => coefficient === 0));
-    if (triangles) tapeTest.ok(triangles.every(count => count === INVALID_TRIANGLE_COUNT));
+    expect(Boolean(coefficients.every(coefficient => coefficient === 0))).toBe(true);
+    if (triangles)
+      expect(Boolean(triangles.every(count => count === INVALID_TRIANGLE_COUNT))).toBe(true);
   }
 }
 
@@ -625,12 +609,12 @@ async function readFloat32Vector(vector: GPUVector<'float32'>): Promise<number[]
   return Array.from(new Float32Array(bytes.buffer, bytes.byteOffset, vector.length));
 }
 
-function destroyExecutionFixture(tapeTest: Test, fixture: ClusteringExecutionFixture): void {
+function destroyExecutionFixture(fixture: ClusteringExecutionFixture): void {
   fixture.compiled?.destroy();
   for (const vector of fixture.vectors) vector.destroy();
-  tapeTest.ok(
-    fixture.buffers.every(buffer => !buffer.destroyed),
+  expect(
+    Boolean(fixture.buffers.every(buffer => !buffer.destroyed)),
     'compiled clustering graphs and borrowed vectors never destroy caller-owned buffers'
-  );
+  ).toBe(true);
   for (const buffer of fixture.buffers) buffer.destroy();
 }

--- a/modules/gpgpu/test/gpu-graph/gpu-graph-modularity-optimization.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph-modularity-optimization.spec.ts
@@ -14,8 +14,7 @@ import {
 } from '@luma.gl/gpgpu/gpu-graph';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test, {type Test} from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {
   addGPUGraphModularityOptimizationToGraphWithDispatchLimit,
   getGPUGraphModularityOptimizationDispatchLayout
@@ -520,23 +519,19 @@ const optimizationScenarios: OptimizationScenario[] = [
   }
 ];
 
-test('GPUGraphModularityOptimization plans bounded three-dimensional graph dispatch', tapeTest => {
-  tapeTest.deepEqual(getGPUGraphModularityOptimizationDispatchLayout(0, 2), {x: 1, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphModularityOptimizationDispatchLayout(513, 2), {x: 2, y: 2, z: 1});
-  tapeTest.deepEqual(getGPUGraphModularityOptimizationDispatchLayout(1025, 2), {x: 2, y: 2, z: 2});
-  tapeTest.throws(
-    () => getGPUGraphModularityOptimizationDispatchLayout(2049, 2),
+it('GPUGraphModularityOptimization plans bounded three-dimensional graph dispatch', () => {
+  expect(getGPUGraphModularityOptimizationDispatchLayout(0, 2)).toEqual({x: 1, y: 1, z: 1});
+  expect(getGPUGraphModularityOptimizationDispatchLayout(513, 2)).toEqual({x: 2, y: 2, z: 1});
+  expect(getGPUGraphModularityOptimizationDispatchLayout(1025, 2)).toEqual({x: 2, y: 2, z: 2});
+  expect(() => getGPUGraphModularityOptimizationDispatchLayout(2049, 2)).toThrow(
     /3D dispatch limit/
   );
-  tapeTest.end();
 });
 
 for (const scenario of optimizationScenarios) {
-  test(`GPUGraphModularityOptimization GPU: ${scenario.name}`, async tapeTest => {
+  it(`GPUGraphModularityOptimization GPU: ${scenario.name}`, async () => {
     const device = await getWebGPUTestDevice();
     if (!device) {
-      tapeTest.comment('WebGPU is not available');
-      tapeTest.end();
       return;
     }
 
@@ -545,44 +540,38 @@ for (const scenario of optimizationScenarios) {
     try {
       compileOptimization(fixture, scenario.maximumWorkgroups);
       executeOptimization(fixture);
-      await assertOptimization(tapeTest, fixture, expected, scenario);
-      tapeTest.deepEqual(
+      await assertOptimization(fixture, expected, scenario);
+      expect(
         fixture.graph.sourceVertices.data.map(chunk => chunk.length),
-        scenario.sourceChunks.map(chunk => chunk.length),
         'optimization preserves all original ordered source chunks'
-      );
+      ).toEqual(scenario.sourceChunks.map(chunk => chunk.length));
       if (scenario.expectedLabels) {
-        tapeTest.deepEqual(
+        expect(
           expected.labels,
-          scenario.expectedLabels,
           'independent greedy modularity oracle confirms the documented stable labels'
-        );
+        ).toEqual(scenario.expectedLabels);
       }
       if (scenario.expectedScore !== undefined) {
-        tapeTest.ok(
-          Math.abs(expected.score - scenario.expectedScore) < SCORE_TOLERANCE,
+        expect(
+          Boolean(Math.abs(expected.score - scenario.expectedScore) < SCORE_TOLERANCE),
           `independent original-edge modularity oracle confirms documented score ${scenario.expectedScore}`
-        );
+        ).toBe(true);
       }
       if (scenario.expectedConvergence !== undefined) {
-        tapeTest.equal(expected.converged, scenario.expectedConvergence);
+        expect(expected.converged).toBe(scenario.expectedConvergence);
       }
       if (scenario.expectedValidity !== undefined) {
-        tapeTest.equal(expected.valid, scenario.expectedValidity);
+        expect(expected.valid).toBe(scenario.expectedValidity);
       }
     } finally {
-      destroyExecutionFixture(tapeTest, fixture);
+      destroyExecutionFixture(fixture);
     }
-
-    tapeTest.end();
   });
 }
 
-test('GPUGraphModularityOptimization composes label propagation and baseline scoring on GPU', async tapeTest => {
+it('GPUGraphModularityOptimization composes label propagation and baseline scoring on GPU', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -626,41 +615,35 @@ test('GPUGraphModularityOptimization composes label propagation and baseline sco
     baseline.addToGraph(fixture.commandGraph);
     fixture.optimization.addToGraph(fixture.commandGraph);
     fixture.compiled = fixture.commandGraph.compile();
-    tapeTest.equal(submit.mock.calls.length, 0, 'GPU pipeline compilation never submits work');
-    tapeTest.equal(
+    expect(submit.mock.calls.length, 'GPU pipeline compilation never submits work').toBe(0);
+    expect(
       seedReadback.mock.calls.length,
-      0,
       'warm-start community assignments never pass through the CPU'
-    );
+    ).toBe(0);
     submit.mockRestore();
 
     executeOptimization(fixture);
-    await assertOptimization(tapeTest, fixture, expected, scenario);
+    await assertOptimization(fixture, expected, scenario);
     const [initialScore] = await readFloat32Vector(baselineScore);
     const [optimizedScore] = await readFloat32Vector(fixture.optimization.modularity);
-    tapeTest.ok(
-      optimizedScore + SCORE_TOLERANCE >= initialScore,
+    expect(
+      Boolean(optimizedScore + SCORE_TOLERANCE >= initialScore),
       'exact GPU-scored local-moving never reduces the label-propagation baseline quality'
-    );
-    tapeTest.equal(
+    ).toBe(true);
+    expect(
       seedReadback.mock.calls.length,
-      0,
       'modularity optimization consumes live caller-owned label propagation output entirely on GPU'
-    );
+    ).toBe(0);
   } finally {
     submit.mockRestore();
     seedReadback.mockRestore();
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-
-  tapeTest.end();
 });
 
-test('GPUGraphModularityOptimization rereads live edge columns and warm starts on each encoding', async tapeTest => {
+it('GPUGraphModularityOptimization rereads live edge columns and warm starts on each encoding', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -684,12 +667,12 @@ test('GPUGraphModularityOptimization rereads live edge columns and warm starts o
 
   try {
     compileOptimization(fixture);
-    tapeTest.equal(submit.mock.calls.length, 0, 'graph construction does not submit commands');
-    tapeTest.ok(sourceReadbacks.every(readback => readback.mock.calls.length === 0));
+    expect(submit.mock.calls.length, 'graph construction does not submit commands').toBe(0);
+    expect(Boolean(sourceReadbacks.every(readback => readback.mock.calls.length === 0))).toBe(true);
     submit.mockRestore();
 
     executeOptimization(fixture);
-    await assertOptimization(tapeTest, fixture, expectedInitial, initial);
+    await assertOptimization(fixture, expectedInitial, initial);
 
     const updated: OptimizationScenario = {
       ...initial,
@@ -702,18 +685,16 @@ test('GPUGraphModularityOptimization rereads live edge columns and warm starts o
       Uint32Array.from(updated.initialCommunities!)
     );
     executeOptimization(fixture);
-    await assertOptimization(tapeTest, fixture, calculateExpectedOptimization(updated), updated);
-    tapeTest.ok(
-      sourceReadbacks.every(readback => readback.mock.calls.length === 0),
+    await assertOptimization(fixture, calculateExpectedOptimization(updated), updated);
+    expect(
+      Boolean(sourceReadbacks.every(readback => readback.mock.calls.length === 0)),
       'repeated graph encoding consumes live edge and seed buffers without CPU synchronization'
-    );
+    ).toBe(true);
   } finally {
     submit.mockRestore();
     for (const readback of sourceReadbacks) readback.mockRestore();
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-
-  tapeTest.end();
 });
 
 /** Replays deterministic single-vertex modularity moves independently over original source rows. */
@@ -1172,7 +1153,6 @@ function executeOptimization(fixture: OptimizationExecutionFixture): void {
 }
 
 async function assertOptimization(
-  tapeTest: Test,
   fixture: OptimizationExecutionFixture,
   expected: ExpectedOptimization,
   scenario: OptimizationScenario
@@ -1183,51 +1163,42 @@ async function assertOptimization(
     readUint32Vector(fixture.topology.invalidEdgeCount),
     readUint32Vector(fixture.topology.forward.overflow)
   ]);
-  tapeTest.deepEqual(
+  expect(
     labels,
-    expected.labels,
     'GPU communities match an independent deterministic globally-best CPU local-moving oracle'
-  );
-  tapeTest.ok(
-    Math.abs(score[0] - expected.score) < SCORE_TOLERANCE,
+  ).toEqual(expected.labels);
+  expect(
+    Boolean(Math.abs(score[0] - expected.score) < SCORE_TOLERANCE),
     `exact GPU modularity ${score[0]} agrees with original-source CPU objective ${expected.score}`
-  );
-  tapeTest.equal(
-    invalidEdges[0],
-    expected.invalidEdgeCount,
-    'invalid source endpoints are excluded'
-  );
-  tapeTest.equal(
-    forwardOverflow[0],
-    Number(expected.forwardOverflow),
-    'CSR overflow stays explicit'
-  );
+  ).toBe(true);
+  expect(invalidEdges[0], 'invalid source endpoints are excluded').toBe(expected.invalidEdgeCount);
+  expect(forwardOverflow[0], 'CSR overflow stays explicit').toBe(Number(expected.forwardOverflow));
   if (expected.valid) {
-    tapeTest.ok(
-      score[0] + SCORE_TOLERANCE >= expected.initialScore,
+    expect(
+      Boolean(score[0] + SCORE_TOLERANCE >= expected.initialScore),
       'strictly positive accepted moves never lower the exact initial partition modularity'
-    );
+    ).toBe(true);
   } else {
-    tapeTest.equal(score[0], 0, 'undefined modularity never publishes a misleading partial score');
-    tapeTest.ok(
-      labels.every(label => label === INVALID_COMMUNITY),
+    expect(score[0], 'undefined modularity never publishes a misleading partial score').toBe(0);
+    expect(
+      Boolean(labels.every(label => label === INVALID_COMMUNITY)),
       'invalid graph states fail closed for every community label'
-    );
+    ).toBe(true);
   }
   if (fixture.optimization.converged) {
     const converged = await readUint32Vector(fixture.optimization.converged);
-    tapeTest.equal(converged[0], Number(expected.converged), 'local convergence is truthful');
+    expect(converged[0], 'local convergence is truthful').toBe(Number(expected.converged));
   }
   if (fixture.optimization.valid) {
     const validity = await readUint32Vector(fixture.optimization.valid);
-    tapeTest.equal(validity[0], Number(expected.valid), 'validity matches the exact scored graph');
+    expect(validity[0], 'validity matches the exact scored graph').toBe(Number(expected.valid));
   }
   if (fixture.topology.reverse) {
     const reverseOverflow = await readUint32Vector(fixture.topology.reverse.overflow);
-    tapeTest.equal(reverseOverflow[0], Number(expected.reverseOverflow));
+    expect(reverseOverflow[0]).toBe(Number(expected.reverseOverflow));
   }
   if (scenario.expectedLabels) {
-    tapeTest.deepEqual(labels, scenario.expectedLabels, 'documented stable tie-break labels match');
+    expect(labels, 'documented stable tie-break labels match').toEqual(scenario.expectedLabels);
   }
 }
 
@@ -1250,12 +1221,12 @@ async function readFloat32Vector(vector: GPUVector<'float32'>): Promise<number[]
   return Array.from(new Float32Array(bytes.buffer, bytes.byteOffset, vector.length));
 }
 
-function destroyExecutionFixture(tapeTest: Test, fixture: OptimizationExecutionFixture): void {
+function destroyExecutionFixture(fixture: OptimizationExecutionFixture): void {
   fixture.compiled?.destroy();
   for (const vector of fixture.vectors) vector.destroy();
-  tapeTest.ok(
-    fixture.buffers.every(buffer => !buffer.destroyed),
+  expect(
+    Boolean(fixture.buffers.every(buffer => !buffer.destroyed)),
     'destroying graph scratch never destroys caller-owned source or destination buffers'
-  );
+  ).toBe(true);
   for (const buffer of fixture.buffers) buffer.destroy();
 }

--- a/modules/gpgpu/test/gpu-graph/gpu-graph-modularity.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph-modularity.spec.ts
@@ -13,8 +13,7 @@ import {
 } from '@luma.gl/gpgpu/gpu-graph';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test, {type Test} from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {addGPUGraphModularityToGraphWithDispatchLimit} from '../../src/gpu-graph/gpu-graph-modularity-internals';
 
 type ScalarFormat = 'uint32' | 'float32';
@@ -300,11 +299,9 @@ const modularityScenarios: ModularityScenario[] = [
 ];
 
 for (const scenario of modularityScenarios) {
-  test(`GPUGraphModularity GPU: ${scenario.name}`, async tapeTest => {
+  it(`GPUGraphModularity GPU: ${scenario.name}`, async () => {
     const device = await getWebGPUTestDevice();
     if (!device) {
-      tapeTest.comment('WebGPU is not available');
-      tapeTest.end();
       return;
     }
 
@@ -313,42 +310,36 @@ for (const scenario of modularityScenarios) {
     try {
       compileModularity(fixture, scenario.maximumWorkgroups);
       executeModularity(fixture);
-      await assertModularity(tapeTest, fixture, expected);
-      tapeTest.deepEqual(
+      await assertModularity(fixture, expected);
+      expect(
         fixture.graph.sourceVertices.data.map(chunk => chunk.length),
-        scenario.sourceChunks.map(chunk => chunk.length),
         'modularity consumes every original ordered source chunk without flattening'
-      );
+      ).toEqual(scenario.sourceChunks.map(chunk => chunk.length));
       if (scenario.expectedScore !== undefined) {
-        tapeTest.ok(
-          Math.abs(expected.score - scenario.expectedScore) < 1e-6,
+        expect(
+          Boolean(Math.abs(expected.score - scenario.expectedScore) < 1e-6),
           'independent CPU modularity oracle agrees with the explicit exact partition score'
-        );
+        ).toBe(true);
       }
       if (scenario.expectedContributions) {
         assertApproximateValues(
-          tapeTest,
           expected.contributions,
           scenario.expectedContributions,
           'independent CPU oracle confirms explicit stable-community contribution rows'
         );
       }
       if (scenario.expectedValid !== undefined) {
-        tapeTest.equal(expected.valid, scenario.expectedValid);
+        expect(expected.valid).toBe(scenario.expectedValid);
       }
     } finally {
-      destroyExecutionFixture(tapeTest, fixture);
+      destroyExecutionFixture(fixture);
     }
-
-    tapeTest.end();
   });
 }
 
-test('GPUGraphModularity scores existing GPU label propagation in the same command graph', async tapeTest => {
+it('GPUGraphModularity scores existing GPU label propagation in the same command graph', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -397,39 +388,32 @@ test('GPUGraphModularity scores existing GPU label propagation in the same comma
     propagation.addToGraph(fixture.commandGraph);
     fixture.modularity.addToGraph(fixture.commandGraph);
     fixture.compiled = fixture.commandGraph.compile();
-    tapeTest.equal(
+    expect(
       submitSpy.mock.calls.length,
-      0,
       'composition declares and compiles without submission'
-    );
-    tapeTest.equal(
+    ).toBe(0);
+    expect(
       readbackSpy.mock.calls.length,
-      0,
       'generated communities are never staged through CPU'
-    );
+    ).toBe(0);
     submitSpy.mockRestore();
 
     executeModularity(fixture);
-    await assertModularity(tapeTest, fixture, calculateExpectedModularity(scenario));
-    tapeTest.equal(
+    await assertModularity(fixture, calculateExpectedModularity(scenario));
+    expect(
       readbackSpy.mock.calls.length,
-      0,
       'the exact partition score consumes live label-propagation output entirely on the GPU'
-    );
+    ).toBe(0);
   } finally {
     submitSpy.mockRestore();
     readbackSpy.mockRestore();
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-
-  tapeTest.end();
 });
 
-test('GPUGraphModularity recomputes scores after caller-owned community and source updates', async tapeTest => {
+it('GPUGraphModularity recomputes scores after caller-owned community and source updates', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -449,27 +433,25 @@ test('GPUGraphModularity recomputes scores after caller-owned community and sour
 
   try {
     compileModularity(fixture);
-    tapeTest.equal(submitSpy.mock.calls.length, 0);
-    tapeTest.ok(readbackSpies.every(spy => spy.mock.calls.length === 0));
+    expect(submitSpy.mock.calls.length).toBe(0);
+    expect(Boolean(readbackSpies.every(spy => spy.mock.calls.length === 0))).toBe(true);
     submitSpy.mockRestore();
     for (const readbackSpy of readbackSpies) readbackSpy.mockRestore();
 
     executeModularity(fixture);
-    await assertModularity(tapeTest, fixture, calculateExpectedModularity(original));
+    await assertModularity(fixture, calculateExpectedModularity(original));
 
     const communityBuffer = fixture.modularity.communities.data[0].buffer as Buffer;
     communityBuffer.write(Uint32Array.from([0, 0, 0, 0]));
     const updated = {...original, communities: [0, 0, 0, 0]};
     executeModularity(fixture);
-    await assertModularity(tapeTest, fixture, calculateExpectedModularity(updated));
-    tapeTest.equal(fixture.modularity.communities.data[0].buffer, communityBuffer);
+    await assertModularity(fixture, calculateExpectedModularity(updated));
+    expect(fixture.modularity.communities.data[0].buffer).toBe(communityBuffer);
   } finally {
     submitSpy.mockRestore();
     for (const readbackSpy of readbackSpies) readbackSpy.mockRestore();
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-
-  tapeTest.end();
 });
 
 /** Evaluates Newman community volumes independently over original graph source partitions. */
@@ -733,7 +715,6 @@ function executeModularity(fixture: ModularityExecutionFixture): void {
 }
 
 async function assertModularity(
-  tapeTest: Test,
   fixture: ModularityExecutionFixture,
   expected: ExpectedModularity
 ): Promise<void> {
@@ -747,35 +728,31 @@ async function assertModularity(
       : Promise.resolve(undefined)
   ]);
 
-  tapeTest.ok(
-    Math.abs(score[0] - expected.score) < 2e-5,
+  expect(
+    Boolean(Math.abs(score[0] - expected.score) < 2e-5),
     `GPU Newman modularity ${score[0]} matches independent weighted CPU score ${expected.score}`
-  );
+  ).toBe(true);
   if (contributions) {
     assertApproximateValues(
-      tapeTest,
       contributions,
       expected.contributions,
       'GPU contributions match stable community identifiers and independent group volumes'
     );
   }
-  if (valid)
-    tapeTest.equal(valid[0], Number(expected.valid), 'validity reports actual score status');
+  if (valid) expect(valid[0], 'validity reports actual score status').toBe(Number(expected.valid));
   if (!expected.valid) {
-    tapeTest.equal(score[0], 0, 'invalid partitions never publish misleading partial scores');
-    if (contributions) tapeTest.ok(contributions.every(contribution => contribution === 0));
+    expect(score[0], 'invalid partitions never publish misleading partial scores').toBe(0);
+    if (contributions)
+      expect(Boolean(contributions.every(contribution => contribution === 0))).toBe(true);
   }
 }
 
-function assertApproximateValues(
-  tapeTest: Test,
-  actual: number[],
-  expected: number[],
-  message: string
-): void {
-  tapeTest.equal(actual.length, expected.length);
+function assertApproximateValues(actual: number[], expected: number[], message: string): void {
+  expect(actual.length).toBe(expected.length);
   for (const [index, value] of actual.entries()) {
-    tapeTest.ok(Math.abs(value - expected[index]) < 2e-5, `${message}: row ${index}`);
+    expect(Boolean(Math.abs(value - expected[index]) < 2e-5), `${message}: row ${index}`).toBe(
+      true
+    );
   }
 }
 
@@ -799,12 +776,12 @@ async function readUint32Vector(vector: GPUVector<'uint32'>): Promise<number[]> 
   return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, vector.length));
 }
 
-function destroyExecutionFixture(tapeTest: Test, fixture: ModularityExecutionFixture): void {
+function destroyExecutionFixture(fixture: ModularityExecutionFixture): void {
   fixture.compiled?.destroy();
   for (const vector of fixture.vectors) vector.destroy();
-  tapeTest.ok(
-    fixture.buffers.every(buffer => !buffer.destroyed),
+  expect(
+    Boolean(fixture.buffers.every(buffer => !buffer.destroyed)),
     'borrowed source chunks, labels, and outputs retain caller-owned buffer lifetime'
-  );
+  ).toBe(true);
   for (const buffer of fixture.buffers) buffer.destroy();
 }

--- a/modules/gpgpu/test/gpu-graph/gpu-graph-page-rank.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph-page-rank.spec.ts
@@ -12,8 +12,7 @@ import {
 } from '@luma.gl/gpgpu/gpu-graph';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test, {type Test} from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {
   addGPUGraphPageRankToGraphWithDispatchLimit,
   getGPUGraphPageRankDispatchLayout
@@ -244,21 +243,18 @@ const pageRankScenarios: PageRankScenario[] = [
   }
 ];
 
-test('GPUGraphPageRank plans bounded three-dimensional pull and reduction dispatch', tapeTest => {
-  tapeTest.deepEqual(getGPUGraphPageRankDispatchLayout(0, 2), {x: 1, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphPageRankDispatchLayout(512, 2), {x: 2, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphPageRankDispatchLayout(513, 2), {x: 2, y: 2, z: 1});
-  tapeTest.deepEqual(getGPUGraphPageRankDispatchLayout(1025, 2), {x: 2, y: 2, z: 2});
-  tapeTest.throws(() => getGPUGraphPageRankDispatchLayout(2049, 2), /3D dispatch limit/);
-  tapeTest.end();
+it('GPUGraphPageRank plans bounded three-dimensional pull and reduction dispatch', () => {
+  expect(getGPUGraphPageRankDispatchLayout(0, 2)).toEqual({x: 1, y: 1, z: 1});
+  expect(getGPUGraphPageRankDispatchLayout(512, 2)).toEqual({x: 2, y: 1, z: 1});
+  expect(getGPUGraphPageRankDispatchLayout(513, 2)).toEqual({x: 2, y: 2, z: 1});
+  expect(getGPUGraphPageRankDispatchLayout(1025, 2)).toEqual({x: 2, y: 2, z: 2});
+  expect(() => getGPUGraphPageRankDispatchLayout(2049, 2)).toThrow(/3D dispatch limit/);
 });
 
 for (const scenario of pageRankScenarios) {
-  test(`GPUGraphPageRank GPU analytics: ${scenario.name}`, async tapeTest => {
+  it(`GPUGraphPageRank GPU analytics: ${scenario.name}`, async () => {
     const device = await getWebGPUTestDevice();
     if (!device) {
-      tapeTest.comment('WebGPU is not available');
-      tapeTest.end();
       return;
     }
 
@@ -267,25 +263,20 @@ for (const scenario of pageRankScenarios) {
     try {
       compilePageRank(fixture, scenario.maximumWorkgroups);
       executePageRank(fixture);
-      await assertPageRank(tapeTest, fixture, expected);
-      tapeTest.deepEqual(
+      await assertPageRank(fixture, expected);
+      expect(
         fixture.graph.sourceVertices.data.map(chunk => chunk.length),
-        scenario.sourceChunks.map(chunk => chunk.length),
         'rank evaluation preserves caller-owned source chunks and empty edge batches'
-      );
+      ).toEqual(scenario.sourceChunks.map(chunk => chunk.length));
     } finally {
-      destroyExecutionFixture(tapeTest, fixture);
+      destroyExecutionFixture(fixture);
     }
-
-    tapeTest.end();
   });
 }
 
-test('GPUGraphPageRank reinitializes normalized scores after source updates without hidden GPU work', async tapeTest => {
+it('GPUGraphPageRank reinitializes normalized scores after source updates without hidden GPU work', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -306,38 +297,31 @@ test('GPUGraphPageRank reinitializes normalized scores after source updates with
 
   try {
     compilePageRank(fixture);
-    tapeTest.equal(
-      submitSpy.mock.calls.length,
-      0,
-      'topology and rank construction never submit work'
-    );
-    tapeTest.ok(
-      sourceReadbackSpies.every(spy => spy.mock.calls.length === 0),
+    expect(submitSpy.mock.calls.length, 'topology and rank construction never submit work').toBe(0);
+    expect(
+      Boolean(sourceReadbackSpies.every(spy => spy.mock.calls.length === 0)),
       'PageRank never reads source edge columns back to the CPU'
-    );
+    ).toBe(true);
     submitSpy.mockRestore();
     for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
 
     executePageRank(fixture);
-    await assertPageRank(tapeTest, fixture, calculateExpectedPageRank(original));
+    await assertPageRank(fixture, calculateExpectedPageRank(original));
 
     const sourceBuffer = fixture.graph.sourceVertices.data[0].buffer as Buffer;
     sourceBuffer.write(Uint32Array.from([9, 1]));
     const updated = {...original, sourceChunks: [[9, 1], [], [2, 4]]};
     executePageRank(fixture);
-    await assertPageRank(tapeTest, fixture, calculateExpectedPageRank(updated));
-    tapeTest.equal(
+    await assertPageRank(fixture, calculateExpectedPageRank(updated));
+    expect(
       fixture.graph.sourceVertices.data[0].buffer,
-      sourceBuffer,
       'repeated ranking preserves exact source chunk and physical buffer identity'
-    );
+    ).toBe(sourceBuffer);
   } finally {
     submitSpy.mockRestore();
     for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-
-  tapeTest.end();
 });
 
 /** Computes unweighted PageRank with exact dangling redistribution and per-step normalization. */
@@ -635,7 +619,6 @@ function executePageRank(fixture: PageRankExecutionFixture): void {
 }
 
 async function assertPageRank(
-  tapeTest: Test,
   fixture: PageRankExecutionFixture,
   expected: ExpectedPageRank
 ): Promise<void> {
@@ -651,60 +634,48 @@ async function assertPageRank(
       : Promise.resolve(undefined)
   ]);
 
-  tapeTest.equal(
-    scores.length,
-    expected.scores.length,
-    'one float32 score is published per vertex'
-  );
+  expect(scores.length, 'one float32 score is published per vertex').toBe(expected.scores.length);
   const largestScoreError = scores.reduce(
     (largest, score, vertexIndex) =>
       Math.max(largest, Math.abs(score - expected.scores[vertexIndex])),
     0
   );
-  tapeTest.ok(
-    largestScoreError <= SCORE_TOLERANCE,
+  expect(
+    Boolean(largestScoreError <= SCORE_TOLERANCE),
     `float32 reverse-pull ranks match the CPU oracle within ${SCORE_TOLERANCE}`
-  );
+  ).toBe(true);
   if (!expected.failed && scores.length > 0) {
-    tapeTest.ok(
-      scores.every(score => Number.isFinite(score) && score >= 0),
+    expect(
+      Boolean(scores.every(score => Number.isFinite(score) && score >= 0)),
       'every score is finite and nonnegative'
-    );
+    ).toBe(true);
     const rankMass = scores.reduce((sum, score) => sum + score, 0);
-    tapeTest.ok(
-      Math.abs(rankMass - 1) <= NORMALIZATION_TOLERANCE,
+    expect(
+      Boolean(Math.abs(rankMass - 1) <= NORMALIZATION_TOLERANCE),
       'dangling redistribution and float32 normalization preserve unit rank mass'
-    );
+    ).toBe(true);
   }
   if (residual) {
-    tapeTest.ok(
-      Math.abs(residual[0] - expected.residual) <= RESIDUAL_TOLERANCE,
+    expect(
+      Boolean(Math.abs(residual[0] - expected.residual) <= RESIDUAL_TOLERANCE),
       'optional residual equals the final normalized L1 PageRank delta'
-    );
+    ).toBe(true);
   }
-  tapeTest.equal(
-    invalidEdgeCount[0],
-    expected.invalidEdgeCount,
-    'invalid graph edges are excluded'
-  );
-  tapeTest.equal(
-    forwardOverflow[0],
-    Number(expected.forwardOverflow),
-    'forward capacity remains explicit'
+  expect(invalidEdgeCount[0], 'invalid graph edges are excluded').toBe(expected.invalidEdgeCount);
+  expect(forwardOverflow[0], 'forward capacity remains explicit').toBe(
+    Number(expected.forwardOverflow)
   );
   if (reverseOverflow) {
-    tapeTest.equal(
-      reverseOverflow[0],
-      Number(expected.reverseOverflow),
-      'reverse capacity remains explicit'
+    expect(reverseOverflow[0], 'reverse capacity remains explicit').toBe(
+      Number(expected.reverseOverflow)
     );
   }
   if (expected.failed) {
-    tapeTest.ok(
-      scores.every(score => score === 0),
+    expect(
+      Boolean(scores.every(score => score === 0)),
       'required CSR overflow fails closed with zero scores'
-    );
-    if (residual) tapeTest.equal(residual[0], 0, 'failed topology publishes a zero final residual');
+    ).toBe(true);
+    if (residual) expect(residual[0], 'failed topology publishes a zero final residual').toBe(0);
   }
 }
 
@@ -728,12 +699,12 @@ async function readFloat32Vector(vector: GPUVector<'float32'>): Promise<number[]
   return Array.from(new Float32Array(bytes.buffer, bytes.byteOffset, vector.length));
 }
 
-function destroyExecutionFixture(tapeTest: Test, fixture: PageRankExecutionFixture): void {
+function destroyExecutionFixture(fixture: PageRankExecutionFixture): void {
   fixture.compiled?.destroy();
   for (const vector of fixture.vectors) vector.destroy();
-  tapeTest.ok(
-    fixture.buffers.every(buffer => !buffer.destroyed),
+  expect(
+    Boolean(fixture.buffers.every(buffer => !buffer.destroyed)),
     'graph-owned PageRank reduction scratch never destroys caller-owned physical buffers'
-  );
+  ).toBe(true);
   for (const buffer of fixture.buffers) buffer.destroy();
 }

--- a/modules/gpgpu/test/gpu-graph/gpu-graph-single-source-shortest-path.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph-single-source-shortest-path.spec.ts
@@ -13,8 +13,7 @@ import {
 } from '@luma.gl/gpgpu/gpu-graph';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test, {type Test} from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {
   addGPUGraphSingleSourceShortestPathToGraphWithDispatchLimit,
   getGPUGraphSingleSourceShortestPathDispatchLayout
@@ -255,24 +254,21 @@ const shortestPathScenarios: ShortestPathScenario[] = [
   }
 ];
 
-test('GPUGraphSingleSourceShortestPath plans bounded three-dimensional GPU work', tapeTest => {
-  tapeTest.deepEqual(getGPUGraphSingleSourceShortestPathDispatchLayout(0, 2), {x: 1, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphSingleSourceShortestPathDispatchLayout(513, 2), {x: 2, y: 2, z: 1});
-  tapeTest.deepEqual(getGPUGraphSingleSourceShortestPathDispatchLayout(1025, 2), {
+it('GPUGraphSingleSourceShortestPath plans bounded three-dimensional GPU work', () => {
+  expect(getGPUGraphSingleSourceShortestPathDispatchLayout(0, 2)).toEqual({x: 1, y: 1, z: 1});
+  expect(getGPUGraphSingleSourceShortestPathDispatchLayout(513, 2)).toEqual({x: 2, y: 2, z: 1});
+  expect(getGPUGraphSingleSourceShortestPathDispatchLayout(1025, 2)).toEqual({
     x: 2,
     y: 2,
     z: 2
   });
-  tapeTest.throws(() => getGPUGraphSingleSourceShortestPathDispatchLayout(2049, 2), /3D dispatch/);
-  tapeTest.end();
+  expect(() => getGPUGraphSingleSourceShortestPathDispatchLayout(2049, 2)).toThrow(/3D dispatch/);
 });
 
 for (const scenario of shortestPathScenarios) {
-  test(`GPUGraphSingleSourceShortestPath GPU traversal: ${scenario.name}`, async tapeTest => {
+  it(`GPUGraphSingleSourceShortestPath GPU traversal: ${scenario.name}`, async () => {
     const device = await getWebGPUTestDevice();
     if (!device) {
-      tapeTest.comment('WebGPU is not available');
-      tapeTest.end();
       return;
     }
 
@@ -281,19 +277,16 @@ for (const scenario of shortestPathScenarios) {
     try {
       compileShortestPath(fixture, scenario.maximumWorkgroups);
       executeShortestPath(fixture);
-      await assertShortestPath(tapeTest, fixture, expected);
+      await assertShortestPath(fixture, expected);
     } finally {
-      destroyExecutionFixture(tapeTest, fixture);
+      destroyExecutionFixture(fixture);
     }
-    tapeTest.end();
   });
 }
 
-test('GPUGraphSingleSourceShortestPath schedules work without submission or source readback', async tapeTest => {
+it('GPUGraphSingleSourceShortestPath schedules work without submission or source readback', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -315,23 +308,18 @@ test('GPUGraphSingleSourceShortestPath schedules work without submission or sour
   const readbacks = sourceBuffers.map(chunk => vi.spyOn(chunk.buffer as Buffer, 'readAsync'));
   try {
     compileShortestPath(fixture);
-    tapeTest.equal(
-      submit.mock.calls.length,
-      0,
-      'constructing and compiling never submits GPU work'
-    );
+    expect(submit.mock.calls.length, 'constructing and compiling never submits GPU work').toBe(0);
     executeShortestPath(fixture);
-    await assertShortestPath(tapeTest, fixture, expected);
-    tapeTest.ok(
-      readbacks.every(readback => readback.mock.calls.length === 0),
+    await assertShortestPath(fixture, expected);
+    expect(
+      Boolean(readbacks.every(readback => readback.mock.calls.length === 0)),
       'weighted graph source buffers are never read back by the GPU operation'
-    );
+    ).toBe(true);
   } finally {
     submit.mockRestore();
     for (const readback of readbacks) readback.mockRestore();
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-  tapeTest.end();
 });
 
 /** Computes the same synchronized float32 Bellman-Ford rounds as the GPU implementation. */
@@ -693,7 +681,6 @@ function executeShortestPath(fixture: ShortestPathExecutionFixture): void {
 }
 
 async function assertShortestPath(
-  tapeTest: Test,
   fixture: ShortestPathExecutionFixture,
   expected: ExpectedShortestPath
 ): Promise<void> {
@@ -712,42 +699,20 @@ async function assertShortestPath(
     readScalarVector(fixture.topology.invalidEdgeCount),
     readScalarVector(fixture.topology.forward.overflow)
   ]);
-  tapeTest.deepEqual(
-    distances,
-    expected.distances,
-    'weighted float32 distances match the CPU oracle'
+  expect(distances, 'weighted float32 distances match the CPU oracle').toEqual(expected.distances);
+  expect(predecessors, 'same-hop shortest routes choose the lowest stable predecessor').toEqual(
+    expected.predecessors
   );
-  tapeTest.deepEqual(
-    predecessors,
-    expected.predecessors,
-    'same-hop shortest routes choose the lowest stable predecessor'
+  expect(converged[0], 'GPU convergence status remains truthful').toBe(Number(expected.converged));
+  expect(invalidWeightCount[0], 'each invalid source-edge weight is counted once').toBe(
+    expected.invalidWeightCount
   );
-  tapeTest.equal(
-    converged[0],
-    Number(expected.converged),
-    'GPU convergence status remains truthful'
-  );
-  tapeTest.equal(
-    invalidWeightCount[0],
-    expected.invalidWeightCount,
-    'each invalid source-edge weight is counted once'
-  );
-  tapeTest.equal(
-    invalidEdgeCount[0],
-    expected.invalidEdgeCount,
-    'invalid endpoints remain excluded'
-  );
-  tapeTest.equal(
-    forwardOverflow[0],
-    Number(expected.forwardOverflow),
-    'forward overflow is explicit'
-  );
+  expect(invalidEdgeCount[0], 'invalid endpoints remain excluded').toBe(expected.invalidEdgeCount);
+  expect(forwardOverflow[0], 'forward overflow is explicit').toBe(Number(expected.forwardOverflow));
   if (fixture.topology.reverse) {
     const reverseOverflow = await readScalarVector(fixture.topology.reverse.overflow);
-    tapeTest.equal(
-      reverseOverflow[0],
-      Number(expected.reverseOverflow),
-      'reverse overflow remains explicit'
+    expect(reverseOverflow[0], 'reverse overflow remains explicit').toBe(
+      Number(expected.reverseOverflow)
     );
   }
 }
@@ -768,12 +733,12 @@ async function readScalarVector(
   );
 }
 
-function destroyExecutionFixture(tapeTest: Test, fixture: ShortestPathExecutionFixture): void {
+function destroyExecutionFixture(fixture: ShortestPathExecutionFixture): void {
   fixture.compiled?.destroy();
   for (const vector of fixture.vectors) vector.destroy();
-  tapeTest.ok(
-    fixture.buffers.every(buffer => !buffer.destroyed),
+  expect(
+    Boolean(fixture.buffers.every(buffer => !buffer.destroyed)),
     'destroying the compiled operation preserves every caller-owned GPU buffer'
-  );
+  ).toBe(true);
   for (const buffer of fixture.buffers) buffer.destroy();
 }

--- a/modules/gpgpu/test/gpu-graph/gpu-graph-spatial-force-layout.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph-spatial-force-layout.spec.ts
@@ -13,8 +13,7 @@ import {
 } from '@luma.gl/gpgpu/gpu-graph';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test, {type Test} from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {
   addGPUGraphSpatialForceLayoutToGraphWithDispatchLimit,
   getGPUGraphSpatialForceLayoutDispatchLayout
@@ -411,21 +410,18 @@ const spatialScenarios: SpatialScenario[] = [
   }
 ];
 
-test('GPUGraphSpatialForceLayout plans bounded 3D vertex, grid, and centroid dispatch', tapeTest => {
-  tapeTest.deepEqual(getGPUGraphSpatialForceLayoutDispatchLayout(0, 2), {x: 1, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphSpatialForceLayoutDispatchLayout(512, 2), {x: 2, y: 1, z: 1});
-  tapeTest.deepEqual(getGPUGraphSpatialForceLayoutDispatchLayout(513, 2), {x: 2, y: 2, z: 1});
-  tapeTest.deepEqual(getGPUGraphSpatialForceLayoutDispatchLayout(1025, 2), {x: 2, y: 2, z: 2});
-  tapeTest.throws(() => getGPUGraphSpatialForceLayoutDispatchLayout(2049, 2), /3D dispatch limit/);
-  tapeTest.end();
+it('GPUGraphSpatialForceLayout plans bounded 3D vertex, grid, and centroid dispatch', () => {
+  expect(getGPUGraphSpatialForceLayoutDispatchLayout(0, 2)).toEqual({x: 1, y: 1, z: 1});
+  expect(getGPUGraphSpatialForceLayoutDispatchLayout(512, 2)).toEqual({x: 2, y: 1, z: 1});
+  expect(getGPUGraphSpatialForceLayoutDispatchLayout(513, 2)).toEqual({x: 2, y: 2, z: 1});
+  expect(getGPUGraphSpatialForceLayoutDispatchLayout(1025, 2)).toEqual({x: 2, y: 2, z: 2});
+  expect(() => getGPUGraphSpatialForceLayoutDispatchLayout(2049, 2)).toThrow(/3D dispatch limit/);
 });
 
 for (const scenario of spatialScenarios) {
-  test(`GPUGraphSpatialForceLayout GPU spatial physics: ${scenario.name}`, async tapeTest => {
+  it(`GPUGraphSpatialForceLayout GPU spatial physics: ${scenario.name}`, async () => {
     const device = await getWebGPUTestDevice();
     if (!device) {
-      tapeTest.comment('WebGPU is not available');
-      tapeTest.end();
       return;
     }
 
@@ -434,33 +430,30 @@ for (const scenario of spatialScenarios) {
     try {
       compileSpatialLayout(fixture, scenario.maximumWorkgroups);
       executeSpatialLayout(fixture);
-      await assertSpatialLayout(tapeTest, fixture, scenario, expected);
-      tapeTest.deepEqual(
+      await assertSpatialLayout(fixture, scenario, expected);
+      expect(
         fixture.graph.sourceVertices.data.map(chunk => chunk.length),
-        scenario.sourceChunks.map(chunk => chunk.length),
         'spatial acceleration preserves caller-owned graph chunks and empty edge batches'
-      );
+      ).toEqual(scenario.sourceChunks.map(chunk => chunk.length));
       if (scenario.differsFromExact) {
         const exact = calculateExpectedSpatialLayout({...scenario, theta: 0});
         const actual = await readCoordinateVector(fixture.layout.positions);
-        tapeTest.ok(
-          actual.some((coordinate, index) => Math.abs(coordinate - exact.positions[index]) > 1e-5),
+        expect(
+          Boolean(
+            actual.some((coordinate, index) => Math.abs(coordinate - exact.positions[index]) > 1e-5)
+          ),
           'far-cell monopoles are explicitly approximate rather than silently presented as exact'
-        );
+        ).toBe(true);
       }
     } finally {
-      destroyExecutionFixture(tapeTest, fixture);
+      destroyExecutionFixture(fixture);
     }
-
-    tapeTest.end();
   });
 }
 
-test('GPUGraphSpatialForceLayout repeatedly rebuilds spatial cells across warm starts and deterministic reset', async tapeTest => {
+it('GPUGraphSpatialForceLayout repeatedly rebuilds spatial cells across warm starts and deterministic reset', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -488,20 +481,16 @@ test('GPUGraphSpatialForceLayout repeatedly rebuilds spatial cells across warm s
 
   try {
     compileSpatialLayout(fixture);
-    tapeTest.equal(
-      submitSpy.mock.calls.length,
-      0,
-      'spatial layout construction never submits work'
-    );
-    tapeTest.ok(
-      sourceReadbackSpies.every(spy => spy.mock.calls.length === 0),
+    expect(submitSpy.mock.calls.length, 'spatial layout construction never submits work').toBe(0);
+    expect(
+      Boolean(sourceReadbackSpies.every(spy => spy.mock.calls.length === 0)),
       'grid rebuilds and approximation never read source edges back to the CPU'
-    );
+    ).toBe(true);
     submitSpy.mockRestore();
     for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
 
     executeSpatialLayout(fixture);
-    await assertSpatialLayout(tapeTest, fixture, initial, expectedInitial);
+    await assertSpatialLayout(fixture, initial, expectedInitial);
 
     const warmStart = {
       ...initial,
@@ -510,23 +499,16 @@ test('GPUGraphSpatialForceLayout repeatedly rebuilds spatial cells across warm s
       reset: 0
     };
     executeSpatialLayout(fixture);
-    await assertSpatialLayout(
-      tapeTest,
-      fixture,
-      warmStart,
-      calculateExpectedSpatialLayout(warmStart)
-    );
+    await assertSpatialLayout(fixture, warmStart, calculateExpectedSpatialLayout(warmStart));
 
     (fixture.layout.reset!.data[0].buffer as Buffer).write(Uint32Array.from([1]));
     executeSpatialLayout(fixture);
-    await assertSpatialLayout(tapeTest, fixture, initial, expectedInitial);
+    await assertSpatialLayout(fixture, initial, expectedInitial);
   } finally {
     submitSpy.mockRestore();
     for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-
-  tapeTest.end();
 });
 
 /** Computes the exact documented flat-grid monopole approximation without GPU-side atomics. */
@@ -1084,7 +1066,6 @@ function executeSpatialLayout(fixture: SpatialExecutionFixture): void {
 }
 
 async function assertSpatialLayout(
-  tapeTest: Test,
   fixture: SpatialExecutionFixture,
   scenario: SpatialScenario,
   expected: ExpectedSpatialLayout
@@ -1118,52 +1099,39 @@ async function assertSpatialLayout(
   ]);
 
   assertClose(
-    tapeTest,
     positions,
     expected.positions,
     'accelerated GPU coordinates match CPU near/far physics'
   );
   assertClose(
-    tapeTest,
     velocities,
     expected.velocities,
     'accelerated GPU velocities preserve exact attraction and damping'
   );
-  tapeTest.deepEqual(
-    offsets,
-    expected.grid.offsets,
-    'row-major cell offsets retain all accepted vertices'
+  expect(offsets, 'row-major cell offsets retain all accepted vertices').toEqual(
+    expected.grid.offsets
   );
   assertClose(
-    tapeTest,
     centers,
     expected.grid.centers,
     'nonempty caller-owned cell centers equal true floating centroids'
   );
-  tapeTest.equal(
-    count[0],
-    expected.grid.acceptedCount,
-    'spatial index reports full in-domain vertex count'
+  expect(count[0], 'spatial index reports full in-domain vertex count').toBe(
+    expected.grid.acceptedCount
   );
-  tapeTest.equal(
-    overflow[0],
-    Number(expected.grid.overflow),
-    'spatial ID capacity overflow stays explicit'
+  expect(overflow[0], 'spatial ID capacity overflow stays explicit').toBe(
+    Number(expected.grid.overflow)
   );
-  tapeTest.equal(invalid[0], expected.invalidEdgeCount, 'invalid source edges remain excluded');
-  tapeTest.equal(
-    topologyOverflow[0],
-    Number(expected.forwardOverflow),
-    'forward topology capacity is explicit'
+  expect(invalid[0], 'invalid source edges remain excluded').toBe(expected.invalidEdgeCount);
+  expect(topologyOverflow[0], 'forward topology capacity is explicit').toBe(
+    Number(expected.forwardOverflow)
   );
   if (reverseOverflow) {
-    tapeTest.equal(
-      reverseOverflow[0],
-      Number(expected.reverseOverflow),
-      'reverse topology capacity is explicit'
+    expect(reverseOverflow[0], 'reverse topology capacity is explicit').toBe(
+      Number(expected.reverseOverflow)
     );
   }
-  if (reset) tapeTest.equal(reset[0], 0, 'one-shot deterministic reset is consumed on the GPU');
+  if (reset) expect(reset[0], 'one-shot deterministic reset is consumed on the GPU').toBe(0);
 
   for (const [cellIndex, expectedVertices] of expected.grid.cells.entries()) {
     const first = offsets[cellIndex];
@@ -1174,52 +1142,44 @@ async function assertSpatialLayout(
     const expectedStored = expectedVertices
       .slice(0, Math.max(0, last - first))
       .sort((left, right) => left - right);
-    tapeTest.deepEqual(
-      actual,
-      expectedStored,
-      'atomic cell placement preserves every stored stable vertex ID'
+    expect(actual, 'atomic cell placement preserves every stored stable vertex ID').toEqual(
+      expectedStored
     );
   }
 
   if (expected.failed) {
-    tapeTest.deepEqual(
-      positions,
-      Array.from(new Float32Array(scenario.positions)),
-      'invalid topology or index preserves render coordinates'
+    expect(positions, 'invalid topology or index preserves render coordinates').toEqual(
+      Array.from(new Float32Array(scenario.positions))
     );
-    tapeTest.ok(
-      velocities.every(velocity => velocity === 0),
+    expect(
+      Boolean(velocities.every(velocity => velocity === 0)),
       'invalid topology or index clears progressive velocities'
-    );
+    ).toBe(true);
   }
 
   for (const [vertexIndex, pinned] of (scenario.pinned ?? []).entries()) {
     if (pinned) {
-      tapeTest.equal(
-        positions[vertexIndex * 2],
-        scenario.positions[vertexIndex * 2],
-        'pinned x never moves'
+      expect(positions[vertexIndex * 2], 'pinned x never moves').toBe(
+        scenario.positions[vertexIndex * 2]
       );
-      tapeTest.equal(
-        positions[vertexIndex * 2 + 1],
-        scenario.positions[vertexIndex * 2 + 1],
-        'pinned y never moves'
+      expect(positions[vertexIndex * 2 + 1], 'pinned y never moves').toBe(
+        scenario.positions[vertexIndex * 2 + 1]
       );
-      tapeTest.equal(velocities[vertexIndex * 2], 0, 'pinned horizontal velocity remains zero');
-      tapeTest.equal(velocities[vertexIndex * 2 + 1], 0, 'pinned vertical velocity remains zero');
+      expect(velocities[vertexIndex * 2], 'pinned horizontal velocity remains zero').toBe(0);
+      expect(velocities[vertexIndex * 2 + 1], 'pinned vertical velocity remains zero').toBe(0);
     }
   }
 }
 
-function assertClose(tapeTest: Test, actual: number[], expected: number[], message: string): void {
+function assertClose(actual: number[], expected: number[], message: string): void {
   const largestError = actual.reduce(
     (largest, value, index) => Math.max(largest, Math.abs(value - expected[index])),
     0
   );
-  tapeTest.ok(
-    largestError <= SPATIAL_TOLERANCE,
+  expect(
+    Boolean(largestError <= SPATIAL_TOLERANCE),
     `${message} within ${SPATIAL_TOLERANCE}: ${largestError}`
-  );
+  ).toBe(true);
 }
 
 async function readUint32Vector(vector: GPUVector<'uint32'>): Promise<number[]> {
@@ -1236,12 +1196,12 @@ async function readCoordinateVector(vector: GPUVector<'float32x2'>): Promise<num
   return Array.from(new Float32Array(bytes.buffer, bytes.byteOffset, vector.length * 2));
 }
 
-function destroyExecutionFixture(tapeTest: Test, fixture: SpatialExecutionFixture): void {
+function destroyExecutionFixture(fixture: SpatialExecutionFixture): void {
   fixture.compiled?.destroy();
   for (const vector of fixture.vectors) vector.destroy();
-  tapeTest.ok(
-    fixture.buffers.every(buffer => !buffer.destroyed),
+  expect(
+    Boolean(fixture.buffers.every(buffer => !buffer.destroyed)),
     'destroying graph-owned grid scratch preserves every caller-owned topology, layout, and index allocation'
-  );
+  ).toBe(true);
   for (const buffer of fixture.buffers) buffer.destroy();
 }

--- a/modules/gpgpu/test/gpu-graph/gpu-graph-topology.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph-topology.spec.ts
@@ -7,7 +7,7 @@ import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
 import {GPUGraph, GPUGraphTopology, type GPUGraphAdjacency} from '@luma.gl/gpgpu/gpu-graph';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test, {type Test} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {addGPUGraphTopologyToGraphWithDispatchLimit} from '../../src/gpu-graph/gpu-graph-topology-internals';
 
 type ScalarFormat = 'uint32' | 'float32';
@@ -165,11 +165,9 @@ const topologyScenarios: TopologyScenario[] = [
 ];
 
 for (const scenario of topologyScenarios) {
-  test(`GPUGraphTopology GPU CSR: ${scenario.name}`, async tapeTest => {
+  it(`GPUGraphTopology GPU CSR: ${scenario.name}`, async () => {
     const device = await getWebGPUTestDevice();
     if (!device) {
-      tapeTest.comment('WebGPU is not available');
-      tapeTest.end();
       return;
     }
 
@@ -178,25 +176,20 @@ for (const scenario of topologyScenarios) {
     try {
       compileTopology(fixture, scenario.maximumWorkgroups);
       executeTopology(fixture);
-      await assertTopology(tapeTest, fixture, expected);
-      tapeTest.deepEqual(
+      await assertTopology(fixture, expected);
+      expect(
         fixture.graph.sourceVertices.data.map(chunk => chunk.length),
-        scenario.sourceChunks.map(chunk => chunk.length),
         'GPU construction retains every source chunk and empty source batch'
-      );
+      ).toEqual(scenario.sourceChunks.map(chunk => chunk.length));
     } finally {
-      destroyExecutionFixture(tapeTest, fixture);
+      destroyExecutionFixture(fixture);
     }
-
-    tapeTest.end();
   });
 }
 
-test('GPUGraphTopology rebuilds overflow, invalid edges, and weighted reverse CSR on every encoding', async tapeTest => {
+it('GPUGraphTopology rebuilds overflow, invalid edges, and weighted reverse CSR on every encoding', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -216,7 +209,7 @@ test('GPUGraphTopology rebuilds overflow, invalid edges, and weighted reverse CS
   try {
     compileTopology(fixture);
     executeTopology(fixture);
-    await assertTopology(tapeTest, fixture, buildExpectedTopology(original));
+    await assertTopology(fixture, buildExpectedTopology(original));
 
     const sourceBuffer = fixture.graph.sourceVertices.data[0].buffer as Buffer;
     sourceBuffer.write(Uint32Array.from([9, 9]));
@@ -226,17 +219,14 @@ test('GPUGraphTopology rebuilds overflow, invalid edges, and weighted reverse CS
     };
 
     executeTopology(fixture);
-    await assertTopology(tapeTest, fixture, buildExpectedTopology(updated));
-    tapeTest.equal(
+    await assertTopology(fixture, buildExpectedTopology(updated));
+    expect(
       fixture.graph.sourceVertices.data[0].buffer,
-      sourceBuffer,
       'rewriting caller-owned source storage never replaces its preserved source chunk'
-    );
+    ).toBe(sourceBuffer);
   } finally {
-    destroyExecutionFixture(tapeTest, fixture);
+    destroyExecutionFixture(fixture);
   }
-
-  tapeTest.end();
 });
 
 /** Computes a CPU reference without promising deterministic atomic order within one CSR row. */
@@ -480,40 +470,30 @@ function executeTopology(fixture: ExecutionFixture): void {
 }
 
 async function assertTopology(
-  tapeTest: Test,
   fixture: ExecutionFixture,
   expected: ExpectedTopology
 ): Promise<void> {
-  await assertAdjacency(tapeTest, 'forward', fixture.topology.forward, expected.forward);
+  await assertAdjacency('forward', fixture.topology.forward, expected.forward);
   if (fixture.topology.reverse && expected.reverse) {
-    await assertAdjacency(tapeTest, 'reverse', fixture.topology.reverse, expected.reverse);
+    await assertAdjacency('reverse', fixture.topology.reverse, expected.reverse);
   }
   const invalidEdgeCount = (await readUint32Vector(fixture.topology.invalidEdgeCount))[0];
-  tapeTest.equal(
-    invalidEdgeCount,
-    expected.invalidEdgeCount,
-    'each invalid source edge is counted once'
+  expect(invalidEdgeCount, 'each invalid source edge is counted once').toBe(
+    expected.invalidEdgeCount
   );
 }
 
 async function assertAdjacency(
-  tapeTest: Test,
   name: string,
   adjacency: GPUGraphAdjacency,
   expected: ExpectedAdjacency
 ): Promise<void> {
   const result = await readAdjacency(adjacency);
   const capacity = adjacency.neighbors.length;
-  tapeTest.deepEqual(
-    result.offsets,
-    expected.offsets,
-    `${name} offsets remain exact and untruncated`
-  );
-  tapeTest.equal(result.count, expected.count, `${name} count reports required adjacency capacity`);
-  tapeTest.equal(
-    result.overflow,
-    Number(expected.count > capacity),
-    `${name} reports capacity overflow`
+  expect(result.offsets, `${name} offsets remain exact and untruncated`).toEqual(expected.offsets);
+  expect(result.count, `${name} count reports required adjacency capacity`).toBe(expected.count);
+  expect(result.overflow, `${name} reports capacity overflow`).toBe(
+    Number(expected.count > capacity)
   );
 
   const actualRows = expected.rows.map((_row, vertexIndex) => {
@@ -531,11 +511,10 @@ async function assertAdjacency(
   const expectedRows = expected.rows.map(row => [...row].sort(compareAdjacencyRecords));
 
   if (expected.count <= capacity) {
-    tapeTest.deepEqual(
+    expect(
       actualRows,
-      expectedRows,
       `${name} preserves every neighbor, stable edge ID, and aligned weight`
-    );
+    ).toEqual(expectedRows);
     return;
   }
 
@@ -556,11 +535,14 @@ async function assertAdjacency(
     });
   });
 
-  tapeTest.ok(rowSizesMatch, `${name} capacity never writes outside each untruncated CSR row`);
-  tapeTest.ok(
-    recordsBelongToExpectedRows,
+  expect(
+    Boolean(rowSizesMatch),
+    `${name} capacity never writes outside each untruncated CSR row`
+  ).toBe(true);
+  expect(
+    Boolean(recordsBelongToExpectedRows),
     `${name} truncated rows contain valid neighbor, edge ID, and weight tuples`
-  );
+  ).toBe(true);
 }
 
 function compareAdjacencyRecords(left: AdjacencyRecord, right: AdjacencyRecord): number {
@@ -593,12 +575,12 @@ async function readFloat32Vector(vector: GPUVector<'float32'>): Promise<number[]
   return Array.from(new Float32Array(bytes.buffer, bytes.byteOffset, vector.length));
 }
 
-function destroyExecutionFixture(tapeTest: Test, fixture: ExecutionFixture): void {
+function destroyExecutionFixture(fixture: ExecutionFixture): void {
   fixture.compiled?.destroy();
   for (const vector of fixture.vectors) vector.destroy();
-  tapeTest.ok(
-    fixture.buffers.every(buffer => !buffer.destroyed),
+  expect(
+    Boolean(fixture.buffers.every(buffer => !buffer.destroyed)),
     'destroying the compiled graph and borrowed vectors preserves caller-owned buffers'
-  );
+  ).toBe(true);
   for (const buffer of fixture.buffers) buffer.destroy();
 }

--- a/modules/gpgpu/test/gpu-graph/gpu-graph.spec.ts
+++ b/modules/gpgpu/test/gpu-graph/gpu-graph.spec.ts
@@ -6,14 +6,11 @@ import {Buffer, type Device} from '@luma.gl/core';
 import {GPUGraph} from '@luma.gl/gpgpu/gpu-graph';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import test from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 
-test('GPUGraph preserves caller-owned WebGPU graph chunks without executing GPU work', async tapeTest => {
+it('GPUGraph preserves caller-owned WebGPU graph chunks without executing GPU work', async () => {
   const device = await getWebGPUTestDevice();
   if (!device) {
-    tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
     return;
   }
 
@@ -52,42 +49,41 @@ test('GPUGraph preserves caller-owned WebGPU graph chunks without executing GPU 
       directed: false
     });
 
-    tapeTest.equal(graph.vertexCount, 9, 'explicit vertex counts retain isolated vertices');
-    tapeTest.equal(graph.edgeCount, 5, 'undirected metadata does not symmetrize source edges');
-    tapeTest.equal(graph.directed, false, 'caller-selected directedness remains explicit');
-    tapeTest.equal(graph.sourceVertices, sourceVertices, 'source vector identity is preserved');
-    tapeTest.equal(graph.targetVertices, targetVertices, 'target vector identity is preserved');
-    tapeTest.equal(graph.edgeWeights, edgeWeights, 'float32 weight vector identity is preserved');
-    tapeTest.equal(graph.edgeIds, edgeIds, 'stable uint32 edge ID vector identity is preserved');
+    expect(graph.vertexCount, 'explicit vertex counts retain isolated vertices').toBe(9);
+    expect(graph.edgeCount, 'undirected metadata does not symmetrize source edges').toBe(5);
+    expect(graph.directed, 'caller-selected directedness remains explicit').toBe(false);
+    expect(graph.sourceVertices, 'source vector identity is preserved').toBe(sourceVertices);
+    expect(graph.targetVertices, 'target vector identity is preserved').toBe(targetVertices);
+    expect(graph.edgeWeights, 'float32 weight vector identity is preserved').toBe(edgeWeights);
+    expect(graph.edgeIds, 'stable uint32 edge ID vector identity is preserved').toBe(edgeIds);
 
     for (const vector of [sourceVertices, targetVertices, edgeWeights, edgeIds]) {
-      tapeTest.deepEqual(
+      expect(
         vector.data.map(chunk => chunk.length),
-        [2, 0, 3],
         `${vector.name} retains its empty middle GPUData chunk`
-      );
+      ).toEqual([2, 0, 3]);
       for (const chunk of vector.data) {
-        tapeTest.ok(
-          buffers.some(buffer => buffer === chunk.buffer),
+        expect(
+          Boolean(buffers.some(buffer => buffer === chunk.buffer)),
           `${vector.name} borrows its original buffer`
-        );
+        ).toBe(true);
       }
     }
 
-    tapeTest.equal(createBufferSpy.mock.calls.length, 0, 'construction allocates no GPU buffers');
-    tapeTest.equal(submitSpy.mock.calls.length, 0, 'construction submits no GPU commands');
-    tapeTest.ok(
-      readbackSpies.every(spy => spy.mock.calls.length === 0),
+    expect(createBufferSpy.mock.calls.length, 'construction allocates no GPU buffers').toBe(0);
+    expect(submitSpy.mock.calls.length, 'construction submits no GPU commands').toBe(0);
+    expect(
+      Boolean(readbackSpies.every(spy => spy.mock.calls.length === 0)),
       'construction never reads source buffers back to the CPU'
-    );
+    ).toBe(true);
 
     for (const vector of [sourceVertices, targetVertices, edgeWeights, edgeIds]) {
       vector.destroy();
     }
-    tapeTest.ok(
-      buffers.every(buffer => !buffer.destroyed),
+    expect(
+      Boolean(buffers.every(buffer => !buffer.destroyed)),
       'destroying borrowed vectors leaves every WebGPU buffer under caller ownership'
-    );
+    ).toBe(true);
   } finally {
     createBufferSpy.mockRestore();
     submitSpy.mockRestore();
@@ -101,8 +97,6 @@ test('GPUGraph preserves caller-owned WebGPU graph chunks without executing GPU 
       buffer.destroy();
     }
   }
-
-  tapeTest.end();
 });
 
 /** Creates borrowed scalar GPU vectors without changing empty source chunk boundaries. */

--- a/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-delta-binary-packed-int64-decoder.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-delta-binary-packed-int64-decoder.node.spec.ts
@@ -3,18 +3,17 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {parseParquetDeltaBinaryPackedInt64Plan} from '@luma.gl/gpgpu/gpu-parse';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 const ENCODED = Uint8Array.from([
   128, 1, 4, 3, 128, 128, 128, 128, 32, 5, 3, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 ]);
 
-test('parseParquetDeltaBinaryPackedInt64Plan retains split signed words', testCase => {
+it('parseParquetDeltaBinaryPackedInt64Plan retains split signed words', () => {
   const plan = parseParquetDeltaBinaryPackedInt64Plan(ENCODED);
-  testCase.equal(plan.valueCount, 3);
-  testCase.equal(plan.firstValueLow, 0);
-  testCase.equal(plan.firstValueHigh, 1);
-  testCase.equal(plan.bytesConsumed, ENCODED.length);
-  testCase.deepEqual(Array.from(plan.miniBlockDescriptors), [1, 2, 14, 3, 0xfffffffd, 0xffffffff]);
-  testCase.end();
+  expect(plan.valueCount).toBe(3);
+  expect(plan.firstValueLow).toBe(0);
+  expect(plan.firstValueHigh).toBe(1);
+  expect(plan.bytesConsumed).toBe(ENCODED.length);
+  expect(Array.from(plan.miniBlockDescriptors)).toEqual([1, 2, 14, 3, 0xfffffffd, 0xffffffff]);
 });

--- a/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-delta-length-byte-array-decoder.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-delta-length-byte-array-decoder.node.spec.ts
@@ -8,24 +8,23 @@ import {
   parseParquetDeltaLengthByteArrayPlan
 } from '@luma.gl/gpgpu/gpu-parse';
 import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
-import test from 'test/utils/vitest-tape';
 import {vi} from 'vitest';
+import {expect, it} from 'vitest';
 
 const ENCODED_LENGTHS = Uint8Array.from([
   128, 1, 4, 3, 6, 3, 3, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 ]);
 const ENCODED = Uint8Array.from([...ENCODED_LENGTHS, 99, 97, 116, 100, 111, 103, 115, 101]);
 
-test('parseParquetDeltaLengthByteArrayPlan locates the contiguous payload', testCase => {
+it('parseParquetDeltaLengthByteArrayPlan locates the contiguous payload', () => {
   const plan = parseParquetDeltaLengthByteArrayPlan(ENCODED);
-  testCase.equal(plan.lengthPlan.valueCount, 3);
-  testCase.equal(plan.lengthPlan.firstValue, 3);
-  testCase.equal(plan.payloadByteOffset, ENCODED_LENGTHS.length);
-  testCase.equal(plan.payloadByteLength, 8);
-  testCase.end();
+  expect(plan.lengthPlan.valueCount).toBe(3);
+  expect(plan.lengthPlan.firstValue).toBe(3);
+  expect(plan.payloadByteOffset).toBe(ENCODED_LENGTHS.length);
+  expect(plan.payloadByteLength).toBe(8);
 });
 
-test('GPUParquetDeltaLengthByteArrayDecoder composes decode and exclusive scan', testCase => {
+it('GPUParquetDeltaLengthByteArrayDecoder composes decode and exclusive scan', () => {
   const plan = parseParquetDeltaLengthByteArrayPlan(ENCODED);
   const graph = new GPUCommandGraph(makeSupportDevice());
   const addComputePass = vi.spyOn(graph, 'addComputePass');
@@ -50,13 +49,11 @@ test('GPUParquetDeltaLengthByteArrayDecoder composes decode and exclusive scan',
     descriptorCount: plan.lengthPlan.descriptorCount,
     firstValue: plan.lengthPlan.firstValue
   }).addToGraph(graph);
-  testCase.ok(addComputePass.mock.calls.length >= 3);
-  testCase.equal(
-    addComputePass.mock.calls[0][0].id,
+  expect(addComputePass.mock.calls.length >= 3).toBe(true);
+  expect(addComputePass.mock.calls[0][0].id).toBe(
     'gpu-parquet-delta-length-byte-array-lengths-unpack'
   );
-  testCase.match(addComputePass.mock.calls.at(-1)?.[0].id ?? '', /offsets/);
-  testCase.end();
+  expect(addComputePass.mock.calls.at(-1)?.[0].id ?? '').toMatch(/offsets/);
 });
 
 function makeSupportDevice(): Device {

--- a/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-dictionary-decoder.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-dictionary-decoder.node.spec.ts
@@ -10,12 +10,11 @@ import {
   makeGPUParquetDictionaryDecoderStats
 } from '@luma.gl/gpgpu/gpu-parse';
 import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
-import test from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 import {WgslReflect} from 'wgsl_reflect';
 
-test('GPUParquetDictionaryDecoder plans arbitrary-width gathers', testCase => {
-  testCase.deepEqual(makeGPUParquetDictionaryDecoderStats(5, 3, 3), {
+it('GPUParquetDictionaryDecoder plans arbitrary-width gathers', () => {
+  expect(makeGPUParquetDictionaryDecoderStats(5, 3, 3)).toEqual({
     valueCount: 5,
     dictionaryValueCount: 3,
     byteWidth: 3,
@@ -24,7 +23,7 @@ test('GPUParquetDictionaryDecoder plans arbitrary-width gathers', testCase => {
     outputWordCount: 4,
     workgroupCount: 1
   });
-  testCase.deepEqual(makeGPUParquetDictionaryDecoderStats(0, 0, 8), {
+  expect(makeGPUParquetDictionaryDecoderStats(0, 0, 8)).toEqual({
     valueCount: 0,
     dictionaryValueCount: 0,
     byteWidth: 8,
@@ -33,11 +32,10 @@ test('GPUParquetDictionaryDecoder plans arbitrary-width gathers', testCase => {
     outputWordCount: 0,
     workgroupCount: 0
   });
-  testCase.throws(() => makeGPUParquetDictionaryDecoderStats(1, 1, 0), /byteWidth.*positive/);
-  testCase.end();
+  expect(() => makeGPUParquetDictionaryDecoderStats(1, 1, 0)).toThrow(/byteWidth.*positive/);
 });
 
-test('GPUParquetDictionaryDecoder validates and emits a byte gather shader', testCase => {
+it('GPUParquetDictionaryDecoder validates and emits a byte gather shader', () => {
   const graph = new GPUCommandGraph(makeSupportDevice());
   const dictionaryHandle = graph.importBuffer({
     id: 'dictionary',
@@ -55,17 +53,13 @@ test('GPUParquetDictionaryDecoder validates and emits a byte gather shader', tes
     byteWidth: 3
   });
   const source = getGPUParquetDictionaryShaderSource(decoder, {x: 1, y: 1, z: 1});
-  testCase.deepEqual(
-    new WgslReflect(source).entry.compute.map(entry => entry.name),
-    ['main']
-  );
-  testCase.match(source, /dictionaryIndex < DICTIONARY_VALUE_COUNT/);
-  testCase.match(source, /dictionaryIndex \* BYTE_WIDTH \+ byteIndexWithinValue/);
-  testCase.doesNotThrow(() => decoder.addToGraph(graph));
-  testCase.end();
+  expect(new WgslReflect(source).entry.compute.map(entry => entry.name)).toEqual(['main']);
+  expect(source).toMatch(/dictionaryIndex < DICTIONARY_VALUE_COUNT/);
+  expect(source).toMatch(/dictionaryIndex \* BYTE_WIDTH \+ byteIndexWithinValue/);
+  expect(() => decoder.addToGraph(graph)).not.toThrow();
 });
 
-test('GPUParquetRleDictionaryDecoder composes two graph nodes through transient indices', testCase => {
+it('GPUParquetRleDictionaryDecoder composes two graph nodes through transient indices', () => {
   const graph = new GPUCommandGraph(makeSupportDevice());
   const addComputePass = vi.spyOn(graph, 'addComputePass');
   const createTransientBuffer = vi.spyOn(graph, 'createTransientBuffer');
@@ -93,13 +87,12 @@ test('GPUParquetRleDictionaryDecoder composes two graph nodes through transient 
     dictionaryValueCount: 3,
     byteWidth: 3
   }).addToGraph(graph);
-  testCase.equal(createTransientBuffer.mock.calls.length, 1);
-  testCase.equal(addComputePass.mock.calls.length, 2);
-  testCase.deepEqual(
-    addComputePass.mock.calls.map(call => call[0].id),
-    ['gpu-parquet-rle-dictionary-indices', 'gpu-parquet-rle-dictionary-gather']
-  );
-  testCase.end();
+  expect(createTransientBuffer.mock.calls.length).toBe(1);
+  expect(addComputePass.mock.calls.length).toBe(2);
+  expect(addComputePass.mock.calls.map(call => call[0].id)).toEqual([
+    'gpu-parquet-rle-dictionary-indices',
+    'gpu-parquet-rle-dictionary-gather'
+  ]);
 });
 
 function makeSupportDevice(): Device {

--- a/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-plain-boolean-decoder.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-plain-boolean-decoder.node.spec.ts
@@ -8,10 +8,10 @@ import {
   getGPUParquetPlainBooleanShaderSource
 } from '@luma.gl/gpgpu/gpu-parse';
 import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {WgslReflect} from 'wgsl_reflect';
 
-test('GPUParquetPlainBooleanDecoder emits LSB-first boolean unpacking WGSL', testCase => {
+it('GPUParquetPlainBooleanDecoder emits LSB-first boolean unpacking WGSL', () => {
   const graph = new GPUCommandGraph(makeSupportDevice());
   const inputHandle = graph.importBuffer({id: 'input', byteLength: 8, usage: Buffer.STORAGE});
   const outputHandle = graph.importBuffer({id: 'output', byteLength: 160, usage: Buffer.STORAGE});
@@ -21,14 +21,10 @@ test('GPUParquetPlainBooleanDecoder emits LSB-first boolean unpacking WGSL', tes
     valueCount: 40
   });
   const source = getGPUParquetPlainBooleanShaderSource(decoder, {x: 1, y: 1, z: 1});
-  testCase.deepEqual(
-    new WgslReflect(source).entry.compute.map(entry => entry.name),
-    ['main']
-  );
-  testCase.match(source, /valueIndex \/ 32u/);
-  testCase.match(source, /valueIndex & 31u/);
-  testCase.doesNotThrow(() => decoder.addToGraph(graph));
-  testCase.end();
+  expect(new WgslReflect(source).entry.compute.map(entry => entry.name)).toEqual(['main']);
+  expect(source).toMatch(/valueIndex \/ 32u/);
+  expect(source).toMatch(/valueIndex & 31u/);
+  expect(() => decoder.addToGraph(graph)).not.toThrow();
 });
 
 function makeSupportDevice(): Device {

--- a/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-plain-byte-array-decoder.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-plain-byte-array-decoder.node.spec.ts
@@ -8,25 +8,23 @@ import {
   parseParquetPlainByteArrayPlan
 } from '@luma.gl/gpgpu/gpu-parse';
 import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
-import test from 'test/utils/vitest-tape';
-import {vi} from 'vitest';
+import {expect, it, vi} from 'vitest';
 
 const ENCODED = Uint8Array.from([
   0, 0, 0, 0, 3, 0, 0, 0, 99, 97, 116, 1, 0, 0, 0, 100, 5, 0, 0, 0, 104, 111, 114, 115, 101
 ]);
 
-test('parseParquetPlainByteArrayPlan exposes generic byte ranges', testCase => {
+it('parseParquetPlainByteArrayPlan exposes generic byte ranges', () => {
   const plan = parseParquetPlainByteArrayPlan(ENCODED, 4);
-  testCase.deepEqual(Array.from(plan.sourceOffsets), [4, 8, 15, 20]);
-  testCase.deepEqual(Array.from(plan.valueLengths), [0, 3, 1, 5]);
-  testCase.deepEqual(Array.from(plan.valueOffsets), [0, 0, 3, 4]);
-  testCase.equal(plan.bytesConsumed, ENCODED.length);
-  testCase.equal(plan.outputByteLength, 9);
-  testCase.throws(() => parseParquetPlainByteArrayPlan(ENCODED.subarray(0, 23), 4), /truncated/);
-  testCase.end();
+  expect(Array.from(plan.sourceOffsets)).toEqual([4, 8, 15, 20]);
+  expect(Array.from(plan.valueLengths)).toEqual([0, 3, 1, 5]);
+  expect(Array.from(plan.valueOffsets)).toEqual([0, 0, 3, 4]);
+  expect(plan.bytesConsumed).toBe(ENCODED.length);
+  expect(plan.outputByteLength).toBe(9);
+  expect(() => parseParquetPlainByteArrayPlan(ENCODED.subarray(0, 23), 4)).toThrow(/truncated/);
 });
 
-test('GPUParquetPlainByteArrayDecoder delegates to GPUByteRangeGather', testCase => {
+it('GPUParquetPlainByteArrayDecoder delegates to GPUByteRangeGather', () => {
   const graph = new GPUCommandGraph(makeSupportDevice());
   const addComputePass = vi.spyOn(graph, 'addComputePass');
   const makeView = (id: string, length: number) => {
@@ -42,8 +40,7 @@ test('GPUParquetPlainByteArrayDecoder delegates to GPUByteRangeGather', testCase
     encodedByteLength: ENCODED.length,
     outputByteLength: 9
   }).addToGraph(graph);
-  testCase.equal(addComputePass.mock.calls[0][0].workload?.operation, 'GPUByteRangeGather');
-  testCase.end();
+  expect(addComputePass.mock.calls[0][0].workload?.operation).toBe('GPUByteRangeGather');
 });
 
 function makeSupportDevice(): Device {

--- a/modules/gpgpu/test/gpu-parse/parquet/parquet-rle-framing.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/parquet-rle-framing.node.spec.ts
@@ -7,37 +7,32 @@ import {
   parseParquetDictionaryIndicesPlan,
   parseParquetLengthPrefixedRleBitPackedRunPlan
 } from '@luma.gl/gpgpu/gpu-parse';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('parseParquetDictionaryIndicesPlan consumes and rebases the bit-width prefix', testCase => {
+it('parseParquetDictionaryIndicesPlan consumes and rebases the bit-width prefix', () => {
   const plan = parseParquetDictionaryIndicesPlan(Uint8Array.from([2, 6, 2]), 3);
-  testCase.equal(plan.bitWidth, 2);
-  testCase.equal(plan.bytesConsumed, 3);
-  testCase.deepEqual(Array.from(plan.runPlan.runDescriptors), [0, 3, 2, 0]);
-  testCase.end();
+  expect(plan.bitWidth).toBe(2);
+  expect(plan.bytesConsumed).toBe(3);
+  expect(Array.from(plan.runPlan.runDescriptors)).toEqual([0, 3, 2, 0]);
 });
 
-test('parseParquetLengthPrefixedRleBitPackedRunPlan consumes Data Page V1 framing', testCase => {
+it('parseParquetLengthPrefixedRleBitPackedRunPlan consumes Data Page V1 framing', () => {
   const plan = parseParquetLengthPrefixedRleBitPackedRunPlan(
     Uint8Array.from([2, 0, 0, 0, 6, 1]),
     1,
     3
   );
-  testCase.equal(plan.bytesConsumed, 6);
-  testCase.deepEqual(Array.from(plan.runDescriptors), [0, 3, 5, 0]);
-  testCase.throws(
-    () => parseParquetLengthPrefixedRleBitPackedRunPlan(Uint8Array.from([3, 0, 0, 0, 6, 1]), 1, 3),
-    /payload is truncated/
-  );
-  testCase.end();
+  expect(plan.bytesConsumed).toBe(6);
+  expect(Array.from(plan.runDescriptors)).toEqual([0, 3, 5, 0]);
+  expect(() =>
+    parseParquetLengthPrefixedRleBitPackedRunPlan(Uint8Array.from([3, 0, 0, 0, 6, 1]), 1, 3)
+  ).toThrow(/payload is truncated/);
 });
 
-test('parseParquetBitPackedRunPlan validates legacy MSB-first payloads', testCase => {
+it('parseParquetBitPackedRunPlan validates legacy MSB-first payloads', () => {
   const plan = parseParquetBitPackedRunPlan(Uint8Array.from([0x05, 0x39, 0x77]), 3, 8);
-  testCase.deepEqual(plan, {bitWidth: 3, valueCount: 8, bytesConsumed: 3});
-  testCase.throws(
-    () => parseParquetBitPackedRunPlan(Uint8Array.from([0x05, 0x39]), 3, 8),
+  expect(plan).toEqual({bitWidth: 3, valueCount: 8, bytesConsumed: 3});
+  expect(() => parseParquetBitPackedRunPlan(Uint8Array.from([0x05, 0x39]), 3, 8)).toThrow(
     /payload is truncated/
   );
-  testCase.end();
 });

--- a/modules/shadertools/test/lib/generator/captialize.node.spec.ts
+++ b/modules/shadertools/test/lib/generator/captialize.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerCapitalizeTests} from './captialize.spec.shared';
 
-registerCapitalizeTests(test);
+registerCapitalizeTests();

--- a/modules/shadertools/test/lib/generator/captialize.spec.shared.ts
+++ b/modules/shadertools/test/lib/generator/captialize.spec.shared.ts
@@ -3,14 +3,15 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {capitalize} from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-export function registerCapitalizeTests(test: TapeTestFunction): void {
-  test('shadertools#capitalize', t => {
-    t.equal(capitalize('hello world'), 'Hello world', 'should capitalize string');
-    t.equal(capitalize('Hello world'), 'Hello world', 'should return already capitalized string');
-    t.equal(capitalize('1'), '1', 'should ignore non-alphabetic string');
-    t.equal(capitalize(''), '', 'should preserve empty strings');
-    t.end();
+export function registerCapitalizeTests(): void {
+  it('shadertools#capitalize', () => {
+    expect(capitalize('hello world'), 'should capitalize string').toBe('Hello world');
+    expect(capitalize('Hello world'), 'should return already capitalized string').toBe(
+      'Hello world'
+    );
+    expect(capitalize('1'), 'should ignore non-alphabetic string').toBe('1');
+    expect(capitalize(''), 'should preserve empty strings').toBe('');
   });
 }

--- a/modules/shadertools/test/lib/generator/captialize.spec.ts
+++ b/modules/shadertools/test/lib/generator/captialize.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerCapitalizeTests} from './captialize.spec.shared';
 
-registerCapitalizeTests(test);
+registerCapitalizeTests();

--- a/modules/shadertools/test/lib/generator/generate-shader.node.spec.ts
+++ b/modules/shadertools/test/lib/generator/generate-shader.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerGenerateShaderTests} from './generate-shader.spec.shared';
 
-registerGenerateShaderTests(test);
+registerGenerateShaderTests();

--- a/modules/shadertools/test/lib/generator/generate-shader.spec.shared.ts
+++ b/modules/shadertools/test/lib/generator/generate-shader.spec.shared.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {ShaderModule, generateShaderForModule, ShaderGenerationOptions} from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 const module: ShaderModule = {
   name: 'test',
@@ -59,14 +59,14 @@ var<uniform> test : Test;`
   }
 ];
 
-export function registerGenerateShaderTests(test: TapeTestFunction): void {
-  test('shadertools#generateGLSLForModule', t => {
+export function registerGenerateShaderTests(): void {
+  it('shadertools#generateGLSLForModule', () => {
     for (const testCase of TEST_CASES) {
       const generatedShader = generateShaderForModule(testCase.module, testCase.options);
-      t.equal(generatedShader, testCase.result, JSON.stringify(testCase.options));
+      expect(generatedShader, JSON.stringify(testCase.options)).toBe(testCase.result);
     }
 
-    t.throws(
+    expect(
       () =>
         generateShaderForModule(
           {
@@ -77,10 +77,7 @@ export function registerGenerateShaderTests(test: TapeTestFunction): void {
           } as ShaderModule,
           {shaderLanguage: 'wgsl'}
         ),
-      /Composite uniform types/,
       'WGSL generation rejects composite uniform types'
-    );
-
-    t.end();
+    ).toThrow(/Composite uniform types/);
   });
 }

--- a/modules/shadertools/test/lib/generator/generate-shader.spec.ts
+++ b/modules/shadertools/test/lib/generator/generate-shader.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerGenerateShaderTests} from './generate-shader.spec.shared';
 
-registerGenerateShaderTests(test);
+registerGenerateShaderTests();

--- a/modules/shadertools/test/lib/glsl-utils/shader-utils.node.spec.ts
+++ b/modules/shadertools/test/lib/glsl-utils/shader-utils.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerShaderUtilsTests} from './shader-utils.spec.shared';
 
-registerShaderUtilsTests(test);
+registerShaderUtilsTests();

--- a/modules/shadertools/test/lib/glsl-utils/shader-utils.spec.shared.ts
+++ b/modules/shadertools/test/lib/glsl-utils/shader-utils.spec.shared.ts
@@ -9,12 +9,12 @@ import {
   typeToChannelSuffix,
   typeToChannelCount
 } from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 type ChannelCount = 1 | 2 | 3 | 4;
 
-export function registerShaderUtilsTests(test: TapeTestFunction): void {
-  test('shader-utils#getQualifierDetails', t => {
+export function registerShaderUtilsTests(): void {
+  it('shader-utils#getQualifierDetails', () => {
     const QUALIFIER_TEST_CASES = [
       {
         line: 'uniform vec2 size;',
@@ -48,16 +48,14 @@ export function registerShaderUtilsTests(test: TapeTestFunction): void {
 
     QUALIFIER_TEST_CASES.forEach(testCase => {
       const result = getQualifierDetails(testCase.line, testCase.qualifiers);
-      t.deepEqual(
+      expect(
         result,
-        testCase.expected,
         `getQualifierDetails should return valid values when line=${testCase.line}`
-      );
+      ).toEqual(testCase.expected);
     });
-    t.end();
   });
 
-  test('shader-utils#getPassthroughFS', t => {
+  it('shader-utils#getPassthroughFS', () => {
     const PASSTHROUGH_TEST_CASES = [
       {
         input: 'myInput',
@@ -91,61 +89,50 @@ void main() {
         inputChannels: testCase.inputChannels,
         output: testCase.output
       });
-      t.equal(
+      expect(
         result,
-        testCase.expected,
         `Passthrough shader should match when channels=${testCase.inputChannels}`
-      );
+      ).toBe(testCase.expected);
     });
 
-    t.ok(
+    expect(
       getPassthroughFS().includes('transform_output'),
       'default passthrough shader is returned without input'
-    );
-    t.throws(() => getPassthroughFS({input: 'myInput'}), /inputChannels/, 'missing channels throw');
-    t.end();
+    ).toBe(true);
+    expect(() => getPassthroughFS({input: 'myInput'})).toThrow(/inputChannels/);
   });
 
-  test('shader-utils#typeToChannelSuffix', t => {
-    t.equal(typeToChannelSuffix('float'), 'x', 'typeToChannelSuffix should return x for float');
-    t.equal(typeToChannelSuffix('vec2'), 'xy', 'typeToChannelSuffix should return xy for vec2');
-    t.equal(typeToChannelSuffix('vec3'), 'xyz', 'typeToChannelSuffix should return xyz for vec3');
-    t.equal(typeToChannelSuffix('vec4'), 'xyzw', 'typeToChannelSuffix should return xyzw for vec4');
-    t.throws(() => typeToChannelSuffix('mat4'), /mat4/, 'invalid suffix types throw');
-    t.end();
+  it('shader-utils#typeToChannelSuffix', () => {
+    expect(typeToChannelSuffix('float'), 'typeToChannelSuffix should return x for float').toBe('x');
+    expect(typeToChannelSuffix('vec2'), 'typeToChannelSuffix should return xy for vec2').toBe('xy');
+    expect(typeToChannelSuffix('vec3'), 'typeToChannelSuffix should return xyz for vec3').toBe(
+      'xyz'
+    );
+    expect(typeToChannelSuffix('vec4'), 'typeToChannelSuffix should return xyzw for vec4').toBe(
+      'xyzw'
+    );
+    expect(() => typeToChannelSuffix('mat4')).toThrow(/mat4/);
   });
 
-  test('shader-utils#typeToChannelCount', t => {
-    t.equal(typeToChannelCount('float'), 1, 'typeToChannelCount should return 1 for float');
-    t.equal(typeToChannelCount('vec2'), 2, 'typeToChannelCount should return 2 for vec2');
-    t.equal(typeToChannelCount('vec3'), 3, 'typeToChannelCount should return 3 for vec3');
-    t.equal(typeToChannelCount('vec4'), 4, 'typeToChannelCount should return 4 for vec4');
-    t.throws(() => typeToChannelCount('mat4'), /mat4/, 'invalid channel count types throw');
-    t.end();
+  it('shader-utils#typeToChannelCount', () => {
+    expect(typeToChannelCount('float'), 'typeToChannelCount should return 1 for float').toBe(1);
+    expect(typeToChannelCount('vec2'), 'typeToChannelCount should return 2 for vec2').toBe(2);
+    expect(typeToChannelCount('vec3'), 'typeToChannelCount should return 3 for vec3').toBe(3);
+    expect(typeToChannelCount('vec4'), 'typeToChannelCount should return 4 for vec4').toBe(4);
+    expect(() => typeToChannelCount('mat4')).toThrow(/mat4/);
   });
 
-  test('shader-utils#convertToVec4', t => {
-    t.equal(
-      convertToVec4('one', 1),
-      'vec4(one, 0.0, 0.0, 1.0)',
-      'convertToVec4 should return right value for float'
+  it('shader-utils#convertToVec4', () => {
+    expect(convertToVec4('one', 1), 'convertToVec4 should return right value for float').toBe(
+      'vec4(one, 0.0, 0.0, 1.0)'
     );
-    t.equal(
-      convertToVec4('one', 2),
-      'vec4(one, 0.0, 1.0)',
-      'convertToVec4 should return right value for vec2'
+    expect(convertToVec4('one', 2), 'convertToVec4 should return right value for vec2').toBe(
+      'vec4(one, 0.0, 1.0)'
     );
-    t.equal(
-      convertToVec4('one', 3),
-      'vec4(one, 1.0)',
-      'convertToVec4 should return right value for vec3'
+    expect(convertToVec4('one', 3), 'convertToVec4 should return right value for vec3').toBe(
+      'vec4(one, 1.0)'
     );
-    t.equal(convertToVec4('one', 4), 'one', 'convertToVec4 should return right value for vec4');
-    t.throws(
-      () => convertToVec4('one', 5 as never),
-      /invalid channels/,
-      'invalid channel counts throw'
-    );
-    t.end();
+    expect(convertToVec4('one', 4), 'convertToVec4 should return right value for vec4').toBe('one');
+    expect(() => convertToVec4('one', 5 as never)).toThrow(/invalid channels/);
   });
 }

--- a/modules/shadertools/test/lib/glsl-utils/shader-utils.spec.ts
+++ b/modules/shadertools/test/lib/glsl-utils/shader-utils.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerShaderUtilsTests} from './shader-utils.spec.shared';
 
-registerShaderUtilsTests(test);
+registerShaderUtilsTests();

--- a/modules/shadertools/test/lib/preprocessor/preprocessor.node.spec.ts
+++ b/modules/shadertools/test/lib/preprocessor/preprocessor.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerPreprocessorTests} from './preprocessor.spec.shared';
 
-registerPreprocessorTests(test);
+registerPreprocessorTests();

--- a/modules/shadertools/test/lib/preprocessor/preprocessor.spec.shared.ts
+++ b/modules/shadertools/test/lib/preprocessor/preprocessor.spec.shared.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {preprocess} from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 const TEST_CASES = [
   {
@@ -97,29 +97,17 @@ var attributePath = 1;
   }
 ];
 
-export function registerPreprocessorTests(test: TapeTestFunction): void {
-  test('preprocess', t => {
+export function registerPreprocessorTests(): void {
+  it('preprocess', () => {
     for (const testCase of TEST_CASES) {
       const result = preprocess(testCase.source, testCase.options);
-      t.equal(result, testCase.result, testCase.title);
+      expect(result, testCase.title).toBe(testCase.result);
     }
 
-    t.throws(
-      () => preprocess('#else\nvalue\n#endif'),
-      /Encountered #else/,
-      'orphaned #else throws'
+    expect(() => preprocess('#else\nvalue\n#endif')).toThrow(/Encountered #else/);
+    expect(() => preprocess('#ifdef USE_SHADOWS\nvalue')).toThrow(/Unterminated conditional block/);
+    expect(() => preprocess('#if USE_A && USE_B\nvalue\n#endif')).toThrow(
+      /Unsupported #if expression/
     );
-    t.throws(
-      () => preprocess('#ifdef USE_SHADOWS\nvalue'),
-      /Unterminated conditional block/,
-      'unterminated conditionals throw'
-    );
-    t.throws(
-      () => preprocess('#if USE_A && USE_B\nvalue\n#endif'),
-      /Unsupported #if expression/,
-      'unsupported #if expressions throw'
-    );
-
-    t.end();
   });
 }

--- a/modules/shadertools/test/lib/preprocessor/preprocessor.spec.ts
+++ b/modules/shadertools/test/lib/preprocessor/preprocessor.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerPreprocessorTests} from './preprocessor.spec.shared';
 
-registerPreprocessorTests(test);
+registerPreprocessorTests();

--- a/modules/shadertools/test/modules/lighting/dirlight.node.spec.ts
+++ b/modules/shadertools/test/modules/lighting/dirlight.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerDirlightTests} from './dirlight.spec.shared';
 
-registerDirlightTests(test);
+registerDirlightTests();

--- a/modules/shadertools/test/modules/lighting/dirlight.spec.shared.ts
+++ b/modules/shadertools/test/modules/lighting/dirlight.spec.shared.ts
@@ -4,30 +4,29 @@
 
 import {checkType} from '@luma.gl/test-utils';
 import {dirlight, ShaderModule} from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 checkType<ShaderModule>(dirlight);
 
-export function registerDirlightTests(test: TapeTestFunction): void {
-  test('shadertools#dirlight', t => {
-    t.deepEqual(
+export function registerDirlightTests(): void {
+  it('shadertools#dirlight', () => {
+    expect(
       dirlight.getUniforms(),
-      {lightDirection: [1, 1, 2]},
       'default dirlight uniforms use the exported default direction'
-    );
-    t.deepEqual(dirlight.getUniforms({}), {}, 'explicit empty dirlight props stay empty');
-    t.deepEqual(
+    ).toEqual({lightDirection: [1, 1, 2]});
+    expect(dirlight.getUniforms({}), 'explicit empty dirlight props stay empty').toEqual({});
+    expect(
       dirlight.getUniforms({lightDirection: [2, 3, 4]}),
-      {lightDirection: [2, 3, 4]},
       'custom lightDirection is preserved'
+    ).toEqual({lightDirection: [2, 3, 4]});
+    expect(dirlight.defaultUniforms.lightDirection, 'default uniforms remain exported').toEqual([
+      1, 1, 2
+    ]);
+    expect(dirlight.fs.includes('dirlight_filterColor'), 'fragment shader source is exported').toBe(
+      true
     );
-    t.deepEqual(
-      dirlight.defaultUniforms.lightDirection,
-      [1, 1, 2],
-      'default uniforms remain exported'
+    expect(dirlight.vs.includes('dirlight_setNormal'), 'vertex shader source is exported').toBe(
+      true
     );
-    t.ok(dirlight.fs.includes('dirlight_filterColor'), 'fragment shader source is exported');
-    t.ok(dirlight.vs.includes('dirlight_setNormal'), 'vertex shader source is exported');
-    t.end();
   });
 }

--- a/modules/shadertools/test/modules/lighting/dirlight.spec.ts
+++ b/modules/shadertools/test/modules/lighting/dirlight.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerDirlightTests} from './dirlight.spec.shared';
 
-registerDirlightTests(test);
+registerDirlightTests();

--- a/modules/shadertools/test/modules/lighting/gouraud-material.node.spec.ts
+++ b/modules/shadertools/test/modules/lighting/gouraud-material.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerGouraudMaterialTests} from './gouraud-material.spec.shared';
 
-registerGouraudMaterialTests(test);
+registerGouraudMaterialTests();

--- a/modules/shadertools/test/modules/lighting/gouraud-material.spec.shared.ts
+++ b/modules/shadertools/test/modules/lighting/gouraud-material.spec.shared.ts
@@ -4,12 +4,12 @@
 
 import type {UniformValue} from '@luma.gl/core';
 import {gouraudMaterial} from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-export function registerGouraudMaterialTests(test: TapeTestFunction): void {
-  test('shadertools#gouraudMaterial', t => {
+export function registerGouraudMaterialTests(): void {
+  it('shadertools#gouraudMaterial', () => {
     let uniforms: Record<string, UniformValue | any> = gouraudMaterial.getUniforms?.({})!;
-    t.deepEqual(uniforms, gouraudMaterial.defaultUniforms, 'Default phong lighting uniforms ok');
+    expect(uniforms, 'Default phong lighting uniforms ok').toEqual(gouraudMaterial.defaultUniforms);
 
     uniforms = gouraudMaterial.getUniforms?.({
       unlit: true,
@@ -18,41 +18,42 @@ export function registerGouraudMaterialTests(test: TapeTestFunction): void {
       shininess: 0.0,
       specularColor: [255, 0, 0]
     })!;
-    t.is(uniforms.unlit, true, 'unlit');
-    t.is(uniforms.ambient, 0, 'ambient');
-    t.is(uniforms.diffuse, 0, 'diffuse');
-    t.is(uniforms.shininess, 0, 'shininess');
-    t.deepEqual(uniforms.specularColor, [255, 0, 0], 'specularColor');
+    expect(uniforms.unlit, 'unlit').toBe(true);
+    expect(uniforms.ambient, 'ambient').toBe(0);
+    expect(uniforms.diffuse, 'diffuse').toBe(0);
+    expect(uniforms.shininess, 'shininess').toBe(0);
+    expect(uniforms.specularColor, 'specularColor').toEqual([255, 0, 0]);
 
     uniforms = gouraudMaterial.getUniforms?.({})!;
-    t.equal(uniforms.unlit, false, 'unlit');
-    t.equal(uniforms.ambient, 0.35, 'ambient');
-    t.equal(uniforms.diffuse, 0.6, 'diffuse');
-    t.equal(uniforms.shininess, 32, 'shininess');
-    t.deepEqual(uniforms.specularColor, [38.25, 38.25, 38.25], 'specularColor');
-    t.ok(gouraudMaterial.defines?.LIGHTING_VERTEX, 'gouraudMaterial enables vertex lighting');
+    expect(uniforms.unlit, 'unlit').toBe(false);
+    expect(uniforms.ambient, 'ambient').toBe(0.35);
+    expect(uniforms.diffuse, 'diffuse').toBe(0.6);
+    expect(uniforms.shininess, 'shininess').toBe(32);
+    expect(uniforms.specularColor, 'specularColor').toEqual([38.25, 38.25, 38.25]);
+    expect(
+      gouraudMaterial.defines?.LIGHTING_VERTEX,
+      'gouraudMaterial enables vertex lighting'
+    ).toBeTruthy();
 
     uniforms = gouraudMaterial.getUniforms?.({
       specularColor: [2, 1, 0.5]
     })!;
-    t.deepEqual(uniforms.specularColor, [2, 1, 0.5], 'float specular colors pass through');
-    t.notOk(
+    expect(uniforms.specularColor, 'float specular colors pass through').toEqual([2, 1, 0.5]);
+    expect(
       'useByteColors' in gouraudMaterial.uniformTypes,
       'gouraudMaterial no longer owns useByteColors'
-    );
-    t.ok(
+    ).toBe(false);
+    expect(
       gouraudMaterial.dependencies?.some(module => module.name === 'floatColors'),
       'gouraudMaterial depends on floatColors'
-    );
-    t.ok(
+    ).toBe(true);
+    expect(
       gouraudMaterial.vs?.includes('floatColors_normalize(material.specularColor)'),
       'vertex shader normalizes specularColor through floatColors'
-    );
-    t.ok(
+    ).toBe(true);
+    expect(
       gouraudMaterial.source?.includes('floatColors_normalize(gouraudMaterial.specularColor)'),
       'WGSL shader normalizes specularColor through floatColors'
-    );
-
-    t.end();
+    ).toBe(true);
   });
 }

--- a/modules/shadertools/test/modules/lighting/gouraud-material.spec.ts
+++ b/modules/shadertools/test/modules/lighting/gouraud-material.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerGouraudMaterialTests} from './gouraud-material.spec.shared';
 
-registerGouraudMaterialTests(test);
+registerGouraudMaterialTests();

--- a/modules/shadertools/test/modules/lighting/lambert-material.node.spec.ts
+++ b/modules/shadertools/test/modules/lighting/lambert-material.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerLambertMaterialTests} from './lambert-material.spec.shared';
 
-registerLambertMaterialTests(test);
+registerLambertMaterialTests();

--- a/modules/shadertools/test/modules/lighting/lambert-material.spec.shared.ts
+++ b/modules/shadertools/test/modules/lighting/lambert-material.spec.shared.ts
@@ -3,28 +3,31 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {lambertMaterial} from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-export function registerLambertMaterialTests(test: TapeTestFunction): void {
-  test('shadertools#lambertMaterial', t => {
+export function registerLambertMaterialTests(): void {
+  it('shadertools#lambertMaterial', () => {
     let uniforms = lambertMaterial.getUniforms({});
-    t.deepEqual(uniforms, lambertMaterial.defaultUniforms, 'Default lambert lighting uniforms ok');
+    expect(uniforms, 'Default lambert lighting uniforms ok').toEqual(
+      lambertMaterial.defaultUniforms
+    );
 
     uniforms = lambertMaterial.getUniforms({
       unlit: true,
       ambient: 0.0,
       diffuse: 0.0
     });
-    t.is(uniforms.unlit, true, 'unlit');
-    t.is(uniforms.ambient, 0, 'ambient');
-    t.is(uniforms.diffuse, 0, 'diffuse');
+    expect(uniforms.unlit, 'unlit').toBe(true);
+    expect(uniforms.ambient, 'ambient').toBe(0);
+    expect(uniforms.diffuse, 'diffuse').toBe(0);
 
     uniforms = lambertMaterial.getUniforms({});
-    t.equal(uniforms.unlit, false, 'unlit');
-    t.equal(uniforms.ambient, 0.35, 'ambient');
-    t.equal(uniforms.diffuse, 0.6, 'diffuse');
-    t.ok(lambertMaterial.defines?.LIGHTING_FRAGMENT, 'lambertMaterial enables fragment lighting');
-
-    t.end();
+    expect(uniforms.unlit, 'unlit').toBe(false);
+    expect(uniforms.ambient, 'ambient').toBe(0.35);
+    expect(uniforms.diffuse, 'diffuse').toBe(0.6);
+    expect(
+      lambertMaterial.defines?.LIGHTING_FRAGMENT,
+      'lambertMaterial enables fragment lighting'
+    ).toBeTruthy();
   });
 }

--- a/modules/shadertools/test/modules/lighting/lambert-material.spec.ts
+++ b/modules/shadertools/test/modules/lighting/lambert-material.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerLambertMaterialTests} from './lambert-material.spec.shared';
 
-registerLambertMaterialTests(test);
+registerLambertMaterialTests();

--- a/modules/shadertools/test/modules/lighting/phong-material.node.spec.ts
+++ b/modules/shadertools/test/modules/lighting/phong-material.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerPhongMaterialTests} from './phong-material.spec.shared';
 
-registerPhongMaterialTests(test);
+registerPhongMaterialTests();

--- a/modules/shadertools/test/modules/lighting/phong-material.spec.shared.ts
+++ b/modules/shadertools/test/modules/lighting/phong-material.spec.shared.ts
@@ -3,12 +3,12 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {phongMaterial} from '@luma.gl/shadertools';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-export function registerPhongMaterialTests(test: TapeTestFunction): void {
-  test('shadertools#phongMaterial', t => {
+export function registerPhongMaterialTests(): void {
+  it('shadertools#phongMaterial', () => {
     let uniforms = phongMaterial.getUniforms({});
-    t.deepEqual(uniforms, phongMaterial.defaultUniforms, 'Default phong lighting uniforms ok');
+    expect(uniforms, 'Default phong lighting uniforms ok').toEqual(phongMaterial.defaultUniforms);
 
     uniforms = phongMaterial.getUniforms({
       unlit: true,
@@ -17,41 +17,42 @@ export function registerPhongMaterialTests(test: TapeTestFunction): void {
       shininess: 0.0,
       specularColor: [255, 0, 0]
     });
-    t.is(uniforms.unlit, true, 'unlit');
-    t.is(uniforms.ambient, 0, 'ambient');
-    t.is(uniforms.diffuse, 0, 'diffuse');
-    t.is(uniforms.shininess, 0, 'shininess');
-    t.deepEqual(uniforms.specularColor, [255, 0, 0], 'specularColor');
+    expect(uniforms.unlit, 'unlit').toBe(true);
+    expect(uniforms.ambient, 'ambient').toBe(0);
+    expect(uniforms.diffuse, 'diffuse').toBe(0);
+    expect(uniforms.shininess, 'shininess').toBe(0);
+    expect(uniforms.specularColor, 'specularColor').toEqual([255, 0, 0]);
 
     uniforms = phongMaterial.getUniforms({});
-    t.equal(uniforms.unlit, false, 'unlit');
-    t.equal(uniforms.ambient, 0.35, 'ambient');
-    t.equal(uniforms.diffuse, 0.6, 'diffuse');
-    t.equal(uniforms.shininess, 32, 'shininess');
-    t.deepEqual(uniforms.specularColor, [38.25, 38.25, 38.25], 'specularColor');
-    t.ok(phongMaterial.defines?.LIGHTING_FRAGMENT, 'phongMaterial enables fragment lighting');
+    expect(uniforms.unlit, 'unlit').toBe(false);
+    expect(uniforms.ambient, 'ambient').toBe(0.35);
+    expect(uniforms.diffuse, 'diffuse').toBe(0.6);
+    expect(uniforms.shininess, 'shininess').toBe(32);
+    expect(uniforms.specularColor, 'specularColor').toEqual([38.25, 38.25, 38.25]);
+    expect(
+      phongMaterial.defines?.LIGHTING_FRAGMENT,
+      'phongMaterial enables fragment lighting'
+    ).toBeTruthy();
 
     uniforms = phongMaterial.getUniforms({
       specularColor: [2, 1, 0.5]
     });
-    t.deepEqual(uniforms.specularColor, [2, 1, 0.5], 'float specular colors pass through');
-    t.notOk(
+    expect(uniforms.specularColor, 'float specular colors pass through').toEqual([2, 1, 0.5]);
+    expect(
       'useByteColors' in phongMaterial.uniformTypes,
       'phongMaterial no longer owns useByteColors'
-    );
-    t.ok(
+    ).toBe(false);
+    expect(
       phongMaterial.dependencies?.some(module => module.name === 'floatColors'),
       'phongMaterial depends on floatColors'
-    );
-    t.ok(
+    ).toBe(true);
+    expect(
       phongMaterial.fs.includes('floatColors_normalize(material.specularColor)'),
       'fragment shader normalizes specularColor through floatColors'
-    );
-    t.ok(
+    ).toBe(true);
+    expect(
       phongMaterial.source.includes('floatColors_normalize(phongMaterial.specularColor)'),
       'WGSL shader normalizes specularColor through floatColors'
-    );
-
-    t.end();
+    ).toBe(true);
   });
 }

--- a/modules/shadertools/test/modules/lighting/phong-material.spec.ts
+++ b/modules/shadertools/test/modules/lighting/phong-material.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerPhongMaterialTests} from './phong-material.spec.shared';
 
-registerPhongMaterialTests(test);
+registerPhongMaterialTests();

--- a/modules/shadertools/test/modules/utils/random.spec.ts
+++ b/modules/shadertools/test/modules/utils/random.spec.ts
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {random} from '@luma.gl/shadertools';
+import {expect, it} from 'vitest';
 
-test('random#build', t => {
-  t.ok(random.fs, 'random module fs is ok');
-  t.end();
+it('random#build', () => {
+  expect(random.fs, 'random module fs is ok').toBeTruthy();
 });

--- a/modules/webgl/test/adapter/device-helpers/webgl-device-info.spec.ts
+++ b/modules/webgl/test/adapter/device-helpers/webgl-device-info.spec.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {GL} from '@luma.gl/webgl/constants';
 import {getDeviceInfo} from '../../../src/adapter/device-helpers/webgl-device-info';
+import {expect, it} from 'vitest';
 
 function createMockGL(options: {
   vendor: string;
@@ -33,26 +33,24 @@ function createMockGL(options: {
   } as WebGL2RenderingContext;
 }
 
-test('getDeviceInfo classifies Apple Silicon WebGL GPUs as integrated', t => {
+it('getDeviceInfo classifies Apple Silicon WebGL GPUs as integrated', () => {
   const gl = createMockGL({
     vendor: 'Apple',
     renderer: 'ANGLE Metal Renderer: Apple M4 Pro, Unspecified Version'
   });
 
   const info = getDeviceInfo(gl, {});
-  t.equal(info.gpu, 'apple', 'identifies Apple GPU vendor');
-  t.equal(info.gpuType, 'integrated', 'classifies Apple Silicon as integrated');
-  t.end();
+  expect(info.gpu, 'identifies Apple GPU vendor').toBe('apple');
+  expect(info.gpuType, 'classifies Apple Silicon as integrated').toBe('integrated');
 });
 
-test('getDeviceInfo leaves ambiguous Apple WebGL GPUs as unknown type', t => {
+it('getDeviceInfo leaves ambiguous Apple WebGL GPUs as unknown type', () => {
   const gl = createMockGL({
     vendor: 'Apple',
     renderer: 'Apple'
   });
 
   const info = getDeviceInfo(gl, {});
-  t.equal(info.gpu, 'apple', 'identifies Apple GPU vendor');
-  t.equal(info.gpuType, 'unknown', 'does not default ambiguous Apple GPUs to discrete');
-  t.end();
+  expect(info.gpu, 'identifies Apple GPU vendor').toBe('apple');
+  expect(info.gpuType, 'does not default ambiguous Apple GPUs to discrete').toBe('unknown');
 });

--- a/modules/webgl/test/adapter/helpers/parse-shader-compiler-log.node.spec.ts
+++ b/modules/webgl/test/adapter/helpers/parse-shader-compiler-log.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerParseShaderCompilerLogTests} from 'test/utils/parse-shader-compiler-log.spec.shared';
 
-registerParseShaderCompilerLogTests(test);
+registerParseShaderCompilerLogTests();

--- a/modules/webgl/test/adapter/helpers/parse-shader-compiler-log.spec.ts
+++ b/modules/webgl/test/adapter/helpers/parse-shader-compiler-log.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerParseShaderCompilerLogTests} from 'test/utils/parse-shader-compiler-log.spec.shared';
 
-registerParseShaderCompilerLogTests(test);
+registerParseShaderCompilerLogTests();

--- a/modules/webgl/test/adapter/helpers/webgl-texture-table.spec.ts
+++ b/modules/webgl/test/adapter/helpers/webgl-texture-table.spec.ts
@@ -2,16 +2,14 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
 import {GL} from '@luma.gl/webgl/constants';
 import {WEBGL_TEXTURE_FORMATS} from '../../../src/adapter/converters/webgl-texture-table';
 
-test('WEBGL_TEXTURE_FORMATS maps ASTC 10x5 formats correctly', t => {
-  t.equal(WEBGL_TEXTURE_FORMATS['astc-10x5-unorm'].gl, GL.COMPRESSED_RGBA_ASTC_10x5_KHR);
-  t.equal(
-    WEBGL_TEXTURE_FORMATS['astc-10x5-unorm-srgb'].gl,
+it('WEBGL_TEXTURE_FORMATS maps ASTC 10x5 formats correctly', () => {
+  expect(WEBGL_TEXTURE_FORMATS['astc-10x5-unorm'].gl).toBe(GL.COMPRESSED_RGBA_ASTC_10x5_KHR);
+  expect(WEBGL_TEXTURE_FORMATS['astc-10x5-unorm-srgb'].gl).toBe(
     GL.COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR
   );
-  t.end();
 });

--- a/modules/webgl/test/adapter/helpers/webgl-topology-utils.node.spec.ts
+++ b/modules/webgl/test/adapter/helpers/webgl-topology-utils.node.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerWebGLTopologyUtilsTests} from './webgl-topology-utils.spec.shared';
 
-registerWebGLTopologyUtilsTests(test);
+registerWebGLTopologyUtilsTests();

--- a/modules/webgl/test/adapter/helpers/webgl-topology-utils.spec.shared.ts
+++ b/modules/webgl/test/adapter/helpers/webgl-topology-utils.spec.shared.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {GL} from '@luma.gl/webgl/constants';
+import {expect, it} from 'vitest';
 import {
   getGLDrawMode,
   getGLPrimitive,
@@ -10,63 +11,60 @@ import {
   getPrimitiveDrawMode,
   getVertexCount
 } from '@luma.gl/webgl/adapter/helpers/webgl-topology-utils';
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
 
-export function registerWebGLTopologyUtilsTests(test: TapeTestFunction): void {
-  test('getPrimitiveDrawMode', t => {
-    t.equals(getPrimitiveDrawMode(GL.POINTS), GL.POINTS, 'point-list');
-    t.equals(getPrimitiveDrawMode(GL.LINES), GL.LINES, 'line-list');
-    t.equals(getPrimitiveDrawMode(GL.LINE_STRIP), GL.LINES, 'line-strip');
-    t.equals(getPrimitiveDrawMode(GL.LINE_LOOP), GL.LINES, 'line-loop');
-    t.equals(getPrimitiveDrawMode(GL.TRIANGLES), GL.TRIANGLES, 'triangle-list');
-    t.equals(getPrimitiveDrawMode(GL.TRIANGLE_STRIP), GL.TRIANGLES, 'triangle-strip');
-    t.equals(getPrimitiveDrawMode(GL.TRIANGLE_FAN), GL.TRIANGLES, 'triangle-fan');
-    t.throws(() => getPrimitiveDrawMode(-1 as any), 'invalid');
-    t.end();
+export function registerWebGLTopologyUtilsTests(): void {
+  it('getPrimitiveDrawMode', () => {
+    expect(getPrimitiveDrawMode(GL.POINTS), 'point-list').toBe(GL.POINTS);
+    expect(getPrimitiveDrawMode(GL.LINES), 'line-list').toBe(GL.LINES);
+    expect(getPrimitiveDrawMode(GL.LINE_STRIP), 'line-strip').toBe(GL.LINES);
+    expect(getPrimitiveDrawMode(GL.LINE_LOOP), 'line-loop').toBe(GL.LINES);
+    expect(getPrimitiveDrawMode(GL.TRIANGLES), 'triangle-list').toBe(GL.TRIANGLES);
+    expect(getPrimitiveDrawMode(GL.TRIANGLE_STRIP), 'triangle-strip').toBe(GL.TRIANGLES);
+    expect(getPrimitiveDrawMode(GL.TRIANGLE_FAN), 'triangle-fan').toBe(GL.TRIANGLES);
+    expect(() => getPrimitiveDrawMode(-1 as any)).toThrow();
   });
 
-  test('getPrimitiveCount', t => {
-    t.equals(getPrimitiveCount({drawMode: GL.POINTS, vertexCount: 12}), 12, 'point-list');
-    t.equals(getPrimitiveCount({drawMode: GL.LINE_LOOP, vertexCount: 12}), 12, 'line-loop');
-    t.equals(getPrimitiveCount({drawMode: GL.LINES, vertexCount: 12}), 6, 'line-list');
-    t.equals(getPrimitiveCount({drawMode: GL.LINE_STRIP, vertexCount: 12}), 11, 'line-strip');
-    t.equals(getPrimitiveCount({drawMode: GL.TRIANGLES, vertexCount: 12}), 4, 'triangle-list');
-    t.equals(
+  it('getPrimitiveCount', () => {
+    expect(getPrimitiveCount({drawMode: GL.POINTS, vertexCount: 12}), 'point-list').toBe(12);
+    expect(getPrimitiveCount({drawMode: GL.LINE_LOOP, vertexCount: 12}), 'line-loop').toBe(12);
+    expect(getPrimitiveCount({drawMode: GL.LINES, vertexCount: 12}), 'line-list').toBe(6);
+    expect(getPrimitiveCount({drawMode: GL.LINE_STRIP, vertexCount: 12}), 'line-strip').toBe(11);
+    expect(getPrimitiveCount({drawMode: GL.TRIANGLES, vertexCount: 12}), 'triangle-list').toBe(4);
+    expect(
       getPrimitiveCount({drawMode: GL.TRIANGLE_STRIP, vertexCount: 12}),
-      10,
       'triangle-strip'
+    ).toBe(10);
+    expect(getPrimitiveCount({drawMode: GL.TRIANGLE_FAN, vertexCount: 12}), 'triangle-fan').toBe(
+      10
     );
-    t.equals(getPrimitiveCount({drawMode: GL.TRIANGLE_FAN, vertexCount: 12}), 10, 'triangle-fan');
-    t.throws(() => getPrimitiveCount({drawMode: -1 as any, vertexCount: 12}), 'invalid');
-    t.end();
+    expect(() => getPrimitiveCount({drawMode: -1 as any, vertexCount: 12})).toThrow();
   });
 
-  test('getVertexCount', t => {
-    t.equals(getVertexCount({drawMode: GL.POINTS, vertexCount: 12}), 12, 'point-list');
-    t.equals(getVertexCount({drawMode: GL.LINE_STRIP, vertexCount: 12}), 22, 'line-strip');
-    t.equals(getVertexCount({drawMode: GL.TRIANGLE_STRIP, vertexCount: 12}), 30, 'triangle-strip');
-    t.equals(getVertexCount({drawMode: GL.TRIANGLE_FAN, vertexCount: 12}), 30, 'triangle-fan');
-    t.throws(() => getVertexCount({drawMode: -1 as any, vertexCount: 12}), 'invalid');
-    t.end();
+  it('getVertexCount', () => {
+    expect(getVertexCount({drawMode: GL.POINTS, vertexCount: 12}), 'point-list').toBe(12);
+    expect(getVertexCount({drawMode: GL.LINE_STRIP, vertexCount: 12}), 'line-strip').toBe(22);
+    expect(getVertexCount({drawMode: GL.TRIANGLE_STRIP, vertexCount: 12}), 'triangle-strip').toBe(
+      30
+    );
+    expect(getVertexCount({drawMode: GL.TRIANGLE_FAN, vertexCount: 12}), 'triangle-fan').toBe(30);
+    expect(() => getVertexCount({drawMode: -1 as any, vertexCount: 12})).toThrow();
   });
 
-  test('getGLDrawMode', t => {
-    t.equals(getGLDrawMode('point-list'), GL.POINTS, 'point-list');
-    t.equals(getGLDrawMode('line-list'), GL.LINES, 'line-list');
-    t.equals(getGLDrawMode('line-strip'), GL.LINE_STRIP, 'line-strip');
-    t.equals(getGLDrawMode('triangle-list'), GL.TRIANGLES, 'triangle-list');
-    t.equals(getGLDrawMode('triangle-strip'), GL.TRIANGLE_STRIP, 'triangle-strip');
-    t.throws(() => getGLDrawMode('quad-list' as any), 'invalid');
-    t.end();
+  it('getGLDrawMode', () => {
+    expect(getGLDrawMode('point-list'), 'point-list').toBe(GL.POINTS);
+    expect(getGLDrawMode('line-list'), 'line-list').toBe(GL.LINES);
+    expect(getGLDrawMode('line-strip'), 'line-strip').toBe(GL.LINE_STRIP);
+    expect(getGLDrawMode('triangle-list'), 'triangle-list').toBe(GL.TRIANGLES);
+    expect(getGLDrawMode('triangle-strip'), 'triangle-strip').toBe(GL.TRIANGLE_STRIP);
+    expect(() => getGLDrawMode('quad-list' as any)).toThrow();
   });
 
-  test('getGLPrimitive', t => {
-    t.equals(getGLPrimitive('point-list'), GL.POINTS, 'point-list');
-    t.equals(getGLPrimitive('line-list'), GL.LINES, 'line-list');
-    t.equals(getGLPrimitive('line-strip'), GL.LINES, 'line-strip');
-    t.equals(getGLPrimitive('triangle-list'), GL.TRIANGLES, 'triangle-list');
-    t.equals(getGLPrimitive('triangle-strip'), GL.TRIANGLES, 'triangle-strip');
-    t.throws(() => getGLPrimitive('quad-list' as any), 'invalid');
-    t.end();
+  it('getGLPrimitive', () => {
+    expect(getGLPrimitive('point-list'), 'point-list').toBe(GL.POINTS);
+    expect(getGLPrimitive('line-list'), 'line-list').toBe(GL.LINES);
+    expect(getGLPrimitive('line-strip'), 'line-strip').toBe(GL.LINES);
+    expect(getGLPrimitive('triangle-list'), 'triangle-list').toBe(GL.TRIANGLES);
+    expect(getGLPrimitive('triangle-strip'), 'triangle-strip').toBe(GL.TRIANGLES);
+    expect(() => getGLPrimitive('quad-list' as any)).toThrow();
   });
 }

--- a/modules/webgl/test/adapter/helpers/webgl-topology-utils.spec.ts
+++ b/modules/webgl/test/adapter/helpers/webgl-topology-utils.spec.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {registerWebGLTopologyUtilsTests} from './webgl-topology-utils.spec.shared';
 
-registerWebGLTopologyUtilsTests(test);
+registerWebGLTopologyUtilsTests();

--- a/modules/webgl/test/adapter/resources/webgl-render-pass.spec.ts
+++ b/modules/webgl/test/adapter/resources/webgl-render-pass.spec.ts
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
-
 import {GL} from '@luma.gl/webgl/constants';
 import {WEBGLRenderPass} from '@luma.gl/webgl';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
+import {expect, it} from 'vitest';
 
-test('WEBGLRenderPass#drawBuffers for framebuffer attachments', async t => {
+it('WEBGLRenderPass#drawBuffers for framebuffer attachments', async () => {
   const device = await getWebGLTestDevice();
   const {gl} = device;
 
@@ -24,19 +23,17 @@ test('WEBGLRenderPass#drawBuffers for framebuffer attachments', async t => {
   const renderPass = new WEBGLRenderPass(device, {framebuffer});
   renderPass.end();
 
-  t.deepEqual(
-    drawBufferCalls[0],
-    [GL.COLOR_ATTACHMENT0, GL.COLOR_ATTACHMENT0 + 1],
-    'uses framebuffer color attachments as draw buffers'
-  );
+  expect(drawBufferCalls[0], 'uses framebuffer color attachments as draw buffers').toEqual([
+    GL.COLOR_ATTACHMENT0,
+    GL.COLOR_ATTACHMENT0 + 1
+  ]);
 
   gl.drawBuffers = originalDrawBuffers;
   framebuffer.destroy();
   device.destroy();
-  t.end();
 });
 
-test('WEBGLRenderPass#drawBuffers for default framebuffer', async t => {
+it('WEBGLRenderPass#drawBuffers for default framebuffer', async () => {
   const device = await getWebGLTestDevice();
   const {gl} = device;
 
@@ -50,14 +47,13 @@ test('WEBGLRenderPass#drawBuffers for default framebuffer', async t => {
   const renderPass = new WEBGLRenderPass(device, {});
   renderPass.end();
 
-  t.deepEqual(drawBufferCalls[0], [GL.BACK], 'draws to GL.BACK for default framebuffer');
+  expect(drawBufferCalls[0], 'draws to GL.BACK for default framebuffer').toEqual([GL.BACK]);
 
   gl.drawBuffers = originalDrawBuffers;
   device.destroy();
-  t.end();
 });
 
-test('WEBGLRenderPass#drawBuffers for explicit default framebuffer wrapper', async t => {
+it('WEBGLRenderPass#drawBuffers for explicit default framebuffer wrapper', async () => {
   const device = await getWebGLTestDevice();
   const {gl} = device;
 
@@ -72,14 +68,15 @@ test('WEBGLRenderPass#drawBuffers for explicit default framebuffer wrapper', asy
   const renderPass = new WEBGLRenderPass(device, {framebuffer});
   renderPass.end();
 
-  t.deepEqual(drawBufferCalls[0], [GL.BACK], 'explicit default framebuffer still draws to GL.BACK');
+  expect(drawBufferCalls[0], 'explicit default framebuffer still draws to GL.BACK').toEqual([
+    GL.BACK
+  ]);
 
   gl.drawBuffers = originalDrawBuffers;
   device.destroy();
-  t.end();
 });
 
-test('WEBGLRenderPass#drawBuffers for wrapped external WebGLFramebuffer', async t => {
+it('WEBGLRenderPass#drawBuffers for wrapped external WebGLFramebuffer', async () => {
   const device = await getWebGLTestDevice();
   const {gl} = device;
 
@@ -104,24 +101,22 @@ test('WEBGLRenderPass#drawBuffers for wrapped external WebGLFramebuffer', async 
 
   // Should not crash accessing colorAttachments.map() on wrapped external framebuffer
   const renderPass = new WEBGLRenderPass(device, {framebuffer});
-  t.ok(renderPass, 'does not crash on wrapped external WebGLFramebuffer');
+  expect(renderPass, 'does not crash on wrapped external WebGLFramebuffer').toBeTruthy();
   renderPass.end();
 
-  t.equal(
+  expect(
     drawBufferCalls.length,
-    0,
     'does not call drawBuffers for wrapped external WebGLFramebuffer'
-  );
+  ).toBe(0);
 
   gl.drawBuffers = originalDrawBuffers;
   framebuffer.destroy();
   gl.deleteRenderbuffer(rb);
   gl.deleteFramebuffer(externalFbo);
   device.destroy();
-  t.end();
 });
 
-test('WEBGLRenderPass flushes deferred default canvas resize', async t => {
+it('WEBGLRenderPass flushes deferred default canvas resize', async () => {
   const device = await getWebGLTestDevice();
   const canvasContext = device.getDefaultCanvasContext();
   const canvas = canvasContext.canvas as HTMLCanvasElement;
@@ -131,20 +126,18 @@ test('WEBGLRenderPass flushes deferred default canvas resize', async t => {
   canvas.height = 150;
   canvasContext.setDrawingBufferSize(640, 480);
 
-  t.equal(canvas.width, 300, 'canvas width is unchanged before default render pass');
-  t.equal(canvas.height, 150, 'canvas height is unchanged before default render pass');
+  expect(canvas.width, 'canvas width is unchanged before default render pass').toBe(300);
+  expect(canvas.height, 'canvas height is unchanged before default render pass').toBe(150);
 
   const renderPass = new WEBGLRenderPass(device, {});
 
-  t.equal(canvas.width, 640, 'default render pass flushes deferred canvas width resize');
-  t.equal(canvas.height, 480, 'default render pass flushes deferred canvas height resize');
-  t.deepEqual(
-    gl.getParameter(GL.VIEWPORT),
-    new Int32Array([0, 0, 640, 480]),
+  expect(canvas.width, 'default render pass flushes deferred canvas width resize').toBe(640);
+  expect(canvas.height, 'default render pass flushes deferred canvas height resize').toBe(480);
+  expect(
+    Array.from(gl.getParameter(GL.VIEWPORT)),
     'viewport uses flushed drawing buffer size'
-  );
+  ).toEqual([0, 0, 640, 480]);
 
   renderPass.end();
   device.destroy();
-  t.end();
 });

--- a/modules/webgl/test/adapter/resources/webgl-texture.spec.ts
+++ b/modules/webgl/test/adapter/resources/webgl-texture.spec.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
+import {expect, it} from 'vitest';
 
-test('WEBGLTexture keeps borrowed handles read-only', async t => {
+it('WEBGLTexture keeps borrowed handles read-only', async () => {
   const device = await getWebGLTestDevice();
   const {gl} = device;
   const textureHandle = gl.createTexture()!;
@@ -37,11 +37,10 @@ test('WEBGLTexture keeps borrowed handles read-only', async t => {
   }) as typeof gl.texStorage2D;
 
   try {
-    t.throws(
+    expect(
       () => device.createTexture({_isHandleBorrowed: true, width: 1, height: 1}),
-      /require.*texture handle/,
       'borrowed wrapper requires an external texture handle'
-    );
+    ).toThrow(/require.*texture handle/);
 
     const texture = device.createTexture({
       handle: textureHandle,
@@ -50,33 +49,31 @@ test('WEBGLTexture keeps borrowed handles read-only', async t => {
       height: 2
     });
 
-    t.true(texture.isHandleBorrowed, 'resource records borrowed handle ownership');
-    t.false(texture.ownsHandle, 'resource does not own borrowed handle');
-    t.equal(methodCallCounts.texStorage2D, 0, 'borrowed wrapper does not allocate storage');
-    t.equal(methodCallCounts.texParameteri, 0, 'borrowed wrapper does not mutate sampler state');
-    t.throws(
+    expect(texture.isHandleBorrowed, 'resource records borrowed handle ownership').toBe(true);
+    expect(texture.ownsHandle, 'resource does not own borrowed handle').toBe(false);
+    expect(methodCallCounts.texStorage2D, 'borrowed wrapper does not allocate storage').toBe(0);
+    expect(methodCallCounts.texParameteri, 'borrowed wrapper does not mutate sampler state').toBe(
+      0
+    );
+    expect(
       () => texture.generateMipmapsWebGL(),
-      /borrowed read-only/,
       'borrowed wrapper rejects mipmap generation'
-    );
-    t.throws(
+    ).toThrow(/borrowed read-only/);
+    expect(
       () => texture.copyElementImage({} as never),
-      /borrowed read-only/,
       'borrowed wrapper rejects element uploads'
-    );
-    t.throws(
+    ).toThrow(/borrowed read-only/);
+    expect(
       () => texture.clone({width: 8, height: 4}),
-      /resize borrowed read-only/,
       'borrowed wrapper rejects resize-like clones'
-    );
-    t.equal(methodCallCounts.generateMipmap, 0, 'rejected mipmap generation does not touch GL');
+    ).toThrow(/resize borrowed read-only/);
+    expect(methodCallCounts.generateMipmap, 'rejected mipmap generation does not touch GL').toBe(0);
 
     texture.destroy();
-    t.equal(
+    expect(
       methodCallCounts.deleteTexture,
-      0,
       'destroying wrapper does not delete borrowed handle'
-    );
+    ).toBe(0);
   } finally {
     gl.deleteTexture = originalDeleteTexture;
     gl.generateMipmap = originalGenerateMipmap;
@@ -85,6 +82,4 @@ test('WEBGLTexture keeps borrowed handles read-only', async t => {
     originalDeleteTexture(textureHandle);
     device.destroy();
   }
-
-  t.end();
 });

--- a/modules/webgl/test/adapter/resources/webgl-transform-feedback.spec.ts
+++ b/modules/webgl/test/adapter/resources/webgl-transform-feedback.spec.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 
 import {Device, Buffer} from '@luma.gl/core';
 import {Model} from '@luma.gl/engine';
+import {expect, it} from 'vitest';
 
 const VS = /* glsl */ `\
 #version 300 es
@@ -28,7 +28,7 @@ void main()
 }
 `;
 
-test('WebGL#TransformFeedback#constructor/destroy', async t => {
+it('WebGL#TransformFeedback#constructor/destroy', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   const buffer1 = webglDevice.createBuffer({byteLength: 16});
@@ -40,18 +40,16 @@ test('WebGL#TransformFeedback#constructor/destroy', async t => {
     buffers: {outValue: buffer2}
   });
 
-  t.pass('TransformFeedback construction successful');
+  expect(tf).toBeTruthy();
 
   tf.destroy();
-  t.pass('TransformFeedback destroy successful');
+  expect(tf).toBeTruthy();
 
   tf.destroy();
-  t.pass('TransformFeedback repeated destroy successful');
-
-  t.end();
+  expect(tf).toBeTruthy();
 });
 
-test('WebGL#TransformFeedback#setBuffers', async t => {
+it('WebGL#TransformFeedback#setBuffers', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   const buffer1 = webglDevice.createBuffer({byteLength: 100});
@@ -65,25 +63,17 @@ test('WebGL#TransformFeedback#setBuffers', async t => {
   });
 
   transformFeedback.setBuffers({0: buffer1, 1: buffer2});
-  t.deepEqual(
-    transformFeedback.buffers,
-    {
-      0: {buffer: buffer1, byteOffset: 0, byteLength: 100},
-      1: {buffer: buffer2, byteOffset: 0, byteLength: 200}
-    },
-    'set by index, 2 buffers'
-  );
+  expect(transformFeedback.buffers, 'set by index, 2 buffers').toEqual({
+    0: {buffer: buffer1, byteOffset: 0, byteLength: 100},
+    1: {buffer: buffer2, byteOffset: 0, byteLength: 200}
+  });
 
   transformFeedback.setBuffers({0: buffer3, 1: buffer2, 2: buffer1});
-  t.deepEqual(
-    transformFeedback.buffers,
-    {
-      0: {buffer: buffer3, byteOffset: 0, byteLength: 300},
-      1: {buffer: buffer2, byteOffset: 0, byteLength: 200},
-      2: {buffer: buffer1, byteOffset: 0, byteLength: 100}
-    },
-    'set by index, 3 buffers'
-  );
+  expect(transformFeedback.buffers, 'set by index, 3 buffers').toEqual({
+    0: {buffer: buffer3, byteOffset: 0, byteLength: 300},
+    1: {buffer: buffer2, byteOffset: 0, byteLength: 200},
+    2: {buffer: buffer1, byteOffset: 0, byteLength: 100}
+  });
 
   /* Generates unused buffer warnings that pollutes log
   transformFeedback.setBuffers({inValue: buffer1, outValue: buffer2, otherValue: buffer3});
@@ -101,11 +91,9 @@ test('WebGL#TransformFeedback#setBuffers', async t => {
     'set by name, 2 buffers unused'
   );
   */
-
-  t.end();
 });
 
-test('WebGL#TransformFeedback#capture', async t => {
+it('WebGL#TransformFeedback#capture', async () => {
   const webglDevice = await getWebGLTestDevice();
 
   // TODO(v9) Test writing with offset into output buffer.
@@ -133,13 +121,9 @@ test('WebGL#TransformFeedback#capture', async t => {
   const outBytes = await outBuffer.readAsync(byteOffset, byteLength);
   const outArray = new Float32Array(outBytes.buffer, outBytes.byteOffset, vertexCount);
 
-  t.deepEqual(
-    Array.from(outArray),
-    Array.from(inArray).map(x => x * 2),
-    'transform feedback output'
+  expect(Array.from(outArray), 'transform feedback output').toEqual(
+    Array.from(inArray).map(x => x * 2)
   );
-
-  t.end();
 });
 
 /**

--- a/modules/webgl/test/adapter/resources/webgl-vertex-array.spec.ts
+++ b/modules/webgl/test/adapter/resources/webgl-vertex-array.spec.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 
 import {VertexArray} from '@luma.gl/core';
 import {GL} from '@luma.gl/webgl/constants';
 import {WEBGLBuffer, WEBGLVertexArray} from '@luma.gl/webgl';
+import {expect, it} from 'vitest';
 
 function createVertexArray(device): WEBGLVertexArray {
   return device.createVertexArray({
@@ -16,24 +16,23 @@ function createVertexArray(device): WEBGLVertexArray {
   }) as WEBGLVertexArray;
 }
 
-test('VertexArray#construct/delete', async t => {
+it('VertexArray#construct/delete', async () => {
   const device = await getWebGLTestDevice();
 
   const vertexArray = device.createVertexArray({
     shaderLayout: {attributes: [], bindings: []},
     bufferLayout: []
   });
-  t.ok(vertexArray instanceof VertexArray, 'VertexArray construction successful');
+  expect(vertexArray instanceof VertexArray, 'VertexArray construction successful').toBe(true);
 
   vertexArray.destroy();
-  t.ok(vertexArray instanceof VertexArray, 'VertexArray delete successful');
+  expect(vertexArray instanceof VertexArray, 'VertexArray delete successful').toBe(true);
 
   vertexArray.destroy();
-  t.ok(vertexArray instanceof VertexArray, 'VertexArray repeated destroy successful');
-  t.end();
+  expect(vertexArray instanceof VertexArray, 'VertexArray repeated destroy successful').toBe(true);
 });
 
-test('WEBGLVertexArray#divisors', async t => {
+it('WEBGLVertexArray#divisors', async () => {
   const device = await getWebGLTestDevice();
 
   const vertexArray = createVertexArray(device);
@@ -45,28 +44,26 @@ test('WEBGLVertexArray#divisors', async t => {
     const divisor = device.gl.getVertexAttrib(i, GL.VERTEX_ATTRIB_ARRAY_DIVISOR);
     device.gl.bindVertexArray(null);
 
-    t.equal(divisor, 0, `vertex attribute ${i} should have 0 divisor`);
+    expect(divisor, `vertex attribute ${i} should have 0 divisor`).toBe(0);
   }
 
   vertexArray.destroy();
-
-  t.end();
 });
 
-test('WEBGLVertexArray#enable', async t => {
+it('WEBGLVertexArray#enable', async () => {
   const device = await getWebGLTestDevice();
 
   const vertexArray = createVertexArray(device);
 
   const maxVertexAttributes = device.limits.maxVertexAttributes;
-  t.ok(maxVertexAttributes >= 8, 'maxVertexAttributes >= 8');
+  expect(maxVertexAttributes >= 8, 'maxVertexAttributes >= 8').toBe(true);
 
   for (let i = 1; i < maxVertexAttributes; i++) {
     device.gl.bindVertexArray(vertexArray.handle);
     const enabled = device.gl.getVertexAttrib(i, GL.VERTEX_ATTRIB_ARRAY_ENABLED);
     device.gl.bindVertexArray(null);
 
-    t.equal(enabled, false, `vertex attribute ${i} should initially be disabled`);
+    expect(enabled, `vertex attribute ${i} should initially be disabled`).toBe(false);
   }
 
   for (let i = 0; i < maxVertexAttributes; i++) {
@@ -79,7 +76,7 @@ test('WEBGLVertexArray#enable', async t => {
     const enabled = device.gl.getVertexAttrib(i, GL.VERTEX_ATTRIB_ARRAY_ENABLED);
     device.gl.bindVertexArray(null);
 
-    t.equal(enabled, true, `vertex attribute ${i} should now be enabled`);
+    expect(enabled, `vertex attribute ${i} should now be enabled`).toBe(true);
   }
 
   for (let i = 1; i < maxVertexAttributes; i++) {
@@ -95,36 +92,36 @@ test('WEBGLVertexArray#enable', async t => {
     const enabled = device.gl.getVertexAttrib(i, GL.VERTEX_ATTRIB_ARRAY_ENABLED);
     device.gl.bindVertexArray(null);
 
-    t.equal(enabled, false, `vertex attribute ${i} should now be disabled`);
+    expect(enabled, `vertex attribute ${i} should now be disabled`).toBe(false);
   }
 
   vertexArray.destroy();
-
-  t.end();
 });
 
-test('WEBGLVertexArray#getConstantBuffer', async t => {
+it('WEBGLVertexArray#getConstantBuffer', async () => {
   const device = await getWebGLTestDevice();
 
   const vertexArray = createVertexArray(device);
 
   const buffer = vertexArray.getConstantBuffer(100, new Float32Array([5, 4, 3])) as WEBGLBuffer;
 
-  t.equal(buffer.byteLength, 1200, 'byteLength should match');
-  t.equal(buffer.bytesUsed, 1200, 'bytesUsed should match');
+  expect(buffer.byteLength, 'byteLength should match').toBe(1200);
+  expect(buffer.bytesUsed, 'bytesUsed should match').toBe(1200);
 
   const reusedBuffer = vertexArray.getConstantBuffer(
     100,
     new Float32Array([5, 3, 2])
   ) as WEBGLBuffer;
-  t.equal(reusedBuffer, buffer, 'buffer should be reused when element count is unchanged');
-  t.equal(reusedBuffer.byteLength, 1200, 'byteLength should be unchanged');
-  t.equal(reusedBuffer.bytesUsed, 1200, 'bytesUsed should reflect the fixed backing allocation');
+  expect(reusedBuffer, 'buffer should be reused when element count is unchanged').toBe(buffer);
+  expect(reusedBuffer.byteLength, 'byteLength should be unchanged').toBe(1200);
+  expect(reusedBuffer.bytesUsed, 'bytesUsed should reflect the fixed backing allocation').toBe(
+    1200
+  );
 
-  t.throws(
+  expect(
     () => vertexArray.getConstantBuffer(5, new Float32Array([5, 3, 2])),
     'changing element count should throw because the backing buffer size is immutable'
-  );
+  ).toThrow();
 
   vertexArray.destroy();
 
@@ -141,6 +138,4 @@ test('WEBGLVertexArray#getConstantBuffer', async t => {
   //   );
   //   t.comment(JSON.stringify(data));
   // }
-
-  t.end();
 });

--- a/modules/webgl/test/adapter/webgl-adapter.spec.ts
+++ b/modules/webgl/test/adapter/webgl-adapter.spec.ts
@@ -2,15 +2,13 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('WebGLAdapter imports from the ESM package entry without circular init errors', async t => {
-  t.plan(2);
-
+it('WebGLAdapter imports from the ESM package entry without circular init errors', async () => {
   // Import the local entry file directly to avoid workspace alias resolution mixing src/dist modules.
   // This regression is about entry-module initialization, not package alias behavior.
   const webglModule = await import('../../src/index');
 
-  t.equal(webglModule.webgl2Adapter.type, 'webgl', 'exports a WebGL adapter instance');
-  t.equal(webglModule.WebGLDevice.name, 'WebGLDevice', 'exports the WebGL device class');
+  expect(webglModule.webgl2Adapter.type, 'exports a WebGL adapter instance').toBe('webgl');
+  expect(webglModule.WebGLDevice.name, 'exports the WebGL device class').toBe('WebGLDevice');
 });

--- a/modules/webgl/test/adapter/webgl-canvas-context.spec.ts
+++ b/modules/webgl/test/adapter/webgl-canvas-context.spec.ts
@@ -2,25 +2,22 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {getWebGLTestDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
 import {WebGLCanvasContext} from '@luma.gl/webgl';
+import {expect, it} from 'vitest';
 
-test('WebGLDevice#canvas context creation', async t => {
-  t.ok(WebGLCanvasContext, 'WebGLCanvasContext defined');
+it('WebGLDevice#canvas context creation', async () => {
+  expect(WebGLCanvasContext, 'WebGLCanvasContext defined').toBeTruthy();
   const webGLTestDevice = await getWebGLTestDevice();
-  t.ok(
+  expect(
     webGLTestDevice.getDefaultCanvasContext() instanceof WebGLCanvasContext,
     'Default context creation ok'
-  );
-  t.end();
+  ).toBe(true);
 });
 
-test('WebGPU default canvas context reuses framebuffer wrappers', async t => {
+it('WebGPU default canvas context reuses framebuffer wrappers', async () => {
   const webGPUDevice = await getWebGPUTestDevice();
   if (!webGPUDevice) {
-    t.pass('WebGPU unavailable, skipped default canvas wrapper reuse test');
-    t.end();
     return;
   }
 
@@ -28,21 +25,15 @@ test('WebGPU default canvas context reuses framebuffer wrappers', async t => {
   const firstFramebuffer = canvasContext.getCurrentFramebuffer();
   const secondFramebuffer = canvasContext.getCurrentFramebuffer();
 
-  t.equal(
-    secondFramebuffer,
-    firstFramebuffer,
-    'WebGPU canvas context reuses its framebuffer wrapper'
+  expect(secondFramebuffer, 'WebGPU canvas context reuses its framebuffer wrapper').toBe(
+    firstFramebuffer
   );
-  t.equal(
+  expect(
     secondFramebuffer.colorAttachments[0],
-    firstFramebuffer.colorAttachments[0],
     'WebGPU canvas context reuses its texture view wrapper'
-  );
-  t.equal(
+  ).toBe(firstFramebuffer.colorAttachments[0]);
+  expect(
     secondFramebuffer.colorAttachments[0].texture,
-    firstFramebuffer.colorAttachments[0].texture,
     'WebGPU canvas context reuses its texture wrapper'
-  );
-
-  t.end();
+  ).toBe(firstFramebuffer.colorAttachments[0].texture);
 });

--- a/modules/webgl/test/adapter/webgl-device.spec.ts
+++ b/modules/webgl/test/adapter/webgl-device.spec.ts
@@ -2,19 +2,18 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {webgl2Adapter} from '@luma.gl/webgl';
+import {expect, it} from 'vitest';
 
 // TODO - duplicates core spec?
-test('WebGLDevice#lost (Promise)', async t => {
+it('WebGLDevice#lost (Promise)', async () => {
   const device = await webgl2Adapter.create({createCanvasContext: true, debug: false});
 
   // Wrap in a promise to make sure tape waits for us
   await new Promise<void>(resolve => {
     setTimeout(() => {
       void device.lost.then(cause => {
-        t.equal(cause.reason, 'destroyed', `Context lost: ${cause.message}`);
-        t.end();
+        expect(cause.reason, `Context lost: ${cause.message}`).toBe('destroyed');
         resolve();
       });
     }, 0);
@@ -24,11 +23,10 @@ test('WebGLDevice#lost (Promise)', async t => {
   device.destroy();
 });
 
-test('WebGLDevice#destroy marks the device lost', async t => {
+it('WebGLDevice#destroy marks the device lost', async () => {
   const device = await webgl2Adapter.create({createCanvasContext: true, debug: false});
 
-  t.equal(device.isLost, false, 'device starts active');
+  expect(device.isLost, 'device starts active').toBe(false);
   device.destroy();
-  t.equal(device.isLost, true, 'destroy synchronously marks the device lost');
-  t.end();
+  expect(device.isLost, 'destroy synchronously marks the device lost').toBe(true);
 });

--- a/modules/webgl/test/context/create-browser-context.spec.ts
+++ b/modules/webgl/test/context/create-browser-context.spec.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {createBrowserContext} from '@luma.gl/webgl/context/helpers/create-browser-context';
+import {expect, it} from 'vitest';
 
 type ListenerMap = Record<string, Set<EventListener>>;
 
@@ -45,7 +45,7 @@ function createMockCanvas(
   return {canvas, dispatchEvent, getListenerCount};
 }
 
-test('createBrowserContext captures creation errors', t => {
+it('createBrowserContext captures creation errors', () => {
   const mock = createMockCanvas(() => {
     mock.dispatchEvent('webglcontextcreationerror', {
       statusMessage: 'Mock GPU unavailable'
@@ -53,25 +53,22 @@ test('createBrowserContext captures creation errors', t => {
     return null;
   });
 
-  t.throws(
+  expect(
     () =>
       createBrowserContext(
         mock.canvas,
         {onContextLost: () => {}, onContextRestored: () => {}},
         {failIfMajorPerformanceCaveat: true}
       ),
-    /Failed to create WebGL context: Mock GPU unavailable/,
     'throws with captured status message'
-  );
-  t.equals(
+  ).toThrow(/Failed to create WebGL context: Mock GPU unavailable/);
+  expect(
     mock.getListenerCount('webglcontextcreationerror'),
-    0,
     'creation listener removed after failure'
-  );
-  t.end();
+  ).toBe(0);
 });
 
-test('createBrowserContext falls back to software renderer', t => {
+it('createBrowserContext falls back to software renderer', () => {
   const gl = {} as WebGL2RenderingContext & {luma?: Record<string, unknown>};
   let creationCalls = 0;
   const mock = createMockCanvas((_type, attributes) => {
@@ -88,23 +85,19 @@ test('createBrowserContext falls back to software renderer', t => {
     {failIfMajorPerformanceCaveat: false}
   );
 
-  t.equals(context, gl, 'returns context from second creation attempt');
-  t.equals(creationCalls, 2, 'attempts creation twice before succeeding');
-  t.equals(
+  expect(context, 'returns context from second creation attempt').toBe(gl);
+  expect(creationCalls, 'attempts creation twice before succeeding').toBe(2);
+  expect(
     (gl.luma as {softwareRenderer?: boolean} | undefined)?.softwareRenderer,
-    true,
     'marks context as software renderer'
-  );
-  t.equals(
+  ).toBe(true);
+  expect(
     mock.getListenerCount('webglcontextcreationerror'),
-    0,
     'creation listener removed after success'
-  );
-  t.equals(mock.getListenerCount('webglcontextlost'), 1, 'context lost listener registered');
-  t.equals(
+  ).toBe(0);
+  expect(mock.getListenerCount('webglcontextlost'), 'context lost listener registered').toBe(1);
+  expect(
     mock.getListenerCount('webglcontextrestored'),
-    1,
     'context restored listener registered'
-  );
-  t.end();
+  ).toBe(1);
 });

--- a/modules/webgl/test/context/debug-bundle.node.spec.ts
+++ b/modules/webgl/test/context/debug-bundle.node.spec.ts
@@ -4,9 +4,9 @@
 
 import {resolve} from 'node:path';
 import esbuild from 'esbuild';
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 
-test('WebGL debug tools stay outside the normal adapter bundle', async t => {
+it('WebGL debug tools stay outside the normal adapter bundle', async () => {
   const sourceAliases = {
     name: 'webgl-source-alias',
     setup(build: esbuild.PluginBuild): void {
@@ -31,17 +31,16 @@ test('WebGL debug tools stay outside the normal adapter bundle', async t => {
   });
   const bundledInputs = Object.keys(buildResult.metafile.inputs);
 
-  t.notOk(
+  expect(
     bundledInputs.some(path => path.endsWith('/webgl-developer-tools.ts')),
     'adapter bundle excludes WebGLDeveloperTools'
-  );
-  t.notOk(
+  ).toBe(false);
+  expect(
     bundledInputs.some(path => path.endsWith('/spector.ts')),
     'adapter bundle excludes Spector integration'
-  );
-  t.ok(
+  ).toBe(false);
+  expect(
     bundledInputs.some(path => path.endsWith('/debug-hooks.ts')),
     'adapter bundle retains only lightweight registration hooks'
-  );
-  t.end();
+  ).toBe(true);
 });

--- a/modules/webgl/test/context/state-tracker/deep-array-equal.spec.ts
+++ b/modules/webgl/test/context/state-tracker/deep-array-equal.spec.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {deepArrayEqual} from '@luma.gl/webgl/context/state-tracker/deep-array-equal';
+import {expect, it} from 'vitest';
 
-test('WebGLState#deepArrayEqual', t => {
+it('WebGLState#deepArrayEqual', () => {
   const ARRAY = [0, 1, 2];
 
   const TEST_CASES = [
@@ -24,7 +24,6 @@ test('WebGLState#deepArrayEqual', t => {
   ];
 
   for (const tc of TEST_CASES) {
-    t.equals(deepArrayEqual(tc.x, tc.y), tc.result, tc.title);
+    expect(deepArrayEqual(tc.x, tc.y), tc.title).toBe(tc.result);
   }
-  t.end();
 });

--- a/modules/webgl/test/utils/fill-array.spec.ts
+++ b/modules/webgl/test/utils/fill-array.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, it} from 'vitest';
 import {fillArray} from '@luma.gl/webgl/utils/fill-array';
 
 const FILL_ARRAY_TEST_CASES = [
@@ -13,15 +13,15 @@ const FILL_ARRAY_TEST_CASES = [
   }
 ];
 
-test('fillArray#import', t => {
-  t.ok(typeof fillArray === 'function', 'fillArray imported OK');
-  t.end();
+it('fillArray#import', () => {
+  expect(typeof fillArray, 'fillArray imported OK').toBe('function');
 });
 
-test('fillArray#tests', t => {
+it('fillArray#tests', () => {
   for (const tc of FILL_ARRAY_TEST_CASES) {
     const result = fillArray(tc.arguments);
-    t.deepEqual(result, tc.result, `fillArray ${tc.title} returned expected result`);
+    expect(result, `fillArray ${tc.title} returned expected result`).toEqual(
+      new Float32Array(tc.result)
+    );
   }
-  t.end();
 });

--- a/test/utils/parse-shader-compiler-log.spec.shared.ts
+++ b/test/utils/parse-shader-compiler-log.spec.shared.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import type {TapeTestFunction} from 'test/utils/vitest-tape';
 import {parseShaderCompilerLog} from '@luma.gl/webgl/adapter/helpers/parse-shader-compiler-log';
+import {expect, it} from 'vitest';
 
 const ERROR_LOG = `\
 WARNING: 0:264: '/' : Zero divided by zero during constant folding generated NaN
@@ -151,29 +151,26 @@ const EXPECTED_MESSAGES = [
   }
 ];
 
-export function registerParseShaderCompilerLogTests(test: TapeTestFunction): void {
-  test('parseShaderCompilerLog', t => {
+export function registerParseShaderCompilerLogTests(): void {
+  it('parseShaderCompilerLog', () => {
     const messages = parseShaderCompilerLog(ERROR_LOG);
-    t.deepEqual(messages, EXPECTED_MESSAGES, 'parseShaderCompilerLog generated correct messages');
+    expect(messages, 'parseShaderCompilerLog generated correct messages').toEqual(
+      EXPECTED_MESSAGES
+    );
 
-    t.deepEqual(
+    expect(
       parseShaderCompilerLog('ERROR: unsupported shader version'),
-      [{message: 'unsupported shader version', type: 'error', lineNum: 0, linePos: 0}],
       'two-segment messages are parsed without line info'
-    );
+    ).toEqual([{message: 'unsupported shader version', type: 'error', lineNum: 0, linePos: 0}]);
 
-    t.deepEqual(
+    expect(
       parseShaderCompilerLog('INFO::invalid'),
-      [{message: ':invalid', type: 'info', lineNum: 0, linePos: 0}],
       'malformed segmented messages fall back to line 0'
-    );
+    ).toEqual([{message: ':invalid', type: 'info', lineNum: 0, linePos: 0}]);
 
-    t.deepEqual(
+    expect(
       parseShaderCompilerLog('\nWARNING: 2:NaN: malformed position'),
-      [{message: 'malformed position', type: 'warning', lineNum: 0, linePos: 2}],
       'blank lines are ignored and NaN line numbers are normalized'
-    );
-
-    t.end();
+    ).toEqual([{message: 'malformed position', type: 'warning', lineNum: 0, linePos: 2}]);
   });
 }


### PR DESCRIPTION
## Summary
- migrate all 50 remaining `modules/gpgpu/test/gpu-core` suites from the Tape compatibility wrapper to native Vitest `it`/`expect`
- cover command-graph planning/history/textures/inspection, data analysis, FFT, convolution, indexing, joins, sorting, BVH, scene resources, spatial queries, and numerical kernels
- preserve GPU/CPU parity, malformed-input validation, resource ownership, dispatch planning, and benchmark assertions
- remove explicit Tape lifecycle boilerplate and update shared assertion helpers to direct Vitest expectations
- continue the stacked migration from #3160 with a package-family batch to accelerate conversion and coverage maintenance

## Verification
- `nvm use`
- `yarn install`
- `yarn lint fix`
- `yarn build`
- targeted GPU-core browser run: 36 files, 183 tests passed
- `yarn test-node`: 402 files passed, 3,188 tests passed, 1 skipped
- `yarn test`: Node passes; headless retains known splat ordering failures and a browser teardown error outside this migration

No production behavior changes are included.