### PR TITLE
fix(website): improve example panels and catalog

### DIFF
--- a/examples/api/render-bundles/app-ui.ts
+++ b/examples/api/render-bundles/app-ui.ts
@@ -3,7 +3,11 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {ColumnPanel, type Panel, type SettingsSchema} from '@deck.gl-community/panels';
-import {ExampleSettingsPanelManager, makeHtmlCustomPanel} from '../../example-panels';
+import {
+  ExampleSettingsPanelManager,
+  makeExampleTabbedPanel,
+  makeHtmlCustomPanel
+} from '../../example-panels';
 
 export const DEFAULT_DRAW_COUNT = 5000;
 const DRAW_COUNT_OPTIONS = [1000, DEFAULT_DRAW_COUNT, 10000];
@@ -16,9 +20,9 @@ export class RenderBundlesUI {
   private modeElement: HTMLElement | null = null;
 
   constructor(settingsPanel: ExampleSettingsPanelManager, drawCount: number) {
-    this.panel = new ColumnPanel({
-      id: 'api-render-bundles-controls',
-      title: 'Render Bundles',
+    const infoPanel = new ColumnPanel({
+      id: 'api-render-bundles-info',
+      title: 'Info',
       panels: [
         makeHtmlCustomPanel({
           id: 'api-render-bundles-description',
@@ -62,9 +66,13 @@ export class RenderBundlesUI {
               this.modeElement = null;
             };
           }
-        }),
-        settingsPanel.makePanel()
+        })
       ]
+    });
+    this.panel = makeExampleTabbedPanel({
+      id: 'api-render-bundles-controls',
+      title: 'Render Bundles',
+      panels: [infoPanel, settingsPanel.makePanel()]
     });
   }
 

--- a/examples/showcase/gltf/app.ts
+++ b/examples/showcase/gltf/app.ts
@@ -29,7 +29,7 @@ import GLTFCatalogApp, {
 } from './gltf-catalog-app';
 import {GLTF_EXTENSION_DEMOS, type GLTFExtensionDemo} from './gltf-extension-demos';
 import {GLTF_STUDIO_DEFAULT_VARIANT, type GLTFAnimationStudioState} from './gltf-animation-studio';
-import {GLTF_STUDIO_ASSETS, getGLTFStudioAsset} from './gltf-studio-assets';
+import {GLTF_ANIMATION_STUDIO_ASSETS, getGLTFStudioAsset} from './gltf-studio-assets';
 
 const PBR_ENVIRONMENT_BASE_URL =
   'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/luma.gl/examples/gltf';
