### PR TITLE
fix(experimental): guard trace zoom GPU memory access

### DIFF
--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -6738,6 +6738,11 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
   }
 
   private setViewTimeRange(timeMin: number, timeMax: number): void {
+    // This is the final CPU boundary before the range is encoded into f32 GPU uniforms. Keeping the
+    // last valid view is safer than allowing NaN or infinity to influence shader indices.
+    if (!Number.isFinite(timeMin) || !Number.isFinite(timeMax) || timeMax <= timeMin) {
+      return;
+    }
     const range = clamp(timeMax - timeMin, 0.5, this.traceDuration);
     const maximumTimeMin = Math.max(0, this.traceDuration - range);
     this.view.timeMin = clamp(timeMin, 0, maximumTimeMin);

--- a/examples/experimental/gpu-trace-viewer/trace-analytics-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-analytics-shaders.ts
@@ -213,7 +213,9 @@ fn main(
       u32(max(floor((lastTime - windowMinimum) / bucketDuration), 0.0)),
       TIME_BUCKET_COUNT - 1u
     );
-    for (var bucketIndex = firstBucket; bucketIndex <= lastBucket; bucketIndex++) {
+    // Keep the storage-writing loop structurally bounded. If a malformed floating-point endpoint
+    // converts to u32 unexpectedly, an inclusive computed bound could wrap and monopolize the GPU.
+    for (var bucketIndex = firstBucket; bucketIndex < TIME_BUCKET_COUNT; bucketIndex++) {
       let bucketStart = windowMinimum + f32(bucketIndex) * bucketDuration;
       let bucketEnd = bucketStart + bucketDuration;
       let overlap = max(0.0, min(spanEnd, bucketEnd) - max(span.start, bucketStart));
@@ -221,6 +223,7 @@ fn main(
         atomicAdd(&results[TIME_BUCKET_COUNTS_OFFSET + bucketIndex], 1u);
         atomicAddFloat(&results[TIME_BUCKET_DURATIONS_OFFSET + bucketIndex], overlap);
       }
+      if (bucketIndex >= lastBucket) { break; }
     }
   }
 }`;

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -1398,6 +1398,7 @@ export function getCandidateDensityShader(props: TraceSpanChunkShaderProps): str
   return /* wgsl */ `
 ${TRACE_SHADER_DECLARATIONS}
 ${getSpanChunkDeclarations(props)}
