### PR TITLE
fix(core): resize the default framebuffer after an external canvas resize

### DIFF
--- a/modules/core/src/adapter/canvas-surface.ts
+++ b/modules/core/src/adapter/canvas-surface.ts
@@ -140,6 +140,8 @@ export abstract class CanvasSurface {
   protected destroyed = false;
   /** Whether the drawing buffer size needs to be resized (deferred resizing to avoid flicker) */
   protected _needsDrawingBufferResize: boolean = true;
+  /** Drawing buffer size the device was last configured for; subclass constructors configure at the initial canvas size */
+  protected _configuredDrawingBufferSize: [number, number] = [0, 0];
 
   abstract get [Symbol.toStringTag](): string;
 
@@ -182,6 +184,7 @@ export abstract class CanvasSurface {
     this.devicePixelHeight = this.canvas.height;
     this.drawingBufferWidth = this.canvas.width;
     this.drawingBufferHeight = this.canvas.height;
+    this._configuredDrawingBufferSize = [this.canvas.width, this.canvas.height];
     this.devicePixelRatio = globalThis.devicePixelRatio || 1;
     this._position = [0, 0];
     this._canvasObserver = new CanvasObserver({
@@ -435,13 +438,21 @@ export abstract class CanvasSurface {
   _resizeDrawingBufferIfNeeded() {
     if (this._needsDrawingBufferResize) {
       this._needsDrawingBufferResize = false;
-      const sizeChanged =
+      const canvasSizeChanged =
         this.drawingBufferWidth !== this.canvas.width ||
         this.drawingBufferHeight !== this.canvas.height;
-      if (sizeChanged) {
+      if (canvasSizeChanged) {
         this.canvas.width = this.drawingBufferWidth;
         this.canvas.height = this.drawingBufferHeight;
+      }
+      // The canvas owner may already have resized the canvas; the device still needs to follow.
+      const [configuredWidth, configuredHeight] = this._configuredDrawingBufferSize;
+      const configuredSizeChanged =
+        this.drawingBufferWidth !== configuredWidth ||
+        this.drawingBufferHeight !== configuredHeight;
+      if (configuredSizeChanged) {
         this._configureDevice();
+        this._configuredDrawingBufferSize = [this.drawingBufferWidth, this.drawingBufferHeight];
       }
     }
   }

--- a/modules/webgl/test/adapter/resources/webgl-render-pass.spec.ts
+++ b/modules/webgl/test/adapter/resources/webgl-render-pass.spec.ts
@@ -141,3 +141,29 @@ it('WEBGLRenderPass flushes deferred default canvas resize', async () => {
   renderPass.end();
   device.destroy();
 });
+
+it('WEBGLRenderPass resizes the default framebuffer after an external canvas resize', async () => {
+  const device = await getWebGLTestDevice();
+  const canvasContext = device.getDefaultCanvasContext();
+  const canvas = canvasContext.canvas as HTMLCanvasElement;
+  canvasContext.setDrawingBufferSize(300, 150);
+  new WEBGLRenderPass(device, {}).end();
+  const framebuffer = canvasContext.getCurrentFramebuffer();
+
+  expect(framebuffer.width, 'framebuffer follows the luma-driven resize').toBe(300);
+
+  // Another library owning the canvas (for example a basemap) has already resized it.
+  canvas.width = 640;
+  canvas.height = 480;
+  canvasContext.setDrawingBufferSize(640, 480);
+
+  expect(framebuffer.width, 'framebuffer is unchanged before default render pass').toBe(300);
+
+  const renderPass = new WEBGLRenderPass(device, {});
+
+  expect(framebuffer.width, 'default render pass resizes framebuffer width').toBe(640);
+  expect(framebuffer.height, 'default render pass resizes framebuffer height').toBe(480);
+
+  renderPass.end();
+  device.destroy();
+});


### PR DESCRIPTION
For #3177

#### Background

When a device is attached to an externally owned canvas (`autoResize: false`), the owner resizes the canvas and then calls `setDrawingBufferSize()` with the size the canvas already has. `_resizeDrawingBufferIfNeeded()` saw no difference between the tracked size and the canvas, so it skipped `_configureDevice()`, and the default `canvas-context-framebuffer` kept its previous size. Consumers that flip viewports against the framebuffer height (deck.gl's interleaved MapLibre/Mapbox overlays) then draw offset by the height difference after every resize. See visgl/deck.gl#9666 and the `Canvas sizing` row of #2743.

#### Change List

- `CanvasSurface` remembers the drawing-buffer size the device was last configured for (the initial canvas size, which the subclass constructors configure at). `_resizeDrawingBufferIfNeeded()` reconfigures when the tracked size differs from that, whether or not it had to write the size onto the canvas itself. Startup and luma-driven resizes behave exactly as before; the only added reconfigure is the case where the canvas owner already resized the canvas. No extra work on WebGPU, whose `_configureDevice()` is unconditional.
- Regression test in `webgl-render-pass.spec.ts`: an externally resized canvas plus `setDrawingBufferSize()` resizes the default framebuffer on the next default render pass.

Reproduces on the 9.4.0 release and on `master`. Verified with the standalone repro from the issue (framebuffer 300x150 stays before the fix, becomes 640x480 with it) and in a deck.gl 9.4.0-beta.4 + MapLibre 6 interleaved app with this change applied to the installed `@luma.gl/core`: shrinking, growing, globe and mercator all stay aligned after a resize.
