### PR TITLE
feat(gpgpu): add GPUVectorModel batch rendering

### DIFF
--- a/modules/gpgpu/src/gpu-data/gpu-vector-model.ts
+++ b/modules/gpgpu/src/gpu-data/gpu-vector-model.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import type {Device, RenderPass} from '@luma.gl/core';
+import type {BufferLayout, Device, RenderPass} from '@luma.gl/core';
 import {Model, type ModelProps} from '@luma.gl/engine';
 import type {GPUData} from './gpu-data';
 import type {GPUVector} from './gpu-vector';
@@ -40,19 +40,22 @@ export type GPUVectorModelDrawBatchesOptions = {
  */
 export class GPUVectorModel extends Model {
   private readonly gpuVectorCount: GPUVectorModelCount;
-  private readonly explicitAttributes: NonNullable<ModelProps['attributes']>;
-  private readonly explicitBindings: NonNullable<ModelProps['bindings']>;
-  private readonly explicitInstanceCount: number;
-  private readonly explicitVertexCount: number;
+  private currentAttributes!: NonNullable<ModelProps['attributes']>;
 
   constructor(device: Device, props: GPUVectorModelProps) {
     const {gpuVectorCount = 'instance', ...modelProps} = props;
     super(device, modelProps);
     this.gpuVectorCount = gpuVectorCount;
-    this.explicitAttributes = {...(modelProps.attributes ?? {})};
-    this.explicitBindings = {...(modelProps.bindings ?? {})};
-    this.explicitInstanceCount = this.instanceCount;
-    this.explicitVertexCount = this.vertexCount;
+    this.currentAttributes = {...(modelProps.attributes ?? {})};
+  }
+
+  /** Tracks the live attribute state so batched draws can restore inherited Model mutations. */
+  override setAttributes(
+    attributes: NonNullable<ModelProps['attributes']>,
+    options?: {disableWarnings?: boolean}
+  ): void {
+    this.currentAttributes = Object.assign(this.currentAttributes ?? {}, attributes);
+    super.setAttributes(attributes, options);
   }
 
   /** Draws each aligned physical chunk without retaining or taking ownership of input vectors. */
@@ -61,6 +64,11 @@ export class GPUVectorModel extends Model {
     {vectors, onBatch}: GPUVectorModelDrawBatchesOptions
   ): boolean {
     const batches = getGPUVectorModelBatches(this.id, vectors);
+    validateGPUVectorModelLayouts(this.id, vectors, this.bufferLayout, this.currentAttributes);
+    const previousAttributes = {...this.currentAttributes};
+    const previousBindings = {...this.bindings};
+    const previousInstanceCount = this.instanceCount;
+    const previousVertexCount = this.vertexCount;
     let drawSuccess = true;
     try {
       for (const batch of batches) {
@@ -72,10 +80,13 @@ export class GPUVectorModel extends Model {
         drawSuccess = super.draw(renderPass) && drawSuccess;
       }
     } finally {
-      this.setAttributes(this.explicitAttributes);
-      this.setBindings(this.explicitBindings);
-      this.setInstanceCount(this.explicitInstanceCount);
-      this.setVertexCount(this.explicitVertexCount);
+      this.setAttributes(previousAttributes);
+      for (const name of Object.keys(this.bindings)) {
+        if (!(name in previousBindings)) delete this.bindings[name];
+      }
+      this.setBindings(previousBindings);
+      this.setInstanceCount(previousInstanceCount);
+      this.setVertexCount(previousVertexCount);
     }
     return drawSuccess;
   }
@@ -85,6 +96,50 @@ export class GPUVectorModel extends Model {
       this.setInstanceCount(rowCount);
     } else if (this.gpuVectorCount === 'vertex') {
       this.setVertexCount(rowCount);
+    }
+  }
+}
+
+function validateGPUVectorModelLayouts(
+  ownerName: string,
+  vectors: Record<string, GPUVector | undefined>,
+  bufferLayouts: BufferLayout[],
+  attributes: NonNullable<ModelProps['attributes']>
+): void {
+  for (const [name, vector] of Object.entries(vectors)) {
+    if (!vector) continue;
+    if (!vector.format) {
+      throw new Error(`${ownerName} GPUVector "${name}" requires a format`);
+    }
+    if (!attributes[name]) {
+      throw new Error(`${ownerName} GPUVector "${name}" requires an existing Model attribute`);
+    }
+    const bufferLayout = bufferLayouts.find(layout => layout.name === name);
+    if (!bufferLayout) {
+      throw new Error(`${ownerName} GPUVector "${name}" requires a Model buffer layout`);
+    }
+    const attributeLayouts = bufferLayout.attributes ?? [];
+    if (attributeLayouts.length > 1) {
+      throw new Error(`${ownerName} GPUVector "${name}" does not support interleaved layouts`);
+    }
+    const attributeLayout = attributeLayouts[0];
+    const format = bufferLayout.format ?? attributeLayout?.format;
+    const byteOffset = attributeLayout?.byteOffset ?? 0;
+    const formatInfo = getGPUVectorFormatInfo(vector.format);
+    const byteStride = bufferLayout.byteStride ?? formatInfo.byteLength;
+    if (
+      format !== vector.format ||
+      byteStride !== vector.byteStride ||
+      vector.rowByteLength !== formatInfo.byteLength
+    ) {
+      throw new Error(`${ownerName} GPUVector "${name}" must match its Model buffer layout`);
+    }
+    for (const chunk of vector.data) {
+      if (chunk.byteOffset !== byteOffset) {
+        throw new Error(
+          `${ownerName} GPUVector "${name}" chunk byte offsets must match its Model buffer layout`
+        );
+      }
     }
   }
 }

--- a/modules/gpgpu/src/gpu-data/gpu-vector-model.ts
+++ b/modules/gpgpu/src/gpu-data/gpu-vector-model.ts
@@ -1,0 +1,139 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Device, RenderPass} from '@luma.gl/core';
+import {Model, type ModelProps} from '@luma.gl/engine';
+import type {GPUData} from './gpu-data';
+import type {GPUVector} from './gpu-vector';
+import {getGPUVectorFormatInfo} from './gpu-vector-format';
+
+/** Controls which draw count follows each physical GPUVector batch row count. */
+export type GPUVectorModelCount = 'instance' | 'vertex' | 'none';
+
+/** Props for a Model that can transiently bind aligned GPUVector chunks. */
+export type GPUVectorModelProps = ModelProps & {
+  /** Draw count updated from each batch. Defaults to `instance`. */
+  gpuVectorCount?: GPUVectorModelCount;
+};
+
+/** One borrowed, row-aligned set of physical GPUData chunks. */
+export type GPUVectorModelBatch = {
+  batchIndex: number;
+  rowIndexOffset: number;
+  rowCount: number;
+  data: Record<string, GPUData>;
+};
+
+/** Per-draw options for rendering aligned GPUVectors without creating table wrappers. */
+export type GPUVectorModelDrawBatchesOptions = {
+  /** Named vectors mapped to Model buffer-layout names. Undefined optional vectors are ignored. */
+  vectors: Record<string, GPUVector | undefined>;
+  /** Called after binding each batch and before its draw call. */
+  onBatch?: (batch: GPUVectorModelBatch) => void;
+};
+
+/**
+ * A Model that borrows aligned GPUVector chunks and draws each physical batch with one pipeline.
+ *
+ * The model never owns, destroys, packs, or transfers its input vectors or GPUData chunks.
+ */
+export class GPUVectorModel extends Model {
+  private readonly gpuVectorCount: GPUVectorModelCount;
+  private readonly explicitAttributes: NonNullable<ModelProps['attributes']>;
+  private readonly explicitBindings: NonNullable<ModelProps['bindings']>;
+  private readonly explicitInstanceCount: number;
+  private readonly explicitVertexCount: number;
+
+  constructor(device: Device, props: GPUVectorModelProps) {
+    const {gpuVectorCount = 'instance', ...modelProps} = props;
+    super(device, modelProps);
+    this.gpuVectorCount = gpuVectorCount;
+    this.explicitAttributes = {...(modelProps.attributes ?? {})};
+    this.explicitBindings = {...(modelProps.bindings ?? {})};
+    this.explicitInstanceCount = this.instanceCount;
+    this.explicitVertexCount = this.vertexCount;
+  }
+
+  /** Draws each aligned physical chunk without retaining or taking ownership of input vectors. */
+  drawBatches(
+    renderPass: RenderPass,
+    {vectors, onBatch}: GPUVectorModelDrawBatchesOptions
+  ): boolean {
+    const batches = getGPUVectorModelBatches(this.id, vectors);
+    let drawSuccess = true;
+    try {
+      for (const batch of batches) {
+        this.setAttributes(
+          Object.fromEntries(Object.entries(batch.data).map(([name, data]) => [name, data.buffer]))
+        );
+        this.setBatchDrawCount(batch.rowCount);
+        onBatch?.(batch);
+        drawSuccess = super.draw(renderPass) && drawSuccess;
+      }
+    } finally {
+      this.setAttributes(this.explicitAttributes);
+      this.setBindings(this.explicitBindings);
+      this.setInstanceCount(this.explicitInstanceCount);
+      this.setVertexCount(this.explicitVertexCount);
+    }
+    return drawSuccess;
+  }
+
+  private setBatchDrawCount(rowCount: number): void {
+    if (this.gpuVectorCount === 'instance') {
+      this.setInstanceCount(rowCount);
+    } else if (this.gpuVectorCount === 'vertex') {
+      this.setVertexCount(rowCount);
+    }
+  }
+}
+
+/** Validates fixed-width vector alignment and returns borrowed batch-local GPUData references. */
+export function getGPUVectorModelBatches(
+  ownerName: string,
+  vectors: Record<string, GPUVector | undefined>
+): GPUVectorModelBatch[] {
+  const entries = Object.entries(vectors).filter(
+    (entry): entry is [string, GPUVector] => entry[1] !== undefined
+  );
+  if (entries.length === 0) return [];
+  const [primaryName, primaryVector] = entries[0];
+  for (const [name, vector] of entries) {
+    if (!vector.format) {
+      throw new Error(`${ownerName} GPUVector "${name}" requires a format`);
+    }
+    const formatInfo = getGPUVectorFormatInfo(vector.format);
+    if (formatInfo.vertexList || formatInfo.valueList || formatInfo.fixedSizeList) {
+      throw new Error(`${ownerName} GPUVector "${name}" requires a fixed-width scalar format`);
+    }
+    if (vector.length !== primaryVector.length) {
+      throw new Error(`${ownerName} GPUVector "${name}" rows must match "${primaryName}" rows`);
+    }
+    if (vector.data.length !== primaryVector.data.length) {
+      throw new Error(`${ownerName} GPUVector chunk counts must align`);
+    }
+  }
+
+  let rowIndexOffset = 0;
+  return primaryVector.data.map((primaryData, batchIndex) => {
+    const data: Record<string, GPUData> = {};
+    for (const [name, vector] of entries) {
+      const chunk = vector.data[batchIndex];
+      if (!chunk || chunk.length !== primaryData.length) {
+        throw new Error(`${ownerName} GPUVector chunk ${batchIndex} row counts must align`);
+      }
+      if (
+        chunk.format !== vector.format ||
+        chunk.byteStride !== vector.byteStride ||
+        chunk.rowByteLength !== vector.rowByteLength
+      ) {
+        throw new Error(`${ownerName} GPUVector "${name}" chunk layout must be stable`);
+      }
+      data[name] = chunk;
+    }
+    const batch = {batchIndex, rowIndexOffset, rowCount: primaryData.length, data};
+    rowIndexOffset += primaryData.length;
+    return batch;
+  });
+}

