### PR TITLE
fix(webgl): accept GLSL bool and struct array members in uniform block reflection validation

### DIFF
--- a/modules/engine/test/lib/model-uniform-block-reflection.spec.ts
+++ b/modules/engine/test/lib/model-uniform-block-reflection.spec.ts
@@ -1,0 +1,68 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {expect, it, vi} from 'vitest';
+import {log} from '@luma.gl/core';
+import {Model} from '@luma.gl/engine';
+import {gouraudMaterial} from '@luma.gl/shadertools';
+import {getWebGLTestDevice} from '@luma.gl/test-utils';
+
+// References a GLSL bool member (`material.unlit`) and struct array members
+// (`lighting.lights[i]`) so both module blocks stay active after linking.
+const LIGHTING_VS = /* glsl */ `\
+#version 300 es
+out vec3 vColor;
+void main() {
+  vColor = lighting.ambientColor + lighting.lights[0].color + lighting.lights[4].position;
+  if (material.unlit) {
+    vColor = vec3(material.ambient);
+  }
+  gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+}
+`;
+
+const LIGHTING_FS = /* glsl */ `\
+#version 300 es
+precision highp float;
+in vec3 vColor;
+out vec4 fragColor;
+void main() {
+  fragColor = vec4(vColor, 1.0);
+}
+`;
+
+it('Model validates gouraudMaterial and lighting uniform blocks against WebGL reflection', async () => {
+  const webglDevice = await getWebGLTestDevice();
+  const fallbackMessages: string[] = [];
+  const logOnce = vi.spyOn(log, 'once').mockImplementation((_level, message) => {
+    fallbackMessages.push(String(message));
+    return () => {};
+  });
+
+  try {
+    const model = new Model(webglDevice, {
+      id: 'uniform-block-reflection-test',
+      topology: 'point-list',
+      vertexCount: 0,
+      vs: LIGHTING_VS,
+      fs: LIGHTING_FS,
+      modules: [gouraudMaterial]
+    });
+
+    const uniformBlockNames = model.pipeline.shaderLayout.bindings
+      .filter(binding => binding.type === 'uniform')
+      .map(binding => binding.name);
+    expect(uniformBlockNames, 'module uniform blocks are active').toEqual(
+      expect.arrayContaining(['gouraudMaterialUniforms', 'lightingUniforms'])
+    );
+    expect(
+      fallbackMessages.filter(message => message.includes('uniform block reflection failed')),
+      'reflected layouts match the module std140 metadata'
+    ).toEqual([]);
+
+    model.destroy();
+  } finally {
+    logOnce.mockRestore();
+  }
+});

