### PR TITLE
chore: add required metadata to package manifests

### DIFF
--- a/modules/deck-arrow-layers/package.json
+++ b/modules/deck-arrow-layers/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "description": "deck.gl layers backed by Apache Arrow and luma.gl GPU vectors",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/luma.gl"
+  },
   "type": "module",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",

--- a/modules/deck-gpu-layers/package.json
+++ b/modules/deck-gpu-layers/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "description": "deck.gl layers using the WebGPU-only GPU compute graph",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/luma.gl"
+  },
   "type": "module",
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",

--- a/modules/scene/package.json
+++ b/modules/scene/package.json
@@ -5,6 +5,13 @@
   "description": "ANARI-inspired declarative rendering for luma.gl",
   "type": "module",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/luma.gl"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",
   "module": "dist/index.js",


### PR DESCRIPTION
#### Change List
- Missing repository metadata required by trusted publisher
- Porting scene's publishConfig.access, which was already added to 9.4-release branch
