### PR TITLE
refactor(examples): separate additional example UI

### DIFF
--- a/examples/deck/gpu-culled-trace/app-ui.ts
+++ b/examples/deck/gpu-culled-trace/app-ui.ts
@@ -1,0 +1,113 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {PickingInfo} from '@deck.gl/core';
+import {ArrowExamplePanelManager} from '../../arrow/arrow-example-panels';
+import {makeHtmlCustomPanel} from '../../example-panels';
+import type {GPUTraceCullingStats} from './gpu-trace-culling-effect';
+import {getTraceRow, type makeDeckTraceData} from './trace-data';
+
+type TraceData = ReturnType<typeof makeDeckTraceData>;
+
+/** Owns the explanatory panels and tooltip for the GPU-culled trace example. */
+export class GPUCulledTraceUserInterface {
+  readonly panelManager: ArrowExamplePanelManager;
+
+  private readonly traceData: TraceData;
+  private statsElement: HTMLElement | null = null;
+  private cullingStats: GPUTraceCullingStats;
+
+  constructor(traceData: TraceData, initialStats: GPUTraceCullingStats) {
+    this.traceData = traceData;
+    this.cullingStats = initialStats;
+    this.panelManager = new ArrowExamplePanelManager({
+      descriptionHtml:
+        '<p style="margin:0;line-height:1.45">One WebGPU command graph culls trace blocks and row-indexed Arrow glyph records before deck.gl draws both layers indirectly.</p>',
+      settingsPanel: () =>
+        makeHtmlCustomPanel({
+          id: 'gpu-culled-trace-culling',
+          title: 'Culling',
+          html: '<div data-gpu-trace-culling-stats></div>',
+          onRender: root => {
+            this.statsElement = root.querySelector('[data-gpu-trace-culling-stats]');
+            renderCullingStats(this.statsElement, this.cullingStats);
+            return () => {
+              this.statsElement = null;
+            };
+          }
+        })
+    });
+    this.panelManager.setTableEntries([
+      {id: 'gpu-trace-text', label: 'Trace text', kind: 'source', table: traceData.textTable}
+    ]);
+  }
+
+  mount(): void {
+    this.panelManager.mount();
+  }
+
+  finalize(): void {
+    this.panelManager.finalize();
+  }
+
+  updateCullingStats(stats: GPUTraceCullingStats): void {
+    this.cullingStats = stats;
+    renderCullingStats(this.statsElement, stats);
+  }
+
+  getTooltip(info: PickingInfo): {html: string} | null {
+    const row = getTraceRow(this.traceData, info.index);
+    if (!row) return null;
+    return {
+      html: `<div><strong>${escapeHtml(row.name)}</strong></div>
+        <div>group: ${row.group}</div>
+        <div>start: ${row.start.toFixed(3)}</div>
+        <div>duration: ${row.duration.toFixed(3)}</div>
+        <div>lane: ${row.lane}</div>`
+    };
+  }
+}
+
+function renderCullingStats(element: HTMLElement | null, stats: GPUTraceCullingStats): void {
+  if (!element) return;
+  const glyphCounts = stats.totalGlyphs
+    ? `${formatCount(stats.visibleGlyphs)} / ${formatCount(stats.totalGlyphs)}`
+    : escapeHtml(stats.labelStatus);
+  element.innerHTML = `<div style="display:grid;grid-template-columns:1fr auto;gap:5px 16px;font:12px/1.45 system-ui,sans-serif;font-variant-numeric:tabular-nums">
+    <span>Visible blocks</span><strong>${formatCount(stats.visibleBlocks)} / ${formatCount(stats.totalBlocks)}</strong>
+    <span>Outside view</span><strong>${formatCount(stats.outsideBlocks)}</strong>
+    <span>Too small (&lt;1 px)</span><strong>${formatCount(stats.smallBlocks)}</strong>
+    <span>Visible glyphs</span><strong>${glyphCounts}</strong>
+    <span>Graph nodes</span><strong>${stats.graphNodeCount}</strong>
+    <span>CPU graph encode</span><strong>${stats.encodeTimeMilliseconds.toFixed(2)} ms</strong>
+    <span>Logical scratch</span><strong>${formatBytes(stats.logicalTransientBytes)}</strong>
+    <span>Physical scratch</span><strong>${formatBytes(stats.physicalTransientBytes)}</strong>
+    <span>Transient reuse</span><strong>${stats.transientReusePercentage.toFixed(0)}%</strong>
+  </div>`;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, character => {
+    const entities: Record<string, string> = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#039;'
+    };
+    return entities[character]!;
+  });
+}
+
+function formatCount(value: number): string {
+  return new Intl.NumberFormat('en-US', {notation: 'compact', maximumFractionDigits: 1}).format(
+    value
+  );
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KiB`;
+  return `${(value / 1024 / 1024).toFixed(1)} MiB`;
+}

--- a/examples/deck/gpu-culled-trace/app.ts
+++ b/examples/deck/gpu-culled-trace/app.ts
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import {OrthographicView, type PickingInfo, type ViewStateChangeParameters} from '@deck.gl/core';
+import {OrthographicView, type ViewStateChangeParameters} from '@deck.gl/core';
 import {buildSdfFontAtlas} from '@luma.gl/text';
-import {ArrowExamplePanelManager} from '../../arrow/arrow-example-panels';
-import {makeHtmlCustomPanel} from '../../example-panels';
 import {ArrowDeck} from '../arrow-deck';
 import {
   getDeckExampleProps,
@@ -15,7 +13,8 @@ import {
 import {GPUCulledArrowTextLayer} from './gpu-culled-arrow-text-layer';
 import {GPUCulledTraceLayer} from './gpu-culled-trace-layer';
 import {GPUTraceCullingEffect, type GPUTraceCullingStats} from './gpu-trace-culling-effect';
-import {getTraceRow, makeDeckTraceData} from './trace-data';
+import {GPUCulledTraceUserInterface} from './app-ui';
+import {makeDeckTraceData} from './trace-data';
 
 const TRACE_ROW_COUNT = 25_000;
 const TRACE_LANE_WINDOW = 72;
@@ -38,7 +37,6 @@ export function createGPUCulledTraceDeck(
   let autoScroll = true;
   let restoreShaderAssembler: (() => void) | null = null;
   let viewState: TraceViewState = {target: [150, TRACE_LANE_WINDOW / 2, 0], zoom: 0};
-  let statsElement: HTMLElement | null = null;
   let cullingStats: GPUTraceCullingStats = {
     totalBlocks: traceData.count,
     visibleBlocks: 0,
@@ -53,27 +51,8 @@ export function createGPUCulledTraceDeck(
     transientReusePercentage: 0,
     labelStatus: 'Waiting for label layer'
   };
-  const panelManager = new ArrowExamplePanelManager({
-    descriptionHtml:
-      '<p style="margin:0;line-height:1.45">One WebGPU command graph culls trace blocks and row-indexed Arrow glyph records before deck.gl draws both layers indirectly.</p>',
-    settingsPanel: () =>
-      makeHtmlCustomPanel({
-        id: 'gpu-culled-trace-culling',
-        title: 'Culling',
-        html: '<div data-gpu-trace-culling-stats></div>',
-        onRender: root => {
-          statsElement = root.querySelector('[data-gpu-trace-culling-stats]');
-          renderCullingStats(statsElement, cullingStats);
-          return () => {
-            statsElement = null;
-          };
-        }
-      })
-  });
-  panelManager.setTableEntries([
-    {id: 'gpu-trace-text', label: 'Trace text', kind: 'source', table: traceData.textTable}
-  ]);
-  panelManager.mount();
+  const userInterface = new GPUCulledTraceUserInterface(traceData, cullingStats);
+  userInterface.mount();
 
   let deck: ArrowDeck<OrthographicView>;
   deck = new ArrowDeck({
@@ -98,7 +77,7 @@ export function createGPUCulledTraceDeck(
       restoreShaderAssembler = null;
       throw error;
     },
-    getTooltip: info => getTooltip(traceData, info),
+    getTooltip: info => userInterface.getTooltip(info),
     onViewStateChange: ({viewState: nextViewState}: ViewStateChangeParameters) => {
       viewState = nextViewState as TraceViewState;
       autoScroll = false;
@@ -109,7 +88,7 @@ export function createGPUCulledTraceDeck(
       cullingEffect = new GPUTraceCullingEffect(device, traceData, {
         onStats: stats => {
           cullingStats = stats;
-          renderCullingStats(statsElement, stats);
+          userInterface.updateCullingStats(stats);
         }
       });
       const resources = cullingEffect.resources;
@@ -158,7 +137,7 @@ export function createGPUCulledTraceDeck(
       restoreShaderAssembler?.();
       restoreShaderAssembler = null;
       cancelAnimationFrame(animationFrame);
-      panelManager.finalize();
+      userInterface.finalize();
     }
   });
 
@@ -185,21 +164,6 @@ export function createGPUCulledTraceDeck(
   return deck;
 }
 
-function getTooltip(
-  data: ReturnType<typeof makeDeckTraceData>,
-  info: PickingInfo
-): {html: string} | null {
-  const row = getTraceRow(data, info.index);
-  if (!row) return null;
-  return {
-    html: `<div><strong>${escapeHtml(row.name)}</strong></div>
-      <div>group: ${row.group}</div>
-      <div>start: ${row.start.toFixed(3)}</div>
-      <div>duration: ${row.duration.toFixed(3)}</div>
-      <div>lane: ${row.lane}</div>`
-  };
-}
-
 function getFontAtlas(): ReturnType<typeof buildSdfFontAtlas> {
   fontAtlas ??= buildSdfFontAtlas({
     characterSet: ' abcdefghijklmnopqrstuvwxyz0123456789-μé',
@@ -210,47 +174,4 @@ function getFontAtlas(): ReturnType<typeof buildSdfFontAtlas> {
     radius: 10
   });
   return fontAtlas;
-}
-
-function escapeHtml(value: string): string {
-  return value.replace(/[&<>"']/g, character => {
-    const entities: Record<string, string> = {
-      '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      '"': '&quot;',
-      "'": '&#039;'
-    };
-    return entities[character]!;
-  });
-}
-
-function renderCullingStats(element: HTMLElement | null, stats: GPUTraceCullingStats): void {
-  if (!element) return;
-  const glyphCounts = stats.totalGlyphs
-    ? `${formatCount(stats.visibleGlyphs)} / ${formatCount(stats.totalGlyphs)}`
-    : escapeHtml(stats.labelStatus);
-  element.innerHTML = `<div style="display:grid;grid-template-columns:1fr auto;gap:5px 16px;font:12px/1.45 system-ui,sans-serif;font-variant-numeric:tabular-nums">
-    <span>Visible blocks</span><strong>${formatCount(stats.visibleBlocks)} / ${formatCount(stats.totalBlocks)}</strong>
-    <span>Outside view</span><strong>${formatCount(stats.outsideBlocks)}</strong>
-    <span>Too small (&lt;1 px)</span><strong>${formatCount(stats.smallBlocks)}</strong>
-    <span>Visible glyphs</span><strong>${glyphCounts}</strong>
-    <span>Graph nodes</span><strong>${stats.graphNodeCount}</strong>
-    <span>CPU graph encode</span><strong>${stats.encodeTimeMilliseconds.toFixed(2)} ms</strong>
-    <span>Logical scratch</span><strong>${formatBytes(stats.logicalTransientBytes)}</strong>
-    <span>Physical scratch</span><strong>${formatBytes(stats.physicalTransientBytes)}</strong>
-    <span>Transient reuse</span><strong>${stats.transientReusePercentage.toFixed(0)}%</strong>
-  </div>`;
-}
-
-function formatCount(value: number): string {
-  return new Intl.NumberFormat('en-US', {notation: 'compact', maximumFractionDigits: 1}).format(
-    value
-  );
-}
-
-function formatBytes(value: number): string {
-  if (value < 1024) return `${value} B`;
-  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KiB`;
-  return `${(value / 1024 / 1024).toFixed(1)} MiB`;
 }

