### PR TITLE
feat(deck): establish GPUVector-first core layer family

### DIFF
--- a/modules/deck-arrow-layers/README.md
+++ b/modules/deck-arrow-layers/README.md
@@ -9,6 +9,37 @@ The layers intentionally do not use deck.gl `AttributeManager` for Arrow columns
 Arrow data is converted once into `GPUVector`/`GPUTable` inputs and bound directly
 to luma.gl models.
 
+## GPUVector-first core family
+
+Arc, Column, GridCell, Icon, Line, PointCloud, and Scatterplot follow a two-level contract:
+
+1. `@deck.gl-community/gpu-layers` renders aligned, batched, caller-owned GPUVectors.
+2. This package resolves Arrow columns, uploads adapter-owned GPUVectors, and releases them when the
+   Arrow layer changes or finalizes.
+
+```ts
+import {ArrowScatterplotLayer} from '@deck.gl-community/arrow-layers';
+
+const layer = new ArrowScatterplotLayer({
+  id: 'arrow-points',
+  data: arrowTable,
+  getPosition: 'geometry',
+  getRadius: 'radius',
+  getFillColor: 'color'
+});
+```
+
+The adapter preserves Arrow record-batch boundaries. Constants remain constants, null-containing
+columns are rejected until the caller selects an explicit replacement policy, and the GPU layer
+never observes an Arrow type. `ArrowTripsLayer` similarly converts aligned timestamp lists before
+delegating to the existing GPUVector path-storage model. `GeoArrowLayer` selects point,
+linestring, polygon, or multipolygon children from field extension metadata without converting to
+GeoJSON.
+
+This package intentionally accepts only Arrow sources. Classic JavaScript arrays and legacy binary
+attributes belong in sibling adapters rather than alternate code paths here. A future unified
+deck.gl public layer may select those adapters internally while retaining the familiar layer names.
+
 ## When to use graph layers
 
 Use the graph adapters when a deck.gl application already owns GPU-resident relationship data and

