### PR TITLE
feat(arrow): add GPU-compiled path accessors POC

### DIFF
--- a/modules/arrow/src/arrow/gpu/arrow-gpu-analytics-adapters.ts
+++ b/modules/arrow/src/arrow/gpu/arrow-gpu-analytics-adapters.ts
@@ -4,6 +4,7 @@
 
 import {Buffer, type Device} from '@luma.gl/core';
 import {GPUData, GPUVector, type GPUVectorBufferProps} from '@luma.gl/gpgpu/gpu-data';
+import {GPUDataFrame} from '@luma.gl/experimental/gpu-dataframe';
 import {
   GPURecordBatch,
   GPUTable,
@@ -100,6 +101,14 @@ export function makeGPUAnalyticsTableFromArrowTable<T extends TypeMap>(
   options?: GPUAnalyticsTableFromArrowTableProps<GPUAnalyticsTypeMapForArrow<T>>
 ): GPUAnalyticsTableFromArrowTableResult<GPUAnalyticsTypeMapForArrow<T>>;
 export function makeGPUAnalyticsTableFromArrowTable<T extends GPUTypeMap = GPUTypeMap>(
+  device: Device,
+  table: Table,
+  options: GPUAnalyticsTableFromArrowTableProps<T> = {}
+): GPUAnalyticsTableFromArrowTableResult<T> {
+  return makeGPUAnalyticsTableFromArrowTableImpl(device, table, options);
+}
+
+function makeGPUAnalyticsTableFromArrowTableImpl<T extends GPUTypeMap = GPUTypeMap>(
   device: Device,
   table: Table,
   options: GPUAnalyticsTableFromArrowTableProps<T> = {}
@@ -206,6 +215,34 @@ export function makeGPUAnalyticsTableFromArrowTable<T extends GPUTypeMap = GPUTy
     }
     for (const data of allocatedValidityData) {
       data.destroy();
+    }
+    throw error;
+  }
+}
+
+/**
+ * Uploads selected Arrow columns into an owned GPUDataFrame ready for compiled GPU expressions.
+ *
+ * The returned dataframe owns the uploaded values and validity vectors. Immutable query views keep
+ * those resources alive, so applications can destroy the source dataframe after compilation.
+ */
+export function makeGPUDataFrameFromArrowTable<T extends TypeMap>(
+  device: Device,
+  table: Table<T>,
+  options?: GPUAnalyticsTableFromArrowTableProps<GPUAnalyticsTypeMapForArrow<T>>
+): GPUDataFrame<GPUAnalyticsTypeMapForArrow<T>>;
+export function makeGPUDataFrameFromArrowTable<T extends GPUTypeMap = GPUTypeMap>(
+  device: Device,
+  table: Table,
+  options: GPUAnalyticsTableFromArrowTableProps<T> = {}
+): GPUDataFrame<T> {
+  const uploaded = makeGPUAnalyticsTableFromArrowTableImpl<T>(device, table, options);
+  try {
+    return new GPUDataFrame<T>({...uploaded, ownership: 'owned'});
+  } catch (error) {
+    uploaded.table.destroy();
+    for (const validity of Object.values(uploaded.validity)) {
+      validity?.destroy();
     }
     throw error;
   }

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -227,6 +227,7 @@ export {
   type PrepareArrowInputProps
 } from './arrow/gpu/arrow-input-schema';
 export {
+  makeGPUDataFrameFromArrowTable,
   makeGPUAnalyticsTableFromArrowTable,
   type GPUAnalyticsDictionary,
   type GPUAnalyticsTableFromArrowTableProps,

--- a/modules/arrow/test/arrow/arrow-gpu-analytics-adapters.node.spec.ts
+++ b/modules/arrow/test/arrow/arrow-gpu-analytics-adapters.node.spec.ts
@@ -6,9 +6,11 @@ import {readFileSync} from 'node:fs';
 
 import {
   makeArrowTableFromGPUAnalyticsTable,
-  makeGPUAnalyticsTableFromArrowTable
+  makeGPUAnalyticsTableFromArrowTable,
+  makeGPUDataFrameFromArrowTable
 } from '@luma.gl/arrow';
 import {Buffer, type BufferProps} from '@luma.gl/core';
+import {GPUDataFrame} from '@luma.gl/experimental/gpu-dataframe';
 import {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {GPURecordBatch, GPUTable} from '@luma.gl/experimental/gpu-tables';
 import {NullDevice} from '@luma.gl/test-utils';
@@ -38,6 +40,30 @@ describe('makeGPUAnalyticsTableFromArrowTable package boundaries', () => {
     expect(packageJson.dependencies?.['@luma.gl/experimental']).toBeDefined();
     expect(packageJson.dependencies?.['@luma.gl/tables']).toBeUndefined();
     expect(packageJson.peerDependencies?.['@luma.gl/experimental']).toBeUndefined();
+  });
+});
+
+describe('makeGPUDataFrameFromArrowTable GPU accessor source', () => {
+  test('creates an owned dataframe without submitting GPU work or changing Arrow batches', () => {
+    const device = new NullDevice({id: 'arrow-gpu-dataframe-source'});
+    const submit = vi.spyOn(device, 'submit');
+    const frame = makeGPUDataFrameFromArrowTable(device, createAnalyticsTable(), {
+      columns: ['fare', 'zone']
+    });
+
+    expect(frame).toBeInstanceOf(GPUDataFrame);
+    expect(frame.ownership).toBe('owned');
+    expect(frame.columnNames).toEqual(['fare', 'zone']);
+    expect(frame.batches.map(batch => batch.numRows)).toEqual([2, 0, 3]);
+    expect(frame.sourceInfo).toEqual([
+      {sourceBatchIndex: 0, sourceRowIndexOffset: 0, sourceRowCount: 2},
+      {sourceBatchIndex: 1, sourceRowIndexOffset: 2, sourceRowCount: 0},
+      {sourceBatchIndex: 2, sourceRowIndexOffset: 2, sourceRowCount: 3}
+    ]);
+    expect(submit).not.toHaveBeenCalled();
+
+    frame.destroy();
+    submit.mockRestore();
   });
 });
 

--- a/modules/arrow/test/arrow/arrow-path-model.spec.ts
+++ b/modules/arrow/test/arrow/arrow-path-model.spec.ts
@@ -15,7 +15,7 @@ import {
   type ArrowPathSourceVectors,
   type PreparedArrowPathGPUVectors
 } from '@luma.gl/arrow';
-import type {Device, RenderPass, ShaderLayout} from '@luma.gl/core';
+import type {Buffer, Device, RenderPass, ShaderLayout} from '@luma.gl/core';
 import {type GPUVector, type GPUVectorFormat} from '@luma.gl/gpgpu/gpu-data';
 import {
   PathAttributeModel,
@@ -842,6 +842,11 @@ it('PathStorageModel emits indexed compute-generated segment records', async () 
     ...pathProps
   });
   const compactPathBytes = await model.compactPathVertexData.readAsync();
+  const visibilityBytes = await (model.rowVisibilityBinding as Buffer).readAsync();
+  expect(
+    Array.from(new Uint32Array(visibilityBytes.buffer, visibilityBytes.byteOffset, 2)),
+    'default visibility allocates one visible flag for every source path row'
+  ).toEqual([1, 1]);
   const generatedPathWords = new Uint32Array(
     compactPathBytes.buffer,
     compactPathBytes.byteOffset,
@@ -1079,9 +1084,10 @@ it('PathStorageModel uses a shared zero origin when view origins are absent', as
     ...pathProps
   });
 
-  expect(model.rowStorageByteLength, 'default row storage does not allocate origins per row').toBe(
-    76
-  );
+  expect(
+    model.rowStorageByteLength,
+    'default row storage shares one origin while retaining one visibility flag per row'
+  ).toBe(80);
   expect(model.pathRangeByteLength, 'path ranges account for per-row storage separately').toBe(32);
 
   model.destroy();

--- a/modules/arrow/test/arrow/arrow-path-model.spec.ts
+++ b/modules/arrow/test/arrow/arrow-path-model.spec.ts
@@ -65,6 +65,13 @@ it('Arrow path-family models declare prepared GPU input schemas', () => {
     [
       ...PathAttributeModel.gpuInputSchema.slice(0, 3),
       {
+        columnName: 'visibility',
+        kind: 'scalars',
+        required: false,
+        formats: ['uint32'],
+        internal: true
+      },
+      {
         columnName: 'timestamps',
         kind: 'time',
         required: false,
@@ -78,6 +85,13 @@ it('Arrow path-family models declare prepared GPU input schemas', () => {
     'Trips storage paths require prepared timestamps'
   ).toEqual([
     ...PathAttributeModel.gpuInputSchema.slice(0, 3),
+    {
+      columnName: 'visibility',
+      kind: 'scalars',
+      required: false,
+      formats: ['uint32'],
+      internal: true
+    },
     {
       columnName: 'timestamps',
       kind: 'time',
@@ -1066,7 +1080,7 @@ it('PathStorageModel uses a shared zero origin when view origins are absent', as
   });
 
   expect(model.rowStorageByteLength, 'default row storage does not allocate origins per row').toBe(
-    72
+    76
   );
   expect(model.pathRangeByteLength, 'path ranges account for per-row storage separately').toBe(32);
 

--- a/modules/deck-arrow-layers/README.md
+++ b/modules/deck-arrow-layers/README.md
@@ -9,6 +9,52 @@ The layers intentionally do not use deck.gl `AttributeManager` for Arrow columns
 Arrow data is converted once into `GPUVector`/`GPUTable` inputs and bound directly
 to luma.gl models.
 
+## GPU-compiled Arrow accessors (POC)
+
+On WebGPU, `ArrowPathLayer` can consume a derived `float32` width vector and the canonical
+`uint32` selection mask from a compiled `GPUDataFrame` query. Re-encoding the query with new
+parameters rewrites the same GPU output allocations: Arrow source columns remain resident, path
+geometry is not expanded again, and no JavaScript accessor loop or CPU readback is required.
+
+```ts
+import {ArrowPathLayer} from '@deck.gl-community/arrow-layers';
+import {makeGPUDataFrameFromArrowTable} from '@luma.gl/arrow';
+import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
+import {
+  column,
+  parameter,
+  type GPUDataFrameQueryParameters
+} from '@luma.gl/experimental/gpu-dataframe';
+
+const frame = makeGPUDataFrameFromArrowTable(device, arrowTable, {columns: ['width']});
+const accessors = frame
+  .withColumn('renderWidth', column('width').multiply(parameter('widthScale', 1)), {
+    format: 'float32'
+  })
+  .filter(column('renderWidth').greaterThan(parameter('minimumWidth', 0)))
+  .select(['renderWidth'])
+  .compile(new GPUCommandGraph<GPUDataFrameQueryParameters>(device));
+
+frame.destroy(); // The compiled query retains its source lease.
+
+const commandEncoder = device.createCommandEncoder();
+accessors.encode(commandEncoder, {widthScale: 2, minimumWidth: 0.5});
+device.submit(commandEncoder.finish());
+
+const layer = new ArrowPathLayer({
+  id: 'gpu-accessor-paths',
+  data: arrowTable,
+  paths: 'path',
+  model: 'storage',
+  width: accessors.table.gpuVectors.renderWidth,
+  visibility: accessors.selectionMask
+});
+```
+
+The layer borrows the query outputs. Destroy `accessors` only after the layer stops using them.
+`visibility` is intentionally a WebGPU storage-model input; zero hides the row while retaining its
+stable source index for picking and optional deferred CPU row resolution.
+
 ## When to use graph layers
 
 Use the graph adapters when a deck.gl application already owns GPU-resident relationship data and

--- a/modules/deck-arrow-layers/src/index.ts
+++ b/modules/deck-arrow-layers/src/index.ts
@@ -12,6 +12,7 @@ export {
   ArrowPathLayer,
   type ArrowPathColorInput,
   type ArrowPathLayerProps,
+  type ArrowPathVisibilityInput,
   type ArrowPathWidthInput
 } from './layers/arrow-path-layer';
 export {

--- a/modules/deck-arrow-layers/src/layers/arrow-path-layer.ts
+++ b/modules/deck-arrow-layers/src/layers/arrow-path-layer.ts
@@ -76,6 +76,8 @@ type ArrowPathWidthSource = ArrowLayerColumnSource<Float32, 'float32'>;
 export type ArrowPathColorInput = ArrowLayerInput<ArrowPathColor, ArrowPathColorSource>;
 /** Constant, Arrow column, or GPU column accepted by ArrowPathLayer.width. */
 export type ArrowPathWidthInput = ArrowLayerInput<number, ArrowPathWidthSource>;
+/** GPU-resident source-row visibility flags accepted by ArrowPathLayer on WebGPU. */
+export type ArrowPathVisibilityInput = GPUVector<'uint32'>;
 
 const DEFAULT_PATH_COLOR: ArrowPathColor = [199, 219, 245, 255];
 const DEFAULT_PATH_WIDTH = 0.0035;
@@ -287,6 +289,7 @@ ${DECK_ARROW_WGSL_COLOR_UTILS}
 @group(0) @binding(auto) var<storage, read> pathRowColors: array<u32>;
 @group(0) @binding(auto) var<storage, read> pathVertexColors: array<u32>;
 @group(0) @binding(auto) var<storage, read> pathRowWidths: array<f32>;
+@group(0) @binding(auto) var<storage, read> pathRowVisibility: array<u32>;
 
 struct PathStorageStyleConfig {
   constantColor: vec4<f32>,
@@ -398,8 +401,9 @@ fn vertexMain(
   outputs.visible = select(
     0.0,
     1.0,
-    inputs.temporalEnabled < 0.5 ||
-      (endMeasure >= inputs.currentTime - inputs.trailLength && startMeasure <= inputs.currentTime)
+    pathRowVisibility[localRowIndex] != 0u &&
+      (inputs.temporalEnabled < 0.5 ||
+        (endMeasure >= inputs.currentTime - inputs.trailLength && startMeasure <= inputs.currentTime))
   );
   return outputs;
 }
@@ -432,6 +436,8 @@ export type ArrowPathLayerProps = Omit<LayerProps, 'data'> &
     color?: ArrowPathColorInput;
     /** Constant width, width source, or width source with an explicit null replacement. */
     width?: ArrowPathWidthInput;
+    /** GPU-resident source-row visibility mask; zero hides a path without CPU filtering. */
+    visibility?: ArrowPathVisibilityInput;
     /** Current path measure used by temporal trail filtering. */
     currentTime?: number;
     /** Visible temporal trail length in path measure units. */
@@ -494,7 +500,9 @@ export class ArrowPathLayer extends Layer<ArrowPathLayerProps> {
       props.paths !== oldProps.paths ||
       props.model !== oldProps.model ||
       props.color !== oldProps.color ||
-      props.width !== oldProps.width;
+      props.width !== oldProps.width ||
+      props.visibility !== oldProps.visibility;
+
     if (sourceChanged) {
       state.sourceInitialized = true;
       void this.loadSource(props);
@@ -643,6 +651,12 @@ export class ArrowPathLayer extends Layer<ArrowPathLayerProps> {
     if (isArrowLayerGPUVector(widthSource)) {
       assertArrowLayerGPUVector('ArrowPathLayer width', widthSource, ['float32']);
     }
+    if (props.visibility) {
+      if (model !== 'storage') {
+        throw new Error('ArrowPathLayer GPU visibility requires the WebGPU storage model');
+      }
+      assertArrowLayerGPUVector('ArrowPathLayer visibility', props.visibility, ['uint32']);
+    }
     const colorSelector =
       model === 'storage' && isArrowLayerGPUVector(colorSource)
         ? undefined
@@ -685,6 +699,9 @@ export class ArrowPathLayer extends Layer<ArrowPathLayerProps> {
       model === 'storage' && isArrowLayerGPUVector(widthSource)
         ? getPathStorageGPUVectorBatch(widthSource, batchIndex, sourceVectors.paths.length)
         : prepared.widths;
+    const preparedVisibilityColumn = props.visibility
+      ? getPathStorageGPUVectorBatch(props.visibility, batchIndex, sourceVectors.paths.length)
+      : undefined;
     const colorColumn =
       preparedColorColumn ??
       new GPUConstant({format: 'unorm8x4', value: new Uint8Array(colorNullValue)});
@@ -718,6 +735,7 @@ export class ArrowPathLayer extends Layer<ArrowPathLayerProps> {
           attributes: constantStyle.attributes,
           ...(colorColumn instanceof GPUVector ? {colors: colorColumn} : {color: colorNullValue}),
           ...(widthColumn instanceof GPUVector ? {widths: widthColumn} : {width: widthNullValue}),
+          ...(preparedVisibilityColumn ? {visibility: preparedVisibilityColumn} : {}),
           topology: 'triangle-list',
           vertexCount: 6
         });
@@ -901,7 +919,7 @@ function hasArrowDataNulls(data: Data): boolean {
 }
 
 function getPathStorageGPUVectorBatch<
-  Format extends 'unorm8x4' | VertexList<'unorm8x4'> | 'float32'
+  Format extends 'unorm8x4' | VertexList<'unorm8x4'> | 'float32' | 'uint32'
 >(vector: GPUVector<Format>, batchIndex: number, expectedRowCount: number): GPUVector<Format> {
   const useWholeVector =
     vector.data.length === 1 && batchIndex === 0 && vector.length === expectedRowCount;

--- a/modules/deck-arrow-layers/test/layers/arrow-layers.spec.ts
+++ b/modules/deck-arrow-layers/test/layers/arrow-layers.spec.ts
@@ -4,10 +4,17 @@
 
 import {Deck, OrthographicView, type Layer, type PickingInfo} from '@deck.gl/core';
 import {ArrowPathLayer, ArrowPolygonLayer, ArrowTextLayer} from '@deck.gl-community/arrow-layers';
-import {makeGPUVectorFromArrow} from '@luma.gl/arrow';
+import {makeGPUDataFrameFromArrowTable, makeGPUVectorFromArrow} from '@luma.gl/arrow';
+import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
+import {
+  column,
+  parameter,
+  type GPUDataFrameQueryParameters
+} from '@luma.gl/experimental/gpu-dataframe';
 import {expect, it} from 'vitest';
-import type {Device} from '@luma.gl/core';
+import {Buffer, type Device} from '@luma.gl/core';
 import type {Model} from '@luma.gl/engine';
+import type {GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {ShaderAssembler} from '@luma.gl/shadertools';
 import {buildBitmapFontAtlas} from '@luma.gl/text';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
@@ -26,6 +33,19 @@ const TEST_MODEL_TIMEOUT_MILLISECONDS = 10_000;
 const TEXT_FONT_ATLAS = buildBitmapFontAtlas({
   characterSet: ' ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/-'
 });
+
+async function readGPUUint32Vector(vector: GPUVector<'uint32'>): Promise<number[][]> {
+  return Promise.all(
+    vector.data.map(async data => {
+      const buffer = data.buffer instanceof Buffer ? data.buffer : data.buffer.buffer;
+      const bytes = await buffer.readAsync(
+        data.byteOffset,
+        data.length * Uint32Array.BYTES_PER_ELEMENT
+      );
+      return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, data.length));
+    })
+  );
+}
 let sharedStorageDeck: {deck: Deck; parent: HTMLDivElement} | null = null;
 let restoreLegacyDeckShaderAssembler: (() => void) | null = null;
 
@@ -405,6 +425,101 @@ it('ArrowPathLayer storage draws streamed batches incrementally and preserves pi
       ).toBe(false);
     }
     callerColorVector.destroy();
+  }
+  void 0;
+});
+
+it('ArrowPathLayer consumes GPU-compiled Arrow width and visibility without rebuilding paths', async () => {
+  const device = await getWebGPUTestDevice('core');
+  if (!device || isSoftwareBackedDevice(device)) {
+    void 0;
+    void 0;
+    return;
+  }
+  const source = makeArrowLineSourceData(
+    {pathCount: 12, pointCount: 8, label: 'GPU accessor paths'},
+    'lines',
+    'float32',
+    'row-colors',
+    'none',
+    6
+  );
+  const sourceTable = new Table(source.sourceVectors);
+  const frame = makeGPUDataFrameFromArrowTable(device, sourceTable, {columns: ['widths']});
+  const compiled = frame
+    .withColumn('gpuWidth', column('widths').multiply(parameter('widthScale', 1)), {
+      format: 'float32'
+    })
+    .filter(column('gpuWidth').greaterThan(parameter('minimumWidth', 0)))
+    .select(['gpuWidth'])
+    .compile(
+      new GPUCommandGraph<GPUDataFrameQueryParameters>(device, {
+        id: 'arrow-path-gpu-accessors'
+      })
+    );
+  frame.destroy();
+
+  const encode = (minimumWidth: number): void => {
+    const commandEncoder = device.createCommandEncoder({id: 'arrow-path-gpu-accessors-encode'});
+    compiled.encode(commandEncoder, {widthScale: 2, minimumWidth});
+    device.submit(commandEncoder.finish());
+  };
+  encode(0);
+
+  let dataError: unknown;
+  const layer = new ArrowPathLayer({
+    id: 'arrow-path-gpu-accessors-test',
+    pickable: true,
+    data: sourceTable,
+    paths: 'paths',
+    color: 'colors',
+    width: compiled.table.gpuVectors.gpuWidth,
+    visibility: compiled.selectionMask,
+    model: 'storage',
+    onDataError: error => {
+      dataError = error;
+    }
+  });
+  const {deck} = getSharedStorageDeck(device);
+
+  try {
+    await waitForDeckInitialization(deck);
+    deck.setProps({layers: [layer]});
+    await waitForModelCount(layer, 2, () => dataError);
+    const models = layer.getModels();
+    const generatedPathBuffers = models.map(
+      model => (model as Model & {compactPathVertexData: unknown}).compactPathVertexData
+    );
+
+    expect(
+      await readGPUUint32Vector(compiled.selectionMask),
+      'the first compiled parameter set keeps every source row visible'
+    ).toEqual([
+      [1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1]
+    ]);
+    expect(
+      models.every(model => Boolean((model as any)._getBindings().pathRowVisibility)),
+      'each preserved Arrow batch binds its GPU selection mask directly for rendering'
+    ).toBe(true);
+
+    encode(100);
+    expect(
+      await readGPUUint32Vector(compiled.selectionMask),
+      'parameter updates rewrite the resident selection mask without CPU filtering'
+    ).toEqual([
+      [0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0]
+    ]);
+    expect(
+      layer
+        .getModels()
+        .map(model => (model as Model & {compactPathVertexData: unknown}).compactPathVertexData),
+      'GPU style changes retain the compute-expanded path geometry'
+    ).toEqual(generatedPathBuffers);
+  } finally {
+    deck.setProps({layers: []});
+    compiled.destroy();
   }
   void 0;
 });

--- a/modules/experimental/src/models/path/gpu/path-storage-gpu-inputs.ts
+++ b/modules/experimental/src/models/path/gpu/path-storage-gpu-inputs.ts
@@ -32,6 +32,8 @@ export type PathStorageBatchInputs = {
   colorsBinding?: Binding;
   /** Optional read-only storage binding for Float32 path widths. */
   widthsBinding?: Binding;
+  /** Optional read-only storage binding for source-row visibility flags. */
+  visibilityBinding?: Binding;
   /** Optional read-only storage binding for prepared Float32 path timestamps. */
   timestampsBinding?: Binding;
 };
@@ -60,6 +62,7 @@ export function resolvePathStorageInputs(
     const segmentCount = recordOffsets[recordOffsets.length - 1] ?? 0;
     const colorData = props.colors?.data[batchIndex];
     const widthData = props.widths?.data[batchIndex];
+    const visibilityData = props.visibility?.data[batchIndex];
     const timestampData = props.timestamps?.data[batchIndex];
     const viewOriginData = props.viewOrigins?.data[batchIndex];
     batches.push({
@@ -88,6 +91,12 @@ export function resolvePathStorageInputs(
       widthsBinding: widthData
         ? getStorageGPUDataBinding(widthData, widthData.length * props.widths!.byteStride)
         : undefined,
+      visibilityBinding: visibilityData
+        ? getStorageGPUDataBinding(
+            visibilityData,
+            visibilityData.length * props.visibility!.byteStride
+          )
+        : undefined,
       timestampsBinding: timestampData
         ? getStorageGPUDataBinding(
             timestampData,
@@ -109,6 +118,7 @@ function assertPathStorageVectorTypes(
     paths: props.paths,
     colors: props.colors,
     widths: props.widths,
+    visibility: props.visibility,
     timestamps: props.timestamps,
     viewOrigins: props.viewOrigins
   });
@@ -119,6 +129,7 @@ function assertPathStorageVectorRowAlignment(props: PathStorageInputProps): void
     ['paths', props.paths],
     ['colors', props.colors],
     ['widths', props.widths],
+    ['visibility', props.visibility],
     ['timestamps', props.timestamps],
     ['viewOrigins', props.viewOrigins]
   ].filter(([, vector]) => vector !== undefined) as Array<[string, GPUVector]>;

--- a/modules/experimental/src/models/path/path-storage-model.ts
+++ b/modules/experimental/src/models/path/path-storage-model.ts
@@ -67,6 +67,13 @@ export const PATH_STORAGE_GPU_INPUT_SCHEMA = [
     formats: ['float32']
   },
   {
+    columnName: 'visibility',
+    kind: 'scalars',
+    required: false,
+    formats: ['uint32'],
+    internal: true
+  },
+  {
     columnName: 'timestamps',
     kind: 'time',
     required: false,
@@ -103,6 +110,7 @@ const DEFAULT_PATH_STORAGE_SOURCE = /* wgsl */ `
   @group(0) @binding(auto) var<storage, read> pathRowColors : array<u32>;
   @group(0) @binding(auto) var<storage, read> pathVertexColors : array<u32>;
   @group(0) @binding(auto) var<storage, read> pathRowWidths : array<f32>;
+  @group(0) @binding(auto) var<storage, read> pathRowVisibility : array<u32>;
 
 struct PathStorageStyleConfig {
   constantColor : vec4<f32>,
@@ -128,6 +136,7 @@ struct VertexInputs {
 struct FragmentInputs {
   @builtin(position) position : vec4<f32>,
   @location(0) color : vec4<f32>,
+  @location(1) @interpolate(flat) visible : f32,
 };
 
 fn unpackPathColor(colorWord: u32) -> vec4<f32> {
@@ -187,6 +196,7 @@ fn vertexMain(inputs: VertexInputs) -> FragmentInputs {
     1.0
   );
   outputs.color = pathStorageStyleConfig.constantColor;
+  outputs.visible = f32(pathRowVisibility[rowIndex] != 0u);
   if (pathStorageStyleConfig.useVertexColors != 0u) {
     outputs.color = mix(
       unpackPathColor(pathVertexColors[inputs.segmentStartPointIndices]),
@@ -201,6 +211,7 @@ fn vertexMain(inputs: VertexInputs) -> FragmentInputs {
 
 @fragment
 fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
+  if (inputs.visible < 0.5) { discard; }
   return inputs.color;
 }
 `;
@@ -213,6 +224,8 @@ export type PathStorageInputProps = Omit<ModelProps, 'instanceCount'> & {
   colors?: GPUVector<'unorm8x4' | VertexList<'unorm8x4'>>;
   /** Optional per-path widths, one GPU row per path. */
   widths?: GPUVector<'float32'>;
+  /** Optional source-row visibility flags; zero hides a path without compacting or readback. */
+  visibility?: GPUVector<'uint32'>;
   /** Optional per-path Float32 temporal stream aligned with path vertices. */
   timestamps?: GPUVector<VertexList<'float32'>>;
   /** Optional per-path view-space origins, one GPU row per path. */
@@ -227,7 +240,7 @@ export type PathStorageInputProps = Omit<ModelProps, 'instanceCount'> & {
 
 type PathStorageRenderProps = Omit<
   PathStorageInputProps,
-  'paths' | 'colors' | 'widths' | 'viewOrigins' | 'color' | 'width'
+  'paths' | 'colors' | 'widths' | 'visibility' | 'viewOrigins' | 'color' | 'width'
 >;
 
 /** Per-source-batch storage bindings retained by {@link PathStorageState}. */
@@ -250,6 +263,8 @@ export type PathStorageBatchState = {
   vertexColorsBinding: Binding;
   /** Read-only storage binding for Float32 path widths. */
   rowWidthsBinding: Binding;
+  /** Read-only storage binding for source-row visibility flags. */
+  rowVisibilityBinding: Binding;
   /** Optional read-only storage binding for prepared Float32 path timestamps. */
   pathTimestampsBinding?: Binding;
   /** Uniform buffer selecting row style bindings and path component count. */
@@ -300,6 +315,8 @@ export type PathStorageState = {
   vertexColorsBinding: Binding;
   /** First batch Float32 path width binding. */
   rowWidthsBinding: Binding;
+  /** First batch source-row visibility binding. */
+  rowVisibilityBinding: Binding;
   /** First batch path style config uniform buffer. */
   styleConfigBuffer: DynamicBuffer;
   /** First generated compact or legacy path segment vertex buffer. */
@@ -317,6 +334,7 @@ type PathStorageDefaultBindings = {
   colorsBinding: Binding;
   vertexColorsBinding: Binding;
   widthsBinding: Binding;
+  visibilityBinding: Binding;
   viewOriginsBinding: Binding;
   byteLength: number;
   ownedResources: PathStorageOwnedResource[];
@@ -327,6 +345,7 @@ type PathStorageBatchRowState = {
   rowColorsBinding: Binding;
   vertexColorsBinding: Binding;
   rowWidthsBinding: Binding;
+  rowVisibilityBinding: Binding;
   styleConfigBuffer: DynamicBuffer;
   ownedResources: PathStorageOwnedResource[];
   ownedByteLength: number;
@@ -366,6 +385,8 @@ export class PathStorageModel extends Model {
   vertexColorsBinding!: Binding;
   /** First batch Float32 path width binding. */
   rowWidthsBinding!: Binding;
+  /** First batch source-row visibility binding. */
+  rowVisibilityBinding!: Binding;
   /** First batch path style config uniform buffer. */
   styleConfigBuffer!: DynamicBuffer;
   /** First generated compact or legacy path segment vertex buffer. */
@@ -406,6 +427,7 @@ export class PathStorageModel extends Model {
       !nextUsesExternalState &&
       (pathProps.colors !== undefined ||
         pathProps.widths !== undefined ||
+        pathProps.visibility !== undefined ||
         pathProps.timestamps !== undefined ||
         pathProps.viewOrigins !== undefined ||
         pathProps.color !== undefined ||
@@ -492,6 +514,7 @@ export class PathStorageModel extends Model {
     this.rowColorsBinding = storageState.rowColorsBinding;
     this.vertexColorsBinding = storageState.vertexColorsBinding;
     this.rowWidthsBinding = storageState.rowWidthsBinding;
+    this.rowVisibilityBinding = storageState.rowVisibilityBinding;
     this.styleConfigBuffer = storageState.styleConfigBuffer;
     this.compactPathVertexData = storageState.compactPathVertexData;
   }
@@ -636,6 +659,7 @@ export function createPathStorageState(
     rowColorsBinding: firstBatch.rowColorsBinding,
     vertexColorsBinding: firstBatch.vertexColorsBinding,
     rowWidthsBinding: firstBatch.rowWidthsBinding,
+    rowVisibilityBinding: firstBatch.rowVisibilityBinding,
     styleConfigBuffer: firstBatch.styleConfigBuffer,
     compactPathVertexData: firstRenderBatch.compactPathVertexData,
     destroy: () => {
@@ -690,6 +714,7 @@ function createPathStorageBindings(
     pathRowColors: batch.rowColorsBinding,
     pathVertexColors: batch.vertexColorsBinding,
     pathRowWidths: batch.rowWidthsBinding,
+    pathRowVisibility: batch.rowVisibilityBinding,
     ...(batch.pathTimestampsBinding ? {pathTimestamps: batch.pathTimestampsBinding} : {}),
     pathStorageStyleConfig: batch.styleConfigBuffer
   };
@@ -778,6 +803,12 @@ function createPathStorageDefaultBindings(
     'float32',
     new Float32Array([props.width ?? DEFAULT_PATH_STORAGE_WIDTH])
   );
+  const visibilityVector = createPathStorageOwnedGpuVector(
+    device,
+    `${id}-default-row-visibility`,
+    'uint32',
+    new Uint32Array([1])
+  );
   const viewOriginsVector = createPathStorageOwnedGpuVector(
     device,
     `${id}-default-view-origins`,
@@ -788,12 +819,14 @@ function createPathStorageDefaultBindings(
     colorsBinding: getPathStorageGpuVectorBinding(colorsVector),
     vertexColorsBinding: getPathStorageGpuVectorBinding(colorsVector),
     widthsBinding: getPathStorageGpuVectorBinding(widthsVector),
+    visibilityBinding: getPathStorageGpuVectorBinding(visibilityVector),
     viewOriginsBinding: getPathStorageGpuVectorBinding(viewOriginsVector),
     byteLength:
       Uint8Array.BYTES_PER_ELEMENT * 4 +
       Float32Array.BYTES_PER_ELEMENT +
+      Uint32Array.BYTES_PER_ELEMENT +
       Float32Array.BYTES_PER_ELEMENT * 4,
-    ownedResources: [colorsVector, widthsVector, viewOriginsVector]
+    ownedResources: [colorsVector, widthsVector, visibilityVector, viewOriginsVector]
   };
 }
 
@@ -824,6 +857,7 @@ function createPathStorageBatchRowState(
         ? batchInput.colorsBinding
         : defaultBindings.vertexColorsBinding,
     rowWidthsBinding: batchInput.widthsBinding ?? defaultBindings.widthsBinding,
+    rowVisibilityBinding: batchInput.visibilityBinding ?? defaultBindings.visibilityBinding,
     styleConfigBuffer,
     ownedResources: [styleConfigBuffer],
     ownedByteLength: styleConfigData.byteLength
@@ -834,7 +868,7 @@ function createPathStorageOwnedGpuVector<FormatT extends GPUVectorFormat>(
   device: Device,
   name: string,
   format: FormatT,
-  data: Uint8Array | Float32Array
+  data: Uint8Array | Uint32Array | Float32Array
 ): GPUVector<FormatT> {
   return new GPUVector({
     type: 'buffer',
@@ -958,6 +992,7 @@ function syncPathStorageStateFirstBatch(storageState: PathStorageState): void {
   storageState.rowColorsBinding = firstBatch.rowColorsBinding;
   storageState.vertexColorsBinding = firstBatch.vertexColorsBinding;
   storageState.rowWidthsBinding = firstBatch.rowWidthsBinding;
+  storageState.rowVisibilityBinding = firstBatch.rowVisibilityBinding;
   storageState.styleConfigBuffer = firstBatch.styleConfigBuffer;
   storageState.compactPathVertexData = firstRenderBatch.compactPathVertexData;
 }

--- a/modules/experimental/src/models/path/path-storage-model.ts
+++ b/modules/experimental/src/models/path/path-storage-model.ts
@@ -334,7 +334,6 @@ type PathStorageDefaultBindings = {
   colorsBinding: Binding;
   vertexColorsBinding: Binding;
   widthsBinding: Binding;
-  visibilityBinding: Binding;
   viewOriginsBinding: Binding;
   byteLength: number;
   ownedResources: PathStorageOwnedResource[];
@@ -803,12 +802,6 @@ function createPathStorageDefaultBindings(
     'float32',
     new Float32Array([props.width ?? DEFAULT_PATH_STORAGE_WIDTH])
   );
-  const visibilityVector = createPathStorageOwnedGpuVector(
-    device,
-    `${id}-default-row-visibility`,
-    'uint32',
-    new Uint32Array([1])
-  );
   const viewOriginsVector = createPathStorageOwnedGpuVector(
     device,
     `${id}-default-view-origins`,
@@ -819,14 +812,12 @@ function createPathStorageDefaultBindings(
     colorsBinding: getPathStorageGpuVectorBinding(colorsVector),
     vertexColorsBinding: getPathStorageGpuVectorBinding(colorsVector),
     widthsBinding: getPathStorageGpuVectorBinding(widthsVector),
-    visibilityBinding: getPathStorageGpuVectorBinding(visibilityVector),
     viewOriginsBinding: getPathStorageGpuVectorBinding(viewOriginsVector),
     byteLength:
       Uint8Array.BYTES_PER_ELEMENT * 4 +
       Float32Array.BYTES_PER_ELEMENT +
-      Uint32Array.BYTES_PER_ELEMENT +
       Float32Array.BYTES_PER_ELEMENT * 4,
-    ownedResources: [colorsVector, widthsVector, visibilityVector, viewOriginsVector]
+    ownedResources: [colorsVector, widthsVector, viewOriginsVector]
   };
 }
 
@@ -846,6 +837,15 @@ function createPathStorageBatchRowState(
     usage: Buffer.UNIFORM | Buffer.COPY_DST | Buffer.COPY_SRC,
     data: styleConfigData
   });
+  const defaultVisibilityVector = batchInput.visibilityBinding
+    ? null
+    : createPathStorageOwnedGpuVector(
+        device,
+        `${props.id || 'path-storage-model'}-default-row-visibility-${batchInput.batchRowIndexBase}`,
+        'uint32',
+        new Uint32Array(batchInput.rowCount).fill(1),
+        batchInput.rowCount
+      );
   return {
     pathViewOriginsBinding: batchInput.viewOriginsBinding ?? defaultBindings.viewOriginsBinding,
     rowColorsBinding:
@@ -857,10 +857,16 @@ function createPathStorageBatchRowState(
         ? batchInput.colorsBinding
         : defaultBindings.vertexColorsBinding,
     rowWidthsBinding: batchInput.widthsBinding ?? defaultBindings.widthsBinding,
-    rowVisibilityBinding: batchInput.visibilityBinding ?? defaultBindings.visibilityBinding,
+    rowVisibilityBinding:
+      batchInput.visibilityBinding ?? getPathStorageGpuVectorBinding(defaultVisibilityVector!),
     styleConfigBuffer,
-    ownedResources: [styleConfigBuffer],
-    ownedByteLength: styleConfigData.byteLength
+    ownedResources: [
+      styleConfigBuffer,
+      ...(defaultVisibilityVector ? [defaultVisibilityVector] : [])
+    ],
+    ownedByteLength:
+      styleConfigData.byteLength +
+      (defaultVisibilityVector ? batchInput.rowCount * Uint32Array.BYTES_PER_ELEMENT : 0)
   };
 }
 
@@ -868,7 +874,8 @@ function createPathStorageOwnedGpuVector<FormatT extends GPUVectorFormat>(
   device: Device,
   name: string,
   format: FormatT,
-  data: Uint8Array | Uint32Array | Float32Array
+  data: Uint8Array | Uint32Array | Float32Array,
+  length: number = 1
 ): GPUVector<FormatT> {
   return new GPUVector({
     type: 'buffer',
@@ -879,7 +886,7 @@ function createPathStorageOwnedGpuVector<FormatT extends GPUVectorFormat>(
       data
     }),
     format,
-    length: 1,
+    length,
     ownsBuffer: true
   });
 }

--- a/modules/experimental/src/models/path/path-trips-storage-model.ts
+++ b/modules/experimental/src/models/path/path-trips-storage-model.ts
@@ -47,6 +47,13 @@ export const PATH_TRIPS_STORAGE_GPU_INPUT_SCHEMA = [
     formats: ['float32']
   },
   {
+    columnName: 'visibility',
+    kind: 'scalars',
+    required: false,
+    formats: ['uint32'],
+    internal: true
+  },
+  {
     columnName: 'timestamps',
     kind: 'time',
     required: true,
@@ -68,6 +75,7 @@ const DEFAULT_PATH_TRIPS_STORAGE_SOURCE = /* wgsl */ `
   @group(0) @binding(auto) var<storage, read> pathRowColors : array<u32>;
   @group(0) @binding(auto) var<storage, read> pathVertexColors : array<u32>;
   @group(0) @binding(auto) var<storage, read> pathRowWidths : array<f32>;
+  @group(0) @binding(auto) var<storage, read> pathRowVisibility : array<u32>;
   @group(0) @binding(auto) var<storage, read> pathTimestamps : array<f32>;
 
 struct PathStorageStyleConfig {
@@ -103,6 +111,7 @@ struct FragmentInputs {
   @builtin(position) position : vec4<f32>,
   @location(0) color : vec4<f32>,
   @location(1) time : f32,
+  @location(2) @interpolate(flat) visible : f32,
 };
 
 fn unpackPathColor(colorWord: u32) -> vec4<f32> {
@@ -177,12 +186,14 @@ fn vertexMain(inputs: VertexInputs) -> FragmentInputs {
     pathTimestamps[segmentEndPointIndex],
     useSegmentEnd
   );
+  outputs.visible = f32(pathRowVisibility[rowIndex] != 0u);
   return outputs;
 }
 
 @fragment
 fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
   if (
+    inputs.visible < 0.5 ||
     inputs.time > tripPathConfig.currentTime ||
     (tripPathConfig.fadeTrail != 0u &&
       inputs.time < tripPathConfig.currentTime - tripPathConfig.trailLength)
@@ -212,6 +223,7 @@ export class PathTripsStorageModel extends PathStorageModel {
         paths: props.paths,
         colors: props.colors,
         widths: props.widths,
+        visibility: props.visibility,
         timestamps: props.timestamps,
         viewOrigins: props.viewOrigins
       });


### PR DESCRIPTION
## Goals

Prove the T4 GPU-native accessor path from Arrow columns through reusable GPU expressions into a real deck.gl layer, without JavaScript accessor loops, CPU filtering, readback, or source re-upload.

## Changes

- add `makeGPUDataFrameFromArrowTable()` as the owned Arrow-to-GPUDataFrame entry point
- add source-row `uint32` visibility vectors to storage-backed path and trips models
- let `ArrowPathLayer` bind a compiled derived width vector and canonical selection mask directly on WebGPU
- preserve Arrow record-batch topology, stable picking row IDs, and compute-expanded path geometry across parameter updates
- document the POC ownership and re-encoding pattern

## POC scope

This intentionally reuses the existing GPUDataFrame expression, filtering, join, aggregation, and Crossfilter infrastructure. The new layer seam proves that its resident outputs can drive rendering directly; follow-ups can generalize the accessor contract across more layer properties and layer families.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn test`: all 3,199 node tests pass; the full concurrent headless run encountered unrelated intermittent GPU tests
- focused headless Arrow path/model suite: 38 tests pass
- isolated unrelated `gpu-graph-deck` retry: 4 tests pass

## Notes

`visibility` is WebGPU storage-model only. The layer borrows query output vectors; applications retain the compiled query until the layer stops consuming those buffers.