--- a/examples/experimental/lucim-volume-lab/app-ui.ts
+++ b/examples/experimental/lucim-volume-lab/app-ui.ts
@@ -1,0 +1,220 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  ExamplePanelManager,
+  makeExamplePanelHostHtml,
+  makeHtmlCustomPanel
+} from '../../example-panels';
+import {VOLUME_LAB_DEFAULT_THRESHOLD, type VolumeLabDataset} from './volume-lab-data';
+import type {VolumeLabAnalysisStatus} from './volume-lab-engine';
+import type {VolumeLabDisplayMode, VolumeLabDisplaySettings} from './volume-lab-renderer';
+
+export const VOLUME_LAB_INFO_HTML = makeExamplePanelHostHtml();
+
+type VolumeLabEncodingStats = {
+  nodeCount: number;
+  computePassCount: number;
+  cpuEncodeTimeMilliseconds: number;
+};
+
+type VolumeLabUserInterfaceProps = {
+  dataset: VolumeLabDataset;
+  residentByteLength: number;
+  nodeCount: number;
+  initialSettings: VolumeLabDisplaySettings;
+  onThresholdChange: (threshold: number) => void;
+  onSettingsChange: (settings: VolumeLabDisplaySettings) => void;
+};
+
+/** Owns the controls and compact readback status for the LuCIM volume lab. */
+export class VolumeLabUserInterface {
+  readonly panels: ExamplePanelManager;
+
+  private readonly props: VolumeLabUserInterfaceProps;
+  private settings: VolumeLabDisplaySettings;
+  private statusElement: HTMLElement | null = null;
+  private encodeElement: HTMLElement | null = null;
+  private thresholdDebounce: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(props: VolumeLabUserInterfaceProps) {
+    this.props = props;
+    this.settings = props.initialSettings;
+    this.panels = new ExamplePanelManager({
+      panel: makeHtmlCustomPanel({
+        id: 'lucim-volume-lab-controls',
+        title: 'LuCIM Volume Lab',
+        html: this.getControlsHtml(),
+        onRender: root => this.attachControls(root)
+      })
+    });
+  }
+
+  mount(): void {
+    this.panels.mount();
+  }
+
+  finalize(): void {
+    if (this.thresholdDebounce) clearTimeout(this.thresholdDebounce);
+    this.panels.finalize();
+  }
+
+  updateEncoding(stats: VolumeLabEncodingStats): void {
+    if (!this.encodeElement) return;
+    this.encodeElement.textContent =
+      `${stats.nodeCount} nodes · ${stats.computePassCount} compute passes · ` +
+      `${stats.cpuEncodeTimeMilliseconds.toFixed(2)} ms CPU encode`;
+  }
+
+  updateAnalysisStatus(status: VolumeLabAnalysisStatus): void {
+    if (!this.statusElement) return;
+    const convergence = status.converged ? 'converged' : 'failed closed';
+    const overflow = status.regionOverflow ? 'capacity overflow' : 'capacity safe';
+    this.statusElement.innerHTML =
+      `<strong>${convergence}</strong> in ${status.iterationCount} rounds · ${overflow}<br />` +
+      'Only convergence, iteration, and overflow scalars were read back.';
+  }
+
+  private attachControls(root: HTMLElement): void {
+    this.statusElement = root.querySelector('[data-volume-status]');
+    this.encodeElement = root.querySelector('[data-volume-encode]');
+    const threshold = getInput(root, '[data-volume-threshold]');
+    const thresholdValue = getElement(root, '[data-volume-threshold-value]');
+    threshold.addEventListener('input', () => {
+      thresholdValue.textContent = `${Number(threshold.value).toFixed(0)} HU`;
+      if (this.thresholdDebounce) clearTimeout(this.thresholdDebounce);
+      this.thresholdDebounce = setTimeout(() => {
+        this.thresholdDebounce = null;
+        this.props.onThresholdChange(Number(threshold.value));
+      }, 90);
+    });
+
+    const mode = root.querySelector<HTMLSelectElement>('[data-volume-mode]');
+    mode?.addEventListener('change', () => {
+      this.updateSettings({mode: mode.value as VolumeLabDisplayMode});
+    });
+    this.attachNumberControl(root, 'window-center', value =>
+      this.updateSettings({windowCenter: value})
+    );
+    this.attachNumberControl(root, 'window-width', value =>
+      this.updateSettings({windowWidth: value})
+    );
+    this.attachNumberControl(root, 'overlay-opacity', value =>
+      this.updateSettings({overlayOpacity: value})
+    );
+    this.attachSliceControl(root, 'slice-x', 0);
+    this.attachSliceControl(root, 'slice-y', 1);
+    this.attachSliceControl(root, 'slice-z', 2);
+    root.querySelector('[data-volume-reset-slices]')?.addEventListener('click', () => {
+      const {width, height, depth} = this.props.dataset.metadata;
+      const slices: [number, number, number] = [
+        Math.floor(width / 2),
+        Math.floor(height / 2),
+        Math.floor(depth / 2)
+      ];
+      this.updateSettings({slices});
+      for (const [index, axis] of (['x', 'y', 'z'] as const).entries()) {
+        const value = slices[index]!;
+        const input = getInput(root, `[data-volume-slice-${axis}]`);
+        input.value = String(value);
+        getElement(root, `[data-volume-slice-${axis}-value]`).textContent = String(value);
+      }
+    });
+  }
+
+  private updateSettings(settings: Partial<VolumeLabDisplaySettings>): void {
+    this.settings = {...this.settings, ...settings};
+    this.props.onSettingsChange(this.settings);
+  }
+
+  private attachNumberControl(
+    root: HTMLElement,
+    name: string,
+    update: (value: number) => void
+  ): void {
+    const input = getInput(root, `[data-volume-${name}]`);
+    const output = getElement(root, `[data-volume-${name}-value]`);
+    input.addEventListener('input', () => {
+      const value = Number(input.value);
+      output.textContent = name === 'overlay-opacity' ? value.toFixed(2) : value.toFixed(0);
+      update(value);
+    });
+  }
+
+  private attachSliceControl(root: HTMLElement, name: string, axis: 0 | 1 | 2): void {
+    const input = getInput(root, `[data-volume-${name}]`);
+    const output = getElement(root, `[data-volume-${name}-value]`);
+    input.addEventListener('input', () => {
+      const slices: [number, number, number] = [...this.settings.slices];
+      slices[axis] = Number(input.value);
+      output.textContent = input.value;
+      this.updateSettings({slices});
+    });
+  }
+
+  private getControlsHtml(): string {
+    const {width, height, depth, spacing} = this.props.dataset.metadata;
+    const [sliceX, sliceY, sliceZ] = this.settings.slices;
+    return `
+      <style>
+        [data-lucim-volume-lab] { color: #d9eff5; font: 12px/1.4 system-ui, sans-serif; }
+        [data-lucim-volume-lab] .volume-intro { color: #9fc4ce; margin: 0 0 12px; }
+        [data-lucim-volume-lab] .volume-views { color: #71d8e8; font-size: 11px; letter-spacing: .04em; margin-bottom: 12px; text-transform: uppercase; }
+        [data-lucim-volume-lab] label { display: grid; gap: 4px; margin: 9px 0; }
+        [data-lucim-volume-lab] label span { display: flex; justify-content: space-between; }
+        [data-lucim-volume-lab] input, [data-lucim-volume-lab] select, [data-lucim-volume-lab] button { width: 100%; }
+        [data-lucim-volume-lab] select, [data-lucim-volume-lab] button { background: #102633; border: 1px solid #2c5662; border-radius: 4px; color: #d9eff5; padding: 6px; }
+        [data-lucim-volume-lab] .volume-card { background: rgba(7, 24, 34, .78); border: 1px solid #214652; border-radius: 6px; margin-top: 10px; padding: 8px; }
+        [data-lucim-volume-lab] .volume-card strong { color: #7fe7f2; }
+      </style>
+      <div data-lucim-volume-lab>
+        <p class="volume-intro">Synthetic, non-diagnostic CT-like density. Persistent values, masks, labels, and region rows remain GPU-resident.</p>
+        <div class="volume-views">Axial · Coronal · Sagittal</div>
+        <label><span>Display</span><select data-volume-mode>
+          <option value="anatomy">Anatomy</option>
+          <option value="threshold">Threshold</option>
+          <option value="components" selected>Components</option>
+        </select></label>
+        ${makeRangeControl('threshold', 'Density threshold', -900, 1200, 10, VOLUME_LAB_DEFAULT_THRESHOLD, `${VOLUME_LAB_DEFAULT_THRESHOLD} HU`)}
+        ${makeRangeControl('window-center', 'Window center', -700, 600, 10, this.settings.windowCenter, String(this.settings.windowCenter))}
+        ${makeRangeControl('window-width', 'Window width', 100, 2200, 25, this.settings.windowWidth, String(this.settings.windowWidth))}
+        ${makeRangeControl('overlay-opacity', 'Overlay opacity', 0, 1, 0.02, this.settings.overlayOpacity, this.settings.overlayOpacity.toFixed(2))}
+        ${makeRangeControl('slice-x', 'Sagittal X', 0, width - 1, 1, sliceX, String(sliceX))}
+        ${makeRangeControl('slice-y', 'Coronal Y', 0, height - 1, 1, sliceY, String(sliceY))}
+        ${makeRangeControl('slice-z', 'Axial Z', 0, depth - 1, 1, sliceZ, String(sliceZ))}
+        <button type="button" data-volume-reset-slices>Center all slices</button>
+        <div class="volume-card"><strong>${width} × ${height} × ${depth}</strong> voxels · ${spacing.join(' × ')} mm<br />${formatBytes(this.props.residentByteLength)} resident including graph scratch · ${this.props.nodeCount} reusable nodes</div>
+        <div class="volume-card" data-volume-encode>Analysis queued</div>
+        <div class="volume-card" data-volume-status>Waiting for compact GPU status</div>
+      </div>`;
+  }
+}
+
+function makeRangeControl(
+  name: string,
+  label: string,
+  minimum: number,
+  maximum: number,
+  step: number,
+  value: number,
+  displayValue: string
+): string {
+  return `<label><span>${label}<output data-volume-${name}-value>${displayValue}</output></span><input data-volume-${name} type="range" min="${minimum}" max="${maximum}" step="${step}" value="${value}" /></label>`;
+}
+
+function getInput(root: HTMLElement, selector: string): HTMLInputElement {
+  const element = root.querySelector<HTMLInputElement>(selector);
+  if (!element) throw new Error(`Missing LuCIM Volume Lab input ${selector}`);
+  return element;
+}
+
+function getElement(root: HTMLElement, selector: string): HTMLElement {
+  const element = root.querySelector<HTMLElement>(selector);
+  if (!element) throw new Error(`Missing LuCIM Volume Lab element ${selector}`);
+  return element;
+}
+
+function formatBytes(byteLength: number): string {
+  return `${(byteLength / 1024 ** 2).toFixed(1)} MiB`;
+}