@@ -178,13 +178,11 @@ export default class AppAnimationLoopTemplate extends GLTFCatalogApp {
     const selectedModelOption = getInitialModelOption(this.modelOptions, currentModelName);
     this.selectedModelValue = encodeModelOption(selectedModelOption);
     this.syncSettingsPanel();
-    if (
-      this.extensionName !== ALL_EXTENSIONS_FILTER &&
-      this.extensionName !== STUDIO_ASSETS_FILTER
-    ) {
-      this.loadModelOption(selectedModelOption);
-    }
     return () => {};
+  }
+
+  override getInitialModelReference(currentModelName: string): GLTFModelReference {
+    return getInitialModelOption(this.modelOptions, currentModelName);
   }
 
   override drawBackground(renderPass: RenderPass): void {
@@ -541,10 +539,12 @@ function getModelOptionsForExtension(
 ): ShowcaseModelMenuOption[] {
   if (extensionName === STUDIO_ASSETS_FILTER) {
     const availableNames = new Set(allModels.map(model => model.name));
-    return GLTF_STUDIO_ASSETS.filter(asset => availableNames.has(asset.name)).map(asset => ({
-      ...asset.model,
-      label: asset.label
-    }));
+    return GLTF_ANIMATION_STUDIO_ASSETS.filter(asset => availableNames.has(asset.name)).map(
+      asset => ({
+        ...asset.model,
+        label: asset.label
+      })
+    );
   }
   if (extensionName === ALL_EXTENSIONS_FILTER) {
     return allModels;

--- a/examples/showcase/gltf/gltf-catalog-app.ts
+++ b/examples/showcase/gltf/gltf-catalog-app.ts
@@ -310,20 +310,22 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           : models.find(model => model.name === this.getDefaultModelName())?.name ||
             models[0]?.name ||
             initialModelName;
-        if (!this.referenceCaptureOptions) {
-          window.localStorage[modelStorageKey] = currentModelName;
-        }
         const cleanupModelMenu = this.initializeModelMenus(models, currentModelName);
         this.cleanupCallbacks.push(cleanupModelMenu);
-        this.loadGLTF(
-          this.referenceCaptureOptions
-            ? {
-                name: this.referenceCaptureOptions.modelName,
-                variant: this.referenceCaptureOptions.variant,
-                fileName: this.referenceCaptureOptions.fileName
-              }
-            : currentModelName
-        );
+        const initialModelReference = this.referenceCaptureOptions
+          ? {
+              name: this.referenceCaptureOptions.modelName,
+              variant: this.referenceCaptureOptions.variant,
+              fileName: this.referenceCaptureOptions.fileName
+            }
+          : this.getInitialModelReference(currentModelName);
+        if (!this.referenceCaptureOptions) {
+          window.localStorage[modelStorageKey] =
+            typeof initialModelReference === 'string'
+              ? initialModelReference
+              : initialModelReference.name;
+        }
+        this.loadGLTF(initialModelReference);
       })
       .catch(error => {
         log.error(
@@ -385,6 +387,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       this.loadGLTF(modelName);
       window.localStorage[this.getModelStorageKey()] = modelName;
     });
+  }
+
+  getInitialModelReference(currentModelName: string): string | GLTFModelReference {
+    return currentModelName;
   }
 
   getDefaultCameraTilt(_modelReference: Required<GLTFModelReference>): number {

--- a/examples/showcase/gltf/gltf-studio-assets.ts
+++ b/examples/showcase/gltf/gltf-studio-assets.ts
@@ -121,6 +121,11 @@ export function getGLTFStudioAssets(
 
 export const GLTF_STUDIO_ASSETS = getGLTFStudioAssets();
 
+/** Curated subset whose source files contain authored animation data. */
+export const GLTF_ANIMATION_STUDIO_ASSETS = GLTF_STUDIO_ASSETS.filter(
+  asset => asset.category === 'animation'
+);
+
 export function getGLTFStudioAsset(name: string): GLTFStudioAsset | undefined {
   return GLTF_STUDIO_ASSETS.find(asset => asset.name === name);
 }

--- a/test/examples/gltf-animation-studio.node.spec.ts
+++ b/test/examples/gltf-animation-studio.node.spec.ts
@@ -16,6 +16,7 @@ import {
 } from '../../examples/showcase/gltf/gltf-animation-studio';
 import {getGLTFReferenceLedger} from '../../examples/showcase/gltf/gltf-reference-ledger';
 import {
+  GLTF_ANIMATION_STUDIO_ASSETS,
   GLTF_STUDIO_ASSETS,
   ROBOT_EXPRESSIVE_SOURCE_REVISION,
   getGLTFStudioAsset
@@ -237,6 +238,15 @@ describe('curated glTF Animation Studio', () => {
         source: 'three.js',
         sourceRevision: ROBOT_EXPRESSIVE_SOURCE_REVISION
       })
+    );
+  });
+
+  test('limits the Animation Studio menu to authored animation assets', () => {
+    expect(GLTF_ANIMATION_STUDIO_ASSETS.length).toBeGreaterThan(0);
+    expect(GLTF_ANIMATION_STUDIO_ASSETS.every(asset => asset.category === 'animation')).toBe(true);
+    expect(GLTF_ANIMATION_STUDIO_ASSETS.map(asset => asset.name)).toContain('RobotExpressive');
+    expect(GLTF_ANIMATION_STUDIO_ASSETS.map(asset => asset.name)).not.toContain(
+      'DiffuseTransmissionPlant'
     );
   });
 

--- a/website/content/examples/experimental/advanced-effects.mdx
+++ b/website/content/examples/experimental/advanced-effects.mdx
@@ -10,14 +10,7 @@ sidebar_custom_props:
 
 import {AdvancedEffectsExample} from '@site/src/examples';
 
-<AdvancedEffectsExample>
-  <div>
-    A procedural city lit by cascaded sun, moving spot, local point, and contact shadows, then
-    composed through SSAO, screen-space reflections, volumetric fog, outlines, temporal AA, and
-    motion blur. Drag the comparison divider and use the debug controls to inspect every shadow
-    source.
-  </div>
-</AdvancedEffectsExample>
+<AdvancedEffectsExample />
 
 Open **Visualization Effects** to browse an accordion for each technique: cascaded and local
 shadow maps, contact shadows, SSAO, the shared SSR pipeline, height fog, outlines, temporal AA,

--- a/website/content/examples/experimental/deferred-rendering.mdx
+++ b/website/content/examples/experimental/deferred-rendering.mdx
@@ -11,18 +11,7 @@ sidebar_custom_props:
 
 import {DeferredRenderingExample} from '@site/src/examples';
 
-<DeferredRenderingExample>
-  <div>
-    A WebGPU-only illumination laboratory that writes five surface targets once, then reconstructs
-    view position from depth and resolves a directional light plus hundreds of compute-clustered
-    storage-buffer point lights in one fullscreen pass. Temporally stabilized GTAO grounds the
-    contacts, diffuse screen-space global illumination transfers colored light between surfaces,
-    stochastic reflections bounce the animated scene across polished floors, and clustered
-    participating media turns the same point lights and sun into colored atmospheric halos and
-    depth-occluded crepuscular god rays. GPU-driven adaptive exposure and floating-point multiscale
-    bloom finish the scene without clipping its brightest highlights.
-  </div>
-</DeferredRenderingExample>
+<DeferredRenderingExample />
 
 Open **Illumination Effects** to inspect the actual render-stack stages through separate
 accordions for clustered deferred lighting, GTAO, diffuse global illumination, screen-space

--- a/website/content/examples/showcase/packet-spraying.mdx
+++ b/website/content/examples/showcase/packet-spraying.mdx
@@ -11,13 +11,4 @@ sidebar_custom_props:
 
 import {PacketSprayingExample} from '@site/src/examples';
 
-<PacketSprayingExample>
-  <div>
-    Two servers send red and green transfers to two destination servers. Their packets interleave
-    on shared links, spread across independent network planes, and separate again at their
-    destinations. Emissive packets illuminate nearby glass switches, metallic server cubes, and
-    reflective links before selective bloom and filmic tone mapping. The example demonstrates the
-    throughput and resilience advantages of Multipath Reliable Connection (MRC), alongside reusable
-    optical materials and order-independent transparency.
-  </div>
-</PacketSprayingExample>
+<PacketSprayingExample />

--- a/website/content/examples/table-of-contents.json
+++ b/website/content/examples/table-of-contents.json
@@ -10,13 +10,7 @@
     "items": [
       "showcase/gaussian-splat-viewer",
       "showcase/gaussian-splats",
-      "showcase/gltf",
       "showcase/instancing",
-      {
-        "type": "doc",
-        "id": "experimental/scene-playground",
-        "label": "Scene Playground"
-      },
       "showcase/globe",
       "showcase/packet-spraying",
       {
@@ -33,6 +27,12 @@
         "type": "doc",
         "id": "showcase/persistence",
         "label": "Effects: Persistence"
+      },
+      "showcase/gltf",
+      {
+        "type": "doc",
+        "id": "experimental/scene-playground",
+        "label": "Scene Playground"
       }
     ]
   },

