### PR TITLE
fix(core): adopt external drawing buffer size

### DIFF
--- a/modules/core/src/adapter/canvas-surface.ts
+++ b/modules/core/src/adapter/canvas-surface.ts
@@ -441,9 +441,29 @@ export abstract class CanvasSurface {
       if (sizeChanged) {
         this.canvas.width = this.drawingBufferWidth;
         this.canvas.height = this.drawingBufferHeight;
-        this._configureDevice();
       }
+      // Reconfigure even when the canvas already had the requested size. An external owner of
+      // canvas sizing (e.g. a base map in deck.gl's interleaved mode) resizes the canvas itself
+      // and then reports the new size via setDrawingBufferSize(), so the canvas never needs to be
+      // written here. Backend resources derived from the drawing buffer size still need to be
+      // reconciled, so a requested resize must not be dropped just because the canvas agrees.
+      this._configureDevice();
+      return;
     }
+    // No resize was requested, but the canvas may still have been resized behind luma.gl's back:
+    // an owner that changes only the backing store (e.g. a host pixel ratio change) does not move
+    // the content box, so the ResizeObserver never fires and no size is ever reported.
+    this._adoptExternalDrawingBufferSize();
+  }
+
+  protected _adoptExternalDrawingBufferSize(): void {
+    const {width, height} = this.canvas;
+    if (this.drawingBufferWidth === width && this.drawingBufferHeight === height) {
+      return;
+    }
+    this.drawingBufferWidth = width;
+    this.drawingBufferHeight = height;
+    this._configureDevice();
   }
 
   _observeDevicePixelRatio() {

--- a/modules/core/test/adapter/canvas-context.spec.ts
+++ b/modules/core/test/adapter/canvas-context.spec.ts
@@ -462,6 +462,111 @@ it('CanvasContext#_observeDevicePixelRatio clamps to max texture size in css-dpr
   void 0;
 });
 