+const DENSITY_BIN_COUNT: u32 = ${TRACE_DENSITY_BIN_COUNT}u;
 struct TraceSpanBatch {
   firstSpanIndex: u32,
   spanCount: u32,
@@ -1459,7 +1460,7 @@ fn main(
     sourceVisible && (isDensityModeActive() || !processExpanded || !threadExpanded) &&
     !retainedExactSpan;
   if (densityVisible && focusVisible) {
-    let maximumBin = f32(${TRACE_DENSITY_BIN_COUNT - 1}u);
+    let maximumBin = f32(DENSITY_BIN_COUNT - 1u);
     let firstBin = u32(clamp(
       floor((span.start - viewUniforms.densityBinOrigin) /
         viewUniforms.densityBinDuration),
@@ -1472,11 +1473,15 @@ fn main(
       0.0,
       maximumBin
     ));
+    // The fixed upper bound prevents malformed view uniforms from wrapping a u32 loop forever.
     // Preserve temporal coverage: a long span contributes to every density bin it crosses.
-    for (var bin = firstBin; bin <= lastBin; bin++) {
+    for (var bin = firstBin; bin < DENSITY_BIN_COUNT; bin++) {
       let densityKey =
-        (u32(lane) * ${TRACE_DENSITY_BIN_COUNT}u + bin) * ${TRACE_GROUPS.length}u + span.group;
-      atomicAdd(&densityBins[densityKey], 1u);
+        (u32(lane) * DENSITY_BIN_COUNT + bin) * ${TRACE_GROUPS.length}u + span.group;
+      if (densityKey < arrayLength(&densityBins)) {
+        atomicAdd(&densityBins[densityKey], 1u);
+      }
+      if (bin >= lastBin) { break; }
     }
   }
 }`;

--- a/modules/experimental/src/controls/flat-controller.ts
+++ b/modules/experimental/src/controls/flat-controller.ts
@@ -114,8 +114,25 @@ export class FlatController {
     const rectangle = this.canvas.getBoundingClientRect();
     const view = this.props.getView();
     const bounds = this.props.getBounds();
+    // Never publish non-finite view state. Timeline consumers commonly upload these values to GPU
+    // uniforms, where NaN-to-u32 conversions can invalidate storage indices or loop bounds.
+    if (
+      !Number.isFinite(horizontalMovement) ||
+      !Number.isFinite(verticalMovement) ||
+      !isFiniteFlatViewState(view) ||
+      !isFiniteFlatViewState(bounds)
+    ) {
+      this.lastPointer = [event.clientX, event.clientY];
+      return;
+    }
     const xRange = view.xMax - view.xMin;
     const yRange = view.yMax - view.yMin;
+    // Finite endpoints are not sufficient: subtracting two very large values can overflow to
+    // Infinity, which would contaminate the derived view state and eventually reach the GPU.
+    if (!Number.isFinite(xRange) || !Number.isFinite(yRange) || xRange <= 0 || yRange <= 0) {
+      this.lastPointer = [event.clientX, event.clientY];
+      return;
+    }
     const xMin = clamp(
       view.xMin - (horizontalMovement / Math.max(rectangle.width, 1)) * xRange,
       bounds.xMin,
@@ -126,7 +143,18 @@ export class FlatController {
       bounds.yMin,
       Math.max(bounds.yMin, bounds.yMax - yRange)
     );
-    this.props.onViewChange({xMin, xMax: xMin + xRange, yMin, yMax: yMin + yRange});
+    const xMax = xMin + xRange;
+    const yMax = yMin + yRange;
+    if (
+      !Number.isFinite(xMin) ||
+      !Number.isFinite(xMax) ||
+      !Number.isFinite(yMin) ||
+      !Number.isFinite(yMax)
+    ) {
+      this.lastPointer = [event.clientX, event.clientY];
+      return;
+    }
+    this.props.onViewChange({xMin, xMax, yMin, yMax});
     this.lastPointer = [event.clientX, event.clientY];
   };
 
@@ -149,16 +177,36 @@ export class FlatController {
 
   private readonly handleWheel = (event: WheelEvent): void => {
     event.preventDefault();
+    const view = this.props.getView();
+    const bounds = this.props.getBounds();
+    // A malformed wheel event or stale view must stop here. Once uploaded, a non-finite zoom range
+    // can turn a bounded GPU aggregation into an effectively unbounded storage-access workload.
+    if (
+      !Number.isFinite(event.clientX) ||
+      !Number.isFinite(event.deltaY) ||
+      !isFiniteFlatViewState(view) ||
+      !isFiniteFlatViewState(bounds)
+    ) {
+      return;
+    }
     const rectangle = this.canvas.getBoundingClientRect();
     const horizontalFraction = clamp(
       (event.clientX - rectangle.left) / Math.max(rectangle.width, 1),
       0,
       1
     );
-    const view = this.props.getView();
-    const bounds = this.props.getBounds();
     const previousRange = view.xMax - view.xMin;
     const maximumRange = bounds.xMax - bounds.xMin;
+    // Validate the arithmetic as well as its inputs because finite endpoints can still produce an
+    // infinite range. Continuing with that range can turn later Infinity - Infinity math into NaN.
+    if (
+      !Number.isFinite(previousRange) ||
+      !Number.isFinite(maximumRange) ||
+      previousRange <= 0 ||
+      maximumRange <= 0
+    ) {
+      return;
+    }
     const rangeTolerance = Math.max(maximumRange, 1) * Number.EPSILON * 8;
     if (event.deltaY > 0 && previousRange >= maximumRange - rangeTolerance) {
       return;
@@ -172,6 +220,9 @@ export class FlatController {
     const requestedXMin = anchor - nextRange * horizontalFraction;
     const xMin = clamp(requestedXMin, bounds.xMin, Math.max(bounds.xMin, bounds.xMax - nextRange));
     const xMax = xMin + nextRange;
+    if (!Number.isFinite(xMin) || !Number.isFinite(xMax)) {
+      return;
+    }
     if (xMin === view.xMin && xMax === view.xMax) {
       return;
     }
@@ -192,6 +243,9 @@ export class FlatController {
       1
     );
     const view = this.props.getView();
+    if (!isFiniteFlatViewState(view)) {
+      return;
+    }
     this.props.onPick?.({
       x: view.xMin + horizontalFraction * (view.xMax - view.xMin),
       y: view.yMin + verticalFraction * (view.yMax - view.yMin),
@@ -333,6 +387,15 @@ export class RectangleSelectController {
     if (pointerId !== null) this.canvas.style.cursor = this.previousCursor;
     this.props.onSelectionChange?.(null);
   }
+}
+
+function isFiniteFlatViewState(view: FlatViewState): boolean {
+  return (
+    Number.isFinite(view.xMin) &&
+    Number.isFinite(view.xMax) &&
+    Number.isFinite(view.yMin) &&
+    Number.isFinite(view.yMax)
+  );
 }
 
 function clamp(value: number, minimum: number, maximum: number): number {

--- a/modules/experimental/src/gpu-trace/gpu-trace-time-buckets.ts
+++ b/modules/experimental/src/gpu-trace/gpu-trace-time-buckets.ts
@@ -402,7 +402,9 @@ fn atomicAddFloat(destination: ptr<storage, atomic<u32>, read_write>, value: f32
   let firstBucket = min(u32(max(floor((start - domainMinimum) / bucketDuration), 0.0)), BUCKET_COUNT - 1u);
   let lastTime = max(start, end - max(abs(end), 1.0) * 1e-7);
   let lastBucket = min(u32(max(floor((lastTime - domainMinimum) / bucketDuration), 0.0)), BUCKET_COUNT - 1u);
-  for (var bucketIndex = firstBucket; bucketIndex <= lastBucket; bucketIndex++) {
+  // BUCKET_COUNT is an independent safety bound for every storage access. Do not rely solely on
+  // float-to-u32 endpoint conversion: an inclusive u32 loop can wrap and keep a GPU queue resident.
+  for (var bucketIndex = firstBucket; bucketIndex < BUCKET_COUNT; bucketIndex++) {
     let bucketStart = domainMinimum + f32(bucketIndex) * bucketDuration;
     let bucketEnd = bucketStart + bucketDuration;
     let overlap = max(0.0, min(end, bucketEnd) - max(start, bucketStart));
@@ -410,6 +412,7 @@ fn atomicAddFloat(destination: ptr<storage, atomic<u32>, read_write>, value: f32
       atomicAdd(&${countTarget}[COUNT_OUTPUT_OFFSET + bucketIndex], 1u);
       atomicAddFloat(&${durationTarget}[DURATION_OUTPUT_OFFSET + bucketIndex], overlap);
     }
+    if (bucketIndex >= lastBucket) { break; }
   }
 }`;
   addComputationPass(graph, {

--- a/test/examples/flat-controller.node.spec.ts
+++ b/test/examples/flat-controller.node.spec.ts
@@ -151,6 +151,57 @@ describe('FlatController', () => {
 
     controller.destroy();
   });
+
+  test('rejects non-finite wheel input before publishing view state', () => {
+    const canvasTarget = new EventTarget();
+    const canvas = Object.assign(canvasTarget, {
+      style: {cursor: '', touchAction: ''},
+      getBoundingClientRect: () => ({left: 0, top: 0, width: 100, height: 100})
+    }) as unknown as HTMLCanvasElement;
+    let interactionCount = 0;
+    let viewChangeCount = 0;
+    const controller = new FlatController(canvas, {
+      getView: () => ({xMin: 25, xMax: 75, yMin: 0, yMax: 100}),
+      getBounds: () => ({xMin: 0, xMax: 100, yMin: 0, yMax: 100}),
+      onInteractionStart: () => interactionCount++,
+      onViewChange: () => viewChangeCount++
+    });
+
+    canvas.dispatchEvent(makeWheelEvent(50, Number.NaN));
+    canvas.dispatchEvent(makeWheelEvent(Number.POSITIVE_INFINITY, 100));
+    expect(interactionCount).toBe(0);
+    expect(viewChangeCount).toBe(0);
+
+    controller.destroy();
+  });
+
+  test('rejects finite view endpoints whose computed range overflows', () => {
+    const canvasTarget = new EventTarget();
+    const canvas = Object.assign(canvasTarget, {
+      style: {cursor: '', touchAction: ''},
+      getBoundingClientRect: () => ({left: 0, top: 0, width: 100, height: 100})
+    }) as unknown as HTMLCanvasElement;
+    let interactionCount = 0;
+    let viewChangeCount = 0;
+    const overflowingView = {
+      xMin: -Number.MAX_VALUE,
+      xMax: Number.MAX_VALUE,
+      yMin: 0,
+      yMax: 100
+    };
+    const controller = new FlatController(canvas, {
+      getView: () => overflowingView,
+      getBounds: () => overflowingView,
+      onInteractionStart: () => interactionCount++,
+      onViewChange: () => viewChangeCount++
+    });
+
+    canvas.dispatchEvent(makeWheelEvent(50, -100));
+    expect(interactionCount).toBe(0);
+    expect(viewChangeCount).toBe(0);
+
+    controller.destroy();
+  });
 });
 
 function makePointerEvent(

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -1023,8 +1023,12 @@ it('GPU trace adaptive LOD shaders parse as WGSL', () => {
   );
   expect(
     getCandidateDensityShader(spanChunk),
-    'density aggregation preserves long-span coverage across bins'
-  ).toMatch(/for \(var bin = firstBin; bin <= lastBin; bin\+\+\)/);
+    'density aggregation has a fixed upper bound while preserving long-span coverage'
+  ).toMatch(/for \(var bin = firstBin; bin < DENSITY_BIN_COUNT; bin\+\+\)/);
+  expect(
+    getCandidateDensityShader(spanChunk),
+    'density aggregation guards every zoom-derived storage access'
+  ).toMatch(/densityKey < arrayLength\(&densityBins\)/);
   expect(
     getCandidateDensityShader(spanChunk),
     'density aggregation uses scroll-stable trace-time bin membership'


### PR DESCRIPTION
## Summary

- reject non-finite pan and wheel state before trace view ranges reach GPU uniforms
- keep density and time-bucket storage loops structurally bounded by fixed capacities
- validate density storage indices before atomic access and document the GPU queue-residency risk
- add regression coverage for malformed wheel input and bounded density aggregation

## Verification

- nvm use: passed with Node 22.22.1
- yarn install: passed with existing peer-dependency warnings
- yarn lint fix: passed
- yarn build: passed
- yarn test-node test/examples/flat-controller.node.spec.ts test/examples/gpu-trace-viewer.node.spec.ts: passed; repository wrapper ran the full node suite with 3,193 passed and 1 skipped
- commit hook: passed formatting and the same full node suite
- yarn test: node phase passed; headless completed with 1,895 passed and 23 skipped, with five failures outside the changed paths in gpu-graph-deck.spec.ts, gpu-paged-splat-renderer.spec.ts, scene-renderer-lighting-parity.spec.ts, and gpu-raster-band-math.spec.ts
- yarn website:build: not run; no website changes
- cd website && yarn build: not run; no website changes

## Risk

The shader loops retain the same logical first/last-bin coverage. Their termination now has an independent fixed-capacity bound, and density writes additionally verify the runtime storage-array length.