--- a/examples/experimental/lucim-volume-lab/app.ts
+++ b/examples/experimental/lucim-volume-lab/app.ts
@@ -4,22 +4,10 @@
 
 import type {Device} from '@luma.gl/core';
 import {AnimationLoopTemplate, type AnimationProps} from '@luma.gl/engine';
-import {
-  ExamplePanelManager,
-  makeExamplePanelHostHtml,
-  makeHtmlCustomPanel
-} from '../../example-panels';
-import {
-  VOLUME_LAB_DEFAULT_THRESHOLD,
-  makeVolumeLabDataset,
-  type VolumeLabDataset
-} from './volume-lab-data';
-import {VolumeLabEngine, type VolumeLabAnalysisStatus} from './volume-lab-engine';
-import {
-  VolumeLabRenderer,
-  type VolumeLabDisplayMode,
-  type VolumeLabDisplaySettings
-} from './volume-lab-renderer';
+import {VOLUME_LAB_INFO_HTML, VolumeLabUserInterface} from './app-ui';
+import {makeVolumeLabDataset, type VolumeLabDataset} from './volume-lab-data';
+import {VolumeLabEngine} from './volume-lab-engine';
+import {VolumeLabRenderer, type VolumeLabDisplaySettings} from './volume-lab-renderer';
 
 export const title = 'LuCIM Volume Lab';
 export const description =
@@ -29,20 +17,17 @@ type VolumeLabAnimationProps = AnimationProps & {dataset?: VolumeLabDataset};
 
 /** Interactive tri-planar inspection of one reusable LuCIM segmentation graph. */
 export default class VolumeLabAnimationLoopTemplate extends AnimationLoopTemplate {
-  static info = makeExamplePanelHostHtml();
+  static info = VOLUME_LAB_INFO_HTML;
   static props = {debug: true};
 
   readonly device: Device;
   readonly dataset: VolumeLabDataset;
   readonly engine: VolumeLabEngine;
   readonly renderer: VolumeLabRenderer;
-  readonly panels: ExamplePanelManager;
+  readonly userInterface: VolumeLabUserInterface;
 
   settings: VolumeLabDisplaySettings;
 
-  private statusElement: HTMLElement | null = null;
-  private encodeElement: HTMLElement | null = null;
-  private thresholdDebounce: ReturnType<typeof setTimeout> | null = null;
   private statusReadToken = 0;
   private finalized = false;
 
@@ -63,25 +48,23 @@ export default class VolumeLabAnimationLoopTemplate extends AnimationLoopTemplat
       windowWidth: 1450,
       overlayOpacity: 0.78
     };