--- a/modules/deck-arrow-layers/package.json
+++ b/modules/deck-arrow-layers/package.json
@@ -22,6 +22,7 @@
   ],
   "sideEffects": false,
   "dependencies": {
+    "@deck.gl-community/gpu-layers": "9.4.0-alpha.4",
     "@deck.gl/core": "9.3.4",
     "@luma.gl/arrow": "9.4.0-alpha.4",
     "@luma.gl/core": "9.4.0-alpha.4",

--- a/modules/deck-arrow-layers/src/index.ts
+++ b/modules/deck-arrow-layers/src/index.ts
@@ -4,6 +4,40 @@
 
 export {OrthographicView, type PickingInfo} from '@deck.gl/core';
 export {
+  ArrowScatterplotLayer,
+  type ArrowScatterplotLayerProps
+} from './layers/arrow-scatterplot-layer';
+export {ArrowLineLayer, type ArrowLineLayerProps} from './layers/arrow-line-layer';
+export {ArrowArcLayer, type ArrowArcLayerProps} from './layers/arrow-arc-layer';
+export {
+  ArrowPointCloudLayer,
+  type ArrowPointCloudLayerProps
+} from './layers/arrow-point-cloud-layer';
+export {ArrowColumnLayer, type ArrowColumnLayerProps} from './layers/arrow-column-layer';
+export {
+  ArrowGridCellLayer,
+  type ArrowGridCellLayerProps
+} from './layers/arrow-grid-cell-layer';
+export {
+  ArrowIconLayer,
+  type ArrowIconLayerProps,
+  type ArrowIconMapping
+} from './layers/arrow-icon-layer';
+export {
+  ArrowTripsLayer,
+  type ArrowTripsLayerProps
+} from './layers/arrow-trips-layer';
+export {
+  ArrowSolidPolygonLayer,
+  type ArrowSolidPolygonLayerProps
+} from './layers/arrow-solid-polygon-layer';
+export {
+  GeoArrowLayer,
+  resolveGeoArrowGeometry,
+  type GeoArrowLayerGeometryType,
+  type GeoArrowLayerProps
+} from './layers/geoarrow-layer';
+export {
   ArrowPolygonLayer,
   type ArrowPolygonColorInput,
   type ArrowPolygonLayerProps

--- a/modules/deck-arrow-layers/src/layers/arrow-arc-layer.ts
+++ b/modules/deck-arrow-layers/src/layers/arrow-arc-layer.ts
@@ -1,0 +1,189 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {CompositeLayer, type Color, type UpdateParameters} from '@deck.gl/core';
+import {GPUArcLayer, type GPUArcLayerProps} from '@deck.gl-community/gpu-layers';
+import type {GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import {DataType, Table, Vector, type FixedSizeList, type Float32, type Uint8} from 'apache-arrow';
+import {
+  destroyLayerGPUVectors,
+  makeLayerGPUVectorFromArrow,
+  type ArrowGPUVectorColumnSelector,
+  type ArrowGPUVectorLayerData
+} from './arrow-gpu-layer-utils';
+
+type PositionType = FixedSizeList<Float32>;
+type ColorType = FixedSizeList<Uint8>;
+
+/** Arrow adapter props retaining deck's standard Arc accessor names. */
+export type ArrowArcLayerProps = Omit<
+  GPUArcLayerProps,
+  | 'getSourcePosition'
+  | 'getTargetPosition'
+  | 'getSourceColor'
+  | 'getTargetColor'
+  | 'getWidth'
+  | 'getHeight'
+> & {
+  data: ArrowGPUVectorLayerData;
+  getSourcePosition: ArrowGPUVectorColumnSelector<PositionType>;
+  getTargetPosition: ArrowGPUVectorColumnSelector<PositionType>;
+  getSourceColor?: Color | ArrowGPUVectorColumnSelector<ColorType>;
+  getTargetColor?: Color | ArrowGPUVectorColumnSelector<ColorType>;
+  getWidth?: number | ArrowGPUVectorColumnSelector<Float32>;
+  getHeight?: number | ArrowGPUVectorColumnSelector<Float32>;
+};
+
+type ArrowArcLayerState = {
+  sourcePositions?: GPUVector<'float32x2'>;
+  targetPositions?: GPUVector<'float32x2'>;
+  sourceColors?: GPUVector<'unorm8x4'>;
+  targetColors?: GPUVector<'unorm8x4'>;
+  widths?: GPUVector<'float32'>;
+  heights?: GPUVector<'float32'>;
+};
+
+/** Converts Arrow columns to owned GPUVectors, then delegates to GPUArcLayer. */
+export class ArrowArcLayer extends CompositeLayer<ArrowArcLayerProps> {
+  static override layerName = 'ArrowArcLayer';
+
+  override initializeState(): void {
+    this.setState({} satisfies ArrowArcLayerState);
+  }
+
+  override updateState({props, oldProps, changeFlags}: UpdateParameters<this>): void {
+    if (
+      changeFlags.dataChanged ||
+      props.getSourcePosition !== oldProps.getSourcePosition ||
+      props.getTargetPosition !== oldProps.getTargetPosition ||
+      props.getSourceColor !== oldProps.getSourceColor ||
+      props.getTargetColor !== oldProps.getTargetColor ||
+      props.getWidth !== oldProps.getWidth ||
+      props.getHeight !== oldProps.getHeight ||
+      !(this.state as ArrowArcLayerState).sourcePositions
+    ) {
+      this.destroyVectors();
+      assertPositionColumn(props.data, props.getSourcePosition, 'getSourcePosition');
+      assertPositionColumn(props.data, props.getTargetPosition, 'getTargetPosition');
+      this.setState({
+        sourcePositions: makeVector(
+          this,
+          props.data,
+          props.getSourcePosition,
+          'source-positions',
+          'float32x2'
+        ),
+        targetPositions: makeVector(
+          this,
+          props.data,
+          props.getTargetPosition,
+          'target-positions',
+          'float32x2'
+        ),
+        sourceColors: makeOptionalVector(
+          this,
+          props.data,
+          props.getSourceColor,
+          'source-colors',
+          'unorm8x4'
+        ),
+        targetColors: makeOptionalVector(
+          this,
+          props.data,
+          props.getTargetColor,
+          'target-colors',
+          'unorm8x4'
+        ),
+        widths: makeOptionalVector(this, props.data, props.getWidth, 'widths', 'float32'),
+        heights: makeOptionalVector(this, props.data, props.getHeight, 'heights', 'float32')
+      } satisfies ArrowArcLayerState);
+    }
+  }
+
+  override renderLayers(): GPUArcLayer | null {
+    const state = this.state as ArrowArcLayerState;
+    if (!state.sourcePositions || !state.targetPositions) return null;
+    const {
+      data,
+      getSourcePosition,
+      getTargetPosition,
+      getSourceColor,
+      getTargetColor,
+      getWidth,
+      getHeight,
+      ...props
+    } = this.props;
+    return new GPUArcLayer({
+      ...props,
+      id: `${this.props.id}-gpu`,
+      getSourcePosition: state.sourcePositions,
+      getTargetPosition: state.targetPositions,
+      getSourceColor: state.sourceColors ?? (isColor(getSourceColor) ? getSourceColor : undefined),
+      getTargetColor: state.targetColors ?? (isColor(getTargetColor) ? getTargetColor : undefined),
+      getWidth: state.widths ?? (typeof getWidth === 'number' ? getWidth : undefined),
+      getHeight: state.heights ?? (typeof getHeight === 'number' ? getHeight : undefined)
+    });
+  }
+
+  override finalizeState(): void {
+    this.destroyVectors();
+  }
+
+  private destroyVectors(): void {
+    destroyLayerGPUVectors(Object.values(this.state as ArrowArcLayerState));
+  }
+}
+
+function makeVector<FormatT extends 'float32x2' | 'float32' | 'unorm8x4'>(
+  layer: ArrowArcLayer,
+  data: ArrowGPUVectorLayerData,
+  selector: ArrowGPUVectorColumnSelector,
+  name: string,
+  format: FormatT
+): GPUVector<FormatT> {
+  return makeLayerGPUVectorFromArrow(layer.context.device, data, selector, {
+    name,
+    id: `${layer.id}-${name}`,
+    format
+  });
+}
+
+function makeOptionalVector<FormatT extends 'float32' | 'unorm8x4'>(
+  layer: ArrowArcLayer,
+  data: ArrowGPUVectorLayerData,
+  selector: number | Color | ArrowGPUVectorColumnSelector | undefined,
+  name: string,
+  format: FormatT
+): GPUVector<FormatT> | undefined {
+  return isSelector(selector) ? makeVector(layer, data, selector, name, format) : undefined;
+}
+
+function assertPositionColumn(
+  data: ArrowGPUVectorLayerData,
+  selector: ArrowGPUVectorColumnSelector<PositionType>,
+  name: string
+): void {
+  const vector = resolveVector(data, selector);
+  if (!DataType.isFixedSizeList(vector.type) || vector.type.listSize !== 2) {
+    throw new Error(`ArrowArcLayer ${name} must be FixedSizeList[2]`);
+  }
+}
+
+function resolveVector(
+  data: ArrowGPUVectorLayerData,
+  selector: ArrowGPUVectorColumnSelector
+): Vector {
+  if (selector instanceof Vector) return selector;
+  const vector = (data instanceof Table ? data : new Table([data])).getChild(selector);
+  if (!vector) throw new Error(`ArrowArcLayer column "${selector}" is missing`);
+  return vector;
+}
+
+function isSelector(value: unknown): value is ArrowGPUVectorColumnSelector {
+  return typeof value === 'string' || value instanceof Vector;
+}
+
+function isColor(value: unknown): value is Color {
+  return Array.isArray(value) || ArrayBuffer.isView(value);
+}

--- a/modules/deck-arrow-layers/src/layers/arrow-column-layer.ts
+++ b/modules/deck-arrow-layers/src/layers/arrow-column-layer.ts
@@ -1,0 +1,146 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {CompositeLayer, type Color, type UpdateParameters} from '@deck.gl/core';
+import {GPUColumnLayer, type GPUColumnLayerProps} from '@deck.gl-community/gpu-layers';
+import type {GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import {DataType, Table, Vector, type FixedSizeList, type Float32, type Uint8} from 'apache-arrow';
+import {
+  destroyLayerGPUVectors,
+  makeLayerGPUVectorFromArrow,
+  type ArrowGPUVectorColumnSelector,
+  type ArrowGPUVectorLayerData
+} from './arrow-gpu-layer-utils';
+
+type PositionType = FixedSizeList<Float32>;
+type ColorType = FixedSizeList<Uint8>;
+
+/** Arrow adapter props retaining deck's standard Column accessor names. */
+export type ArrowColumnLayerProps = Omit<
+  GPUColumnLayerProps,
+  'getPosition' | 'getFillColor' | 'getRadius' | 'getElevation'
+> & {
+  data: ArrowGPUVectorLayerData;
+  getPosition: ArrowGPUVectorColumnSelector<PositionType>;
+  getFillColor?: Color | ArrowGPUVectorColumnSelector<ColorType>;
+  getRadius?: number | ArrowGPUVectorColumnSelector<Float32>;
+  getElevation?: number | ArrowGPUVectorColumnSelector<Float32>;
+};
+
+type ArrowColumnLayerState = {
+  positions?: GPUVector<'float32x2'>;
+  colors?: GPUVector<'unorm8x4'>;
+  radii?: GPUVector<'float32'>;
+  elevations?: GPUVector<'float32'>;
+};
+
+/** Converts Arrow columns to owned GPUVectors, then delegates to GPUColumnLayer. */
+export class ArrowColumnLayer extends CompositeLayer<ArrowColumnLayerProps> {
+  static override layerName = 'ArrowColumnLayer';
+
+  override initializeState(): void {
+    this.setState({} satisfies ArrowColumnLayerState);
+  }
+
+  override updateState({props, oldProps, changeFlags}: UpdateParameters<this>): void {
+    if (
+      changeFlags.dataChanged ||
+      props.getPosition !== oldProps.getPosition ||
+      props.getFillColor !== oldProps.getFillColor ||
+      props.getRadius !== oldProps.getRadius ||
+      props.getElevation !== oldProps.getElevation ||
+      !(this.state as ArrowColumnLayerState).positions
+    ) {
+      this.destroyVectors();
+      assertPositionColumn(props.data, props.getPosition);
+      this.setState({
+        positions: makeVector(this, props.data, props.getPosition, 'positions', 'float32x2'),
+        colors: makeOptionalVector(this, props.data, props.getFillColor, 'colors', 'unorm8x4'),
+        radii: makeOptionalVector(this, props.data, props.getRadius, 'radii', 'float32'),
+        elevations: makeOptionalVector(
+          this,
+          props.data,
+          props.getElevation,
+          'elevations',
+          'float32'
+        )
+      } satisfies ArrowColumnLayerState);
+    }
+  }
+
+  override renderLayers(): GPUColumnLayer | null {
+    const state = this.state as ArrowColumnLayerState;
+    if (!state.positions) return null;
+    const {data, getPosition, getFillColor, getRadius, getElevation, ...props} = this.props;
+    return new GPUColumnLayer({
+      ...props,
+      id: `${this.props.id}-gpu`,
+      getPosition: state.positions,
+      getFillColor: state.colors ?? (isColor(getFillColor) ? getFillColor : undefined),
+      getRadius: state.radii ?? (typeof getRadius === 'number' ? getRadius : undefined),
+      getElevation:
+        state.elevations ?? (typeof getElevation === 'number' ? getElevation : undefined)
+    });
+  }
+
+  override finalizeState(): void {
+    this.destroyVectors();
+  }
+
+  private destroyVectors(): void {
+    destroyLayerGPUVectors(Object.values(this.state as ArrowColumnLayerState));
+  }
+}
+
+function makeVector<FormatT extends 'float32x2' | 'float32' | 'unorm8x4'>(
+  layer: ArrowColumnLayer,
+  data: ArrowGPUVectorLayerData,
+  selector: ArrowGPUVectorColumnSelector,
+  name: string,
+  format: FormatT
+): GPUVector<FormatT> {
+  return makeLayerGPUVectorFromArrow(layer.context.device, data, selector, {
+    name,
+    id: `${layer.id}-${name}`,
+    format
+  });
+}
+
+function makeOptionalVector<FormatT extends 'float32' | 'unorm8x4'>(
+  layer: ArrowColumnLayer,
+  data: ArrowGPUVectorLayerData,
+  selector: number | Color | ArrowGPUVectorColumnSelector | undefined,
+  name: string,
+  format: FormatT
+): GPUVector<FormatT> | undefined {
+  return isSelector(selector) ? makeVector(layer, data, selector, name, format) : undefined;
+}
+
+function assertPositionColumn(
+  data: ArrowGPUVectorLayerData,
+  selector: ArrowGPUVectorColumnSelector
+): void {
+  const vector = resolveVector(data, selector);
+  if (!DataType.isFixedSizeList(vector.type) || vector.type.listSize !== 2) {
+    throw new Error('ArrowColumnLayer getPosition must be FixedSizeList[2]');
+  }
+}
+
+function resolveVector(
+  data: ArrowGPUVectorLayerData,
+  selector: ArrowGPUVectorColumnSelector
+): Vector {
+  if (selector instanceof Vector) return selector;
+  const vector = (data instanceof Table ? data : new Table([data])).getChild(selector);
+  if (!vector) throw new Error(`ArrowColumnLayer column "${selector}" is missing`);
+  return vector;
+}
+
+function isSelector(value: unknown): value is ArrowGPUVectorColumnSelector {
+  return typeof value === 'string' || value instanceof Vector;
+}
+
+function isColor(value: unknown): value is Color {
+  return Array.isArray(value) || ArrayBuffer.isView(value);
+}

--- a/modules/deck-arrow-layers/src/layers/arrow-gpu-layer-utils.ts
+++ b/modules/deck-arrow-layers/src/layers/arrow-gpu-layer-utils.ts
@@ -1,0 +1,43 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {getArrowVectorByPath, makeGPUVectorFromArrow} from '@luma.gl/arrow';
+import type {Device} from '@luma.gl/core';
+import type {GPUVector, GPUVectorFormat} from '@luma.gl/gpgpu/gpu-data';
+import {RecordBatch, Table, Vector, type DataType} from 'apache-arrow';
+
+/** Materialized Arrow sources accepted by synchronous GPUVector adapters. */
+export type ArrowGPUVectorLayerData = Table | RecordBatch;
+/** Named or direct Arrow vector selected for one semantic GPUVector input. */
+export type ArrowGPUVectorColumnSelector<TypeT extends DataType = DataType> =
+  | string
+  | Vector<TypeT>;
+
+/** Resolves a column and uploads it as an adapter-owned GPUVector. */
+export function makeLayerGPUVectorFromArrow<FormatT extends GPUVectorFormat>(
+  device: Device,
+  data: ArrowGPUVectorLayerData,
+  selector: ArrowGPUVectorColumnSelector,
+  options: {name: string; id: string; format: FormatT}
+): GPUVector<FormatT> {
+  const vector =
+    selector instanceof Vector
+      ? selector
+      : getArrowVectorByPath(data instanceof Table ? data : new Table([data]), selector);
+  if (!vector) throw new Error(`Arrow GPU layer column "${String(selector)}" is missing`);
+  if (vector.data.some(chunk => chunk.nullCount > 0)) {
+    throw new Error(`Arrow GPU layer column "${options.name}" contains null rows`);
+  }
+  return makeGPUVectorFromArrow(device, vector, {
+    name: options.name,
+    id: options.id,
+    format: options.format,
+    preserveDataChunks: true
+  });
+}
+
+/** Destroys only vectors created and owned by an Arrow adapter. */
+export function destroyLayerGPUVectors(vectors: Array<GPUVector | undefined>): void {
+  for (const vector of vectors) vector?.destroy();
+}

--- a/modules/deck-arrow-layers/src/layers/arrow-gpu-layer-utils.ts
+++ b/modules/deck-arrow-layers/src/layers/arrow-gpu-layer-utils.ts
@@ -5,7 +5,7 @@
 import {getArrowVectorByPath, makeGPUVectorFromArrow} from '@luma.gl/arrow';
 import type {Device} from '@luma.gl/core';
 import type {GPUVector, GPUVectorFormat} from '@luma.gl/gpgpu/gpu-data';
-import {RecordBatch, Table, Vector, type DataType} from 'apache-arrow';
+import {DataType, Float32, RecordBatch, Table, Uint8, Vector} from 'apache-arrow';
 
 /** Materialized Arrow sources accepted by synchronous GPUVector adapters. */
 export type ArrowGPUVectorLayerData = Table | RecordBatch;
@@ -29,12 +29,60 @@ export function makeLayerGPUVectorFromArrow<FormatT extends GPUVectorFormat>(
   if (vector.data.some(chunk => chunk.nullCount > 0)) {
     throw new Error(`Arrow GPU layer column "${options.name}" contains null rows`);
   }
+  assertLayerArrowVectorFormat(vector, options.format, options.name);
   return makeGPUVectorFromArrow(device, vector, {
     name: options.name,
     id: options.id,
     format: options.format,
     preserveDataChunks: true
   });
+}
+
+/** Rejects Arrow storage that cannot be borrowed under the requested GPU byte format. */
+export function assertLayerArrowVectorFormat(
+  vector: Vector,
+  format: GPUVectorFormat,
+  name: string
+): void {
+  const floatListSize = getFloat32ListSize(format);
+  if (floatListSize !== null) {
+    if (
+      !DataType.isFixedSizeList(vector.type) ||
+      vector.type.listSize !== floatListSize ||
+      !(vector.type.children[0]?.type instanceof Float32)
+    ) {
+      throw new Error(
+        `Arrow GPU layer column "${name}" must be FixedSizeList<Float32>[${floatListSize}] for ${format}`
+      );
+    }
+    return;
+  }
+  if (format === 'float32' && !(vector.type instanceof Float32)) {
+    throw new Error(`Arrow GPU layer column "${name}" must be Float32 for ${format}`);
+  }
+  if (
+    format === 'unorm8x4' &&
+    (!DataType.isFixedSizeList(vector.type) ||
+      vector.type.listSize !== 4 ||
+      !(vector.type.children[0]?.type instanceof Uint8))
+  ) {
+    throw new Error(
+      `Arrow GPU layer column "${name}" must be FixedSizeList<Uint8>[4] for ${format}`
+    );
+  }
+}
+
+function getFloat32ListSize(format: GPUVectorFormat): 2 | 3 | 4 | null {
+  switch (format) {
+    case 'float32x2':
+      return 2;
+    case 'float32x3':
+      return 3;
+    case 'float32x4':
+      return 4;
+    default:
+      return null;
+  }
 }
 
 /** Destroys only vectors created and owned by an Arrow adapter. */

--- a/modules/deck-arrow-layers/src/layers/arrow-grid-cell-layer.ts
+++ b/modules/deck-arrow-layers/src/layers/arrow-grid-cell-layer.ts
@@ -1,0 +1,39 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {CompositeLayer, type Color, type LayerProps} from '@deck.gl/core';
+import type {FixedSizeList, Float32, Uint8} from 'apache-arrow';
+import {ArrowColumnLayer} from './arrow-column-layer';
+import type {ArrowGPUVectorColumnSelector, ArrowGPUVectorLayerData} from './arrow-gpu-layer-utils';
+
+type PositionType = FixedSizeList<Float32>;
+type ColorType = FixedSizeList<Uint8>;
+
+/** Arrow adapter props retaining deck's standard GridCell accessor names. */
+export type ArrowGridCellLayerProps = Omit<LayerProps, 'data'> & {
+  data: ArrowGPUVectorLayerData;
+  getPosition: ArrowGPUVectorColumnSelector<PositionType>;
+  getFillColor?: Color | ArrowGPUVectorColumnSelector<ColorType>;
+  getCellSize?: number | ArrowGPUVectorColumnSelector<Float32>;
+  getElevation?: number | ArrowGPUVectorColumnSelector<Float32>;
+  cellSizeScale?: number;
+  elevationScale?: number;
+};
+
+/** Square-cell Arrow specialization that delegates conversion to ArrowColumnLayer. */
+export class ArrowGridCellLayer extends CompositeLayer<ArrowGridCellLayerProps> {
+  static override layerName = 'ArrowGridCellLayer';
+
+  override renderLayers(): ArrowColumnLayer {
+    const {getCellSize, cellSizeScale, ...props} = this.props;
+    return new ArrowColumnLayer({
+      ...props,
+      id: `${this.props.id}-column`,
+      getRadius: getCellSize,
+      radiusScale: (cellSizeScale ?? 1) / Math.SQRT2,
+      diskResolution: 4,
+      angle: 45
+    });
+  }
+}

--- a/modules/deck-arrow-layers/src/layers/arrow-icon-layer.ts
+++ b/modules/deck-arrow-layers/src/layers/arrow-icon-layer.ts
@@ -1,0 +1,269 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {CompositeLayer, type Color, type UpdateParameters} from '@deck.gl/core';
+import {GPUIconLayer, type GPUIconLayerProps} from '@deck.gl-community/gpu-layers';
+import {makeArrowFixedSizeListVector} from '@luma.gl/arrow';
+import type {GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import {
+  DataType,
+  Float32,
+  Table,
+  Vector,
+  makeVector,
+  vectorFromArray,
+  type FixedSizeList,
+  type Uint8
+} from 'apache-arrow';
+import {
+  destroyLayerGPUVectors,
+  makeLayerGPUVectorFromArrow,
+  type ArrowGPUVectorColumnSelector,
+  type ArrowGPUVectorLayerData
+} from './arrow-gpu-layer-utils';
+
+type PositionType = FixedSizeList<Float32>;
+type ColorType = FixedSizeList<Uint8>;
+
+/** Prepacked deck icon atlas entry used by the Arrow icon-name adapter. */
+export type ArrowIconMapping = Record<
+  string,
+  {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    anchorX?: number;
+    anchorY?: number;
+    mask?: boolean;
+  }
+>;
+
+/** Arrow adapter props retaining deck's standard Icon accessor names. */
+export type ArrowIconLayerProps = Omit<
+  GPUIconLayerProps,
+  | 'getPosition'
+  | 'iconOffsets'
+  | 'iconFrames'
+  | 'iconColorModes'
+  | 'getColor'
+  | 'getSize'
+  | 'getAngle'
+  | 'getPixelOffset'
+  | 'iconMapping'
+> & {
+  data: ArrowGPUVectorLayerData;
+  iconMapping: ArrowIconMapping;
+  getPosition: ArrowGPUVectorColumnSelector<PositionType>;
+  getIcon: ArrowGPUVectorColumnSelector;
+  getColor?: Color | ArrowGPUVectorColumnSelector<ColorType>;
+  getSize?: number | ArrowGPUVectorColumnSelector<Float32>;
+  getAngle?: number | ArrowGPUVectorColumnSelector<Float32>;
+  getPixelOffset?: ArrowGPUVectorColumnSelector<PositionType>;
+};
+
+type ArrowIconLayerState = {
+  positions?: GPUVector<'float32x2'>;
+  iconOffsets?: GPUVector<'float32x2'>;
+  iconFrames?: GPUVector<'float32x4'>;
+  iconColorModes?: GPUVector<'float32'>;
+  colors?: GPUVector<'unorm8x4'>;
+  sizes?: GPUVector<'float32'>;
+  angles?: GPUVector<'float32'>;
+  pixelOffsets?: GPUVector<'float32x2'>;
+};
+
+/** Converts Arrow columns and icon identifiers to owned GPUVectors before GPU icon rendering. */
+export class ArrowIconLayer extends CompositeLayer<ArrowIconLayerProps> {
+  static override layerName = 'ArrowIconLayer';
+
+  override initializeState(): void {
+    this.setState({} satisfies ArrowIconLayerState);
+  }
+
+  override updateState({props, oldProps, changeFlags}: UpdateParameters<this>): void {
+    if (
+      changeFlags.dataChanged ||
+      props.getPosition !== oldProps.getPosition ||
+      props.getIcon !== oldProps.getIcon ||
+      props.iconMapping !== oldProps.iconMapping ||
+      props.getColor !== oldProps.getColor ||
+      props.getSize !== oldProps.getSize ||
+      props.getAngle !== oldProps.getAngle ||
+      props.getPixelOffset !== oldProps.getPixelOffset ||
+      !(this.state as ArrowIconLayerState).positions
+    ) {
+      this.destroyVectors();
+      this.setState(this.makeVectors(props));
+    }
+  }
+
+  override renderLayers(): GPUIconLayer | null {
+    const state = this.state as ArrowIconLayerState;
+    if (!state.positions || !state.iconOffsets || !state.iconFrames || !state.iconColorModes) {
+      return null;
+    }
+    const {data, getPosition, getIcon, getColor, getSize, getAngle, getPixelOffset, ...props} =
+      this.props;
+    return new GPUIconLayer({
+      ...props,
+      id: `${this.props.id}-gpu`,
+      getPosition: state.positions,
+      iconOffsets: state.iconOffsets,
+      iconFrames: state.iconFrames,
+      iconColorModes: state.iconColorModes,
+      getColor: state.colors ?? (isColor(getColor) ? getColor : undefined),
+      getSize: state.sizes ?? (typeof getSize === 'number' ? getSize : undefined),
+      getAngle: state.angles ?? (typeof getAngle === 'number' ? getAngle : undefined),
+      getPixelOffset: state.pixelOffsets
+    });
+  }
+
+  override finalizeState(): void {
+    this.destroyVectors();
+  }
+
+  private makeVectors(props: ArrowIconLayerProps): ArrowIconLayerState {
+    const positionFormat = getPositionFormat(props.data, props.getPosition);
+    const iconSource = resolveVector(props.data, props.getIcon);
+    const iconOffsets = new Float32Array(iconSource.length * 2);
+    const iconFrames = new Float32Array(iconSource.length * 4);
+    const iconColorModes = new Float32Array(iconSource.length);
+    for (let rowIndex = 0; rowIndex < iconSource.length; rowIndex++) {
+      const iconName = String(iconSource.get(rowIndex));
+      const icon = props.iconMapping[iconName];
+      if (!icon) throw new Error(`ArrowIconLayer iconMapping has no entry for "${iconName}"`);
+      iconOffsets.set(
+        [
+          icon.width / 2 - (icon.anchorX ?? icon.width / 2),
+          icon.height / 2 - (icon.anchorY ?? icon.height / 2)
+        ],
+        rowIndex * 2
+      );
+      iconFrames.set([icon.x, icon.y, icon.width, icon.height], rowIndex * 4);
+      iconColorModes[rowIndex] = icon.mask ? 1 : 0;
+    }
+    const offsetVector = makeChunkedFixedSizeListVector(iconSource, iconOffsets, 2);
+    const frameVector = makeChunkedFixedSizeListVector(iconSource, iconFrames, 4);
+    const colorModeVector = makeChunkedScalarVector(iconSource, iconColorModes);
+    return {
+      positions: makeLayerGPUVectorFromArrow(this.context.device, props.data, props.getPosition, {
+        name: 'positions',
+        id: `${this.id}-positions`,
+        format: positionFormat
+      }),
+      iconOffsets: makeLayerGPUVectorFromArrow(this.context.device, props.data, offsetVector, {
+        name: 'iconOffsets',
+        id: `${this.id}-icon-offsets`,
+        format: 'float32x2'
+      }),
+      iconFrames: makeLayerGPUVectorFromArrow(this.context.device, props.data, frameVector, {
+        name: 'iconFrames',
+        id: `${this.id}-icon-frames`,
+        format: 'float32x4'
+      }),
+      iconColorModes: makeLayerGPUVectorFromArrow(
+        this.context.device,
+        props.data,
+        colorModeVector,
+        {
+          name: 'iconColorModes',
+          id: `${this.id}-icon-color-modes`,
+          format: 'float32'
+        }
+      ),
+      colors: makeOptionalVector(this, props.data, props.getColor, 'colors', 'unorm8x4'),
+      sizes: makeOptionalVector(this, props.data, props.getSize, 'sizes', 'float32'),
+      angles: makeOptionalVector(this, props.data, props.getAngle, 'angles', 'float32'),
+      pixelOffsets: props.getPixelOffset
+        ? makeLayerGPUVectorFromArrow(this.context.device, props.data, props.getPixelOffset, {
+            name: 'pixelOffsets',
+            id: `${this.id}-pixel-offsets`,
+            format: 'float32x2'
+          })
+        : undefined
+    };
+  }
+
+  private destroyVectors(): void {
+    destroyLayerGPUVectors(Object.values(this.state as ArrowIconLayerState));
+  }
+}
+
+function makeOptionalVector<FormatT extends 'float32' | 'unorm8x4'>(
+  layer: ArrowIconLayer,
+  data: ArrowGPUVectorLayerData,
+  selector: number | Color | ArrowGPUVectorColumnSelector | undefined,
+  name: string,
+  format: FormatT
+): GPUVector<FormatT> | undefined {
+  if (!(typeof selector === 'string' || selector instanceof Vector)) return undefined;
+  return makeLayerGPUVectorFromArrow(layer.context.device, data, selector, {
+    name,
+    id: `${layer.id}-${name}`,
+    format
+  });
+}
+
+function resolveVector(
+  data: ArrowGPUVectorLayerData,
+  selector: ArrowGPUVectorColumnSelector
+): Vector {
+  if (selector instanceof Vector) return selector;
+  const vector = (data instanceof Table ? data : new Table([data])).getChild(selector);
+  if (!vector) throw new Error(`ArrowIconLayer column "${selector}" is missing`);
+  return vector;
+}
+
+function makeChunkedFixedSizeListVector(
+  source: Vector,
+  values: Float32Array,
+  listSize: 2 | 4
+): Vector<FixedSizeList<Float32>> {
+  const chunks = [];
+  let rowOffset = 0;
+  for (const sourceChunk of source.data) {
+    const valueStart = rowOffset * listSize;
+    const valueEnd = valueStart + sourceChunk.length * listSize;
+    chunks.push(
+      ...makeArrowFixedSizeListVector(
+        new Float32(),
+        listSize,
+        values.subarray(valueStart, valueEnd)
+      ).data
+    );
+    rowOffset += sourceChunk.length;
+  }
+  return makeVector(chunks) as Vector<FixedSizeList<Float32>>;
+}
+
+function makeChunkedScalarVector(source: Vector, values: Float32Array): Vector<Float32> {
+  const chunks = [];
+  let rowOffset = 0;
+  for (const sourceChunk of source.data) {
+    chunks.push(
+      ...vectorFromArray(
+        Array.from(values.subarray(rowOffset, rowOffset + sourceChunk.length)),
+        new Float32()
+      ).data
+    );
+    rowOffset += sourceChunk.length;
+  }
+  return makeVector(chunks) as Vector<Float32>;
+}
+
+function getPositionFormat(
+  data: ArrowGPUVectorLayerData,
+  selector: ArrowGPUVectorColumnSelector<PositionType>
+): 'float32x2' {
+  const vector = resolveVector(data, selector);
+  if (!DataType.isFixedSizeList(vector.type) || vector.type.listSize !== 2) {
+    throw new Error('ArrowIconLayer positions must be FixedSizeList[2]');
+  }
+  return 'float32x2';
+}
+
+function isColor(value: unknown): value is Color {
+  return Array.isArray(value) || ArrayBuffer.isView(value);
+}

--- a/modules/deck-arrow-layers/src/layers/arrow-icon-layer.ts
+++ b/modules/deck-arrow-layers/src/layers/arrow-icon-layer.ts
@@ -13,6 +13,7 @@ import {
   Vector,
   makeVector,
   vectorFromArray,
+  type Data,
   type FixedSizeList,
   type Uint8
 } from 'apache-arrow';
@@ -221,7 +222,7 @@ function makeChunkedFixedSizeListVector(
   values: Float32Array,
   listSize: 2 | 4
 ): Vector<FixedSizeList<Float32>> {
-  const chunks = [];
+  const chunks: Data<FixedSizeList<Float32>>[] = [];
   let rowOffset = 0;
   for (const sourceChunk of source.data) {
     const valueStart = rowOffset * listSize;
@@ -235,11 +236,11 @@ function makeChunkedFixedSizeListVector(
     );
     rowOffset += sourceChunk.length;
   }
-  return makeVector(chunks) as Vector<FixedSizeList<Float32>>;
+  return makeVector(chunks);
 }
 
 function makeChunkedScalarVector(source: Vector, values: Float32Array): Vector<Float32> {
-  const chunks = [];
+  const chunks: Data<Float32>[] = [];
   let rowOffset = 0;
   for (const sourceChunk of source.data) {
     chunks.push(
@@ -250,7 +251,7 @@ function makeChunkedScalarVector(source: Vector, values: Float32Array): Vector<F
     );
     rowOffset += sourceChunk.length;
   }
-  return makeVector(chunks) as Vector<Float32>;
+  return makeVector(chunks);
 }
 
 function getPositionFormat(

--- a/modules/deck-arrow-layers/src/layers/arrow-line-layer.ts
+++ b/modules/deck-arrow-layers/src/layers/arrow-line-layer.ts
@@ -1,0 +1,135 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {CompositeLayer, type Color, type UpdateParameters} from '@deck.gl/core';
+import {GPULineLayer, type GPULineLayerProps} from '@deck.gl-community/gpu-layers';
+import type {GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import {DataType, Table, Vector, type FixedSizeList, type Float32, type Uint8} from 'apache-arrow';
+import {
+  destroyLayerGPUVectors,
+  makeLayerGPUVectorFromArrow,
+  type ArrowGPUVectorColumnSelector,
+  type ArrowGPUVectorLayerData
+} from './arrow-gpu-layer-utils';
+
+type PositionType = FixedSizeList<Float32>;
+type ColorType = FixedSizeList<Uint8>;
+
+/** Arrow adapter props retaining deck's standard Line accessor names. */
+export type ArrowLineLayerProps = Omit<
+  GPULineLayerProps,
+  'getSourcePosition' | 'getTargetPosition' | 'getColor' | 'getWidth'
+> & {
+  data: ArrowGPUVectorLayerData;
+  getSourcePosition: ArrowGPUVectorColumnSelector<PositionType>;
+  getTargetPosition: ArrowGPUVectorColumnSelector<PositionType>;
+  getColor?: Color | ArrowGPUVectorColumnSelector<ColorType>;
+  getWidth?: number | ArrowGPUVectorColumnSelector<Float32>;
+};
+
+type ArrowLineLayerState = {
+  sourcePositions?: GPUVector<'float32x2'>;
+  targetPositions?: GPUVector<'float32x2'>;
+  colors?: GPUVector<'unorm8x4'>;
+  widths?: GPUVector<'float32'>;
+};
+
+/** Converts Arrow columns to owned GPUVectors, then delegates to GPULineLayer. */
+export class ArrowLineLayer extends CompositeLayer<ArrowLineLayerProps> {
+  static override layerName = 'ArrowLineLayer';
+
+  override initializeState(): void {
+    this.setState({} satisfies ArrowLineLayerState);
+  }
+
+  override updateState({props, oldProps, changeFlags}: UpdateParameters<this>): void {
+    if (
+      changeFlags.dataChanged ||
+      props.getSourcePosition !== oldProps.getSourcePosition ||
+      props.getTargetPosition !== oldProps.getTargetPosition ||
+      props.getColor !== oldProps.getColor ||
+      props.getWidth !== oldProps.getWidth ||
+      !(this.state as ArrowLineLayerState).sourcePositions
+    ) {
+      this.destroyVectors();
+      const sourceFormat = getPositionFormat(props.data, props.getSourcePosition);
+      const targetFormat = getPositionFormat(props.data, props.getTargetPosition);
+      if (sourceFormat !== targetFormat) {
+        throw new Error('ArrowLineLayer source and target position dimensions must match');
+      }
+      this.setState({
+        sourcePositions: makeLayerGPUVectorFromArrow(
+          this.context.device,
+          props.data,
+          props.getSourcePosition,
+          {name: 'sourcePositions', id: `${this.id}-source`, format: sourceFormat}
+        ),
+        targetPositions: makeLayerGPUVectorFromArrow(
+          this.context.device,
+          props.data,
+          props.getTargetPosition,
+          {name: 'targetPositions', id: `${this.id}-target`, format: targetFormat}
+        ),
+        colors: isSelector(props.getColor)
+          ? makeLayerGPUVectorFromArrow(this.context.device, props.data, props.getColor, {
+              name: 'colors',
+              id: `${this.id}-colors`,
+              format: 'unorm8x4'
+            })
+          : undefined,
+        widths: isSelector(props.getWidth)
+          ? makeLayerGPUVectorFromArrow(this.context.device, props.data, props.getWidth, {
+              name: 'widths',
+              id: `${this.id}-widths`,
+              format: 'float32'
+            })
+          : undefined
+      } satisfies ArrowLineLayerState);
+    }
+  }
+
+  override renderLayers(): GPULineLayer | null {
+    const state = this.state as ArrowLineLayerState;
+    if (!state.sourcePositions || !state.targetPositions) return null;
+    const {data, getSourcePosition, getTargetPosition, getColor, getWidth, ...props} = this.props;
+    return new GPULineLayer({
+      ...props,
+      id: `${this.props.id}-gpu`,
+      getSourcePosition: state.sourcePositions,
+      getTargetPosition: state.targetPositions,
+      getColor: state.colors ?? (isColor(getColor) ? getColor : undefined),
+      getWidth: state.widths ?? (typeof getWidth === 'number' ? getWidth : undefined)
+    });
+  }
+
+  override finalizeState(): void {
+    this.destroyVectors();
+  }
+
+  private destroyVectors(): void {
+    destroyLayerGPUVectors(Object.values(this.state as ArrowLineLayerState));
+  }
+}
+
+function getPositionFormat(
+  data: ArrowGPUVectorLayerData,
+  selector: ArrowGPUVectorColumnSelector<PositionType>
+): 'float32x2' {
+  const vector =
+    selector instanceof Vector
+      ? selector
+      : (data instanceof Table ? data : new Table([data])).getChild(selector);
+  if (!vector || !DataType.isFixedSizeList(vector.type) || vector.type.listSize !== 2) {
+    throw new Error('ArrowLineLayer positions must be FixedSizeList[2]');
+  }
+  return 'float32x2';
+}
+
+function isSelector(value: unknown): value is ArrowGPUVectorColumnSelector {
+  return typeof value === 'string' || value instanceof Vector;
+}
+
+function isColor(value: unknown): value is Color {
+  return Array.isArray(value) || ArrayBuffer.isView(value);
+}

--- a/modules/deck-arrow-layers/src/layers/arrow-path-layer.ts
+++ b/modules/deck-arrow-layers/src/layers/arrow-path-layer.ts
@@ -273,7 +273,8 @@ const DECK_PATH_STORAGE_SHADER_LAYOUT: ShaderLayout = {
     {name: 'rowIndices', location: 2, type: 'u32', stepMode: 'instance'},
     {name: 'currentTime', location: 3, type: 'f32', stepMode: 'instance'},
     {name: 'trailLength', location: 4, type: 'f32', stepMode: 'instance'},
-    {name: 'temporalEnabled', location: 5, type: 'f32', stepMode: 'instance'}
+    {name: 'temporalEnabled', location: 5, type: 'f32', stepMode: 'instance'},
+    {name: 'fadeTrail', location: 6, type: 'f32', stepMode: 'instance'}
   ],
   bindings: []
 };
@@ -287,6 +288,7 @@ ${DECK_ARROW_WGSL_COLOR_UTILS}
 @group(0) @binding(auto) var<storage, read> pathRowColors: array<u32>;
 @group(0) @binding(auto) var<storage, read> pathVertexColors: array<u32>;
 @group(0) @binding(auto) var<storage, read> pathRowWidths: array<f32>;
+@group(0) @binding(auto) var<storage, read> pathTimestamps: array<f32>;
 
 struct PathStorageStyleConfig {
   constantColor: vec4<f32>,
@@ -309,6 +311,7 @@ struct PathStorageVertexInputs {
   @location(3) currentTime: f32,
   @location(4) trailLength: f32,
   @location(5) temporalEnabled: f32,
+  @location(6) fadeTrail: f32,
 };
 
 struct PathStorageVertexOutputs {
@@ -316,6 +319,7 @@ struct PathStorageVertexOutputs {
   @location(0) color: vec4<f32>,
   @location(1) @interpolate(flat) pickingColor: vec3<f32>,
   @location(2) @interpolate(flat) visible: f32,
+  @location(3) trailOpacity: f32,
 };
 
 fn unpackStoragePathColor(colorWord: u32) -> vec4<f32> {
@@ -393,13 +397,28 @@ fn vertexMain(
     outputs.color = unpackStoragePathColor(pathRowColors[localRowIndex]);
   }
   outputs.pickingColor = deck_encodePickingColor(inputs.rowIndex);
-  let startMeasure = startPosition.w;
-  let endMeasure = endPosition.w;
+  let usesTimestampColumn = inputs.temporalEnabled > 1.5;
+  let startMeasure = select(
+    startPosition.w,
+    pathTimestamps[inputs.segmentStartPointIndex],
+    usesTimestampColumn
+  );
+  let endMeasure = select(
+    endPosition.w,
+    pathTimestamps[segmentEndPointIndex],
+    usesTimestampColumn
+  );
   outputs.visible = select(
     0.0,
     1.0,
     inputs.temporalEnabled < 0.5 ||
       (endMeasure >= inputs.currentTime - inputs.trailLength && startMeasure <= inputs.currentTime)
+  );
+  let vertexMeasure = mix(startMeasure, endMeasure, corner.x);
+  outputs.trailOpacity = select(
+    1.0,
+    clamp((vertexMeasure - (inputs.currentTime - inputs.trailLength)) / max(inputs.trailLength, 0.000001), 0.0, 1.0),
+    usesTimestampColumn && inputs.fadeTrail > 0.5
   );
   return outputs;
 }
@@ -407,7 +426,9 @@ fn vertexMain(
 @fragment
 fn fragmentMain(inputs: PathStorageVertexOutputs) -> @location(0) vec4<f32> {
   if (inputs.visible < 0.5) { discard; }
-  return deck_filterColor(inputs.color, inputs.pickingColor);
+  var color = deck_filterColor(inputs.color, inputs.pickingColor);
+  color.a *= inputs.trailOpacity;
+  return color;
 }
 `;
 
@@ -419,11 +440,12 @@ type ArrowPathLayerBatch = {
   rowIndexOffset: number;
   rowCount: number;
   temporalBuffer: Buffer | null;
+  timestampColumnEnabled: boolean;
 };
 
 /** Deck-facing props for an Arrow-backed path layer. */
 export type ArrowPathLayerProps = Omit<LayerProps, 'data'> &
-  Omit<ArrowPathSourceVectorSelectors, 'timestamps' | 'colors' | 'widths'> & {
+  Omit<ArrowPathSourceVectorSelectors, 'colors' | 'widths'> & {
     /** Arrow table or preserved record-batch source. */
     data?: ArrowRecordBatchSource | null;
     /** GPU path model. Storage is available on WebGPU; auto selects it when supported. */
@@ -438,6 +460,8 @@ export type ArrowPathLayerProps = Omit<LayerProps, 'data'> &
     trailLength?: number;
     /** Enables temporal filtering against the fourth coordinate component. */
     temporalEnabled?: boolean;
+    /** Fades timestamp-backed trip segments across the visible trail. */
+    fadeTrail?: boolean;
     /** Called after one streamed record batch has been prepared and appended. */
     onDataBatch?: (update: {
       loadedBatchCount: number;
@@ -495,7 +519,8 @@ export class ArrowPathLayer extends Layer<ArrowPathLayerProps> {
       props.model !== oldProps.model ||
       props.color !== oldProps.color ||
       props.width !== oldProps.width;
-    if (sourceChanged) {
+    const timestampSourceChanged = props.timestamps !== oldProps.timestamps;
+    if (sourceChanged || timestampSourceChanged) {
       state.sourceInitialized = true;
       void this.loadSource(props);
       return;
@@ -503,7 +528,8 @@ export class ArrowPathLayer extends Layer<ArrowPathLayerProps> {
     if (
       props.currentTime !== oldProps.currentTime ||
       props.trailLength !== oldProps.trailLength ||
-      props.temporalEnabled !== oldProps.temporalEnabled
+      props.temporalEnabled !== oldProps.temporalEnabled ||
+      props.fadeTrail !== oldProps.fadeTrail
     ) {
       for (const batch of state.batches) {
         updateDeckPathTemporalStyle(batch, props);
@@ -657,7 +683,10 @@ export class ArrowPathLayer extends Layer<ArrowPathLayerProps> {
         selectors: {
           paths: props.paths,
           colors: colorSelector ?? null,
-          widths: widthSelector ?? null
+          widths: widthSelector ?? null,
+          ...(model === 'storage' && props.timestamps !== undefined
+            ? {timestamps: props.timestamps}
+            : {})
         }
       }),
       colorNullValue,
@@ -700,7 +729,9 @@ export class ArrowPathLayer extends Layer<ArrowPathLayerProps> {
       width: widthNullValue,
       currentTime: props.currentTime ?? 0,
       trailLength: props.trailLength ?? 0,
-      temporalEnabled: props.temporalEnabled ?? false
+      temporalEnabled: props.temporalEnabled ?? false,
+      timestampColumnEnabled: Boolean(sourceVectors.timestamps),
+      fadeTrail: props.fadeTrail ?? false
     });
     let renderModel: Model;
     try {
@@ -716,6 +747,7 @@ export class ArrowPathLayer extends Layer<ArrowPathLayerProps> {
           shaderLayout: DECK_PATH_STORAGE_SHADER_LAYOUT,
           bufferLayout: constantStyle.bufferLayout,
           attributes: constantStyle.attributes,
+          bindings: {pathTimestamps: constantStyle.defaultTimestampBuffer},
           ...(colorColumn instanceof GPUVector ? {colors: colorColumn} : {color: colorNullValue}),
           ...(widthColumn instanceof GPUVector ? {widths: widthColumn} : {width: widthNullValue}),
           topology: 'triangle-list',
@@ -761,7 +793,8 @@ export class ArrowPathLayer extends Layer<ArrowPathLayerProps> {
       batchIndex,
       rowIndexOffset,
       rowCount,
-      temporalBuffer: constantStyle.temporalBuffer
+      temporalBuffer: constantStyle.temporalBuffer,
+      timestampColumnEnabled: Boolean(sourceVectors.timestamps)
     };
     const batches = [...this.getLayerState().batches, batch];
     this.setState({batches, loadVersion, sourceInitialized: true});
@@ -933,7 +966,9 @@ function createDeckPathConstantStyle(
     width,
     currentTime,
     trailLength,
-    temporalEnabled
+    temporalEnabled,
+    timestampColumnEnabled,
+    fadeTrail
   }: {
     id: string;
     hasColors: boolean;
@@ -943,6 +978,8 @@ function createDeckPathConstantStyle(
     currentTime: number;
     trailLength: number;
     temporalEnabled: boolean;
+    timestampColumnEnabled: boolean;
+    fadeTrail: boolean;
   }
 ): {
   bufferLayout: BufferLayout[];
@@ -950,12 +987,14 @@ function createDeckPathConstantStyle(
   constantAttributes: Record<string, TypedArray>;
   buffers: Buffer[];
   temporalBuffer: Buffer | null;
+  defaultTimestampBuffer: Buffer | null;
 } {
   const bufferLayout: BufferLayout[] = [];
   const attributes: Record<string, Buffer> = {};
   const constantAttributes: Record<string, TypedArray> = {};
   const buffers: Buffer[] = [];
   let temporalBuffer: Buffer | null = null;
+  let defaultTimestampBuffer: Buffer | null = null;
 
   if (!hasColors) {
     // WebGL sets integer constant attributes through vertexAttribI4uiv, so retain four lanes.
@@ -997,7 +1036,13 @@ function createDeckPathConstantStyle(
     }
   }
 
-  const temporalValues = makeDeckPathTemporalValues({currentTime, trailLength, temporalEnabled});
+  const temporalValues = makeDeckPathTemporalValues({
+    currentTime,
+    trailLength,
+    temporalEnabled,
+    timestampColumnEnabled,
+    fadeTrail
+  });
   bufferLayout.push({
     name: CONSTANT_PATH_TEMPORAL_BUFFER,
     byteStride: 0,
@@ -1005,33 +1050,51 @@ function createDeckPathConstantStyle(
     attributes: [
       {attribute: 'currentTime', format: 'float32', byteOffset: 0},
       {attribute: 'trailLength', format: 'float32', byteOffset: 4},
-      {attribute: 'temporalEnabled', format: 'float32', byteOffset: 8}
+      {attribute: 'temporalEnabled', format: 'float32', byteOffset: 8},
+      {attribute: 'fadeTrail', format: 'float32', byteOffset: 12}
     ]
   });
   if (device.type === 'webgl') {
     constantAttributes['currentTime'] = temporalValues.subarray(0, 1);
     constantAttributes['trailLength'] = temporalValues.subarray(1, 2);
     constantAttributes['temporalEnabled'] = temporalValues.subarray(2, 3);
+    constantAttributes['fadeTrail'] = temporalValues.subarray(3, 4);
   } else {
     temporalBuffer = device.createBuffer({id: `${id}-constant-temporal`, data: temporalValues});
     attributes[CONSTANT_PATH_TEMPORAL_BUFFER] = temporalBuffer;
     buffers.push(temporalBuffer);
+    defaultTimestampBuffer = device.createBuffer({
+      id: `${id}-default-timestamp`,
+      data: new Float32Array([0]),
+      usage: Buffer.STORAGE
+    });
+    buffers.push(defaultTimestampBuffer);
   }
 
-  return {bufferLayout, attributes, constantAttributes, buffers, temporalBuffer};
+  return {
+    bufferLayout,
+    attributes,
+    constantAttributes,
+    buffers,
+    temporalBuffer,
+    defaultTimestampBuffer
+  };
 }
 
 function updateDeckPathTemporalStyle(batch: ArrowPathLayerBatch, props: ArrowPathLayerProps): void {
   const temporalValues = makeDeckPathTemporalValues({
     currentTime: props.currentTime ?? 0,
     trailLength: props.trailLength ?? 0,
-    temporalEnabled: props.temporalEnabled ?? false
+    temporalEnabled: props.temporalEnabled ?? false,
+    timestampColumnEnabled: batch.timestampColumnEnabled,
+    fadeTrail: props.fadeTrail ?? false
   });
   if (batch.model.device.type === 'webgl') {
     batch.model.setConstantAttributes({
       currentTime: temporalValues.subarray(0, 1),
       trailLength: temporalValues.subarray(1, 2),
-      temporalEnabled: temporalValues.subarray(2, 3)
+      temporalEnabled: temporalValues.subarray(2, 3),
+      fadeTrail: temporalValues.subarray(3, 4)
     });
   } else {
     batch.temporalBuffer?.write(temporalValues);
@@ -1041,13 +1104,18 @@ function updateDeckPathTemporalStyle(batch: ArrowPathLayerBatch, props: ArrowPat
 function makeDeckPathTemporalValues({
   currentTime,
   trailLength,
-  temporalEnabled
+  temporalEnabled,
+  timestampColumnEnabled,
+  fadeTrail
 }: {
   currentTime: number;
   trailLength: number;
   temporalEnabled: boolean;
+  timestampColumnEnabled: boolean;
+  fadeTrail: boolean;
 }): Float32Array {
-  return new Float32Array([currentTime, trailLength, temporalEnabled ? 1 : 0]);
+  const temporalMode = timestampColumnEnabled ? 2 : temporalEnabled ? 1 : 0;
+  return new Float32Array([currentTime, trailLength, temporalMode, fadeTrail ? 1 : 0]);
 }
 
 function resolveDeckPathModel(

--- a/modules/deck-arrow-layers/src/layers/arrow-point-cloud-layer.ts
+++ b/modules/deck-arrow-layers/src/layers/arrow-point-cloud-layer.ts
@@ -1,0 +1,130 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {CompositeLayer, type Color, type UpdateParameters} from '@deck.gl/core';
+import {GPUPointCloudLayer, type GPUPointCloudLayerProps} from '@deck.gl-community/gpu-layers';
+import type {GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import {DataType, Table, Vector, type FixedSizeList, type Float32, type Uint8} from 'apache-arrow';
+import {
+  destroyLayerGPUVectors,
+  makeLayerGPUVectorFromArrow,
+  type ArrowGPUVectorColumnSelector,
+  type ArrowGPUVectorLayerData
+} from './arrow-gpu-layer-utils';
+
+type PositionType = FixedSizeList<Float32>;
+type ColorType = FixedSizeList<Uint8>;
+
+/** Arrow adapter props retaining deck's standard PointCloud accessor names. */
+export type ArrowPointCloudLayerProps = Omit<
+  GPUPointCloudLayerProps,
+  'getPosition' | 'getNormal' | 'getColor'
+> & {
+  data: ArrowGPUVectorLayerData;
+  getPosition: ArrowGPUVectorColumnSelector<PositionType>;
+  getNormal?: ArrowGPUVectorColumnSelector<PositionType>;
+  getColor?: Color | ArrowGPUVectorColumnSelector<ColorType>;
+};
+
+type ArrowPointCloudLayerState = {
+  positions?: GPUVector<'float32x3'>;
+  normals?: GPUVector<'float32x3'>;
+  colors?: GPUVector<'unorm8x4'>;
+};
+
+/** Converts Arrow columns to owned GPUVectors, then delegates to GPUPointCloudLayer. */
+export class ArrowPointCloudLayer extends CompositeLayer<ArrowPointCloudLayerProps> {
+  static override layerName = 'ArrowPointCloudLayer';
+
+  override initializeState(): void {
+    this.setState({} satisfies ArrowPointCloudLayerState);
+  }
+
+  override updateState({props, oldProps, changeFlags}: UpdateParameters<this>): void {
+    if (
+      changeFlags.dataChanged ||
+      props.getPosition !== oldProps.getPosition ||
+      props.getNormal !== oldProps.getNormal ||
+      props.getColor !== oldProps.getColor ||
+      !(this.state as ArrowPointCloudLayerState).positions
+    ) {
+      this.destroyVectors();
+      assertVector3(props.data, props.getPosition, 'getPosition');
+      if (props.getNormal) assertVector3(props.data, props.getNormal, 'getNormal');
+      this.setState({
+        positions: makeVector(this, props.data, props.getPosition, 'positions', 'float32x3'),
+        normals: props.getNormal
+          ? makeVector(this, props.data, props.getNormal, 'normals', 'float32x3')
+          : undefined,
+        colors: isSelector(props.getColor)
+          ? makeVector(this, props.data, props.getColor, 'colors', 'unorm8x4')
+          : undefined
+      } satisfies ArrowPointCloudLayerState);
+    }
+  }
+
+  override renderLayers(): GPUPointCloudLayer | null {
+    const state = this.state as ArrowPointCloudLayerState;
+    if (!state.positions) return null;
+    const {data, getPosition, getNormal, getColor, ...props} = this.props;
+    return new GPUPointCloudLayer({
+      ...props,
+      id: `${this.props.id}-gpu`,
+      getPosition: state.positions,
+      getNormal: state.normals,
+      getColor: state.colors ?? (isColor(getColor) ? getColor : undefined)
+    });
+  }
+
+  override finalizeState(): void {
+    this.destroyVectors();
+  }
+
+  private destroyVectors(): void {
+    destroyLayerGPUVectors(Object.values(this.state as ArrowPointCloudLayerState));
+  }
+}
+
+function makeVector<FormatT extends 'float32x3' | 'unorm8x4'>(
+  layer: ArrowPointCloudLayer,
+  data: ArrowGPUVectorLayerData,
+  selector: ArrowGPUVectorColumnSelector,
+  name: string,
+  format: FormatT
+): GPUVector<FormatT> {
+  return makeLayerGPUVectorFromArrow(layer.context.device, data, selector, {
+    name,
+    id: `${layer.id}-${name}`,
+    format
+  });
+}
+
+function assertVector3(
+  data: ArrowGPUVectorLayerData,
+  selector: ArrowGPUVectorColumnSelector,
+  name: string
+): void {
+  const vector = resolveVector(data, selector);
+  if (!DataType.isFixedSizeList(vector.type) || vector.type.listSize !== 3) {
+    throw new Error(`ArrowPointCloudLayer ${name} must be FixedSizeList[3]`);
+  }
+}
+
+function resolveVector(
+  data: ArrowGPUVectorLayerData,
+  selector: ArrowGPUVectorColumnSelector
+): Vector {
+  if (selector instanceof Vector) return selector;
+  const vector = (data instanceof Table ? data : new Table([data])).getChild(selector);
+  if (!vector) throw new Error(`ArrowPointCloudLayer column "${selector}" is missing`);
+  return vector;
+}
+
+function isSelector(value: unknown): value is ArrowGPUVectorColumnSelector {
+  return typeof value === 'string' || value instanceof Vector;
+}
+
+function isColor(value: unknown): value is Color {
+  return Array.isArray(value) || ArrayBuffer.isView(value);
+}

--- a/modules/deck-arrow-layers/src/layers/arrow-scatterplot-layer.ts
+++ b/modules/deck-arrow-layers/src/layers/arrow-scatterplot-layer.ts
@@ -1,0 +1,136 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {CompositeLayer, type Color, type UpdateParameters} from '@deck.gl/core';
+import {GPUScatterplotLayer, type GPUScatterplotLayerProps} from '@deck.gl-community/gpu-layers';
+import type {GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import {DataType, Table, Vector, type FixedSizeList, type Float32, type Uint8} from 'apache-arrow';
+import {
+  destroyLayerGPUVectors,
+  makeLayerGPUVectorFromArrow,
+  type ArrowGPUVectorColumnSelector,
+  type ArrowGPUVectorLayerData
+} from './arrow-gpu-layer-utils';
+
+type PositionType = FixedSizeList<Float32>;
+type ColorType = FixedSizeList<Uint8>;
+type ScalarAccessor = number | ArrowGPUVectorColumnSelector<Float32>;
+type ColorAccessor = Color | ArrowGPUVectorColumnSelector<ColorType>;
+
+/** Arrow adapter props retaining deck's standard Scatterplot accessor names. */
+export type ArrowScatterplotLayerProps = Omit<
+  GPUScatterplotLayerProps,
+  'getPosition' | 'getRadius' | 'getFillColor'
+> & {
+  data: ArrowGPUVectorLayerData;
+  getPosition: ArrowGPUVectorColumnSelector<PositionType>;
+  getRadius?: ScalarAccessor;
+  getFillColor?: ColorAccessor;
+};
+
+type ArrowScatterplotLayerState = {
+  positions?: GPUVector<'float32x2'>;
+  radii?: GPUVector<'float32'>;
+  fillColors?: GPUVector<'unorm8x4'>;
+};
+
+/** Converts Arrow columns to owned GPUVectors, then delegates to GPUScatterplotLayer. */
+export class ArrowScatterplotLayer extends CompositeLayer<ArrowScatterplotLayerProps> {
+  static override layerName = 'ArrowScatterplotLayer';
+
+  override initializeState(): void {
+    this.setState({} satisfies ArrowScatterplotLayerState);
+  }
+
+  override updateState({props, oldProps, changeFlags}: UpdateParameters<this>): void {
+    if (
+      changeFlags.dataChanged ||
+      props.getPosition !== oldProps.getPosition ||
+      props.getRadius !== oldProps.getRadius ||
+      props.getFillColor !== oldProps.getFillColor ||
+      !(this.state as ArrowScatterplotLayerState).positions
+    ) {
+      this.destroyVectors();
+      this.setState(this.makeVectors(props));
+    }
+  }
+
+  override renderLayers(): GPUScatterplotLayer | null {
+    const state = this.state as ArrowScatterplotLayerState;
+    if (!state.positions) return null;
+    const {data, getPosition, getRadius, getFillColor, ...props} = this.props;
+    return new GPUScatterplotLayer({
+      ...props,
+      id: `${this.props.id}-gpu`,
+      getPosition: state.positions,
+      getRadius: state.radii ?? (typeof getRadius === 'number' ? getRadius : undefined),
+      getFillColor: state.fillColors ?? (isColor(getFillColor) ? getFillColor : undefined)
+    });
+  }
+
+  override finalizeState(): void {
+    this.destroyVectors();
+  }
+
+  private makeVectors(props: ArrowScatterplotLayerProps): ArrowScatterplotLayerState {
+    const positionFormat = getPositionFormat(props.data, props.getPosition, 'getPosition');
+    return {
+      positions: makeLayerGPUVectorFromArrow(this.context.device, props.data, props.getPosition, {
+        name: 'positions',
+        id: `${this.id}-positions`,
+        format: positionFormat
+      }),
+      radii: makeOptionalVector(this, props.data, props.getRadius, 'radii', 'float32'),
+      fillColors: makeOptionalVector(
+        this,
+        props.data,
+        props.getFillColor,
+        'fill-colors',
+        'unorm8x4'
+      )
+    };
+  }
+
+  private destroyVectors(): void {
+    destroyLayerGPUVectors(Object.values(this.state as ArrowScatterplotLayerState));
+  }
+}
+
+function makeOptionalVector<FormatT extends 'float32' | 'unorm8x4'>(
+  layer: ArrowScatterplotLayer,
+  data: ArrowGPUVectorLayerData,
+  selector: number | Color | ArrowGPUVectorColumnSelector | undefined,
+  name: string,
+  format: FormatT
+): GPUVector<FormatT> | undefined {
+  if (!isSelector(selector)) return undefined;
+  return makeLayerGPUVectorFromArrow(layer.context.device, data, selector, {
+    name,
+    id: `${layer.id}-${name}`,
+    format
+  });
+}
+
+function getPositionFormat(
+  data: ArrowGPUVectorLayerData,
+  selector: ArrowGPUVectorColumnSelector<PositionType>,
+  inputName: string
+): 'float32x2' {
+  const vector =
+    selector instanceof Vector
+      ? selector
+      : (data instanceof Table ? data : new Table([data])).getChild(selector);
+  if (!vector || !DataType.isFixedSizeList(vector.type) || vector.type.listSize !== 2) {
+    throw new Error(`ArrowScatterplotLayer ${inputName} must be FixedSizeList[2]`);
+  }
+  return 'float32x2';
+}
+
+function isSelector(value: unknown): value is ArrowGPUVectorColumnSelector {
+  return typeof value === 'string' || value instanceof Vector;
+}
+
+function isColor(value: unknown): value is Color {
+  return Array.isArray(value) || ArrayBuffer.isView(value);
+}

--- a/modules/deck-arrow-layers/src/layers/arrow-solid-polygon-layer.ts
+++ b/modules/deck-arrow-layers/src/layers/arrow-solid-polygon-layer.ts
@@ -1,0 +1,35 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {ArrowPolygonSourceVectorSelectors} from '@luma.gl/arrow';
+import {CompositeLayer, type LayerProps} from '@deck.gl/core';
+import {
+  ArrowPolygonLayer,
+  type ArrowPolygonColorInput,
+  type ArrowPolygonLayerProps
+} from './arrow-polygon-layer';
+
+/** SolidPolygon-compatible names over the luma-native Arrow polygon renderer. */
+export type ArrowSolidPolygonLayerProps = Omit<LayerProps, 'data'> &
+  Omit<ArrowPolygonLayerProps, 'polygons' | 'color'> & {
+    /** GeoArrow polygon column, matching deck's getPolygon semantic. */
+    getPolygon?: ArrowPolygonSourceVectorSelectors['polygons'];
+    /** Filled polygon color, matching deck's getFillColor semantic. */
+    getFillColor?: ArrowPolygonColorInput;
+  };
+
+/** Deck SolidPolygon naming adapter; tessellation and buffers remain Arrow-native. */
+export class ArrowSolidPolygonLayer extends CompositeLayer<ArrowSolidPolygonLayerProps> {
+  static override layerName = 'ArrowSolidPolygonLayer';
+
+  override renderLayers(): ArrowPolygonLayer {
+    const {getPolygon, getFillColor, ...props} = this.props;
+    return new ArrowPolygonLayer({
+      ...props,
+      id: `${this.props.id}-polygon`,
+      polygons: getPolygon,
+      color: getFillColor
+    } as ArrowPolygonLayerProps);
+  }
+}

--- a/modules/deck-arrow-layers/src/layers/arrow-trips-layer.ts
+++ b/modules/deck-arrow-layers/src/layers/arrow-trips-layer.ts
@@ -1,0 +1,34 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {ArrowPathSourceVectorSelectors} from '@luma.gl/arrow';
+import {ArrowPathLayer, type ArrowPathLayerProps} from './arrow-path-layer';
+import {DECK_ARROW_ALPHA_BLEND_PARAMETERS} from './arrow-layer-types';
+
+/** Trips specialization backed by aligned Arrow path and timestamp columns. */
+export type ArrowTripsLayerProps = Omit<
+  ArrowPathLayerProps,
+  'model' | 'temporalEnabled' | 'timestamps'
+> & {
+  /** Per-path temporal values aligned with path vertices. */
+  timestamps: NonNullable<ArrowPathSourceVectorSelectors['timestamps']>;
+  /** Current animation time in the prepared timestamp unit. */
+  currentTime: number;
+  /** Visible trail length in the prepared timestamp unit. */
+  trailLength: number;
+  /** Whether older trail vertices fade across the trail window. Defaults to true. */
+  fadeTrail?: boolean;
+};
+
+/** WebGPU Arrow TripsLayer that never appends timestamps to CPU coordinate arrays. */
+export class ArrowTripsLayer extends ArrowPathLayer {
+  static override layerName = 'ArrowTripsLayer';
+  static override defaultProps = {
+    ...ArrowPathLayer.defaultProps,
+    model: 'storage',
+    temporalEnabled: true,
+    fadeTrail: true,
+    parameters: DECK_ARROW_ALPHA_BLEND_PARAMETERS
+  };
+}

--- a/modules/deck-arrow-layers/src/layers/geoarrow-layer.ts
+++ b/modules/deck-arrow-layers/src/layers/geoarrow-layer.ts
@@ -1,0 +1,138 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {CompositeLayer, type Layer, type LayerProps} from '@deck.gl/core';
+import {RecordBatch, Table} from 'apache-arrow';
+import {ArrowScatterplotLayer, type ArrowScatterplotLayerProps} from './arrow-scatterplot-layer';
+import {ArrowPathLayer, type ArrowPathLayerProps} from './arrow-path-layer';
+import {
+  ArrowSolidPolygonLayer,
+  type ArrowSolidPolygonLayerProps
+} from './arrow-solid-polygon-layer';
+
+/** Native GeoArrow geometries dispatched by the composite layer. */
+export type GeoArrowLayerGeometryType =
+  | 'geoarrow.point'
+  | 'geoarrow.linestring'
+  | 'geoarrow.polygon'
+  | 'geoarrow.multipolygon';
+
+/** GeoArrow metadata-driven composite props. Geometry-specific props pass to the selected child. */
+export type GeoArrowLayerProps = Omit<LayerProps, 'data'> & {
+  data: Table | RecordBatch;
+  /** Geometry column. Defaults to the first field with GeoArrow extension metadata. */
+  getGeometry?: string;
+  /** Explicit native encoding when extension metadata is absent. */
+  geometryType?: GeoArrowLayerGeometryType;
+  /** Point radius column or constant. */
+  getRadius?: ArrowScatterplotLayerProps['getRadius'];
+  /** Point fill or polygon fill color. */
+  getFillColor?:
+    | ArrowScatterplotLayerProps['getFillColor']
+    | ArrowSolidPolygonLayerProps['getFillColor'];
+  /** Linestring color. */
+  getColor?: ArrowPathLayerProps['color'];
+  /** Linestring width. */
+  getWidth?: ArrowPathLayerProps['width'];
+  /** Optional pre-tessellated polygon interpretation. */
+  tessellated?: ArrowSolidPolygonLayerProps['tessellated'];
+  /** GPU model selection forwarded to the selected native renderer. */
+  model?: ArrowPathLayerProps['model'];
+};
+
+/** Selects an Arrow core layer from GeoArrow field metadata without materializing GeoJSON. */
+export class GeoArrowLayer extends CompositeLayer<GeoArrowLayerProps> {
+  static override layerName = 'GeoArrowLayer';
+
+  override renderLayers(): Layer {
+    const {
+      data,
+      getGeometry,
+      geometryType,
+      getRadius,
+      getFillColor,
+      getColor,
+      getWidth,
+      tessellated,
+      model,
+      ...layerProps
+    } = this.props;
+    const geometry = resolveGeoArrowGeometry(data, getGeometry, geometryType);
+    switch (geometry.geometryType) {
+      case 'geoarrow.point':
+        return new ArrowScatterplotLayer({
+          ...layerProps,
+          id: `${this.props.id}-points`,
+          data,
+          getPosition: geometry.columnName,
+          getRadius,
+          getFillColor: getFillColor as ArrowScatterplotLayerProps['getFillColor']
+        } as ArrowScatterplotLayerProps);
+      case 'geoarrow.linestring':
+        return new ArrowPathLayer({
+          ...layerProps,
+          id: `${this.props.id}-paths`,
+          data,
+          paths: geometry.columnName,
+          color: getColor,
+          width: getWidth,
+          model
+        } as ArrowPathLayerProps);
+      case 'geoarrow.polygon':
+      case 'geoarrow.multipolygon':
+        return new ArrowSolidPolygonLayer({
+          ...layerProps,
+          id: `${this.props.id}-polygons`,
+          data,
+          getPolygon: geometry.columnName,
+          getFillColor: getFillColor as ArrowSolidPolygonLayerProps['getFillColor'],
+          tessellated,
+          model
+        } as ArrowSolidPolygonLayerProps);
+    }
+  }
+}
+
+/** Resolves one native GeoArrow geometry column from schema extension metadata. */
+export function resolveGeoArrowGeometry(
+  data: Table | RecordBatch,
+  columnName?: string,
+  explicitGeometryType?: GeoArrowLayerGeometryType
+): {columnName: string; geometryType: GeoArrowLayerGeometryType} {
+  const fields = data.schema.fields;
+  const field = columnName
+    ? fields.find(candidate => candidate.name === columnName)
+    : fields.find(candidate =>
+        getGeoArrowExtensionName(candidate.metadata)?.startsWith('geoarrow.')
+      );
+  if (!field) {
+    throw new Error(
+      columnName
+        ? `GeoArrowLayer geometry column "${columnName}" is missing`
+        : 'GeoArrowLayer could not find a GeoArrow extension field'
+    );
+  }
+  const extensionName = explicitGeometryType ?? getGeoArrowExtensionName(field.metadata);
+  if (!isSupportedGeoArrowGeometryType(extensionName)) {
+    throw new Error(
+      `GeoArrowLayer does not yet dispatch "${extensionName ?? 'untyped'}"; use a native point, linestring, polygon, or multipolygon field`
+    );
+  }
+  return {columnName: field.name, geometryType: extensionName};
+}
+
+function getGeoArrowExtensionName(metadata: Map<string, string>): string | undefined {
+  return metadata.get('ARROW:extension:name') ?? metadata.get('ARROW:extension_name');
+}
+
+function isSupportedGeoArrowGeometryType(
+  value: string | undefined
+): value is GeoArrowLayerGeometryType {
+  return (
+    value === 'geoarrow.point' ||
+    value === 'geoarrow.linestring' ||
+    value === 'geoarrow.polygon' ||
+    value === 'geoarrow.multipolygon'
+  );
+}

--- a/modules/deck-arrow-layers/test/layers/arrow-layers.node.spec.ts
+++ b/modules/deck-arrow-layers/test/layers/arrow-layers.node.spec.ts
@@ -4,7 +4,23 @@
 
 import {expect, it} from 'vitest';
 import {ArrowPathLayer, ArrowPolygonLayer, ArrowTextLayer} from '@deck.gl-community/arrow-layers';
+import {makeArrowFixedSizeListVector} from '@luma.gl/arrow';
 import type {Model} from '@luma.gl/engine';
+import {Float32, Float64} from 'apache-arrow';
+import {assertLayerArrowVectorFormat} from '../../src/layers/arrow-gpu-layer-utils';
+
+it('Arrow GPU layer adapters reject columns whose storage does not match the GPU format', () => {
+  const float32Positions = makeArrowFixedSizeListVector(new Float32(), 2, new Float32Array([1, 2]));
+  const float64Positions = makeArrowFixedSizeListVector(new Float64(), 2, new Float64Array([1, 2]));
+
+  expect(() =>
+    assertLayerArrowVectorFormat(float32Positions, 'float32x2', 'positions')
+  ).not.toThrow();
+  expect(() => assertLayerArrowVectorFormat(float64Positions, 'float32x2', 'positions')).toThrow(
+    'FixedSizeList<Float32>[2]'
+  );
+  void 0;
+});
 
 it('Arrow deck layers do not use AttributeManager for Arrow GPU vectors', () => {
   const layers = [

--- a/modules/deck-arrow-layers/test/layers/arrow-layers.spec.ts
+++ b/modules/deck-arrow-layers/test/layers/arrow-layers.spec.ts
@@ -3,15 +3,29 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Deck, OrthographicView, type Layer, type PickingInfo} from '@deck.gl/core';
-import {ArrowPathLayer, ArrowPolygonLayer, ArrowTextLayer} from '@deck.gl-community/arrow-layers';
-import {makeGPUVectorFromArrow} from '@luma.gl/arrow';
+import {
+  ArrowArcLayer,
+  ArrowColumnLayer,
+  ArrowLineLayer,
+  ArrowPathLayer,
+  ArrowPointCloudLayer,
+  ArrowPolygonLayer,
+  ArrowScatterplotLayer,
+  ArrowTextLayer
+} from '@deck.gl-community/arrow-layers';
+import {
+  ArrowPolygonRenderer,
+  makeArrowFixedSizeListVector,
+  makeGPUVectorFromArrow
+} from '@luma.gl/arrow';
+import {GPUPathLayer, GPUSolidPolygonLayer} from '@deck.gl-community/gpu-layers';
 import {expect, it} from 'vitest';
 import type {Device} from '@luma.gl/core';
 import type {Model} from '@luma.gl/engine';
 import {ShaderAssembler} from '@luma.gl/shadertools';
 import {buildBitmapFontAtlas} from '@luma.gl/text';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import {Table, vectorFromArray, type RecordBatch} from 'apache-arrow';
+import {Float32, Table, Uint8, vectorFromArray, type RecordBatch} from 'apache-arrow';
 import {afterAll, vi} from 'vitest';
 import {
   makeArrowLineRecordBatches,
@@ -32,6 +46,157 @@ let restoreLegacyDeckShaderAssembler: (() => void) | null = null;
 afterAll(() => {
   restoreLegacyDeckShaderAssembler?.();
   finalizeSharedStorageDeck();
+});
+
+it('GPUVector-first Arrow fixed-width adapters create direct WebGPU models', async () => {
+  const device = await getWebGPUTestDevice('core');
+  if (!device || isSoftwareBackedDevice(device)) {
+    void 0;
+    return;
+  }
+  const positions = makeArrowFixedSizeListVector(
+    new Float32(),
+    2,
+    new Float32Array([-20, -10, 0, 20, 20, -10])
+  );
+  const targets = makeArrowFixedSizeListVector(
+    new Float32(),
+    2,
+    new Float32Array([0, 20, 20, -10, -20, -10])
+  );
+  const positions3 = makeArrowFixedSizeListVector(
+    new Float32(),
+    3,
+    new Float32Array([-20, -10, 0, 0, 20, 2, 20, -10, 4])
+  );
+  const colors = makeArrowFixedSizeListVector(
+    new Uint8(),
+    4,
+    new Uint8Array([255, 80, 40, 255, 40, 180, 255, 255, 120, 255, 80, 255])
+  );
+  const data = new Table({positions, positions3, targets, colors});
+  const scatterplot = new ArrowScatterplotLayer({
+    id: 'gpu-vector-arrow-scatterplot',
+    data,
+    getPosition: 'positions',
+    getRadius: 4,
+    getFillColor: 'colors'
+  });
+  const lines = new ArrowLineLayer({
+    id: 'gpu-vector-arrow-lines',
+    data,
+    getSourcePosition: 'positions',
+    getTargetPosition: 'targets',
+    getColor: 'colors'
+  });
+  const arcs = new ArrowArcLayer({
+    id: 'gpu-vector-arrow-arcs',
+    data,
+    getSourcePosition: 'positions',
+    getTargetPosition: 'targets',
+    getSourceColor: 'colors',
+    getWidth: 2,
+    getHeight: 5
+  });
+  const columns = new ArrowColumnLayer({
+    id: 'gpu-vector-arrow-columns',
+    data,
+    getPosition: 'positions',
+    getFillColor: 'colors',
+    getRadius: 4,
+    getElevation: 5
+  });
+  const pointCloud = new ArrowPointCloudLayer({
+    id: 'gpu-vector-arrow-point-cloud',
+    data,
+    getPosition: 'positions3',
+    getColor: 'colors',
+    pointSize: 4
+  });
+  const {deck, parent} = createTestDeck(device);
+  try {
+    await waitForDeckInitialization(deck);
+    const layers = [scatterplot, lines, arcs, columns, pointCloud];
+    deck.setProps({layers});
+    const models = await waitForCompositeModels(layers);
+    await Promise.all(models.map(waitForPipeline));
+    expect(models.every(model => model.device.type === 'webgpu')).toBe(true);
+  } finally {
+    deck.finalize();
+    parent.remove();
+  }
+  void 0;
+});
+
+it('GPUPathLayer renders variable-length GPUVectors without an Arrow dependency', async () => {
+  const device = await getWebGPUTestDevice('core');
+  if (!device || isSoftwareBackedDevice(device)) {
+    void 0;
+    return;
+  }
+  const source = makeArrowLineSourceData(
+    {pathCount: 3, pointCount: 5, label: 'gpu path core'},
+    'lines',
+    'float32',
+    'row-colors',
+    'none'
+  );
+  const paths = makeGPUVectorFromArrow(device, source.sourceVectors.paths, {
+    name: 'paths',
+    id: 'gpu-path-core-paths',
+    format: 'vertex-list<float32x2>',
+    preserveDataChunks: true
+  });
+  const layer = new GPUPathLayer({id: 'gpu-path-core', getPath: paths, getWidth: 2});
+  const {deck, parent} = createTestDeck(device);
+  try {
+    await waitForDeckInitialization(deck);
+    deck.setProps({layers: [layer]});
+    const model = await waitForLayerModel(layer);
+    await waitForPipeline(model);
+  } finally {
+    deck.finalize();
+    parent.remove();
+    paths.destroy();
+  }
+  void 0;
+});
+
+it('GPUSolidPolygonLayer renders adapter-prepared tessellated GPUVectors', async () => {
+  const device = await getWebGPUTestDevice('core');
+  if (!device || isSoftwareBackedDevice(device)) {
+    void 0;
+    return;
+  }
+  const source = makeArrowPolygonExampleData('10k-stream', 'polygon', 'row-colors');
+  const batch = source.recordBatches[0]!;
+  const prepared = await ArrowPolygonRenderer.convertToGPUVectors(
+    device,
+    {
+      polygons: batch.getChild('polygons')!.slice(0, 3) as never,
+      colors: batch.getChild('colors')!.slice(0, 3) as never
+    },
+    {id: 'gpu-solid-polygon-core', tessellated: source.tessellated}
+  );
+  const layer = new GPUSolidPolygonLayer({
+    id: 'gpu-solid-polygon-core',
+    positions: prepared.positions,
+    rowIndices: prepared.rowIndices,
+    indices: prepared.indices,
+    getFillColor: prepared.colors
+  });
+  const {deck, parent} = createTestDeck(device);
+  try {
+    await waitForDeckInitialization(deck);
+    deck.setProps({layers: [layer]});
+    const model = await waitForLayerModel(layer);
+    await waitForPipeline(model);
+  } finally {
+    deck.finalize();
+    parent.remove();
+    prepared.destroy();
+  }
+  void 0;
 });
 
 it('Arrow deck layers return source row indices from Deck picking', async () => {
@@ -669,6 +834,21 @@ async function waitForLayerModel(
     await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
   }
   throw new Error(`${layer.id} did not create a draw model`);
+}
+
+async function waitForCompositeModels(layers: Layer[]): Promise<Model[]> {
+  const timeout = Date.now() + TEST_MODEL_TIMEOUT_MILLISECONDS;
+  while (Date.now() < timeout) {
+    const models = layers.flatMap(getLayerModels);
+    if (models.length === layers.length) return models;
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+  }
+  throw new Error('GPUVector Arrow composite layers did not create draw models');
+}
+
+function getLayerModels(layer: Layer): Model[] {
+  const subLayers = (layer as Layer & {getSubLayers?: () => Layer[]}).getSubLayers?.() ?? [];
+  return [...layer.getModels(), ...subLayers.flatMap(getLayerModels)];
 }
 
 async function waitForModelCount(

--- a/modules/deck-arrow-layers/tsconfig.json
+++ b/modules/deck-arrow-layers/tsconfig.json
@@ -8,6 +8,7 @@
     "outDir": "dist"
   },
   "references": [
+    {"path": "../deck-gpu-layers"},
     {"path": "../arrow"},
     {"path": "../core"},
     {"path": "../engine"},

--- a/modules/deck-gpu-layers/README.md
+++ b/modules/deck-gpu-layers/README.md
@@ -2,6 +2,47 @@
 
 Reusable deck.gl layers for GPU-selected spatial data.
 
+## GPUVector layer core
+
+The GPU layer family defines the rendering ABI below Arrow, classic JavaScript, and classic binary
+inputs. It consumes caller-owned GPU data, does not import Apache Arrow, and never destroys input
+vectors.
+
+The fixed-width primitives are `GPUArcLayer`, `GPUColumnLayer`, `GPUGridCellLayer`, `GPUIconLayer`,
+`GPULineLayer`, `GPUPointCloudLayer`, and `GPUScatterplotLayer`. They consume row-aligned
+`GPUVector` objects and preserve every physical chunk as a separate draw batch. `GPUBitmapLayer`
+accepts an already loaded `Texture`; a bitmap has no tabular column to convert.
+
+```ts
+import {GPUScatterplotLayer} from '@deck.gl-community/gpu-layers';
+
+const layer = new GPUScatterplotLayer({
+  id: 'points',
+  getPosition: positions, // GPUVector<'float32x2'>
+  getRadius: radii, // number or GPUVector<'float32'>
+  getFillColor: colors // Color or GPUVector<'unorm8x4'>
+});
+```
+
+All non-constant vectors must have identical row counts and physical chunk boundaries. This makes
+streaming and ownership deterministic: adapters append batches explicitly, while the renderer
+neither combines nor repacks them. Picking uses global row indices and attaches physical batch
+provenance as `PickingInfo.gpuVector`.
+
+Variable geometry stays GPU-native as well:
+
+- `GPUPathLayer` consumes `GPUVector<'vertex-list<float32xN>'>` and expands segments on the GPU.
+- `GPUSolidPolygonLayer` consumes tessellated position, row-index, color, and triangle-index
+  GPUVectors prepared by an adapter.
+- `GPUPolygonLayer` composes the solid fill and path outline cores without copying either input.
+- `GPUTextLayer` consumes caller-owned `GPUTextData`, whose chosen strategy owns glyph GPUVectors
+  and atlas metadata.
+
+GeoJSON and GeoArrow are source formats rather than rendering primitives. Their adapters split
+features into these GPU cores. The same rule applies to future classic JavaScript and classic
+binary compatibility: each input family converts or borrows GPUVectors and delegates to the same
+renderer.
+
 `LuSpatialPointLayer` binds caller-owned position and point-ID buffers directly and replays a
 caller-owned `DrawCommandBuffer`. The layer owns only its render model and style-uniform buffer;
 query results, indirect commands, and source positions remain owned by the application.
@@ -90,3 +131,9 @@ are sampled asynchronously and never gate the GPU-driven render path. Readbacks 
 `onStats` is supplied, or explicitly with `enableDiagnostics`. The effect owns every buffer and
 graph it creates; Deck calls `cleanup`, while applications may call `destroy` when an effect is
 constructed but never adopted.
+
+## Tiled sources
+
+Tiled GPUVector and Arrow adapters are intentionally outside this layer core. They should integrate
+with deck.gl's proposed shared tile layer so cache ownership, refinement, cancellation, and request
+deduplication remain common infrastructure rather than being reimplemented in this package.

--- a/modules/deck-gpu-layers/README.md
+++ b/modules/deck-gpu-layers/README.md
@@ -10,7 +10,8 @@ vectors.
 
 The fixed-width primitives are `GPUArcLayer`, `GPUColumnLayer`, `GPUGridCellLayer`, `GPUIconLayer`,
 `GPULineLayer`, `GPUPointCloudLayer`, and `GPUScatterplotLayer`. They consume row-aligned
-`GPUVector` objects and preserve every physical chunk as a separate draw batch. `GPUBitmapLayer`
+`GPUVector` objects. Each layer owns one `GPUVectorModel`, which preserves every physical chunk as
+a separate draw call without creating a model or deck child layer per chunk. `GPUBitmapLayer`
 accepts an already loaded `Texture`; a bitmap has no tabular column to convert.
 
 ```ts

--- a/modules/deck-gpu-layers/package.json
+++ b/modules/deck-gpu-layers/package.json
@@ -31,6 +31,8 @@
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",
     "@luma.gl/experimental": "9.4.0-alpha.4",
-    "@luma.gl/shadertools": "9.4.0-alpha.4"
+    "@luma.gl/gpgpu": "9.4.0-alpha.4",
+    "@luma.gl/shadertools": "9.4.0-alpha.4",
+    "@luma.gl/text": "9.4.0-alpha.4"
   }
 }

--- a/modules/deck-gpu-layers/src/index.ts
+++ b/modules/deck-gpu-layers/src/index.ts
@@ -6,3 +6,23 @@ export {
   LuSpatialPointLayer,
   type LuSpatialPointLayerProps
 } from './layers/luspatial-point-layer';
+export {GPUScatterplotLayer, type GPUScatterplotLayerProps} from './layers/gpu-scatterplot-layer';
+export {GPULineLayer, type GPULineLayerProps} from './layers/gpu-line-layer';
+export {GPUIconLayer, type GPUIconLayerProps} from './layers/gpu-icon-layer';
+export {GPUArcLayer, type GPUArcLayerProps} from './layers/gpu-arc-layer';
+export {GPUPointCloudLayer, type GPUPointCloudLayerProps} from './layers/gpu-point-cloud-layer';
+export {GPUColumnLayer, type GPUColumnLayerProps} from './layers/gpu-column-layer';
+export {GPUGridCellLayer, type GPUGridCellLayerProps} from './layers/gpu-grid-cell-layer';
+export {
+  GPUBitmapLayer,
+  type GPUBitmapBounds,
+  type GPUBitmapLayerProps
+} from './layers/gpu-bitmap-layer';
+export {GPUPathLayer, type GPUPathLayerProps} from './layers/gpu-path-layer';
+export {
+  GPUSolidPolygonLayer,
+  type GPUSolidPolygonLayerProps
+} from './layers/gpu-solid-polygon-layer';
+export {GPUTextLayer, type GPUTextLayerProps} from './layers/gpu-text-layer';
+export {GPUPolygonLayer, type GPUPolygonLayerProps} from './layers/gpu-polygon-layer';
+export type {GPUVectorLayerPickingInfo} from './layers/gpu-vector-layer-utils';

--- a/modules/deck-gpu-layers/src/layers/gpu-arc-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-arc-layer.ts
@@ -3,7 +3,6 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {
-  CompositeLayer,
   Layer,
   picking,
   project32,
@@ -14,12 +13,13 @@ import {
   type UpdateParameters
 } from '@deck.gl/core';
 import {Buffer, type RenderPass} from '@luma.gl/core';
-import {Model} from '@luma.gl/engine';
-import type {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import type {Model} from '@luma.gl/engine';
+import {GPUVectorModel, type GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {
-  getGPUDataBuffer,
+  getGPUVectorBuffer,
   getGPUVectorLayerBatches,
-  makeGPUDataBufferLayout,
+  getGPUVectorPickingProvenance,
+  makeGPUVectorBufferLayout,
   type GPUVectorLayerPickingInfo
 } from './gpu-vector-layer-utils';
 
@@ -37,19 +37,11 @@ export type GPUArcLayerProps = Omit<LayerProps, 'data'> & {
   numSegments?: number;
 };
 
-type GPUArcBatchProps = Omit<GPUArcLayerProps, 'getSourcePosition' | 'getTargetPosition'> & {
-  sourcePositions: GPUData<'float32x2'>;
-  targetPositions: GPUData<'float32x2'>;
-  sourceColors?: GPUData<'unorm8x4'>;
-  targetColors?: GPUData<'unorm8x4'>;
-  widths?: GPUData<'float32'>;
-  heights?: GPUData<'float32'>;
-  rowCount: number;
-  batchIndex: number;
-  rowIndexOffset: number;
+type GPUArcLayerState = {
+  model: GPUVectorModel | null;
+  styleBuffer: Buffer | null;
+  defaults: Buffer[];
 };
-
-type GPUArcBatchState = {model: Model | null; styleBuffer: Buffer | null; defaults: Buffer[]};
 
 const GPU_ARC_SHADER = /* wgsl */ `
 struct ArcStyle {
@@ -138,8 +130,9 @@ fn getArcPosition(sourcePosition: vec2<f32>, targetPosition: vec2<f32>, progress
   return vec4<f32>(input.color.rgb, input.color.a * layer.opacity);
 }`;
 
-class GPUArcBatchLayer extends Layer<GPUArcBatchProps> {
-  static override layerName = 'GPUArcBatchLayer';
+/** Chunk-preserving GPUVector curved-arc layer. */
+export class GPUArcLayer extends Layer<GPUArcLayerProps> {
+  static override layerName = 'GPUArcLayer';
 
   override getAttributeManager() {
     return null;
@@ -147,6 +140,37 @@ class GPUArcBatchLayer extends Layer<GPUArcBatchProps> {
 
   override initializeState({device}: LayerContext): void {
     if (device.type !== 'webgpu') throw new Error('GPUArcLayer requires WebGPU');
+    const sourceColors = isGPUVector(this.props.getSourceColor)
+      ? this.props.getSourceColor
+      : undefined;
+    const targetColors = isGPUVector(this.props.getTargetColor)
+      ? this.props.getTargetColor
+      : undefined;
+    const widths = isGPUVector(this.props.getWidth) ? this.props.getWidth : undefined;
+    const heights = isGPUVector(this.props.getHeight) ? this.props.getHeight : undefined;
+    getGPUVectorLayerBatches(
+      this.id,
+      {
+        sourcePositions: this.props.getSourcePosition,
+        targetPositions: this.props.getTargetPosition,
+        sourceColors,
+        targetColors,
+        widths,
+        heights
+      },
+      {
+        sourcePositions: ['float32x2'],
+        targetPositions: ['float32x2'],
+        sourceColors: ['unorm8x4'],
+        targetColors: ['unorm8x4'],
+        widths: ['float32'],
+        heights: ['float32']
+      }
+    );
+    if (this.props.getSourcePosition.data.length === 0) {
+      this.setState({model: null, styleBuffer: null, defaults: []} satisfies GPUArcLayerState);
+      return;
+    }
     const styleBuffer = device.createBuffer({
       id: `${this.id}-style`,
       byteLength: 80,
@@ -158,73 +182,71 @@ class GPUArcBatchLayer extends Layer<GPUArcBatchProps> {
       device.createBuffer({data: new Float32Array([1])}),
       device.createBuffer({data: new Float32Array([1])})
     ];
-    const model = new Model(device, {
+    const model = new GPUVectorModel(device, {
       ...this.getShaders({modules: [project32, picking], source: GPU_ARC_SHADER}),
       id: `${this.id}-model`,
       topology: 'triangle-list',
       isInstanced: true,
       vertexCount: Math.max(1, this.props.numSegments ?? 32) * 6,
-      instanceCount: this.props.rowCount,
+      instanceCount: 0,
       attributes: {
-        sourcePositions: getGPUDataBuffer(this.props.sourcePositions),
-        targetPositions: getGPUDataBuffer(this.props.targetPositions),
-        sourceColors: this.props.sourceColors
-          ? getGPUDataBuffer(this.props.sourceColors)
-          : defaults[0]!,
-        targetColors: this.props.targetColors
-          ? getGPUDataBuffer(this.props.targetColors)
-          : defaults[1]!,
-        widths: this.props.widths ? getGPUDataBuffer(this.props.widths) : defaults[2]!,
-        heights: this.props.heights ? getGPUDataBuffer(this.props.heights) : defaults[3]!
+        sourcePositions: getGPUVectorBuffer(this.props.getSourcePosition),
+        targetPositions: getGPUVectorBuffer(this.props.getTargetPosition),
+        sourceColors: sourceColors ? getGPUVectorBuffer(sourceColors) : defaults[0]!,
+        targetColors: targetColors ? getGPUVectorBuffer(targetColors) : defaults[1]!,
+        widths: widths ? getGPUVectorBuffer(widths) : defaults[2]!,
+        heights: heights ? getGPUVectorBuffer(heights) : defaults[3]!
       },
       bufferLayout: [
-        makeGPUDataBufferLayout(this.props.sourcePositions, 'sourcePositions'),
-        makeGPUDataBufferLayout(this.props.targetPositions, 'targetPositions'),
-        this.props.sourceColors
-          ? makeGPUDataBufferLayout(this.props.sourceColors, 'sourceColors')
+        makeGPUVectorBufferLayout(this.props.getSourcePosition, 'sourcePositions'),
+        makeGPUVectorBufferLayout(this.props.getTargetPosition, 'targetPositions'),
+        sourceColors
+          ? makeGPUVectorBufferLayout(sourceColors, 'sourceColors')
           : makeConstantLayout('sourceColors', 'unorm8x4'),
-        this.props.targetColors
-          ? makeGPUDataBufferLayout(this.props.targetColors, 'targetColors')
+        targetColors
+          ? makeGPUVectorBufferLayout(targetColors, 'targetColors')
           : makeConstantLayout('targetColors', 'unorm8x4'),
-        this.props.widths
-          ? makeGPUDataBufferLayout(this.props.widths, 'widths')
+        widths
+          ? makeGPUVectorBufferLayout(widths, 'widths')
           : makeConstantLayout('widths', 'float32'),
-        this.props.heights
-          ? makeGPUDataBufferLayout(this.props.heights, 'heights')
+        heights
+          ? makeGPUVectorBufferLayout(heights, 'heights')
           : makeConstantLayout('heights', 'float32')
       ],
       bindings: {arcStyle: styleBuffer}
     });
     model.userData['boundInputs'] = [
-      this.props.sourcePositions,
-      this.props.targetPositions,
-      this.props.sourceColors,
-      this.props.targetColors,
-      this.props.widths,
-      this.props.heights,
-      this.props.numSegments,
-      this.props.rowCount
+      this.props.getSourcePosition,
+      this.props.getTargetPosition,
+      sourceColors,
+      targetColors,
+      widths,
+      heights,
+      this.props.numSegments
     ];
-    this.setState({model, styleBuffer, defaults} satisfies GPUArcBatchState);
+    this.setState({model, styleBuffer, defaults} satisfies GPUArcLayerState);
   }
 
   override getModels(): Model[] {
-    const model = (this.state as GPUArcBatchState).model;
+    const model = (this.state as GPUArcLayerState).model;
     return model ? [model] : [];
   }
 
   override updateState({props}: UpdateParameters<this>): void {
-    const boundInputs = ((this.state as GPUArcBatchState).model?.userData['boundInputs'] ??
+    const boundInputs = ((this.state as GPUArcLayerState).model?.userData['boundInputs'] ??
       []) as unknown[];
+    const sourceColors = isGPUVector(props.getSourceColor) ? props.getSourceColor : undefined;
+    const targetColors = isGPUVector(props.getTargetColor) ? props.getTargetColor : undefined;
+    const widths = isGPUVector(props.getWidth) ? props.getWidth : undefined;
+    const heights = isGPUVector(props.getHeight) ? props.getHeight : undefined;
     if (
-      props.sourcePositions !== boundInputs[0] ||
-      props.targetPositions !== boundInputs[1] ||
-      props.sourceColors !== boundInputs[2] ||
-      props.targetColors !== boundInputs[3] ||
-      props.widths !== boundInputs[4] ||
-      props.heights !== boundInputs[5] ||
-      props.numSegments !== boundInputs[6] ||
-      props.rowCount !== boundInputs[7]
+      props.getSourcePosition !== boundInputs[0] ||
+      props.getTargetPosition !== boundInputs[1] ||
+      sourceColors !== boundInputs[2] ||
+      targetColors !== boundInputs[3] ||
+      widths !== boundInputs[4] ||
+      heights !== boundInputs[5] ||
+      props.numSegments !== boundInputs[6]
     ) {
       this.destroyResources();
       this.initializeState(this.context);
@@ -232,8 +254,16 @@ class GPUArcBatchLayer extends Layer<GPUArcBatchProps> {
   }
 
   override draw({renderPass}: {renderPass: RenderPass}): void {
-    const {model, styleBuffer} = this.state as GPUArcBatchState;
+    const {model, styleBuffer} = this.state as GPUArcLayerState;
     if (!model || !styleBuffer) return;
+    const sourceColors = isGPUVector(this.props.getSourceColor)
+      ? this.props.getSourceColor
+      : undefined;
+    const targetColors = isGPUVector(this.props.getTargetColor)
+      ? this.props.getTargetColor
+      : undefined;
+    const widths = isGPUVector(this.props.getWidth) ? this.props.getWidth : undefined;
+    const heights = isGPUVector(this.props.getHeight) ? this.props.getHeight : undefined;
     const defaultColor: Color = [0, 0, 0, 255];
     const sourceColor = isColor(this.props.getSourceColor)
       ? this.props.getSourceColor
@@ -259,25 +289,33 @@ class GPUArcBatchLayer extends Layer<GPUArcBatchProps> {
     uints.set(
       [
         Math.max(1, this.props.numSegments ?? 32),
-        this.props.sourceColors ? 1 : 0,
-        this.props.targetColors ? 1 : 0,
-        this.props.widths ? 1 : 0,
-        this.props.heights ? 1 : 0,
-        this.props.rowIndexOffset
+        sourceColors ? 1 : 0,
+        targetColors ? 1 : 0,
+        widths ? 1 : 0,
+        heights ? 1 : 0,
+        0
       ],
       13
     );
-    styleBuffer.write(new Uint8Array(bytes));
-    model.draw(renderPass);
+    model.drawBatches(renderPass, {
+      vectors: {
+        sourcePositions: this.props.getSourcePosition,
+        targetPositions: this.props.getTargetPosition,
+        sourceColors,
+        targetColors,
+        widths,
+        heights
+      },
+      onBatch: batch => {
+        uints[18] = batch.rowIndexOffset;
+        styleBuffer.write(new Uint8Array(bytes));
+      }
+    });
   }
 
   override getPickingInfo({info}: {info: PickingInfo}): PickingInfo {
     const result = info as GPUVectorLayerPickingInfo;
-    result.gpuVector = {
-      rowIndex: result.index,
-      batchIndex: this.props.batchIndex,
-      batchRowIndex: result.index - this.props.rowIndexOffset
-    };
+    result.gpuVector = getGPUVectorPickingProvenance(this.props.getSourcePosition, result.index);
     return result;
   }
 
@@ -287,66 +325,11 @@ class GPUArcBatchLayer extends Layer<GPUArcBatchProps> {
   }
 
   private destroyResources(): void {
-    const state = this.state as GPUArcBatchState;
+    const state = this.state as GPUArcLayerState;
     state.model?.destroy();
     state.styleBuffer?.destroy();
     state.defaults.forEach(buffer => buffer.destroy());
     this.setState({model: null, styleBuffer: null, defaults: []});
-  }
-}
-
-/** Chunk-preserving GPUVector curved-arc composite. */
-export class GPUArcLayer extends CompositeLayer<GPUArcLayerProps> {
-  static override layerName = 'GPUArcLayer';
-
-  override renderLayers(): GPUArcBatchLayer[] {
-    const {
-      getSourcePosition,
-      getTargetPosition,
-      getSourceColor,
-      getTargetColor,
-      getWidth,
-      getHeight,
-      ...props
-    } = this.props;
-    return getGPUVectorLayerBatches(
-      this.id,
-      {
-        sourcePositions: getSourcePosition,
-        targetPositions: getTargetPosition,
-        sourceColors: isGPUVector(getSourceColor) ? getSourceColor : undefined,
-        targetColors: isGPUVector(getTargetColor) ? getTargetColor : undefined,
-        widths: isGPUVector(getWidth) ? getWidth : undefined,
-        heights: isGPUVector(getHeight) ? getHeight : undefined
-      },
-      {
-        sourcePositions: ['float32x2'],
-        targetPositions: ['float32x2'],
-        sourceColors: ['unorm8x4'],
-        targetColors: ['unorm8x4'],
-        widths: ['float32'],
-        heights: ['float32']
-      }
-    ).map(
-      batch =>
-        new GPUArcBatchLayer({
-          ...props,
-          id: `${this.props.id}-batch-${batch.batchIndex}`,
-          getSourceColor,
-          getTargetColor,
-          getWidth,
-          getHeight,
-          sourcePositions: batch.data['sourcePositions'] as GPUData<'float32x2'>,
-          targetPositions: batch.data['targetPositions'] as GPUData<'float32x2'>,
-          sourceColors: batch.data['sourceColors'] as GPUData<'unorm8x4'> | undefined,
-          targetColors: batch.data['targetColors'] as GPUData<'unorm8x4'> | undefined,
-          widths: batch.data['widths'] as GPUData<'float32'> | undefined,
-          heights: batch.data['heights'] as GPUData<'float32'> | undefined,
-          rowCount: batch.rowCount,
-          batchIndex: batch.batchIndex,
-          rowIndexOffset: batch.rowIndexOffset
-        })
-    );
   }
 }
 

--- a/modules/deck-gpu-layers/src/layers/gpu-arc-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-arc-layer.ts
@@ -1,0 +1,372 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  CompositeLayer,
+  Layer,
+  picking,
+  project32,
+  type Color,
+  type LayerContext,
+  type LayerProps,
+  type PickingInfo,
+  type UpdateParameters
+} from '@deck.gl/core';
+import {Buffer, type RenderPass} from '@luma.gl/core';
+import {Model} from '@luma.gl/engine';
+import type {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import {
+  getGPUDataBuffer,
+  getGPUVectorLayerBatches,
+  makeGPUDataBufferLayout,
+  type GPUVectorLayerPickingInfo
+} from './gpu-vector-layer-utils';
+
+/** GPUVector-native curved-arc props. Input vectors are borrowed. */
+export type GPUArcLayerProps = Omit<LayerProps, 'data'> & {
+  getSourcePosition: GPUVector<'float32x2'>;
+  getTargetPosition: GPUVector<'float32x2'>;
+  getSourceColor?: Color | GPUVector<'unorm8x4'>;
+  getTargetColor?: Color | GPUVector<'unorm8x4'>;
+  getWidth?: number | GPUVector<'float32'>;
+  getHeight?: number | GPUVector<'float32'>;
+  widthScale?: number;
+  widthMinPixels?: number;
+  widthMaxPixels?: number;
+  numSegments?: number;
+};
+
+type GPUArcBatchProps = Omit<GPUArcLayerProps, 'getSourcePosition' | 'getTargetPosition'> & {
+  sourcePositions: GPUData<'float32x2'>;
+  targetPositions: GPUData<'float32x2'>;
+  sourceColors?: GPUData<'unorm8x4'>;
+  targetColors?: GPUData<'unorm8x4'>;
+  widths?: GPUData<'float32'>;
+  heights?: GPUData<'float32'>;
+  rowCount: number;
+  batchIndex: number;
+  rowIndexOffset: number;
+};
+
+type GPUArcBatchState = {model: Model | null; styleBuffer: Buffer | null; defaults: Buffer[]};
+
+const GPU_ARC_SHADER = /* wgsl */ `
+struct ArcStyle {
+  sourceColor: vec4<f32>,
+  targetColor: vec4<f32>,
+  width: f32,
+  height: f32,
+  widthScale: f32,
+  widthMinPixels: f32,
+  widthMaxPixels: f32,
+  numSegments: u32,
+  useSourceColors: u32,
+  useTargetColors: u32,
+  useWidths: u32,
+  useHeights: u32,
+  rowIndexOffset: u32,
+};
+@group(0) @binding(auto) var<uniform> arcStyle: ArcStyle;
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec4<f32>,
+  @location(1) @interpolate(flat) pickingColor: vec3<f32>,
+};
+
+fn encodePickingColor(rowIndex: u32) -> vec3<f32> {
+  let value = rowIndex + 1u;
+  return vec3<f32>(f32(value % 256u), f32((value / 256u) % 256u), f32((value / 65536u) % 256u)) / 255.0;
+}
+
+fn getCorner(vertexIndex: u32) -> vec2<f32> {
+  let corners = array<vec2<f32>, 6>(
+    vec2<f32>(0.0, -1.0), vec2<f32>(1.0, -1.0), vec2<f32>(0.0, 1.0),
+    vec2<f32>(0.0, 1.0), vec2<f32>(1.0, -1.0), vec2<f32>(1.0, 1.0)
+  );
+  return corners[vertexIndex % 6u];
+}
+
+fn getArcPosition(sourcePosition: vec2<f32>, targetPosition: vec2<f32>, progress: f32, height: f32) -> vec3<f32> {
+  let linear = mix(sourcePosition, targetPosition, progress);
+  return vec3<f32>(linear, 4.0 * progress * (1.0 - progress) * height);
+}
+
+@vertex fn vertexMain(
+  @location(0) sourcePositions: vec2<f32>,
+  @location(1) targetPositions: vec2<f32>,
+  @location(2) sourceColors: vec4<f32>,
+  @location(3) targetColors: vec4<f32>,
+  @location(4) widths: f32,
+  @location(5) heights: f32,
+  @builtin(vertex_index) vertexIndex: u32,
+  @builtin(instance_index) instanceIndex: u32
+) -> VertexOutput {
+  let segmentIndex = vertexIndex / 6u;
+  let corner = getCorner(vertexIndex);
+  let startProgress = f32(segmentIndex) / f32(arcStyle.numSegments);
+  let endProgress = f32(segmentIndex + 1u) / f32(arcStyle.numSegments);
+  let height = select(arcStyle.height, heights, arcStyle.useHeights != 0u);
+  let startWorld = getArcPosition(sourcePositions, targetPositions, startProgress, height);
+  let endWorld = getArcPosition(sourcePositions, targetPositions, endProgress, height);
+  let startClip = project_position_to_clipspace(startWorld, vec3<f32>(0.0), vec3<f32>(0.0));
+  let endClip = project_position_to_clipspace(endWorld, vec3<f32>(0.0), vec3<f32>(0.0));
+  let delta = endClip.xy / endClip.w - startClip.xy / startClip.w;
+  let direction = select(vec2<f32>(1.0, 0.0), normalize(delta), length(delta) > 0.000001);
+  let normal = vec2<f32>(-direction.y, direction.x);
+  let width = clamp(select(arcStyle.width, widths, arcStyle.useWidths != 0u) * arcStyle.widthScale, arcStyle.widthMinPixels, arcStyle.widthMaxPixels);
+  var clipPosition = mix(startClip, endClip, corner.x);
+  clipPosition = vec4<f32>(clipPosition.xy + project_pixel_size_to_clipspace(normal * corner.y * width * 0.5) * clipPosition.w, clipPosition.z, clipPosition.w);
+  let progress = mix(startProgress, endProgress, corner.x);
+  let pickingColor = encodePickingColor(instanceIndex + arcStyle.rowIndexOffset);
+  geometry.worldPosition = mix(startWorld, endWorld, corner.x);
+  geometry.pickingColor = pickingColor;
+  var output: VertexOutput;
+  output.position = clipPosition;
+  output.color = mix(
+    select(arcStyle.sourceColor, sourceColors, arcStyle.useSourceColors != 0u),
+    select(arcStyle.targetColor, targetColors, arcStyle.useTargetColors != 0u),
+    progress
+  );
+  output.pickingColor = pickingColor;
+  return output;
+}
+
+@fragment fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  if (picking.isActive > 0.5) { return vec4<f32>(input.pickingColor, 1.0); }
+  return vec4<f32>(input.color.rgb, input.color.a * layer.opacity);
+}`;
+
+class GPUArcBatchLayer extends Layer<GPUArcBatchProps> {
+  static override layerName = 'GPUArcBatchLayer';
+
+  override getAttributeManager() {
+    return null;
+  }
+
+  override initializeState({device}: LayerContext): void {
+    if (device.type !== 'webgpu') throw new Error('GPUArcLayer requires WebGPU');
+    const styleBuffer = device.createBuffer({
+      id: `${this.id}-style`,
+      byteLength: 80,
+      usage: Buffer.UNIFORM | Buffer.COPY_DST
+    });
+    const defaults = [
+      device.createBuffer({data: new Uint8Array([0, 0, 0, 255])}),
+      device.createBuffer({data: new Uint8Array([0, 0, 0, 255])}),
+      device.createBuffer({data: new Float32Array([1])}),
+      device.createBuffer({data: new Float32Array([1])})
+    ];
+    const model = new Model(device, {
+      ...this.getShaders({modules: [project32, picking], source: GPU_ARC_SHADER}),
+      id: `${this.id}-model`,
+      topology: 'triangle-list',
+      isInstanced: true,
+      vertexCount: Math.max(1, this.props.numSegments ?? 32) * 6,
+      instanceCount: this.props.rowCount,
+      attributes: {
+        sourcePositions: getGPUDataBuffer(this.props.sourcePositions),
+        targetPositions: getGPUDataBuffer(this.props.targetPositions),
+        sourceColors: this.props.sourceColors
+          ? getGPUDataBuffer(this.props.sourceColors)
+          : defaults[0]!,
+        targetColors: this.props.targetColors
+          ? getGPUDataBuffer(this.props.targetColors)
+          : defaults[1]!,
+        widths: this.props.widths ? getGPUDataBuffer(this.props.widths) : defaults[2]!,
+        heights: this.props.heights ? getGPUDataBuffer(this.props.heights) : defaults[3]!
+      },
+      bufferLayout: [
+        makeGPUDataBufferLayout(this.props.sourcePositions, 'sourcePositions'),
+        makeGPUDataBufferLayout(this.props.targetPositions, 'targetPositions'),
+        this.props.sourceColors
+          ? makeGPUDataBufferLayout(this.props.sourceColors, 'sourceColors')
+          : makeConstantLayout('sourceColors', 'unorm8x4'),
+        this.props.targetColors
+          ? makeGPUDataBufferLayout(this.props.targetColors, 'targetColors')
+          : makeConstantLayout('targetColors', 'unorm8x4'),
+        this.props.widths
+          ? makeGPUDataBufferLayout(this.props.widths, 'widths')
+          : makeConstantLayout('widths', 'float32'),
+        this.props.heights
+          ? makeGPUDataBufferLayout(this.props.heights, 'heights')
+          : makeConstantLayout('heights', 'float32')
+      ],
+      bindings: {arcStyle: styleBuffer}
+    });
+    model.userData['boundInputs'] = [
+      this.props.sourcePositions,
+      this.props.targetPositions,
+      this.props.sourceColors,
+      this.props.targetColors,
+      this.props.widths,
+      this.props.heights,
+      this.props.numSegments,
+      this.props.rowCount
+    ];
+    this.setState({model, styleBuffer, defaults} satisfies GPUArcBatchState);
+  }
+
+  override getModels(): Model[] {
+    const model = (this.state as GPUArcBatchState).model;
+    return model ? [model] : [];
+  }
+
+  override updateState({props}: UpdateParameters<this>): void {
+    const boundInputs = ((this.state as GPUArcBatchState).model?.userData['boundInputs'] ??
+      []) as unknown[];
+    if (
+      props.sourcePositions !== boundInputs[0] ||
+      props.targetPositions !== boundInputs[1] ||
+      props.sourceColors !== boundInputs[2] ||
+      props.targetColors !== boundInputs[3] ||
+      props.widths !== boundInputs[4] ||
+      props.heights !== boundInputs[5] ||
+      props.numSegments !== boundInputs[6] ||
+      props.rowCount !== boundInputs[7]
+    ) {
+      this.destroyResources();
+      this.initializeState(this.context);
+    }
+  }
+
+  override draw({renderPass}: {renderPass: RenderPass}): void {
+    const {model, styleBuffer} = this.state as GPUArcBatchState;
+    if (!model || !styleBuffer) return;
+    const defaultColor: Color = [0, 0, 0, 255];
+    const sourceColor = isColor(this.props.getSourceColor)
+      ? this.props.getSourceColor
+      : defaultColor;
+    const targetColor = isColor(this.props.getTargetColor)
+      ? this.props.getTargetColor
+      : sourceColor;
+    const bytes = new ArrayBuffer(80);
+    const floats = new Float32Array(bytes);
+    const uints = new Uint32Array(bytes);
+    floats.set(normalizeColor(sourceColor));
+    floats.set(normalizeColor(targetColor), 4);
+    floats.set(
+      [
+        typeof this.props.getWidth === 'number' ? this.props.getWidth : 1,
+        typeof this.props.getHeight === 'number' ? this.props.getHeight : 1,
+        this.props.widthScale ?? 1,
+        this.props.widthMinPixels ?? 0,
+        this.props.widthMaxPixels ?? 1e9
+      ],
+      8
+    );
+    uints.set(
+      [
+        Math.max(1, this.props.numSegments ?? 32),
+        this.props.sourceColors ? 1 : 0,
+        this.props.targetColors ? 1 : 0,
+        this.props.widths ? 1 : 0,
+        this.props.heights ? 1 : 0,
+        this.props.rowIndexOffset
+      ],
+      13
+    );
+    styleBuffer.write(new Uint8Array(bytes));
+    model.draw(renderPass);
+  }
+
+  override getPickingInfo({info}: {info: PickingInfo}): PickingInfo {
+    const result = info as GPUVectorLayerPickingInfo;
+    result.gpuVector = {
+      rowIndex: result.index,
+      batchIndex: this.props.batchIndex,
+      batchRowIndex: result.index - this.props.rowIndexOffset
+    };
+    return result;
+  }
+
+  override finalizeState(context: LayerContext): void {
+    this.destroyResources();
+    super.finalizeState(context);
+  }
+
+  private destroyResources(): void {
+    const state = this.state as GPUArcBatchState;
+    state.model?.destroy();
+    state.styleBuffer?.destroy();
+    state.defaults.forEach(buffer => buffer.destroy());
+    this.setState({model: null, styleBuffer: null, defaults: []});
+  }
+}
+
+/** Chunk-preserving GPUVector curved-arc composite. */
+export class GPUArcLayer extends CompositeLayer<GPUArcLayerProps> {
+  static override layerName = 'GPUArcLayer';
+
+  override renderLayers(): GPUArcBatchLayer[] {
+    const {
+      getSourcePosition,
+      getTargetPosition,
+      getSourceColor,
+      getTargetColor,
+      getWidth,
+      getHeight,
+      ...props
+    } = this.props;
+    return getGPUVectorLayerBatches(
+      this.id,
+      {
+        sourcePositions: getSourcePosition,
+        targetPositions: getTargetPosition,
+        sourceColors: isGPUVector(getSourceColor) ? getSourceColor : undefined,
+        targetColors: isGPUVector(getTargetColor) ? getTargetColor : undefined,
+        widths: isGPUVector(getWidth) ? getWidth : undefined,
+        heights: isGPUVector(getHeight) ? getHeight : undefined
+      },
+      {
+        sourcePositions: ['float32x2'],
+        targetPositions: ['float32x2'],
+        sourceColors: ['unorm8x4'],
+        targetColors: ['unorm8x4'],
+        widths: ['float32'],
+        heights: ['float32']
+      }
+    ).map(
+      batch =>
+        new GPUArcBatchLayer({
+          ...props,
+          id: `${this.props.id}-batch-${batch.batchIndex}`,
+          getSourceColor,
+          getTargetColor,
+          getWidth,
+          getHeight,
+          sourcePositions: batch.data['sourcePositions'] as GPUData<'float32x2'>,
+          targetPositions: batch.data['targetPositions'] as GPUData<'float32x2'>,
+          sourceColors: batch.data['sourceColors'] as GPUData<'unorm8x4'> | undefined,
+          targetColors: batch.data['targetColors'] as GPUData<'unorm8x4'> | undefined,
+          widths: batch.data['widths'] as GPUData<'float32'> | undefined,
+          heights: batch.data['heights'] as GPUData<'float32'> | undefined,
+          rowCount: batch.rowCount,
+          batchIndex: batch.batchIndex,
+          rowIndexOffset: batch.rowIndexOffset
+        })
+    );
+  }
+}
+
+function makeConstantLayout(name: string, format: 'unorm8x4' | 'float32') {
+  return {
+    name,
+    byteStride: 0,
+    stepMode: 'instance' as const,
+    attributes: [{attribute: name, format}]
+  };
+}
+
+function normalizeColor(color: Color): [number, number, number, number] {
+  return [color[0] / 255, color[1] / 255, color[2] / 255, (color[3] ?? 255) / 255];
+}
+
+function isGPUVector(value: unknown): value is GPUVector {
+  return Boolean(value && typeof value === 'object' && 'data' in value && 'format' in value);
+}
+
+function isColor(value: unknown): value is Color {
+  return Array.isArray(value) || ArrayBuffer.isView(value);
+}

--- a/modules/deck-gpu-layers/src/layers/gpu-bitmap-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-bitmap-layer.ts
@@ -1,0 +1,155 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  Layer,
+  picking,
+  project32,
+  type Color,
+  type LayerContext,
+  type LayerProps,
+  type PickingInfo,
+  type UpdateParameters
+} from '@deck.gl/core';
+import {Buffer, type RenderPass, type Texture} from '@luma.gl/core';
+import {Model} from '@luma.gl/engine';
+
+/** Bounds of one bitmap in source coordinates: left, bottom, right, top. */
+export type GPUBitmapBounds = readonly [number, number, number, number];
+
+/** Texture-native bitmap props. Loading URLs and images belongs in an adapter. */
+export type GPUBitmapLayerProps = Omit<LayerProps, 'data'> & {
+  image: Texture;
+  bounds: GPUBitmapBounds;
+  tintColor?: Color;
+  transparentColor?: Color;
+};
+
+type GPUBitmapLayerState = {model: Model | null; styleBuffer: Buffer | null};
+
+const GPU_BITMAP_SHADER = /* wgsl */ `
+struct BitmapStyle {
+  bounds: vec4<f32>,
+  tintColor: vec4<f32>,
+  transparentColor: vec4<f32>,
+};
+@group(0) @binding(auto) var<uniform> bitmapStyle: BitmapStyle;
+@group(0) @binding(auto) var bitmapTexture: texture_2d<f32>;
+@group(0) @binding(auto) var bitmapSampler: sampler;
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) uv: vec2<f32>,
+  @location(1) @interpolate(flat) pickingColor: vec3<f32>,
+};
+
+fn getCorner(vertexIndex: u32) -> vec2<f32> {
+  let corners = array<vec2<f32>, 6>(
+    vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+    vec2<f32>(0.0, 1.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0)
+  );
+  return corners[vertexIndex];
+}
+
+@vertex fn vertexMain(@builtin(vertex_index) vertexIndex: u32) -> VertexOutput {
+  let corner = getCorner(vertexIndex);
+  let position = vec2<f32>(
+    mix(bitmapStyle.bounds.x, bitmapStyle.bounds.z, corner.x),
+    mix(bitmapStyle.bounds.y, bitmapStyle.bounds.w, corner.y)
+  );
+  geometry.worldPosition = vec3<f32>(position, 0.0);
+  geometry.pickingColor = vec3<f32>(1.0 / 255.0, 0.0, 0.0);
+  var output: VertexOutput;
+  output.position = project_position_to_clipspace(vec3<f32>(position, 0.0), vec3<f32>(0.0), vec3<f32>(0.0));
+  output.uv = vec2<f32>(corner.x, 1.0 - corner.y);
+  output.pickingColor = geometry.pickingColor;
+  return output;
+}
+
+@fragment fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  if (picking.isActive > 0.5) { return vec4<f32>(input.pickingColor, 1.0); }
+  let sampled = textureSample(bitmapTexture, bitmapSampler, input.uv);
+  let transparentDistance = distance(sampled.rgb, bitmapStyle.transparentColor.rgb);
+  let alpha = select(sampled.a, 0.0, transparentDistance < 0.001 && bitmapStyle.transparentColor.a >= 0.0);
+  return vec4<f32>(sampled.rgb * bitmapStyle.tintColor.rgb, alpha * bitmapStyle.tintColor.a * layer.opacity);
+}`;
+
+/** Direct texture-backed bitmap core. This layer has no tabular input to convert to GPUVectors. */
+export class GPUBitmapLayer extends Layer<GPUBitmapLayerProps> {
+  static override layerName = 'GPUBitmapLayer';
+
+  override getAttributeManager() {
+    return null;
+  }
+
+  override initializeState({device}: LayerContext): void {
+    if (device.type !== 'webgpu') throw new Error('GPUBitmapLayer requires WebGPU');
+    const styleBuffer = device.createBuffer({
+      id: `${this.id}-style`,
+      byteLength: 48,
+      usage: Buffer.UNIFORM | Buffer.COPY_DST
+    });
+    const model = new Model(device, {
+      ...this.getShaders({modules: [project32, picking], source: GPU_BITMAP_SHADER}),
+      id: `${this.id}-model`,
+      topology: 'triangle-list',
+      vertexCount: 6,
+      bindings: {
+        bitmapStyle: styleBuffer,
+        bitmapTexture: this.props.image,
+        bitmapSampler: this.props.image.sampler
+      }
+    });
+    model.userData['boundInputs'] = [this.props.image];
+    this.setState({model, styleBuffer} satisfies GPUBitmapLayerState);
+  }
+
+  override getModels(): Model[] {
+    const model = (this.state as GPUBitmapLayerState).model;
+    return model ? [model] : [];
+  }
+
+  override updateState({props}: UpdateParameters<this>): void {
+    const boundInputs = ((this.state as GPUBitmapLayerState).model?.userData['boundInputs'] ??
+      []) as unknown[];
+    if (props.image !== boundInputs[0]) {
+      this.destroyResources();
+      this.initializeState(this.context);
+    }
+  }
+
+  override draw({renderPass}: {renderPass: RenderPass}): void {
+    const {model, styleBuffer} = this.state as GPUBitmapLayerState;
+    if (!model || !styleBuffer) return;
+    const tintColor: Color = this.props.tintColor ?? [255, 255, 255, 255];
+    const transparentColor = this.props.transparentColor;
+    const values = new Float32Array(12);
+    values.set(this.props.bounds);
+    values.set(normalizeColor(tintColor), 4);
+    values.set(transparentColor ? normalizeColor(transparentColor) : [0, 0, 0, -1], 8);
+    styleBuffer.write(values);
+    model.draw(renderPass);
+  }
+
+  override getPickingInfo({info}: {info: PickingInfo}): PickingInfo {
+    if (info.index >= 0) info.index = 0;
+    return info;
+  }
+
+  override finalizeState(context: LayerContext): void {
+    this.destroyResources();
+    super.finalizeState(context);
+  }
+
+  private destroyResources(): void {
+    const state = this.state as GPUBitmapLayerState;
+    state.model?.destroy();
+    state.styleBuffer?.destroy();
+    this.setState({model: null, styleBuffer: null});
+  }
+}
+
+function normalizeColor(color: Color): [number, number, number, number] {
+  return [color[0] / 255, color[1] / 255, color[2] / 255, (color[3] ?? 255) / 255];
+}

--- a/modules/deck-gpu-layers/src/layers/gpu-column-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-column-layer.ts
@@ -1,0 +1,339 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  CompositeLayer,
+  Layer,
+  picking,
+  project32,
+  type Color,
+  type LayerContext,
+  type LayerProps,
+  type PickingInfo,
+  type UpdateParameters
+} from '@deck.gl/core';
+import {Buffer, type RenderPass} from '@luma.gl/core';
+import {Model} from '@luma.gl/engine';
+import type {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import {
+  getGPUDataBuffer,
+  getGPUVectorLayerBatches,
+  makeGPUDataBufferLayout,
+  type GPUVectorLayerPickingInfo
+} from './gpu-vector-layer-utils';
+
+/** GPUVector-native extruded column props. Input vectors are borrowed. */
+export type GPUColumnLayerProps = Omit<LayerProps, 'data'> & {
+  getPosition: GPUVector<'float32x2'>;
+  getFillColor?: Color | GPUVector<'unorm8x4'>;
+  getRadius?: number | GPUVector<'float32'>;
+  getElevation?: number | GPUVector<'float32'>;
+  radiusScale?: number;
+  elevationScale?: number;
+  diskResolution?: number;
+  angle?: number;
+};
+
+type GPUColumnBatchProps = Omit<GPUColumnLayerProps, 'getPosition'> & {
+  positions: GPUData<'float32x2'>;
+  colors?: GPUData<'unorm8x4'>;
+  radii?: GPUData<'float32'>;
+  elevations?: GPUData<'float32'>;
+  rowCount: number;
+  batchIndex: number;
+  rowIndexOffset: number;
+};
+
+type GPUColumnBatchState = {model: Model | null; styleBuffer: Buffer | null; defaults: Buffer[]};
+
+const GPU_COLUMN_SHADER = /* wgsl */ `
+struct ColumnStyle {
+  color: vec4<f32>,
+  radius: f32,
+  elevation: f32,
+  radiusScale: f32,
+  elevationScale: f32,
+  diskResolution: u32,
+  useColors: u32,
+  useRadii: u32,
+  useElevations: u32,
+  rowIndexOffset: u32,
+  angle: f32,
+  _padding0: u32,
+  _padding1: u32,
+};
+@group(0) @binding(auto) var<uniform> columnStyle: ColumnStyle;
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec4<f32>,
+  @location(1) shade: f32,
+  @location(2) @interpolate(flat) pickingColor: vec3<f32>,
+};
+
+fn encodePickingColor(rowIndex: u32) -> vec3<f32> {
+  let value = rowIndex + 1u;
+  return vec3<f32>(f32(value % 256u), f32((value / 256u) % 256u), f32((value / 65536u) % 256u)) / 255.0;
+}
+
+fn sideAngleSelector(vertexIndex: u32) -> f32 {
+  let selectors = array<f32, 6>(0.0, 1.0, 0.0, 0.0, 1.0, 1.0);
+  return selectors[vertexIndex % 6u];
+}
+
+fn sideHeightSelector(vertexIndex: u32) -> f32 {
+  let selectors = array<f32, 6>(0.0, 0.0, 1.0, 1.0, 0.0, 1.0);
+  return selectors[vertexIndex % 6u];
+}
+
+@vertex fn vertexMain(
+  @location(0) positions: vec2<f32>,
+  @location(1) colors: vec4<f32>,
+  @location(2) radii: f32,
+  @location(3) elevations: f32,
+  @builtin(vertex_index) vertexIndex: u32,
+  @builtin(instance_index) instanceIndex: u32
+) -> VertexOutput {
+  let sideVertexCount = columnStyle.diskResolution * 6u;
+  var radialOffset = vec2<f32>(0.0);
+  var heightProgress = 1.0;
+  var shade = 1.0;
+  if (vertexIndex < sideVertexCount) {
+    let segmentIndex = vertexIndex / 6u;
+    let segmentProgress = (f32(segmentIndex) + sideAngleSelector(vertexIndex)) / f32(columnStyle.diskResolution);
+    let angle = segmentProgress * 6.28318530718 + radians(columnStyle.angle);
+    radialOffset = vec2<f32>(cos(angle), sin(angle));
+    heightProgress = sideHeightSelector(vertexIndex);
+    shade = 0.55 + 0.35 * abs(radialOffset.y);
+  } else {
+    let topVertexIndex = vertexIndex - sideVertexCount;
+    let segmentIndex = topVertexIndex / 3u;
+    let triangleVertexIndex = topVertexIndex % 3u;
+    if (triangleVertexIndex != 0u) {
+      let edgeOffset = triangleVertexIndex - 1u;
+      let angle = f32(segmentIndex + edgeOffset) / f32(columnStyle.diskResolution) * 6.28318530718 + radians(columnStyle.angle);
+      radialOffset = vec2<f32>(cos(angle), sin(angle));
+    }
+  }
+  let radius = select(columnStyle.radius, radii, columnStyle.useRadii != 0u) * columnStyle.radiusScale;
+  let elevation = select(columnStyle.elevation, elevations, columnStyle.useElevations != 0u) * columnStyle.elevationScale;
+  let worldPosition = vec3<f32>(positions, elevation * heightProgress);
+  var clipPosition = project_position_to_clipspace(worldPosition, vec3<f32>(0.0), vec3<f32>(0.0));
+  clipPosition = vec4<f32>(clipPosition.xy + project_pixel_size_to_clipspace(radialOffset * radius) * clipPosition.w, clipPosition.z, clipPosition.w);
+  let pickingColor = encodePickingColor(instanceIndex + columnStyle.rowIndexOffset);
+  geometry.worldPosition = worldPosition;
+  geometry.pickingColor = pickingColor;
+  var output: VertexOutput;
+  output.position = clipPosition;
+  output.color = select(columnStyle.color, colors, columnStyle.useColors != 0u);
+  output.shade = shade;
+  output.pickingColor = pickingColor;
+  return output;
+}
+
+@fragment fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  if (picking.isActive > 0.5) { return vec4<f32>(input.pickingColor, 1.0); }
+  return vec4<f32>(input.color.rgb * input.shade, input.color.a * layer.opacity);
+}`;
+
+class GPUColumnBatchLayer extends Layer<GPUColumnBatchProps> {
+  static override layerName = 'GPUColumnBatchLayer';
+
+  override getAttributeManager() {
+    return null;
+  }
+
+  override initializeState({device}: LayerContext): void {
+    if (device.type !== 'webgpu') throw new Error('GPUColumnLayer requires WebGPU');
+    const styleBuffer = device.createBuffer({
+      id: `${this.id}-style`,
+      byteLength: 64,
+      usage: Buffer.UNIFORM | Buffer.COPY_DST
+    });
+    const defaults = [
+      device.createBuffer({data: new Uint8Array([0, 0, 0, 255])}),
+      device.createBuffer({data: new Float32Array([1])}),
+      device.createBuffer({data: new Float32Array([1])})
+    ];
+    const diskResolution = normalizeDiskResolution(this.props.diskResolution);
+    const model = new Model(device, {
+      ...this.getShaders({modules: [project32, picking], source: GPU_COLUMN_SHADER}),
+      id: `${this.id}-model`,
+      topology: 'triangle-list',
+      isInstanced: true,
+      vertexCount: diskResolution * 9,
+      instanceCount: this.props.rowCount,
+      attributes: {
+        positions: getGPUDataBuffer(this.props.positions),
+        colors: this.props.colors ? getGPUDataBuffer(this.props.colors) : defaults[0]!,
+        radii: this.props.radii ? getGPUDataBuffer(this.props.radii) : defaults[1]!,
+        elevations: this.props.elevations ? getGPUDataBuffer(this.props.elevations) : defaults[2]!
+      },
+      bufferLayout: [
+        makeGPUDataBufferLayout(this.props.positions, 'positions'),
+        this.props.colors
+          ? makeGPUDataBufferLayout(this.props.colors, 'colors')
+          : makeConstantLayout('colors', 'unorm8x4'),
+        this.props.radii
+          ? makeGPUDataBufferLayout(this.props.radii, 'radii')
+          : makeConstantLayout('radii', 'float32'),
+        this.props.elevations
+          ? makeGPUDataBufferLayout(this.props.elevations, 'elevations')
+          : makeConstantLayout('elevations', 'float32')
+      ],
+      bindings: {columnStyle: styleBuffer}
+    });
+    model.userData['boundInputs'] = [
+      this.props.positions,
+      this.props.colors,
+      this.props.radii,
+      this.props.elevations,
+      this.props.diskResolution,
+      this.props.rowCount
+    ];
+    this.setState({model, styleBuffer, defaults} satisfies GPUColumnBatchState);
+  }
+
+  override getModels(): Model[] {
+    const model = (this.state as GPUColumnBatchState).model;
+    return model ? [model] : [];
+  }
+
+  override updateState({props}: UpdateParameters<this>): void {
+    const boundInputs = ((this.state as GPUColumnBatchState).model?.userData['boundInputs'] ??
+      []) as unknown[];
+    if (
+      props.positions !== boundInputs[0] ||
+      props.colors !== boundInputs[1] ||
+      props.radii !== boundInputs[2] ||
+      props.elevations !== boundInputs[3] ||
+      props.diskResolution !== boundInputs[4] ||
+      props.rowCount !== boundInputs[5]
+    ) {
+      this.destroyResources();
+      this.initializeState(this.context);
+    }
+  }
+
+  override draw({renderPass}: {renderPass: RenderPass}): void {
+    const {model, styleBuffer} = this.state as GPUColumnBatchState;
+    if (!model || !styleBuffer) return;
+    const defaultColor: Color = [0, 0, 0, 255];
+    const color = isColor(this.props.getFillColor) ? this.props.getFillColor : defaultColor;
+    const bytes = new ArrayBuffer(64);
+    const floats = new Float32Array(bytes);
+    const uints = new Uint32Array(bytes);
+    floats.set(normalizeColor(color));
+    floats.set(
+      [
+        typeof this.props.getRadius === 'number' ? this.props.getRadius : 1,
+        typeof this.props.getElevation === 'number' ? this.props.getElevation : 1,
+        this.props.radiusScale ?? 1,
+        this.props.elevationScale ?? 1
+      ],
+      4
+    );
+    uints.set(
+      [
+        normalizeDiskResolution(this.props.diskResolution),
+        this.props.colors ? 1 : 0,
+        this.props.radii ? 1 : 0,
+        this.props.elevations ? 1 : 0,
+        this.props.rowIndexOffset
+      ],
+      8
+    );
+    floats[13] = this.props.angle ?? 0;
+    styleBuffer.write(new Uint8Array(bytes));
+    model.draw(renderPass);
+  }
+
+  override getPickingInfo({info}: {info: PickingInfo}): PickingInfo {
+    const result = info as GPUVectorLayerPickingInfo;
+    result.gpuVector = {
+      rowIndex: result.index,
+      batchIndex: this.props.batchIndex,
+      batchRowIndex: result.index - this.props.rowIndexOffset
+    };
+    return result;
+  }
+
+  override finalizeState(context: LayerContext): void {
+    this.destroyResources();
+    super.finalizeState(context);
+  }
+
+  private destroyResources(): void {
+    const state = this.state as GPUColumnBatchState;
+    state.model?.destroy();
+    state.styleBuffer?.destroy();
+    state.defaults.forEach(buffer => buffer.destroy());
+    this.setState({model: null, styleBuffer: null, defaults: []});
+  }
+}
+
+/** Chunk-preserving GPUVector extruded-column composite. */
+export class GPUColumnLayer extends CompositeLayer<GPUColumnLayerProps> {
+  static override layerName = 'GPUColumnLayer';
+
+  override renderLayers(): GPUColumnBatchLayer[] {
+    const {getPosition, getFillColor, getRadius, getElevation, ...props} = this.props;
+    return getGPUVectorLayerBatches(
+      this.id,
+      {
+        positions: getPosition,
+        colors: isGPUVector(getFillColor) ? getFillColor : undefined,
+        radii: isGPUVector(getRadius) ? getRadius : undefined,
+        elevations: isGPUVector(getElevation) ? getElevation : undefined
+      },
+      {
+        positions: ['float32x2'],
+        colors: ['unorm8x4'],
+        radii: ['float32'],
+        elevations: ['float32']
+      }
+    ).map(
+      batch =>
+        new GPUColumnBatchLayer({
+          ...props,
+          id: `${this.props.id}-batch-${batch.batchIndex}`,
+          getFillColor,
+          getRadius,
+          getElevation,
+          positions: batch.data['positions'] as GPUData<'float32x2'>,
+          colors: batch.data['colors'] as GPUData<'unorm8x4'> | undefined,
+          radii: batch.data['radii'] as GPUData<'float32'> | undefined,
+          elevations: batch.data['elevations'] as GPUData<'float32'> | undefined,
+          rowCount: batch.rowCount,
+          batchIndex: batch.batchIndex,
+          rowIndexOffset: batch.rowIndexOffset
+        })
+    );
+  }
+}
+
+function normalizeDiskResolution(value: number | undefined): number {
+  return Math.max(3, Math.floor(value ?? 12));
+}
+
+function makeConstantLayout(name: string, format: 'unorm8x4' | 'float32') {
+  return {
+    name,
+    byteStride: 0,
+    stepMode: 'instance' as const,
+    attributes: [{attribute: name, format}]
+  };
+}
+
+function normalizeColor(color: Color): [number, number, number, number] {
+  return [color[0] / 255, color[1] / 255, color[2] / 255, (color[3] ?? 255) / 255];
+}
+
+function isGPUVector(value: unknown): value is GPUVector {
+  return Boolean(value && typeof value === 'object' && 'data' in value && 'format' in value);
+}
+
+function isColor(value: unknown): value is Color {
+  return Array.isArray(value) || ArrayBuffer.isView(value);
+}

--- a/modules/deck-gpu-layers/src/layers/gpu-column-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-column-layer.ts
@@ -3,7 +3,6 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {
-  CompositeLayer,
   Layer,
   picking,
   project32,
@@ -14,12 +13,13 @@ import {
   type UpdateParameters
 } from '@deck.gl/core';
 import {Buffer, type RenderPass} from '@luma.gl/core';
-import {Model} from '@luma.gl/engine';
-import type {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import type {Model} from '@luma.gl/engine';
+import {GPUVectorModel, type GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {
-  getGPUDataBuffer,
+  getGPUVectorBuffer,
   getGPUVectorLayerBatches,
-  makeGPUDataBufferLayout,
+  getGPUVectorPickingProvenance,
+  makeGPUVectorBufferLayout,
   type GPUVectorLayerPickingInfo
 } from './gpu-vector-layer-utils';
 
@@ -35,17 +35,11 @@ export type GPUColumnLayerProps = Omit<LayerProps, 'data'> & {
   angle?: number;
 };
 
-type GPUColumnBatchProps = Omit<GPUColumnLayerProps, 'getPosition'> & {
-  positions: GPUData<'float32x2'>;
-  colors?: GPUData<'unorm8x4'>;
-  radii?: GPUData<'float32'>;
-  elevations?: GPUData<'float32'>;
-  rowCount: number;
-  batchIndex: number;
-  rowIndexOffset: number;
+type GPUColumnLayerState = {
+  model: GPUVectorModel | null;
+  styleBuffer: Buffer | null;
+  defaults: Buffer[];
 };
-
-type GPUColumnBatchState = {model: Model | null; styleBuffer: Buffer | null; defaults: Buffer[]};
 
 const GPU_COLUMN_SHADER = /* wgsl */ `
 struct ColumnStyle {
@@ -137,8 +131,9 @@ fn sideHeightSelector(vertexIndex: u32) -> f32 {
   return vec4<f32>(input.color.rgb * input.shade, input.color.a * layer.opacity);
 }`;
 
-class GPUColumnBatchLayer extends Layer<GPUColumnBatchProps> {
-  static override layerName = 'GPUColumnBatchLayer';
+/** Chunk-preserving GPUVector extruded-column layer. */
+export class GPUColumnLayer extends Layer<GPUColumnLayerProps> {
+  static override layerName = 'GPUColumnLayer';
 
   override getAttributeManager() {
     return null;
@@ -146,6 +141,23 @@ class GPUColumnBatchLayer extends Layer<GPUColumnBatchProps> {
 
   override initializeState({device}: LayerContext): void {
     if (device.type !== 'webgpu') throw new Error('GPUColumnLayer requires WebGPU');
+    const colors = isGPUVector(this.props.getFillColor) ? this.props.getFillColor : undefined;
+    const radii = isGPUVector(this.props.getRadius) ? this.props.getRadius : undefined;
+    const elevations = isGPUVector(this.props.getElevation) ? this.props.getElevation : undefined;
+    getGPUVectorLayerBatches(
+      this.id,
+      {positions: this.props.getPosition, colors, radii, elevations},
+      {
+        positions: ['float32x2'],
+        colors: ['unorm8x4'],
+        radii: ['float32'],
+        elevations: ['float32']
+      }
+    );
+    if (this.props.getPosition.data.length === 0) {
+      this.setState({model: null, styleBuffer: null, defaults: []} satisfies GPUColumnLayerState);
+      return;
+    }
     const styleBuffer = device.createBuffer({
       id: `${this.id}-style`,
       byteLength: 64,
@@ -157,59 +169,58 @@ class GPUColumnBatchLayer extends Layer<GPUColumnBatchProps> {
       device.createBuffer({data: new Float32Array([1])})
     ];
     const diskResolution = normalizeDiskResolution(this.props.diskResolution);
-    const model = new Model(device, {
+    const model = new GPUVectorModel(device, {
       ...this.getShaders({modules: [project32, picking], source: GPU_COLUMN_SHADER}),
       id: `${this.id}-model`,
       topology: 'triangle-list',
       isInstanced: true,
       vertexCount: diskResolution * 9,
-      instanceCount: this.props.rowCount,
+      instanceCount: 0,
       attributes: {
-        positions: getGPUDataBuffer(this.props.positions),
-        colors: this.props.colors ? getGPUDataBuffer(this.props.colors) : defaults[0]!,
-        radii: this.props.radii ? getGPUDataBuffer(this.props.radii) : defaults[1]!,
-        elevations: this.props.elevations ? getGPUDataBuffer(this.props.elevations) : defaults[2]!
+        positions: getGPUVectorBuffer(this.props.getPosition),
+        colors: colors ? getGPUVectorBuffer(colors) : defaults[0]!,
+        radii: radii ? getGPUVectorBuffer(radii) : defaults[1]!,
+        elevations: elevations ? getGPUVectorBuffer(elevations) : defaults[2]!
       },
       bufferLayout: [
-        makeGPUDataBufferLayout(this.props.positions, 'positions'),
-        this.props.colors
-          ? makeGPUDataBufferLayout(this.props.colors, 'colors')
+        makeGPUVectorBufferLayout(this.props.getPosition, 'positions'),
+        colors
+          ? makeGPUVectorBufferLayout(colors, 'colors')
           : makeConstantLayout('colors', 'unorm8x4'),
-        this.props.radii
-          ? makeGPUDataBufferLayout(this.props.radii, 'radii')
-          : makeConstantLayout('radii', 'float32'),
-        this.props.elevations
-          ? makeGPUDataBufferLayout(this.props.elevations, 'elevations')
+        radii ? makeGPUVectorBufferLayout(radii, 'radii') : makeConstantLayout('radii', 'float32'),
+        elevations
+          ? makeGPUVectorBufferLayout(elevations, 'elevations')
           : makeConstantLayout('elevations', 'float32')
       ],
       bindings: {columnStyle: styleBuffer}
     });
     model.userData['boundInputs'] = [
-      this.props.positions,
-      this.props.colors,
-      this.props.radii,
-      this.props.elevations,
-      this.props.diskResolution,
-      this.props.rowCount
+      this.props.getPosition,
+      colors,
+      radii,
+      elevations,
+      this.props.diskResolution
     ];
-    this.setState({model, styleBuffer, defaults} satisfies GPUColumnBatchState);
+    this.setState({model, styleBuffer, defaults} satisfies GPUColumnLayerState);
   }
 
   override getModels(): Model[] {
-    const model = (this.state as GPUColumnBatchState).model;
+    const model = (this.state as GPUColumnLayerState).model;
     return model ? [model] : [];
   }
 
   override updateState({props}: UpdateParameters<this>): void {
-    const boundInputs = ((this.state as GPUColumnBatchState).model?.userData['boundInputs'] ??
+    const boundInputs = ((this.state as GPUColumnLayerState).model?.userData['boundInputs'] ??
       []) as unknown[];
+    const colors = isGPUVector(props.getFillColor) ? props.getFillColor : undefined;
+    const radii = isGPUVector(props.getRadius) ? props.getRadius : undefined;
+    const elevations = isGPUVector(props.getElevation) ? props.getElevation : undefined;
     if (
-      props.positions !== boundInputs[0] ||
-      props.colors !== boundInputs[1] ||
-      props.radii !== boundInputs[2] ||
-      props.elevations !== boundInputs[3] ||
-      props.diskResolution !== boundInputs[4] ||
-      props.rowCount !== boundInputs[5]
+      props.getPosition !== boundInputs[0] ||
+      colors !== boundInputs[1] ||
+      radii !== boundInputs[2] ||
+      elevations !== boundInputs[3] ||
+      props.diskResolution !== boundInputs[4]
     ) {
       this.destroyResources();
       this.initializeState(this.context);
@@ -217,8 +228,11 @@ class GPUColumnBatchLayer extends Layer<GPUColumnBatchProps> {
   }
 
   override draw({renderPass}: {renderPass: RenderPass}): void {
-    const {model, styleBuffer} = this.state as GPUColumnBatchState;
+    const {model, styleBuffer} = this.state as GPUColumnLayerState;
     if (!model || !styleBuffer) return;
+    const colors = isGPUVector(this.props.getFillColor) ? this.props.getFillColor : undefined;
+    const radii = isGPUVector(this.props.getRadius) ? this.props.getRadius : undefined;
+    const elevations = isGPUVector(this.props.getElevation) ? this.props.getElevation : undefined;
     const defaultColor: Color = [0, 0, 0, 255];
     const color = isColor(this.props.getFillColor) ? this.props.getFillColor : defaultColor;
     const bytes = new ArrayBuffer(64);
@@ -237,25 +251,26 @@ class GPUColumnBatchLayer extends Layer<GPUColumnBatchProps> {
     uints.set(
       [
         normalizeDiskResolution(this.props.diskResolution),
-        this.props.colors ? 1 : 0,
-        this.props.radii ? 1 : 0,
-        this.props.elevations ? 1 : 0,
-        this.props.rowIndexOffset
+        colors ? 1 : 0,
+        radii ? 1 : 0,
+        elevations ? 1 : 0,
+        0
       ],
       8
     );
     floats[13] = this.props.angle ?? 0;
-    styleBuffer.write(new Uint8Array(bytes));
-    model.draw(renderPass);
+    model.drawBatches(renderPass, {
+      vectors: {positions: this.props.getPosition, colors, radii, elevations},
+      onBatch: batch => {
+        uints[12] = batch.rowIndexOffset;
+        styleBuffer.write(new Uint8Array(bytes));
+      }
+    });
   }
 
   override getPickingInfo({info}: {info: PickingInfo}): PickingInfo {
     const result = info as GPUVectorLayerPickingInfo;
-    result.gpuVector = {
-      rowIndex: result.index,
-      batchIndex: this.props.batchIndex,
-      batchRowIndex: result.index - this.props.rowIndexOffset
-    };
+    result.gpuVector = getGPUVectorPickingProvenance(this.props.getPosition, result.index);
     return result;
   }
 
@@ -265,51 +280,11 @@ class GPUColumnBatchLayer extends Layer<GPUColumnBatchProps> {
   }
 
   private destroyResources(): void {
-    const state = this.state as GPUColumnBatchState;
+    const state = this.state as GPUColumnLayerState;
     state.model?.destroy();
     state.styleBuffer?.destroy();
     state.defaults.forEach(buffer => buffer.destroy());
     this.setState({model: null, styleBuffer: null, defaults: []});
-  }
-}
-
-/** Chunk-preserving GPUVector extruded-column composite. */
-export class GPUColumnLayer extends CompositeLayer<GPUColumnLayerProps> {
-  static override layerName = 'GPUColumnLayer';
-
-  override renderLayers(): GPUColumnBatchLayer[] {
-    const {getPosition, getFillColor, getRadius, getElevation, ...props} = this.props;
-    return getGPUVectorLayerBatches(
-      this.id,
-      {
-        positions: getPosition,
-        colors: isGPUVector(getFillColor) ? getFillColor : undefined,
-        radii: isGPUVector(getRadius) ? getRadius : undefined,
-        elevations: isGPUVector(getElevation) ? getElevation : undefined
-      },
-      {
-        positions: ['float32x2'],
-        colors: ['unorm8x4'],
-        radii: ['float32'],
-        elevations: ['float32']
-      }
-    ).map(
-      batch =>
-        new GPUColumnBatchLayer({
-          ...props,
-          id: `${this.props.id}-batch-${batch.batchIndex}`,
-          getFillColor,
-          getRadius,
-          getElevation,
-          positions: batch.data['positions'] as GPUData<'float32x2'>,
-          colors: batch.data['colors'] as GPUData<'unorm8x4'> | undefined,
-          radii: batch.data['radii'] as GPUData<'float32'> | undefined,
-          elevations: batch.data['elevations'] as GPUData<'float32'> | undefined,
-          rowCount: batch.rowCount,
-          batchIndex: batch.batchIndex,
-          rowIndexOffset: batch.rowIndexOffset
-        })
-    );
   }
 }
 

--- a/modules/deck-gpu-layers/src/layers/gpu-grid-cell-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-grid-cell-layer.ts
@@ -1,0 +1,34 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {CompositeLayer, type Color, type LayerProps} from '@deck.gl/core';
+import type {GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import {GPUColumnLayer} from './gpu-column-layer';
+
+/** GPUVector-native square grid-cell props. Input vectors are borrowed. */
+export type GPUGridCellLayerProps = Omit<LayerProps, 'data'> & {
+  getPosition: GPUVector<'float32x2'>;
+  getFillColor?: Color | GPUVector<'unorm8x4'>;
+  getCellSize?: number | GPUVector<'float32'>;
+  getElevation?: number | GPUVector<'float32'>;
+  cellSizeScale?: number;
+  elevationScale?: number;
+};
+
+/** Square-cell specialization of the GPUVector column core. */
+export class GPUGridCellLayer extends CompositeLayer<GPUGridCellLayerProps> {
+  static override layerName = 'GPUGridCellLayer';
+
+  override renderLayers(): GPUColumnLayer {
+    const {getCellSize, cellSizeScale, ...props} = this.props;
+    return new GPUColumnLayer({
+      ...props,
+      id: `${this.props.id}-column`,
+      getRadius: getCellSize,
+      radiusScale: (cellSizeScale ?? 1) / Math.SQRT2,
+      diskResolution: 4,
+      angle: 45
+    });
+  }
+}

--- a/modules/deck-gpu-layers/src/layers/gpu-icon-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-icon-layer.ts
@@ -3,7 +3,6 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {
-  CompositeLayer,
   Layer,
   picking,
   project32,
@@ -14,12 +13,13 @@ import {
   type UpdateParameters
 } from '@deck.gl/core';
 import {Buffer, type RenderPass, type Texture} from '@luma.gl/core';
-import {Model} from '@luma.gl/engine';
-import type {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import type {Model} from '@luma.gl/engine';
+import {GPUVectorModel, type GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {
-  getGPUDataBuffer,
+  getGPUVectorBuffer,
   getGPUVectorLayerBatches,
-  makeGPUDataBufferLayout,
+  getGPUVectorPickingProvenance,
+  makeGPUVectorBufferLayout,
   type GPUVectorLayerPickingInfo
 } from './gpu-vector-layer-utils';
 
@@ -38,23 +38,11 @@ export type GPUIconLayerProps = Omit<LayerProps, 'data'> & {
   alphaCutoff?: number;
 };
 
-type GPUIconBatchProps = Omit<
-  GPUIconLayerProps,
-  'getPosition' | 'iconOffsets' | 'iconFrames' | 'iconColorModes'
-> & {
-  positions: GPUData<'float32x2'>;
-  offsets: GPUData<'float32x2'>;
-  frames: GPUData<'float32x4'>;
-  colorModes: GPUData<'float32'>;
-  colors?: GPUData<'unorm8x4'>;
-  sizes?: GPUData<'float32'>;
-  angles?: GPUData<'float32'>;
-  pixelOffsets?: GPUData<'float32x2'>;
-  rowCount: number;
-  batchIndex: number;
-  rowIndexOffset: number;
+type GPUIconLayerState = {
+  model: GPUVectorModel | null;
+  styleBuffer: Buffer | null;
+  defaults: Buffer[];
 };
-type GPUIconBatchState = {model: Model | null; styleBuffer: Buffer | null; defaults: Buffer[]};
 
 const GPU_ICON_SHADER = /* wgsl */ `
 struct IconStyle { textureSize: vec2<f32>, color: vec4<f32>, size: f32, sizeScale: f32, alphaCutoff: f32, angle: f32, useColors: u32, useSizes: u32, useAngles: u32, rowIndexOffset: u32 };
@@ -75,13 +63,44 @@ fn getCorner(vertexIndex: u32) -> vec2<f32> { let corners = array<vec2<f32>, 6>(
 @fragment fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> { let sample = textureSample(iconTexture, iconTextureSampler, input.uv); if (sample.a < iconStyle.alphaCutoff) { discard; } if (picking.isActive > 0.5) { return vec4<f32>(input.pickingColor,1.0); } let rgb = select(sample.rgb, input.color.rgb, input.colorMode > 0.5); return vec4<f32>(rgb, sample.a * input.color.a * layer.opacity); }
 `;
 
-class GPUIconBatchLayer extends Layer<GPUIconBatchProps> {
-  static override layerName = 'GPUIconBatchLayer';
+/** Chunk-preserving GPUVector icon layer. */
+export class GPUIconLayer extends Layer<GPUIconLayerProps> {
+  static override layerName = 'GPUIconLayer';
   override getAttributeManager() {
     return null;
   }
   override initializeState({device}: LayerContext): void {
     if (device.type !== 'webgpu') throw new Error('GPUIconLayer requires WebGPU');
+    const colors = isGPUVector(this.props.getColor) ? this.props.getColor : undefined;
+    const sizes = isGPUVector(this.props.getSize) ? this.props.getSize : undefined;
+    const angles = isGPUVector(this.props.getAngle) ? this.props.getAngle : undefined;
+    getGPUVectorLayerBatches(
+      this.id,
+      {
+        positions: this.props.getPosition,
+        offsets: this.props.iconOffsets,
+        frames: this.props.iconFrames,
+        colorModes: this.props.iconColorModes,
+        colors,
+        sizes,
+        angles,
+        pixelOffsets: this.props.getPixelOffset
+      },
+      {
+        positions: ['float32x2'],
+        offsets: ['float32x2'],
+        frames: ['float32x4'],
+        colorModes: ['float32'],
+        colors: ['unorm8x4'],
+        sizes: ['float32'],
+        angles: ['float32'],
+        pixelOffsets: ['float32x2']
+      }
+    );
+    if (this.props.getPosition.data.length === 0) {
+      this.setState({model: null, styleBuffer: null, defaults: []} satisfies GPUIconLayerState);
+      return;
+    }
     const styleBuffer = device.createBuffer({
       id: `${this.id}-style`,
       byteLength: 64,
@@ -93,31 +112,26 @@ class GPUIconBatchLayer extends Layer<GPUIconBatchProps> {
       device.createBuffer({data: new Float32Array([0])}),
       device.createBuffer({data: new Float32Array([0, 0])})
     ];
-    const optional = [
-      this.props.colors,
-      this.props.sizes,
-      this.props.angles,
-      this.props.pixelOffsets
-    ] as const;
+    const optional = [colors, sizes, angles, this.props.getPixelOffset] as const;
     const names = ['colors', 'sizes', 'angles', 'pixelOffsets'];
     const formats = ['unorm8x4', 'float32', 'float32', 'float32x2'] as const;
     const attributes: Record<string, Buffer> = {
-      positions: getGPUDataBuffer(this.props.positions),
-      offsets: getGPUDataBuffer(this.props.offsets),
-      frames: getGPUDataBuffer(this.props.frames),
-      colorModes: getGPUDataBuffer(this.props.colorModes)
+      positions: getGPUVectorBuffer(this.props.getPosition),
+      offsets: getGPUVectorBuffer(this.props.iconOffsets),
+      frames: getGPUVectorBuffer(this.props.iconFrames),
+      colorModes: getGPUVectorBuffer(this.props.iconColorModes)
     };
     const layouts = [
-      makeGPUDataBufferLayout(this.props.positions, 'positions'),
-      makeGPUDataBufferLayout(this.props.offsets, 'offsets'),
-      makeGPUDataBufferLayout(this.props.frames, 'frames'),
-      makeGPUDataBufferLayout(this.props.colorModes, 'colorModes')
+      makeGPUVectorBufferLayout(this.props.getPosition, 'positions'),
+      makeGPUVectorBufferLayout(this.props.iconOffsets, 'offsets'),
+      makeGPUVectorBufferLayout(this.props.iconFrames, 'frames'),
+      makeGPUVectorBufferLayout(this.props.iconColorModes, 'colorModes')
     ];
-    optional.forEach((data, index) => {
-      attributes[names[index]!] = data ? getGPUDataBuffer(data) : defaults[index]!;
+    optional.forEach((vector, index) => {
+      attributes[names[index]!] = vector ? getGPUVectorBuffer(vector) : defaults[index]!;
       layouts.push(
-        data
-          ? makeGPUDataBufferLayout(data, names[index]!)
+        vector
+          ? makeGPUVectorBufferLayout(vector, names[index]!)
           : {
               name: names[index]!,
               byteStride: 0,
@@ -126,13 +140,13 @@ class GPUIconBatchLayer extends Layer<GPUIconBatchProps> {
             }
       );
     });
-    const model = new Model(device, {
+    const model = new GPUVectorModel(device, {
       ...this.getShaders({modules: [project32, picking], source: GPU_ICON_SHADER}),
       id: `${this.id}-model`,
       topology: 'triangle-list',
       isInstanced: true,
       vertexCount: 6,
-      instanceCount: this.props.rowCount,
+      instanceCount: 0,
       attributes,
       bufferLayout: layouts,
       bindings: {
@@ -142,45 +156,49 @@ class GPUIconBatchLayer extends Layer<GPUIconBatchProps> {
       }
     });
     model.userData['boundInputs'] = [
-      this.props.positions,
-      this.props.offsets,
-      this.props.frames,
-      this.props.colorModes,
-      this.props.colors,
-      this.props.sizes,
-      this.props.angles,
-      this.props.pixelOffsets,
-      this.props.iconAtlas,
-      this.props.rowCount
+      this.props.getPosition,
+      this.props.iconOffsets,
+      this.props.iconFrames,
+      this.props.iconColorModes,
+      colors,
+      sizes,
+      angles,
+      this.props.getPixelOffset,
+      this.props.iconAtlas
     ];
-    this.setState({model, styleBuffer, defaults} satisfies GPUIconBatchState);
+    this.setState({model, styleBuffer, defaults} satisfies GPUIconLayerState);
   }
   override getModels(): Model[] {
-    const model = (this.state as GPUIconBatchState).model;
+    const model = (this.state as GPUIconLayerState).model;
     return model ? [model] : [];
   }
   override updateState({props}: UpdateParameters<this>): void {
-    const boundInputs = ((this.state as GPUIconBatchState).model?.userData['boundInputs'] ??
+    const boundInputs = ((this.state as GPUIconLayerState).model?.userData['boundInputs'] ??
       []) as unknown[];
+    const colors = isGPUVector(props.getColor) ? props.getColor : undefined;
+    const sizes = isGPUVector(props.getSize) ? props.getSize : undefined;
+    const angles = isGPUVector(props.getAngle) ? props.getAngle : undefined;
     if (
-      props.positions !== boundInputs[0] ||
-      props.offsets !== boundInputs[1] ||
-      props.frames !== boundInputs[2] ||
-      props.colorModes !== boundInputs[3] ||
-      props.colors !== boundInputs[4] ||
-      props.sizes !== boundInputs[5] ||
-      props.angles !== boundInputs[6] ||
-      props.pixelOffsets !== boundInputs[7] ||
-      props.iconAtlas !== boundInputs[8] ||
-      props.rowCount !== boundInputs[9]
+      props.getPosition !== boundInputs[0] ||
+      props.iconOffsets !== boundInputs[1] ||
+      props.iconFrames !== boundInputs[2] ||
+      props.iconColorModes !== boundInputs[3] ||
+      colors !== boundInputs[4] ||
+      sizes !== boundInputs[5] ||
+      angles !== boundInputs[6] ||
+      props.getPixelOffset !== boundInputs[7] ||
+      props.iconAtlas !== boundInputs[8]
     ) {
       this.destroyResources();
       this.initializeState(this.context);
     }
   }
   override draw({renderPass}: {renderPass: RenderPass}): void {
-    const {model, styleBuffer} = this.state as GPUIconBatchState;
+    const {model, styleBuffer} = this.state as GPUIconLayerState;
     if (!model || !styleBuffer) return;
+    const colors = isGPUVector(this.props.getColor) ? this.props.getColor : undefined;
+    const sizes = isGPUVector(this.props.getSize) ? this.props.getSize : undefined;
+    const angles = isGPUVector(this.props.getAngle) ? this.props.getAngle : undefined;
     const [r, g, b, a = 255] = isColor(this.props.getColor) ? this.props.getColor : [0, 0, 0, 255];
     const bytes = new ArrayBuffer(64);
     const floats = new Float32Array(bytes);
@@ -196,25 +214,27 @@ class GPUIconBatchLayer extends Layer<GPUIconBatchProps> {
       ],
       8
     );
-    uints.set(
-      [
-        this.props.colors ? 1 : 0,
-        this.props.sizes ? 1 : 0,
-        this.props.angles ? 1 : 0,
-        this.props.rowIndexOffset
-      ],
-      12
-    );
-    styleBuffer.write(new Uint8Array(bytes));
-    model.draw(renderPass);
+    uints.set([colors ? 1 : 0, sizes ? 1 : 0, angles ? 1 : 0, 0], 12);
+    model.drawBatches(renderPass, {
+      vectors: {
+        positions: this.props.getPosition,
+        offsets: this.props.iconOffsets,
+        frames: this.props.iconFrames,
+        colorModes: this.props.iconColorModes,
+        colors,
+        sizes,
+        angles,
+        pixelOffsets: this.props.getPixelOffset
+      },
+      onBatch: batch => {
+        uints[15] = batch.rowIndexOffset;
+        styleBuffer.write(new Uint8Array(bytes));
+      }
+    });
   }
   override getPickingInfo({info}: {info: PickingInfo}): PickingInfo {
     const result = info as GPUVectorLayerPickingInfo;
-    result.gpuVector = {
-      rowIndex: result.index,
-      batchIndex: this.props.batchIndex,
-      batchRowIndex: result.index - this.props.rowIndexOffset
-    };
+    result.gpuVector = getGPUVectorPickingProvenance(this.props.getPosition, result.index);
     return result;
   }
   override finalizeState(context: LayerContext): void {
@@ -222,72 +242,11 @@ class GPUIconBatchLayer extends Layer<GPUIconBatchProps> {
     super.finalizeState(context);
   }
   private destroyResources(): void {
-    const state = this.state as GPUIconBatchState;
+    const state = this.state as GPUIconLayerState;
     state.model?.destroy();
     state.styleBuffer?.destroy();
     state.defaults.forEach(buffer => buffer.destroy());
     this.setState({model: null, styleBuffer: null, defaults: []});
-  }
-}
-
-/** Chunk-preserving GPUVector icon composite. */
-export class GPUIconLayer extends CompositeLayer<GPUIconLayerProps> {
-  static override layerName = 'GPUIconLayer';
-  override renderLayers(): GPUIconBatchLayer[] {
-    const {
-      getPosition,
-      iconOffsets,
-      iconFrames,
-      iconColorModes,
-      getColor,
-      getSize,
-      getAngle,
-      getPixelOffset,
-      ...props
-    } = this.props;
-    return getGPUVectorLayerBatches(
-      this.id,
-      {
-        positions: getPosition,
-        offsets: iconOffsets,
-        frames: iconFrames,
-        colorModes: iconColorModes,
-        colors: isGPUVector(getColor) ? getColor : undefined,
-        sizes: isGPUVector(getSize) ? getSize : undefined,
-        angles: isGPUVector(getAngle) ? getAngle : undefined,
-        pixelOffsets: getPixelOffset
-      },
-      {
-        positions: ['float32x2'],
-        offsets: ['float32x2'],
-        frames: ['float32x4'],
-        colorModes: ['float32'],
-        colors: ['unorm8x4'],
-        sizes: ['float32'],
-        angles: ['float32'],
-        pixelOffsets: ['float32x2']
-      }
-    ).map(
-      batch =>
-        new GPUIconBatchLayer({
-          ...props,
-          id: `${this.props.id}-batch-${batch.batchIndex}`,
-          getColor,
-          getSize,
-          getAngle,
-          positions: batch.data['positions'] as GPUData<'float32x2'>,
-          offsets: batch.data['offsets'] as GPUData<'float32x2'>,
-          frames: batch.data['frames'] as GPUData<'float32x4'>,
-          colorModes: batch.data['colorModes'] as GPUData<'float32'>,
-          colors: batch.data['colors'] as GPUData<'unorm8x4'> | undefined,
-          sizes: batch.data['sizes'] as GPUData<'float32'> | undefined,
-          angles: batch.data['angles'] as GPUData<'float32'> | undefined,
-          pixelOffsets: batch.data['pixelOffsets'] as GPUData<'float32x2'> | undefined,
-          rowCount: batch.rowCount,
-          batchIndex: batch.batchIndex,
-          rowIndexOffset: batch.rowIndexOffset
-        })
-    );
   }
 }
 function isGPUVector(value: unknown): value is GPUVector {

--- a/modules/deck-gpu-layers/src/layers/gpu-icon-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-icon-layer.ts
@@ -1,0 +1,292 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  CompositeLayer,
+  Layer,
+  picking,
+  project32,
+  type Color,
+  type LayerContext,
+  type LayerProps,
+  type PickingInfo,
+  type UpdateParameters
+} from '@deck.gl/core';
+import {Buffer, type RenderPass, type Texture} from '@luma.gl/core';
+import {Model} from '@luma.gl/engine';
+import type {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import {
+  getGPUDataBuffer,
+  getGPUVectorLayerBatches,
+  makeGPUDataBufferLayout,
+  type GPUVectorLayerPickingInfo
+} from './gpu-vector-layer-utils';
+
+/** GPUVector-native icon props with adapter-prepared atlas metadata. */
+export type GPUIconLayerProps = Omit<LayerProps, 'data'> & {
+  iconAtlas: Texture;
+  getPosition: GPUVector<'float32x2'>;
+  iconOffsets: GPUVector<'float32x2'>;
+  iconFrames: GPUVector<'float32x4'>;
+  iconColorModes: GPUVector<'float32'>;
+  getColor?: Color | GPUVector<'unorm8x4'>;
+  getSize?: number | GPUVector<'float32'>;
+  getAngle?: number | GPUVector<'float32'>;
+  getPixelOffset?: GPUVector<'float32x2'>;
+  sizeScale?: number;
+  alphaCutoff?: number;
+};
+
+type GPUIconBatchProps = Omit<
+  GPUIconLayerProps,
+  'getPosition' | 'iconOffsets' | 'iconFrames' | 'iconColorModes'
+> & {
+  positions: GPUData<'float32x2'>;
+  offsets: GPUData<'float32x2'>;
+  frames: GPUData<'float32x4'>;
+  colorModes: GPUData<'float32'>;
+  colors?: GPUData<'unorm8x4'>;
+  sizes?: GPUData<'float32'>;
+  angles?: GPUData<'float32'>;
+  pixelOffsets?: GPUData<'float32x2'>;
+  rowCount: number;
+  batchIndex: number;
+  rowIndexOffset: number;
+};
+type GPUIconBatchState = {model: Model | null; styleBuffer: Buffer | null; defaults: Buffer[]};
+
+const GPU_ICON_SHADER = /* wgsl */ `
+struct IconStyle { textureSize: vec2<f32>, color: vec4<f32>, size: f32, sizeScale: f32, alphaCutoff: f32, useColors: u32, useSizes: u32, rowIndexOffset: u32, _padding: u32 };
+@group(0) @binding(auto) var<uniform> iconStyle: IconStyle;
+@group(0) @binding(auto) var iconTexture: texture_2d<f32>;
+@group(0) @binding(auto) var iconTextureSampler: sampler;
+struct VertexOutput { @builtin(position) position: vec4<f32>, @location(0) uv: vec2<f32>, @location(1) color: vec4<f32>, @location(2) colorMode: f32, @location(3) @interpolate(flat) pickingColor: vec3<f32> };
+fn encodePickingColor(rowIndex: u32) -> vec3<f32> { let value = rowIndex + 1u; return vec3<f32>(f32(value % 256u), f32((value / 256u) % 256u), f32((value / 65536u) % 256u)) / 255.0; }
+fn getCorner(vertexIndex: u32) -> vec2<f32> { let corners = array<vec2<f32>, 6>(vec2<f32>(-1.0,-1.0),vec2<f32>(1.0,-1.0),vec2<f32>(-1.0,1.0),vec2<f32>(-1.0,1.0),vec2<f32>(1.0,-1.0),vec2<f32>(1.0,1.0)); return corners[vertexIndex]; }
+@vertex fn vertexMain(@location(0) positions: vec2<f32>, @location(1) offsets: vec2<f32>, @location(2) frames: vec4<f32>, @location(3) colorModes: f32, @location(4) colors: vec4<f32>, @location(5) sizes: f32, @location(6) angles: f32, @location(7) pixelOffsets: vec2<f32>, @builtin(vertex_index) vertexIndex: u32, @builtin(instance_index) instanceIndex: u32) -> VertexOutput {
+  let corner = getCorner(vertexIndex); let size = select(iconStyle.size, sizes, iconStyle.useSizes != 0u) * iconStyle.sizeScale;
+  let radians = angles * 0.01745329252; let rotation = mat2x2<f32>(cos(radians), sin(radians), -sin(radians), cos(radians));
+  let pixel = rotation * ((corner * frames.zw * 0.5 + offsets) * size) + pixelOffsets;
+  let pickingColor = encodePickingColor(instanceIndex + iconStyle.rowIndexOffset); geometry.worldPosition = vec3<f32>(positions, 0.0); geometry.pickingColor = pickingColor;
+  var clip = project_position_to_clipspace(vec3<f32>(positions,0.0),vec3<f32>(0.0),vec3<f32>(0.0)); clip = vec4<f32>(clip.xy + project_pixel_size_to_clipspace(pixel) * clip.w, clip.z, clip.w);
+  var output: VertexOutput; output.position = clip; output.uv = (frames.xy + (corner * 0.5 + 0.5) * frames.zw) / iconStyle.textureSize; output.color = select(iconStyle.color, colors, iconStyle.useColors != 0u); output.colorMode = colorModes; output.pickingColor = pickingColor; return output;
+}
+@fragment fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> { let sample = textureSample(iconTexture, iconTextureSampler, input.uv); if (sample.a < iconStyle.alphaCutoff) { discard; } if (picking.isActive > 0.5) { return vec4<f32>(input.pickingColor,1.0); } let rgb = select(sample.rgb, input.color.rgb, input.colorMode > 0.5); return vec4<f32>(rgb, sample.a * input.color.a * layer.opacity); }
+`;
+
+class GPUIconBatchLayer extends Layer<GPUIconBatchProps> {
+  static override layerName = 'GPUIconBatchLayer';
+  override getAttributeManager() {
+    return null;
+  }
+  override initializeState({device}: LayerContext): void {
+    if (device.type !== 'webgpu') throw new Error('GPUIconLayer requires WebGPU');
+    const styleBuffer = device.createBuffer({
+      id: `${this.id}-style`,
+      byteLength: 64,
+      usage: Buffer.UNIFORM | Buffer.COPY_DST
+    });
+    const defaults = [
+      device.createBuffer({data: new Uint8Array([0, 0, 0, 255])}),
+      device.createBuffer({data: new Float32Array([1])}),
+      device.createBuffer({data: new Float32Array([0])}),
+      device.createBuffer({data: new Float32Array([0, 0])})
+    ];
+    const optional = [
+      this.props.colors,
+      this.props.sizes,
+      this.props.angles,
+      this.props.pixelOffsets
+    ] as const;
+    const names = ['colors', 'sizes', 'angles', 'pixelOffsets'];
+    const formats = ['unorm8x4', 'float32', 'float32', 'float32x2'] as const;
+    const attributes: Record<string, Buffer> = {
+      positions: getGPUDataBuffer(this.props.positions),
+      offsets: getGPUDataBuffer(this.props.offsets),
+      frames: getGPUDataBuffer(this.props.frames),
+      colorModes: getGPUDataBuffer(this.props.colorModes)
+    };
+    const layouts = [
+      makeGPUDataBufferLayout(this.props.positions, 'positions'),
+      makeGPUDataBufferLayout(this.props.offsets, 'offsets'),
+      makeGPUDataBufferLayout(this.props.frames, 'frames'),
+      makeGPUDataBufferLayout(this.props.colorModes, 'colorModes')
+    ];
+    optional.forEach((data, index) => {
+      attributes[names[index]!] = data ? getGPUDataBuffer(data) : defaults[index]!;
+      layouts.push(
+        data
+          ? makeGPUDataBufferLayout(data, names[index]!)
+          : {
+              name: names[index]!,
+              byteStride: 0,
+              stepMode: 'instance',
+              attributes: [{attribute: names[index]!, format: formats[index]!, byteOffset: 0}]
+            }
+      );
+    });
+    const model = new Model(device, {
+      ...this.getShaders({modules: [project32, picking], source: GPU_ICON_SHADER}),
+      id: `${this.id}-model`,
+      topology: 'triangle-list',
+      isInstanced: true,
+      vertexCount: 6,
+      instanceCount: this.props.rowCount,
+      attributes,
+      bufferLayout: layouts,
+      bindings: {
+        iconStyle: styleBuffer,
+        iconTexture: this.props.iconAtlas,
+        iconTextureSampler: this.props.iconAtlas.sampler
+      }
+    });
+    model.userData['boundInputs'] = [
+      this.props.positions,
+      this.props.offsets,
+      this.props.frames,
+      this.props.colorModes,
+      this.props.colors,
+      this.props.sizes,
+      this.props.angles,
+      this.props.pixelOffsets,
+      this.props.iconAtlas,
+      this.props.rowCount
+    ];
+    this.setState({model, styleBuffer, defaults} satisfies GPUIconBatchState);
+  }
+  override getModels(): Model[] {
+    const model = (this.state as GPUIconBatchState).model;
+    return model ? [model] : [];
+  }
+  override updateState({props}: UpdateParameters<this>): void {
+    const boundInputs = ((this.state as GPUIconBatchState).model?.userData['boundInputs'] ??
+      []) as unknown[];
+    if (
+      props.positions !== boundInputs[0] ||
+      props.offsets !== boundInputs[1] ||
+      props.frames !== boundInputs[2] ||
+      props.colorModes !== boundInputs[3] ||
+      props.colors !== boundInputs[4] ||
+      props.sizes !== boundInputs[5] ||
+      props.angles !== boundInputs[6] ||
+      props.pixelOffsets !== boundInputs[7] ||
+      props.iconAtlas !== boundInputs[8] ||
+      props.rowCount !== boundInputs[9]
+    ) {
+      this.destroyResources();
+      this.initializeState(this.context);
+    }
+  }
+  override draw({renderPass}: {renderPass: RenderPass}): void {
+    const {model, styleBuffer} = this.state as GPUIconBatchState;
+    if (!model || !styleBuffer) return;
+    const [r, g, b, a = 255] = isColor(this.props.getColor) ? this.props.getColor : [0, 0, 0, 255];
+    const bytes = new ArrayBuffer(64);
+    const floats = new Float32Array(bytes);
+    const uints = new Uint32Array(bytes);
+    floats.set([this.props.iconAtlas.width, this.props.iconAtlas.height]);
+    floats.set([r / 255, g / 255, b / 255, a / 255], 4);
+    floats.set(
+      [
+        typeof this.props.getSize === 'number' ? this.props.getSize : 1,
+        this.props.sizeScale ?? 1,
+        this.props.alphaCutoff ?? 0.05
+      ],
+      8
+    );
+    uints.set(
+      [this.props.colors ? 1 : 0, this.props.sizes ? 1 : 0, this.props.rowIndexOffset, 0],
+      11
+    );
+    styleBuffer.write(new Uint8Array(bytes));
+    model.draw(renderPass);
+  }
+  override getPickingInfo({info}: {info: PickingInfo}): PickingInfo {
+    const result = info as GPUVectorLayerPickingInfo;
+    result.gpuVector = {
+      rowIndex: result.index,
+      batchIndex: this.props.batchIndex,
+      batchRowIndex: result.index - this.props.rowIndexOffset
+    };
+    return result;
+  }
+  override finalizeState(context: LayerContext): void {
+    this.destroyResources();
+    super.finalizeState(context);
+  }
+  private destroyResources(): void {
+    const state = this.state as GPUIconBatchState;
+    state.model?.destroy();
+    state.styleBuffer?.destroy();
+    state.defaults.forEach(buffer => buffer.destroy());
+    this.setState({model: null, styleBuffer: null, defaults: []});
+  }
+}
+
+/** Chunk-preserving GPUVector icon composite. */
+export class GPUIconLayer extends CompositeLayer<GPUIconLayerProps> {
+  static override layerName = 'GPUIconLayer';
+  override renderLayers(): GPUIconBatchLayer[] {
+    const {
+      getPosition,
+      iconOffsets,
+      iconFrames,
+      iconColorModes,
+      getColor,
+      getSize,
+      getAngle,
+      getPixelOffset,
+      ...props
+    } = this.props;
+    return getGPUVectorLayerBatches(
+      this.id,
+      {
+        positions: getPosition,
+        offsets: iconOffsets,
+        frames: iconFrames,
+        colorModes: iconColorModes,
+        colors: isGPUVector(getColor) ? getColor : undefined,
+        sizes: isGPUVector(getSize) ? getSize : undefined,
+        angles: isGPUVector(getAngle) ? getAngle : undefined,
+        pixelOffsets: getPixelOffset
+      },
+      {
+        positions: ['float32x2'],
+        offsets: ['float32x2'],
+        frames: ['float32x4'],
+        colorModes: ['float32'],
+        colors: ['unorm8x4'],
+        sizes: ['float32'],
+        angles: ['float32'],
+        pixelOffsets: ['float32x2']
+      }
+    ).map(
+      batch =>
+        new GPUIconBatchLayer({
+          ...props,
+          id: `${this.props.id}-batch-${batch.batchIndex}`,
+          getColor,
+          getSize,
+          getAngle,
+          positions: batch.data['positions'] as GPUData<'float32x2'>,
+          offsets: batch.data['offsets'] as GPUData<'float32x2'>,
+          frames: batch.data['frames'] as GPUData<'float32x4'>,
+          colorModes: batch.data['colorModes'] as GPUData<'float32'>,
+          colors: batch.data['colors'] as GPUData<'unorm8x4'> | undefined,
+          sizes: batch.data['sizes'] as GPUData<'float32'> | undefined,
+          angles: batch.data['angles'] as GPUData<'float32'> | undefined,
+          pixelOffsets: batch.data['pixelOffsets'] as GPUData<'float32x2'> | undefined,
+          rowCount: batch.rowCount,
+          batchIndex: batch.batchIndex,
+          rowIndexOffset: batch.rowIndexOffset
+        })
+    );
+  }
+}
+function isGPUVector(value: unknown): value is GPUVector {
+  return Boolean(value && typeof value === 'object' && 'data' in value && 'format' in value);
+}
+function isColor(value: unknown): value is Color {
+  return Array.isArray(value) || ArrayBuffer.isView(value);
+}

--- a/modules/deck-gpu-layers/src/layers/gpu-icon-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-icon-layer.ts
@@ -57,7 +57,7 @@ type GPUIconBatchProps = Omit<
 type GPUIconBatchState = {model: Model | null; styleBuffer: Buffer | null; defaults: Buffer[]};
 
 const GPU_ICON_SHADER = /* wgsl */ `
-struct IconStyle { textureSize: vec2<f32>, color: vec4<f32>, size: f32, sizeScale: f32, alphaCutoff: f32, useColors: u32, useSizes: u32, rowIndexOffset: u32, _padding: u32 };
+struct IconStyle { textureSize: vec2<f32>, color: vec4<f32>, size: f32, sizeScale: f32, alphaCutoff: f32, angle: f32, useColors: u32, useSizes: u32, useAngles: u32, rowIndexOffset: u32 };
 @group(0) @binding(auto) var<uniform> iconStyle: IconStyle;
 @group(0) @binding(auto) var iconTexture: texture_2d<f32>;
 @group(0) @binding(auto) var iconTextureSampler: sampler;
@@ -66,7 +66,7 @@ fn encodePickingColor(rowIndex: u32) -> vec3<f32> { let value = rowIndex + 1u; r
 fn getCorner(vertexIndex: u32) -> vec2<f32> { let corners = array<vec2<f32>, 6>(vec2<f32>(-1.0,-1.0),vec2<f32>(1.0,-1.0),vec2<f32>(-1.0,1.0),vec2<f32>(-1.0,1.0),vec2<f32>(1.0,-1.0),vec2<f32>(1.0,1.0)); return corners[vertexIndex]; }
 @vertex fn vertexMain(@location(0) positions: vec2<f32>, @location(1) offsets: vec2<f32>, @location(2) frames: vec4<f32>, @location(3) colorModes: f32, @location(4) colors: vec4<f32>, @location(5) sizes: f32, @location(6) angles: f32, @location(7) pixelOffsets: vec2<f32>, @builtin(vertex_index) vertexIndex: u32, @builtin(instance_index) instanceIndex: u32) -> VertexOutput {
   let corner = getCorner(vertexIndex); let size = select(iconStyle.size, sizes, iconStyle.useSizes != 0u) * iconStyle.sizeScale;
-  let radians = angles * 0.01745329252; let rotation = mat2x2<f32>(cos(radians), sin(radians), -sin(radians), cos(radians));
+  let angle = select(iconStyle.angle, angles, iconStyle.useAngles != 0u); let radians = angle * 0.01745329252; let rotation = mat2x2<f32>(cos(radians), sin(radians), -sin(radians), cos(radians));
   let pixel = rotation * ((corner * frames.zw * 0.5 + offsets) * size) + pixelOffsets;
   let pickingColor = encodePickingColor(instanceIndex + iconStyle.rowIndexOffset); geometry.worldPosition = vec3<f32>(positions, 0.0); geometry.pickingColor = pickingColor;
   var clip = project_position_to_clipspace(vec3<f32>(positions,0.0),vec3<f32>(0.0),vec3<f32>(0.0)); clip = vec4<f32>(clip.xy + project_pixel_size_to_clipspace(pixel) * clip.w, clip.z, clip.w);
@@ -191,13 +191,19 @@ class GPUIconBatchLayer extends Layer<GPUIconBatchProps> {
       [
         typeof this.props.getSize === 'number' ? this.props.getSize : 1,
         this.props.sizeScale ?? 1,
-        this.props.alphaCutoff ?? 0.05
+        this.props.alphaCutoff ?? 0.05,
+        typeof this.props.getAngle === 'number' ? this.props.getAngle : 0
       ],
       8
     );
     uints.set(
-      [this.props.colors ? 1 : 0, this.props.sizes ? 1 : 0, this.props.rowIndexOffset, 0],
-      11
+      [
+        this.props.colors ? 1 : 0,
+        this.props.sizes ? 1 : 0,
+        this.props.angles ? 1 : 0,
+        this.props.rowIndexOffset
+      ],
+      12
     );
     styleBuffer.write(new Uint8Array(bytes));
     model.draw(renderPass);

--- a/modules/deck-gpu-layers/src/layers/gpu-line-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-line-layer.ts
@@ -1,0 +1,281 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  CompositeLayer,
+  Layer,
+  picking,
+  project32,
+  type Color,
+  type LayerContext,
+  type LayerProps,
+  type PickingInfo,
+  type UpdateParameters
+} from '@deck.gl/core';
+import {Buffer, type RenderPass} from '@luma.gl/core';
+import {Model} from '@luma.gl/engine';
+import type {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import {
+  getGPUDataBuffer,
+  getGPUVectorLayerBatches,
+  makeGPUDataBufferLayout,
+  type GPUVectorLayerPickingInfo
+} from './gpu-vector-layer-utils';
+
+/** GPUVector-native straight line props. All input vectors are borrowed. */
+export type GPULineLayerProps = Omit<LayerProps, 'data'> & {
+  getSourcePosition: GPUVector<'float32x2'>;
+  getTargetPosition: GPUVector<'float32x2'>;
+  getColor?: Color | GPUVector<'unorm8x4'>;
+  getWidth?: number | GPUVector<'float32'>;
+  widthScale?: number;
+  widthMinPixels?: number;
+  widthMaxPixels?: number;
+};
+
+type GPULineBatchProps = Omit<GPULineLayerProps, 'getSourcePosition' | 'getTargetPosition'> & {
+  sourcePositions: GPUData<'float32x2'>;
+  targetPositions: GPUData<'float32x2'>;
+  colors?: GPUData<'unorm8x4'>;
+  widths?: GPUData<'float32'>;
+  rowCount: number;
+  batchIndex: number;
+  rowIndexOffset: number;
+};
+type GPULineBatchState = {model: Model | null; styleBuffer: Buffer | null; defaults: Buffer[]};
+
+const GPU_LINE_SHADER = /* wgsl */ `
+struct LineStyle {
+  color: vec4<f32>,
+  width: f32,
+  widthScale: f32,
+  widthMinPixels: f32,
+  widthMaxPixels: f32,
+  useColors: u32,
+  useWidths: u32,
+  rowIndexOffset: u32,
+  _padding: u32,
+};
+@group(0) @binding(auto) var<uniform> lineStyle: LineStyle;
+struct VertexOutput { @builtin(position) position: vec4<f32>, @location(0) color: vec4<f32>, @location(1) @interpolate(flat) pickingColor: vec3<f32> };
+fn encodePickingColor(rowIndex: u32) -> vec3<f32> { let value = rowIndex + 1u; return vec3<f32>(f32(value % 256u), f32((value / 256u) % 256u), f32((value / 65536u) % 256u)) / 255.0; }
+fn getCorner(vertexIndex: u32) -> vec2<f32> {
+  let corners = array<vec2<f32>, 6>(
+    vec2<f32>(0.0, -1.0), vec2<f32>(1.0, -1.0), vec2<f32>(0.0, 1.0),
+    vec2<f32>(0.0, 1.0), vec2<f32>(1.0, -1.0), vec2<f32>(1.0, 1.0)
+  );
+  return corners[vertexIndex];
+}
+@vertex fn vertexMain(
+  @location(0) sourcePositions: vec2<f32>,
+  @location(1) targetPositions: vec2<f32>,
+  @location(2) colors: vec4<f32>,
+  @location(3) widths: f32,
+  @builtin(vertex_index) vertexIndex: u32,
+  @builtin(instance_index) instanceIndex: u32
+) -> VertexOutput {
+  let corner = getCorner(vertexIndex);
+  let sourceClip = project_position_to_clipspace(vec3<f32>(sourcePositions, 0.0), vec3<f32>(0.0), vec3<f32>(0.0));
+  let targetClip = project_position_to_clipspace(vec3<f32>(targetPositions, 0.0), vec3<f32>(0.0), vec3<f32>(0.0));
+  let delta = targetClip.xy / targetClip.w - sourceClip.xy / sourceClip.w;
+  let direction = select(vec2<f32>(1.0, 0.0), normalize(delta), length(delta) > 0.000001);
+  let normal = vec2<f32>(-direction.y, direction.x);
+  let width = clamp(
+    select(lineStyle.width, widths, lineStyle.useWidths != 0u) * lineStyle.widthScale,
+    lineStyle.widthMinPixels,
+    lineStyle.widthMaxPixels
+  );
+  var clipPosition = mix(sourceClip, targetClip, corner.x);
+  clipPosition = vec4<f32>(clipPosition.xy + project_pixel_size_to_clipspace(normal * corner.y * width * 0.5) * clipPosition.w, clipPosition.z, clipPosition.w);
+  let pickingColor = encodePickingColor(instanceIndex + lineStyle.rowIndexOffset);
+  geometry.worldPosition = vec3<f32>(mix(sourcePositions, targetPositions, corner.x), 0.0); geometry.pickingColor = pickingColor;
+  var output: VertexOutput;
+  output.position = clipPosition;
+  output.color = select(lineStyle.color, colors, lineStyle.useColors != 0u);
+  output.pickingColor = pickingColor;
+  return output;
+}
+@fragment fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> { if (picking.isActive > 0.5) { return vec4<f32>(input.pickingColor, 1.0); } return vec4<f32>(input.color.rgb, input.color.a * layer.opacity); }
+`;
+
+class GPULineBatchLayer extends Layer<GPULineBatchProps> {
+  static override layerName = 'GPULineBatchLayer';
+  override getAttributeManager() {
+    return null;
+  }
+
+  override initializeState({device}: LayerContext): void {
+    if (device.type !== 'webgpu') throw new Error('GPULineLayer requires WebGPU');
+    const styleBuffer = device.createBuffer({
+      id: `${this.id}-style`,
+      byteLength: 48,
+      usage: Buffer.UNIFORM | Buffer.COPY_DST
+    });
+    const defaultColor = device.createBuffer({
+      id: `${this.id}-default-color`,
+      data: new Uint8Array([0, 0, 0, 255])
+    });
+    const defaultWidth = device.createBuffer({
+      id: `${this.id}-default-width`,
+      data: new Float32Array([1])
+    });
+    const model = new Model(device, {
+      ...this.getShaders({modules: [project32, picking], source: GPU_LINE_SHADER}),
+      id: `${this.id}-model`,
+      topology: 'triangle-list',
+      isInstanced: true,
+      vertexCount: 6,
+      instanceCount: this.props.rowCount,
+      attributes: {
+        sourcePositions: getGPUDataBuffer(this.props.sourcePositions),
+        targetPositions: getGPUDataBuffer(this.props.targetPositions),
+        colors: this.props.colors ? getGPUDataBuffer(this.props.colors) : defaultColor,
+        widths: this.props.widths ? getGPUDataBuffer(this.props.widths) : defaultWidth
+      },
+      bufferLayout: [
+        makeGPUDataBufferLayout(this.props.sourcePositions, 'sourcePositions'),
+        makeGPUDataBufferLayout(this.props.targetPositions, 'targetPositions'),
+        this.props.colors
+          ? makeGPUDataBufferLayout(this.props.colors, 'colors')
+          : {
+              name: 'colors',
+              byteStride: 0,
+              stepMode: 'instance',
+              attributes: [{attribute: 'colors', format: 'unorm8x4'}]
+            },
+        this.props.widths
+          ? makeGPUDataBufferLayout(this.props.widths, 'widths')
+          : {
+              name: 'widths',
+              byteStride: 0,
+              stepMode: 'instance',
+              attributes: [{attribute: 'widths', format: 'float32'}]
+            }
+      ],
+      bindings: {lineStyle: styleBuffer}
+    });
+    model.userData['boundInputs'] = [
+      this.props.sourcePositions,
+      this.props.targetPositions,
+      this.props.colors,
+      this.props.widths,
+      this.props.rowCount
+    ];
+    this.setState({
+      model,
+      styleBuffer,
+      defaults: [defaultColor, defaultWidth]
+    } satisfies GPULineBatchState);
+  }
+
+  override getModels(): Model[] {
+    const model = (this.state as GPULineBatchState).model;
+    return model ? [model] : [];
+  }
+  override updateState({props}: UpdateParameters<this>): void {
+    const boundInputs = ((this.state as GPULineBatchState).model?.userData['boundInputs'] ??
+      []) as unknown[];
+    if (
+      props.sourcePositions !== boundInputs[0] ||
+      props.targetPositions !== boundInputs[1] ||
+      props.colors !== boundInputs[2] ||
+      props.widths !== boundInputs[3] ||
+      props.rowCount !== boundInputs[4]
+    ) {
+      this.destroyResources();
+      this.initializeState(this.context);
+    }
+  }
+  override draw({renderPass}: {renderPass: RenderPass}): void {
+    const {model, styleBuffer} = this.state as GPULineBatchState;
+    if (!model || !styleBuffer) return;
+    const [red, green, blue, alpha = 255] = isColor(this.props.getColor)
+      ? this.props.getColor
+      : [0, 0, 0, 255];
+    const bytes = new ArrayBuffer(48);
+    const floats = new Float32Array(bytes);
+    const uints = new Uint32Array(bytes);
+    floats.set([
+      red / 255,
+      green / 255,
+      blue / 255,
+      alpha / 255,
+      typeof this.props.getWidth === 'number' ? this.props.getWidth : 1,
+      this.props.widthScale ?? 1,
+      this.props.widthMinPixels ?? 0,
+      this.props.widthMaxPixels ?? 1e9
+    ]);
+    uints.set(
+      [this.props.colors ? 1 : 0, this.props.widths ? 1 : 0, this.props.rowIndexOffset, 0],
+      8
+    );
+    styleBuffer.write(new Uint8Array(bytes));
+    model.draw(renderPass);
+  }
+  override getPickingInfo({info}: {info: PickingInfo}): PickingInfo {
+    const pickingInfo = info as GPUVectorLayerPickingInfo;
+    pickingInfo.gpuVector = {
+      rowIndex: pickingInfo.index,
+      batchIndex: this.props.batchIndex,
+      batchRowIndex: pickingInfo.index - this.props.rowIndexOffset
+    };
+    return pickingInfo;
+  }
+  override finalizeState(context: LayerContext): void {
+    this.destroyResources();
+    super.finalizeState(context);
+  }
+  private destroyResources(): void {
+    const state = this.state as GPULineBatchState;
+    state.model?.destroy();
+    state.styleBuffer?.destroy();
+    state.defaults.forEach(buffer => buffer.destroy());
+    this.setState({model: null, styleBuffer: null, defaults: []});
+  }
+}
+
+/** Chunk-preserving GPUVector straight-line composite. */
+export class GPULineLayer extends CompositeLayer<GPULineLayerProps> {
+  static override layerName = 'GPULineLayer';
+  override renderLayers(): GPULineBatchLayer[] {
+    const {getSourcePosition, getTargetPosition, getColor, getWidth, ...props} = this.props;
+    return getGPUVectorLayerBatches(
+      this.id,
+      {
+        sourcePositions: getSourcePosition,
+        targetPositions: getTargetPosition,
+        colors: isGPUVector(getColor) ? getColor : undefined,
+        widths: isGPUVector(getWidth) ? getWidth : undefined
+      },
+      {
+        sourcePositions: ['float32x2'],
+        targetPositions: ['float32x2'],
+        colors: ['unorm8x4'],
+        widths: ['float32']
+      }
+    ).map(
+      batch =>
+        new GPULineBatchLayer({
+          ...props,
+          id: `${this.props.id}-batch-${batch.batchIndex}`,
+          getColor,
+          getWidth,
+          sourcePositions: batch.data['sourcePositions'] as GPUData<'float32x2'>,
+          targetPositions: batch.data['targetPositions'] as GPUData<'float32x2'>,
+          colors: batch.data['colors'] as GPUData<'unorm8x4'> | undefined,
+          widths: batch.data['widths'] as GPUData<'float32'> | undefined,
+          rowCount: batch.rowCount,
+          batchIndex: batch.batchIndex,
+          rowIndexOffset: batch.rowIndexOffset
+        })
+    );
+  }
+}
+
+function isGPUVector(value: unknown): value is GPUVector {
+  return Boolean(value && typeof value === 'object' && 'data' in value && 'format' in value);
+}
+function isColor(value: unknown): value is Color {
+  return Array.isArray(value) || ArrayBuffer.isView(value);
+}

--- a/modules/deck-gpu-layers/src/layers/gpu-line-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-line-layer.ts
@@ -3,7 +3,6 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {
-  CompositeLayer,
   Layer,
   picking,
   project32,
@@ -14,12 +13,13 @@ import {
   type UpdateParameters
 } from '@deck.gl/core';
 import {Buffer, type RenderPass} from '@luma.gl/core';
-import {Model} from '@luma.gl/engine';
-import type {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import type {Model} from '@luma.gl/engine';
+import {GPUVectorModel, type GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {
-  getGPUDataBuffer,
+  getGPUVectorBuffer,
   getGPUVectorLayerBatches,
-  makeGPUDataBufferLayout,
+  getGPUVectorPickingProvenance,
+  makeGPUVectorBufferLayout,
   type GPUVectorLayerPickingInfo
 } from './gpu-vector-layer-utils';
 
@@ -34,16 +34,11 @@ export type GPULineLayerProps = Omit<LayerProps, 'data'> & {
   widthMaxPixels?: number;
 };
 
-type GPULineBatchProps = Omit<GPULineLayerProps, 'getSourcePosition' | 'getTargetPosition'> & {
-  sourcePositions: GPUData<'float32x2'>;
-  targetPositions: GPUData<'float32x2'>;
-  colors?: GPUData<'unorm8x4'>;
-  widths?: GPUData<'float32'>;
-  rowCount: number;
-  batchIndex: number;
-  rowIndexOffset: number;
+type GPULineLayerState = {
+  model: GPUVectorModel | null;
+  styleBuffer: Buffer | null;
+  defaults: Buffer[];
 };
-type GPULineBatchState = {model: Model | null; styleBuffer: Buffer | null; defaults: Buffer[]};
 
 const GPU_LINE_SHADER = /* wgsl */ `
 struct LineStyle {
@@ -99,14 +94,36 @@ fn getCorner(vertexIndex: u32) -> vec2<f32> {
 @fragment fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> { if (picking.isActive > 0.5) { return vec4<f32>(input.pickingColor, 1.0); } return vec4<f32>(input.color.rgb, input.color.a * layer.opacity); }
 `;
 
-class GPULineBatchLayer extends Layer<GPULineBatchProps> {
-  static override layerName = 'GPULineBatchLayer';
+/** Chunk-preserving GPUVector straight-line layer. */
+export class GPULineLayer extends Layer<GPULineLayerProps> {
+  static override layerName = 'GPULineLayer';
   override getAttributeManager() {
     return null;
   }
 
   override initializeState({device}: LayerContext): void {
     if (device.type !== 'webgpu') throw new Error('GPULineLayer requires WebGPU');
+    const colors = isGPUVector(this.props.getColor) ? this.props.getColor : undefined;
+    const widths = isGPUVector(this.props.getWidth) ? this.props.getWidth : undefined;
+    getGPUVectorLayerBatches(
+      this.id,
+      {
+        sourcePositions: this.props.getSourcePosition,
+        targetPositions: this.props.getTargetPosition,
+        colors,
+        widths
+      },
+      {
+        sourcePositions: ['float32x2'],
+        targetPositions: ['float32x2'],
+        colors: ['unorm8x4'],
+        widths: ['float32']
+      }
+    );
+    if (this.props.getSourcePosition.data.length === 0) {
+      this.setState({model: null, styleBuffer: null, defaults: []} satisfies GPULineLayerState);
+      return;
+    }
     const styleBuffer = device.createBuffer({
       id: `${this.id}-style`,
       byteLength: 48,
@@ -120,32 +137,32 @@ class GPULineBatchLayer extends Layer<GPULineBatchProps> {
       id: `${this.id}-default-width`,
       data: new Float32Array([1])
     });
-    const model = new Model(device, {
+    const model = new GPUVectorModel(device, {
       ...this.getShaders({modules: [project32, picking], source: GPU_LINE_SHADER}),
       id: `${this.id}-model`,
       topology: 'triangle-list',
       isInstanced: true,
       vertexCount: 6,
-      instanceCount: this.props.rowCount,
+      instanceCount: 0,
       attributes: {
-        sourcePositions: getGPUDataBuffer(this.props.sourcePositions),
-        targetPositions: getGPUDataBuffer(this.props.targetPositions),
-        colors: this.props.colors ? getGPUDataBuffer(this.props.colors) : defaultColor,
-        widths: this.props.widths ? getGPUDataBuffer(this.props.widths) : defaultWidth
+        sourcePositions: getGPUVectorBuffer(this.props.getSourcePosition),
+        targetPositions: getGPUVectorBuffer(this.props.getTargetPosition),
+        colors: colors ? getGPUVectorBuffer(colors) : defaultColor,
+        widths: widths ? getGPUVectorBuffer(widths) : defaultWidth
       },
       bufferLayout: [
-        makeGPUDataBufferLayout(this.props.sourcePositions, 'sourcePositions'),
-        makeGPUDataBufferLayout(this.props.targetPositions, 'targetPositions'),
-        this.props.colors
-          ? makeGPUDataBufferLayout(this.props.colors, 'colors')
+        makeGPUVectorBufferLayout(this.props.getSourcePosition, 'sourcePositions'),
+        makeGPUVectorBufferLayout(this.props.getTargetPosition, 'targetPositions'),
+        colors
+          ? makeGPUVectorBufferLayout(colors, 'colors')
           : {
               name: 'colors',
               byteStride: 0,
               stepMode: 'instance',
               attributes: [{attribute: 'colors', format: 'unorm8x4'}]
             },
-        this.props.widths
-          ? makeGPUDataBufferLayout(this.props.widths, 'widths')
+        widths
+          ? makeGPUVectorBufferLayout(widths, 'widths')
           : {
               name: 'widths',
               byteStride: 0,
@@ -156,40 +173,42 @@ class GPULineBatchLayer extends Layer<GPULineBatchProps> {
       bindings: {lineStyle: styleBuffer}
     });
     model.userData['boundInputs'] = [
-      this.props.sourcePositions,
-      this.props.targetPositions,
-      this.props.colors,
-      this.props.widths,
-      this.props.rowCount
+      this.props.getSourcePosition,
+      this.props.getTargetPosition,
+      colors,
+      widths
     ];
     this.setState({
       model,
       styleBuffer,
       defaults: [defaultColor, defaultWidth]
-    } satisfies GPULineBatchState);
+    } satisfies GPULineLayerState);
   }
 
   override getModels(): Model[] {
-    const model = (this.state as GPULineBatchState).model;
+    const model = (this.state as GPULineLayerState).model;
     return model ? [model] : [];
   }
   override updateState({props}: UpdateParameters<this>): void {
-    const boundInputs = ((this.state as GPULineBatchState).model?.userData['boundInputs'] ??
+    const boundInputs = ((this.state as GPULineLayerState).model?.userData['boundInputs'] ??
       []) as unknown[];
+    const colors = isGPUVector(props.getColor) ? props.getColor : undefined;
+    const widths = isGPUVector(props.getWidth) ? props.getWidth : undefined;
     if (
-      props.sourcePositions !== boundInputs[0] ||
-      props.targetPositions !== boundInputs[1] ||
-      props.colors !== boundInputs[2] ||
-      props.widths !== boundInputs[3] ||
-      props.rowCount !== boundInputs[4]
+      props.getSourcePosition !== boundInputs[0] ||
+      props.getTargetPosition !== boundInputs[1] ||
+      colors !== boundInputs[2] ||
+      widths !== boundInputs[3]
     ) {
       this.destroyResources();
       this.initializeState(this.context);
     }
   }
   override draw({renderPass}: {renderPass: RenderPass}): void {
-    const {model, styleBuffer} = this.state as GPULineBatchState;
+    const {model, styleBuffer} = this.state as GPULineLayerState;
     if (!model || !styleBuffer) return;
+    const colors = isGPUVector(this.props.getColor) ? this.props.getColor : undefined;
+    const widths = isGPUVector(this.props.getWidth) ? this.props.getWidth : undefined;
     const [red, green, blue, alpha = 255] = isColor(this.props.getColor)
       ? this.props.getColor
       : [0, 0, 0, 255];
@@ -206,20 +225,26 @@ class GPULineBatchLayer extends Layer<GPULineBatchProps> {
       this.props.widthMinPixels ?? 0,
       this.props.widthMaxPixels ?? 1e9
     ]);
-    uints.set(
-      [this.props.colors ? 1 : 0, this.props.widths ? 1 : 0, this.props.rowIndexOffset, 0],
-      8
-    );
-    styleBuffer.write(new Uint8Array(bytes));
-    model.draw(renderPass);
+    uints.set([colors ? 1 : 0, widths ? 1 : 0, 0, 0], 8);
+    model.drawBatches(renderPass, {
+      vectors: {
+        sourcePositions: this.props.getSourcePosition,
+        targetPositions: this.props.getTargetPosition,
+        colors,
+        widths
+      },
+      onBatch: batch => {
+        uints[10] = batch.rowIndexOffset;
+        styleBuffer.write(new Uint8Array(bytes));
+      }
+    });
   }
   override getPickingInfo({info}: {info: PickingInfo}): PickingInfo {
     const pickingInfo = info as GPUVectorLayerPickingInfo;
-    pickingInfo.gpuVector = {
-      rowIndex: pickingInfo.index,
-      batchIndex: this.props.batchIndex,
-      batchRowIndex: pickingInfo.index - this.props.rowIndexOffset
-    };
+    pickingInfo.gpuVector = getGPUVectorPickingProvenance(
+      this.props.getSourcePosition,
+      pickingInfo.index
+    );
     return pickingInfo;
   }
   override finalizeState(context: LayerContext): void {
@@ -227,49 +252,11 @@ class GPULineBatchLayer extends Layer<GPULineBatchProps> {
     super.finalizeState(context);
   }
   private destroyResources(): void {
-    const state = this.state as GPULineBatchState;
+    const state = this.state as GPULineLayerState;
     state.model?.destroy();
     state.styleBuffer?.destroy();
     state.defaults.forEach(buffer => buffer.destroy());
     this.setState({model: null, styleBuffer: null, defaults: []});
-  }
-}
-
-/** Chunk-preserving GPUVector straight-line composite. */
-export class GPULineLayer extends CompositeLayer<GPULineLayerProps> {
-  static override layerName = 'GPULineLayer';
-  override renderLayers(): GPULineBatchLayer[] {
-    const {getSourcePosition, getTargetPosition, getColor, getWidth, ...props} = this.props;
-    return getGPUVectorLayerBatches(
-      this.id,
-      {
-        sourcePositions: getSourcePosition,
-        targetPositions: getTargetPosition,
-        colors: isGPUVector(getColor) ? getColor : undefined,
-        widths: isGPUVector(getWidth) ? getWidth : undefined
-      },
-      {
-        sourcePositions: ['float32x2'],
-        targetPositions: ['float32x2'],
-        colors: ['unorm8x4'],
-        widths: ['float32']
-      }
-    ).map(
-      batch =>
-        new GPULineBatchLayer({
-          ...props,
-          id: `${this.props.id}-batch-${batch.batchIndex}`,
-          getColor,
-          getWidth,
-          sourcePositions: batch.data['sourcePositions'] as GPUData<'float32x2'>,
-          targetPositions: batch.data['targetPositions'] as GPUData<'float32x2'>,
-          colors: batch.data['colors'] as GPUData<'unorm8x4'> | undefined,
-          widths: batch.data['widths'] as GPUData<'float32'> | undefined,
-          rowCount: batch.rowCount,
-          batchIndex: batch.batchIndex,
-          rowIndexOffset: batch.rowIndexOffset
-        })
-    );
   }
 }
 

--- a/modules/deck-gpu-layers/src/layers/gpu-path-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-path-layer.ts
@@ -1,0 +1,299 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  Layer,
+  picking,
+  project32,
+  type Color,
+  type LayerContext,
+  type LayerProps,
+  type PickingInfo,
+  type UpdateParameters
+} from '@deck.gl/core';
+import {Buffer, type RenderPass, type ShaderLayout} from '@luma.gl/core';
+import type {Model} from '@luma.gl/engine';
+import type {GPUVector, VertexList} from '@luma.gl/gpgpu/gpu-data';
+import {PathStorageModel} from '@luma.gl/experimental/models';
+import {
+  getGPUVectorPickingProvenance,
+  type GPUVectorLayerPickingInfo
+} from './gpu-vector-layer-utils';
+
+/** GPUVector-native variable-length path props. Input vectors are borrowed. */
+export type GPUPathLayerProps = Omit<LayerProps, 'data'> & {
+  getPath: GPUVector<VertexList<'float32x2' | 'float32x3' | 'float32x4'>>;
+  getColor?: Color | GPUVector<'unorm8x4' | VertexList<'unorm8x4'>>;
+  getWidth?: number | GPUVector<'float32'>;
+  getTimestamps?: GPUVector<VertexList<'float32'>>;
+  viewOrigins?: GPUVector<'float32x4'>;
+  currentTime?: number;
+  trailLength?: number;
+  fadeTrail?: boolean;
+};
+
+type GPUPathLayerState = {
+  model: PathStorageModel | null;
+  temporalBuffer: Buffer | null;
+  defaultTimestampBuffer: Buffer | null;
+};
+
+const GPU_PATH_SHADER_LAYOUT: ShaderLayout = {
+  attributes: [
+    {name: 'segmentStartPointIndices', location: 0, type: 'u32', stepMode: 'instance'},
+    {name: 'segmentFlags', location: 1, type: 'u32', stepMode: 'instance'},
+    {name: 'rowIndices', location: 2, type: 'u32', stepMode: 'instance'}
+  ],
+  bindings: []
+};
+
+const GPU_PATH_SHADER = /* wgsl */ `
+@group(0) @binding(auto) var<storage, read> pathValues: array<f32>;
+@group(0) @binding(auto) var<storage, read> pathRanges: array<vec4<u32>>;
+@group(0) @binding(auto) var<storage, read> pathViewOrigins: array<vec4<f32>>;
+@group(0) @binding(auto) var<storage, read> pathRowColors: array<u32>;
+@group(0) @binding(auto) var<storage, read> pathVertexColors: array<u32>;
+@group(0) @binding(auto) var<storage, read> pathRowWidths: array<f32>;
+@group(0) @binding(auto) var<storage, read> pathTimestamps: array<f32>;
+
+struct PathStorageStyleConfig {
+  constantColor: vec4<f32>,
+  constantWidth: f32,
+  useRowColors: u32,
+  useRowWidths: u32,
+  batchRowIndexBase: u32,
+  pathComponentCount: u32,
+  useViewOrigins: u32,
+  useVertexColors: u32,
+  _padding1: u32,
+};
+@group(0) @binding(auto) var<uniform> pathStorageStyleConfig: PathStorageStyleConfig;
+
+struct PathLayerStyle {
+  currentTime: f32,
+  trailLength: f32,
+  temporalMode: u32,
+  fadeTrail: u32,
+};
+@group(0) @binding(auto) var<uniform> pathLayerStyle: PathLayerStyle;
+
+struct VertexInputs {
+  @location(0) segmentStartPointIndex: u32,
+  @location(1) segmentFlags: u32,
+  @location(2) rowIndex: u32,
+};
+
+struct VertexOutputs {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec4<f32>,
+  @location(1) @interpolate(flat) pickingColor: vec3<f32>,
+  @location(2) @interpolate(flat) visible: f32,
+  @location(3) trailOpacity: f32,
+};
+
+fn encodePickingColor(rowIndex: u32) -> vec3<f32> {
+  let value = rowIndex + 1u;
+  return vec3<f32>(f32(value % 256u), f32((value / 256u) % 256u), f32((value / 65536u) % 256u)) / 255.0;
+}
+
+fn unpackPathColor(colorWord: u32) -> vec4<f32> {
+  return vec4<f32>(
+    f32(colorWord & 255u),
+    f32((colorWord >> 8u) & 255u),
+    f32((colorWord >> 16u) & 255u),
+    f32((colorWord >> 24u) & 255u)
+  ) / 255.0;
+}
+
+fn readPathComponent(pointIndex: u32, componentIndex: u32) -> f32 {
+  if (componentIndex >= pathStorageStyleConfig.pathComponentCount) { return 0.0; }
+  return pathValues[pointIndex * pathStorageStyleConfig.pathComponentCount + componentIndex];
+}
+
+fn readPathPoint(pointIndex: u32) -> vec4<f32> {
+  return vec4<f32>(
+    readPathComponent(pointIndex, 0u),
+    readPathComponent(pointIndex, 1u),
+    readPathComponent(pointIndex, 2u),
+    readPathComponent(pointIndex, 3u)
+  );
+}
+
+fn getCorner(vertexIndex: u32) -> vec2<f32> {
+  let corners = array<vec2<f32>, 6>(
+    vec2<f32>(0.0, -1.0), vec2<f32>(1.0, -1.0), vec2<f32>(1.0, 1.0),
+    vec2<f32>(0.0, -1.0), vec2<f32>(1.0, 1.0), vec2<f32>(0.0, 1.0)
+  );
+  return corners[vertexIndex % 6u];
+}
+
+@vertex fn vertexMain(
+  inputs: VertexInputs,
+  @builtin(vertex_index) vertexIndex: u32
+) -> VertexOutputs {
+  let localRowIndex = inputs.rowIndex - pathStorageStyleConfig.batchRowIndexBase;
+  let pathRange = pathRanges[localRowIndex];
+  let endPointIndex = min(inputs.segmentStartPointIndex + 1u, pathRange.y - 1u);
+  let viewOrigin = select(vec4<f32>(0.0), pathViewOrigins[localRowIndex], pathStorageStyleConfig.useViewOrigins != 0u);
+  let startWorld = readPathPoint(inputs.segmentStartPointIndex) + viewOrigin;
+  let endWorld = readPathPoint(endPointIndex) + viewOrigin;
+  let startClip = project_position_to_clipspace(startWorld.xyz, vec3<f32>(0.0), vec3<f32>(0.0));
+  let endClip = project_position_to_clipspace(endWorld.xyz, vec3<f32>(0.0), vec3<f32>(0.0));
+  let delta = endClip.xy / endClip.w - startClip.xy / startClip.w;
+  let direction = select(vec2<f32>(1.0, 0.0), normalize(delta), length(delta) > 0.000001);
+  let normal = vec2<f32>(-direction.y, direction.x);
+  let corner = getCorner(vertexIndex);
+  let width = select(pathStorageStyleConfig.constantWidth, pathRowWidths[localRowIndex], pathStorageStyleConfig.useRowWidths != 0u);
+  var clipPosition = mix(startClip, endClip, corner.x);
+  clipPosition = vec4<f32>(clipPosition.xy + project_pixel_size_to_clipspace(normal * corner.y * width * 0.5) * clipPosition.w, clipPosition.z, clipPosition.w);
+  var color = pathStorageStyleConfig.constantColor;
+  if (pathStorageStyleConfig.useVertexColors != 0u) {
+    color = mix(unpackPathColor(pathVertexColors[inputs.segmentStartPointIndex]), unpackPathColor(pathVertexColors[endPointIndex]), corner.x);
+  } else if (pathStorageStyleConfig.useRowColors != 0u) {
+    color = unpackPathColor(pathRowColors[localRowIndex]);
+  }
+  let useTimestampColumn = pathLayerStyle.temporalMode == 2u;
+  let startMeasure = select(startWorld.w, pathTimestamps[inputs.segmentStartPointIndex], useTimestampColumn);
+  let endMeasure = select(endWorld.w, pathTimestamps[endPointIndex], useTimestampColumn);
+  let temporalEnabled = pathLayerStyle.temporalMode != 0u;
+  let visible = !temporalEnabled || (endMeasure >= pathLayerStyle.currentTime - pathLayerStyle.trailLength && startMeasure <= pathLayerStyle.currentTime);
+  let vertexMeasure = mix(startMeasure, endMeasure, corner.x);
+  let trailOpacity = select(1.0, clamp((vertexMeasure - (pathLayerStyle.currentTime - pathLayerStyle.trailLength)) / max(pathLayerStyle.trailLength, 0.000001), 0.0, 1.0), useTimestampColumn && pathLayerStyle.fadeTrail != 0u);
+  let pickingColor = encodePickingColor(inputs.rowIndex);
+  geometry.worldPosition = mix(startWorld.xyz, endWorld.xyz, corner.x);
+  geometry.pickingColor = pickingColor;
+  var output: VertexOutputs;
+  output.position = clipPosition;
+  output.color = color;
+  output.pickingColor = pickingColor;
+  output.visible = select(0.0, 1.0, visible);
+  output.trailOpacity = trailOpacity;
+  return output;
+}
+
+@fragment fn fragmentMain(input: VertexOutputs) -> @location(0) vec4<f32> {
+  if (input.visible < 0.5) { discard; }
+  if (picking.isActive > 0.5) { return vec4<f32>(input.pickingColor, 1.0); }
+  return vec4<f32>(input.color.rgb, input.color.a * input.trailOpacity * layer.opacity);
+}`;
+
+/** Deck host for the GPU-only variable-length path model. */
+export class GPUPathLayer extends Layer<GPUPathLayerProps> {
+  static override layerName = 'GPUPathLayer';
+
+  override getAttributeManager() {
+    return null;
+  }
+
+  override initializeState({device}: LayerContext): void {
+    if (device.type !== 'webgpu') throw new Error('GPUPathLayer requires WebGPU');
+    this.setState({model: null, temporalBuffer: null, defaultTimestampBuffer: null});
+    this.createModel();
+  }
+
+  override updateState({props}: UpdateParameters<this>): void {
+    const boundInputs = ((this.state as GPUPathLayerState).model?.userData['boundInputs'] ??
+      []) as unknown[];
+    if (
+      props.getPath !== boundInputs[0] ||
+      props.getColor !== boundInputs[1] ||
+      props.getWidth !== boundInputs[2] ||
+      props.getTimestamps !== boundInputs[3] ||
+      props.viewOrigins !== boundInputs[4]
+    ) {
+      this.destroyModel();
+      this.createModel();
+    }
+  }
+
+  override getModels(): Model[] {
+    const model = (this.state as GPUPathLayerState | undefined)?.model;
+    return model ? [model] : [];
+  }
+
+  override draw({renderPass}: {renderPass: RenderPass}): void {
+    const {model, temporalBuffer} = this.state as GPUPathLayerState;
+    if (!model || !temporalBuffer) return;
+    const values = new ArrayBuffer(16);
+    const floats = new Float32Array(values);
+    const uints = new Uint32Array(values);
+    floats.set([this.props.currentTime ?? 0, this.props.trailLength ?? 0]);
+    uints.set(
+      [
+        this.props.getTimestamps ? 2 : this.props.currentTime !== undefined ? 1 : 0,
+        this.props.fadeTrail ? 1 : 0
+      ],
+      2
+    );
+    temporalBuffer.write(new Uint8Array(values));
+    model.draw(renderPass);
+  }
+
+  override getPickingInfo({info}: {info: PickingInfo}): PickingInfo {
+    const result = info as GPUVectorLayerPickingInfo;
+    result.gpuVector = getGPUVectorPickingProvenance(this.props.getPath, result.index);
+    return result;
+  }
+
+  override finalizeState(context: LayerContext): void {
+    this.destroyModel();
+    super.finalizeState(context);
+  }
+
+  private createModel(): void {
+    const {device} = this.context;
+    const temporalBuffer = device.createBuffer({
+      id: `${this.id}-temporal-style`,
+      byteLength: 16,
+      usage: Buffer.UNIFORM | Buffer.COPY_DST
+    });
+    const defaultTimestampBuffer = device.createBuffer({
+      id: `${this.id}-default-timestamp`,
+      data: new Float32Array([0]),
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+    const color = isGPUVector(this.props.getColor)
+      ? undefined
+      : normalizeColor(this.props.getColor ?? [0, 0, 0, 255]);
+    const model = new PathStorageModel(device, {
+      ...this.getShaders({modules: [project32, picking], source: GPU_PATH_SHADER}),
+      id: `${this.id}-model`,
+      shaderLayout: GPU_PATH_SHADER_LAYOUT,
+      paths: this.props.getPath,
+      ...(isGPUVector(this.props.getColor) ? {colors: this.props.getColor} : {color}),
+      ...(isGPUVector(this.props.getWidth)
+        ? {widths: this.props.getWidth}
+        : {width: typeof this.props.getWidth === 'number' ? this.props.getWidth : 1}),
+      ...(this.props.getTimestamps ? {timestamps: this.props.getTimestamps} : {}),
+      ...(this.props.viewOrigins ? {viewOrigins: this.props.viewOrigins} : {}),
+      bindings: {pathLayerStyle: temporalBuffer, pathTimestamps: defaultTimestampBuffer},
+      topology: 'triangle-list',
+      vertexCount: 6
+    });
+    model.userData['boundInputs'] = [
+      this.props.getPath,
+      this.props.getColor,
+      this.props.getWidth,
+      this.props.getTimestamps,
+      this.props.viewOrigins
+    ];
+    this.setState({model, temporalBuffer, defaultTimestampBuffer} satisfies GPUPathLayerState);
+  }
+
+  private destroyModel(): void {
+    const state = this.state as GPUPathLayerState;
+    state.model?.destroy();
+    state.temporalBuffer?.destroy();
+    state.defaultTimestampBuffer?.destroy();
+    this.setState({model: null, temporalBuffer: null, defaultTimestampBuffer: null});
+  }
+}
+
+function normalizeColor(color: Color): [number, number, number, number] {
+  return [color[0], color[1], color[2], color[3] ?? 255];
+}
+
+function isGPUVector(value: unknown): value is GPUVector {
+  return Boolean(value && typeof value === 'object' && 'data' in value && 'format' in value);
+}

--- a/modules/deck-gpu-layers/src/layers/gpu-point-cloud-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-point-cloud-layer.ts
@@ -3,7 +3,6 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {
-  CompositeLayer,
   Layer,
   picking,
   project32,
@@ -14,12 +13,13 @@ import {
   type UpdateParameters
 } from '@deck.gl/core';
 import {Buffer, type RenderPass} from '@luma.gl/core';
-import {Model} from '@luma.gl/engine';
-import type {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import type {Model} from '@luma.gl/engine';
+import {GPUVectorModel, type GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {
-  getGPUDataBuffer,
+  getGPUVectorBuffer,
   getGPUVectorLayerBatches,
-  makeGPUDataBufferLayout,
+  getGPUVectorPickingProvenance,
+  makeGPUVectorBufferLayout,
   type GPUVectorLayerPickingInfo
 } from './gpu-vector-layer-utils';
 
@@ -31,17 +31,8 @@ export type GPUPointCloudLayerProps = Omit<LayerProps, 'data'> & {
   pointSize?: number;
 };
 
-type GPUPointCloudBatchProps = Omit<GPUPointCloudLayerProps, 'getPosition' | 'getNormal'> & {
-  positions: GPUData<'float32x3'>;
-  normals?: GPUData<'float32x3'>;
-  colors?: GPUData<'unorm8x4'>;
-  rowCount: number;
-  batchIndex: number;
-  rowIndexOffset: number;
-};
-
-type GPUPointCloudBatchState = {
-  model: Model | null;
+type GPUPointCloudLayerState = {
+  model: GPUVectorModel | null;
   styleBuffer: Buffer | null;
   defaults: Buffer[];
 };
@@ -105,8 +96,9 @@ fn getCorner(vertexIndex: u32) -> vec2<f32> {
   return vec4<f32>(input.color.rgb * input.lighting, input.color.a * layer.opacity);
 }`;
 
-class GPUPointCloudBatchLayer extends Layer<GPUPointCloudBatchProps> {
-  static override layerName = 'GPUPointCloudBatchLayer';
+/** Chunk-preserving GPUVector point-cloud layer. */
+export class GPUPointCloudLayer extends Layer<GPUPointCloudLayerProps> {
+  static override layerName = 'GPUPointCloudLayer';
 
   override getAttributeManager() {
     return null;
@@ -114,6 +106,20 @@ class GPUPointCloudBatchLayer extends Layer<GPUPointCloudBatchProps> {
 
   override initializeState({device}: LayerContext): void {
     if (device.type !== 'webgpu') throw new Error('GPUPointCloudLayer requires WebGPU');
+    const colors = isGPUVector(this.props.getColor) ? this.props.getColor : undefined;
+    getGPUVectorLayerBatches(
+      this.id,
+      {positions: this.props.getPosition, normals: this.props.getNormal, colors},
+      {positions: ['float32x3'], normals: ['float32x3'], colors: ['unorm8x4']}
+    );
+    if (this.props.getPosition.data.length === 0) {
+      this.setState({
+        model: null,
+        styleBuffer: null,
+        defaults: []
+      } satisfies GPUPointCloudLayerState);
+      return;
+    }
     const styleBuffer = device.createBuffer({
       id: `${this.id}-style`,
       byteLength: 32,
@@ -121,52 +127,47 @@ class GPUPointCloudBatchLayer extends Layer<GPUPointCloudBatchProps> {
     });
     const defaultNormal = device.createBuffer({data: new Float32Array([0, 0, 1])});
     const defaultColor = device.createBuffer({data: new Uint8Array([0, 0, 0, 255])});
-    const model = new Model(device, {
+    const model = new GPUVectorModel(device, {
       ...this.getShaders({modules: [project32, picking], source: GPU_POINT_CLOUD_SHADER}),
       id: `${this.id}-model`,
       topology: 'triangle-list',
       isInstanced: true,
       vertexCount: 6,
-      instanceCount: this.props.rowCount,
+      instanceCount: 0,
       attributes: {
-        positions: getGPUDataBuffer(this.props.positions),
-        normals: this.props.normals ? getGPUDataBuffer(this.props.normals) : defaultNormal,
-        colors: this.props.colors ? getGPUDataBuffer(this.props.colors) : defaultColor
+        positions: getGPUVectorBuffer(this.props.getPosition),
+        normals: this.props.getNormal ? getGPUVectorBuffer(this.props.getNormal) : defaultNormal,
+        colors: colors ? getGPUVectorBuffer(colors) : defaultColor
       },
       bufferLayout: [
-        makeGPUDataBufferLayout(this.props.positions, 'positions'),
-        this.props.normals
-          ? makeGPUDataBufferLayout(this.props.normals, 'normals')
+        makeGPUVectorBufferLayout(this.props.getPosition, 'positions'),
+        this.props.getNormal
+          ? makeGPUVectorBufferLayout(this.props.getNormal, 'normals')
           : makeConstantLayout('normals', 'float32x3'),
-        this.props.colors
-          ? makeGPUDataBufferLayout(this.props.colors, 'colors')
+        colors
+          ? makeGPUVectorBufferLayout(colors, 'colors')
           : makeConstantLayout('colors', 'unorm8x4')
       ],
       bindings: {pointCloudStyle: styleBuffer}
     });
-    model.userData['boundInputs'] = [
-      this.props.positions,
-      this.props.normals,
-      this.props.colors,
-      this.props.rowCount
-    ];
+    model.userData['boundInputs'] = [this.props.getPosition, this.props.getNormal, colors];
     this.setState({model, styleBuffer, defaults: [defaultNormal, defaultColor]});
   }
 
   override getModels(): Model[] {
-    return (this.state as GPUPointCloudBatchState).model
-      ? [(this.state as GPUPointCloudBatchState).model!]
+    return (this.state as GPUPointCloudLayerState).model
+      ? [(this.state as GPUPointCloudLayerState).model!]
       : [];
   }
 
   override updateState({props}: UpdateParameters<this>): void {
-    const boundInputs = ((this.state as GPUPointCloudBatchState).model?.userData['boundInputs'] ??
+    const boundInputs = ((this.state as GPUPointCloudLayerState).model?.userData['boundInputs'] ??
       []) as unknown[];
+    const colors = isGPUVector(props.getColor) ? props.getColor : undefined;
     if (
-      props.positions !== boundInputs[0] ||
-      props.normals !== boundInputs[1] ||
-      props.colors !== boundInputs[2] ||
-      props.rowCount !== boundInputs[3]
+      props.getPosition !== boundInputs[0] ||
+      props.getNormal !== boundInputs[1] ||
+      colors !== boundInputs[2]
     ) {
       this.destroyResources();
       this.initializeState(this.context);
@@ -174,8 +175,9 @@ class GPUPointCloudBatchLayer extends Layer<GPUPointCloudBatchProps> {
   }
 
   override draw({renderPass}: {renderPass: RenderPass}): void {
-    const {model, styleBuffer} = this.state as GPUPointCloudBatchState;
+    const {model, styleBuffer} = this.state as GPUPointCloudLayerState;
     if (!model || !styleBuffer) return;
+    const colors = isGPUVector(this.props.getColor) ? this.props.getColor : undefined;
     const [red, green, blue, alpha = 255] = isColor(this.props.getColor)
       ? this.props.getColor
       : [0, 0, 0, 255];
@@ -183,21 +185,19 @@ class GPUPointCloudBatchLayer extends Layer<GPUPointCloudBatchProps> {
     const floats = new Float32Array(bytes);
     const uints = new Uint32Array(bytes);
     floats.set([red / 255, green / 255, blue / 255, alpha / 255, this.props.pointSize ?? 1]);
-    uints.set(
-      [this.props.colors ? 1 : 0, this.props.normals ? 1 : 0, this.props.rowIndexOffset],
-      5
-    );
-    styleBuffer.write(new Uint8Array(bytes));
-    model.draw(renderPass);
+    uints.set([colors ? 1 : 0, this.props.getNormal ? 1 : 0, 0], 5);
+    model.drawBatches(renderPass, {
+      vectors: {positions: this.props.getPosition, normals: this.props.getNormal, colors},
+      onBatch: batch => {
+        uints[7] = batch.rowIndexOffset;
+        styleBuffer.write(new Uint8Array(bytes));
+      }
+    });
   }
 
   override getPickingInfo({info}: {info: PickingInfo}): PickingInfo {
     const result = info as GPUVectorLayerPickingInfo;
-    result.gpuVector = {
-      rowIndex: result.index,
-      batchIndex: this.props.batchIndex,
-      batchRowIndex: result.index - this.props.rowIndexOffset
-    };
+    result.gpuVector = getGPUVectorPickingProvenance(this.props.getPosition, result.index);
     return result;
   }
 
@@ -207,42 +207,11 @@ class GPUPointCloudBatchLayer extends Layer<GPUPointCloudBatchProps> {
   }
 
   private destroyResources(): void {
-    const state = this.state as GPUPointCloudBatchState;
+    const state = this.state as GPUPointCloudLayerState;
     state.model?.destroy();
     state.styleBuffer?.destroy();
     state.defaults.forEach(buffer => buffer.destroy());
     this.setState({model: null, styleBuffer: null, defaults: []});
-  }
-}
-
-/** Chunk-preserving GPUVector point-cloud composite. */
-export class GPUPointCloudLayer extends CompositeLayer<GPUPointCloudLayerProps> {
-  static override layerName = 'GPUPointCloudLayer';
-
-  override renderLayers(): GPUPointCloudBatchLayer[] {
-    const {getPosition, getNormal, getColor, ...props} = this.props;
-    return getGPUVectorLayerBatches(
-      this.id,
-      {
-        positions: getPosition,
-        normals: getNormal,
-        colors: isGPUVector(getColor) ? getColor : undefined
-      },
-      {positions: ['float32x3'], normals: ['float32x3'], colors: ['unorm8x4']}
-    ).map(
-      batch =>
-        new GPUPointCloudBatchLayer({
-          ...props,
-          id: `${this.props.id}-batch-${batch.batchIndex}`,
-          getColor,
-          positions: batch.data['positions'] as GPUData<'float32x3'>,
-          normals: batch.data['normals'] as GPUData<'float32x3'> | undefined,
-          colors: batch.data['colors'] as GPUData<'unorm8x4'> | undefined,
-          rowCount: batch.rowCount,
-          batchIndex: batch.batchIndex,
-          rowIndexOffset: batch.rowIndexOffset
-        })
-    );
   }
 }
 

--- a/modules/deck-gpu-layers/src/layers/gpu-point-cloud-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-point-cloud-layer.ts
@@ -1,0 +1,264 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  CompositeLayer,
+  Layer,
+  picking,
+  project32,
+  type Color,
+  type LayerContext,
+  type LayerProps,
+  type PickingInfo,
+  type UpdateParameters
+} from '@deck.gl/core';
+import {Buffer, type RenderPass} from '@luma.gl/core';
+import {Model} from '@luma.gl/engine';
+import type {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import {
+  getGPUDataBuffer,
+  getGPUVectorLayerBatches,
+  makeGPUDataBufferLayout,
+  type GPUVectorLayerPickingInfo
+} from './gpu-vector-layer-utils';
+
+/** GPUVector-native point-cloud props. Input vectors are borrowed. */
+export type GPUPointCloudLayerProps = Omit<LayerProps, 'data'> & {
+  getPosition: GPUVector<'float32x3'>;
+  getNormal?: GPUVector<'float32x3'>;
+  getColor?: Color | GPUVector<'unorm8x4'>;
+  pointSize?: number;
+};
+
+type GPUPointCloudBatchProps = Omit<GPUPointCloudLayerProps, 'getPosition' | 'getNormal'> & {
+  positions: GPUData<'float32x3'>;
+  normals?: GPUData<'float32x3'>;
+  colors?: GPUData<'unorm8x4'>;
+  rowCount: number;
+  batchIndex: number;
+  rowIndexOffset: number;
+};
+
+type GPUPointCloudBatchState = {
+  model: Model | null;
+  styleBuffer: Buffer | null;
+  defaults: Buffer[];
+};
+
+const GPU_POINT_CLOUD_SHADER = /* wgsl */ `
+struct PointCloudStyle {
+  color: vec4<f32>,
+  pointSize: f32,
+  useColors: u32,
+  useNormals: u32,
+  rowIndexOffset: u32,
+};
+@group(0) @binding(auto) var<uniform> pointCloudStyle: PointCloudStyle;
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) corner: vec2<f32>,
+  @location(1) color: vec4<f32>,
+  @location(2) lighting: f32,
+  @location(3) @interpolate(flat) pickingColor: vec3<f32>,
+};
+
+fn encodePickingColor(rowIndex: u32) -> vec3<f32> {
+  let value = rowIndex + 1u;
+  return vec3<f32>(f32(value % 256u), f32((value / 256u) % 256u), f32((value / 65536u) % 256u)) / 255.0;
+}
+
+fn getCorner(vertexIndex: u32) -> vec2<f32> {
+  let corners = array<vec2<f32>, 6>(
+    vec2<f32>(-1.0, -1.0), vec2<f32>(1.0, -1.0), vec2<f32>(-1.0, 1.0),
+    vec2<f32>(-1.0, 1.0), vec2<f32>(1.0, -1.0), vec2<f32>(1.0, 1.0)
+  );
+  return corners[vertexIndex];
+}
+
+@vertex fn vertexMain(
+  @location(0) positions: vec3<f32>,
+  @location(1) normals: vec3<f32>,
+  @location(2) colors: vec4<f32>,
+  @builtin(vertex_index) vertexIndex: u32,
+  @builtin(instance_index) instanceIndex: u32
+) -> VertexOutput {
+  let corner = getCorner(vertexIndex);
+  let pickingColor = encodePickingColor(instanceIndex + pointCloudStyle.rowIndexOffset);
+  var clipPosition = project_position_to_clipspace(positions, vec3<f32>(0.0), vec3<f32>(0.0));
+  clipPosition = vec4<f32>(clipPosition.xy + project_pixel_size_to_clipspace(corner * pointCloudStyle.pointSize * 0.5) * clipPosition.w, clipPosition.z, clipPosition.w);
+  geometry.worldPosition = positions;
+  geometry.pickingColor = pickingColor;
+  var output: VertexOutput;
+  output.position = clipPosition;
+  output.corner = corner;
+  output.color = select(pointCloudStyle.color, colors, pointCloudStyle.useColors != 0u);
+  output.lighting = select(1.0, 0.35 + 0.65 * abs(normalize(normals).z), pointCloudStyle.useNormals != 0u);
+  output.pickingColor = pickingColor;
+  return output;
+}
+
+@fragment fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  if (dot(input.corner, input.corner) > 1.0) { discard; }
+  if (picking.isActive > 0.5) { return vec4<f32>(input.pickingColor, 1.0); }
+  return vec4<f32>(input.color.rgb * input.lighting, input.color.a * layer.opacity);
+}`;
+
+class GPUPointCloudBatchLayer extends Layer<GPUPointCloudBatchProps> {
+  static override layerName = 'GPUPointCloudBatchLayer';
+
+  override getAttributeManager() {
+    return null;
+  }
+
+  override initializeState({device}: LayerContext): void {
+    if (device.type !== 'webgpu') throw new Error('GPUPointCloudLayer requires WebGPU');
+    const styleBuffer = device.createBuffer({
+      id: `${this.id}-style`,
+      byteLength: 32,
+      usage: Buffer.UNIFORM | Buffer.COPY_DST
+    });
+    const defaultNormal = device.createBuffer({data: new Float32Array([0, 0, 1])});
+    const defaultColor = device.createBuffer({data: new Uint8Array([0, 0, 0, 255])});
+    const model = new Model(device, {
+      ...this.getShaders({modules: [project32, picking], source: GPU_POINT_CLOUD_SHADER}),
+      id: `${this.id}-model`,
+      topology: 'triangle-list',
+      isInstanced: true,
+      vertexCount: 6,
+      instanceCount: this.props.rowCount,
+      attributes: {
+        positions: getGPUDataBuffer(this.props.positions),
+        normals: this.props.normals ? getGPUDataBuffer(this.props.normals) : defaultNormal,
+        colors: this.props.colors ? getGPUDataBuffer(this.props.colors) : defaultColor
+      },
+      bufferLayout: [
+        makeGPUDataBufferLayout(this.props.positions, 'positions'),
+        this.props.normals
+          ? makeGPUDataBufferLayout(this.props.normals, 'normals')
+          : makeConstantLayout('normals', 'float32x3'),
+        this.props.colors
+          ? makeGPUDataBufferLayout(this.props.colors, 'colors')
+          : makeConstantLayout('colors', 'unorm8x4')
+      ],
+      bindings: {pointCloudStyle: styleBuffer}
+    });
+    model.userData['boundInputs'] = [
+      this.props.positions,
+      this.props.normals,
+      this.props.colors,
+      this.props.rowCount
+    ];
+    this.setState({model, styleBuffer, defaults: [defaultNormal, defaultColor]});
+  }
+
+  override getModels(): Model[] {
+    return (this.state as GPUPointCloudBatchState).model
+      ? [(this.state as GPUPointCloudBatchState).model!]
+      : [];
+  }
+
+  override updateState({props}: UpdateParameters<this>): void {
+    const boundInputs = ((this.state as GPUPointCloudBatchState).model?.userData['boundInputs'] ??
+      []) as unknown[];
+    if (
+      props.positions !== boundInputs[0] ||
+      props.normals !== boundInputs[1] ||
+      props.colors !== boundInputs[2] ||
+      props.rowCount !== boundInputs[3]
+    ) {
+      this.destroyResources();
+      this.initializeState(this.context);
+    }
+  }
+
+  override draw({renderPass}: {renderPass: RenderPass}): void {
+    const {model, styleBuffer} = this.state as GPUPointCloudBatchState;
+    if (!model || !styleBuffer) return;
+    const [red, green, blue, alpha = 255] = isColor(this.props.getColor)
+      ? this.props.getColor
+      : [0, 0, 0, 255];
+    const bytes = new ArrayBuffer(32);
+    const floats = new Float32Array(bytes);
+    const uints = new Uint32Array(bytes);
+    floats.set([red / 255, green / 255, blue / 255, alpha / 255, this.props.pointSize ?? 1]);
+    uints.set(
+      [this.props.colors ? 1 : 0, this.props.normals ? 1 : 0, this.props.rowIndexOffset],
+      5
+    );
+    styleBuffer.write(new Uint8Array(bytes));
+    model.draw(renderPass);
+  }
+
+  override getPickingInfo({info}: {info: PickingInfo}): PickingInfo {
+    const result = info as GPUVectorLayerPickingInfo;
+    result.gpuVector = {
+      rowIndex: result.index,
+      batchIndex: this.props.batchIndex,
+      batchRowIndex: result.index - this.props.rowIndexOffset
+    };
+    return result;
+  }
+
+  override finalizeState(context: LayerContext): void {
+    this.destroyResources();
+    super.finalizeState(context);
+  }
+
+  private destroyResources(): void {
+    const state = this.state as GPUPointCloudBatchState;
+    state.model?.destroy();
+    state.styleBuffer?.destroy();
+    state.defaults.forEach(buffer => buffer.destroy());
+    this.setState({model: null, styleBuffer: null, defaults: []});
+  }
+}
+
+/** Chunk-preserving GPUVector point-cloud composite. */
+export class GPUPointCloudLayer extends CompositeLayer<GPUPointCloudLayerProps> {
+  static override layerName = 'GPUPointCloudLayer';
+
+  override renderLayers(): GPUPointCloudBatchLayer[] {
+    const {getPosition, getNormal, getColor, ...props} = this.props;
+    return getGPUVectorLayerBatches(
+      this.id,
+      {
+        positions: getPosition,
+        normals: getNormal,
+        colors: isGPUVector(getColor) ? getColor : undefined
+      },
+      {positions: ['float32x3'], normals: ['float32x3'], colors: ['unorm8x4']}
+    ).map(
+      batch =>
+        new GPUPointCloudBatchLayer({
+          ...props,
+          id: `${this.props.id}-batch-${batch.batchIndex}`,
+          getColor,
+          positions: batch.data['positions'] as GPUData<'float32x3'>,
+          normals: batch.data['normals'] as GPUData<'float32x3'> | undefined,
+          colors: batch.data['colors'] as GPUData<'unorm8x4'> | undefined,
+          rowCount: batch.rowCount,
+          batchIndex: batch.batchIndex,
+          rowIndexOffset: batch.rowIndexOffset
+        })
+    );
+  }
+}
+
+function makeConstantLayout(name: string, format: 'float32x3' | 'unorm8x4') {
+  return {
+    name,
+    byteStride: 0,
+    stepMode: 'instance' as const,
+    attributes: [{attribute: name, format}]
+  };
+}
+
+function isGPUVector(value: unknown): value is GPUVector {
+  return Boolean(value && typeof value === 'object' && 'data' in value && 'format' in value);
+}
+
+function isColor(value: unknown): value is Color {
+  return Array.isArray(value) || ArrayBuffer.isView(value);
+}

--- a/modules/deck-gpu-layers/src/layers/gpu-polygon-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-polygon-layer.ts
@@ -1,0 +1,66 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {CompositeLayer, type Color, type LayerProps} from '@deck.gl/core';
+import type {GPUVector, VertexList} from '@luma.gl/gpgpu/gpu-data';
+import {GPUPathLayer} from './gpu-path-layer';
+import {GPUSolidPolygonLayer} from './gpu-solid-polygon-layer';
+
+/** GPUVector-native filled-and-stroked polygon props. All input vectors are borrowed. */
+export type GPUPolygonLayerProps = Omit<LayerProps, 'data'> & {
+  positions: GPUVector<VertexList<'float32x4'>>;
+  rowIndices: GPUVector<VertexList<'uint32'>>;
+  indices: GPUVector<VertexList<'uint32'>>;
+  getFillColor?: Color | GPUVector<VertexList<'unorm8x4'>>;
+  getPath?: GPUVector<VertexList<'float32x2' | 'float32x3' | 'float32x4'>>;
+  getLineColor?: Color | GPUVector<'unorm8x4' | VertexList<'unorm8x4'>>;
+  getLineWidth?: number | GPUVector<'float32'>;
+  filled?: boolean;
+  stroked?: boolean;
+};
+
+/** Fill-and-outline composite over the specialized polygon and path GPU cores. */
+export class GPUPolygonLayer extends CompositeLayer<GPUPolygonLayerProps> {
+  static override layerName = 'GPUPolygonLayer';
+
+  override renderLayers(): Array<GPUSolidPolygonLayer | GPUPathLayer> {
+    const {
+      positions,
+      rowIndices,
+      indices,
+      getFillColor,
+      getPath,
+      getLineColor,
+      getLineWidth,
+      filled = true,
+      stroked = Boolean(getPath),
+      ...props
+    } = this.props;
+    const layers: Array<GPUSolidPolygonLayer | GPUPathLayer> = [];
+    if (filled) {
+      layers.push(
+        new GPUSolidPolygonLayer({
+          ...props,
+          id: `${this.props.id}-fill`,
+          positions,
+          rowIndices,
+          indices,
+          getFillColor
+        })
+      );
+    }
+    if (stroked && getPath) {
+      layers.push(
+        new GPUPathLayer({
+          ...props,
+          id: `${this.props.id}-stroke`,
+          getPath,
+          getColor: getLineColor,
+          getWidth: getLineWidth
+        })
+      );
+    }
+    return layers;
+  }
+}

--- a/modules/deck-gpu-layers/src/layers/gpu-scatterplot-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-scatterplot-layer.ts
@@ -1,0 +1,282 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  CompositeLayer,
+  Layer,
+  picking,
+  project32,
+  type Color,
+  type GetPickingInfoParams,
+  type LayerContext,
+  type LayerProps,
+  type PickingInfo,
+  type UpdateParameters
+} from '@deck.gl/core';
+import {Buffer, type RenderPass} from '@luma.gl/core';
+import {Model} from '@luma.gl/engine';
+import type {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import {
+  getGPUDataBuffer,
+  getGPUVectorLayerBatches,
+  makeGPUDataBufferLayout,
+  type GPUVectorLayerPickingInfo
+} from './gpu-vector-layer-utils';
+
+/** GPUVector-native scatterplot props. All input vectors are borrowed. */
+export type GPUScatterplotLayerProps = Omit<LayerProps, 'data'> & {
+  getPosition: GPUVector<'float32x2'>;
+  getRadius?: number | GPUVector<'float32'>;
+  getFillColor?: Color | GPUVector<'unorm8x4'>;
+  radiusScale?: number;
+  radiusMinPixels?: number;
+  radiusMaxPixels?: number;
+};
+
+type GPUScatterplotBatchLayerProps = Omit<GPUScatterplotLayerProps, 'getPosition'> & {
+  positions: GPUData<'float32x2'>;
+  radii?: GPUData<'float32'>;
+  fillColors?: GPUData<'unorm8x4'>;
+  rowCount: number;
+  batchIndex: number;
+  rowIndexOffset: number;
+};
+
+type GPUScatterplotBatchState = {model: Model | null; styleBuffer: Buffer | null};
+
+const GPU_SCATTERPLOT_SHADER = /* wgsl */ `
+struct ScatterStyle {
+  color: vec4<f32>,
+  radius: f32,
+  radiusScale: f32,
+  radiusMinPixels: f32,
+  radiusMaxPixels: f32,
+  useRadii: u32,
+  useColors: u32,
+  rowIndexOffset: u32,
+  _padding: u32,
+};
+@group(0) @binding(auto) var<uniform> scatterStyle: ScatterStyle;
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) corner: vec2<f32>,
+  @location(1) color: vec4<f32>,
+  @location(2) @interpolate(flat) pickingColor: vec3<f32>,
+};
+
+fn encodePickingColor(rowIndex: u32) -> vec3<f32> {
+  let value = rowIndex + 1u;
+  return vec3<f32>(f32(value % 256u), f32((value / 256u) % 256u), f32((value / 65536u) % 256u)) / 255.0;
+}
+
+fn getCorner(vertexIndex: u32) -> vec2<f32> {
+  let corners = array<vec2<f32>, 6>(
+    vec2<f32>(-1.0, -1.0), vec2<f32>(1.0, -1.0), vec2<f32>(-1.0, 1.0),
+    vec2<f32>(-1.0, 1.0), vec2<f32>(1.0, -1.0), vec2<f32>(1.0, 1.0)
+  );
+  return corners[vertexIndex];
+}
+
+@vertex fn vertexMain(
+  @location(0) positions: vec2<f32>,
+  @location(1) radii: f32,
+  @location(2) fillColors: vec4<f32>,
+  @builtin(vertex_index) vertexIndex: u32,
+  @builtin(instance_index) instanceIndex: u32
+) -> VertexOutput {
+  let corner = getCorner(vertexIndex);
+  let radius = clamp(select(scatterStyle.radius, radii, scatterStyle.useRadii != 0u) * scatterStyle.radiusScale, scatterStyle.radiusMinPixels, scatterStyle.radiusMaxPixels);
+  let pickingColor = encodePickingColor(instanceIndex + scatterStyle.rowIndexOffset);
+  geometry.worldPosition = vec3<f32>(positions, 0.0);
+  geometry.pickingColor = pickingColor;
+  var clipPosition = project_position_to_clipspace(vec3<f32>(positions, 0.0), vec3<f32>(0.0), vec3<f32>(0.0));
+  clipPosition = vec4<f32>(clipPosition.xy + project_pixel_size_to_clipspace(corner * radius) * clipPosition.w, clipPosition.z, clipPosition.w);
+  var output: VertexOutput;
+  output.position = clipPosition;
+  output.corner = corner;
+  output.color = select(scatterStyle.color, fillColors, scatterStyle.useColors != 0u);
+  output.pickingColor = pickingColor;
+  return output;
+}
+
+@fragment fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  let radiusSquared = dot(input.corner, input.corner);
+  if (radiusSquared > 1.0) { discard; }
+  if (picking.isActive > 0.5) { return vec4<f32>(input.pickingColor, 1.0); }
+  let coverage = 1.0 - smoothstep(0.81, 1.0, radiusSquared);
+  return vec4<f32>(input.color.rgb, input.color.a * layer.opacity * coverage);
+}`;
+
+class GPUScatterplotBatchLayer extends Layer<GPUScatterplotBatchLayerProps> {
+  static override layerName = 'GPUScatterplotBatchLayer';
+
+  override getAttributeManager() {
+    return null;
+  }
+
+  override initializeState({device}: LayerContext): void {
+    if (device.type !== 'webgpu') throw new Error('GPUScatterplotLayer requires WebGPU');
+    const styleBuffer = device.createBuffer({
+      id: `${this.id}-style`,
+      byteLength: 48,
+      usage: Buffer.UNIFORM | Buffer.COPY_DST
+    });
+    const defaultRadius = device.createBuffer({
+      id: `${this.id}-default-radius`,
+      data: new Float32Array([1])
+    });
+    const defaultColor = device.createBuffer({
+      id: `${this.id}-default-color`,
+      data: new Uint8Array([0, 0, 0, 255])
+    });
+    const model = new Model(device, {
+      ...this.getShaders({modules: [project32, picking], source: GPU_SCATTERPLOT_SHADER}),
+      id: `${this.id}-model`,
+      topology: 'triangle-list',
+      isInstanced: true,
+      vertexCount: 6,
+      instanceCount: this.props.rowCount,
+      attributes: {
+        positions: getGPUDataBuffer(this.props.positions),
+        radii: this.props.radii ? getGPUDataBuffer(this.props.radii) : defaultRadius,
+        fillColors: this.props.fillColors ? getGPUDataBuffer(this.props.fillColors) : defaultColor
+      },
+      bufferLayout: [
+        makeGPUDataBufferLayout(this.props.positions, 'positions'),
+        this.props.radii
+          ? makeGPUDataBufferLayout(this.props.radii, 'radii')
+          : {
+              name: 'radii',
+              byteStride: 0,
+              stepMode: 'instance',
+              attributes: [{attribute: 'radii', format: 'float32'}]
+            },
+        this.props.fillColors
+          ? makeGPUDataBufferLayout(this.props.fillColors, 'fillColors')
+          : {
+              name: 'fillColors',
+              byteStride: 0,
+              stepMode: 'instance',
+              attributes: [{attribute: 'fillColors', format: 'unorm8x4'}]
+            }
+      ],
+      bindings: {scatterStyle: styleBuffer}
+    });
+    model.userData['ownedDefaultBuffers'] = [defaultRadius, defaultColor];
+    model.userData['boundInputs'] = [
+      this.props.positions,
+      this.props.radii,
+      this.props.fillColors,
+      this.props.rowCount
+    ];
+    this.setState({model, styleBuffer} satisfies GPUScatterplotBatchState);
+  }
+
+  override getModels(): Model[] {
+    const model = (this.state as GPUScatterplotBatchState).model;
+    return model ? [model] : [];
+  }
+
+  override updateState({props}: UpdateParameters<this>): void {
+    const boundInputs = ((this.state as GPUScatterplotBatchState).model?.userData['boundInputs'] ??
+      []) as unknown[];
+    if (
+      props.positions !== boundInputs[0] ||
+      props.radii !== boundInputs[1] ||
+      props.fillColors !== boundInputs[2] ||
+      props.rowCount !== boundInputs[3]
+    ) {
+      this.destroyResources();
+      this.initializeState(this.context);
+    }
+  }
+
+  override draw({renderPass}: {renderPass: RenderPass}): void {
+    const {model, styleBuffer} = this.state as GPUScatterplotBatchState;
+    if (!model || !styleBuffer) return;
+    const [red, green, blue, alpha = 255] = isColor(this.props.getFillColor)
+      ? this.props.getFillColor
+      : [0, 0, 0, 255];
+    const bytes = new ArrayBuffer(48);
+    const floats = new Float32Array(bytes);
+    const uints = new Uint32Array(bytes);
+    floats.set([
+      red / 255,
+      green / 255,
+      blue / 255,
+      alpha / 255,
+      typeof this.props.getRadius === 'number' ? this.props.getRadius : 1,
+      this.props.radiusScale ?? 1,
+      this.props.radiusMinPixels ?? 0,
+      this.props.radiusMaxPixels ?? 1e9
+    ]);
+    uints.set(
+      [this.props.radii ? 1 : 0, this.props.fillColors ? 1 : 0, this.props.rowIndexOffset, 0],
+      8
+    );
+    styleBuffer.write(new Uint8Array(bytes));
+    model.draw(renderPass);
+  }
+
+  override getPickingInfo(params: GetPickingInfoParams): PickingInfo {
+    const info = params.info as GPUVectorLayerPickingInfo;
+    const batchRowIndex = info.index - this.props.rowIndexOffset;
+    info.gpuVector = {rowIndex: info.index, batchIndex: this.props.batchIndex, batchRowIndex};
+    return info;
+  }
+
+  override finalizeState(context: LayerContext): void {
+    this.destroyResources();
+    super.finalizeState(context);
+  }
+
+  private destroyResources(): void {
+    const state = this.state as GPUScatterplotBatchState;
+    const owned = state.model?.userData['ownedDefaultBuffers'] as Buffer[] | undefined;
+    state.model?.destroy();
+    owned?.forEach(buffer => buffer.destroy());
+    state.styleBuffer?.destroy();
+    this.setState({model: null, styleBuffer: null});
+  }
+}
+
+/** Chunk-preserving GPUVector scatterplot composite. */
+export class GPUScatterplotLayer extends CompositeLayer<GPUScatterplotLayerProps> {
+  static override layerName = 'GPUScatterplotLayer';
+
+  override renderLayers(): GPUScatterplotBatchLayer[] {
+    const {getPosition, getRadius, getFillColor, ...props} = this.props;
+    return getGPUVectorLayerBatches(
+      this.id,
+      {
+        positions: getPosition,
+        radii: isGPUVector(getRadius) ? getRadius : undefined,
+        fillColors: isGPUVector(getFillColor) ? getFillColor : undefined
+      },
+      {positions: ['float32x2'], radii: ['float32'], fillColors: ['unorm8x4']}
+    ).map(
+      batch =>
+        new GPUScatterplotBatchLayer({
+          ...props,
+          id: `${this.props.id}-batch-${batch.batchIndex}`,
+          getRadius,
+          getFillColor,
+          positions: batch.data['positions'] as GPUData<'float32x2'>,
+          radii: batch.data['radii'] as GPUData<'float32'> | undefined,
+          fillColors: batch.data['fillColors'] as GPUData<'unorm8x4'> | undefined,
+          rowCount: batch.rowCount,
+          batchIndex: batch.batchIndex,
+          rowIndexOffset: batch.rowIndexOffset
+        })
+    );
+  }
+}
+
+function isGPUVector(value: unknown): value is GPUVector {
+  return Boolean(value && typeof value === 'object' && 'data' in value && 'format' in value);
+}
+function isColor(value: unknown): value is Color {
+  return Array.isArray(value) || ArrayBuffer.isView(value);
+}

--- a/modules/deck-gpu-layers/src/layers/gpu-scatterplot-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-scatterplot-layer.ts
@@ -3,7 +3,6 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {
-  CompositeLayer,
   Layer,
   picking,
   project32,
@@ -15,12 +14,13 @@ import {
   type UpdateParameters
 } from '@deck.gl/core';
 import {Buffer, type RenderPass} from '@luma.gl/core';
-import {Model} from '@luma.gl/engine';
-import type {GPUData, GPUVector} from '@luma.gl/gpgpu/gpu-data';
+import type {Model} from '@luma.gl/engine';
+import {GPUVectorModel, type GPUVector} from '@luma.gl/gpgpu/gpu-data';
 import {
-  getGPUDataBuffer,
+  getGPUVectorBuffer,
   getGPUVectorLayerBatches,
-  makeGPUDataBufferLayout,
+  getGPUVectorPickingProvenance,
+  makeGPUVectorBufferLayout,
   type GPUVectorLayerPickingInfo
 } from './gpu-vector-layer-utils';
 
@@ -34,16 +34,7 @@ export type GPUScatterplotLayerProps = Omit<LayerProps, 'data'> & {
   radiusMaxPixels?: number;
 };
 
-type GPUScatterplotBatchLayerProps = Omit<GPUScatterplotLayerProps, 'getPosition'> & {
-  positions: GPUData<'float32x2'>;
-  radii?: GPUData<'float32'>;
-  fillColors?: GPUData<'unorm8x4'>;
-  rowCount: number;
-  batchIndex: number;
-  rowIndexOffset: number;
-};
-
-type GPUScatterplotBatchState = {model: Model | null; styleBuffer: Buffer | null};
+type GPUScatterplotLayerState = {model: GPUVectorModel | null; styleBuffer: Buffer | null};
 
 const GPU_SCATTERPLOT_SHADER = /* wgsl */ `
 struct ScatterStyle {
@@ -109,8 +100,9 @@ fn getCorner(vertexIndex: u32) -> vec2<f32> {
   return vec4<f32>(input.color.rgb, input.color.a * layer.opacity * coverage);
 }`;
 
-class GPUScatterplotBatchLayer extends Layer<GPUScatterplotBatchLayerProps> {
-  static override layerName = 'GPUScatterplotBatchLayer';
+/** Chunk-preserving GPUVector scatterplot layer. */
+export class GPUScatterplotLayer extends Layer<GPUScatterplotLayerProps> {
+  static override layerName = 'GPUScatterplotLayer';
 
   override getAttributeManager() {
     return null;
@@ -118,6 +110,17 @@ class GPUScatterplotBatchLayer extends Layer<GPUScatterplotBatchLayerProps> {
 
   override initializeState({device}: LayerContext): void {
     if (device.type !== 'webgpu') throw new Error('GPUScatterplotLayer requires WebGPU');
+    const radii = isGPUVector(this.props.getRadius) ? this.props.getRadius : undefined;
+    const fillColors = isGPUVector(this.props.getFillColor) ? this.props.getFillColor : undefined;
+    getGPUVectorLayerBatches(
+      this.id,
+      {positions: this.props.getPosition, radii, fillColors},
+      {positions: ['float32x2'], radii: ['float32'], fillColors: ['unorm8x4']}
+    );
+    if (this.props.getPosition.data.length === 0) {
+      this.setState({model: null, styleBuffer: null} satisfies GPUScatterplotLayerState);
+      return;
+    }
     const styleBuffer = device.createBuffer({
       id: `${this.id}-style`,
       byteLength: 48,
@@ -131,30 +134,30 @@ class GPUScatterplotBatchLayer extends Layer<GPUScatterplotBatchLayerProps> {
       id: `${this.id}-default-color`,
       data: new Uint8Array([0, 0, 0, 255])
     });
-    const model = new Model(device, {
+    const model = new GPUVectorModel(device, {
       ...this.getShaders({modules: [project32, picking], source: GPU_SCATTERPLOT_SHADER}),
       id: `${this.id}-model`,
       topology: 'triangle-list',
       isInstanced: true,
       vertexCount: 6,
-      instanceCount: this.props.rowCount,
+      instanceCount: 0,
       attributes: {
-        positions: getGPUDataBuffer(this.props.positions),
-        radii: this.props.radii ? getGPUDataBuffer(this.props.radii) : defaultRadius,
-        fillColors: this.props.fillColors ? getGPUDataBuffer(this.props.fillColors) : defaultColor
+        positions: getGPUVectorBuffer(this.props.getPosition),
+        radii: radii ? getGPUVectorBuffer(radii) : defaultRadius,
+        fillColors: fillColors ? getGPUVectorBuffer(fillColors) : defaultColor
       },
       bufferLayout: [
-        makeGPUDataBufferLayout(this.props.positions, 'positions'),
-        this.props.radii
-          ? makeGPUDataBufferLayout(this.props.radii, 'radii')
+        makeGPUVectorBufferLayout(this.props.getPosition, 'positions'),
+        radii
+          ? makeGPUVectorBufferLayout(radii, 'radii')
           : {
               name: 'radii',
               byteStride: 0,
               stepMode: 'instance',
               attributes: [{attribute: 'radii', format: 'float32'}]
             },
-        this.props.fillColors
-          ? makeGPUDataBufferLayout(this.props.fillColors, 'fillColors')
+        fillColors
+          ? makeGPUVectorBufferLayout(fillColors, 'fillColors')
           : {
               name: 'fillColors',
               byteStride: 0,
@@ -165,28 +168,24 @@ class GPUScatterplotBatchLayer extends Layer<GPUScatterplotBatchLayerProps> {
       bindings: {scatterStyle: styleBuffer}
     });
     model.userData['ownedDefaultBuffers'] = [defaultRadius, defaultColor];
-    model.userData['boundInputs'] = [
-      this.props.positions,
-      this.props.radii,
-      this.props.fillColors,
-      this.props.rowCount
-    ];
-    this.setState({model, styleBuffer} satisfies GPUScatterplotBatchState);
+    model.userData['boundInputs'] = [this.props.getPosition, radii, fillColors];
+    this.setState({model, styleBuffer} satisfies GPUScatterplotLayerState);
   }
 
   override getModels(): Model[] {
-    const model = (this.state as GPUScatterplotBatchState).model;
+    const model = (this.state as GPUScatterplotLayerState).model;
     return model ? [model] : [];
   }
 
   override updateState({props}: UpdateParameters<this>): void {
-    const boundInputs = ((this.state as GPUScatterplotBatchState).model?.userData['boundInputs'] ??
+    const boundInputs = ((this.state as GPUScatterplotLayerState).model?.userData['boundInputs'] ??
       []) as unknown[];
+    const radii = isGPUVector(props.getRadius) ? props.getRadius : undefined;
+    const fillColors = isGPUVector(props.getFillColor) ? props.getFillColor : undefined;
     if (
-      props.positions !== boundInputs[0] ||
-      props.radii !== boundInputs[1] ||
-      props.fillColors !== boundInputs[2] ||
-      props.rowCount !== boundInputs[3]
+      props.getPosition !== boundInputs[0] ||
+      radii !== boundInputs[1] ||
+      fillColors !== boundInputs[2]
     ) {
       this.destroyResources();
       this.initializeState(this.context);
@@ -194,8 +193,10 @@ class GPUScatterplotBatchLayer extends Layer<GPUScatterplotBatchLayerProps> {
   }
 
   override draw({renderPass}: {renderPass: RenderPass}): void {
-    const {model, styleBuffer} = this.state as GPUScatterplotBatchState;
+    const {model, styleBuffer} = this.state as GPUScatterplotLayerState;
     if (!model || !styleBuffer) return;
+    const radii = isGPUVector(this.props.getRadius) ? this.props.getRadius : undefined;
+    const fillColors = isGPUVector(this.props.getFillColor) ? this.props.getFillColor : undefined;
     const [red, green, blue, alpha = 255] = isColor(this.props.getFillColor)
       ? this.props.getFillColor
       : [0, 0, 0, 255];
@@ -212,18 +213,19 @@ class GPUScatterplotBatchLayer extends Layer<GPUScatterplotBatchLayerProps> {
       this.props.radiusMinPixels ?? 0,
       this.props.radiusMaxPixels ?? 1e9
     ]);
-    uints.set(
-      [this.props.radii ? 1 : 0, this.props.fillColors ? 1 : 0, this.props.rowIndexOffset, 0],
-      8
-    );
-    styleBuffer.write(new Uint8Array(bytes));
-    model.draw(renderPass);
+    uints.set([radii ? 1 : 0, fillColors ? 1 : 0, 0, 0], 8);
+    model.drawBatches(renderPass, {
+      vectors: {positions: this.props.getPosition, radii, fillColors},
+      onBatch: batch => {
+        uints[10] = batch.rowIndexOffset;
+        styleBuffer.write(new Uint8Array(bytes));
+      }
+    });
   }
 
   override getPickingInfo(params: GetPickingInfoParams): PickingInfo {
     const info = params.info as GPUVectorLayerPickingInfo;
-    const batchRowIndex = info.index - this.props.rowIndexOffset;
-    info.gpuVector = {rowIndex: info.index, batchIndex: this.props.batchIndex, batchRowIndex};
+    info.gpuVector = getGPUVectorPickingProvenance(this.props.getPosition, info.index);
     return info;
   }
 
@@ -233,44 +235,12 @@ class GPUScatterplotBatchLayer extends Layer<GPUScatterplotBatchLayerProps> {
   }
 
   private destroyResources(): void {
-    const state = this.state as GPUScatterplotBatchState;
+    const state = this.state as GPUScatterplotLayerState;
     const owned = state.model?.userData['ownedDefaultBuffers'] as Buffer[] | undefined;
     state.model?.destroy();
     owned?.forEach(buffer => buffer.destroy());
     state.styleBuffer?.destroy();
     this.setState({model: null, styleBuffer: null});
-  }
-}
-
-/** Chunk-preserving GPUVector scatterplot composite. */
-export class GPUScatterplotLayer extends CompositeLayer<GPUScatterplotLayerProps> {
-  static override layerName = 'GPUScatterplotLayer';
-
-  override renderLayers(): GPUScatterplotBatchLayer[] {
-    const {getPosition, getRadius, getFillColor, ...props} = this.props;
-    return getGPUVectorLayerBatches(
-      this.id,
-      {
-        positions: getPosition,
-        radii: isGPUVector(getRadius) ? getRadius : undefined,
-        fillColors: isGPUVector(getFillColor) ? getFillColor : undefined
-      },
-      {positions: ['float32x2'], radii: ['float32'], fillColors: ['unorm8x4']}
-    ).map(
-      batch =>
-        new GPUScatterplotBatchLayer({
-          ...props,
-          id: `${this.props.id}-batch-${batch.batchIndex}`,
-          getRadius,
-          getFillColor,
-          positions: batch.data['positions'] as GPUData<'float32x2'>,
-          radii: batch.data['radii'] as GPUData<'float32'> | undefined,
-          fillColors: batch.data['fillColors'] as GPUData<'unorm8x4'> | undefined,
-          rowCount: batch.rowCount,
-          batchIndex: batch.batchIndex,
-          rowIndexOffset: batch.rowIndexOffset
-        })
-    );
   }
 }
 

--- a/modules/deck-gpu-layers/src/layers/gpu-solid-polygon-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-solid-polygon-layer.ts
@@ -1,0 +1,152 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  Layer,
+  picking,
+  project32,
+  type Color,
+  type LayerContext,
+  type LayerProps,
+  type PickingInfo,
+  type UpdateParameters
+} from '@deck.gl/core';
+import type {RenderPass} from '@luma.gl/core';
+import type {Model} from '@luma.gl/engine';
+import {GPUConstant, type GPUVector, type VertexList} from '@luma.gl/gpgpu/gpu-data';
+import {PolygonAttributeModel} from '@luma.gl/experimental/models';
+import {
+  getGPUVectorPickingProvenance,
+  type GPUVectorLayerPickingInfo
+} from './gpu-vector-layer-utils';
+
+/** GPUVector-native tessellated filled-polygon props. Input vectors are borrowed. */
+export type GPUSolidPolygonLayerProps = Omit<LayerProps, 'data'> & {
+  positions: GPUVector<VertexList<'float32x4'>>;
+  rowIndices: GPUVector<VertexList<'uint32'>>;
+  indices: GPUVector<VertexList<'uint32'>>;
+  getFillColor?: Color | GPUVector<VertexList<'unorm8x4'>>;
+};
+
+type GPUSolidPolygonLayerState = {model: PolygonAttributeModel | null};
+
+const GPU_SOLID_POLYGON_SHADER = /* wgsl */ `
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec4<f32>,
+  @location(1) @interpolate(flat) pickingColor: vec3<f32>,
+};
+
+fn encodePickingColor(rowIndex: u32) -> vec3<f32> {
+  let value = rowIndex + 1u;
+  return vec3<f32>(f32(value % 256u), f32((value / 256u) % 256u), f32((value / 65536u) % 256u)) / 255.0;
+}
+
+@vertex fn vertexMain(
+  @location(0) positions: vec4<f32>,
+  @location(1) colors: vec4<f32>,
+  @location(2) rowIndices: u32
+) -> VertexOutput {
+  let pickingColor = encodePickingColor(rowIndices);
+  geometry.worldPosition = positions.xyz;
+  geometry.pickingColor = pickingColor;
+  var output: VertexOutput;
+  output.position = project_position_to_clipspace(positions.xyz, vec3<f32>(0.0), vec3<f32>(0.0));
+  output.color = colors;
+  output.pickingColor = pickingColor;
+  return output;
+}
+
+@fragment fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  if (picking.isActive > 0.5) { return vec4<f32>(input.pickingColor, 1.0); }
+  return vec4<f32>(input.color.rgb, input.color.a * layer.opacity);
+}`;
+
+/** Deck host for already tessellated polygon GPUVectors. Tessellation belongs in adapters. */
+export class GPUSolidPolygonLayer extends Layer<GPUSolidPolygonLayerProps> {
+  static override layerName = 'GPUSolidPolygonLayer';
+
+  override getAttributeManager() {
+    return null;
+  }
+
+  override initializeState({device}: LayerContext): void {
+    if (device.type !== 'webgpu') throw new Error('GPUSolidPolygonLayer requires WebGPU');
+    this.setState({model: null});
+    this.createModel();
+  }
+
+  override updateState({props}: UpdateParameters<this>): void {
+    const boundInputs = ((this.state as GPUSolidPolygonLayerState).model?.userData['boundInputs'] ??
+      []) as unknown[];
+    if (
+      props.positions !== boundInputs[0] ||
+      props.rowIndices !== boundInputs[1] ||
+      props.indices !== boundInputs[2] ||
+      props.getFillColor !== boundInputs[3]
+    ) {
+      this.destroyModel();
+      this.createModel();
+    }
+  }
+
+  override getModels(): Model[] {
+    const model = (this.state as GPUSolidPolygonLayerState | undefined)?.model;
+    return model ? [model] : [];
+  }
+
+  override draw({renderPass}: {renderPass: RenderPass}): void {
+    (this.state as GPUSolidPolygonLayerState).model?.draw(renderPass);
+  }
+
+  override getPickingInfo({info}: {info: PickingInfo}): PickingInfo {
+    const result = info as GPUVectorLayerPickingInfo;
+    result.gpuVector = getGPUVectorPickingProvenance(this.props.positions, result.index);
+    return result;
+  }
+
+  override finalizeState(context: LayerContext): void {
+    this.destroyModel();
+    super.finalizeState(context);
+  }
+
+  private createModel(): void {
+    const shaderProps = this.getShaders({
+      modules: [project32, picking],
+      source: GPU_SOLID_POLYGON_SHADER
+    });
+    const color = isGPUVector(this.props.getFillColor)
+      ? this.props.getFillColor
+      : new GPUConstant({
+          format: 'unorm8x4',
+          value: new Uint8Array(this.props.getFillColor ?? [0, 0, 0, 255])
+        });
+    const model = new PolygonAttributeModel(this.context.device, {
+      ...shaderProps,
+      id: `${this.id}-model`,
+      positions: this.props.positions,
+      colors: color,
+      rowIndices: this.props.rowIndices,
+      indices: this.props.indices,
+      shaderInputs: shaderProps.shaderInputs as never
+    });
+    model.userData['boundInputs'] = [
+      this.props.positions,
+      this.props.rowIndices,
+      this.props.indices,
+      this.props.getFillColor
+    ];
+    this.setState({model} satisfies GPUSolidPolygonLayerState);
+  }
+
+  private destroyModel(): void {
+    const state = this.state as GPUSolidPolygonLayerState | undefined;
+    state?.model?.destroy();
+    if (state) this.setState({model: null});
+  }
+}
+
+function isGPUVector(value: unknown): value is GPUVector {
+  return Boolean(value && typeof value === 'object' && 'data' in value && 'format' in value);
+}

--- a/modules/deck-gpu-layers/src/layers/gpu-text-layer.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-text-layer.ts
@@ -1,0 +1,94 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  Layer,
+  type LayerContext,
+  type LayerProps,
+  type PickingInfo,
+  type UpdateParameters
+} from '@deck.gl/core';
+import type {RenderPass} from '@luma.gl/core';
+import type {Model, ModelProps} from '@luma.gl/engine';
+import {TextRenderer, type GPUTextData} from '@luma.gl/text';
+import {getTextRendererModel} from '@luma.gl/text/experimental';
+import type {GPUVectorLayerPickingInfo} from './gpu-vector-layer-utils';
+
+/** GPU-native prepared text props. Input text batches and atlas resources are borrowed. */
+export type GPUTextLayerProps = Omit<LayerProps, 'data'> & {
+  textData: GPUTextData | readonly GPUTextData[];
+  /** Optional Deck-specific shader overrides applied to the prepared text strategy. */
+  modelProps?: ModelProps;
+};
+
+type GPUTextLayerState = {
+  renderer: TextRenderer | null;
+  boundTextData: GPUTextLayerProps['textData'] | null;
+  boundModelProps: ModelProps | undefined;
+};
+
+/** Deck host for caller-owned GPUTextData produced by any text adapter. */
+export class GPUTextLayer extends Layer<GPUTextLayerProps> {
+  static override layerName = 'GPUTextLayer';
+
+  override getAttributeManager() {
+    return null;
+  }
+
+  override initializeState({device}: LayerContext): void {
+    this.setState({
+      renderer: new TextRenderer(device, {
+        data: this.props.textData,
+        modelProps: this.props.modelProps
+      }),
+      boundTextData: this.props.textData,
+      boundModelProps: this.props.modelProps
+    } satisfies GPUTextLayerState);
+  }
+
+  override updateState({props}: UpdateParameters<this>): void {
+    const state = this.state as GPUTextLayerState;
+    if (props.textData !== state.boundTextData || props.modelProps !== state.boundModelProps) {
+      state.renderer?.setProps({data: props.textData, modelProps: props.modelProps});
+      this.setState({boundTextData: props.textData, boundModelProps: props.modelProps});
+    }
+  }
+
+  override getModels(): Model[] {
+    const renderer = (this.state as GPUTextLayerState | undefined)?.renderer;
+    return renderer ? [getTextRendererModel(renderer)] : [];
+  }
+
+  override draw({renderPass}: {renderPass: RenderPass}): void {
+    (this.state as GPUTextLayerState).renderer?.draw(renderPass);
+  }
+
+  override getPickingInfo({info}: {info: PickingInfo}): PickingInfo {
+    const result = info as GPUVectorLayerPickingInfo;
+    const batches = normalizeTextData(this.props.textData);
+    const batchIndex = batches.findIndex(
+      batch =>
+        result.index >= batch.rowIndexBase && result.index < batch.rowIndexBase + batch.rowCount
+    );
+    const batch = batches[batchIndex];
+    result.gpuVector = batch
+      ? {
+          rowIndex: result.index,
+          batchIndex,
+          batchRowIndex: result.index - batch.rowIndexBase
+        }
+      : {rowIndex: result.index, batchIndex: -1, batchRowIndex: -1};
+    return result;
+  }
+
+  override finalizeState(context: LayerContext): void {
+    (this.state as GPUTextLayerState | undefined)?.renderer?.destroy();
+    this.setState({renderer: null, boundTextData: null, boundModelProps: undefined});
+    super.finalizeState(context);
+  }
+}
+
+function normalizeTextData(data: GPUTextData | readonly GPUTextData[]): readonly GPUTextData[] {
+  return 'strategy' in data ? [data] : data;
+}

--- a/modules/deck-gpu-layers/src/layers/gpu-vector-layer-utils.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-vector-layer-utils.ts
@@ -1,0 +1,114 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {PickingInfo} from '@deck.gl/core';
+import type {Buffer, BufferLayout, VertexFormat} from '@luma.gl/core';
+import type {GPUData, GPUVector, GPUVectorFormat} from '@luma.gl/gpgpu/gpu-data';
+import {getGPUVectorFormatInfo} from '@luma.gl/gpgpu/gpu-data';
+import {DynamicBuffer} from '@luma.gl/engine';
+
+/** One physical, row-aligned set of GPUVector chunks rendered as a deck child layer. */
+export type GPUVectorLayerBatch = {
+  batchIndex: number;
+  rowIndexOffset: number;
+  rowCount: number;
+  data: Record<string, GPUData>;
+};
+
+/** Global row and physical chunk provenance attached to GPUVector layer picking results. */
+export type GPUVectorLayerPickingInfo = PickingInfo & {
+  gpuVector?: {rowIndex: number; batchIndex: number; batchRowIndex: number};
+};
+
+/** Resolves global picking identity back to a physical GPUVector chunk. */
+export function getGPUVectorPickingProvenance(
+  vector: GPUVector,
+  rowIndex: number
+): {rowIndex: number; batchIndex: number; batchRowIndex: number} {
+  let rowIndexOffset = 0;
+  for (const [batchIndex, data] of vector.data.entries()) {
+    if (rowIndex < rowIndexOffset + data.length) {
+      return {rowIndex, batchIndex, batchRowIndex: rowIndex - rowIndexOffset};
+    }
+    rowIndexOffset += data.length;
+  }
+  return {rowIndex, batchIndex: -1, batchRowIndex: -1};
+}
+
+/** Validates vector formats and returns aligned physical batches without packing or copying. */
+export function getGPUVectorLayerBatches(
+  ownerName: string,
+  vectors: Record<string, GPUVector | undefined>,
+  formats: Record<string, readonly GPUVectorFormat[]>
+): GPUVectorLayerBatch[] {
+  const entries = Object.entries(vectors).filter((entry): entry is [string, GPUVector] =>
+    Boolean(entry[1])
+  );
+  if (entries.length === 0) return [];
+  const [primaryName, primaryVector] = entries[0];
+  for (const [name, vector] of entries) {
+    const acceptedFormats = formats[name];
+    if (!vector.format || !acceptedFormats?.includes(vector.format)) {
+      throw new Error(
+        `${ownerName} ${name} GPUVector.format "${vector.format ?? 'undefined'}" must be one of ${acceptedFormats?.join(', ') ?? 'the declared formats'}`
+      );
+    }
+    if (vector.length !== primaryVector.length) {
+      throw new Error(
+        `${ownerName} ${name} rows must match ${primaryName} rows (${vector.length} !== ${primaryVector.length})`
+      );
+    }
+    if (vector.data.length !== primaryVector.data.length) {
+      throw new Error(`${ownerName} GPUVector chunk counts must align`);
+    }
+  }
+
+  let rowIndexOffset = 0;
+  return primaryVector.data.map((primaryData, batchIndex) => {
+    const data: Record<string, GPUData> = {};
+    for (const [name, vector] of entries) {
+      const chunk = vector.data[batchIndex];
+      if (!chunk || chunk.length !== primaryData.length) {
+        throw new Error(`${ownerName} GPUVector chunk ${batchIndex} row counts must align`);
+      }
+      data[name] = chunk;
+    }
+    const batch = {
+      batchIndex,
+      rowIndexOffset,
+      rowCount: primaryData.length,
+      data
+    };
+    rowIndexOffset += primaryData.length;
+    return batch;
+  });
+}
+
+/** Returns the luma buffer behind a fixed-width GPUData chunk. */
+export function getGPUDataBuffer(data: GPUData): Buffer {
+  return data.buffer instanceof DynamicBuffer ? data.buffer.buffer : data.buffer;
+}
+
+/** Describes one borrowed GPUData chunk as a model vertex buffer. */
+export function makeGPUDataBufferLayout(data: GPUData, name: string): BufferLayout {
+  if (!data.format || typeof data.format !== 'string') {
+    throw new Error('GPU deck layers require a scalar GPUVectorFormat');
+  }
+  const formatInfo = getGPUVectorFormatInfo(data.format);
+  if (formatInfo.vertexList || formatInfo.valueList || formatInfo.fixedSizeList) {
+    throw new Error(`GPU deck binary attributes do not accept ${data.format}`);
+  }
+  return {
+    name,
+    stepMode: 'instance',
+    byteStride: data.byteStride,
+    attributes: [
+      {
+        attribute: name,
+        format: data.format as VertexFormat,
+        byteOffset: data.byteOffset
+      }
+    ]
+  };
+}

--- a/modules/deck-gpu-layers/src/layers/gpu-vector-layer-utils.ts
+++ b/modules/deck-gpu-layers/src/layers/gpu-vector-layer-utils.ts
@@ -5,10 +5,10 @@
 import type {PickingInfo} from '@deck.gl/core';
 import type {Buffer, BufferLayout, VertexFormat} from '@luma.gl/core';
 import type {GPUData, GPUVector, GPUVectorFormat} from '@luma.gl/gpgpu/gpu-data';
-import {getGPUVectorFormatInfo} from '@luma.gl/gpgpu/gpu-data';
+import {getGPUVectorFormatInfo, getGPUVectorModelBatches} from '@luma.gl/gpgpu/gpu-data';
 import {DynamicBuffer} from '@luma.gl/engine';
 
-/** One physical, row-aligned set of GPUVector chunks rendered as a deck child layer. */
+/** One physical, row-aligned set of GPUVector chunks rendered as a model draw batch. */
 export type GPUVectorLayerBatch = {
   batchIndex: number;
   rowIndexOffset: number;
@@ -46,7 +46,6 @@ export function getGPUVectorLayerBatches(
     Boolean(entry[1])
   );
   if (entries.length === 0) return [];
-  const [primaryName, primaryVector] = entries[0];
   for (const [name, vector] of entries) {
     const acceptedFormats = formats[name];
     if (!vector.format || !acceptedFormats?.includes(vector.format)) {
@@ -54,40 +53,20 @@ export function getGPUVectorLayerBatches(
         `${ownerName} ${name} GPUVector.format "${vector.format ?? 'undefined'}" must be one of ${acceptedFormats?.join(', ') ?? 'the declared formats'}`
       );
     }
-    if (vector.length !== primaryVector.length) {
-      throw new Error(
-        `${ownerName} ${name} rows must match ${primaryName} rows (${vector.length} !== ${primaryVector.length})`
-      );
-    }
-    if (vector.data.length !== primaryVector.data.length) {
-      throw new Error(`${ownerName} GPUVector chunk counts must align`);
-    }
   }
-
-  let rowIndexOffset = 0;
-  return primaryVector.data.map((primaryData, batchIndex) => {
-    const data: Record<string, GPUData> = {};
-    for (const [name, vector] of entries) {
-      const chunk = vector.data[batchIndex];
-      if (!chunk || chunk.length !== primaryData.length) {
-        throw new Error(`${ownerName} GPUVector chunk ${batchIndex} row counts must align`);
-      }
-      data[name] = chunk;
-    }
-    const batch = {
-      batchIndex,
-      rowIndexOffset,
-      rowCount: primaryData.length,
-      data
-    };
-    rowIndexOffset += primaryData.length;
-    return batch;
-  });
+  return getGPUVectorModelBatches(ownerName, Object.fromEntries(entries));
 }
 
 /** Returns the luma buffer behind a fixed-width GPUData chunk. */
 export function getGPUDataBuffer(data: GPUData): Buffer {
   return data.buffer instanceof DynamicBuffer ? data.buffer.buffer : data.buffer;
+}
+
+/** Returns the first physical buffer used to initialize a GPUVectorModel attribute. */
+export function getGPUVectorBuffer(vector: GPUVector): Buffer {
+  const data = vector.data[0];
+  if (!data) throw new Error('GPU deck layers require a non-empty GPUVector');
+  return getGPUDataBuffer(data);
 }
 
 /** Describes one borrowed GPUData chunk as a model vertex buffer. */
@@ -111,4 +90,11 @@ export function makeGPUDataBufferLayout(data: GPUData, name: string): BufferLayo
       }
     ]
   };
+}
+
+/** Describes a fixed-width GPUVector as a GPUVectorModel vertex buffer. */
+export function makeGPUVectorBufferLayout(vector: GPUVector, name: string): BufferLayout {
+  const data = vector.data[0];
+  if (!data) throw new Error('GPU deck layers require a non-empty GPUVector');
+  return makeGPUDataBufferLayout(data, name);
 }

--- a/modules/deck-gpu-layers/test/gpu-vector-layers.node.spec.ts
+++ b/modules/deck-gpu-layers/test/gpu-vector-layers.node.spec.ts
@@ -1,0 +1,103 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {PickingInfo} from '@deck.gl/core';
+import {
+  GPUArcLayer,
+  GPUColumnLayer,
+  GPUGridCellLayer,
+  GPULineLayer,
+  GPUPointCloudLayer,
+  GPUScatterplotLayer,
+  type GPUVectorLayerPickingInfo
+} from '@deck.gl-community/gpu-layers';
+import type {Buffer} from '@luma.gl/core';
+import {GPUData, GPUVector, type GPUVectorFormat} from '@luma.gl/gpgpu/gpu-data';
+import {describe, expect, test, vi} from 'vitest';
+
+describe('GPUVector deck layers', () => {
+  test('preserve physical chunks and global picking provenance', () => {
+    const positions = makeChunkedVector('positions', 'float32x2', [2, 3]);
+    const radii = makeChunkedVector('radii', 'float32', [2, 3]);
+    const layer = new GPUScatterplotLayer({
+      id: 'gpu-scatterplot',
+      getPosition: positions,
+      getRadius: radii
+    });
+
+    const children = layer.renderLayers();
+    expect(children.map(child => child.props['rowCount'])).toEqual([2, 3]);
+    const secondInfo = children[1]!.getPickingInfo({
+      info: {index: 3} as PickingInfo
+    } as never) as GPUVectorLayerPickingInfo;
+    expect(secondInfo.index).toBe(3);
+    expect(secondInfo.gpuVector).toEqual({rowIndex: 3, batchIndex: 1, batchRowIndex: 1});
+  });
+
+  test('rejects misaligned semantic vector chunks', () => {
+    const sourcePositions = makeChunkedVector('source', 'float32x2', [2, 3]);
+    const targetPositions = makeChunkedVector('target', 'float32x2', [1, 4]);
+    const layer = new GPULineLayer({
+      id: 'gpu-lines',
+      getSourcePosition: sourcePositions,
+      getTargetPosition: targetPositions
+    });
+
+    expect(() => layer.renderLayers()).toThrow('chunk 0 row counts must align');
+  });
+
+  test('borrows GPUVector buffers without taking ownership', () => {
+    const destroy = vi.fn();
+    const positions = makeChunkedVector('positions', 'float32x2', [2], destroy);
+    const layer = new GPUScatterplotLayer({id: 'borrowed', getPosition: positions});
+
+    layer.renderLayers();
+    layer.finalizeState({} as never);
+
+    expect(destroy).not.toHaveBeenCalled();
+  });
+
+  test('preserves batches across the complete fixed-width primitive family', () => {
+    const positions2 = makeChunkedVector('positions2', 'float32x2', [2, 3]);
+    const positions3 = makeChunkedVector('positions3', 'float32x3', [2, 3]);
+    const targets = makeChunkedVector('targets', 'float32x2', [2, 3]);
+    const layers = [
+      new GPUArcLayer({
+        id: 'arcs',
+        getSourcePosition: positions2,
+        getTargetPosition: targets
+      }),
+      new GPUColumnLayer({id: 'columns', getPosition: positions2}),
+      new GPUGridCellLayer({id: 'cells', getPosition: positions2}),
+      new GPUPointCloudLayer({id: 'point-cloud', getPosition: positions3})
+    ];
+
+    expect(layers[0]!.renderLayers()).toHaveLength(2);
+    expect(layers[1]!.renderLayers()).toHaveLength(2);
+    expect(layers[2]!.renderLayers()).toBeInstanceOf(GPUColumnLayer);
+    expect(layers[3]!.renderLayers()).toHaveLength(2);
+  });
+});
+
+function makeChunkedVector<FormatT extends GPUVectorFormat>(
+  name: string,
+  format: FormatT,
+  chunkLengths: number[],
+  destroy = vi.fn()
+): GPUVector<FormatT> {
+  const components = format.endsWith('x2') ? 2 : format.endsWith('x3') ? 3 : 1;
+  const bytesPerRow = components * Float32Array.BYTES_PER_ELEMENT;
+  const data = chunkLengths.map(
+    length =>
+      new GPUData<FormatT>({
+        buffer: {byteLength: length * bytesPerRow, destroy} as unknown as Buffer,
+        format,
+        length,
+        byteStride: bytesPerRow,
+        rowByteLength: bytesPerRow,
+        ownsBuffer: false
+      })
+  );
+  return new GPUVector({type: 'data', name, format, data, ownsData: false});
+}

--- a/modules/deck-gpu-layers/test/gpu-vector-layers.node.spec.ts
+++ b/modules/deck-gpu-layers/test/gpu-vector-layers.node.spec.ts
@@ -7,14 +7,16 @@ import {
   GPUArcLayer,
   GPUColumnLayer,
   GPUGridCellLayer,
+  GPUIconLayer,
   GPULineLayer,
   GPUPointCloudLayer,
   GPUScatterplotLayer,
   type GPUVectorLayerPickingInfo
 } from '@deck.gl-community/gpu-layers';
-import type {Buffer} from '@luma.gl/core';
+import type {Buffer, RenderPass, Texture} from '@luma.gl/core';
 import {GPUData, GPUVector, type GPUVectorFormat} from '@luma.gl/gpgpu/gpu-data';
 import {describe, expect, test, vi} from 'vitest';
+import {getGPUVectorLayerBatches} from '../src/layers/gpu-vector-layer-utils';
 
 describe('GPUVector deck layers', () => {
   test('preserve physical chunks and global picking provenance', () => {
@@ -26,9 +28,13 @@ describe('GPUVector deck layers', () => {
       getRadius: radii
     });
 
-    const children = layer.renderLayers();
-    expect(children.map(child => child.props['rowCount'])).toEqual([2, 3]);
-    const secondInfo = children[1]!.getPickingInfo({
+    const batches = getGPUVectorLayerBatches(
+      layer.id,
+      {positions, radii},
+      {positions: ['float32x2'], radii: ['float32']}
+    );
+    expect(batches.map(batch => batch.rowCount)).toEqual([2, 3]);
+    const secondInfo = layer.getPickingInfo({
       info: {index: 3} as PickingInfo
     } as never) as GPUVectorLayerPickingInfo;
     expect(secondInfo.index).toBe(3);
@@ -38,30 +44,30 @@ describe('GPUVector deck layers', () => {
   test('rejects misaligned semantic vector chunks', () => {
     const sourcePositions = makeChunkedVector('source', 'float32x2', [2, 3]);
     const targetPositions = makeChunkedVector('target', 'float32x2', [1, 4]);
-    const layer = new GPULineLayer({
-      id: 'gpu-lines',
-      getSourcePosition: sourcePositions,
-      getTargetPosition: targetPositions
-    });
-
-    expect(() => layer.renderLayers()).toThrow('chunk 0 row counts must align');
+    expect(() =>
+      getGPUVectorLayerBatches(
+        'gpu-lines',
+        {sourcePositions, targetPositions},
+        {sourcePositions: ['float32x2'], targetPositions: ['float32x2']}
+      )
+    ).toThrow('chunk 0 row counts must align');
   });
 
   test('borrows GPUVector buffers without taking ownership', () => {
     const destroy = vi.fn();
     const positions = makeChunkedVector('positions', 'float32x2', [2], destroy);
-    const layer = new GPUScatterplotLayer({id: 'borrowed', getPosition: positions});
-
-    layer.renderLayers();
-    layer.finalizeState({} as never);
+    getGPUVectorLayerBatches('borrowed', {positions}, {positions: ['float32x2']});
 
     expect(destroy).not.toHaveBeenCalled();
   });
 
-  test('preserves batches across the complete fixed-width primitive family', () => {
+  test('uses one GPUVectorModel-backed layer across every fixed-width primitive batch', () => {
     const positions2 = makeChunkedVector('positions2', 'float32x2', [2, 3]);
     const positions3 = makeChunkedVector('positions3', 'float32x3', [2, 3]);
     const targets = makeChunkedVector('targets', 'float32x2', [2, 3]);
+    const offsets = makeChunkedVector('offsets', 'float32x2', [2, 3]);
+    const frames = makeChunkedVector('frames', 'float32x4', [2, 3]);
+    const colorModes = makeChunkedVector('colorModes', 'float32', [2, 3]);
     const layers = [
       new GPUArcLayer({
         id: 'arcs',
@@ -69,14 +75,57 @@ describe('GPUVector deck layers', () => {
         getTargetPosition: targets
       }),
       new GPUColumnLayer({id: 'columns', getPosition: positions2}),
-      new GPUGridCellLayer({id: 'cells', getPosition: positions2}),
-      new GPUPointCloudLayer({id: 'point-cloud', getPosition: positions3})
+      new GPUIconLayer({
+        id: 'icons',
+        iconAtlas: {} as Texture,
+        getPosition: positions2,
+        iconOffsets: offsets,
+        iconFrames: frames,
+        iconColorModes: colorModes
+      }),
+      new GPULineLayer({
+        id: 'lines',
+        getSourcePosition: positions2,
+        getTargetPosition: targets
+      }),
+      new GPUPointCloudLayer({id: 'point-cloud', getPosition: positions3}),
+      new GPUScatterplotLayer({id: 'scatterplot', getPosition: positions2})
     ];
 
-    expect(layers[0]!.renderLayers()).toHaveLength(2);
-    expect(layers[1]!.renderLayers()).toHaveLength(2);
-    expect(layers[2]!.renderLayers()).toBeInstanceOf(GPUColumnLayer);
-    expect(layers[3]!.renderLayers()).toHaveLength(2);
+    for (const layer of layers) {
+      expect('renderLayers' in layer).toBe(false);
+    }
+
+    const gridCellLayer = new GPUGridCellLayer({id: 'cells', getPosition: positions2});
+    const columnLayer = gridCellLayer.renderLayers();
+    expect(columnLayer).toBeInstanceOf(GPUColumnLayer);
+    expect('renderLayers' in columnLayer).toBe(false);
+  });
+
+  test('delegates physical chunks to one GPUVectorModel draw', () => {
+    const positions = makeChunkedVector('positions', 'float32x2', [2, 3]);
+    const radii = makeChunkedVector('radii', 'float32', [2, 3]);
+    const layer = new GPUScatterplotLayer({
+      id: 'gpu-scatterplot-model',
+      getPosition: positions,
+      getRadius: radii
+    });
+    const rowIndexOffsets: number[] = [];
+    const write = vi.fn((data: Uint8Array) => {
+      rowIndexOffsets.push(new Uint32Array(data.buffer, data.byteOffset, data.byteLength / 4)[10]!);
+    });
+    const drawBatches = vi.fn((_renderPass, options) => {
+      options.onBatch?.({batchIndex: 0, rowIndexOffset: 0, rowCount: 2, data: {}});
+      options.onBatch?.({batchIndex: 1, rowIndexOffset: 2, rowCount: 3, data: {}});
+      return true;
+    });
+    layer.state = {model: {drawBatches}, styleBuffer: {write}} as never;
+
+    layer.draw({renderPass: {} as RenderPass});
+
+    expect(drawBatches).toHaveBeenCalledOnce();
+    expect(drawBatches.mock.calls[0]![1].vectors).toEqual({positions, radii});
+    expect(rowIndexOffsets).toEqual([0, 2]);
   });
 });
 
@@ -86,7 +135,13 @@ function makeChunkedVector<FormatT extends GPUVectorFormat>(
   chunkLengths: number[],
   destroy = vi.fn()
 ): GPUVector<FormatT> {
-  const components = format.endsWith('x2') ? 2 : format.endsWith('x3') ? 3 : 1;
+  const components = format.endsWith('x2')
+    ? 2
+    : format.endsWith('x3')
+      ? 3
+      : format.endsWith('x4')
+        ? 4
+        : 1;
   const bytesPerRow = components * Float32Array.BYTES_PER_ELEMENT;
   const data = chunkLengths.map(
     length =>

--- a/modules/deck-gpu-layers/test/index.ts
+++ b/modules/deck-gpu-layers/test/index.ts
@@ -4,3 +4,4 @@
 
 import './luspatial-point-layer.node.spec';
 import './luspatial-geographic-point-query-effect.node.spec';
+import './gpu-vector-layers.node.spec';

--- a/modules/deck-gpu-layers/test/luspatial-point-layer.node.spec.ts
+++ b/modules/deck-gpu-layers/test/luspatial-point-layer.node.spec.ts
@@ -174,7 +174,7 @@ describe('LuSpatialPointLayer rendering', () => {
 });
 
 describe('@deck.gl-community/gpu-layers package boundary', () => {
-  test('depends only on Deck and the generic luma render/indirect-draw APIs', () => {
+  test('depends only on Deck and GPU-native luma rendering APIs', () => {
     const packageJson = JSON.parse(
       readFileSync(new URL('../package.json', import.meta.url), 'utf8')
     ) as {sideEffects?: boolean; dependencies?: Record<string, string>};
@@ -185,7 +185,9 @@ describe('@deck.gl-community/gpu-layers package boundary', () => {
       '@luma.gl/core',
       '@luma.gl/engine',
       '@luma.gl/experimental',
-      '@luma.gl/shadertools'
+      '@luma.gl/gpgpu',
+      '@luma.gl/shadertools',
+      '@luma.gl/text'
     ]);
   });
 });

--- a/modules/deck-gpu-layers/tsconfig.json
+++ b/modules/deck-gpu-layers/tsconfig.json
@@ -10,6 +10,8 @@
   "references": [
     {"path": "../core"},
     {"path": "../engine"},
-    {"path": "../experimental"}
+    {"path": "../experimental"},
+    {"path": "../gpgpu"},
+    {"path": "../text"}
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2684,6 +2684,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/arrow-layers@workspace:modules/deck-arrow-layers"
   dependencies:
+    "@deck.gl-community/gpu-layers": "npm:9.4.0-alpha.4"
     "@deck.gl/core": "npm:9.3.4"
     "@luma.gl/arrow": "npm:9.4.0-alpha.4"
     "@luma.gl/core": "npm:9.4.0-alpha.4"
@@ -2695,7 +2696,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@deck.gl-community/gpu-layers@workspace:*, @deck.gl-community/gpu-layers@workspace:modules/deck-gpu-layers":
+"@deck.gl-community/gpu-layers@npm:9.4.0-alpha.4, @deck.gl-community/gpu-layers@workspace:*, @deck.gl-community/gpu-layers@workspace:modules/deck-gpu-layers":
   version: 0.0.0-use.local
   resolution: "@deck.gl-community/gpu-layers@workspace:modules/deck-gpu-layers"
   dependencies:
@@ -2703,7 +2704,9 @@ __metadata:
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
     "@luma.gl/experimental": "npm:9.4.0-alpha.4"
+    "@luma.gl/gpgpu": "npm:9.4.0-alpha.4"
     "@luma.gl/shadertools": "npm:9.4.0-alpha.4"
+    "@luma.gl/text": "npm:9.4.0-alpha.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Goals

- Establish `GPUVector` batches as the canonical rendering ABI for the deck.gl v10 layer core.
- Keep Apache Arrow outside the renderer boundary: Arrow adapters upload or convert columns into shared `@luma.gl/gpgpu/gpu-data` vectors, then delegate to the GPU core.
- Preserve Arrow record-batch and chunk boundaries, GPU-resident inputs, and ownership so streaming does not imply CPU repacking or buffer copies.
- Provide a broad enough layer family to validate the architecture across fixed-width, variable-length, texture, polygon, path, temporal, and text workloads.

## Changes

### GPUVector rendering core

Adds Arrow-free, WebGPU-first core layers in `@deck.gl-community/gpu-layers`:

- `GPUScatterplotLayer`
- `GPULineLayer`
- `GPUIconLayer`
- `GPUArcLayer`
- `GPUPointCloudLayer`
- `GPUColumnLayer`
- `GPUGridCellLayer`
- `GPUBitmapLayer`
- `GPUPathLayer`
- `GPUSolidPolygonLayer`
- `GPUPolygonLayer`
- `GPUTextLayer`

The six fixed-width primitive layers now use the `GPUVectorModel` landed in #3170. Each deck layer owns one model and replays aligned physical `GPUVector` chunks as draw batches through one pipeline, instead of creating one deck child layer and one model per chunk. The layers validate aligned chunk topology and formats, return global row plus batch-local picking provenance, and borrow caller-owned input buffers.

Path and polygon layers consume explicit variable-geometry GPU representations and use the existing GPU expansion and tessellation models rather than materializing JS rows.

### Arrow adapters

Adds Arrow-only adapters in `@deck.gl-community/arrow-layers` for scatterplot, line, icon, arc, point cloud, column, grid cell, path, trips, solid polygon, and GeoArrow geometry dispatch. Adapters own only the vectors they create and preserve Arrow chunk boundaries during upload.

`ArrowTripsLayer` adds timestamp, trail, and fade plumbing on top of the path storage model. `GeoArrowLayer` dispatches point, line string, polygon, and multipolygon extension metadata to the appropriate Arrow adapter.

### Boundary and follow-ups

- Classic JS object-array and classic deck.gl binary inputs are intentionally not accepted by the GPU core. They can be sibling converters to the same `GPUVector` ABI in a follow-up, allowing stable public deck.gl layer names without multiple rendering implementations.
- Tiled orchestration is intentionally excluded. A future GPUVector or Arrow tile adapter should use the proposed shared tile layer in deck.gl so caching, refinement, cancellation, and request deduplication remain shared infrastructure.
- DGGS layers remain outside this core family.

## Verification

- `yarn lint fix` — pass; no fixes required.
- `yarn build` — pass across the full monorepo, including both deck packages.
- `yarn test-node` / commit hook — pass: 404 files passed, 1 skipped; 3,207 tests passed, 1 skipped.
- GPUVector architecture coverage verifies one layer/model across all six fixed-width primitives, aligned physical batches, global picking provenance, and borrowed-buffer ownership.
- `yarn test` — node phase passes. The headless phase has four unrelated WebGPU baseline failures in raster, scene, and splat tests. The only initially failing deck-arrow GPU Graph interaction test passed 4/4 when rerun alone.
- GitHub CI — rerunning after the rebase onto latest `master` and the `GPUVectorModel` integration.

## Risks and review notes

- This is a foundational v10/POC rendering core, not yet full deck.gl v9 prop/accessor parity. Units, advanced joins and caps, transitions, and complete styling parity should be reviewed and layered onto the stable GPUVector boundary.
- The direct rendering layers currently target WebGPU. The adapter boundary is designed so CPU upload versus GPGPU conversion, including fp64 to 2xfp32 transforms, can be selected without changing layer rendering APIs.
- Input GPU vectors are caller-owned; adapter-created vectors are adapter-owned. Review lifecycle changes carefully because avoiding copies depends on this distinction.