--- a/modules/webgl/src/adapter/converters/webgl-shadertypes.ts
+++ b/modules/webgl/src/adapter/converters/webgl-shadertypes.ts
@@ -74,10 +74,12 @@ const WEBGL_SHADER_TYPES: Record<GLUniformType, VariableShaderType> = {
   [GL.UNSIGNED_INT_VEC3]: 'vec3<u32>',
   [GL.UNSIGNED_INT_VEC4]: 'vec4<u32>',
 
-  [GL.BOOL]: 'f32',
-  [GL.BOOL_VEC2]: 'vec2<f32>',
-  [GL.BOOL_VEC3]: 'vec3<f32>',
-  [GL.BOOL_VEC4]: 'vec4<f32>',
+  // GLSL bools have no luma shader type. They occupy 4-byte integer slots in std140 layouts
+  // and are set through the integer uniform setters, so they are represented as `i32`.
+  [GL.BOOL]: 'i32',
+  [GL.BOOL_VEC2]: 'vec2<i32>',
+  [GL.BOOL_VEC3]: 'vec3<i32>',
+  [GL.BOOL_VEC4]: 'vec4<i32>',
 
   // TODO - are sizes/components below correct?
   [GL.FLOAT_MAT2]: 'mat2x2<f32>',

--- a/modules/webgl/src/adapter/helpers/get-shader-layout-from-glsl.ts
+++ b/modules/webgl/src/adapter/helpers/get-shader-layout-from-glsl.ts
@@ -698,26 +698,28 @@ function getUniformInfosFromTypes(
       throw new Error(`Nested uniform arrays are not supported for ${name}`);
     }
 
-    for (const [memberName, memberType] of Object.entries(
-      type as Record<string, CompositeShaderType>
-    )) {
-      if (typeof memberType !== 'string') {
-        throw new Error(`Composite uniform array members are not supported for ${name}`);
+    const memberEntries = Object.entries(type as Record<string, CompositeShaderType>);
+    if (memberEntries.some(([, memberType]) => typeof memberType !== 'string')) {
+      throw new Error(`Composite uniform array members are not supported for ${name}`);
+    }
+
+    // WebGL reflects each member of each struct array element as its own non-array uniform
+    // (`lights[0].color`, `lights[1].color`, ...), so expand the declared array the same way.
+    for (let elementIndex = 0; elementIndex < arrayLength; elementIndex++) {
+      for (const [memberName] of memberEntries) {
+        const elementName = `${name}[${elementIndex}].${memberName}`;
+        const field = fields[elementName];
+        if (!field) {
+          throw new Error(`Missing std140 array layout field ${elementName}`);
+        }
+        uniforms.push({
+          name: elementName,
+          format: field.shaderType,
+          arrayLength: 1,
+          byteOffset: field.offset * 4,
+          byteStride: 0
+        });
       }
-      const firstName = `${name}[0].${memberName}`;
-      const secondName = `${name}[1].${memberName}`;
-      const firstField = fields[firstName];
-      const secondField = arrayLength > 1 ? fields[secondName] : undefined;
-      if (!firstField) {
-        throw new Error(`Missing std140 array layout field ${firstName}`);
-      }
-      uniforms.push({
-        name: firstName,
-        format: firstField.shaderType,
-        arrayLength,
-        byteOffset: firstField.offset * 4,
-        byteStride: secondField ? (secondField.offset - firstField.offset) * 4 : 0
-      });
     }
   };
 

--- a/modules/webgl/test/adapter/helpers/get-shader-layout-from-glsl.spec.ts
+++ b/modules/webgl/test/adapter/helpers/get-shader-layout-from-glsl.spec.ts
@@ -4,12 +4,23 @@
 
 import {expect, it, vi} from 'vitest';
 
+import {log} from '@luma.gl/core';
 import {GL} from '@luma.gl/webgl/constants';
 import {getShaderLayoutFromGLSL} from '@luma.gl/webgl';
+
+type ReflectedUniform = {
+  name: string;
+  type: number;
+  size?: number;
+  byteOffset: number;
+  byteStride?: number;
+};
 
 type ReflectionOptions = {
   activeBlockCount?: number;
   activeUniformInfo?: WebGLActiveInfo | null;
+  /** Per-uniform driver results. Overrides `activeUniformInfo`, `uniformIndices` and `uniformTypes`. */
+  activeUniforms?: ReflectedUniform[];
   blockIndexByName?: Record<string, number>;
   blockName?: string | null;
   nullBlockParameter?: number;
@@ -24,8 +35,18 @@ function makeReflectionContext(options: ReflectionOptions = {}): {
 } {
   const activeBlockCount = options.activeBlockCount ?? 1;
   const blockName = options.blockName === undefined ? 'rawUniforms' : options.blockName;
-  const uniformIndices = options.uniformIndices === undefined ? [4] : options.uniformIndices;
-  const uniformTypes = options.uniformTypes === undefined ? [GL.FLOAT] : options.uniformTypes;
+  const activeUniforms = options.activeUniforms;
+  const firstUniformIndex = 4;
+  const uniformIndices = activeUniforms
+    ? activeUniforms.map((_uniform, index) => firstUniformIndex + index)
+    : options.uniformIndices === undefined
+      ? [firstUniformIndex]
+      : options.uniformIndices;
+  const uniformTypes = activeUniforms
+    ? activeUniforms.map(uniform => uniform.type)
+    : options.uniformTypes === undefined
+      ? [GL.FLOAT]
+      : options.uniformTypes;
   const activeUniformInfo =
     options.activeUniformInfo === undefined
       ? ({name: 'raw.value', size: 1, type: GL.FLOAT} as WebGLActiveInfo)
@@ -38,13 +59,19 @@ function makeReflectionContext(options: ReflectionOptions = {}): {
         case GL.UNIFORM_TYPE:
           return uniformTypes;
         case GL.UNIFORM_SIZE:
-          return uniformTypes && uniformTypes.map(() => 1);
+          return activeUniforms
+            ? activeUniforms.map(uniform => uniform.size ?? 1)
+            : uniformTypes && uniformTypes.map(() => 1);
         case GL.UNIFORM_BLOCK_INDEX:
           return uniformTypes && uniformTypes.map(() => uniformBlockIndex);
         case GL.UNIFORM_OFFSET:
-          return uniformTypes && uniformTypes.map((_value, index) => index * 16);
+          return activeUniforms
+            ? activeUniforms.map(uniform => uniform.byteOffset)
+            : uniformTypes && uniformTypes.map((_value, index) => index * 16);
         case GL.UNIFORM_ARRAY_STRIDE:
-          return uniformTypes && uniformTypes.map(() => 0);
+          return activeUniforms
+            ? activeUniforms.map(uniform => uniform.byteStride ?? 0)
+            : uniformTypes && uniformTypes.map(() => 0);
         default:
           throw new Error(`Unexpected active uniform parameter ${parameter}`);
       }
@@ -94,7 +121,13 @@ function makeReflectionContext(options: ReflectionOptions = {}): {
       }
     },
     getActiveUniforms,
-    getActiveUniform: () => activeUniformInfo
+    getActiveUniform: (_program: WebGLProgram, uniformIndex: number) => {
+      if (!activeUniforms) {
+        return activeUniformInfo;
+      }
+      const uniform = activeUniforms[uniformIndex - firstUniformIndex];
+      return uniform && {name: uniform.name, size: uniform.size ?? 1, type: uniform.type};
+    }
   } as unknown as WebGL2RenderingContext;
 
   return {gl, getActiveUniforms};
@@ -241,4 +274,148 @@ it('getShaderLayoutFromGLSL validates nullable uniform block parameters', () => 
   expect(() => getShaderLayoutFromGLSL(gl, program)).toThrow(
     /uniform block "rawUniforms".*UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES returned null/
   );
+});
+
+it('getShaderLayoutFromGLSL reflects GLSL bool members as i32 for raw GLSL blocks', () => {
+  const {gl} = makeReflectionContext({
+    activeUniforms: [
+      {name: 'raw.flag', type: GL.BOOL, byteOffset: 0},
+      {name: 'raw.flags', type: GL.BOOL_VEC2, byteOffset: 8}
+    ]
+  });
+
+  const shaderLayout = getShaderLayoutFromGLSL(gl, program);
+
+  expect(shaderLayout.bindings[0]).toMatchObject({
+    name: 'rawUniforms',
+    uniforms: [
+      {name: 'raw.flag', format: 'i32', byteOffset: 0, byteStride: 0, arrayLength: 1},
+      {name: 'raw.flags', format: 'vec2<i32>', byteOffset: 8, byteStride: 0, arrayLength: 1}
+    ]
+  });
+});
+
+it('getShaderLayoutFromGLSL validates GLSL bool members declared as i32 in module metadata', () => {
+  const {gl} = makeReflectionContext({
+    blockIndexByName: {materialUniforms: 0},
+    activeUniforms: [
+      {name: 'material.unlit', type: GL.BOOL, byteOffset: 0},
+      {name: 'material.ambient', type: GL.FLOAT, byteOffset: 4}
+    ]
+  });
+  const logOnce = vi.spyOn(log, 'once').mockImplementation(() => () => {});
+
+  try {
+    const shaderLayout = getShaderLayoutFromGLSL(gl, program, {
+      uniformBlockLayouts: [
+        {name: 'materialUniforms', uniformTypes: {unlit: 'i32', ambient: 'f32'}}
+      ]
+    });
+
+    expect(logOnce, 'no reflection fallback warning').not.toHaveBeenCalled();
+    expect(shaderLayout.bindings[0]).toMatchObject({
+      name: 'materialUniforms',
+      minBindingSize: 16,
+      uniforms: [
+        {name: 'unlit', format: 'i32', byteOffset: 0},
+        {name: 'ambient', format: 'f32', byteOffset: 4}
+      ]
+    });
+  } finally {
+    logOnce.mockRestore();
+  }
+});
+
+it('getShaderLayoutFromGLSL expands struct arrays per element to match WebGL reflection', () => {
+  const {gl} = makeReflectionContext({
+    blockIndexByName: {lightingUniforms: 0},
+    activeUniforms: [
+      {name: 'lighting.lightCount', type: GL.INT, byteOffset: 0},
+      {name: 'lighting.lights[0].color', type: GL.FLOAT_VEC3, byteOffset: 16},
+      {name: 'lighting.lights[0].intensity', type: GL.FLOAT, byteOffset: 28},
+      {name: 'lighting.lights[1].color', type: GL.FLOAT_VEC3, byteOffset: 32},
+      {name: 'lighting.lights[1].intensity', type: GL.FLOAT, byteOffset: 44}
+    ]
+  });
+  const logOnce = vi.spyOn(log, 'once').mockImplementation(() => () => {});
+
+  try {
+    const shaderLayout = getShaderLayoutFromGLSL(gl, program, {
+      uniformBlockLayouts: [
+        {
+          name: 'lightingUniforms',
+          uniformTypes: {
+            lightCount: 'i32',
+            lights: [{color: 'vec3<f32>', intensity: 'f32'}, 2]
+          }
+        }
+      ]
+    });
+
+    expect(logOnce, 'no reflection fallback warning').not.toHaveBeenCalled();
+    expect(shaderLayout.bindings[0]).toEqual({
+      type: 'uniform',
+      name: 'lightingUniforms',
+      group: 0,
+      location: 0,
+      visibility: 0,
+      minBindingSize: 48,
+      uniforms: [
+        {name: 'lightCount', format: 'i32', byteOffset: 0, byteStride: 0, arrayLength: 1},
+        {
+          name: 'lights[0].color',
+          format: 'vec3<f32>',
+          byteOffset: 16,
+          byteStride: 0,
+          arrayLength: 1
+        },
+        {name: 'lights[0].intensity', format: 'f32', byteOffset: 28, byteStride: 0, arrayLength: 1},
+        {
+          name: 'lights[1].color',
+          format: 'vec3<f32>',
+          byteOffset: 32,
+          byteStride: 0,
+          arrayLength: 1
+        },
+        {name: 'lights[1].intensity', format: 'f32', byteOffset: 44, byteStride: 0, arrayLength: 1}
+      ]
+    });
+  } finally {
+    logOnce.mockRestore();
+  }
+});
+
+it('getShaderLayoutFromGLSL warns and keeps module metadata when reflected offsets diverge', () => {
+  const {gl} = makeReflectionContext({
+    blockIndexByName: {materialUniforms: 0},
+    activeUniforms: [
+      {name: 'material.unlit', type: GL.BOOL, byteOffset: 0},
+      {name: 'material.ambient', type: GL.FLOAT, byteOffset: 16}
+    ]
+  });
+  const logOnce = vi.spyOn(log, 'once').mockImplementation(() => () => {});
+
+  try {
+    const shaderLayout = getShaderLayoutFromGLSL(gl, program, {
+      uniformBlockLayouts: [
+        {name: 'materialUniforms', uniformTypes: {unlit: 'i32', ambient: 'f32'}}
+      ]
+    });
+
+    expect(logOnce).toHaveBeenCalledWith(
+      0,
+      expect.stringMatching(
+        /reflected layout for "material.ambient" does not match supplied std140 metadata/
+      )
+    );
+    expect(shaderLayout.bindings[0]).toMatchObject({
+      name: 'materialUniforms',
+      uniforms: [
+        {name: 'unlit', byteOffset: 0},
+        {name: 'ambient', byteOffset: 4}
+      ]
+    });
+  } finally {
+    logOnce.mockRestore();
+  }
 });


### PR DESCRIPTION
Fixes #3187

### Background

Since 9.4.0 `@luma.gl/webgl` reflects each linked uniform block and compares it with the std140 metadata built from module `uniformTypes`. Two common declarations fail that comparison although their byte layouts agree, so every affected program logs a level-0 warning and falls back to the supplied metadata. This fires for luma's own `gouraudMaterial` / `lighting` modules and for deck.gl 9.4 layers that use them or `DataFilterExtension`.

### Change List

- `webgl-shadertypes.ts`: map `GL.BOOL` / `BOOL_VEC2..4` to `i32` / `vecN<i32>` instead of `f32`. A GLSL bool occupies a 4-byte integer slot in std140 and is set through the integer uniform setters (see `set-uniform.ts`), and luma's own modules already declare GLSL bools as `'i32'` (`unlit`, `enabled`, `invert`, the pbr `*Enabled` flags).
- `get-shader-layout-from-glsl.ts`: expand declared struct arrays per element (`lights[0].color`, `lights[1].color`, …, each `arrayLength: 1`, `byteStride: 0`). This matches how WebGL reports struct array members and how raw GLSL blocks were already reflected, so the validator still compares every member's offset and format strictly.
- Tests (first commit, red until the fix commit is applied on top):
  - `get-shader-layout-from-glsl.spec.ts`: the mocked reflection context now accepts per-uniform driver results; new cases cover bool members (raw and module-backed), per-element struct arrays, and a real offset divergence that must still warn and fall back.
  - `model-uniform-block-reflection.spec.ts` (engine, headless): builds a `Model` with `gouraudMaterial` and `lighting` on a WebGL device and asserts the linked blocks validate without a reflection fallback. This is the reproduction from the issue.

### Commits

The branch is two commits:

**test(webgl): cover uniform block reflection of GLSL bools and struct arrays**

Test-only. Extends the mocked reflection fixture and adds the new unit cases and the headless engine spec. Checked out by itself, the two specs report 5 failures highlighting the warnings from issue #3187 

**fix(webgl): accept GLSL bool and struct array members in uniform block reflection validation**

Source-only. The two changes in `webgl-shadertypes.ts` and `get-shader-layout-from-glsl.ts` described above.