--- a/website/src/react-luma/components/info-box.tsx
+++ b/website/src/react-luma/components/info-box.tsx
@@ -80,6 +80,15 @@ const INFO_BOX_CHROME_STYLE = `
 [data-info-box-appearance='cinematic'] [data-luma-example-source] .token.comment {
   color: var(--luma-example-text-muted) !important;
 }
+[data-info-box-appearance='cinematic'] [data-luma-example-info-content] pre {
+  background: var(--luma-example-surface) !important;
+  color: var(--luma-example-text) !important;
+}
+[data-info-box-appearance='cinematic'] [data-luma-example-info-content] :not(pre) > code {
+  background: var(--luma-example-surface-raised) !important;
+  border: 1px solid var(--luma-example-border) !important;
+  color: var(--luma-example-text) !important;
+}
 @media (prefers-reduced-motion: reduce) {
   [data-info-box-appearance] [data-luma-example-chrome-action] {
     transition: none;
@@ -631,6 +640,7 @@ function InfoBoxView(props: InfoBoxViewProps) {
         ) : null}
         <div
           ref={infoContentRef}
+          data-luma-example-info-content=""
           hidden={!hasPanelTabs && activeTab !== 'info'}
           aria-hidden={!hasPanelTabs && activeTab !== 'info'}
           style={{minWidth: 0, minHeight: 0, flex: '1 1 auto', overflow: 'auto'}}

--- a/website/src/react-luma/components/luma-example.tsx
+++ b/website/src/react-luma/components/luma-example.tsx
@@ -178,7 +178,7 @@ export const ExampleStage: FC<ExampleStageProps> = (props: ExampleStageProps) =>
   <div
     data-luma-example-page=""
     className={props.className}
-    style={{position: 'relative', width: '100%', overflow: 'hidden', ...props.style}}
+    style={{position: 'relative', width: '100%', height: '100%', overflow: 'hidden', ...props.style}}
   >
     {props.children}
   </div>


### PR DESCRIPTION
Goals

- Restore example website usability on the latest master after #3180 landed.
- Keep the same user-facing fixes available for the 9.4 release line.

Changes

- Move example descriptions into panel tabs and split Render Bundles settings into a dedicated tab.
- Improve dark-mode code contrast and restore Texture Tester page scrolling.
- Limit Animation Studio to glTF assets that actually contain animation-focused samples.
- Move glTF Asset Studio and Scene Playground to the bottom of Showcase.

Verification

- `nvm use`: unavailable in this shell (`nvm: command not found`).
- `yarn install`: dependencies already installed and lockfile validation passed.
- `yarn lint fix`: passed.
- `yarn build`: passed.
- `yarn test-node`: 3,258 passed, 7 skipped.
- `yarn test`: node phase passed; headless phase hit one unrelated flaky graph-slider assertion. A separate full `yarn test-headless` retry passed all 294 files / 1,938 tests.
- `yarn website:build`: passed; validated 876 raw documentation pages.
- `(cd website && yarn build)`: passed; validated 876 raw documentation pages.
- Production-build browser smoke check confirmed readable dark code colors, top-level packet-spraying tabs with no leading description, and Render Bundles Info / Settings / Source tabs.
