### PR TITLE
feat(shadertools): add hybrid fp64 arithmetic mode

### DIFF
--- a/docs/api-guide/shaders/gpu-floating-point-precision.md
+++ b/docs/api-guide/shaders/gpu-floating-point-precision.md
@@ -23,9 +23,14 @@ while retaining the classic path where it is known to work.
 
 The two Mandelbrot views follow the same deep zoom. The left view uses native
 `f32`; the right uses luma.gl's `fp64arithmetic` double-single representation.
+On Apple WebGPU, the live FP64 pane uses a hybrid double-single path: integer
+operations reconstruct the critical high-part residuals while native `f32`
+accumulates lower-order terms. This is faster than fully integer-controlled
+arithmetic and more optimizer-resistant than the classic path, but it is not
+fully reliable. The fully integer-controlled path remains available in the benchmark.
 On WebGPU, use the benchmark below the canvases to compare native `f32`,
-automatic selection, the classic transforms, and the integer-controlled path
-on the active device.
+automatic selection, the classic transforms, the hybrid path, and the
+integer-controlled path on the active device.
 
 <DeferredFP64Example embeddedHeight={900} />
 

--- a/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
+++ b/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
@@ -14,16 +14,18 @@ Use it directly when you only need the arithmetic primitives and want to avoid
 including the full `fp64` function library.
 
 See [GPU Floating-Point Precision Techniques](/docs/api-guide/shaders/gpu-floating-point-precision)
-for the numerical guarantees and tradeoffs of classic and integer-assisted
+for the numerical guarantees and tradeoffs of classic, hybrid, and integer-assisted
 double-single, native and software binary64, fixed point, and exact deltas. The
 [Mandelbrot and compute benchmark](/examples/experimental/fp64) runs these
 paths on the active GPU.
 
 ## Live WebGPU benchmark
 
-The Mandelbrot views below compare native `f32` and double-single precision on
-your current device. Select **Run WebGPU benchmark** to measure native `f32`,
-automatic selection, classic double-single, and integer-controlled
+The Mandelbrot views below compare native `f32` and double-single precision.
+On Apple WebGPU, the live FP64 pane uses a hybrid path that reconstructs critical
+high-part residuals with integer operations while accumulating lower-order terms
+with native `f32`. Select **Run WebGPU benchmark** to measure native `f32`,
+automatic selection, classic, hybrid, and integer-controlled
 double-single across add, multiply, divide, and square-root workloads. Each
 result reports its measured GPU timestamp or queue-completion timing alongside
 numerical error; the benchmark runs only when requested.
@@ -59,17 +61,24 @@ and rounds each result back to the existing `vec2f` representation. This avoids
 depending on floating-point expressions that Metal may reassociate or contract.
 
 The selection is a shader define, so it can also be forced on for another
-adapter or disabled on Apple:
+adapter, replaced with the hybrid path, or disabled on Apple:
 
 ```ts
 const computation = new Computation(device, {
   // ...
   modules: [fp64arithmetic],
   defines: {
-    LUMA_FP64_INTEGER_ARITHMETIC: true // false overrides the Apple default
+    LUMA_FP64_INTEGER_ARITHMETIC: false, // overrides the Apple default
+    LUMA_FP64_HYBRID_ARITHMETIC: true
   }
 });
 ```
+
+Hybrid arithmetic reconstructs the high-high `twoSum` and `twoProd` residuals
+with integer operations, then accumulates the lower limbs and multiplication
+cross terms with native `f32`. It uses fewer integer decode, alignment, and
+rounding passes than the fully controlled path. It is intended as a throughput
+and precision compromise, not as an optimizer-independent correctness mode.
 
 The integer path favors correctness over throughput. It preserves the public
 double-single API and provides approximately 48 significand bits while both
@@ -117,9 +126,9 @@ representable in the `f32` exponent range. Terrestrial longitude/latitude,
 projected metre coordinates, and their local deltas are comfortably inside
 that range; this helper is not a general replacement for binary64 arithmetic.
 
-A full bitwise drop-in implementation of `fp64f32` arithmetic is intentionally
-not exposed. That approach is too expensive for iterative fragment shaders and
-can stress some GPU drivers.
+A full bitwise IEEE binary64 drop-in is intentionally not exposed. That approach
+is substantially more expensive than the double-single paths and can stress
+some GPU drivers.
 
 `aBits` and `bBits` use canonical high/low word order:
 

--- a/docs/api-reference/shadertools/shader-modules/fp64.md
+++ b/docs/api-reference/shadertools/shader-modules/fp64.md
@@ -32,7 +32,9 @@ helpers.
 
 The side-by-side Mandelbrot views show where fp32 loses detail as the animated zoom deepens. On
 WebGPU, the example uses `fp64arithmetic`, and the panel below the canvases can
-benchmark each arithmetic path on the active device:
+benchmark each arithmetic path on the active device. On Apple WebGPU, the live FP64 pane uses the
+hybrid path with integer-reconstructed high residuals and native low-term accumulation; the
+benchmark retains the fully reliable integer-controlled path:
 
 <DeferredFP64Example embeddedHeight={900} />
 