-    this.panels = new ExamplePanelManager({
-      panel: makeHtmlCustomPanel({
-        id: 'lucim-volume-lab-controls',
-        title: 'LuCIM Volume Lab',
-        html: this.getControlsHtml(),
-        onRender: root => this.attachControls(root)
-      })
+    this.userInterface = new VolumeLabUserInterface({
+      dataset: this.dataset,
+      residentByteLength: this.engine.residentByteLength,
+      nodeCount: this.engine.nodeCount,
+      initialSettings: this.settings,
+      onThresholdChange: threshold => this.engine.setThreshold(threshold),
+      onSettingsChange: settings => {
+        this.settings = settings;
+      }
     });
-    this.panels.mount();
+    this.userInterface.mount();
   }
 
   override onRender({device}: AnimationProps): void {
     const encoding = this.engine.encodeIfNeeded(device.commandEncoder);
     if (encoding) {
-      if (this.encodeElement) {
-        this.encodeElement.textContent =
-          `${encoding.stats.nodeCount} nodes · ${encoding.stats.computePassCount} compute passes · ` +
-          `${encoding.stats.cpuEncodeTimeMilliseconds.toFixed(2)} ms CPU encode`;
-      }
+      this.userInterface.updateEncoding(encoding.stats);
       const version = this.engine.version;
       const token = ++this.statusReadToken;
       setTimeout(() => void this.readAnalysisStatus(version, token), 0);
@@ -93,8 +76,7 @@ export default class VolumeLabAnimationLoopTemplate extends AnimationLoopTemplat
   override onFinalize(): void {
     if (this.finalized) return;
     this.finalized = true;
-    if (this.thresholdDebounce) clearTimeout(this.thresholdDebounce);
-    this.panels.finalize();
+    this.userInterface.finalize();
     this.renderer.destroy();
     this.engine.destroy();
   }
@@ -108,152 +90,6 @@ export default class VolumeLabAnimationLoopTemplate extends AnimationLoopTemplat
     ) {
       return;
     }
-    this.updateAnalysisStatus(status);
+    this.userInterface.updateAnalysisStatus(status);
   }
-
-  private updateAnalysisStatus(status: VolumeLabAnalysisStatus): void {
-    if (!this.statusElement) return;
-    const convergence = status.converged ? 'converged' : 'failed closed';
-    const overflow = status.regionOverflow ? 'capacity overflow' : 'capacity safe';
-    this.statusElement.innerHTML =
-      `<strong>${convergence}</strong> in ${status.iterationCount} rounds · ${overflow}<br />` +
-      'Only convergence, iteration, and overflow scalars were read back.';
-  }
-
-  private attachControls(root: HTMLElement): void {
-    this.statusElement = root.querySelector('[data-volume-status]');
-    this.encodeElement = root.querySelector('[data-volume-encode]');
-    const threshold = getInput(root, '[data-volume-threshold]');
-    const thresholdValue = getElement(root, '[data-volume-threshold-value]');
-    threshold.addEventListener('input', () => {
-      thresholdValue.textContent = `${Number(threshold.value).toFixed(0)} HU`;
-      if (this.thresholdDebounce) clearTimeout(this.thresholdDebounce);
-      this.thresholdDebounce = setTimeout(() => {
-        this.thresholdDebounce = null;
-        this.engine.setThreshold(Number(threshold.value));
-      }, 90);
-    });
-
-    const mode = root.querySelector<HTMLSelectElement>('[data-volume-mode]');
-    mode?.addEventListener('change', () => {
-      this.settings = {...this.settings, mode: mode.value as VolumeLabDisplayMode};
-    });
-    this.attachNumberControl(root, 'window-center', value => {
-      this.settings = {...this.settings, windowCenter: value};
-    });
-    this.attachNumberControl(root, 'window-width', value => {
-      this.settings = {...this.settings, windowWidth: value};
-    });
-    this.attachNumberControl(root, 'overlay-opacity', value => {
-      this.settings = {...this.settings, overlayOpacity: value};
-    });
-    this.attachSliceControl(root, 'slice-x', 0);
-    this.attachSliceControl(root, 'slice-y', 1);
-    this.attachSliceControl(root, 'slice-z', 2);
-    root.querySelector('[data-volume-reset-slices]')?.addEventListener('click', () => {
-      const {width, height, depth} = this.dataset.metadata;
-      const slices: [number, number, number] = [
-        Math.floor(width / 2),
-        Math.floor(height / 2),
-        Math.floor(depth / 2)
-      ];
-      this.settings = {...this.settings, slices};
-      for (const [index, axis] of (['x', 'y', 'z'] as const).entries()) {
-        const value = slices[index]!;
-        const input = getInput(root, `[data-volume-slice-${axis}]`);
-        input.value = String(value);
-        getElement(root, `[data-volume-slice-${axis}-value]`).textContent = String(value);
-      }
-    });
-  }
-
-  private attachNumberControl(
-    root: HTMLElement,
-    name: string,
-    update: (value: number) => void
-  ): void {
-    const input = getInput(root, `[data-volume-${name}]`);
-    const output = getElement(root, `[data-volume-${name}-value]`);
-    input.addEventListener('input', () => {
-      const value = Number(input.value);
-      output.textContent = name === 'overlay-opacity' ? value.toFixed(2) : value.toFixed(0);
-      update(value);
-    });
-  }
-
-  private attachSliceControl(root: HTMLElement, name: string, axis: 0 | 1 | 2): void {
-    const input = getInput(root, `[data-volume-${name}]`);
-    const output = getElement(root, `[data-volume-${name}-value]`);
-    input.addEventListener('input', () => {
-      const slices: [number, number, number] = [...this.settings.slices];
-      slices[axis] = Number(input.value);
-      output.textContent = input.value;
-      this.settings = {...this.settings, slices};
-    });
-  }
-
-  private getControlsHtml(): string {
-    const {width, height, depth, spacing} = this.dataset.metadata;
-    const [sliceX, sliceY, sliceZ] = this.settings.slices;
-    return `
-      <style>
-        [data-lucim-volume-lab] { color: #d9eff5; font: 12px/1.4 system-ui, sans-serif; }
-        [data-lucim-volume-lab] .volume-intro { color: #9fc4ce; margin: 0 0 12px; }
-        [data-lucim-volume-lab] .volume-views { color: #71d8e8; font-size: 11px; letter-spacing: .04em; margin-bottom: 12px; text-transform: uppercase; }
-        [data-lucim-volume-lab] label { display: grid; gap: 4px; margin: 9px 0; }
-        [data-lucim-volume-lab] label span { display: flex; justify-content: space-between; }
-        [data-lucim-volume-lab] input, [data-lucim-volume-lab] select, [data-lucim-volume-lab] button { width: 100%; }
-        [data-lucim-volume-lab] select, [data-lucim-volume-lab] button { background: #102633; border: 1px solid #2c5662; border-radius: 4px; color: #d9eff5; padding: 6px; }
-        [data-lucim-volume-lab] .volume-card { background: rgba(7, 24, 34, .78); border: 1px solid #214652; border-radius: 6px; margin-top: 10px; padding: 8px; }
-        [data-lucim-volume-lab] .volume-card strong { color: #7fe7f2; }
-      </style>
-      <div data-lucim-volume-lab>
-        <p class="volume-intro">Synthetic, non-diagnostic CT-like density. Persistent values, masks, labels, and region rows remain GPU-resident.</p>
-        <div class="volume-views">Axial · Coronal · Sagittal</div>
-        <label><span>Display</span><select data-volume-mode>
-          <option value="anatomy">Anatomy</option>
-          <option value="threshold">Threshold</option>
-          <option value="components" selected>Components</option>
-        </select></label>
-        ${makeRangeControl('threshold', 'Density threshold', -900, 1200, 10, VOLUME_LAB_DEFAULT_THRESHOLD, `${VOLUME_LAB_DEFAULT_THRESHOLD} HU`)}
-        ${makeRangeControl('window-center', 'Window center', -700, 600, 10, this.settings.windowCenter, String(this.settings.windowCenter))}
-        ${makeRangeControl('window-width', 'Window width', 100, 2200, 25, this.settings.windowWidth, String(this.settings.windowWidth))}
-        ${makeRangeControl('overlay-opacity', 'Overlay opacity', 0, 1, 0.02, this.settings.overlayOpacity, this.settings.overlayOpacity.toFixed(2))}
-        ${makeRangeControl('slice-x', 'Sagittal X', 0, width - 1, 1, sliceX, String(sliceX))}
-        ${makeRangeControl('slice-y', 'Coronal Y', 0, height - 1, 1, sliceY, String(sliceY))}
-        ${makeRangeControl('slice-z', 'Axial Z', 0, depth - 1, 1, sliceZ, String(sliceZ))}
-        <button type="button" data-volume-reset-slices>Center all slices</button>
-        <div class="volume-card"><strong>${width} × ${height} × ${depth}</strong> voxels · ${spacing.join(' × ')} mm<br />${formatBytes(this.engine.residentByteLength)} resident including graph scratch · ${this.engine.nodeCount} reusable nodes</div>
-        <div class="volume-card" data-volume-encode>Analysis queued</div>
-        <div class="volume-card" data-volume-status>Waiting for compact GPU status</div>
-      </div>`;
-  }
-}
-
-function makeRangeControl(
-  name: string,
-  label: string,
-  minimum: number,
-  maximum: number,
-  step: number,
-  value: number,
-  displayValue: string
-): string {
-  return `<label><span>${label}<output data-volume-${name}-value>${displayValue}</output></span><input data-volume-${name} type="range" min="${minimum}" max="${maximum}" step="${step}" value="${value}" /></label>`;
-}
-
-function getInput(root: HTMLElement, selector: string): HTMLInputElement {
-  const element = root.querySelector<HTMLInputElement>(selector);
-  if (!element) throw new Error(`Missing LuCIM Volume Lab input ${selector}`);
-  return element;
-}
-
-function getElement(root: HTMLElement, selector: string): HTMLElement {
-  const element = root.querySelector<HTMLElement>(selector);
-  if (!element) throw new Error(`Missing LuCIM Volume Lab element ${selector}`);
-  return element;
-}
-
-function formatBytes(byteLength: number): string {
-  return `${(byteLength / 1024 ** 2).toFixed(1)} MiB`;
 }