--- a/modules/gpgpu/src/gpu-data/index.ts
+++ b/modules/gpgpu/src/gpu-data/index.ts
@@ -38,6 +38,14 @@ export {
   type GPUVectorFromInterleavedProps
 } from './gpu-vector';
 export {
+  GPUVectorModel,
+  getGPUVectorModelBatches,
+  type GPUVectorModelBatch,
+  type GPUVectorModelCount,
+  type GPUVectorModelDrawBatchesOptions,
+  type GPUVectorModelProps
+} from './gpu-vector-model';
+export {
   getGPUDataBuffersForLayout,
   getGPUVectorBuffer,
   getGPUVectorBuffersForLayout,

--- a/modules/gpgpu/test/gpu-data/gpu-vector-model.node.spec.ts
+++ b/modules/gpgpu/test/gpu-data/gpu-vector-model.node.spec.ts
@@ -62,6 +62,9 @@ it('GPUVectorModel draws aligned borrowed chunks without taking buffer ownership
     isInstanced: true,
     vertexCount: 1
   });
+  const previousBuffer = device.createBuffer({data: new Float32Array([9, 9])});
+  model.setAttributes({positions: previousBuffer});
+  model.setInstanceCount(7);
   const renderPass = device.getDefaultRenderPass();
   const drawCalls: Array<{instanceCount?: number; buffer?: Buffer}> = [];
   const draw = renderPass.draw.bind(renderPass);