--- a/examples/experimental/fp64/app.tsx
+++ b/examples/experimental/fp64/app.tsx
@@ -30,17 +30,25 @@ type AppProps = {
 type AppState = {
   benchmarkError: string | null;
   benchmarkResults: FP64ComputeBenchmarkResult[] | null;
-  currentZoomLabel: string;
+  fp64RenderTiming: FP64RenderTiming | null;
   initializationError: string | null;
   isBenchmarkRunning: boolean;
   isReady: boolean;
+  renderWidth: number;
   selectedArithmeticMode: FP64ArithmeticMode;
   selectedBackend: RenderingBackend;
   selectedPresetId: ZoomPresetId;
+  zoomDepth: number;
 };
 
 type RenderingBackend = 'auto' | 'webgl' | 'webgpu';
 type FP64ArithmeticMode = 'classic' | 'hybrid' | 'integer';
+type FP64RenderTimingSource = 'CPU encode' | 'GPU completion';
+
+type FP64RenderTiming = {
+  milliseconds: number;
+  source: FP64RenderTimingSource;
+};
 
 type ZoomPresetId = 'seahorse' | 'elephant';
 
@@ -82,16 +90,28 @@ type VisualizationRenderer = {
   presentationContext: PresentationContext | null;
   shaderInputs: ShaderInputs<any> | null;
   spec: VisualizationSpec;
+  timing: VisualizationTiming | null;
+};
+
+type VisualizationTiming = {
+  destroyed: boolean;
+  readPending: boolean;
+  smoothedMilliseconds: number | null;
+  source: FP64RenderTimingSource | null;
 };
 
 const CANVAS_WIDTH = 420;
 const CANVAS_HEIGHT = 280;
+const MIN_RENDER_WIDTH = 160;
+const MAX_RENDER_WIDTH = 640;
+const RENDER_ASPECT_RATIO = CANVAS_WIDTH / CANVAS_HEIGHT;
 const FIXED_ITERATION_LIMIT = 1400;
 const FULLSCREEN_POSITIONS = new Float32Array([-1, -1, -1, 1, 1, -1, 1, 1]);
 const INITIAL_PIXEL_SCALE = 1.35;
 const MIN_PIXEL_SCALE = 1e-12;
-const ZOOM_RATE = 0.45;
-const ZOOM_CYCLE_DURATION = Math.log2(INITIAL_PIXEL_SCALE / MIN_PIXEL_SCALE) / ZOOM_RATE;
+const MAX_ZOOM_DEPTH = Math.log2(INITIAL_PIXEL_SCALE / MIN_PIXEL_SCALE);
+const RENDER_TIMING_SAMPLE_INTERVAL = 5;
+const RENDER_TIMING_SMOOTHING = 0.2;
 const ZOOM_PRESETS: Record<ZoomPresetId, ZoomPreset> = {
   seahorse: {
     label: 'Seahorse',
@@ -127,13 +147,15 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     this.state = {
       benchmarkError: null,
       benchmarkResults: null,
-      currentZoomLabel: formatZoomScale(INITIAL_PIXEL_SCALE),
+      fp64RenderTiming: null,
       initializationError: null,
       isBenchmarkRunning: false,
       isReady: false,
+      renderWidth: CANVAS_WIDTH,
       selectedArithmeticMode: 'hybrid',
       selectedBackend: 'auto',
-      selectedPresetId: DEFAULT_PRESET_ID
+      selectedPresetId: DEFAULT_PRESET_ID,
+      zoomDepth: 0
     };
     const hasExternalDevice = Boolean(props.device || props.presentationDevice);
     this.settingsPanel = new ExampleSettingsPanelManager({
@@ -142,7 +164,9 @@ export default class App extends React.PureComponent<AppProps, AppState> {
       settings: {
         selectedArithmeticMode: 'hybrid',
         selectedBackend: 'auto',
-        selectedPresetId: DEFAULT_PRESET_ID
+        selectedPresetId: DEFAULT_PRESET_ID,
+        renderWidth: CANVAS_WIDTH,
+        zoomDepth: 0
       },
       onSettingsChange: this.handleSettingsChange
     });
@@ -187,6 +211,22 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     if (previousState.selectedPresetId !== this.state.selectedPresetId) {
       this.renderer?.setZoomPreset(ZOOM_PRESETS[this.state.selectedPresetId]);
     }
+
+    if (previousState.zoomDepth !== this.state.zoomDepth) {
+      this.renderer?.setZoomDepth(this.state.zoomDepth);
+    }
+
+    if (previousState.renderWidth !== this.state.renderWidth) {
+      this.renderer?.setRenderWidth(this.state.renderWidth);
+    }
+
+    if (
+      this.state.fp64RenderTiming &&
+      (previousState.zoomDepth !== this.state.zoomDepth ||
+        previousState.renderWidth !== this.state.renderWidth)
+    ) {
+      this.setState({fp64RenderTiming: null});
+    }
   }
 
   override componentWillUnmount(): void {
@@ -203,7 +243,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     this.setState({
       benchmarkError: null,
       benchmarkResults: null,
-      currentZoomLabel: formatZoomScale(INITIAL_PIXEL_SCALE),
+      fp64RenderTiming: null,
       initializationError: null,
       isBenchmarkRunning: false,
       isReady: false
@@ -222,7 +262,9 @@ export default class App extends React.PureComponent<AppProps, AppState> {
         canvases as HTMLCanvasElement[],
         ZOOM_PRESETS[this.state.selectedPresetId],
         this.state.selectedArithmeticMode,
-        this.handleFrame
+        this.state.zoomDepth,
+        this.state.renderWidth,
+        this.handleFP64RenderTiming
       );
 
       if (!this.isReadyForInitialization(initializationGeneration)) {
@@ -261,14 +303,17 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     const {
       benchmarkError,
       benchmarkResults,
-      currentZoomLabel,
+      fp64RenderTiming,
       initializationError,
       isBenchmarkRunning,
       isReady,
+      renderWidth,
       selectedArithmeticMode,
-      selectedPresetId
+      selectedPresetId,
+      zoomDepth
     } = this.state;
     const selectedPreset = ZOOM_PRESETS[selectedPresetId];
+    const currentZoomLabel = formatZoomScale(getPixelScale(zoomDepth));
     const visualizationSpecs = getVisualizationSpecs();
 
     return (
@@ -292,7 +337,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
             display: 'grid',
             gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 320px), 1fr))',
             gap: 20,
-            alignItems: 'start',
+            alignItems: 'stretch',
             minWidth: 0
           }}
         >
@@ -300,7 +345,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
             <div
               data-fp64-visualization={visualization.kind}
               key={visualization.kind}
-              style={{display: 'grid', gap: 12, minWidth: 0}}
+              style={{display: 'grid', gridTemplateRows: '1fr auto', gap: 12, minWidth: 0}}
             >
               <ExamplePaneCopy
                 description={visualization.description}
@@ -314,7 +359,9 @@ export default class App extends React.PureComponent<AppProps, AppState> {
                   currentZoomLabel,
                   visualization.kind,
                   this.device,
-                  selectedArithmeticMode
+                  selectedArithmeticMode,
+                  fp64RenderTiming,
+                  renderWidth
                 )}
               />
             </div>
@@ -353,6 +400,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     return await luma.createDevice({
       adapters: [webgpuAdapter, webgl2Adapter],
       type: selectedBackend === 'auto' ? 'best-available' : selectedBackend,
+      featureLevel: 'best-available',
       createCanvasContext: {
         canvas: new OffscreenCanvas(CANVAS_WIDTH, CANVAS_HEIGHT),
         width: CANVAS_WIDTH,
@@ -373,10 +421,14 @@ export default class App extends React.PureComponent<AppProps, AppState> {
       changedSettings,
       'selectedArithmeticMode'
     )?.nextValue;
+    const zoomDepth = getChangedSetting(changedSettings, 'zoomDepth')?.nextValue;
+    const renderWidth = getChangedSetting(changedSettings, 'renderWidth')?.nextValue;
     if (
       isZoomPresetId(selectedPresetId) ||
       isRenderingBackend(selectedBackend) ||
-      isFP64ArithmeticMode(selectedArithmeticMode)
+      isFP64ArithmeticMode(selectedArithmeticMode) ||
+      isZoomDepth(zoomDepth) ||
+      isRenderWidth(renderWidth)
     ) {
       this.setState({
         selectedArithmeticMode: isFP64ArithmeticMode(selectedArithmeticMode)
@@ -385,17 +437,18 @@ export default class App extends React.PureComponent<AppProps, AppState> {
         selectedBackend: isRenderingBackend(selectedBackend)
           ? selectedBackend
           : this.state.selectedBackend,
+        renderWidth: isRenderWidth(renderWidth) ? renderWidth : this.state.renderWidth,
         selectedPresetId: isZoomPresetId(selectedPresetId)
           ? selectedPresetId
-          : this.state.selectedPresetId
+          : this.state.selectedPresetId,
+        zoomDepth: isZoomDepth(zoomDepth) ? zoomDepth : this.state.zoomDepth
       });
     }
   };
 
-  private handleFrame = (pixelScale: number): void => {
-    const currentZoomLabel = formatZoomScale(pixelScale);
-    if (currentZoomLabel !== this.state.currentZoomLabel) {
-      this.setState({currentZoomLabel});
+  private handleFP64RenderTiming = (fp64RenderTiming: FP64RenderTiming): void => {
+    if (this.isComponentMounted) {
+      this.setState({fp64RenderTiming});
     }
   };
 
@@ -477,6 +530,29 @@ export function makeFP64SettingsSchema(includeBackend = true): SettingsSchema {
               label: preset.label,
               value
             }))
+          },
+          {
+            name: 'zoomDepth',
+            label: 'Zoom depth (powers of 2)',
+            description: 'Scrub the same fixed zoom level in both precision views.',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: MAX_ZOOM_DEPTH,
+            step: 0.1,
+            sliderDebounceMs: 0
+          },
+          {
+            name: 'renderWidth',
+            label: 'Render-buffer width (pixels)',
+            description:
+              'Changes GPU fragment workload for both views without changing their CSS size.',
+            type: 'number',
+            persist: 'none',
+            min: MIN_RENDER_WIDTH,
+            max: MAX_RENDER_WIDTH,
+            step: 20,
+            sliderDebounceMs: 80
           }
         ]
       }
@@ -496,6 +572,14 @@ function isFP64ArithmeticMode(value: unknown): value is FP64ArithmeticMode {
   return value === 'classic' || value === 'hybrid' || value === 'integer';
 }
 
+function isZoomDepth(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isRenderWidth(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
 export function renderToDOM(
   container: HTMLElement,
   props: {device?: Device | null; presentationDevice?: Device | null} = {}
@@ -511,11 +595,14 @@ export function renderToDOM(
 class MultiCanvasRenderer {
   readonly device: Device;
   readonly fullscreenBuffer: ReturnType<Device['createBuffer']>;
-  readonly onFrame?: (pixelScale: number) => void;
+  readonly onFP64RenderTiming?: (timing: FP64RenderTiming) => void;
+  readonly renderingOrder: VisualizationRenderer[];
   readonly visualizations: VisualizationRenderer[];
 
   animationFrame: number | null = null;
-  startTime = 0;
+  frameIndex = 0;
+  isRunning = false;
+  zoomDepth: number;
   zoomPreset: ZoomPreset;
 
   constructor(
@@ -523,10 +610,13 @@ class MultiCanvasRenderer {
     canvases: HTMLCanvasElement[],
     zoomPreset: ZoomPreset,
     arithmeticMode: FP64ArithmeticMode,
-    onFrame?: (pixelScale: number) => void
+    zoomDepth: number,
+    renderWidth: number,
+    onFP64RenderTiming?: (timing: FP64RenderTiming) => void
   ) {
     this.device = device;
-    this.onFrame = onFrame;
+    this.onFP64RenderTiming = onFP64RenderTiming;
+    this.zoomDepth = zoomDepth;
     this.zoomPreset = zoomPreset;
     this.fullscreenBuffer = device.createBuffer({data: FULLSCREEN_POSITIONS});
     this.visualizations = getVisualizationSpecs().map((spec, index) => {
@@ -536,7 +626,8 @@ class MultiCanvasRenderer {
           canvases[index],
           this.fullscreenBuffer,
           spec,
-          arithmeticMode
+          arithmeticMode,
+          renderWidth
         );
       } catch (error) {
         return {
@@ -544,21 +635,27 @@ class MultiCanvasRenderer {
           model: null,
           presentationContext: null,
           shaderInputs: null,
-          spec
+          spec,
+          timing: null
         };
       }
     });
+    this.renderingOrder = [
+      ...this.visualizations.filter(visualization => visualization.spec.kind === 'fp64'),
+      ...this.visualizations.filter(visualization => visualization.spec.kind === 'fp32')
+    ];
   }
 
   start(): void {
-    if (this.animationFrame !== null) {
+    if (this.isRunning) {
       return;
     }
-    this.startTime = performance.now();
+    this.isRunning = true;
     this.animationFrame = requestAnimationFrame(this.animate);
   }
 
   pause(): void {
+    this.isRunning = false;
     if (this.animationFrame !== null) {
       cancelAnimationFrame(this.animationFrame);
       this.animationFrame = null;
@@ -568,7 +665,8 @@ class MultiCanvasRenderer {
   destroy(): void {
     this.pause();
 
-    for (const visualization of this.visualizations) {
+    for (const visualization of this.renderingOrder) {
+      destroyVisualizationTiming(visualization.timing);
       visualization.model?.destroy();
       visualization.presentationContext?.destroy();
     }
@@ -578,7 +676,19 @@ class MultiCanvasRenderer {
 
   setZoomPreset(zoomPreset: ZoomPreset): void {
     this.zoomPreset = zoomPreset;
-    this.startTime = performance.now();
+  }
+
+  setZoomDepth(zoomDepth: number): void {
+    this.zoomDepth = zoomDepth;
+    this.resetRenderTiming();
+  }
+
+  setRenderWidth(renderWidth: number): void {
+    const renderHeight = getRenderHeight(renderWidth);
+    for (const visualization of this.visualizations) {
+      visualization.presentationContext?.setDrawingBufferSize(renderWidth, renderHeight);
+    }
+    this.resetRenderTiming();
   }
 
   hasActiveVisualizations(): boolean {
@@ -596,17 +706,43 @@ class MultiCanvasRenderer {
       );
   }
 
-  private animate = (timestamp: number): void => {
-    const time = (timestamp - this.startTime) / 1000;
-    const pixelScale = getPixelScale(time);
-
-    this.onFrame?.(pixelScale);
-
+  private resetRenderTiming(): void {
     for (const visualization of this.visualizations) {
-      renderVisualization(this.device, visualization, time, this.zoomPreset);
+      if (visualization.timing) {
+        visualization.timing.smoothedMilliseconds = null;
+        visualization.timing.source = null;
+      }
+    }
+  }
+
+  private animate = (): void => {
+    this.animationFrame = null;
+    const pixelScale = getPixelScale(this.zoomDepth);
+    const sampleTiming = this.frameIndex % RENDER_TIMING_SAMPLE_INTERVAL === 0;
+
+    for (const visualization of this.renderingOrder) {
+      renderVisualization(
+        this.device,
+        visualization,
+        pixelScale,
+        this.zoomPreset,
+        sampleTiming ? this.onFP64RenderTiming : undefined
+      );
     }
 
-    this.animationFrame = requestAnimationFrame(this.animate);
+    this.frameIndex++;
+    const submittedWork = waitForSubmittedWork(this.device);
+    if (submittedWork) {
+      void submittedWork.then(this.scheduleNextFrame, this.scheduleNextFrame);
+    } else {
+      this.scheduleNextFrame();
+    }
+  };
+
+  private scheduleNextFrame = (): void => {
+    if (this.isRunning) {
+      this.animationFrame = requestAnimationFrame(this.animate);
+    }
   };
 }
 
@@ -615,7 +751,8 @@ function createVisualizationRenderer(
   canvas: HTMLCanvasElement,
   buffer: ReturnType<Device['createBuffer']>,
   spec: VisualizationSpec,
-  arithmeticMode: FP64ArithmeticMode
+  arithmeticMode: FP64ArithmeticMode,
+  renderWidth: number
 ): VisualizationRenderer {
   const presentationContext = device.createPresentationContext({
     canvas,
@@ -624,6 +761,7 @@ function createVisualizationRenderer(
     autoResize: false,
     useDevicePixels: false
   });
+  presentationContext.setDrawingBufferSize(renderWidth, getRenderHeight(renderWidth));
 
   const shaderInputs =
     spec.kind === 'fp64'
@@ -656,7 +794,8 @@ function createVisualizationRenderer(
     model,
     presentationContext,
     shaderInputs,
-    spec
+    spec,
+    timing: spec.kind === 'fp64' ? createVisualizationTiming() : null
   };
 }
 
@@ -690,8 +829,9 @@ export function getVisualizationDefines(
 function renderVisualization(
   device: Device,
   visualization: VisualizationRenderer,
-  elapsedTime: number,
-  zoomPreset: ZoomPreset
+  pixelScale: number,
+  zoomPreset: ZoomPreset,
+  onFP64RenderTiming?: (timing: FP64RenderTiming) => void
 ): void {
   if (!visualization.model || !visualization.presentationContext || !visualization.shaderInputs) {
     return;
@@ -704,7 +844,7 @@ function renderVisualization(
   const aspectRatio = width / Math.max(height, 1);
   const centerX = zoomPreset.centerX;
   const centerY = zoomPreset.centerY;
-  const scale = getPixelScale(elapsedTime);
+  const scale = pixelScale;
   const fp64CenterX = split64(centerX);
   const fp64CenterY = split64(centerY);
   const fp64Scale = split64(scale);
@@ -735,6 +875,9 @@ function renderVisualization(
 
   visualization.model.updateShaderInputs();
 
+  const timing = visualization.timing;
+  const measureTiming = Boolean(onFP64RenderTiming && timing && !timing.readPending);
+  const cpuStartTime = measureTiming ? performance.now() : 0;
   const renderPass = device.beginRenderPass({
     framebuffer,
     clearColor: visualization.spec.clearColor
@@ -743,6 +886,72 @@ function renderVisualization(
   visualization.model.draw(renderPass);
   renderPass.end();
   visualization.presentationContext.present();
+
+  if (measureTiming && timing && onFP64RenderTiming) {
+    const cpuMilliseconds = performance.now() - cpuStartTime;
+    const submittedWork = waitForSubmittedWork(device);
+    if (submittedWork) {
+      readFP64CompletionTiming(timing, submittedWork, cpuStartTime, onFP64RenderTiming);
+    } else {
+      updateFP64RenderTiming(timing, cpuMilliseconds, 'CPU encode', onFP64RenderTiming);
+    }
+  }
+}
+
+function createVisualizationTiming(): VisualizationTiming {
+  return {
+    destroyed: false,
+    readPending: false,
+    smoothedMilliseconds: null,
+    source: null
+  };
+}
+
+function destroyVisualizationTiming(timing: VisualizationTiming | null): void {
+  if (!timing) {
+    return;
+  }
+  timing.destroyed = true;
+}
+
+function readFP64CompletionTiming(
+  timing: VisualizationTiming,
+  submittedWork: Promise<void>,
+  startTime: number,
+  onFP64RenderTiming: (timing: FP64RenderTiming) => void
+): void {
+  timing.readPending = true;
+  void submittedWork
+    .then(() => {
+      updateFP64RenderTiming(
+        timing,
+        performance.now() - startTime,
+        'GPU completion',
+        onFP64RenderTiming
+      );
+    })
+    .catch(() => {})
+    .finally(() => {
+      timing.readPending = false;
+    });
+}
+
+function updateFP64RenderTiming(
+  timing: VisualizationTiming,
+  milliseconds: number,
+  source: FP64RenderTimingSource,
+  onFP64RenderTiming: (timing: FP64RenderTiming) => void
+): void {
+  if (timing.destroyed || !Number.isFinite(milliseconds) || milliseconds <= 0) {
+    return;
+  }
+  timing.smoothedMilliseconds =
+    timing.smoothedMilliseconds === null || timing.source !== source
+      ? milliseconds
+      : timing.smoothedMilliseconds * (1 - RENDER_TIMING_SMOOTHING) +
+        milliseconds * RENDER_TIMING_SMOOTHING;
+  timing.source = source;
+  onFP64RenderTiming({milliseconds: timing.smoothedMilliseconds, source});
 }
 
 function split64(value: number): [number, number] {
@@ -756,9 +965,21 @@ function computeIterationLimit(pixelScale: number): number {
   return Math.min(FIXED_ITERATION_LIMIT, Math.round(220 + zoomDepth * 28));
 }
 
-function getPixelScale(elapsedTime: number): number {
-  const cycleTime = elapsedTime % ZOOM_CYCLE_DURATION;
-  return INITIAL_PIXEL_SCALE * Math.pow(0.5, cycleTime * ZOOM_RATE);
+function getPixelScale(zoomDepth: number): number {
+  const clampedZoomDepth = Math.max(0, Math.min(MAX_ZOOM_DEPTH, zoomDepth));
+  return INITIAL_PIXEL_SCALE * Math.pow(0.5, clampedZoomDepth);
+}
+
+function getRenderHeight(renderWidth: number): number {
+  return Math.round(renderWidth / RENDER_ASPECT_RATIO);
+}
+
+function waitForSubmittedWork(device: Device): Promise<void> | null {
+  if (device.type !== 'webgpu') {
+    return null;
+  }
+  const queue = (device.handle as {queue?: {onSubmittedWorkDone?: () => Promise<void>}}).queue;
+  return queue?.onSubmittedWorkDone?.() || null;
 }
 
 function formatZoomScale(pixelScale: number): string {
@@ -770,21 +991,37 @@ function getOverlayLines(
   currentZoomLabel: string,
   kind: 'fp32' | 'fp64',
   device: Device | null,
-  arithmeticMode: FP64ArithmeticMode
+  arithmeticMode: FP64ArithmeticMode,
+  fp64RenderTiming: FP64RenderTiming | null,
+  renderWidth: number
 ): string[] {
   const precisionLabel =
     device?.type === 'webgpu' ? `fp64 ${arithmeticMode}` : 'fp64 classic (WebGL2)';
 
-  return [
+  const overlayLines = [
     'mode = mandelbrot zoom',
     `target = ${zoomPreset.label}`,
     `x = ${zoomPreset.centerX}`,
     `y = ${zoomPreset.centerY}`,
     `scale = ${currentZoomLabel}`,
+    `render buffer = ${renderWidth} × ${getRenderHeight(renderWidth)}`,
     `zoom = ${INITIAL_PIXEL_SCALE} -> ${MIN_PIXEL_SCALE}`,
     kind === 'fp32' ? 'precision = native fp32' : `precision = ${precisionLabel}`,
     'iterations = adaptive'
   ];
+  if (kind === 'fp64') {
+    overlayLines.push(
+      fp64RenderTiming ? formatFP64RenderTiming(fp64RenderTiming) : 'fp64 render = sampling…'
+    );
+  }
+  return overlayLines;
+}
+
+export function formatFP64RenderTiming(timing: FP64RenderTiming): string {
+  const framesPerSecondEquivalent = 1000 / timing.milliseconds;
+  const milliseconds =
+    timing.milliseconds < 1 ? timing.milliseconds.toFixed(3) : timing.milliseconds.toFixed(2);
+  return `fp64 ${timing.source} = ${milliseconds} ms · ${framesPerSecondEquivalent.toFixed(1)} FPS-equivalent`;
 }
 
 function ExamplePaneCopy(props: {description: string; title: string}): React.ReactNode {
@@ -1378,7 +1615,7 @@ function getVisualizationSpecs(): VisualizationSpec[] {
     {
       clearColor: [0.02, 0.015, 0.04, 1],
       description:
-        'Single-precision Mandelbrot fragment shader. The view starts on the Seahorse target and zooms in from there.',
+        'Single-precision Mandelbrot fragment shader. Use the shared zoom slider to inspect the selected target.',
       fragmentShaderGLSL: MANDELBROT32_FRAGMENT_SHADER,
       fragmentShaderWGSL: MANDELBROT32_FRAGMENT_WGSL,
       kind: 'fp32',
@@ -1387,7 +1624,7 @@ function getVisualizationSpecs(): VisualizationSpec[] {
     {
       clearColor: [0.01, 0.015, 0.03, 1],
       description:
-        'FP64 Mandelbrot fragment shader using fp64arithmetic. On Apple WebGPU, the live zoom uses a hybrid path with integer-reconstructed high residuals and native low-term accumulation; the fully reliable integer path remains available in the benchmark.',
+        'FP64 Mandelbrot fragment shader using fp64arithmetic. On Apple WebGPU, hybrid mode uses integer-reconstructed high residuals and native low-term accumulation; the fully reliable integer path remains available in the benchmark.',
       fragmentShaderGLSL: MANDELBROT64_FRAGMENT_SHADER,
       fragmentShaderWGSL: MANDELBROT64_FRAGMENT_WGSL,
       kind: 'fp64',

--- a/examples/experimental/fp64/app.tsx
+++ b/examples/experimental/fp64/app.tsx
@@ -34,8 +34,13 @@ type AppState = {
   initializationError: string | null;
   isBenchmarkRunning: boolean;
   isReady: boolean;
+  selectedArithmeticMode: FP64ArithmeticMode;
+  selectedBackend: RenderingBackend;
   selectedPresetId: ZoomPresetId;
 };
+
+type RenderingBackend = 'auto' | 'webgl' | 'webgpu';
+type FP64ArithmeticMode = 'classic' | 'hybrid' | 'integer';
 
 type ZoomPresetId = 'seahorse' | 'elephant';
 
@@ -50,7 +55,6 @@ type Mandelbrot32Uniforms = {
   center: [number, number];
   pixelScale: number;
   aspectRatio: number;
-  time: number;
   iterationLimit: number;
 };
 
@@ -60,7 +64,6 @@ type Mandelbrot64Uniforms = {
   centerY: [number, number];
   pixelScale: [number, number];
   aspectRatio: number;
-  time: number;
   iterationLimit: number;
 };
 
@@ -87,7 +90,7 @@ const FIXED_ITERATION_LIMIT = 1400;
 const FULLSCREEN_POSITIONS = new Float32Array([-1, -1, -1, 1, 1, -1, 1, 1]);
 const INITIAL_PIXEL_SCALE = 1.35;
 const MIN_PIXEL_SCALE = 1e-12;
-const ZOOM_RATE = 1.2;
+const ZOOM_RATE = 0.45;
 const ZOOM_CYCLE_DURATION = Math.log2(INITIAL_PIXEL_SCALE / MIN_PIXEL_SCALE) / ZOOM_RATE;
 const ZOOM_PRESETS: Record<ZoomPresetId, ZoomPreset> = {
   seahorse: {
@@ -128,12 +131,19 @@ export default class App extends React.PureComponent<AppProps, AppState> {
       initializationError: null,
       isBenchmarkRunning: false,
       isReady: false,
+      selectedArithmeticMode: 'hybrid',
+      selectedBackend: 'auto',
       selectedPresetId: DEFAULT_PRESET_ID
     };
+    const hasExternalDevice = Boolean(props.device || props.presentationDevice);
     this.settingsPanel = new ExampleSettingsPanelManager({
       id: 'fp64-settings',
-      schema: makeFP64SettingsSchema(),
-      settings: {selectedPresetId: DEFAULT_PRESET_ID},
+      schema: makeFP64SettingsSchema(!hasExternalDevice),
+      settings: {
+        selectedArithmeticMode: 'hybrid',
+        selectedBackend: 'auto',
+        selectedPresetId: DEFAULT_PRESET_ID
+      },
       onSettingsChange: this.handleSettingsChange
     });
     this.panels = new ExamplePanelManager({
@@ -156,6 +166,20 @@ export default class App extends React.PureComponent<AppProps, AppState> {
       previousProps.device !== this.props.device ||
       previousProps.presentationDevice !== this.props.presentationDevice
     ) {
+      await this.initialize();
+      return;
+    }
+
+    if (
+      !this.props.device &&
+      !this.props.presentationDevice &&
+      previousState.selectedBackend !== this.state.selectedBackend
+    ) {
+      await this.initialize();
+      return;
+    }
+
+    if (previousState.selectedArithmeticMode !== this.state.selectedArithmeticMode) {
       await this.initialize();
       return;
     }
@@ -192,11 +216,12 @@ export default class App extends React.PureComponent<AppProps, AppState> {
       }
 
       const externalDevice = this.props.device || this.props.presentationDevice;
-      const device = externalDevice || (await this.createOwnedDevice());
+      const device = externalDevice || (await this.createOwnedDevice(this.state.selectedBackend));
       const renderer = new MultiCanvasRenderer(
         device,
         canvases as HTMLCanvasElement[],
         ZOOM_PRESETS[this.state.selectedPresetId],
+        this.state.selectedArithmeticMode,
         this.handleFrame
       );
 
@@ -240,10 +265,10 @@ export default class App extends React.PureComponent<AppProps, AppState> {
       initializationError,
       isBenchmarkRunning,
       isReady,
+      selectedArithmeticMode,
       selectedPresetId
     } = this.state;
     const selectedPreset = ZOOM_PRESETS[selectedPresetId];
-    const overlayLines = getOverlayLines(selectedPreset, currentZoomLabel);
     const visualizationSpecs = getVisualizationSpecs();
 
     return (
@@ -284,7 +309,13 @@ export default class App extends React.PureComponent<AppProps, AppState> {
               <ExamplePaneCanvas
                 canvasRef={this.canvasRefs[index]}
                 isReady={isReady}
-                overlayLines={overlayLines}
+                overlayLines={getOverlayLines(
+                  selectedPreset,
+                  currentZoomLabel,
+                  visualization.kind,
+                  this.device,
+                  selectedArithmeticMode
+                )}
               />
             </div>
           ))}
@@ -314,13 +345,14 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     this.ownsDevice = false;
   }
 
-  private async createOwnedDevice(): Promise<Device> {
+  private async createOwnedDevice(selectedBackend: RenderingBackend): Promise<Device> {
     if (typeof OffscreenCanvas === 'undefined') {
       throw new Error('This example requires OffscreenCanvas support.');
     }
 
     return await luma.createDevice({
       adapters: [webgpuAdapter, webgl2Adapter],
+      type: selectedBackend === 'auto' ? 'best-available' : selectedBackend,
       createCanvasContext: {
         canvas: new OffscreenCanvas(CANVAS_WIDTH, CANVAS_HEIGHT),
         width: CANVAS_WIDTH,
@@ -336,8 +368,27 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     changedSettings?: SettingsChangeDescriptor[]
   ): void => {
     const selectedPresetId = getChangedSetting(changedSettings, 'selectedPresetId')?.nextValue;
-    if (isZoomPresetId(selectedPresetId)) {
-      this.setState({selectedPresetId});
+    const selectedBackend = getChangedSetting(changedSettings, 'selectedBackend')?.nextValue;
+    const selectedArithmeticMode = getChangedSetting(
+      changedSettings,
+      'selectedArithmeticMode'
+    )?.nextValue;
+    if (
+      isZoomPresetId(selectedPresetId) ||
+      isRenderingBackend(selectedBackend) ||
+      isFP64ArithmeticMode(selectedArithmeticMode)
+    ) {
+      this.setState({
+        selectedArithmeticMode: isFP64ArithmeticMode(selectedArithmeticMode)
+          ? selectedArithmeticMode
+          : this.state.selectedArithmeticMode,
+        selectedBackend: isRenderingBackend(selectedBackend)
+          ? selectedBackend
+          : this.state.selectedBackend,
+        selectedPresetId: isZoomPresetId(selectedPresetId)
+          ? selectedPresetId
+          : this.state.selectedPresetId
+      });
     }
   };
 
@@ -379,7 +430,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
   };
 }
 
-function makeFP64SettingsSchema(): SettingsSchema {
+export function makeFP64SettingsSchema(includeBackend = true): SettingsSchema {
   return {
     title: 'Settings',
     sections: [
@@ -388,6 +439,35 @@ function makeFP64SettingsSchema(): SettingsSchema {
         name: 'View',
         initiallyCollapsed: false,
         settings: [
+          ...(includeBackend
+            ? [
+                {
+                  name: 'selectedBackend',
+                  label: 'Rendering backend',
+                  description: 'Recreates the example on the selected graphics API.',
+                  type: 'select' as const,
+                  persist: 'none' as const,
+                  options: [
+                    {label: 'Auto (WebGPU preferred)', value: 'auto'},
+                    {label: 'WebGPU', value: 'webgpu'},
+                    {label: 'WebGL2', value: 'webgl'}
+                  ]
+                }
+              ]
+            : []),
+          {
+            name: 'selectedArithmeticMode',
+            label: 'FP64 arithmetic',
+            description:
+              'WebGPU only. Classic is fastest, hybrid protects critical residuals, and integer is fully controlled but slow.',
+            type: 'select',
+            persist: 'none',
+            options: [
+              {label: 'Classic · fast', value: 'classic'},
+              {label: 'Hybrid · balanced', value: 'hybrid'},
+              {label: 'Integer · reliable', value: 'integer'}
+            ]
+          },
           {
             name: 'selectedPresetId',
             label: 'Zoom target',
@@ -406,6 +486,14 @@ function makeFP64SettingsSchema(): SettingsSchema {
 
 function isZoomPresetId(value: unknown): value is ZoomPresetId {
   return value === 'seahorse' || value === 'elephant';
+}
+
+function isRenderingBackend(value: unknown): value is RenderingBackend {
+  return value === 'auto' || value === 'webgl' || value === 'webgpu';
+}
+
+function isFP64ArithmeticMode(value: unknown): value is FP64ArithmeticMode {
+  return value === 'classic' || value === 'hybrid' || value === 'integer';
 }
 
 export function renderToDOM(
@@ -434,6 +522,7 @@ class MultiCanvasRenderer {
     device: Device,
     canvases: HTMLCanvasElement[],
     zoomPreset: ZoomPreset,
+    arithmeticMode: FP64ArithmeticMode,
     onFrame?: (pixelScale: number) => void
   ) {
     this.device = device;
@@ -442,7 +531,13 @@ class MultiCanvasRenderer {
     this.fullscreenBuffer = device.createBuffer({data: FULLSCREEN_POSITIONS});
     this.visualizations = getVisualizationSpecs().map((spec, index) => {
       try {
-        return createVisualizationRenderer(device, canvases[index], this.fullscreenBuffer, spec);
+        return createVisualizationRenderer(
+          device,
+          canvases[index],
+          this.fullscreenBuffer,
+          spec,
+          arithmeticMode
+        );
       } catch (error) {
         return {
           error: error instanceof Error ? error.message : String(error),
@@ -519,7 +614,8 @@ function createVisualizationRenderer(
   device: Device,
   canvas: HTMLCanvasElement,
   buffer: ReturnType<Device['createBuffer']>,
-  spec: VisualizationSpec
+  spec: VisualizationSpec,
+  arithmeticMode: FP64ArithmeticMode
 ): VisualizationRenderer {
   const presentationContext = device.createPresentationContext({
     canvas,
@@ -545,6 +641,7 @@ function createVisualizationRenderer(
     vs: FULLSCREEN_VERTEX_SHADER,
     fs: spec.fragmentShaderGLSL,
     modules: spec.kind === 'fp64' ? [fp64arithmetic] : [],
+    defines: getVisualizationDefines(device, spec.kind, arithmeticMode),
     bufferLayout: [{name: 'position', format: 'float32x2'}],
     attributes: {
       position: buffer
@@ -554,7 +651,40 @@ function createVisualizationRenderer(
     shaderInputs
   });
 
-  return {error: null, model, presentationContext, shaderInputs, spec};
+  return {
+    error: null,
+    model,
+    presentationContext,
+    shaderInputs,
+    spec
+  };
+}
+
+export function getVisualizationDefines(
+  device: {info: Pick<Device['info'], 'gpu'>; type: Device['type']},
+  kind: 'fp32' | 'fp64',
+  arithmeticMode: FP64ArithmeticMode
+): Record<string, boolean> {
+  if (kind !== 'fp64' || device.type !== 'webgpu') {
+    return {};
+  }
+  switch (arithmeticMode) {
+    case 'classic':
+      return {
+        LUMA_FP64_HYBRID_ARITHMETIC: false,
+        LUMA_FP64_INTEGER_ARITHMETIC: false
+      };
+    case 'hybrid':
+      return {
+        LUMA_FP64_HYBRID_ARITHMETIC: true,
+        LUMA_FP64_INTEGER_ARITHMETIC: false
+      };
+    case 'integer':
+      return {
+        LUMA_FP64_HYBRID_ARITHMETIC: false,
+        LUMA_FP64_INTEGER_ARITHMETIC: true
+      };
+  }
 }
 
 function renderVisualization(
@@ -588,7 +718,6 @@ function renderVisualization(
         centerY: fp64CenterY,
         pixelScale: fp64Scale,
         aspectRatio,
-        time: elapsedTime,
         iterationLimit
       }
     });
@@ -599,7 +728,6 @@ function renderVisualization(
         center: [centerX, centerY],
         pixelScale: scale,
         aspectRatio,
-        time: elapsedTime,
         iterationLimit
       }
     });
@@ -637,7 +765,16 @@ function formatZoomScale(pixelScale: number): string {
   return pixelScale.toExponential(3);
 }
 
-function getOverlayLines(zoomPreset: ZoomPreset, currentZoomLabel: string): string[] {
+function getOverlayLines(
+  zoomPreset: ZoomPreset,
+  currentZoomLabel: string,
+  kind: 'fp32' | 'fp64',
+  device: Device | null,
+  arithmeticMode: FP64ArithmeticMode
+): string[] {
+  const precisionLabel =
+    device?.type === 'webgpu' ? `fp64 ${arithmeticMode}` : 'fp64 classic (WebGL2)';
+
   return [
     'mode = mandelbrot zoom',
     `target = ${zoomPreset.label}`,
@@ -645,7 +782,7 @@ function getOverlayLines(zoomPreset: ZoomPreset, currentZoomLabel: string): stri
     `y = ${zoomPreset.centerY}`,
     `scale = ${currentZoomLabel}`,
     `zoom = ${INITIAL_PIXEL_SCALE} -> ${MIN_PIXEL_SCALE}`,
-    'fp64 = fp64arithmetic',
+    kind === 'fp32' ? 'precision = native fp32' : `precision = ${precisionLabel}`,
     'iterations = adaptive'
   ];
 }
@@ -766,8 +903,8 @@ function FP64BenchmarkPanel(props: {
           <h3 style={{margin: '0 0 6px'}}>FP64 compute benchmark</h3>
           <p style={{margin: 0, lineHeight: 1.45}}>
             Runs dependent add, multiply, divide, and square-root recurrences across 8,192 GPU
-            lanes. Results compare native float32, automatic selection, classic double-single, and
-            the Metal-safe integer double-single path. The Mandelbrot animation pauses while the
+            lanes. Results compare native float32, automatic selection, classic, hybrid, and
+            integer-controlled double-single arithmetic. The Mandelbrot animation pauses while the
             benchmark runs.
           </p>
         </div>
@@ -881,6 +1018,8 @@ function formatBenchmarkMode(mode: FP64BenchmarkMode): string {
       return 'FP64 automatic';
     case 'classic':
       return 'FP64 classic';
+    case 'hybrid':
+      return 'FP64 hybrid';
     case 'integer':
       return 'FP64 integer';
     case 'float32':
@@ -905,7 +1044,6 @@ const mandelbrot32: ShaderModule<Mandelbrot32Uniforms> = {
     center: 'vec2<f32>',
     pixelScale: 'f32',
     aspectRatio: 'f32',
-    time: 'f32',
     iterationLimit: 'f32'
   }
 };
@@ -919,7 +1057,6 @@ const mandelbrot64: ShaderModule<Mandelbrot64Uniforms> = {
     centerY: 'vec2<f32>',
     pixelScale: 'vec2<f32>',
     aspectRatio: 'f32',
-    time: 'f32',
     iterationLimit: 'f32'
   }
 };
@@ -967,16 +1104,16 @@ layout(std140) uniform mandelbrot32Uniforms {
   vec2 center;
   float pixelScale;
   float aspectRatio;
-  float time;
   float iterationLimit;
 } mandelbrot32;
 
 const int MAX_ITERATIONS = 2048;
 const float ESCAPE_RADIUS_SQUARED = 256.0;
+const float COLOR_FREQUENCY = 0.025;
 const float TAU = 6.28318530718;
 
 vec3 palette(float value) {
-  vec3 phase = vec3(0.18, 0.41, 0.73) + mandelbrot32.time * vec3(0.008, 0.012, 0.02);
+  vec3 phase = vec3(0.18, 0.41, 0.73);
   return 0.5 + 0.5 * cos(TAU * (value + phase));
 }
 
@@ -1013,9 +1150,9 @@ void main(void) {
   }
 
   float smoothIteration = escapedIteration + 1.0 - log2(log2(max(radiusSquared, 1.000001)));
-  float colorPosition = smoothIteration / mandelbrot32.iterationLimit;
+  float colorPosition = smoothIteration * COLOR_FREQUENCY;
   vec3 color = palette(colorPosition);
-  color *= 0.55 + 0.45 * smoothstep(0.0, 1.0, colorPosition);
+  color *= 0.55 + 0.45 * smoothstep(0.0, 80.0, smoothIteration);
 
   fragColor = vec4(color, 1.0);
 }
@@ -1027,7 +1164,6 @@ struct Mandelbrot32Uniforms {
   center: vec2<f32>,
   pixelScale: f32,
   aspectRatio: f32,
-  time: f32,
   iterationLimit: f32,
 };
 
@@ -1035,10 +1171,11 @@ struct Mandelbrot32Uniforms {
 
 const MAX_ITERATIONS: i32 = 2048;
 const ESCAPE_RADIUS_SQUARED: f32 = 256.0;
+const COLOR_FREQUENCY: f32 = 0.025;
 const TAU: f32 = 6.28318530718;
 
 fn palette32(value: f32) -> vec3<f32> {
-  let phase = vec3<f32>(0.18, 0.41, 0.73) + mandelbrot32.time * vec3<f32>(0.008, 0.012, 0.02);
+  let phase = vec3<f32>(0.18, 0.41, 0.73);
   return 0.5 + 0.5 * cos(TAU * (value + phase));
 }
 
@@ -1076,9 +1213,9 @@ fn fragmentMain(inputs: FragmentOutput) -> @location(0) vec4<f32> {
 
   let smoothIteration =
     escapedIteration + 1.0 - log2(log2(max(radiusSquared, 1.000001)));
-  let colorPosition = smoothIteration / mandelbrot32.iterationLimit;
+  let colorPosition = smoothIteration * COLOR_FREQUENCY;
   var color = palette32(colorPosition);
-  color = color * (0.55 + 0.45 * smoothstep(0.0, 1.0, colorPosition));
+  color = color * (0.55 + 0.45 * smoothstep(0.0, 80.0, smoothIteration));
   return vec4<f32>(color, 1.0);
 }
 `;
@@ -1096,16 +1233,16 @@ layout(std140) uniform mandelbrot64Uniforms {
   vec2 centerY;
   vec2 pixelScale;
   float aspectRatio;
-  float time;
   float iterationLimit;
 } mandelbrot64;
 
 const int MAX_ITERATIONS = 2048;
 const float ESCAPE_RADIUS_SQUARED = 256.0;
+const float COLOR_FREQUENCY = 0.025;
 const float TAU = 6.28318530718;
 
 vec3 palette(float value) {
-  vec3 phase = vec3(0.18, 0.41, 0.73) + mandelbrot64.time * vec3(0.008, 0.012, 0.02);
+  vec3 phase = vec3(0.18, 0.41, 0.73);
   return 0.5 + 0.5 * cos(TAU * (value + phase));
 }
 
@@ -1154,9 +1291,9 @@ void main(void) {
   }
 
   float smoothIteration = escapedIteration + 1.0 - log2(log2(max(radiusSquared, 1.000001)));
-  float colorPosition = smoothIteration / mandelbrot64.iterationLimit;
+  float colorPosition = smoothIteration * COLOR_FREQUENCY;
   vec3 color = palette(colorPosition);
-  color *= 0.55 + 0.45 * smoothstep(0.0, 1.0, colorPosition);
+  color *= 0.55 + 0.45 * smoothstep(0.0, 80.0, smoothIteration);
 
   fragColor = vec4(color, 1.0);
 }
@@ -1169,7 +1306,6 @@ struct Mandelbrot64Uniforms {
   centerY: vec2<f32>,
   pixelScale: vec2<f32>,
   aspectRatio: f32,
-  time: f32,
   iterationLimit: f32,
 };
 
@@ -1177,10 +1313,11 @@ struct Mandelbrot64Uniforms {
 
 const MAX_ITERATIONS: i32 = 2048;
 const ESCAPE_RADIUS_SQUARED: f32 = 256.0;
+const COLOR_FREQUENCY: f32 = 0.025;
 const TAU: f32 = 6.28318530718;
 
 fn palette64(value: f32) -> vec3<f32> {
-  let phase = vec3<f32>(0.18, 0.41, 0.73) + mandelbrot64.time * vec3<f32>(0.008, 0.012, 0.02);
+  let phase = vec3<f32>(0.18, 0.41, 0.73);
   return 0.5 + 0.5 * cos(TAU * (value + phase));
 }
 
@@ -1229,9 +1366,9 @@ fn fragmentMain(inputs: FragmentOutput) -> @location(0) vec4<f32> {
 
   let smoothIteration =
     escapedIteration + 1.0 - log2(log2(max(radiusSquared, 1.000001)));
-  let colorPosition = smoothIteration / mandelbrot64.iterationLimit;
+  let colorPosition = smoothIteration * COLOR_FREQUENCY;
   var color = palette64(colorPosition);
-  color = color * (0.55 + 0.45 * smoothstep(0.0, 1.0, colorPosition));
+  color = color * (0.55 + 0.45 * smoothstep(0.0, 80.0, smoothIteration));
   return vec4<f32>(color, 1.0);
 }
 `;
@@ -1250,7 +1387,7 @@ function getVisualizationSpecs(): VisualizationSpec[] {
     {
       clearColor: [0.01, 0.015, 0.03, 1],
       description:
-        'FP64 Mandelbrot fragment shader using fp64arithmetic, with center and scale split into hi/lo parts before upload.',
+        'FP64 Mandelbrot fragment shader using fp64arithmetic. On Apple WebGPU, the live zoom uses a hybrid path with integer-reconstructed high residuals and native low-term accumulation; the fully reliable integer path remains available in the benchmark.',
       fragmentShaderGLSL: MANDELBROT64_FRAGMENT_SHADER,
       fragmentShaderWGSL: MANDELBROT64_FRAGMENT_WGSL,
       kind: 'fp64',

--- a/examples/experimental/fp64/fp64-compute-benchmark.ts
+++ b/examples/experimental/fp64/fp64-compute-benchmark.ts
@@ -176,15 +176,13 @@ function makeComputation(
   } else if (mode === 'integer') {
     defines['LUMA_FP64_INTEGER_ARITHMETIC'] = true;
   }
-  const usesClassicSplit =
-    operation !== 'add' &&
-    (mode === 'classic' || (mode === 'automatic' && device.info.gpu !== 'apple'));
+  const usesFP64ArithmeticUniform = requiresFP64ArithmeticUniform(mode, operation, device.info.gpu);
   const storageBindings: ComputeShaderLayout['bindings'] = [
     {name: 'inputValues', type: 'read-only-storage', group: 0, location: 1},
     {name: 'outputValues', type: 'storage', group: 0, location: 2}
   ];
   const shaderLayout: ComputeShaderLayout = {
-    bindings: usesClassicSplit
+    bindings: usesFP64ArithmeticUniform
       ? [
           {
             name: 'fp64arithmeticUniforms',
@@ -204,11 +202,22 @@ function makeComputation(
     defines,
     shaderLayout,
     // Do not create a managed module-uniform binding when the selected path
-    // cannot reach classic split(). The declaration is absent from the
-    // caller-owned layout in those cases and an extra logical binding would
-    // produce a misleading validation warning.
-    shaderInputs: new ShaderInputs(usesClassicSplit ? {fp64arithmetic} : {})
+    // cannot reach classic split() or hybrid fp64_runtime_zero(). The declaration
+    // is absent from the caller-owned layout in those cases and an extra logical
+    // binding would produce a misleading validation warning.
+    shaderInputs: new ShaderInputs(usesFP64ArithmeticUniform ? {fp64arithmetic} : {})
   });
+}
+
+export function requiresFP64ArithmeticUniform(
+  mode: FP64BenchmarkMode,
+  operation: FP64BenchmarkOperation,
+  gpu: Device['info']['gpu']
+): boolean {
+  const usesClassicSplit =
+    operation !== 'add' && (mode === 'classic' || (mode === 'automatic' && gpu !== 'apple'));
+  const usesHybridRuntimeZero = mode === 'hybrid' && operation === 'divide';
+  return usesClassicSplit || usesHybridRuntimeZero;
 }
 
 function makeBenchmarkShader(operation: FP64BenchmarkOperation, useFloat32: boolean): string {

--- a/examples/experimental/fp64/fp64-compute-benchmark.ts
+++ b/examples/experimental/fp64/fp64-compute-benchmark.ts
@@ -6,7 +6,7 @@ import {Buffer, type ComputeShaderLayout, type Device, type QuerySet} from '@lum
 import {Computation, ShaderInputs} from '@luma.gl/engine';
 import {fp64arithmetic, type ShaderModule} from '@luma.gl/shadertools';
 
-export type FP64BenchmarkMode = 'automatic' | 'classic' | 'integer' | 'float32';
+export type FP64BenchmarkMode = 'automatic' | 'classic' | 'hybrid' | 'integer' | 'float32';
 export type FP64BenchmarkOperation = 'add' | 'multiply' | 'divide' | 'square root';
 
 type FP64ComputeBenchmarkResultBase = {
@@ -40,7 +40,13 @@ const FP64_ARITHMETIC_UNIFORM_BINDING = 100;
 // without cloning the module so future metadata remains attached.
 const FP64_BENCHMARK_MODULE: ShaderModule<any, any, any> = fp64arithmetic;
 
-const BENCHMARK_MODES: FP64BenchmarkMode[] = ['automatic', 'classic', 'integer', 'float32'];
+const BENCHMARK_MODES: FP64BenchmarkMode[] = [
+  'automatic',
+  'classic',
+  'hybrid',
+  'integer',
+  'float32'
+];
 const BENCHMARK_OPERATIONS: FP64BenchmarkOperation[] = ['add', 'multiply', 'divide', 'square root'];
 
 type BenchmarkInputs = {
@@ -163,6 +169,9 @@ function makeComputation(
   const useFloat32 = mode === 'float32';
   const defines: Record<string, boolean | number> = {};
   if (mode === 'classic') {
+    defines['LUMA_FP64_INTEGER_ARITHMETIC'] = false;
+  } else if (mode === 'hybrid') {
+    defines['LUMA_FP64_HYBRID_ARITHMETIC'] = true;
     defines['LUMA_FP64_INTEGER_ARITHMETIC'] = false;
   } else if (mode === 'integer') {
     defines['LUMA_FP64_INTEGER_ARITHMETIC'] = true;

--- a/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl-hybrid.ts
+++ b/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl-hybrid.ts
@@ -1,0 +1,129 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {fp64arithmeticWGSLIntegerPrimitives} from './fp64-arithmetic-wgsl-integer';
+
+/**
+ * Optimizer-resistant double-single arithmetic that reconstructs the critical
+ * high-part residuals with integer operations while accumulating lower-order
+ * terms with native f32 arithmetic.
+ *
+ * This deliberately trades strict correctness for substantially less integer
+ * work than the fully integer-controlled implementation.
+ */
+export const fp64arithmeticWGSLHybrid = /* wgsl */ `\
+${fp64arithmeticWGSLIntegerPrimitives}
+
+#ifndef LUMA_FP64_PREDICATE_ONLY
+fn split(a: f32) -> vec2f {
+  let aBits = bitcast<u32>(a);
+  let decoded = fp64_decode_f32_bits(aBits);
+  if (decoded.isZero || decoded.isInf || decoded.isNan) {
+    return vec2f(a, 0.0);
+  }
+
+  var roundedHigh = decoded.significand >> 12u;
+  let remainder = decoded.significand & 0xfffu;
+  if (remainder > 0x800u || (remainder == 0x800u && (roundedHigh & 1u) == 1u)) {
+    roundedHigh = roundedHigh + 1u;
+  }
+  var highMagnitude = vec2u(0u, roundedHigh << 12u);
+  var highBits = fp64_make_f32_bits_from_u64(
+    decoded.sign,
+    highMagnitude,
+    decoded.baseExponent
+  );
+  if (fp64_decode_f32_bits(highBits).isInf) {
+    roundedHigh = decoded.significand >> 12u;
+    highMagnitude = vec2u(0u, roundedHigh << 12u);
+    highBits = fp64_make_f32_bits_from_u64(
+      decoded.sign,
+      highMagnitude,
+      decoded.baseExponent
+    );
+  }
+  let lowBits = fp64_make_residual_f32_bits(
+    decoded.sign,
+    vec2u(0u, decoded.significand),
+    decoded.baseExponent,
+    highBits
+  );
+  return vec2f(bitcast<f32>(highBits), bitcast<f32>(lowBits));
+}
+
+fn split2(a: vec2f) -> vec2f {
+  var result = split(a.x);
+  result.y = result.y + a.y;
+  return result;
+}
+
+fn quickTwoSum(a: f32, b: f32) -> vec2f {
+  return fp64_two_sum_integer(a, b);
+}
+#endif
+
+fn twoSum(a: f32, b: f32) -> vec2f {
+  return fp64_two_sum_integer(a, b);
+}
+
+fn twoSub(a: f32, b: f32) -> vec2f {
+  let bBits = bitcast<u32>(b) ^ 0x80000000u;
+  let resultBits = fp64_two_sum_integer_bits(bitcast<u32>(a), bBits);
+  return vec2f(bitcast<f32>(resultBits.x), bitcast<f32>(resultBits.y));
+}
+
+#ifndef LUMA_FP64_PREDICATE_ONLY
+fn twoSqr(a: f32) -> vec2f {
+  return fp64_two_prod_integer(a, a);
+}
+
+fn twoProd(a: f32, b: f32) -> vec2f {
+  return fp64_two_prod_integer(a, b);
+}
+#endif
+
+fn sum_fp64(a: vec2f, b: vec2f) -> vec2f {
+  let highSum = fp64_two_sum_integer(a.x, b.x);
+  let lowSum = prevent_fp64_optimization((a.y + b.y) + highSum.y);
+  return fp64_two_sum_integer(highSum.x, lowSum);
+}
+
+fn sub_fp64(a: vec2f, b: vec2f) -> vec2f {
+  let highDifference = twoSub(a.x, b.x);
+  let lowDifference = prevent_fp64_optimization((a.y - b.y) + highDifference.y);
+  return fp64_two_sum_integer(highDifference.x, lowDifference);
+}
+
+fn mul_fp64(a: vec2f, b: vec2f) -> vec2f {
+  let highProduct = fp64_two_prod_integer(a.x, b.x);
+  let crossTerms = prevent_fp64_optimization(a.x * b.y + a.y * b.x);
+  let lowTerms = prevent_fp64_optimization((crossTerms + a.y * b.y) + highProduct.y);
+  return fp64_two_sum_integer(highProduct.x, lowTerms);
+}
+
+#ifndef LUMA_FP64_PREDICATE_ONLY
+fn div_fp64(a: vec2f, b: vec2f) -> vec2f {
+  let estimate = prevent_fp64_optimization(1.0 / b.x);
+  let quotient = mul_fp64(a, vec2f(estimate, fp64_runtime_zero()));
+  let remainder = prevent_fp64_optimization(sub_fp64(a, mul_fp64(b, quotient)).x);
+  return sum_fp64(quotient, twoProd(estimate, remainder));
+}
+
+fn sqrt_fp64(a: vec2f) -> vec2f {
+  if (a.x == 0.0 && a.y == 0.0) {
+    return vec2f(0.0, 0.0);
+  }
+  if (a.x < 0.0) {
+    let nanValue = fp64_nan(a.x);
+    return vec2f(nanValue, nanValue);
+  }
+
+  let reciprocalRoot = prevent_fp64_optimization(1.0 / sqrt(a.x));
+  let estimate = prevent_fp64_optimization(a.x * reciprocalRoot);
+  let difference = prevent_fp64_optimization(sub_fp64(a, twoSqr(estimate)).x);
+  let correction = twoProd(prevent_fp64_optimization(reciprocalRoot * 0.5), difference);
+  return sum_fp64(vec2f(estimate, 0.0), correction);
+}
+#endif
+`;

--- a/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl-integer.ts
+++ b/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl-integer.ts
@@ -10,7 +10,7 @@
  * This source is interpolated into fp64-arithmetic-wgsl.ts after the shared
  * integer helpers. It intentionally keeps the public vec2<f32> API unchanged.
  */
-export const fp64arithmeticWGSLInteger = /* wgsl */ `\
+export const fp64arithmeticWGSLIntegerPrimitives = /* wgsl */ `\
 struct Fp64F32Bits {
   sign: u32,
   baseExponent: i32,
@@ -290,6 +290,11 @@ fn fp64_divide_f32_integer(aValue: f32, bValue: f32) -> f32 {
 }
 #endif
 
+`;
+
+export const fp64arithmeticWGSLInteger = /* wgsl */ `\
+${fp64arithmeticWGSLIntegerPrimitives}
+
 #ifndef LUMA_FP64_PREDICATE_ONLY
 fn split(a: f32) -> vec2f {
   let aBits = bitcast<u32>(a);
@@ -363,13 +368,110 @@ fn twoProd(a: f32, b: f32) -> vec2f {
 }
 #endif
 
-fn sum_fp64(a: vec2f, b: vec2f) -> vec2f {
+struct Fp64IntegerAccumulator {
+  sign: u32,
+  magnitude: vec2u,
+};
+
+fn fp64_accumulate_f32_integer(
+  accumulator: Fp64IntegerAccumulator,
+  value: Fp64F32Bits,
+  commonBaseExponent: i32
+) -> Fp64IntegerAccumulator {
+  if (value.isZero) {
+    return accumulator;
+  }
+
+  let magnitude = fp64_u64_shift_left(
+    vec2u(0u, value.significand),
+    u32(value.baseExponent - commonBaseExponent)
+  );
+  if (fp64_u64_is_zero(accumulator.magnitude)) {
+    return Fp64IntegerAccumulator(value.sign, magnitude);
+  }
+  if (accumulator.sign == value.sign) {
+    return Fp64IntegerAccumulator(
+      accumulator.sign,
+      fp64_u64_add(accumulator.magnitude, magnitude)
+    );
+  }
+
+  let comparison = fp64_u64_compare(accumulator.magnitude, magnitude);
+  if (comparison == 0) {
+    return Fp64IntegerAccumulator(0u, vec2u(0u));
+  }
+  if (comparison > 0) {
+    return Fp64IntegerAccumulator(
+      accumulator.sign,
+      fp64_u64_sub(accumulator.magnitude, magnitude)
+    );
+  }
+  return Fp64IntegerAccumulator(
+    value.sign,
+    fp64_u64_sub(magnitude, accumulator.magnitude)
+  );
+}
+
+fn fp64_sum_integer_unfused(a: vec2f, b: vec2f) -> vec2f {
   var sum = fp64_two_sum_integer(a.x, b.x);
   let lowSum = fp64_two_sum_integer(a.y, b.y);
   sum.y = fp64_round_add_integer(sum.y, lowSum.x);
   sum = fp64_two_sum_integer(sum.x, sum.y);
   sum.y = fp64_round_add_integer(sum.y, lowSum.y);
   return fp64_two_sum_integer(sum.x, sum.y);
+}
+
+fn sum_fp64(a: vec2f, b: vec2f) -> vec2f {
+  let aHigh = fp64_decode_f32_bits(bitcast<u32>(a.x));
+  let aLow = fp64_decode_f32_bits(bitcast<u32>(a.y));
+  let bHigh = fp64_decode_f32_bits(bitcast<u32>(b.x));
+  let bLow = fp64_decode_f32_bits(bitcast<u32>(b.y));
+  if (
+    aHigh.isInf || aHigh.isNan || aLow.isInf || aLow.isNan ||
+    bHigh.isInf || bHigh.isNan || bLow.isInf || bLow.isNan
+  ) {
+    return fp64_sum_integer_unfused(a, b);
+  }
+
+  var minimumBaseExponent = 2147483647;
+  var maximumBaseExponent = -2147483647;
+  if (!aHigh.isZero) {
+    minimumBaseExponent = min(minimumBaseExponent, aHigh.baseExponent);
+    maximumBaseExponent = max(maximumBaseExponent, aHigh.baseExponent);
+  }
+  if (!aLow.isZero) {
+    minimumBaseExponent = min(minimumBaseExponent, aLow.baseExponent);
+    maximumBaseExponent = max(maximumBaseExponent, aLow.baseExponent);
+  }
+  if (!bHigh.isZero) {
+    minimumBaseExponent = min(minimumBaseExponent, bHigh.baseExponent);
+    maximumBaseExponent = max(maximumBaseExponent, bHigh.baseExponent);
+  }
+  if (!bLow.isZero) {
+    minimumBaseExponent = min(minimumBaseExponent, bLow.baseExponent);
+    maximumBaseExponent = max(maximumBaseExponent, bLow.baseExponent);
+  }
+  if (maximumBaseExponent < minimumBaseExponent) {
+    return vec2f(0.0, 0.0);
+  }
+
+  // Four 24-bit significands spanning at most 38 bits fit in the 64-bit
+  // accumulator, including the two extra carry bits needed by their sum.
+  if (maximumBaseExponent - minimumBaseExponent > 38) {
+    return fp64_sum_integer_unfused(a, b);
+  }
+
+  var accumulator = Fp64IntegerAccumulator(0u, vec2u(0u));
+  accumulator = fp64_accumulate_f32_integer(accumulator, aHigh, minimumBaseExponent);
+  accumulator = fp64_accumulate_f32_integer(accumulator, aLow, minimumBaseExponent);
+  accumulator = fp64_accumulate_f32_integer(accumulator, bHigh, minimumBaseExponent);
+  accumulator = fp64_accumulate_f32_integer(accumulator, bLow, minimumBaseExponent);
+  let resultBits = fp64_split_accumulator_bits(
+    accumulator.sign,
+    accumulator.magnitude,
+    minimumBaseExponent
+  );
+  return vec2f(bitcast<f32>(resultBits.x), bitcast<f32>(resultBits.y));
 }
 
 fn sub_fp64(a: vec2f, b: vec2f) -> vec2f {
@@ -383,11 +485,9 @@ fn sub_fp64(a: vec2f, b: vec2f) -> vec2f {
 fn mul_fp64(a: vec2f, b: vec2f) -> vec2f {
   var product = fp64_two_prod_integer(a.x, b.x);
   let crossProduct1 = fp64_round_mul_integer(a.x, b.y);
-  product.y = fp64_round_add_integer(product.y, crossProduct1);
-  product = fp64_two_sum_integer(product.x, product.y);
+  product = sum_fp64(product, vec2f(crossProduct1, 0.0));
   let crossProduct2 = fp64_round_mul_integer(a.y, b.x);
-  product.y = fp64_round_add_integer(product.y, crossProduct2);
-  return fp64_two_sum_integer(product.x, product.y);
+  return sum_fp64(product, vec2f(crossProduct2, 0.0));
 }
 
 #ifndef LUMA_FP64_PREDICATE_ONLY

--- a/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl.ts
+++ b/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {fp64arithmeticWGSLInteger} from './fp64-arithmetic-wgsl-integer';
+import {fp64arithmeticWGSLHybrid} from './fp64-arithmetic-wgsl-hybrid';
 
 /** WGSL source for fp64 arithmetic helpers and raw binary64 subtraction. */
 export const fp64arithmeticWGSL = /* wgsl */ `\
@@ -631,6 +632,9 @@ fn prevent_fp64_optimization(value: f32) -> f32 {
 #ifdef LUMA_FP64_INTEGER_ARITHMETIC
 ${fp64arithmeticWGSLInteger}
 #else
+#ifdef LUMA_FP64_HYBRID_ARITHMETIC
+${fp64arithmeticWGSLHybrid}
+#else
 fn split(a: f32) -> vec2f {
   let splitValue = prevent_fp64_optimization(fp64arithmetic.SPLIT + fp64_runtime_zero());
   let t = prevent_fp64_optimization(a * splitValue);
@@ -814,6 +818,7 @@ fn sqrt_fp64(a: vec2f) -> vec2f {
   return sum_fp64(vec2f(yn, 0.0), prod);
 #endif
 }
+#endif
 #endif
 #endif
 

--- a/modules/shadertools/test/lib/shader-assembly/assemble-wgsl-auto-bindings.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembly/assemble-wgsl-auto-bindings.spec.ts
@@ -21,6 +21,7 @@ const PLATFORM_INFO: PlatformInfo = {
 };
 
 const FP64_INTEGER_MARKER = 'fn fp64_two_sum_integer_bits';
+const FP64_HYBRID_MARKER = 'let crossTerms = prevent_fp64_optimization';
 const FP64_CLASSIC_MARKER = 'let splitValue = prevent_fp64_optimization';
 const FP64_PREDICATE_MARKERS = ['fn twoSum', 'fn twoSub', 'fn mul_fp64', 'fn sub_fp64'] as const;
 const FP64_GENERIC_VALUE_MARKERS = [
@@ -158,6 +159,28 @@ it('assembleWGSLShader#selects optimizer-independent fp64 arithmetic', () => {
   expect(
     Boolean(disabledSource.includes(FP64_INTEGER_MARKER)),
     'false override removes integer arithmetic'
+  ).toBe(false);
+
+  const hybridSource = shaderAssembler.assembleWGSLShader({
+    platformInfo: {...PLATFORM_INFO, gpu: 'apple'},
+    source: APP_WGSL,
+    modules: [fp64arithmetic],
+    defines: {
+      LUMA_FP64_HYBRID_ARITHMETIC: true,
+      LUMA_FP64_INTEGER_ARITHMETIC: false
+    }
+  }).source;
+  expect(
+    Boolean(hybridSource.includes(FP64_INTEGER_MARKER)),
+    'hybrid mode retains integer primitives'
+  ).toBe(true);
+  expect(
+    Boolean(hybridSource.includes(FP64_HYBRID_MARKER)),
+    'callers can select hybrid arithmetic'
+  ).toBe(true);
+  expect(
+    Boolean(hybridSource.includes(FP64_CLASSIC_MARKER)),
+    'hybrid mode omits classic arithmetic'
   ).toBe(false);
 
   void 0;

--- a/test/examples/fp64-responsive-layout.node.spec.ts
+++ b/test/examples/fp64-responsive-layout.node.spec.ts
@@ -10,6 +10,7 @@ import FP64App, {
   getVisualizationDefines,
   makeFP64SettingsSchema
 } from '../../examples/experimental/fp64/app';
+import {requiresFP64ArithmeticUniform} from '../../examples/experimental/fp64/fp64-compute-benchmark';
 
 describe('FP64 example responsive layout', () => {
   test('keeps each precision description paired with its canvas when the panes stack', () => {
@@ -69,6 +70,14 @@ describe('FP64 example responsive layout', () => {
     expect(formatFP64RenderTiming({milliseconds: 0.25, source: 'CPU encode'})).toBe(
       'fp64 CPU encode = 0.250 ms · 4000.0 FPS-equivalent'
     );
+  });
+
+  test('binds the fp64 module uniform for every benchmark path that reads it', () => {
+    expect(requiresFP64ArithmeticUniform('hybrid', 'divide', 'apple')).toBe(true);
+    expect(requiresFP64ArithmeticUniform('hybrid', 'multiply', 'apple')).toBe(false);
+    expect(requiresFP64ArithmeticUniform('automatic', 'divide', 'apple')).toBe(false);
+    expect(requiresFP64ArithmeticUniform('automatic', 'divide', 'nvidia')).toBe(true);
+    expect(requiresFP64ArithmeticUniform('classic', 'add', 'nvidia')).toBe(false);
   });
 
   test('selects explicit FP64 arithmetic modes on WebGPU', () => {

--- a/test/examples/fp64-responsive-layout.node.spec.ts
+++ b/test/examples/fp64-responsive-layout.node.spec.ts
@@ -6,6 +6,7 @@ import React from 'react';
 import {renderToStaticMarkup} from 'react-dom/server';
 import {describe, expect, test} from 'vitest';
 import FP64App, {
+  formatFP64RenderTiming,
   getVisualizationDefines,
   makeFP64SettingsSchema
 } from '../../examples/experimental/fp64/app';
@@ -21,6 +22,7 @@ describe('FP64 example responsive layout', () => {
     expect(markup).toContain(
       'grid-template-columns:repeat(auto-fit, minmax(min(100%, 320px), 1fr))'
     );
+    expect(markup.match(/grid-template-rows:1fr auto/g)?.length).toBe(2);
     expect(singlePrecisionPane).toBeGreaterThanOrEqual(0);
     expect(singlePrecisionCanvas).toBeGreaterThan(singlePrecisionPane);
     expect(doublePrecisionPane).toBeGreaterThan(singlePrecisionCanvas);
@@ -40,6 +42,8 @@ describe('FP64 example responsive layout', () => {
     const settings = makeFP64SettingsSchema().sections.flatMap(section => section.settings);
     const backendSetting = settings.find(setting => setting.name === 'selectedBackend');
     const arithmeticSetting = settings.find(setting => setting.name === 'selectedArithmeticMode');
+    const zoomSetting = settings.find(setting => setting.name === 'zoomDepth');
+    const renderWidthSetting = settings.find(setting => setting.name === 'renderWidth');
 
     expect(backendSetting?.options).toContainEqual({label: 'WebGL2', value: 'webgl'});
     expect(arithmeticSetting?.options).toEqual([
@@ -47,8 +51,23 @@ describe('FP64 example responsive layout', () => {
       {label: 'Hybrid · balanced', value: 'hybrid'},
       {label: 'Integer · reliable', value: 'integer'}
     ]);
+    expect(zoomSetting).toEqual(
+      expect.objectContaining({type: 'number', min: 0, step: 0.1, sliderDebounceMs: 0})
+    );
+    expect(renderWidthSetting).toEqual(
+      expect.objectContaining({type: 'number', min: 160, max: 640, step: 20})
+    );
     expect(makeFP64SettingsSchema(false).sections[0].settings).not.toContainEqual(
       expect.objectContaining({name: 'selectedBackend'})
+    );
+  });
+
+  test('formats render time as an explicitly labeled FPS-equivalent', () => {
+    expect(formatFP64RenderTiming({milliseconds: 4, source: 'GPU completion'})).toBe(
+      'fp64 GPU completion = 4.00 ms · 250.0 FPS-equivalent'
+    );
+    expect(formatFP64RenderTiming({milliseconds: 0.25, source: 'CPU encode'})).toBe(
+      'fp64 CPU encode = 0.250 ms · 4000.0 FPS-equivalent'
     );
   });
 

--- a/test/examples/fp64-responsive-layout.node.spec.ts
+++ b/test/examples/fp64-responsive-layout.node.spec.ts
@@ -5,7 +5,10 @@
 import React from 'react';
 import {renderToStaticMarkup} from 'react-dom/server';
 import {describe, expect, test} from 'vitest';
-import FP64App from '../../examples/experimental/fp64/app';
+import FP64App, {
+  getVisualizationDefines,
+  makeFP64SettingsSchema
+} from '../../examples/experimental/fp64/app';
 
 describe('FP64 example responsive layout', () => {
   test('keeps each precision description paired with its canvas when the panes stack', () => {
@@ -31,5 +34,42 @@ describe('FP64 example responsive layout', () => {
     expect(markup).toContain('left:12px;right:12px;bottom:12px;box-sizing:border-box');
     expect(markup).toContain('max-width:calc(100% - 24px)');
     expect(markup.match(/overflow-wrap:anywhere/g)?.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('offers an explicit WebGL2 backend for standalone rendering', () => {
+    const settings = makeFP64SettingsSchema().sections.flatMap(section => section.settings);
+    const backendSetting = settings.find(setting => setting.name === 'selectedBackend');
+    const arithmeticSetting = settings.find(setting => setting.name === 'selectedArithmeticMode');
+
+    expect(backendSetting?.options).toContainEqual({label: 'WebGL2', value: 'webgl'});
+    expect(arithmeticSetting?.options).toEqual([
+      {label: 'Classic · fast', value: 'classic'},
+      {label: 'Hybrid · balanced', value: 'hybrid'},
+      {label: 'Integer · reliable', value: 'integer'}
+    ]);
+    expect(makeFP64SettingsSchema(false).sections[0].settings).not.toContainEqual(
+      expect.objectContaining({name: 'selectedBackend'})
+    );
+  });
+
+  test('selects explicit FP64 arithmetic modes on WebGPU', () => {
+    const appleWebGPUDevice = {info: {gpu: 'apple' as const}, type: 'webgpu' as const};
+    const otherWebGPUDevice = {info: {gpu: 'nvidia' as const}, type: 'webgpu' as const};
+    const webGLDevice = {info: {gpu: 'apple' as const}, type: 'webgl' as const};
+
+    expect(getVisualizationDefines(appleWebGPUDevice, 'fp32', 'hybrid')).toEqual({});
+    expect(getVisualizationDefines(appleWebGPUDevice, 'fp64', 'hybrid')).toEqual({
+      LUMA_FP64_HYBRID_ARITHMETIC: true,
+      LUMA_FP64_INTEGER_ARITHMETIC: false
+    });
+    expect(getVisualizationDefines(otherWebGPUDevice, 'fp64', 'classic')).toEqual({
+      LUMA_FP64_HYBRID_ARITHMETIC: false,
+      LUMA_FP64_INTEGER_ARITHMETIC: false
+    });
+    expect(getVisualizationDefines(otherWebGPUDevice, 'fp64', 'integer')).toEqual({
+      LUMA_FP64_HYBRID_ARITHMETIC: false,
+      LUMA_FP64_INTEGER_ARITHMETIC: true
+    });
+    expect(getVisualizationDefines(webGLDevice, 'fp64', 'integer')).toEqual({});
   });
 });

--- a/website/content/examples/experimental/fp64.mdx
+++ b/website/content/examples/experimental/fp64.mdx
@@ -30,12 +30,13 @@ import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs
         `@luma.gl/shadertools`.
       </div>
       <div style={{marginBottom: 12}}>
-        On Apple WebGPU/Metal, `fp64arithmetic` automatically selects an integer-controlled
+        On Apple WebGPU/Metal, automatic arithmetic selection uses an integer-controlled
         double-single implementation. That reliable path is too expensive for an iterative
-        per-pixel Mandelbrot shader, so the live FP64 pane uses a hybrid path: integer operations
-        reconstruct the critical high-part residuals while native `f32` accumulates lower-order
-        terms. The benchmark still exercises the fully reliable path. Other GPUs use the classic
-        floating-point error transforms by default.
+        per-pixel Mandelbrot shader, so the live FP64 pane defaults to a hybrid path on every
+        WebGPU backend: integer operations reconstruct the critical high-part residuals while
+        native `f32` accumulates lower-order terms. The benchmark still exercises the fully
+        reliable path, and its automatic mode uses classic floating-point error transforms on
+        non-Apple GPUs.
       </div>
       <div style={{marginBottom: 12}}>
         The opt-in WebGPU benchmark below the canvases compares automatic selection, classic,

--- a/website/content/examples/experimental/fp64.mdx
+++ b/website/content/examples/experimental/fp64.mdx
@@ -31,14 +31,17 @@ import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs
       </div>
       <div style={{marginBottom: 12}}>
         On Apple WebGPU/Metal, `fp64arithmetic` automatically selects an integer-controlled
-        double-single implementation. Other GPUs use the classic floating-point error transforms by
-        default.
+        double-single implementation. That reliable path is too expensive for an iterative
+        per-pixel Mandelbrot shader, so the live FP64 pane uses a hybrid path: integer operations
+        reconstruct the critical high-part residuals while native `f32` accumulates lower-order
+        terms. The benchmark still exercises the fully reliable path. Other GPUs use the classic
+        floating-point error transforms by default.
       </div>
       <div style={{marginBottom: 12}}>
-        The opt-in WebGPU benchmark below the canvases compares automatic selection, both explicit
-        double-single paths, and native float32 for add, multiply, divide, and square-root compute
-        workloads. It reports timing and numerical error together; the results are diagnostic and do
-        not impose performance thresholds.
+        The opt-in WebGPU benchmark below the canvases compares automatic selection, classic,
+        hybrid, fully integer-controlled, and native float32 arithmetic for add, multiply, divide,
+        and square-root compute workloads. It reports timing and numerical error together; the
+        results are diagnostic and do not impose performance thresholds.
       </div>
     </div>
   </ExampleHeader>


### PR DESCRIPTION
## Summary

- add a generic hybrid WGSL double-single arithmetic mode with integer-controlled high residuals and native low-term accumulation
- optimize the fully integer path with fused sign-magnitude accumulation
- add WebGPU, WebGL2, and fp64 arithmetic selectors to the Mandelbrot example
- replace automatic zoom with a shared zoom slider, add shared render-buffer resolution control, and align the two canvases with CSS grid
- show sampled fp64 queue-completion time and its FPS-equivalent without building a GPU work backlog
- stabilize Mandelbrot coloring and expand fp64 benchmark coverage

## Verification

- yarn lint fix
- yarn build
- yarn test-node test/examples/fp64-responsive-layout.node.spec.ts (full node suite: 3195 passed, 1 skipped)
- yarn examples:typecheck
- embedded-browser layout check: canvas tops aligned exactly; CSS canvases remained 602 x 401.3 while both drawing buffers resized to 240 x 160

## Browser note

The embedded browser GPU process later disabled both WebGPU and WebGL2 after repeated Apple timestamp-query experiments. The final implementation removes live timestamp queries and uses queue completion timing instead. A fresh browser process is required to rerun final GPU rendering locally.