--- a/examples/experimental/volumetric-fire-forge/app-ui.ts
+++ b/examples/experimental/volumetric-fire-forge/app-ui.ts
@@ -1,0 +1,366 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {SettingsChangeDescriptor, SettingsSchema} from '@deck.gl-community/panels';
+import {
+  ExamplePanelManager,
+  ExampleSettingsPanelManager,
+  makeExamplePanelHostHtml,
+  makeExampleTabbedPanel,
+  makeHtmlCustomPanel
+} from '../../example-panels';
+import type {VolumetricFireForgeRenderSettings} from './volumetric-fire-forge-renderer';
+import {VOLUMETRIC_FIRE_FORGE_PRESETS} from './volumetric-fire-forge-scene';
+import {VOLUMETRIC_FIRE_DEBUG_VIEWS} from './volumetric-fire-forge-shaders';
+
+export const VOLUMETRIC_FIRE_FORGE_INFO_HTML = makeExamplePanelHostHtml();
+
+export type VolumetricFireQuality = 'Interactive' | 'High' | 'Cinematic';
+
+export const VOLUMETRIC_FIRE_QUALITY_DIMENSIONS: Record<
+  VolumetricFireQuality,
+  readonly [number, number, number]
+> = {
+  Interactive: [40, 48, 32],
+  High: [56, 72, 48],
+  Cinematic: [72, 96, 60]
+};
+
+export type VolumetricFireForgeSettings = VolumetricFireForgeRenderSettings & {
+  preset: string;
+  quality: VolumetricFireQuality;
+  paused: boolean;
+  timeScale: number;
+  buoyancyScale: number;
+  turbulenceScale: number;
+  reactionScale: number;
+  autoOrbitCamera: boolean;
+};
+
+export const DEFAULT_VOLUMETRIC_FIRE_FORGE_SETTINGS: VolumetricFireForgeSettings = {
+  preset: 'foundry',
+  quality: 'High',
+  paused: false,
+  timeScale: 1,
+  buoyancyScale: 1,
+  turbulenceScale: 1,
+  reactionScale: 1,
+  autoOrbitCamera: true,
+  debugView: 'Final',
+  sampleCount: 88,
+  densityAbsorption: 2.8,
+  emissionStrength: 3.2,
+  smokeScattering: 0.9,
+  shadowStrength: 0.74,
+  exposure: 0.88,
+  bloomThreshold: 0.7,
+  bloomIntensity: 0.76,
+  bloomRadius: 12
+};
+
+type VolumetricFireForgeUserInterfaceProps = {
+  preferredColorFormat: string;
+  settings: VolumetricFireForgeSettings;
+  onSettingsChange: (
+    settings: Record<string, unknown>,
+    changedSettings?: SettingsChangeDescriptor[]
+  ) => void;
+  onReset: () => void;
+  onSingleStep: () => void;
+  onResetCamera: () => void;
+  onToggleSound: () => void;
+  onArmAudio: () => void;
+};
+
+type VolumetricFireForgeTelemetry = {
+  dimensions: readonly number[];
+  stepsThisFrame: number;
+  graphNodeCount: number;
+  sceneColorFormat: string;
+  secondsUntilNextFlare: number;
+};
+
+/** Owns the panels and document-level controls for the fire forge. */
+export class VolumetricFireForgeUserInterface {
+  readonly settingsPanel: ExampleSettingsPanelManager;
+  readonly panels: ExamplePanelManager;
+
+  private readonly props: VolumetricFireForgeUserInterfaceProps;
+  private resetButton: HTMLElement | null = null;
+  private singleStepButton: HTMLElement | null = null;
+  private resetCameraButton: HTMLElement | null = null;
+  private soundButton: HTMLElement | null = null;
+
+  constructor(props: VolumetricFireForgeUserInterfaceProps) {
+    this.props = props;
+    this.settingsPanel = new ExampleSettingsPanelManager({
+      id: 'volumetric-fire-forge-settings',
+      schema: makeVolumetricFireForgeSettingsSchema(),
+      settings: props.settings,
+      sectionPresentation: 'accordion',
+      onSettingsChange: props.onSettingsChange
+    });
+    this.panels = new ExamplePanelManager({panel: this.makePanel()});
+  }
+
+  mount(): void {
+    this.panels.mount();
+  }
+
+  initialize(): void {
+    this.resetButton = document.getElementById('volumetric-fire-reset');
+    this.singleStepButton = document.getElementById('volumetric-fire-single-step');
+    this.resetCameraButton = document.getElementById('volumetric-fire-reset-camera');
+    this.soundButton = document.getElementById('volumetric-fire-toggle-sound');
+    document.addEventListener('keydown', this.handleKeyDown);
+    this.resetButton?.addEventListener('click', this.props.onReset);
+    this.singleStepButton?.addEventListener('click', this.props.onSingleStep);
+    this.resetCameraButton?.addEventListener('click', this.props.onResetCamera);
+    this.soundButton?.addEventListener('click', this.props.onToggleSound);
+  }
+
+  finalize(): void {
+    document.removeEventListener('keydown', this.handleKeyDown);
+    this.resetButton?.removeEventListener('click', this.props.onReset);
+    this.singleStepButton?.removeEventListener('click', this.props.onSingleStep);
+    this.resetCameraButton?.removeEventListener('click', this.props.onResetCamera);
+    this.soundButton?.removeEventListener('click', this.props.onToggleSound);
+    this.resetButton = null;
+    this.singleStepButton = null;
+    this.resetCameraButton = null;
+    this.soundButton = null;
+    this.settingsPanel.finalize();
+    this.panels.finalize();
+  }
+
+  updateSoundButton(muted: boolean): void {
+    if (!this.soundButton) return;
+    this.soundButton.textContent = muted ? 'Unmute sound' : 'Mute sound';
+    this.soundButton.setAttribute('aria-pressed', String(muted));
+  }
+
+  updateTelemetry(telemetry: VolumetricFireForgeTelemetry): void {
+    const telemetryElement = document.getElementById('volumetric-fire-telemetry');
+    if (!telemetryElement) return;
+    const voxelCount = telemetry.dimensions.reduce((product, dimension) => product * dimension, 1);
+    telemetryElement.textContent =
+      `${telemetry.dimensions.join(' × ')} · ${voxelCount.toLocaleString()} voxels · ` +
+      `${telemetry.stepsThisFrame} solver step${telemetry.stepsThisFrame === 1 ? '' : 's'} · ` +
+      `${telemetry.graphNodeCount} GPU nodes · ${telemetry.sceneColorFormat} · ` +
+      `next flare ${Math.max(telemetry.secondsUntilNextFlare, 0).toFixed(1)} s`;
+  }
+
+  private makePanel() {
+    return makeExampleTabbedPanel({
+      id: 'volumetric-fire-forge-tabs',
+      title: `Volumetric Fire Forge${this.props.preferredColorFormat === 'rgba16float' ? ' · HDR' : ''}`,
+      panels: [
+        makeHtmlCustomPanel({
+          id: 'volumetric-fire-forge-overview',
+          title: 'Overview',
+          html: `
+            <p><b>Reactive fire, not a flipbook.</b> WebGPU evolves velocity, pressure, fuel, heat, and smoke in a solid-aware 3D volume. A depth-clipped ray marcher turns the live fields into heat-shaped HDR emission, Beer-Lambert extinction, self-shadowed smoke, and bloom.</p>
+            <p>Click a flame for an individual HDR flare and low combustion whoomph; drag to orbit. Automatic flares follow a repeatable irregular schedule. Inspect density, temperature, fuel, age, velocity, obstacles, and transmittance without a GPU readback.</p>
+            <p><button id="volumetric-fire-reset">Reset fire</button> <button id="volumetric-fire-single-step">Single step</button> <button id="volumetric-fire-reset-camera">Reset camera</button> <button id="volumetric-fire-toggle-sound" aria-pressed="false">Mute sound</button></p>
+            <p id="volumetric-fire-telemetry"></p>
+          `
+        }),
+        this.settingsPanel.makePanel(),
+        makeHtmlCustomPanel({
+          id: 'volumetric-fire-forge-background',
+          title: 'Pipeline',
+          html: '<p><b>One encoder, no CPU staging:</b> fixed 60 Hz solver steps and the volume compositor are recorded in order before the frame is submitted. Opaque depth stops the ray at forge surfaces; a world-to-volume transform keeps the collision mask, visible geometry, and 3D sampling aligned.</p><p><b>Stable exposure:</b> the forge uses fixed exposure so rapidly changing flames never pump the whole screen. HDR energy remains linear through multiscale bloom and reaches extended-range displays through the final tone map.</p>'
+        })
+      ]
+    });
+  }
+
+  private readonly handleKeyDown = (): void => {
+    this.props.onArmAudio();
+  };
+}
+
+export function makeVolumetricFireForgeSettingsSchema(): SettingsSchema {
+  return {
+    title: 'Fire Forge Controls',
+    sections: [
+      {
+        id: 'fire-state',
+        name: 'Fire State',
+        initiallyCollapsed: false,
+        settings: [
+          {
+            name: 'preset',
+            label: 'Preset',
+            type: 'select',
+            persist: 'none',
+            options: VOLUMETRIC_FIRE_FORGE_PRESETS.map(preset => ({
+              value: preset.id,
+              label: preset.label
+            }))
+          },
+          {
+            name: 'quality',
+            label: 'Volume Quality',
+            type: 'select',
+            persist: 'none',
+            options: Object.keys(VOLUMETRIC_FIRE_QUALITY_DIMENSIONS)
+          },
+          {name: 'paused', label: 'Pause Solver', type: 'boolean', persist: 'none'},
+          {
+            name: 'timeScale',
+            label: 'Time Scale',
+            type: 'number',
+            persist: 'none',
+            min: 0.25,
+            max: 2,
+            step: 0.05
+          }
+        ]
+      },
+      {
+        id: 'simulation',
+        name: 'Simulation',
+        initiallyCollapsed: true,
+        settings: [
+          {
+            name: 'buoyancyScale',
+            label: 'Buoyancy',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 2,
+            step: 0.05
+          },
+          {
+            name: 'turbulenceScale',
+            label: 'Turbulence',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 2.5,
+            step: 0.05
+          },
+          {
+            name: 'reactionScale',
+            label: 'Reaction Rate',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 2,
+            step: 0.05
+          }
+        ]
+      },
+      {
+        id: 'volume-rendering',
+        name: 'Volume Rendering',
+        initiallyCollapsed: false,
+        settings: [
+          {
+            name: 'debugView',
+            label: 'View',
+            type: 'select',
+            persist: 'none',
+            options: [...VOLUMETRIC_FIRE_DEBUG_VIEWS]
+          },
+          {
+            name: 'sampleCount',
+            label: 'Ray Samples',
+            type: 'number',
+            persist: 'none',
+            min: 24,
+            max: 160,
+            step: 4
+          },
+          {
+            name: 'densityAbsorption',
+            label: 'Smoke Absorption',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 6,
+            step: 0.05
+          },
+          {
+            name: 'emissionStrength',
+            label: 'HDR Emission',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 8,
+            step: 0.1
+          },
+          {
+            name: 'smokeScattering',
+            label: 'Smoke Light',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 3,
+            step: 0.05
+          },
+          {
+            name: 'shadowStrength',
+            label: 'Self Shadow',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1,
+            step: 0.05
+          }
+        ]
+      },
+      {
+        id: 'camera-output',
+        name: 'Camera & HDR',
+        initiallyCollapsed: true,
+        settings: [
+          {
+            name: 'autoOrbitCamera',
+            label: 'Auto Orbit',
+            type: 'boolean',
+            persist: 'none'
+          },
+          {
+            name: 'exposure',
+            label: 'Fixed Exposure',
+            type: 'number',
+            persist: 'none',
+            min: 0.2,
+            max: 2,
+            step: 0.05
+          },
+          {
+            name: 'bloomThreshold',
+            label: 'Bloom Threshold',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 3,
+            step: 0.05
+          },
+          {
+            name: 'bloomIntensity',
+            label: 'Bloom Intensity',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 3,
+            step: 0.05
+          },
+          {
+            name: 'bloomRadius',
+            label: 'Bloom Radius',
+            type: 'number',
+            persist: 'none',
+            min: 1,
+            max: 24,
+            step: 1
+          }
+        ]
+      }
+    ]
+  };
+}

