### PR TITLE
feat(engine): add pinch roll to OrbitControls

### DIFF
--- a/docs/api-guide/engine/interactivity.md
+++ b/docs/api-guide/engine/interactivity.md
@@ -24,7 +24,7 @@ backend-specific event handler.
 
 Engine provides focused helpers, not an application-wide event system:
 
-- `OrbitControls` converts canvas pointer, pinch, two-finger pan, and wheel input into camera state.
+- `OrbitControls` converts canvas pointer, pinch, optional two-finger roll and pan, and wheel input into camera state.
 - `PickingManager` renders object identity into an offscreen target and reads the identity at a
   requested pixel.
 - Highlighting remains a normal render concern. Store the hovered or selected identity, pass it
@@ -37,9 +37,9 @@ portable touch and pointer gestures.
 ## Camera interaction
 
 `OrbitControls` attaches mouse, wheel, and touch orbit behavior to one HTML canvas. A single
-finger rotates the camera, two fingers pinch to zoom, and enabling panning lets two fingers move
-the orbit target. Update the controls before deriving the view matrix, then invalidate the view
-only when its state changes.
+finger changes yaw and pitch; two fingers pinch to zoom; enabling rotation lets a twist roll the
+camera up axis; enabling panning lets two fingers move the orbit target. Update the controls
+before deriving the view matrix, then invalidate the view only when its state changes.
 
 ```ts
 import {OrbitControls} from '@luma.gl/engine';
@@ -55,7 +55,8 @@ const controls = new OrbitControls(canvas, {
 function updateCamera(timeMilliseconds: number): void {
   controls.update(timeMilliseconds);
   const eyePosition = controls.getEyePosition();
-  // Build the view matrix from eyePosition and controls.props.target.
+  const upDirection = controls.getUpDirection();
+  // Build the view matrix from eyePosition, controls.props.target, and upDirection.
 }
 
 // Remove pointer listeners and restore canvas styles when finished.

--- a/docs/api-reference/engine/orbit-controls.md
+++ b/docs/api-reference/engine/orbit-controls.md
@@ -4,7 +4,7 @@ import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
 
 <EngineDocsTabs group="interaction" active="orbit-controls" />
 
-`OrbitControls` adds pointer-driven orbiting, wheel and pinch zoom, optional panning, automatic rotation, and configurable camera bounds to an HTML canvas. The controls maintain a camera position around a target without depending on a specific renderer, scene graph, or GPU backend.
+`OrbitControls` adds pointer-driven orbiting, optional two-finger camera roll, wheel and pinch zoom, optional panning, automatic orbiting, and configurable camera bounds to an HTML canvas. The controls maintain a camera position and up direction around a target without depending on a specific renderer, scene graph, or GPU backend.
 
 ## Usage
 
@@ -30,7 +30,7 @@ function render(timeMilliseconds: number): void {
   viewMatrix.lookAt({
     eye: controls.getEyePosition(),
     center: controls.props.target,
-    up: [0, 1, 0]
+    up: controls.getUpDirection()
   });
 
   // Use viewMatrix to draw the current animation frame.
@@ -60,6 +60,7 @@ type OrbitControlsProps = {
   distance?: number;
   yaw?: number;
   pitch?: number;
+  roll?: number;
   minDistance?: number;
   maxDistance?: number;
   minPitch?: number;
@@ -68,6 +69,7 @@ type OrbitControlsProps = {
   pitchSpeed?: number;
   zoomSpeed?: number;
   enabled?: boolean;
+  enableRotate?: boolean;
   enableZoom?: boolean;
   enablePan?: boolean;
   panSpeed?: number;
@@ -83,6 +85,7 @@ type OrbitControlsProps = {
 | `distance` | `10` | Initial distance from the orbit target, in world-space units. |
 | `yaw` | `0` | Initial horizontal orbit angle in radians. |
 | `pitch` | `0.25` | Initial vertical orbit angle in radians. |
+| `roll` | `0` | Initial rotation of the camera up axis around the viewing direction, in radians. |
 | `minDistance` | `1` | Minimum distance from the target. |
 | `maxDistance` | `100` | Maximum distance from the target. |
 | `minPitch` | `-Math.PI / 2 + 0.01` | Lowest allowed pitch angle in radians. |
@@ -91,6 +94,7 @@ type OrbitControlsProps = {
 | `pitchSpeed` | `rotateSpeed` | Optional vertical rotation applied per CSS pixel. Negative values invert the vertical drag direction. |
 | `zoomSpeed` | `0.001` | Exponential wheel-zoom sensitivity. |
 | `enabled` | `true` | Whether pointer, touch, wheel, and automatic camera interactions are active. |
+| `enableRotate` | `false` | Whether a two-finger twist can rotate the camera up axis. Orbiting remains enabled when this is `false`. |
 | `enableZoom` | `true` | Whether mouse-wheel and two-finger pinch gestures can change the camera distance. |
 | `enablePan` | `false` | Whether Shift-dragging and two-finger touch movement can pan the orbit target. |
 | `panSpeed` | `0.0018` | Target movement per CSS pixel, scaled by the current camera distance. |
@@ -115,6 +119,10 @@ Current horizontal orbit angle in radians. Applications can read or adjust this 
 ### `pitch: number`
 
 Current vertical orbit angle in radians. Pointer interaction and `setProps()` clamp this value between `minPitch` and `maxPitch`.
+
+### `roll: number`
+
+Current rotation of the camera up axis around its viewing direction, in radians. Two-finger twist gestures update this value when `enableRotate` is enabled.
 
 ### `distance: number`
 
@@ -153,6 +161,10 @@ Returns the current world-space camera position computed from `target`, `yaw`, `
 
 At `yaw: 0` and `pitch: 0`, the camera is positioned on the positive Z side of its target. Positive pitch moves the camera upward.
 
