### PR TITLE
feat(examples): make scene JSON editor collapsible

### DIFF
--- a/examples/experimental/fp64/app-ui.tsx
+++ b/examples/experimental/fp64/app-ui.tsx
@@ -14,9 +14,11 @@ export function makeFP64ExampleLayout(props: {
   canvasWidth: number;
   device: Device | null;
   initializationError: string | null;
+  isAutoZooming: boolean;
   isBenchmarkRunning: boolean;
   isReady: boolean;
   onRunBenchmark: () => Promise<void>;
+  onToggleAutoZoom: () => void;
   settingsHostId: string;
   visualizations: Array<{
     canvasRef: React.RefObject<HTMLCanvasElement>;
@@ -42,10 +44,18 @@ export function makeFP64ExampleLayout(props: {
         <p style={{color: '#b00020', margin: 0}}>{props.initializationError}</p>
       ) : null}
       <div id={props.settingsHostId} />
+      <button
+        onClick={props.onToggleAutoZoom}
+        style={{alignSelf: 'flex-start', padding: '7px 12px'}}
+        type="button"
+      >
+        {props.isAutoZooming ? 'Stop automatic zoom' : 'Start automatic zoom'}
+      </button>
       <div
         style={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 320px), 1fr))',
+          // Keep the precision views side by side so their zoomed regions can be compared directly.
+          gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
           gap: 20,
           alignItems: 'stretch',
           minWidth: 0
@@ -55,9 +65,8 @@ export function makeFP64ExampleLayout(props: {
           <div
             data-fp64-visualization={visualization.kind}
             key={visualization.kind}
-            style={{display: 'grid', gridTemplateRows: '1fr auto', gap: 12, minWidth: 0}}
+            style={{display: 'grid', gridTemplateRows: 'auto 1fr', gap: 12, minWidth: 0}}
           >
-            <ExamplePaneCopy description={visualization.description} title={visualization.title} />
             <ExamplePaneCanvas
               canvasHeight={props.canvasHeight}
               canvasRef={visualization.canvasRef}
@@ -65,6 +74,7 @@ export function makeFP64ExampleLayout(props: {
               isReady={props.isReady}
               overlayLines={visualization.overlayLines}
             />
+            <ExamplePaneCopy description={visualization.description} title={visualization.title} />
           </div>
         ))}
       </div>
@@ -139,18 +149,18 @@ function ExamplePaneCanvas(props: {
       <div
         style={{
           position: 'absolute',
-          left: 12,
-          right: 12,
-          bottom: 12,
+          left: 6,
+          right: 6,
+          bottom: 6,
           boxSizing: 'border-box',
-          maxWidth: 'calc(100% - 24px)',
-          padding: '8px 10px',
-          background: 'rgba(0, 0, 0, 0.68)',
+          maxWidth: 'calc(100% - 12px)',
+          padding: '5px 7px',
+          background: 'rgba(0, 0, 0, 0.52)',
           color: '#fff',
           fontFamily: 'monospace',
-          fontSize: 12,
-          lineHeight: 1.45,
-          borderRadius: 8,
+          fontSize: 10,
+          lineHeight: 1.25,
+          borderRadius: 5,
           overflowWrap: 'anywhere',
           pointerEvents: 'none'
         }}

--- a/examples/experimental/fp64/app.tsx
+++ b/examples/experimental/fp64/app.tsx
@@ -1134,11 +1134,8 @@ void main(void) {
   float escapedIteration = mandelbrot32.iterationLimit;
   float radiusSquared = 0.0;
 
-  for (int iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
-    if (float(iteration) >= mandelbrot32.iterationLimit) {
-      break;
-    }
-
+  int iterationLimit = int(mandelbrot32.iterationLimit);
+  for (int iteration = 0; iteration < MAX_ITERATIONS && iteration < iterationLimit; iteration++) {
     float nextX = z.x * z.x - z.y * z.y + c.x;
     float nextY = 2.0 * z.x * z.y + c.y;
     z = vec2(nextX, nextY);
@@ -1197,11 +1194,8 @@ fn fragmentMain(inputs: FragmentOutput) -> @location(0) vec4<f32> {
   var escapedIteration = mandelbrot32.iterationLimit;
   var radiusSquared = 0.0;
 
-  for (var iteration: i32 = 0; iteration < MAX_ITERATIONS; iteration = iteration + 1) {
-    if (f32(iteration) >= mandelbrot32.iterationLimit) {
-      break;
-    }
-
+  let iterationLimit = i32(mandelbrot32.iterationLimit);
+  for (var iteration: i32 = 0; iteration < MAX_ITERATIONS && iteration < iterationLimit; iteration = iteration + 1) {
     let nextX = z.x * z.x - z.y * z.y + c.x;
     let nextY = 2.0 * z.x * z.y + c.y;
     z = vec2<f32>(nextX, nextY);
@@ -1268,11 +1262,8 @@ void main(void) {
   float escapedIteration = mandelbrot64.iterationLimit;
   float radiusSquared = 0.0;
 
-  for (int iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
-    if (float(iteration) >= mandelbrot64.iterationLimit) {
-      break;
-    }
-
+  int iterationLimit = int(mandelbrot64.iterationLimit);
+  for (int iteration = 0; iteration < MAX_ITERATIONS && iteration < iterationLimit; iteration++) {
     vec2 xSquared = mul_fp64(zx, zx);
     vec2 ySquared = mul_fp64(zy, zy);
     vec2 xy = mul_fp64(zx, zy);
@@ -1343,11 +1334,8 @@ fn fragmentMain(inputs: FragmentOutput) -> @location(0) vec4<f32> {
   var escapedIteration = mandelbrot64.iterationLimit;
   var radiusSquared = 0.0;
 
-  for (var iteration: i32 = 0; iteration < MAX_ITERATIONS; iteration = iteration + 1) {
-    if (f32(iteration) >= mandelbrot64.iterationLimit) {
-      break;
-    }
-
+  let iterationLimit = i32(mandelbrot64.iterationLimit);
+  for (var iteration: i32 = 0; iteration < MAX_ITERATIONS && iteration < iterationLimit; iteration = iteration + 1) {
     let xSquared = mul_fp64(zx, zx);
     let ySquared = mul_fp64(zy, zy);
     let xy = mul_fp64(zx, zy);

--- a/examples/experimental/fp64/app.tsx
+++ b/examples/experimental/fp64/app.tsx
@@ -29,6 +29,7 @@ type AppState = {
   benchmarkResults: FP64ComputeBenchmarkResult[] | null;
   fp64RenderTiming: FP64RenderTiming | null;
   initializationError: string | null;
+  isAutoZooming: boolean;
   isBenchmarkRunning: boolean;
   isReady: boolean;
   renderWidth: number;
@@ -108,17 +109,20 @@ const FIXED_ITERATION_LIMIT = 768;
 const BASE_ITERATION_LIMIT = 160;
 const ITERATION_GROWTH_PER_ZOOM = 18;
 const RENDER_INTERVAL_MILLISECONDS = 50;
+const AUTO_ZOOM_SPEED = 2.5;
 const FULLSCREEN_POSITIONS = new Float32Array([-1, -1, -1, 1, 1, -1, 1, 1]);
 const INITIAL_PIXEL_SCALE = 1.35;
-const MIN_PIXEL_SCALE = 1e-12;
+// Stop just before fp64 precision and the selected landmark begin to break down.
+const MIN_PIXEL_SCALE = 1e-9;
 const MAX_ZOOM_DEPTH = Math.log2(INITIAL_PIXEL_SCALE / MIN_PIXEL_SCALE);
 const RENDER_TIMING_SAMPLE_INTERVAL = 5;
 const RENDER_TIMING_SMOOTHING = 0.2;
 const ZOOM_PRESETS: Record<ZoomPresetId, ZoomPreset> = {
   seahorse: {
     label: 'Seahorse',
-    centerX: -0.743643887037151,
-    centerY: 0.13182590420533
+    // Deep-zoom landmark from the classic seahorse-valley sequence.
+    centerX: -0.7436442,
+    centerY: 0.1318261
   },
   elephant: {
     label: 'Elephant',
@@ -140,6 +144,9 @@ export default class App extends React.PureComponent<AppProps, AppState> {
   private ownsDevice = false;
   private initializationGeneration = 0;
   private isComponentMounted = false;
+  private autoZoomAnimationFrame: number | null = null;
+  private autoZoomLastTime = 0;
+  private autoZoomPanelRefreshCount = 0;
   readonly settingsPanel: ExampleSettingsPanelManager;
   readonly panels: ExamplePanelManager;
 
@@ -151,6 +158,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
       benchmarkResults: null,
       fp64RenderTiming: null,
       initializationError: null,
+      isAutoZooming: true,
       isBenchmarkRunning: false,
       isReady: false,
       renderWidth: DEFAULT_RENDER_WIDTH,
@@ -234,6 +242,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
   override componentWillUnmount(): void {
     this.isComponentMounted = false;
     this.initializationGeneration++;
+    this.stopAutoZoom();
     this.panels.finalize();
     this.settingsPanel.finalize();
     this.destroyResources();
@@ -281,6 +290,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
       this.renderer = renderer;
       this.ownsDevice = !externalDevice;
       this.renderer.start();
+      this.startAutoZoom();
 
       const rendererErrors = this.renderer.getInitializationErrors();
 
@@ -307,6 +317,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
       benchmarkResults,
       fp64RenderTiming,
       initializationError,
+      isAutoZooming,
       isBenchmarkRunning,
       isReady,
       renderWidth,
@@ -329,6 +340,8 @@ export default class App extends React.PureComponent<AppProps, AppState> {
       isBenchmarkRunning,
       isReady,
       onRunBenchmark: this.handleRunBenchmark,
+      isAutoZooming,
+      onToggleAutoZoom: this.handleToggleAutoZoom,
       settingsHostId: FP64_SETTINGS_HOST_ID,
       visualizations: visualizationSpecs.map((visualization, index) => ({
         canvasRef: this.canvasRefs[index],
@@ -422,6 +435,50 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     }
   };
 
+  private handleToggleAutoZoom = (): void => {
+    if (this.state.isAutoZooming) {
+      this.stopAutoZoom();
+    } else {
+      this.startAutoZoom();
+    }
+  };
+
+  private startAutoZoom(): void {
+    if (this.autoZoomAnimationFrame !== null) {
+      return;
+    }
+    this.autoZoomLastTime = performance.now();
+    this.autoZoomPanelRefreshCount = 0;
+    this.setState({isAutoZooming: true});
+    this.autoZoomAnimationFrame = requestAnimationFrame(this.animateAutoZoom);
+  }
+
+  private stopAutoZoom(): void {
+    if (this.autoZoomAnimationFrame !== null) {
+      cancelAnimationFrame(this.autoZoomAnimationFrame);
+      this.autoZoomAnimationFrame = null;
+    }
+    if (this.state.isAutoZooming && this.isComponentMounted) {
+      this.setState({isAutoZooming: false});
+    }
+  }
+
+  private animateAutoZoom = (time: number): void => {
+    this.autoZoomAnimationFrame = null;
+    if (!this.state.isAutoZooming) {
+      return;
+    }
+    const elapsedSeconds = Math.min((time - this.autoZoomLastTime) / 1000, 0.1);
+    this.autoZoomLastTime = time;
+    const nextZoomDepth =
+      (this.state.zoomDepth + elapsedSeconds * AUTO_ZOOM_SPEED) % (MAX_ZOOM_DEPTH + 0.01);
+    this.settingsPanel.setSettingValue('zoomDepth', nextZoomDepth);
+    if (this.autoZoomPanelRefreshCount++ % 4 === 0) {
+      this.panels.refresh();
+    }
+    this.autoZoomAnimationFrame = requestAnimationFrame(this.animateAutoZoom);
+  };
+
   private handleRunBenchmark = async (): Promise<void> => {
     const device = this.device;
     const renderer = this.renderer;
@@ -430,6 +487,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     }
 
     const initializationGeneration = this.initializationGeneration;
+    this.stopAutoZoom();
     renderer?.pause();
     this.setState({benchmarkError: null, benchmarkResults: null, isBenchmarkRunning: true});
 
@@ -985,19 +1043,14 @@ function getOverlayLines(
     device?.type === 'webgpu' ? `fp64 ${arithmeticMode}` : 'fp64 classic (WebGL2)';
 
   const overlayLines = [
-    'mode = mandelbrot zoom',
-    `target = ${zoomPreset.label}`,
-    `x = ${zoomPreset.centerX}`,
-    `y = ${zoomPreset.centerY}`,
-    `scale = ${currentZoomLabel}`,
-    `render buffer = ${renderWidth} × ${getRenderHeight(renderWidth)}`,
-    `zoom = ${INITIAL_PIXEL_SCALE} -> ${MIN_PIXEL_SCALE}`,
-    kind === 'fp32' ? 'precision = native fp32' : `precision = ${precisionLabel}`,
-    'iterations = adaptive'
+    `${zoomPreset.label} · scale ${currentZoomLabel}`,
+    `center ${zoomPreset.centerX.toFixed(6)}, ${zoomPreset.centerY.toFixed(6)}`,
+    `${renderWidth}×${getRenderHeight(renderWidth)} · ${kind === 'fp32' ? 'native fp32' : precisionLabel}`,
+    'adaptive iterations'
   ];
   if (kind === 'fp64') {
     overlayLines.push(
-      fp64RenderTiming ? formatFP64RenderTiming(fp64RenderTiming) : 'fp64 render = sampling…'
+      fp64RenderTiming ? formatFP64RenderTiming(fp64RenderTiming) : 'GPU timing: sampling…'
     );
   }
   return overlayLines;

--- a/examples/experimental/fp64/app.tsx
+++ b/examples/experimental/fp64/app.tsx
@@ -99,8 +99,10 @@ type VisualizationTiming = {
 
 const CANVAS_WIDTH = 420;
 const CANVAS_HEIGHT = 280;
-const MIN_RENDER_WIDTH = 160;
-const MAX_RENDER_WIDTH = 640;
+// Keep the expensive Mandelbrot fragment passes bounded even when the canvas is displayed larger.
+const DEFAULT_RENDER_WIDTH = 192;
+const MIN_RENDER_WIDTH = 96;
+const MAX_RENDER_WIDTH = 256;
 const RENDER_ASPECT_RATIO = CANVAS_WIDTH / CANVAS_HEIGHT;
 const FIXED_ITERATION_LIMIT = 1400;
 const FULLSCREEN_POSITIONS = new Float32Array([-1, -1, -1, 1, 1, -1, 1, 1]);
@@ -148,7 +150,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
       initializationError: null,
       isBenchmarkRunning: false,
       isReady: false,
-      renderWidth: CANVAS_WIDTH,
+      renderWidth: DEFAULT_RENDER_WIDTH,
       selectedArithmeticMode: 'hybrid',
       selectedBackend: 'auto',
       selectedPresetId: DEFAULT_PRESET_ID,
@@ -162,7 +164,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
         selectedArithmeticMode: 'hybrid',
         selectedBackend: 'auto',
         selectedPresetId: DEFAULT_PRESET_ID,
-        renderWidth: CANVAS_WIDTH,
+        renderWidth: DEFAULT_RENDER_WIDTH,
         zoomDepth: 0
       },
       onSettingsChange: this.handleSettingsChange
@@ -511,7 +513,7 @@ export function makeFP64SettingsSchema(includeBackend = true): SettingsSchema {
             name: 'renderWidth',
             label: 'Render-buffer width (pixels)',
             description:
-              'Changes GPU fragment workload for both views without changing their CSS size.',
+              'Changes the bounded GPU fragment workload for both views without changing their CSS size.',
             type: 'number',
             persist: 'none',
             min: MIN_RENDER_WIDTH,
@@ -649,9 +651,10 @@ class MultiCanvasRenderer {
   }
 
   setRenderWidth(renderWidth: number): void {
-    const renderHeight = getRenderHeight(renderWidth);
+    const boundedRenderWidth = clampRenderWidth(renderWidth);
+    const renderHeight = getRenderHeight(boundedRenderWidth);
     for (const visualization of this.visualizations) {
-      visualization.presentationContext?.setDrawingBufferSize(renderWidth, renderHeight);
+      visualization.presentationContext?.setDrawingBufferSize(boundedRenderWidth, renderHeight);
     }
     this.resetRenderTiming();
   }
@@ -719,6 +722,7 @@ function createVisualizationRenderer(
   arithmeticMode: FP64ArithmeticMode,
   renderWidth: number
 ): VisualizationRenderer {
+  renderWidth = clampRenderWidth(renderWidth);
   const presentationContext = device.createPresentationContext({
     canvas,
     width: CANVAS_WIDTH,
@@ -937,6 +941,10 @@ function getPixelScale(zoomDepth: number): number {
 
 function getRenderHeight(renderWidth: number): number {
   return Math.round(renderWidth / RENDER_ASPECT_RATIO);
+}
+
+function clampRenderWidth(renderWidth: number): number {
+  return Math.max(MIN_RENDER_WIDTH, Math.min(MAX_RENDER_WIDTH, Math.round(renderWidth)));
 }
 
 function waitForSubmittedWork(device: Device): Promise<void> | null {

--- a/examples/experimental/fp64/app.tsx
+++ b/examples/experimental/fp64/app.tsx
@@ -113,16 +113,16 @@ const AUTO_ZOOM_SPEED = 2.5;
 const FULLSCREEN_POSITIONS = new Float32Array([-1, -1, -1, 1, 1, -1, 1, 1]);
 const INITIAL_PIXEL_SCALE = 1.35;
 // Stop just before fp64 precision and the selected landmark begin to break down.
-const MIN_PIXEL_SCALE = 1e-9;
+const MIN_PIXEL_SCALE = 4e-9;
 const MAX_ZOOM_DEPTH = Math.log2(INITIAL_PIXEL_SCALE / MIN_PIXEL_SCALE);
 const RENDER_TIMING_SAMPLE_INTERVAL = 5;
 const RENDER_TIMING_SMOOTHING = 0.2;
 const ZOOM_PRESETS: Record<ZoomPresetId, ZoomPreset> = {
   seahorse: {
     label: 'Seahorse',
-    // Deep-zoom landmark from the classic seahorse-valley sequence.
+    // Slightly nudged toward the visible detail in the low-resolution tour.
     centerX: -0.7436442,
-    centerY: 0.1318261
+    centerY: 0.131826105
   },
   elephant: {
     label: 'Elephant',
@@ -474,7 +474,9 @@ export default class App extends React.PureComponent<AppProps, AppState> {
       (this.state.zoomDepth + elapsedSeconds * AUTO_ZOOM_SPEED) % (MAX_ZOOM_DEPTH + 0.01);
     this.settingsPanel.setSettingValue('zoomDepth', nextZoomDepth);
     if (this.autoZoomPanelRefreshCount++ % 4 === 0) {
-      this.panels.refresh();
+      // Recreate the settings panel so its controlled range input follows the
+      // animated value instead of only updating the renderer and overlay.
+      this.panels.setPanel(this.settingsPanel.makePanel());
     }
     this.autoZoomAnimationFrame = requestAnimationFrame(this.animateAutoZoom);
   };
@@ -1110,7 +1112,7 @@ function getVisualizationSpecs(): VisualizationSpec[] {
     {
       clearColor: [0.01, 0.015, 0.03, 1],
       description:
-        'FP64 Mandelbrot fragment shader using fp64arithmetic. On Apple WebGPU, hybrid mode uses integer-reconstructed high residuals and native low-term accumulation; the fully reliable integer path remains available in the benchmark.',
+        'Mandelbrot rendered with luma.gl double-single fp64 emulation (WebGPU exposes f32 here, not native hardware fp64). The compute benchmark below separately measures dependent fp64 add, multiply, divide, and square-root operations.',
       fragmentShaderGLSL: MANDELBROT64_FRAGMENT_SHADER,
       fragmentShaderWGSL: MANDELBROT64_FRAGMENT_WGSL,
       kind: 'fp64',

--- a/examples/experimental/fp64/app.tsx
+++ b/examples/experimental/fp64/app.tsx
@@ -104,7 +104,10 @@ const DEFAULT_RENDER_WIDTH = 192;
 const MIN_RENDER_WIDTH = 96;
 const MAX_RENDER_WIDTH = 256;
 const RENDER_ASPECT_RATIO = CANVAS_WIDTH / CANVAS_HEIGHT;
-const FIXED_ITERATION_LIMIT = 1400;
+const FIXED_ITERATION_LIMIT = 768;
+const BASE_ITERATION_LIMIT = 160;
+const ITERATION_GROWTH_PER_ZOOM = 18;
+const RENDER_INTERVAL_MILLISECONDS = 50;
 const FULLSCREEN_POSITIONS = new Float32Array([-1, -1, -1, 1, 1, -1, 1, 1]);
 const INITIAL_PIXEL_SCALE = 1.35;
 const MIN_PIXEL_SCALE = 1e-12;
@@ -568,6 +571,7 @@ class MultiCanvasRenderer {
 
   animationFrame: number | null = null;
   frameIndex = 0;
+  nextRenderTime = 0;
   isRunning = false;
   zoomDepth: number;
   zoomPreset: ZoomPreset;
@@ -618,6 +622,7 @@ class MultiCanvasRenderer {
       return;
     }
     this.isRunning = true;
+    this.nextRenderTime = 0;
     this.animationFrame = requestAnimationFrame(this.animate);
   }
 
@@ -683,8 +688,13 @@ class MultiCanvasRenderer {
     }
   }
 
-  private animate = (): void => {
+  private animate = (time: number): void => {
     this.animationFrame = null;
+    if (time < this.nextRenderTime) {
+      this.scheduleNextFrame();
+      return;
+    }
+    this.nextRenderTime = time + RENDER_INTERVAL_MILLISECONDS;
     const pixelScale = getPixelScale(this.zoomDepth);
     const sampleTiming = this.frameIndex % RENDER_TIMING_SAMPLE_INTERVAL === 0;
 
@@ -931,7 +941,10 @@ function split64(value: number): [number, number] {
 
 function computeIterationLimit(pixelScale: number): number {
   const zoomDepth = Math.max(0, Math.log2(INITIAL_PIXEL_SCALE / pixelScale));
-  return Math.min(FIXED_ITERATION_LIMIT, Math.round(220 + zoomDepth * 28));
+  return Math.min(
+    FIXED_ITERATION_LIMIT,
+    Math.round(BASE_ITERATION_LIMIT + zoomDepth * ITERATION_GROWTH_PER_ZOOM)
+  );
 }
 
 function getPixelScale(zoomDepth: number): number {
@@ -1100,7 +1113,7 @@ layout(std140) uniform mandelbrot32Uniforms {
   float iterationLimit;
 } mandelbrot32;
 
-const int MAX_ITERATIONS = 2048;
+const int MAX_ITERATIONS = 1024;
 const float ESCAPE_RADIUS_SQUARED = 256.0;
 const float COLOR_FREQUENCY = 0.025;
 const float TAU = 6.28318530718;
@@ -1162,7 +1175,7 @@ struct Mandelbrot32Uniforms {
 
 @group(0) @binding(auto) var<uniform> mandelbrot32 : Mandelbrot32Uniforms;
 
-const MAX_ITERATIONS: i32 = 2048;
+const MAX_ITERATIONS: i32 = 1024;
 const ESCAPE_RADIUS_SQUARED: f32 = 256.0;
 const COLOR_FREQUENCY: f32 = 0.025;
 const TAU: f32 = 6.28318530718;
@@ -1229,7 +1242,7 @@ layout(std140) uniform mandelbrot64Uniforms {
   float iterationLimit;
 } mandelbrot64;
 
-const int MAX_ITERATIONS = 2048;
+const int MAX_ITERATIONS = 1024;
 const float ESCAPE_RADIUS_SQUARED = 256.0;
 const float COLOR_FREQUENCY = 0.025;
 const float TAU = 6.28318530718;
@@ -1269,8 +1282,8 @@ void main(void) {
     zx = nextX;
     zy = nextY;
 
-    vec2 magnitudeSquared = sum_fp64(mul_fp64(zx, zx), mul_fp64(zy, zy));
-    radiusSquared = magnitudeSquared.x + magnitudeSquared.y;
+    // The high terms are sufficient for the bailout threshold and avoid two fp64 multiplies.
+    radiusSquared = dot(vec2(nextX.x, nextY.x), vec2(nextX.x, nextY.x));
 
     if (radiusSquared > ESCAPE_RADIUS_SQUARED) {
       escapedIteration = float(iteration);
@@ -1304,7 +1317,7 @@ struct Mandelbrot64Uniforms {
 
 @group(0) @binding(auto) var<uniform> mandelbrot64 : Mandelbrot64Uniforms;
 
-const MAX_ITERATIONS: i32 = 2048;
+const MAX_ITERATIONS: i32 = 1024;
 const ESCAPE_RADIUS_SQUARED: f32 = 256.0;
 const COLOR_FREQUENCY: f32 = 0.025;
 const TAU: f32 = 6.28318530718;
@@ -1344,8 +1357,8 @@ fn fragmentMain(inputs: FragmentOutput) -> @location(0) vec4<f32> {
     zx = nextX;
     zy = nextY;
 
-    let magnitudeSquared = sum_fp64(mul_fp64(zx, zx), mul_fp64(zy, zy));
-    radiusSquared = magnitudeSquared.x + magnitudeSquared.y;
+    // The high terms are sufficient for the bailout threshold and avoid two fp64 multiplies.
+    radiusSquared = dot(vec2<f32>(nextX.x, nextY.x), vec2<f32>(nextX.x, nextY.x));
 
     if (radiusSquared > ESCAPE_RADIUS_SQUARED) {
       escapedIteration = f32(iteration);

--- a/examples/showcase/scene/playground.html
+++ b/examples/showcase/scene/playground.html
@@ -180,6 +180,23 @@
         letter-spacing: 0.08em;
       }
 
+      .editor-toggle {
+        flex: none;
+        padding: 7px 9px;
+        border: 1px solid rgba(191, 203, 247, 0.16);
+        border-radius: 5px;
+        background: rgba(191, 203, 247, 0.06);
+        color: var(--muted);
+        cursor: pointer;
+        font-size: 9px;
+        letter-spacing: 0.06em;
+      }
+
+      .editor-toggle:hover {
+        border-color: rgba(176, 155, 255, 0.35);
+        color: #fff;
+      }
+
       .workspace {
         display: grid;
         grid-template-columns: minmax(370px, 42%) minmax(0, 1fr);
@@ -322,6 +339,14 @@
         grid-template-rows: minmax(0, 1fr);
         overflow: hidden;
         background: #090c17;
+      }
+
+      .workspace.editor-collapsed {
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      .workspace.editor-collapsed .editor-panel {
+        display: none;
       }
 
       .preview-canvas {
@@ -528,10 +553,13 @@
         </select>
         <input id="usd-file-input" type="file" accept=".usd,.usda,.usdz,.gltf,.glb" hidden />
         <div id="backend-label" class="backend-label">CONNECTING DEVICE…</div>
+        <button id="editor-toggle" class="editor-toggle" type="button" aria-controls="scene-editor-panel" aria-expanded="true">
+          HIDE EDITOR
+        </button>
       </section>
 
       <section class="workspace">
-        <section class="editor-panel" aria-label="JSON scene editor">
+        <section id="scene-editor-panel" class="editor-panel" aria-label="JSON scene editor">
           <div class="panel-toolbar">
             <span class="section-label">SCENE.JSON</span>
             <div class="editor-actions">

--- a/examples/showcase/scene/playground.ts
+++ b/examples/showcase/scene/playground.ts
@@ -34,6 +34,7 @@ export default class ANARIPlayground extends AnimationLoopTemplate {
   private readonly orbitControls: OrbitControls;
   private importRequest = 0;
   private animationScrubbing = false;
+  private editorCollapsed = false;
 
   constructor({device}: AnimationProps) {
     super();
@@ -127,6 +128,18 @@ export default class ANARIPlayground extends AnimationLoopTemplate {
   }
 
   private initializeControls(): void {
+    const editorToggle = getRequiredElement('editor-toggle', HTMLButtonElement);
+    const workspace = editorToggle
+      .closest<HTMLElement>('.shell')
+      ?.querySelector<HTMLElement>('.workspace');
+    editorToggle.addEventListener('click', () => {
+      if (!workspace) return;
+      this.editorCollapsed = !this.editorCollapsed;
+      workspace.classList.toggle('editor-collapsed', this.editorCollapsed);
+      editorToggle.setAttribute('aria-expanded', String(!this.editorCollapsed));
+      editorToggle.textContent = this.editorCollapsed ? 'SHOW EDITOR' : 'HIDE EDITOR';
+    });
+
     const presetList = getRequiredElement('preset-list', HTMLDivElement);
     for (const [presetIndex, preset] of PLAYGROUND_PRESETS.entries()) {
       const button = document.createElement('button');

--- a/test/examples/fp64-responsive-layout.node.spec.ts
+++ b/test/examples/fp64-responsive-layout.node.spec.ts
@@ -56,7 +56,7 @@ describe('FP64 example responsive layout', () => {
       expect.objectContaining({type: 'number', min: 0, step: 0.1, sliderDebounceMs: 0})
     );
     expect(renderWidthSetting).toEqual(
-      expect.objectContaining({type: 'number', min: 160, max: 640, step: 20})
+      expect.objectContaining({type: 'number', min: 96, max: 256, step: 20})
     );
     expect(makeFP64SettingsSchema(false).sections[0].settings).not.toContainEqual(
       expect.objectContaining({name: 'selectedBackend'})

--- a/test/examples/fp64-responsive-layout.node.spec.ts
+++ b/test/examples/fp64-responsive-layout.node.spec.ts
@@ -13,17 +13,15 @@ import FP64App, {
 import {requiresFP64ArithmeticUniform} from '../../examples/experimental/fp64/fp64-compute-benchmark';
 
 describe('FP64 example responsive layout', () => {
-  test('keeps each precision description paired with its canvas when the panes stack', () => {
+  test('keeps both precision panes aligned in a two-column grid', () => {
     const markup = renderToStaticMarkup(React.createElement(FP64App));
     const singlePrecisionPane = markup.indexOf('data-fp64-visualization="fp32"');
     const singlePrecisionCanvas = markup.indexOf('<canvas', singlePrecisionPane);
     const doublePrecisionPane = markup.indexOf('data-fp64-visualization="fp64"');
     const doublePrecisionCanvas = markup.indexOf('<canvas', doublePrecisionPane);
 
-    expect(markup).toContain(
-      'grid-template-columns:repeat(auto-fit, minmax(min(100%, 320px), 1fr))'
-    );
-    expect(markup.match(/grid-template-rows:1fr auto/g)?.length).toBe(2);
+    expect(markup).toContain('grid-template-columns:repeat(2, minmax(0, 1fr))');
+    expect(markup.match(/grid-template-rows:auto 1fr/g)?.length).toBe(2);
     expect(singlePrecisionPane).toBeGreaterThanOrEqual(0);
     expect(singlePrecisionCanvas).toBeGreaterThan(singlePrecisionPane);
     expect(doublePrecisionPane).toBeGreaterThan(singlePrecisionCanvas);
@@ -34,8 +32,8 @@ describe('FP64 example responsive layout', () => {
     const markup = renderToStaticMarkup(React.createElement(FP64App));
 
     expect(markup).toContain('box-sizing:border-box;display:block;width:100%');
-    expect(markup).toContain('left:12px;right:12px;bottom:12px;box-sizing:border-box');
-    expect(markup).toContain('max-width:calc(100% - 24px)');
+    expect(markup).toContain('left:6px;right:6px;bottom:6px;box-sizing:border-box');
+    expect(markup).toContain('max-width:calc(100% - 12px)');
     expect(markup.match(/overflow-wrap:anywhere/g)?.length).toBeGreaterThanOrEqual(3);
   });
 


### PR DESCRIPTION
## Summary
- Add an accessible hide/show control for the scene JSON editor.
- Let the rendered preview span the full workspace when the editor is collapsed, improving small-screen usability.

## Verification
- `node_modules/.bin/tsc -p examples/showcase/scene/tsconfig.json --noEmit`
- `yarn lint fix`
- `git diff --check`
- Node tests: 408 files passed, 1 skipped.