--- a/examples/experimental/volumetric-fire-forge/app.ts
+++ b/examples/experimental/volumetric-fire-forge/app.ts
@@ -7,14 +7,13 @@ import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, OrbitControls} from '@luma.gl/engine';
 import {VolumetricFireSimulation} from '@luma.gl/experimental';
 import {Matrix4, radians, type NumberArray3} from '@math.gl/core';
-import type {Panel, SettingsChangeDescriptor, SettingsSchema} from '@deck.gl-community/panels';
 import {
-  ExamplePanelManager,
-  ExampleSettingsPanelManager,
-  makeExamplePanelHostHtml,
-  makeExampleTabbedPanel,
-  makeHtmlCustomPanel
-} from '../../example-panels';
+  DEFAULT_VOLUMETRIC_FIRE_FORGE_SETTINGS,
+  VOLUMETRIC_FIRE_FORGE_INFO_HTML,
+  VOLUMETRIC_FIRE_QUALITY_DIMENSIONS,
+  VolumetricFireForgeUserInterface,
+  type VolumetricFireForgeSettings
+} from './app-ui';
 import {VolumetricFireForgeAudio} from './volumetric-fire-forge-audio';
 import {
   advanceVolumetricFireForgeFlareSchedule,
@@ -33,11 +32,13 @@ import {
   VOLUMETRIC_FIRE_FORGE_PRESETS,
   type VolumetricFireForgePreset
 } from './volumetric-fire-forge-scene';
-import {
-  VolumetricFireForgeRenderer,
-  type VolumetricFireForgeRenderSettings
-} from './volumetric-fire-forge-renderer';
-import {VOLUMETRIC_FIRE_DEBUG_VIEWS} from './volumetric-fire-forge-shaders';
+import {VolumetricFireForgeRenderer} from './volumetric-fire-forge-renderer';
+
+export {
+  DEFAULT_VOLUMETRIC_FIRE_FORGE_SETTINGS,
+  makeVolumetricFireForgeSettingsSchema
+} from './app-ui';
+export type {VolumetricFireForgeSettings} from './app-ui';
 
 export const title = 'Volumetric Fire Forge';
 export const description =
@@ -53,49 +54,6 @@ const INITIAL_WARMUP_STEP_COUNT = 24;
 const CLICK_MOVEMENT_THRESHOLD_PIXELS = 7;
 const CLICK_BURNER_RADIUS_PIXELS = 72;
 const CLICKED_FLARE_INTENSITY = 1.28;
-
-type VolumetricFireQuality = 'Interactive' | 'High' | 'Cinematic';
-
-const VOLUMETRIC_FIRE_QUALITY_DIMENSIONS: Record<
-  VolumetricFireQuality,
-  readonly [number, number, number]
-> = {
-  Interactive: [40, 48, 32],
-  High: [56, 72, 48],
-  Cinematic: [72, 96, 60]
-};
-
-export type VolumetricFireForgeSettings = VolumetricFireForgeRenderSettings & {
-  preset: string;
-  quality: VolumetricFireQuality;
-  paused: boolean;
-  timeScale: number;
-  buoyancyScale: number;
-  turbulenceScale: number;
-  reactionScale: number;
-  autoOrbitCamera: boolean;
-};
-
-export const DEFAULT_VOLUMETRIC_FIRE_FORGE_SETTINGS: VolumetricFireForgeSettings = {
-  preset: 'foundry',
-  quality: 'High',
-  paused: false,
-  timeScale: 1,
-  buoyancyScale: 1,
-  turbulenceScale: 1,
-  reactionScale: 1,
-  autoOrbitCamera: true,
-  debugView: 'Final',
-  sampleCount: 88,
-  densityAbsorption: 2.8,
-  emissionStrength: 3.2,
-  smokeScattering: 0.9,
-  shadowStrength: 0.74,
-  exposure: 0.88,
-  bloomThreshold: 0.7,
-  bloomIntensity: 0.76,
-  bloomRadius: 12
-};
 
 type VolumetricFireForgeConstructorProps = AnimationProps & {
   simulationDimensions?: readonly [number, number, number];
@@ -115,12 +73,11 @@ type PointerStart = {
 
 /** WebGPU fire laboratory with a fixed-step compute solver and HDR volume rendering. */
 export default class VolumetricFireForgeAnimationLoopTemplate extends AnimationLoopTemplate {
-  static info = makeExamplePanelHostHtml();
+  static info = VOLUMETRIC_FIRE_FORGE_INFO_HTML;
 
   readonly device: Device;
   readonly renderer: VolumetricFireForgeRenderer;
-  readonly settingsPanel: ExampleSettingsPanelManager;
-  readonly panels: ExamplePanelManager;
+  readonly userInterface: VolumetricFireForgeUserInterface;
   readonly flareAudio = new VolumetricFireForgeAudio();
 
   simulation!: VolumetricFireSimulation;
@@ -168,26 +125,25 @@ export default class VolumetricFireForgeAnimationLoopTemplate extends AnimationL
     this.simulationDimensionsOverride = simulationDimensions;
     this.pressureIterations = pressureIterations;
     let renderer: VolumetricFireForgeRenderer | undefined;
-    let settingsPanel: ExampleSettingsPanelManager | undefined;
-    let panels: ExamplePanelManager | undefined;
+    let userInterface: VolumetricFireForgeUserInterface | undefined;
     try {
       this.rebuildSimulation();
       renderer = new VolumetricFireForgeRenderer(device, width, height);
       this.renderer = renderer;
-      settingsPanel = new ExampleSettingsPanelManager({
-        id: 'volumetric-fire-forge-settings',
-        schema: makeVolumetricFireForgeSettingsSchema(),
+      userInterface = new VolumetricFireForgeUserInterface({
+        preferredColorFormat: device.preferredColorFormat,
         settings: this.settings,
-        sectionPresentation: 'accordion',
-        onSettingsChange: this.handleSettingsChange
+        onSettingsChange: this.handleSettingsChange,
+        onReset: this.handleReset,
+        onSingleStep: this.handleSingleStep,
+        onResetCamera: this.handleResetCamera,
+        onToggleSound: this.handleToggleSound,
+        onArmAudio: () => void this.flareAudio.arm()
       });
-      this.settingsPanel = settingsPanel;
-      panels = new ExamplePanelManager({panel: this.makePanel()});
-      this.panels = panels;
-      panels.mount();
+      this.userInterface = userInterface;
+      userInterface.mount();
     } catch (error) {
-      panels?.finalize();
-      settingsPanel?.finalize();
+      userInterface?.finalize();
       renderer?.destroy();
       this.simulation?.destroy();
       this.obstacleTexture?.destroy();
@@ -213,18 +169,8 @@ export default class VolumetricFireForgeAnimationLoopTemplate extends AnimationL
       canvas.addEventListener('pointerup', this.handleCanvasPointerUp);
       canvas.addEventListener('pointercancel', this.handleCanvasPointerCancel);
     }
-    document.addEventListener('keydown', this.handleKeyDown);
-    document.getElementById('volumetric-fire-reset')?.addEventListener('click', this.handleReset);
-    document
-      .getElementById('volumetric-fire-single-step')
-      ?.addEventListener('click', this.handleSingleStep);
-    document
-      .getElementById('volumetric-fire-reset-camera')
-      ?.addEventListener('click', this.handleResetCamera);
-    document
-      .getElementById('volumetric-fire-toggle-sound')
-      ?.addEventListener('click', this.handleToggleSound);
-    this.updateSoundButton();
+    this.userInterface.initialize();
+    this.userInterface.updateSoundButton(this.flareAudio.muted);
   }
 
   onRender({device, width, height, aspect, time}: AnimationProps): void {
@@ -260,7 +206,13 @@ export default class VolumetricFireForgeAnimationLoopTemplate extends AnimationL
       burnerFlareIntensities: this.burnerFlareIntensities,
       settings: this.settings
     });
-    this.updateTelemetry();
+    this.userInterface.updateTelemetry({
+      dimensions: this.simulation.dimensions,
+      stepsThisFrame: this.stepsThisFrame,
+      graphNodeCount: this.simulation.stats.nodeOrder.length,
+      sceneColorFormat: this.renderer.sceneColorFormat,
+      secondsUntilNextFlare: this.flareSchedule.nextFlareTimeSeconds - this.simulationTimeSeconds
+    });
     this.frameIndex += this.stepsThisFrame;
   }
 
@@ -269,22 +221,8 @@ export default class VolumetricFireForgeAnimationLoopTemplate extends AnimationL
     this.canvas?.removeEventListener('pointerup', this.handleCanvasPointerUp);
     this.canvas?.removeEventListener('pointercancel', this.handleCanvasPointerCancel);
     this.canvas = null;
-    document.removeEventListener('keydown', this.handleKeyDown);
-    document
-      .getElementById('volumetric-fire-reset')
-      ?.removeEventListener('click', this.handleReset);
-    document
-      .getElementById('volumetric-fire-single-step')
-      ?.removeEventListener('click', this.handleSingleStep);
-    document
-      .getElementById('volumetric-fire-reset-camera')
-      ?.removeEventListener('click', this.handleResetCamera);
-    document
-      .getElementById('volumetric-fire-toggle-sound')
-      ?.removeEventListener('click', this.handleToggleSound);
     this.flareAudio.destroy();
-    this.settingsPanel.finalize();
-    this.panels.finalize();
+    this.userInterface.finalize();
     this.orbitControls?.destroy();
     this.renderer.destroy();
     this.simulation.destroy();
@@ -546,35 +484,7 @@ export default class VolumetricFireForgeAnimationLoopTemplate extends AnimationL
     );
   }
 
-  private makePanel(): Panel {
-    return makeExampleTabbedPanel({
-      id: 'volumetric-fire-forge-tabs',
-      title: `Volumetric Fire Forge${this.device.preferredColorFormat === 'rgba16float' ? ' · HDR' : ''}`,
-      panels: [
-        makeHtmlCustomPanel({
-          id: 'volumetric-fire-forge-overview',
-          title: 'Overview',
-          html: `
-            <p><b>Reactive fire, not a flipbook.</b> WebGPU evolves velocity, pressure, fuel, heat, and smoke in a solid-aware 3D volume. A depth-clipped ray marcher turns the live fields into heat-shaped HDR emission, Beer-Lambert extinction, self-shadowed smoke, and bloom.</p>
-            <p>Click a flame for an individual HDR flare and low combustion whoomph; drag to orbit. Automatic flares follow a repeatable irregular schedule. Inspect density, temperature, fuel, age, velocity, obstacles, and transmittance without a GPU readback.</p>
-            <p><button id="volumetric-fire-reset">Reset fire</button> <button id="volumetric-fire-single-step">Single step</button> <button id="volumetric-fire-reset-camera">Reset camera</button> <button id="volumetric-fire-toggle-sound" aria-pressed="false">Mute sound</button></p>
-            <p id="volumetric-fire-telemetry"></p>
-          `
-        }),
-        this.settingsPanel.makePanel(),
-        makeHtmlCustomPanel({
-          id: 'volumetric-fire-forge-background',
-          title: 'Pipeline',
-          html: '<p><b>One encoder, no CPU staging:</b> fixed 60 Hz solver steps and the volume compositor are recorded in order before the frame is submitted. Opaque depth stops the ray at forge surfaces; a world-to-volume transform keeps the collision mask, visible geometry, and 3D sampling aligned.</p><p><b>Stable exposure:</b> the forge uses fixed exposure so rapidly changing flames never pump the whole screen. HDR energy remains linear through multiscale bloom and reaches extended-range displays through the final tone map.</p>'
-        })
-      ]
-    });
-  }
-
-  private readonly handleSettingsChange = (
-    nextSettings: Record<string, unknown>,
-    _changedSettings?: SettingsChangeDescriptor[]
-  ): void => {
+  private readonly handleSettingsChange = (nextSettings: Record<string, unknown>): void => {
     const previousSettings = this.settings;
     this.settings = {...this.settings, ...(nextSettings as VolumetricFireForgeSettings)};
     if (previousSettings.quality !== this.settings.quality && !this.simulationDimensionsOverride) {
@@ -648,227 +558,11 @@ export default class VolumetricFireForgeAnimationLoopTemplate extends AnimationL
     this.pointerStart = null;
   };
 
-  private readonly handleKeyDown = (): void => {
-    void this.flareAudio.arm();
-  };
-
   private readonly handleToggleSound = (): void => {
     this.flareAudio.setMuted(!this.flareAudio.muted);
     if (!this.flareAudio.muted) {
       void this.flareAudio.arm();
     }
-    this.updateSoundButton();
-  };
-
-  private updateSoundButton(): void {
-    const soundButton = document.getElementById('volumetric-fire-toggle-sound');
-    if (!soundButton) {
-      return;
-    }
-    soundButton.textContent = this.flareAudio.muted ? 'Unmute sound' : 'Mute sound';
-    soundButton.setAttribute('aria-pressed', String(this.flareAudio.muted));
-  }
-
-  private updateTelemetry(): void {
-    const telemetryElement = document.getElementById('volumetric-fire-telemetry');
-    if (!telemetryElement) {
-      return;
-    }
-    const voxelCount = this.simulation.dimensions.reduce(
-      (product, dimension) => product * dimension,
-      1
-    );
-    telemetryElement.textContent =
-      `${this.simulation.dimensions.join(' × ')} · ${voxelCount.toLocaleString()} voxels · ` +
-      `${this.stepsThisFrame} solver step${this.stepsThisFrame === 1 ? '' : 's'} · ` +
-      `${this.simulation.stats.nodeOrder.length} GPU nodes · ${this.renderer.sceneColorFormat} · ` +
-      `next flare ${Math.max(
-        this.flareSchedule.nextFlareTimeSeconds - this.simulationTimeSeconds,
-        0
-      ).toFixed(1)} s`;
-  }
-}
-
-export function makeVolumetricFireForgeSettingsSchema(): SettingsSchema {
-  return {
-    title: 'Fire Forge Controls',
-    sections: [
-      {
-        id: 'fire-state',
-        name: 'Fire State',
-        initiallyCollapsed: false,
-        settings: [
-          {
-            name: 'preset',
-            label: 'Preset',
-            type: 'select',
-            persist: 'none',
-            options: VOLUMETRIC_FIRE_FORGE_PRESETS.map(preset => ({
-              value: preset.id,
-              label: preset.label
-            }))
-          },
-          {
-            name: 'quality',
-            label: 'Volume Quality',
-            type: 'select',
-            persist: 'none',
-            options: Object.keys(VOLUMETRIC_FIRE_QUALITY_DIMENSIONS)
-          },
-          {name: 'paused', label: 'Pause Solver', type: 'boolean', persist: 'none'},
-          {
-            name: 'timeScale',
-            label: 'Time Scale',
-            type: 'number',
-            persist: 'none',
-            min: 0.25,
-            max: 2,
-            step: 0.05
-          }
-        ]
-      },
-      {
-        id: 'simulation',
-        name: 'Simulation',
-        initiallyCollapsed: true,
-        settings: [
-          {
-            name: 'buoyancyScale',
-            label: 'Buoyancy',
-            type: 'number',
-            persist: 'none',
-            min: 0,
-            max: 2,
-            step: 0.05
-          },
-          {
-            name: 'turbulenceScale',
-            label: 'Turbulence',
-            type: 'number',
-            persist: 'none',
-            min: 0,
-            max: 2.5,
-            step: 0.05
-          },
-          {
-            name: 'reactionScale',
-            label: 'Reaction Rate',
-            type: 'number',
-            persist: 'none',
-            min: 0,
-            max: 2,
-            step: 0.05
-          }
-        ]
-      },
-      {
-        id: 'volume-rendering',
-        name: 'Volume Rendering',
-        initiallyCollapsed: false,
-        settings: [
-          {
-            name: 'debugView',
-            label: 'View',
-            type: 'select',
-            persist: 'none',
-            options: [...VOLUMETRIC_FIRE_DEBUG_VIEWS]
-          },
-          {
-            name: 'sampleCount',
-            label: 'Ray Samples',
-            type: 'number',
-            persist: 'none',
-            min: 24,
-            max: 160,
-            step: 4
-          },
-          {
-            name: 'densityAbsorption',
-            label: 'Smoke Absorption',
-            type: 'number',
-            persist: 'none',
-            min: 0,
-            max: 6,
-            step: 0.05
-          },
-          {
-            name: 'emissionStrength',
-            label: 'HDR Emission',
-            type: 'number',
-            persist: 'none',
-            min: 0,
-            max: 8,
-            step: 0.1
-          },
-          {
-            name: 'smokeScattering',
-            label: 'Smoke Light',
-            type: 'number',
-            persist: 'none',
-            min: 0,
-            max: 3,
-            step: 0.05
-          },
-          {
-            name: 'shadowStrength',
-            label: 'Self Shadow',
-            type: 'number',
-            persist: 'none',
-            min: 0,
-            max: 1,
-            step: 0.05
-          }
-        ]
-      },
-      {
-        id: 'camera-output',
-        name: 'Camera & HDR',
-        initiallyCollapsed: true,
-        settings: [
-          {
-            name: 'autoOrbitCamera',
-            label: 'Auto Orbit',
-            type: 'boolean',
-            persist: 'none'
-          },
-          {
-            name: 'exposure',
-            label: 'Fixed Exposure',
-            type: 'number',
-            persist: 'none',
-            min: 0.2,
-            max: 2,
-            step: 0.05
-          },
-          {
-            name: 'bloomThreshold',
-            label: 'Bloom Threshold',
-            type: 'number',
-            persist: 'none',
-            min: 0,
-            max: 3,
-            step: 0.05
-          },
-          {
-            name: 'bloomIntensity',
-            label: 'Bloom Intensity',
-            type: 'number',
-            persist: 'none',
-            min: 0,
-            max: 3,
-            step: 0.05
-          },
-          {
-            name: 'bloomRadius',
-            label: 'Bloom Radius',
-            type: 'number',
-            persist: 'none',
-            min: 1,
-            max: 24,
-            step: 1
-          }
-        ]
-      }
-    ]
+    this.userInterface.updateSoundButton(this.flareAudio.muted);
   };
 }


### PR DESCRIPTION
Follow-up to #3185.

## Goals

Keep example `app.ts` files focused on the luma.gl and deck.gl API path by moving presentation-specific code into companion modules.

## Changes

- move GPU-culled trace panels, tooltip markup, formatting, and telemetry rendering into `app-ui.ts`
- move LuCIM Volume Lab controls, markup, status rendering, and UI debouncing into `app-ui.ts`
- move Volumetric Fire Forge panels, settings schema, document controls, sound-button state, and telemetry formatting into `app-ui.ts`
- preserve existing exports from the fire-forge entry while reducing the three `app.ts` files from 1,389 to 842 lines

## Verification

- `yarn lint fix`
- `yarn examples:typecheck`
- `yarn build`
- `yarn test` (3,258 node tests and 1,938 browser tests passed)
- focused LuCIM and Volumetric Fire Forge browser tests
- `yarn website:build`
- `(cd website && yarn build)`
- dependencies were already installed; no manifest or lockfile changes required `yarn install`
- Node v22.22.1 matches `.nvmrc`