@@ -86,15 +89,57 @@ it('GPUVectorModel draws aligned borrowed chunks without taking buffer ownership
     {batchIndex: 0, rowIndexOffset: 0},
     {batchIndex: 1, rowIndexOffset: 2}
   ]);
+  expect(model.instanceCount).toBe(7);
+  expect(renderPass.vertexArray?.attributes[0]).toBe(previousBuffer);
 
   model.destroy();
   expect(firstBuffer.destroyed).toBe(false);
   expect(secondBuffer.destroyed).toBe(false);
+  previousBuffer.destroy();
   positions.destroy();
   expect(firstBuffer.destroyed).toBe(true);
   expect(secondBuffer.destroyed).toBe(true);
   renderPass.destroy();
   void 0;
+});
+
+it('GPUVectorModel rejects layouts that cannot represent vector format or chunk offset', () => {
+  const device = new NullDevice({});
+  const buffer = device.createBuffer({byteLength: 24});
+  const positions = new GPUVector<'float32x2'>({
+    type: 'data',
+    name: 'positions',
+    format: 'float32x2',
+    data: [new GPUData({buffer, byteOffset: 8, format: 'float32x2', length: 2})]
+  });
+  const model = new GPUVectorModel(device, {
+    id: 'gpu-vector-layout-test',
+    vs: VERTEX_SHADER,
+    fs: FRAGMENT_SHADER,
+    shaderLayout: SHADER_LAYOUT,
+    bufferLayout: [{name: 'positions', format: 'float32x2', stepMode: 'instance'}],
+    attributes: {positions: buffer},
+    isInstanced: true,
+    vertexCount: 1
+  });
+  const renderPass = device.getDefaultRenderPass();
+
+  expect(() => model.drawBatches(renderPass, {vectors: {positions}})).toThrow(
+    'chunk byte offsets must match its Model buffer layout'
+  );
+  const colors = new GPUVector<'unorm8x4'>({
+    type: 'data',
+    name: 'positions',
+    format: 'unorm8x4',
+    data: [new GPUData({buffer, format: 'unorm8x4', length: 2})]
+  });
+  expect(() => model.drawBatches(renderPass, {vectors: {positions: colors}})).toThrow(
+    'must match its Model buffer layout'
+  );
+
+  model.destroy();
+  renderPass.destroy();
+  buffer.destroy();
 });
 
 it('getGPUVectorModelBatches validates aligned fixed-width chunks', () => {

--- a/modules/gpgpu/test/gpu-data/gpu-vector-model.node.spec.ts
+++ b/modules/gpgpu/test/gpu-data/gpu-vector-model.node.spec.ts
@@ -1,0 +1,142 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {expect, it} from 'vitest';
+import type {Buffer, ShaderLayout} from '@luma.gl/core';
+import {NullDevice} from '@luma.gl/test-utils';
+import {
+  GPUData,
+  GPUVector,
+  GPUVectorModel,
+  getGPUVectorModelBatches
+} from '@luma.gl/gpgpu/gpu-data';
+
+const SHADER_LAYOUT = {
+  attributes: [{name: 'positions', location: 0, type: 'vec2<f32>', stepMode: 'instance'}],
+  bindings: []
+} satisfies ShaderLayout;
+
+const VERTEX_SHADER = /* glsl */ `#version 300 es
+in vec2 positions;
+void main() { gl_Position = vec4(positions, 0.0, 1.0); }
+`;
+
+const FRAGMENT_SHADER = /* glsl */ `#version 300 es
+precision highp float;
+out vec4 fragColor;
+void main() { fragColor = vec4(1.0); }
+`;
+
+it('GPUVectorModel draws aligned borrowed chunks without taking buffer ownership', () => {
+  const device = new NullDevice({});
+  const firstBuffer = device.createBuffer({data: new Float32Array([0, 0, 1, 1])});
+  const secondBuffer = device.createBuffer({data: new Float32Array([2, 2, 3, 3, 4, 4])});
+  const positions = new GPUVector<'float32x2'>({
+    type: 'data',
+    name: 'positions',
+    format: 'float32x2',
+    data: [
+      new GPUData({
+        buffer: firstBuffer,
+        format: 'float32x2',
+        length: 2,
+        ownsBuffer: true
+      }),
+      new GPUData({
+        buffer: secondBuffer,
+        format: 'float32x2',
+        length: 3,
+        ownsBuffer: true
+      })
+    ],
+    ownsData: true
+  });
+  const model = new GPUVectorModel(device, {
+    id: 'gpu-vector-model-test',
+    vs: VERTEX_SHADER,
+    fs: FRAGMENT_SHADER,
+    shaderLayout: SHADER_LAYOUT,
+    bufferLayout: [{name: 'positions', format: 'float32x2', stepMode: 'instance'}],
+    attributes: {positions: firstBuffer},
+    isInstanced: true,
+    vertexCount: 1
+  });
+  const renderPass = device.getDefaultRenderPass();
+  const drawCalls: Array<{instanceCount?: number; buffer?: Buffer}> = [];
+  const draw = renderPass.draw.bind(renderPass);
+  renderPass.draw = options => {
+    drawCalls.push({
+      instanceCount: options.instanceCount,
+      buffer: renderPass.vertexArray?.attributes[0] as Buffer
+    });
+    return draw(options);
+  };
+
+  const batches: Array<{batchIndex: number; rowIndexOffset: number}> = [];
+  expect(
+    model.drawBatches(renderPass, {
+      vectors: {positions},
+      onBatch: ({batchIndex, rowIndexOffset}) => batches.push({batchIndex, rowIndexOffset})
+    })
+  ).toBe(true);
+  expect(drawCalls.map(call => call.instanceCount)).toEqual([2, 3]);
+  expect(drawCalls.map(call => call.buffer)).toEqual([firstBuffer, secondBuffer]);
+  expect(batches).toEqual([
+    {batchIndex: 0, rowIndexOffset: 0},
+    {batchIndex: 1, rowIndexOffset: 2}
+  ]);
+
+  model.destroy();
+  expect(firstBuffer.destroyed).toBe(false);
+  expect(secondBuffer.destroyed).toBe(false);
+  positions.destroy();
+  expect(firstBuffer.destroyed).toBe(true);
+  expect(secondBuffer.destroyed).toBe(true);
+  renderPass.destroy();
+  void 0;
+});
+
+it('getGPUVectorModelBatches validates aligned fixed-width chunks', () => {
+  const device = new NullDevice({});
+  const positions = makeVector(device, 'positions', 'float32x2', [2, 3]);
+  const colors = makeVector(device, 'colors', 'unorm8x4', [2, 3]);
+
+  expect(getGPUVectorModelBatches('test-model', {positions, colors})).toMatchObject([
+    {batchIndex: 0, rowIndexOffset: 0, rowCount: 2},
+    {batchIndex: 1, rowIndexOffset: 2, rowCount: 3}
+  ]);
+
+  const misalignedColors = makeVector(device, 'colors', 'unorm8x4', [3, 2]);
+  expect(() =>
+    getGPUVectorModelBatches('test-model', {positions, colors: misalignedColors})
+  ).toThrow('chunk 0 row counts must align');
+
+  positions.destroy();
+  colors.destroy();
+  misalignedColors.destroy();
+});
+
+function makeVector(
+  device: NullDevice,
+  name: string,
+  format: 'float32x2' | 'unorm8x4',
+  chunkLengths: number[]
+): GPUVector<'float32x2' | 'unorm8x4'> {
+  const byteStride = 8;
+  return new GPUVector({
+    type: 'data',
+    name,
+    format,
+    data: chunkLengths.map(
+      length =>
+        new GPUData({
+          buffer: device.createBuffer({byteLength: length * byteStride}),
+          format,
+          length,
+          ownsBuffer: true
+        })
+    ),
+    ownsData: true
+  });
+}


### PR DESCRIPTION
## Goals

Provide the small rendering primitive needed by the GPUVector-native deck layer family in #3169, without adding GPUVector knowledge to `@luma.gl/engine` `Model` or introducing GPUTable ownership ambiguity.

## Changes

- add `GPUVectorModel` to `@luma.gl/gpgpu/gpu-data`
- draw aligned fixed-width GPUVector chunks through one Model/pipeline
- support instance-count, vertex-count, and caller-managed draw counts
- expose per-batch index, global row offset, row count, and borrowed GPUData to a pre-draw callback
- validate row/chunk/layout alignment without packing or copying
- restore explicit model attributes, bindings, and draw counts after batched drawing
- document and test strict borrowed-buffer ownership

## Relationship to #3169

This is a prerequisite PR intended to make #3169 smaller and easier to review. The GPU layer family will consume this abstraction in a follow-up/rebase; this PR contains no deck layer implementation.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn test-node modules/gpgpu/test/gpu-data/gpu-vector-model.node.spec.ts` (repository Node suite: 404 passed, 1 skipped; 3205 tests passed, 1 skipped)
- `yarn test`: Node suite passed; headless suite completed with 5 unrelated existing WebGPU/render failures in gpu-raster, scene-renderer lighting, gpu-paged-splat-renderer, and gpu-graph-deck tests