+it('CanvasContext#_resizeDrawingBufferIfNeeded reconfigures when a reported size already matches the canvas', () => {
+  if (!isBrowser()) {
+    void 0;
+    return;
+  }
+
+  // An external owner of canvas sizing resizes the canvas and then reports the new size, so the
+  // canvas already agrees by the time luma.gl flushes. The requested reconfigure must still run,
+  // otherwise backend resources sized from the drawing buffer keep their previous size.
+  const canvasContext = new TestCanvasContext({autoResize: false, width: 400, height: 300}, false);
+  let configureDeviceCalls = 0;
+  (canvasContext as any)._configureDevice = () => {
+    configureDeviceCalls++;
+  };
+
+  canvasContext._resizeDrawingBufferIfNeeded();
+  configureDeviceCalls = 0;
+
+  canvasContext.canvas.width = 800;
+  canvasContext.canvas.height = 600;
+  canvasContext.setDrawingBufferSize(800, 600);
+  canvasContext._resizeDrawingBufferIfNeeded();
+
+  expect(
+    configureDeviceCalls,
+    'a reported resize reconfigures the device even when the canvas needs no write'
+  ).toBe(1);
+  expect(
+    [canvasContext.canvas.width, canvasContext.canvas.height],
+    'the externally owned canvas size is left untouched'
+  ).toEqual([800, 600]);
+
+  canvasContext.destroy();
+  void 0;
+});
+
+it('CanvasContext#_resizeDrawingBufferIfNeeded adopts externally driven canvas resizes', () => {
+  if (!isBrowser()) {
+    void 0;
+    return;
+  }
+
+  // autoResize: false means an external owner (e.g. a base map in deck.gl's interleaved mode)
+  // assigns canvas.width/height. luma.gl never observes those assignments, so the tracked
+  // drawing buffer size has to be reconciled from the canvas on read.
+  const canvasContext = new TestCanvasContext({autoResize: false, width: 400, height: 300}, false);
+  let configureDeviceCalls = 0;
+  (canvasContext as any)._configureDevice = () => {
+    configureDeviceCalls++;
+  };
+
+  // Clear the initial pending resize the constructor sets up
+  canvasContext._resizeDrawingBufferIfNeeded();
+  configureDeviceCalls = 0;
+
+  canvasContext.canvas.width = 800;
+  canvasContext.canvas.height = 600;
+  canvasContext._resizeDrawingBufferIfNeeded();
+
+  expect(
+    canvasContext.getDrawingBufferSize(),
+    'tracked drawing buffer size follows an externally resized canvas'
+  ).toEqual([800, 600]);
+  expect(configureDeviceCalls, 'device is reconfigured for the new canvas size').toBe(1);
+
+  // A second read with no further canvas change must not reconfigure again
+  canvasContext._resizeDrawingBufferIfNeeded();
+  expect(configureDeviceCalls, 'unchanged canvas size does not reconfigure the device').toBe(1);
+
+  canvasContext.destroy();
+  void 0;
+});
+
+it('CanvasContext#_resizeDrawingBufferIfNeeded still pushes luma.gl driven resizes to the canvas', () => {
+  if (!isBrowser()) {
+    void 0;
+    return;
+  }
+
+  const canvasContext = new TestCanvasContext({width: 400, height: 300}, false);
+  let configureDeviceCalls = 0;
+  (canvasContext as any)._configureDevice = () => {
+    configureDeviceCalls++;
+  };
+
+  canvasContext._resizeDrawingBufferIfNeeded();
+  configureDeviceCalls = 0;
+
+  canvasContext.setDrawingBufferSize(1000, 500);
+  canvasContext._resizeDrawingBufferIfNeeded();
+
+  expect(
+    [canvasContext.canvas.width, canvasContext.canvas.height],
+    'a pending luma.gl driven resize is written to the canvas'
+  ).toEqual([1000, 500]);
+  expect(
+    canvasContext.getDrawingBufferSize(),
+    'the requested drawing buffer size is not overwritten by the canvas'
+  ).toEqual([1000, 500]);
+  expect(configureDeviceCalls, 'device is reconfigured once for the luma.gl driven resize').toBe(1);
+
+  canvasContext.destroy();
+  void 0;
+});
+
 it('CanvasContext#_startObservers defers DOM observation until explicitly started', () => {
   if (!isBrowser()) {
     void 0;

--- a/modules/webgl/test/adapter/webgl-canvas-context.spec.ts
+++ b/modules/webgl/test/adapter/webgl-canvas-context.spec.ts
@@ -15,6 +15,40 @@ it('WebGLDevice#canvas context creation', async () => {
   ).toBe(true);
 });
 
+it('WebGLCanvasContext#default framebuffer tracks externally resized canvas', async () => {
+  const webGLTestDevice = await getWebGLTestDevice();
+  const canvasContext = webGLTestDevice.getDefaultCanvasContext();
+  const {canvas} = canvasContext;
+  const originalWidth = canvas.width;
+  const originalHeight = canvas.height;
+  const originalDrawingBufferSize = canvasContext.getDrawingBufferSize();
+
+  try {
+    const framebuffer = canvasContext.getCurrentFramebuffer();
+
+    // Simulate an external owner of canvas sizing, e.g. a base map in deck.gl's interleaved mode
+    canvas.width = originalWidth + 64;
+    canvas.height = originalHeight + 32;
+
+    const resizedFramebuffer = canvasContext.getCurrentFramebuffer();
+
+    expect(resizedFramebuffer, 'canvas context reuses its framebuffer wrapper').toBe(framebuffer);
+    expect(
+      [resizedFramebuffer.width, resizedFramebuffer.height],
+      'default framebuffer wrapper follows an externally resized canvas'
+    ).toEqual([canvas.width, canvas.height]);
+    expect(
+      canvasContext.getDrawingBufferSize(),
+      'tracked drawing buffer size follows an externally resized canvas'
+    ).toEqual([canvas.width, canvas.height]);
+  } finally {
+    canvas.width = originalWidth;
+    canvas.height = originalHeight;
+    canvasContext.setDrawingBufferSize(...originalDrawingBufferSize);
+    canvasContext.getCurrentFramebuffer();
+  }
+});
+
 it('WebGPU default canvas context reuses framebuffer wrappers', async () => {
   const webGPUDevice = await getWebGPUTestDevice();
   if (!webGPUDevice) {


### PR DESCRIPTION
#### Background

Basemap browser demo in deck broken in 9.4


https://github.com/user-attachments/assets/ddca20fe-a83e-4166-9c04-f99246dfec69

Not sure if this is the intended design in luma, putting up this as a potential fix

<!-- For all the PRs -->
#### Change List
- Detect out of sync buffer size and adopt in luma
- Tests