+### `getUpDirection(): OrbitPosition`
+
+Returns the normalized camera up direction derived from the current yaw, pitch, and roll. Pass this value as the `up` direction when building a view matrix so two-finger rotation is visible.
+
 ### `setProps(props: OrbitControlsProps): void`
 
 Updates the orbit configuration without replacing the controls or reattaching event listeners.
@@ -168,7 +180,7 @@ controls.setProps({
 });
 ```
 
-Changing `yaw`, `pitch`, or `distance` through `setProps()` also updates the configured camera pose used by `reset()`.
+Changing `yaw`, `pitch`, `roll`, or `distance` through `setProps()` also updates the configured camera pose used by `reset()`.
 
 ### `setAutoRotate(autoRotate: boolean): void`
 
@@ -180,7 +192,7 @@ controls.setAutoRotate(false);
 
 ### `reset(): void`
 
-Restores the configured yaw, pitch, and distance. The restored pitch and distance respect the current configured bounds.
+Restores the configured yaw, pitch, roll, and distance. The restored pitch and distance respect the current configured bounds.
 
 ### `destroy(): void`
 
@@ -191,6 +203,7 @@ Removes all pointer and wheel listeners, releases active pointer capture, and re
 - Drag with the primary mouse button, one touch pointer, or a pen pointer to orbit the target.
 - Scroll the wheel to zoom. Wheel deltas are bounded before applying exponential zoom so large trackpad or mouse events cannot produce an excessive distance jump.
 - Pinch two touch points apart to zoom in or together to zoom out. Pinch distance respects the same configured bounds as wheel zoom.
+- Set `enableRotate: true` to twist two touch points and roll the camera up axis around the viewing direction. Rotation uses the shortest change in touch angle when the gesture crosses the `-pi`/`pi` boundary. Single-pointer yaw and pitch orbiting remain available regardless of this option.
 - Set `enablePan: true` to pan with Shift-dragging or by moving the midpoint of a two-finger touch gesture.
 - Pointer capture keeps every active touch or pointer associated with the canvas, even outside its bounds.
 - Releasing one finger resumes one-pointer orbiting without a positional jump; `pointercancel`, disabling controls, and `destroy()` release the relevant captures.

--- a/examples/showcase/gaussian-splats/app.ts
+++ b/examples/showcase/gaussian-splats/app.ts
@@ -82,6 +82,7 @@ type GaussianSplatRADQualityMode = 'interactive' | 'settling' | 'settled';
 type GaussianSplatCameraState = {
   yaw: number;
   pitch: number;
+  roll: number;
   distance: number;
   target: readonly [number, number, number];
   viewportWidth: number;
@@ -100,7 +101,7 @@ export function makeGaussianSplatInfoHtml(): string {
 <section data-gaussian-splats-panel style="display:grid;gap:13px;min-width:248px;max-width:310px">
   <div data-gaussian-splats-description style="font-size:12px;line-height:1.55;opacity:.8">
     Four independent GPU batches reveal a chromatic observatory of rotated, anisotropic Gaussians.
-    Drag to orbit; scroll to zoom.
+    Drag to orbit; pinch to zoom and twist to roll.
   </div>
   <div style="display:flex;justify-content:space-between;font-size:12px">
     <span>Visible splats</span><strong data-gaussian-splats-count>0 / 0</strong>
@@ -334,6 +335,7 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
       maxPitch: 1.32,
       rotateSpeed: -0.006,
       pitchSpeed: -0.005,
+      enableRotate: true,
       autoRotate: this.autoOrbit,
       autoRotateSpeed: 0.12,
       onInteractionStart: this.handleCameraInteraction
@@ -384,10 +386,12 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
     const cameraPitch =
       (this.orbitControls?.pitch ?? this.cameraHomePitch) +
       (this.autoOrbit ? Math.sin(elapsedTimeMilliseconds * 0.00022) * 0.11 : 0);
+    const cameraRoll = this.orbitControls?.roll ?? 0;
     const cameraDistance = this.orbitControls?.distance ?? this.cameraHomeDistance;
     const cameraState: GaussianSplatCameraState = {
       yaw: cameraYaw,
       pitch: cameraPitch,
+      roll: cameraRoll,
       distance: cameraDistance,
       target: this.cameraTarget,
       viewportWidth: Math.max(width, 1),
@@ -691,10 +695,13 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
 
   private updateRendererCamera(cameraState: GaussianSplatCameraState): void {
     const cosinePitch = Math.cos(cameraState.pitch);
+    const sinePitch = Math.sin(cameraState.pitch);
+    const cosineYaw = Math.cos(cameraState.yaw);
+    const sineYaw = Math.sin(cameraState.yaw);
     const horizontalDistance = cosinePitch * cameraState.distance;
-    const forwardDistance = Math.cos(cameraState.yaw) * horizontalDistance;
-    const rightDistance = Math.sin(cameraState.yaw) * horizontalDistance;
-    const upwardDistance = Math.sin(cameraState.pitch) * cameraState.distance;
+    const forwardDistance = cosineYaw * horizontalDistance;
+    const rightDistance = sineYaw * horizontalDistance;
+    const upwardDistance = sinePitch * cameraState.distance;
     const cameraPosition: [number, number, number] = [
       cameraState.target[0] +
         this.cameraFrame.forward[0] * forwardDistance +
@@ -708,6 +715,26 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
         this.cameraFrame.forward[2] * forwardDistance +
         this.cameraFrame.right[2] * rightDistance +
         this.cameraFrame.up[2] * upwardDistance
+    ];
+    const cameraRight: [number, number, number] = [
+      this.cameraFrame.right[0] * cosineYaw - this.cameraFrame.forward[0] * sineYaw,
+      this.cameraFrame.right[1] * cosineYaw - this.cameraFrame.forward[1] * sineYaw,
+      this.cameraFrame.right[2] * cosineYaw - this.cameraFrame.forward[2] * sineYaw
+    ];
+    const cameraUp: [number, number, number] = [
+      this.cameraFrame.up[0] * cosinePitch -
+        (this.cameraFrame.forward[0] * cosineYaw + this.cameraFrame.right[0] * sineYaw) * sinePitch,
+      this.cameraFrame.up[1] * cosinePitch -
+        (this.cameraFrame.forward[1] * cosineYaw + this.cameraFrame.right[1] * sineYaw) * sinePitch,
+      this.cameraFrame.up[2] * cosinePitch -
+        (this.cameraFrame.forward[2] * cosineYaw + this.cameraFrame.right[2] * sineYaw) * sinePitch
+    ];
+    const cosineRoll = Math.cos(cameraState.roll);
+    const sineRoll = Math.sin(cameraState.roll);
+    const rolledCameraUp: [number, number, number] = [
+      cameraUp[0] * cosineRoll + cameraRight[0] * sineRoll,
+      cameraUp[1] * cosineRoll + cameraRight[1] * sineRoll,
+      cameraUp[2] * cosineRoll + cameraRight[2] * sineRoll
     ];
     const near = this.localLoadersConfiguration
       ? Math.max(Math.min(cameraState.distance * 0.02, this.cameraSceneRadius * 0.05), 0.001)
@@ -724,7 +751,7 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
     const viewMatrix = new Matrix4().lookAt({
       eye: cameraPosition,
       center: cameraState.target,
-      up: this.cameraFrame.up
+      up: rolledCameraUp
     });
     const modelViewProjectionMatrix = new Matrix4(projectionMatrix).multiplyRight(viewMatrix);
     const cameraProps: Pick<SplatRendererProps, 'modelViewProjectionMatrix' | 'viewportSize'> = {
@@ -867,6 +894,7 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
     const minimumCameraDistance = Math.max(this.cameraSceneRadius * 0.02, 0.025);
     this.orbitControls?.setProps({
       target: this.cameraTarget,
+      roll: 0,
       distance: fittedDistance,
       minDistance: this.localLoadersConfiguration?.camera
         ? Math.min(minimumCameraDistance, fittedDistance * 0.5)
@@ -900,10 +928,10 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
     if (this.localLoadersConfiguration && descriptionElement) {
       descriptionElement.textContent =
         this.localLoadersConfiguration.sceneId === 'coit'
-          ? 'Explore Coit Tower and San Francisco with camera-prioritized Gaussian pages. Drag to orbit; scroll to zoom.'
+          ? 'Explore Coit Tower and San Francisco with camera-prioritized Gaussian pages. Drag to orbit; pinch to zoom and twist to roll.'
           : this.localLoadersConfiguration.loaderMode === 'local'
-            ? 'Complete Gaussian splat scenes streamed through the local loaders.gl 5 alpha checkout. Drag to orbit; scroll to zoom.'
-            : 'Complete Gaussian splat scenes streamed through loaders.gl 5 alpha. Drag to orbit; scroll to zoom.';
+            ? 'Complete Gaussian splat scenes streamed through the local loaders.gl 5 alpha checkout. Drag to orbit; pinch to zoom and twist to roll.'
+            : 'Complete Gaussian splat scenes streamed through loaders.gl 5 alpha. Drag to orbit; pinch to zoom and twist to roll.';
     }
 
     if (this.device.type === 'webgpu' && executionControl && executionElement) {
@@ -1292,6 +1320,7 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
     this.orbitControls?.setProps({
       yaw: this.cameraHomeYaw,
       pitch: this.cameraHomePitch,
+      roll: 0,
       distance: this.cameraHomeDistance
     });
   };
@@ -1345,6 +1374,7 @@ function hasSameCameraState(
     previousCameraState &&
       cameraState.yaw === previousCameraState.yaw &&
       cameraState.pitch === previousCameraState.pitch &&
+      cameraState.roll === previousCameraState.roll &&
       cameraState.distance === previousCameraState.distance &&
       cameraState.viewportWidth === previousCameraState.viewportWidth &&
       cameraState.viewportHeight === previousCameraState.viewportHeight &&

--- a/modules/engine/src/controls/orbit-controls.ts
+++ b/modules/engine/src/controls/orbit-controls.ts
@@ -9,6 +9,7 @@ export type OrbitControlsProps = {
   distance?: number;
   yaw?: number;
   pitch?: number;
+  roll?: number;
   minDistance?: number;
   maxDistance?: number;
   minPitch?: number;
@@ -17,6 +18,7 @@ export type OrbitControlsProps = {
   pitchSpeed?: number;
   zoomSpeed?: number;
   enabled?: boolean;
+  enableRotate?: boolean;
   enableZoom?: boolean;
   enablePan?: boolean;
   panSpeed?: number;
@@ -35,6 +37,7 @@ const DEFAULT_PROPS: ResolvedOrbitControlsProps = {
   distance: 10,
   yaw: 0,
   pitch: 0.25,
+  roll: 0,
   minDistance: 1,
   maxDistance: 100,
   minPitch: -Math.PI / 2 + 0.01,
@@ -42,6 +45,7 @@ const DEFAULT_PROPS: ResolvedOrbitControlsProps = {
   rotateSpeed: 0.006,
   zoomSpeed: 0.001,
   enabled: true,
+  enableRotate: false,
   enableZoom: true,
   enablePan: false,
   panSpeed: 0.0018,
@@ -50,7 +54,7 @@ const DEFAULT_PROPS: ResolvedOrbitControlsProps = {
 };
 
 /**
- * Pointer orbit, wheel and pinch zoom, and optional automatic rotation controls for a canvas.
+ * Pointer orbit, optional pinch roll, wheel and pinch zoom, and automatic rotation controls.
  *
  * Call {@link update} once per frame with an animation-loop timestamp in milliseconds before
  * reading {@link getEyePosition}. Manual dragging temporarily pauses automatic rotation and
@@ -61,12 +65,14 @@ export class OrbitControls {
   readonly props: ResolvedOrbitControlsProps;
   yaw: number;
   pitch: number;
+  roll: number;
   distance: number;
 
   private dragging = false;
   private readonly activePointers = new Map<number, [number, number]>();
   private lastPointer: [number, number] = [0, 0];
   private previousPinchDistance: number | null = null;
+  private previousPinchAngle: number | null = null;
   private previousTimeMilliseconds: number | null = null;
   private readonly previousCursor: string;
   private readonly previousTouchAction: string;
@@ -77,6 +83,7 @@ export class OrbitControls {
     this.props.target = [...this.props.target];
     this.yaw = this.props.yaw;
     this.pitch = clampNumber(this.props.pitch, this.props.minPitch, this.props.maxPitch);
+    this.roll = this.props.roll;
     this.distance = clampNumber(
       this.props.distance,
       this.props.minDistance,
@@ -120,6 +127,34 @@ export class OrbitControls {
     ];
   }
 
+  /** Returns the camera up direction after applying pitch and optional two-finger roll. */
+  getUpDirection(): OrbitPosition {
+    return this.getCameraFrame().up;
+  }
+
+  private getCameraFrame(): {right: OrbitPosition; up: OrbitPosition} {
+    const sineYaw = Math.sin(this.yaw);
+    const cosineYaw = Math.cos(this.yaw);
+    const sinePitch = Math.sin(this.pitch);
+    const cosinePitch = Math.cos(this.pitch);
+    const sineRoll = Math.sin(this.roll);
+    const cosineRoll = Math.cos(this.roll);
+    const right: OrbitPosition = [cosineYaw, 0, -sineYaw];
+    const up: OrbitPosition = [-sinePitch * sineYaw, cosinePitch, -sinePitch * cosineYaw];
+    return {
+      right: [
+        right[0] * cosineRoll - up[0] * sineRoll,
+        right[1] * cosineRoll - up[1] * sineRoll,
+        right[2] * cosineRoll - up[2] * sineRoll
+      ],
+      up: [
+        up[0] * cosineRoll + right[0] * sineRoll,
+        up[1] * cosineRoll + right[1] * sineRoll,
+        up[2] * cosineRoll + right[2] * sineRoll
+      ]
+    };
+  }
+
   /** Enables or pauses automatic rotation without losing the current manual angle. */
   setAutoRotate(autoRotate: boolean): void {
     this.props.autoRotate = autoRotate;
@@ -140,6 +175,9 @@ export class OrbitControls {
     if (props.pitch !== undefined || props.minPitch !== undefined || props.maxPitch !== undefined) {
       this.pitch = clampNumber(props.pitch ?? this.pitch, this.props.minPitch, this.props.maxPitch);
     }
+    if (props.roll !== undefined) {
+      this.roll = props.roll;
+    }
     if (
       props.distance !== undefined ||
       props.minDistance !== undefined ||
@@ -153,10 +191,11 @@ export class OrbitControls {
     }
   }
 
-  /** Restores the configured starting angle and zoom. */
+  /** Restores the configured starting orbit, roll, and zoom. */
   reset(): void {
     this.yaw = this.props.yaw;
     this.pitch = clampNumber(this.props.pitch, this.props.minPitch, this.props.maxPitch);
+    this.roll = this.props.roll;
     this.distance = clampNumber(
       this.props.distance,
       this.props.minDistance,
@@ -193,9 +232,10 @@ export class OrbitControls {
     if (this.activePointers.size === 1) {
       this.lastPointer = [event.clientX, event.clientY];
     } else {
-      const {center, distance} = this.getMultiPointerState();
+      const {center, distance, angle} = this.getMultiPointerState();
       this.lastPointer = center;
       this.previousPinchDistance = distance;
+      this.previousPinchAngle = distance > 0 ? angle : null;
     }
     this.canvas.setPointerCapture(event.pointerId);
     this.canvas.style.cursor = 'grabbing';
@@ -208,7 +248,7 @@ export class OrbitControls {
 
     this.activePointers.set(event.pointerId, [event.clientX, event.clientY]);
     if (this.activePointers.size > 1) {
-      const {center, distance} = this.getMultiPointerState();
+      const {center, distance, angle} = this.getMultiPointerState();
       if (this.props.enablePan) {
         this.panTarget(center[0] - this.lastPointer[0], center[1] - this.lastPointer[1]);
       }
@@ -219,8 +259,12 @@ export class OrbitControls {
           this.props.maxDistance
         );
       }
+      if (this.props.enableRotate && this.previousPinchAngle !== null && distance > 0) {
+        this.roll += normalizeAngleDelta(angle - this.previousPinchAngle);
+      }
       this.lastPointer = center;
       this.previousPinchDistance = distance;
+      this.previousPinchAngle = distance > 0 ? angle : null;
       return;
     }
 
@@ -249,6 +293,7 @@ export class OrbitControls {
     }
     this.activePointers.delete(event.pointerId);
     this.previousPinchDistance = null;
+    this.previousPinchAngle = null;
 
     const remainingPointer = this.activePointers.entries().next().value;
     if (remainingPointer) {
@@ -267,25 +312,28 @@ export class OrbitControls {
     }
     this.activePointers.clear();
     this.previousPinchDistance = null;
+    this.previousPinchAngle = null;
     this.canvas.style.cursor = 'grab';
   }
 
-  private getMultiPointerState(): {center: [number, number]; distance: number} {
+  private getMultiPointerState(): {center: [number, number]; distance: number; angle: number} {
     const [firstPointer, secondPointer] = this.activePointers.values();
     const deltaX = secondPointer[0] - firstPointer[0];
     const deltaY = secondPointer[1] - firstPointer[1];
     return {
       center: [(firstPointer[0] + secondPointer[0]) / 2, (firstPointer[1] + secondPointer[1]) / 2],
-      distance: Math.hypot(deltaX, deltaY)
+      distance: Math.hypot(deltaX, deltaY),
+      angle: Math.atan2(deltaY, deltaX)
     };
   }
 
   private panTarget(deltaX: number, deltaY: number): void {
     const panScale = this.distance * this.props.panSpeed;
+    const {right, up} = this.getCameraFrame();
     this.props.target = [
-      this.props.target[0] - Math.cos(this.yaw) * deltaX * panScale,
-      this.props.target[1] + deltaY * panScale,
-      this.props.target[2] + Math.sin(this.yaw) * deltaX * panScale
+      this.props.target[0] + (-right[0] * deltaX + up[0] * deltaY) * panScale,
+      this.props.target[1] + (-right[1] * deltaX + up[1] * deltaY) * panScale,
+      this.props.target[2] + (-right[2] * deltaX + up[2] * deltaY) * panScale
     ];
   }
 
@@ -306,4 +354,8 @@ export class OrbitControls {
 
 function clampNumber(value: number, minimum: number, maximum: number): number {
   return Math.min(Math.max(value, minimum), maximum);
+}
+
+function normalizeAngleDelta(angle: number): number {
+  return Math.atan2(Math.sin(angle), Math.cos(angle));
 }

--- a/modules/engine/test/controls/orbit-controls.spec.ts
+++ b/modules/engine/test/controls/orbit-controls.spec.ts
@@ -79,6 +79,27 @@ it('OrbitControls advances and bounds automatic rotation using millisecond times
   void 0;
 });
 
+it('OrbitControls derives its camera up direction from orbit pitch and roll', () => {
+  const controls = new OrbitControls(makeTestCanvas(), {
+    yaw: Math.PI / 2,
+    pitch: 0,
+    roll: Math.PI / 2
+  });
+
+  const upDirection = controls.getUpDirection();
+  expect(
+    Boolean(Math.abs(upDirection[0]) < 1e-12),
+    'rolls around the current viewing direction'
+  ).toBe(true);
+  expect(Boolean(Math.abs(upDirection[1]) < 1e-12), 'removes the original vertical component').toBe(
+    true
+  );
+  expect(upDirection[2], 'returns the rolled camera up axis').toBe(-1);
+
+  controls.destroy();
+  void 0;
+});
+
 it('OrbitControls captures pointer drags, clamps pitch, and ignores unrelated pointers', () => {
   const canvas = makeTestCanvas();
   let interactionCount = 0;
@@ -198,6 +219,44 @@ it('OrbitControls optionally pans its target while shift-dragging', () => {
   void 0;
 });
 
+it('OrbitControls pans in the rolled camera screen axes', () => {
+  const canvas = makeTestCanvas();
+  const controls = new OrbitControls(canvas, {
+    target: [0, 0, 0],
+    yaw: 0,
+    pitch: 0,
+    roll: Math.PI / 2,
+    distance: 10,
+    enablePan: true,
+    panSpeed: 0.1
+  });
+
+  canvas.dispatchTestEvent('pointerdown', {
+    button: 0,
+    pointerId: 5,
+    clientX: 0,
+    clientY: 0
+  });
+  canvas.dispatchTestEvent('pointermove', {
+    pointerId: 5,
+    clientX: 2,
+    clientY: 3,
+    shiftKey: true
+  });
+
+  const target = controls.props.target;
+  expect(Math.abs(target[0] - 3), 'maps vertical input along the rolled up axis').toBeLessThan(
+    1e-12
+  );
+  expect(Math.abs(target[1] - 2), 'maps horizontal input along the rolled right axis').toBeLessThan(
+    1e-12
+  );
+  expect(Math.abs(target[2]), 'keeps the pan inside the rolled screen plane').toBeLessThan(1e-12);
+
+  controls.destroy();
+  void 0;
+});
+
 it('OrbitControls pinch zooms with two touch pointers inside configured bounds', () => {
   const canvas = makeTestCanvas();
   let interactionCount = 0;
@@ -241,6 +300,61 @@ it('OrbitControls pinch zooms with two touch pointers inside configured bounds',
   void 0;
 });
 
+it('OrbitControls rolls its up direction with a two-finger twist across the angle boundary', () => {
+  const canvas = makeTestCanvas();
+  const controls = new OrbitControls(canvas, {
+    yaw: 1,
+    roll: 0.5,
+    distance: 10,
+    enableRotate: true,
+    enableZoom: false
+  });
+
+  canvas.dispatchTestEvent('pointerdown', {
+    button: 0,
+    pointerId: 1,
+    pointerType: 'touch',
+    clientX: 0,
+    clientY: 0
+  });
+  canvas.dispatchTestEvent('pointerdown', {
+    button: 0,
+    pointerId: 2,
+    pointerType: 'touch',
+    clientX: -100,
+    clientY: 1
+  });
+  canvas.dispatchTestEvent('pointermove', {
+    pointerId: 2,
+    clientX: -100,
+    clientY: -1
+  });
+
+  const expectedRoll = 0.5 + 2 * Math.atan2(1, 100);
+  expect(
+    Boolean(Math.abs(controls.roll - expectedRoll) < 1e-12),
+    'uses the shortest roll across -pi'
+  ).toBe(true);
+  expect(controls.yaw, 'leaves the orbit yaw unchanged').toBe(1);
+  expect(controls.distance, 'rotates independently of disabled pinch zoom').toBe(10);
+
+  canvas.dispatchTestEvent('pointerup', {pointerId: 2});
+  canvas.dispatchTestEvent('pointerdown', {
+    button: 0,
+    pointerId: 3,
+    pointerType: 'touch',
+    clientX: 100,
+    clientY: 0
+  });
+  expect(
+    Boolean(Math.abs(controls.roll - expectedRoll) < 1e-12),
+    'starts a new twist without reusing the previous pinch angle'
+  ).toBe(true);
+
+  controls.destroy();
+  void 0;
+});
+
 it('OrbitControls pans with the center of a two-finger touch gesture', () => {
   const canvas = makeTestCanvas();
   const controls = new OrbitControls(canvas, {
@@ -248,6 +362,7 @@ it('OrbitControls pans with the center of a two-finger touch gesture', () => {
     yaw: 0,
     pitch: 0,
     distance: 10,
+    enableRotate: false,
     enablePan: true,
     enableZoom: false,
     panSpeed: 0.01
@@ -272,7 +387,7 @@ it('OrbitControls pans with the center of a two-finger touch gesture', () => {
 
   expect(controls.props.target, 'moves the target with the touch midpoint').toEqual([-1, 2, 0]);
   expect(controls.distance, 'respects independently disabled touch zoom').toBe(10);
-  expect(controls.yaw, 'does not rotate while two touch pointers are active').toBe(0);
+  expect(controls.roll, 'respects independently disabled up-axis rotation').toBe(0);
 
   canvas.dispatchTestEvent('pointerup', {pointerId: 4});
   expect(canvas.hasPointerCapture(4), 'releases the lifted touch pointer').toBe(false);
@@ -283,6 +398,40 @@ it('OrbitControls pans with the center of a two-finger touch gesture', () => {
     Boolean(controls.yaw < 0),
     'continues one-finger orbiting without a pointer-position jump'
   ).toBe(true);
+
+  controls.destroy();
+  void 0;
+});
+
+it('OrbitControls disables up-axis rotation without disabling orbit or zoom', () => {
+  const canvas = makeTestCanvas();
+  const controls = new OrbitControls(canvas, {
+    yaw: 0,
+    distance: 10,
+    enableRotate: false
+  });
+
+  canvas.dispatchTestEvent('pointerdown', {
+    button: 0,
+    pointerId: 7,
+    pointerType: 'touch',
+    clientX: 0,
+    clientY: 0
+  });
+  canvas.dispatchTestEvent('pointermove', {pointerId: 7, clientX: 20, clientY: 0});
+  expect(controls.yaw, 'continues one-finger orbiting').toBe(-0.12);
+
+  canvas.dispatchTestEvent('pointerdown', {
+    button: 0,
+    pointerId: 8,
+    pointerType: 'touch',
+    clientX: 120,
+    clientY: 0
+  });
+  canvas.dispatchTestEvent('pointermove', {pointerId: 8, clientX: 20, clientY: 200});
+
+  expect(controls.roll, 'ignores two-finger up-axis rotation').toBe(0);
+  expect(Boolean(controls.distance < 10), 'continues to apply pinch zoom').toBe(true);
 
   controls.destroy();
   void 0;
@@ -403,6 +552,7 @@ it('OrbitControls updates camera configuration, preserves live state, and resets
   const controls = new OrbitControls(makeTestCanvas(), {
     yaw: 0.1,
     pitch: 0.2,
+    roll: 0.3,
     distance: 8,
     maxDistance: 20
   });
@@ -412,6 +562,7 @@ it('OrbitControls updates camera configuration, preserves live state, and resets
     target,
     yaw: 0.7,
     pitch: 1,
+    roll: 0.6,
     maxPitch: 0.5,
     distance: 25,
     maxDistance: 15
@@ -421,6 +572,7 @@ it('OrbitControls updates camera configuration, preserves live state, and resets
   expect(controls.props.target, 'copies dynamically updated orbit targets').toEqual([3, 4, 5]);
   expect(controls.yaw, 'applies the updated yaw immediately').toBe(0.7);
   expect(controls.pitch, 'clamps pitch against its updated limit').toBe(0.5);
+  expect(controls.roll, 'applies the updated roll immediately').toBe(0.6);
   expect(controls.distance, 'clamps distance against its updated limit').toBe(15);
 
   controls.setProps({minDistance: 2});
@@ -428,11 +580,13 @@ it('OrbitControls updates camera configuration, preserves live state, and resets
 
   controls.yaw = 0;
   controls.pitch = 0;
+  controls.roll = 0;
   controls.distance = 4;
   controls.reset();
 
   expect(controls.yaw, 'resets to the latest configured yaw').toBe(0.7);
   expect(controls.pitch, 'resets to the latest bounded pitch').toBe(0.5);
+  expect(controls.roll, 'resets to the latest configured roll').toBe(0.6);
   expect(controls.distance, 'resets to the latest bounded distance').toBe(15);
 
   controls.destroy();


### PR DESCRIPTION
## Summary

- add opt-in two-finger roll that rotates the camera up axis without disabling yaw/pitch orbiting
- expose roll state and getUpDirection() for view-matrix construction
- translate pan deltas through the rolled camera right/up basis
- enable and apply pinch roll in the Gaussian splat viewer, including its custom camera frame
- document the new control option and interaction behavior

## Verification

- nvm use
- yarn lint fix
- yarn test-node (3,205 passed; 1 skipped)
- yarn build
- git diff --check

Not run: yarn install (existing dependencies used), full yarn test, yarn website:build, and (cd website && yarn build). CI runs the repository gates.