### PR TITLE
Extend automatic GPU Parquet decoding

### DIFF
--- a/modules/gpgpu/src/gpu-parse/README.md
+++ b/modules/gpgpu/src/gpu-parse/README.md
@@ -53,7 +53,7 @@ public class matrix for every scalar type. Object-oriented operations such as `G
 | `parseParquetPlainByteArrayPlan` | PLAIN BYTE_ARRAY has interleaved lengths | source offsets, lengths, compacted offsets, output size |
 | `parseParquetRleBitPackedRunPlan` | an unframed hybrid stream is isolated | fixed-width run descriptors |
 | `parseParquetDictionaryIndicesPlan` | indices include a leading bit-width byte | bit width and rebased run descriptors |
-| `parseParquetLengthPrefixedRleBitPackedRunPlan` | Data Page V1 RLE/levels include a length | rebased run descriptors |
+| `parseParquetLengthPrefixedRleBitPackedRunPlan` | Data Page V1 levels or RLE values include a length | rebased run descriptors |
 | `parseParquetBitPackedRunPlan` | deprecated standalone BIT_PACKED is encountered | validated MSB-first payload metadata |
 | `parseParquetDeltaBinaryPackedPlan` | INT32 uses DELTA_BINARY_PACKED | mini-block descriptors and first value |
 | `parseParquetDeltaBinaryPackedInt64Plan` | INT64 uses DELTA_BINARY_PACKED | split-word mini-block descriptors and first value |
@@ -97,8 +97,9 @@ unless a function explicitly documents an isolated slice.
 - BYTE_STREAM_SPLIT INT32, INT64, FLOAT, DOUBLE, or FIXED_LEN_BYTE_ARRAY uses
   `GPUParquetByteStreamSplitDecoder`.
 - PLAIN BOOLEAN uses `GPUParquetPlainBooleanDecoder`.
-- RLE BOOLEAN uses `GPUParquetRleBitPackedDecoder` with bit width one. The automatic page adapter
-  selects this path and returns the same one-uint32-per-row layout as PLAIN BOOLEAN.
+- RLE BOOLEAN uses `parseParquetLengthPrefixedRleBitPackedRunPlan` followed by
+  `GPUParquetRleBitPackedDecoder` with bit width one. The automatic page adapter consumes the
+  four-byte value-stream envelope and returns the same one-uint32-per-row layout as PLAIN BOOLEAN.
 - PLAIN BYTE_ARRAY uses `parseParquetPlainByteArrayPlan` and
   `GPUParquetPlainByteArrayDecoder`. Its metadata layout is directly compatible with
   `GPUByteRangeGather`.

--- a/modules/gpgpu/src/gpu-parse/README.md
+++ b/modules/gpgpu/src/gpu-parse/README.md
@@ -132,6 +132,9 @@ const plan = planGPUParquetEncodedPageBatch(encodedBatch, {
 });
 ```
 
+An all-null page has zero physical values and therefore a known empty result. The adapter emits an
+`empty-byte-array` plan for that case without invoking the callback or parsing absent delta headers.
+
 ### Levels and page versions
 
 - Data Page V1 levels have a four-byte encoded-length prefix; use

--- a/modules/gpgpu/src/gpu-parse/README.md
+++ b/modules/gpgpu/src/gpu-parse/README.md
@@ -97,6 +97,8 @@ unless a function explicitly documents an isolated slice.
 - BYTE_STREAM_SPLIT INT32, INT64, FLOAT, DOUBLE, or FIXED_LEN_BYTE_ARRAY uses
   `GPUParquetByteStreamSplitDecoder`.
 - PLAIN BOOLEAN uses `GPUParquetPlainBooleanDecoder`.
+- RLE BOOLEAN uses `GPUParquetRleBitPackedDecoder` with bit width one. The automatic page adapter
+  selects this path and returns the same one-uint32-per-row layout as PLAIN BOOLEAN.
 - PLAIN BYTE_ARRAY uses `parseParquetPlainByteArrayPlan` and
   `GPUParquetPlainByteArrayDecoder`. Its metadata layout is directly compatible with
   `GPUByteRangeGather`.
@@ -116,6 +118,18 @@ Use `parseParquetDictionaryIndicesPlan`, then either:
 `GPUParquetDeltaLengthByteArrayDecoder` outputs lengths and exclusive offsets. The payload after
 `payloadByteOffset` is already contiguous. `GPUParquetDeltaByteArrayDecoder` additionally follows
 prefix references across any number of preceding rows and emits fully reconstructed bytes.
+
+`DELTA_BYTE_ARRAY` does not carry its final reconstructed byte length in the encoded payload.
+Automatic planning therefore needs `getPageOutputByteLength` to return an exact length from
+application or loader metadata. Without it, the page remains an explicit `missing-output-capacity`
+CPU fallback instead of guessing an allocation or adding a GPU readback barrier:
+
+```ts
+const plan = planGPUParquetEncodedPageBatch(encodedBatch, {
+  getPageOutputByteLength: (column, page) =>
+    decodedSizes.get(`${column.path.join('.')}:${page.pageOrdinal}`)
+});
+```
 
 ### Levels and page versions
 
@@ -140,6 +154,13 @@ Both supported codecs use CPU planning plus the same `GPULZByteDecompressor` GPU
 Use the codec-specific GPU wrapper when operation names and metrics should retain codec semantics;
 use `GPULZByteDecompressor` directly when another byte-oriented LZ format can produce the same
 descriptor contract.
+
+Codec support is a capability statement, not a performance promise. The generic resolver favors
+compact descriptors and deterministic overlapping-copy semantics; binary descriptor searches and
+irregular backreference chains can make either LZ4_RAW or Snappy slower than a mature CPU/Wasm
+decoder. Measure with representative pages. Prefer CPU decompression followed by deferred GPU value
+decoding when that split gives a better crossover, and reserve preserved compression for workloads
+where transfer savings and GPU reuse repay planning and execution costs.
 
 ## loaders.gl integration
 
@@ -211,7 +232,8 @@ controlled pipelines.
 - Encodings whose serial control headers remain hidden inside a compressed value payload. The
   loader may CPU-decompress these pages while still deferring their value decoding.
 - Encodings with no bounded automatic output allocation. Lower-level operations remain available
-  when an application supplies an explicit output capacity.
+  when an application supplies an explicit output capacity. `DELTA_BYTE_ARRAY` is automatic when
+  `getPageOutputByteLength` supplies its exact reconstructed length.
 
 CPU decoding remains the loaders.gl default. `readPages()` is the explicit opt-in, and mixed
 CPU/GPU execution remains caller-owned because loaders.gl should not depend on luma.gl.
@@ -232,12 +254,12 @@ policy boundaries become CPU fallbacks; corrupt data is never relabeled as an un
 | Encoding or codec | Status | Notes |
 | --- | --- | --- |
 | PLAIN fixed, BOOLEAN, BYTE_ARRAY | Supported | zero-copy, bit expansion, or generic range gather |
-| RLE / hybrid bit packing | Supported | bit widths 0–32; V1/V2 framing adapters |
+| RLE / hybrid bit packing | Supported | bit widths 0–32; V1/V2 level framing and BOOLEAN values |
 | BIT_PACKED | Compatibility support | deprecated MSB-first level encoding has a distinct decoder |
 | RLE_DICTIONARY / PLAIN_DICTIONARY | Supported | fixed and variable dictionaries |
 | DELTA_BINARY_PACKED | INT32 and INT64 supported | INT64 uses split uint32 words and modulo-2^64 scan |
 | DELTA_LENGTH_BYTE_ARRAY | Supported | lengths, offsets, zero-copy payload |
-| DELTA_BYTE_ARRAY | Supported | full prefix reconstruction |
+| DELTA_BYTE_ARRAY | Supported | full prefix reconstruction; automatic adapter needs exact output byte length |
 | BYTE_STREAM_SPLIT | Supported | all specified physical types except INT96 |
 | LZ4_RAW | Supported | raw blocks and overlapping matches |
 | Snappy | Supported | raw Snappy blocks, all literal and copy tag forms |
@@ -247,22 +269,23 @@ policy boundaries become CPU fallbacks; corrupt data is never relabeled as an un
 
 ## Follow-up roadmap
 
-Tranches 1 and 2 are complete: the package has composable low-level operations, and loaders.gl
-encoded-page batches can now be validated, uploaded once, and executed as mixed GPU/CPU command
-graphs. Further work should remain incremental. Each tranche below has a useful stopping point and
-does not require turning `gpu-parse` into a complete Parquet parser.
+Tranches 1–3 are complete: the package has composable low-level operations; loaders.gl encoded-page
+batches can be validated, uploaded once, and executed as mixed GPU/CPU command graphs; and
+decompressed V1 framing, variable dictionaries, RLE BOOLEAN, and bounded `DELTA_BYTE_ARRAY` pages
+flow through the automatic adapter. Further work should remain incremental. Each tranche below has
+a useful stopping point and does not require turning `gpu-parse` into a complete Parquet parser.
 
 | Tranche | Priority | Scope | Completion bar |
 | --- | --- | --- | --- |
-| 3. Close inexpensive adapter gaps | Recommended next | Let a loader choose preserve-compressed, CPU-decompress-but-keep-encoded, or CPU-decode per page; automatically use `DELTA_BYTE_ARRAY` when an exact output capacity is available; accept variable dictionaries and V1 level framing after loader-side decompression | Common supported encodings stop falling back merely because compression hides their serial control headers; no GPU metadata parser is introduced |
+| 3. Close inexpensive adapter gaps | Complete | Loader-selected preserved compression or CPU-decompressed encoded pages; automatic bounded `DELTA_BYTE_ARRAY`; variable dictionaries; decompressed V1 level framing; RLE BOOLEAN values | Common supported encodings no longer fall back for adapter-only gaps; no GPU metadata parser was introduced |
 | 4. Extract generic materialization primitives | High value | Generalize validity expansion, segmented offsets, compaction, scatter, and byte-range assembly from the Parquet level and byte-array paths | The same operations can materialize another columnar format without importing Parquet-specific classes |
 | 5. Assemble nested GPU columns | Selective | Compose multiple definition/repetition depths into validity, row, and list offsets; expose chunk-preserving `GPUData`/`GPUVector` results without adding Arrow to `@luma.gl/gpgpu` | Common required, optional, list, and nested-list columns can remain GPU-resident through their consumer boundary |
 | 6. Streaming and throughput | Measure first | Reuse compiled graph templates, pool upload/output buffers, batch compatible pages and columns, add backpressure, and benchmark CPU/GPU crossover thresholds | Sustained row-group streaming has bounded memory and published evidence for when GPU deferral pays off |
 | 7. Conformance and hardening | Ongoing | Add files from multiple Parquet writers, differential CPU/GPU decoding, planner fuzzing, malformed/truncated inputs, empty/all-null pages, large offsets, and maximum-width stress cases | Every automatic path is covered by independent writer fixtures and corruption tests; fallbacks remain distinguishable from malformed data |
 | 8. Demand-driven format additions | Optional | Evaluate ALP and focused logical conversions such as DECIMAL or legacy INT96 only when real datasets justify them | A new operation has a bounded layout, a reusable primitive where possible, fixtures, benchmarks, and a documented CPU fallback |
 
-The intended order is 3, 4, and then whichever of 5–7 is justified by an actual consumer. Tranche 8
-is not a completeness checklist.
+The intended next step is tranche 4, then whichever of 5–7 is justified by an actual consumer.
+Tranche 8 is not a completeness checklist.
 
 ### Roadmap stop line
 

--- a/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-delta-byte-array-decoder.ts
+++ b/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-delta-byte-array-decoder.ts
@@ -27,6 +27,8 @@ export type GPUParquetDeltaByteArrayDecoderProps = {
   suffixMiniBlockDescriptors: GraphDataView<'uint32'>;
   prefixLengths: GraphDataView<'uint32'>;
   suffixLengths: GraphDataView<'uint32'>;
+  /** Reconstructed byte length for each value. */
+  valueLengths: GraphDataView<'uint32'>;
   valueOffsets: GraphDataView<'uint32'>;
   output: GraphDataView<'uint32'>;
   encodedByteLength: number;
@@ -78,12 +80,7 @@ export class GPUParquetDeltaByteArrayDecoder {
       firstValue: this.props.firstSuffixLength
     }).addToGraph(graph);
 
-    const valueLengths = createTransientView(
-      graph,
-      `${this.id}-value-lengths`,
-      'uint32',
-      this.props.valueCount
-    );
+    const valueLengths = this.props.valueLengths;
     const suffixOffsets = createTransientView(
       graph,
       `${this.id}-suffix-offsets`,
@@ -384,6 +381,7 @@ function validateProps(props: Readonly<GPUParquetDeltaByteArrayDecoderProps>): v
   for (const [name, view] of Object.entries({
     prefixLengths: props.prefixLengths,
     suffixLengths: props.suffixLengths,
+    valueLengths: props.valueLengths,
     valueOffsets: props.valueOffsets
   })) {
     if (view.length < props.valueCount) {
@@ -396,6 +394,7 @@ function validateProps(props: Readonly<GPUParquetDeltaByteArrayDecoderProps>): v
   const writableBuffers = [
     props.prefixLengths.buffer,
     props.suffixLengths.buffer,
+    props.valueLengths.buffer,
     props.valueOffsets.buffer,
     props.output.buffer
   ];
@@ -418,6 +417,7 @@ function validateOwnership<Parameters>(
     props.suffixMiniBlockDescriptors,
     props.prefixLengths,
     props.suffixLengths,
+    props.valueLengths,
     props.valueOffsets,
     props.output
   ]) {

--- a/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-delta-byte-array-decoder.ts
+++ b/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-delta-byte-array-decoder.ts
@@ -351,6 +351,7 @@ function validateProps(props: Readonly<GPUParquetDeltaByteArrayDecoderProps>): v
     suffixMiniBlockDescriptors: props.suffixMiniBlockDescriptors,
     prefixLengths: props.prefixLengths,
     suffixLengths: props.suffixLengths,
+    valueLengths: props.valueLengths,
     valueOffsets: props.valueOffsets,
     output: props.output
   })) {

--- a/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-encoded-page-batch.ts
+++ b/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-encoded-page-batch.ts
@@ -306,6 +306,15 @@ function addValuesToGraph<Parameters>(
         byteLength: plan.decodedByteLength
       });
     }
+    case 'empty-byte-array':
+      return Object.freeze({
+        layout: 'byte-array' as const,
+        values: input,
+        lengths: createTransientResultView(graph, `${id}-lengths`, 0),
+        offsets: createTransientResultView(graph, `${id}-offsets`, 0),
+        valueCount: 0,
+        byteLength: 0
+      });
     case 'rle-boolean': {
       const values = createTransientResultView(graph, `${id}-values`, plan.valueCount);
       new GPUParquetRleBitPackedDecoder({

--- a/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-encoded-page-batch.ts
+++ b/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-encoded-page-batch.ts
@@ -17,6 +17,7 @@ import {GPUParquetByteStreamSplitDecoder} from './gpu-parquet-byte-stream-split-
 import {GPUParquetDeltaBinaryPackedDecoder} from './gpu-parquet-delta-binary-packed-decoder';
 import {GPUParquetDeltaBinaryPackedInt64Decoder} from './gpu-parquet-delta-binary-packed-int64-decoder';
 import {GPUParquetDeltaLengthByteArrayDecoder} from './gpu-parquet-delta-length-byte-array-decoder';
+import {GPUParquetDeltaByteArrayDecoder} from './gpu-parquet-delta-byte-array-decoder';
 import {GPUParquetPlainBooleanDecoder} from './gpu-parquet-plain-boolean-decoder';
 import {GPUParquetPlainByteArrayDecoder} from './gpu-parquet-plain-byte-array-decoder';
 import {GPUParquetRleBitPackedDecoder} from './gpu-parquet-rle-bit-packed-decoder';
@@ -305,6 +306,25 @@ function addValuesToGraph<Parameters>(
         byteLength: plan.decodedByteLength
       });
     }
+    case 'rle-boolean': {
+      const values = createTransientResultView(graph, `${id}-values`, plan.valueCount);
+      new GPUParquetRleBitPackedDecoder({
+        id: `${id}-rle-boolean`,
+        input,
+        runDescriptors: createUploadView(graph, inputHandle, plan.runDescriptors),
+        output: values,
+        encodedByteLength: input.length * 4,
+        valueCount: plan.valueCount,
+        runCount: plan.runPlan.runCount,
+        bitWidth: 1
+      }).addToGraph(graph);
+      return Object.freeze({
+        layout: 'uint32' as const,
+        values,
+        valueCount: plan.valueCount,
+        byteLength: plan.decodedByteLength
+      });
+    }
     case 'plain-byte-array': {
       const values = createTransientPackedBytes(
         graph,
@@ -392,6 +412,62 @@ function addValuesToGraph<Parameters>(
       return Object.freeze({
         layout: 'byte-array' as const,
         values: createUploadView(graph, inputHandle, plan.payload),
+        lengths,
+        offsets,
+        valueCount: plan.valueCount,
+        byteLength: plan.decodedByteLength
+      });
+    }
+    case 'delta-byte-array': {
+      const prefixLengths = createTransientResultView(
+        graph,
+        `${id}-prefix-lengths`,
+        plan.valueCount
+      );
+      const suffixLengths = createTransientResultView(
+        graph,
+        `${id}-suffix-lengths`,
+        plan.valueCount
+      );
+      const lengths = createTransientResultView(graph, `${id}-lengths`, plan.valueCount);
+      const offsets = createTransientResultView(graph, `${id}-offsets`, plan.valueCount);
+      const values = createTransientPackedBytes(
+        graph,
+        `${id}-values`,
+        plan.decodedByteLength,
+        Buffer.STORAGE | Buffer.COPY_SRC
+      );
+      new GPUParquetDeltaByteArrayDecoder({
+        id: `${id}-delta-byte-array`,
+        input,
+        prefixMiniBlockDescriptors: createUploadView(
+          graph,
+          inputHandle,
+          plan.prefixMiniBlockDescriptors
+        ),
+        suffixMiniBlockDescriptors: createUploadView(
+          graph,
+          inputHandle,
+          plan.suffixMiniBlockDescriptors
+        ),
+        prefixLengths,
+        suffixLengths,
+        valueLengths: lengths,
+        valueOffsets: offsets,
+        output: values,
+        encodedByteLength: input.length * 4,
+        suffixDataByteOffset: plan.deltaPlan.suffixDataByteOffset,
+        suffixDataByteLength: plan.deltaPlan.suffixDataByteLength,
+        outputByteCapacity: plan.decodedByteLength,
+        valueCount: plan.valueCount,
+        prefixDescriptorCount: plan.deltaPlan.prefixLengthPlan.descriptorCount,
+        suffixDescriptorCount: plan.deltaPlan.suffixLengthPlan.descriptorCount,
+        firstPrefixLength: plan.deltaPlan.prefixLengthPlan.firstValue,
+        firstSuffixLength: plan.deltaPlan.suffixLengthPlan.firstValue
+      }).addToGraph(graph);
+      return Object.freeze({
+        layout: 'byte-array' as const,
+        values,
         lengths,
         offsets,
         valueCount: plan.valueCount,

--- a/modules/gpgpu/src/gpu-parse/parquet/parquet-encoded-page-batch.ts
+++ b/modules/gpgpu/src/gpu-parse/parquet/parquet-encoded-page-batch.ts
@@ -159,6 +159,11 @@ export type GPUParquetValuePlan =
       decodedByteLength: number;
     }>
   | Readonly<{
+      kind: 'empty-byte-array';
+      valueCount: 0;
+      decodedByteLength: 0;
+    }>
+  | Readonly<{
       kind: 'rle-boolean';
       valueCount: number;
       decodedByteLength: number;
@@ -717,6 +722,14 @@ function planValues(
       valueCount,
       byteWidth,
       decodedByteLength
+    });
+  }
+
+  if (encoding === 'DELTA_BYTE_ARRAY' && physicalType === 'BYTE_ARRAY' && valueCount === 0) {
+    return Object.freeze({
+      kind: 'empty-byte-array' as const,
+      valueCount: 0 as const,
+      decodedByteLength: 0 as const
     });
   }
 

--- a/modules/gpgpu/src/gpu-parse/parquet/parquet-encoded-page-batch.ts
+++ b/modules/gpgpu/src/gpu-parse/parquet/parquet-encoded-page-batch.ts
@@ -31,6 +31,7 @@ import {
 import {
   parseParquetBitPackedRunPlan,
   parseParquetDictionaryIndicesPlan,
+  parseParquetLengthPrefixedRleBitPackedRunPlan,
   type ParquetBitPackedPlan,
   type ParquetDictionaryIndicesPlan
 } from './parquet-rle-framing';
@@ -726,7 +727,7 @@ function planValues(
     );
   }
   if (encoding === 'RLE' && physicalType === 'BOOLEAN') {
-    const runPlan = parseParquetRleBitPackedRunPlan(encoded, 1, valueCount);
+    const runPlan = parseParquetLengthPrefixedRleBitPackedRunPlan(encoded, 1, valueCount);
     return Object.freeze({
       kind: 'rle-boolean' as const,
       valueCount,

--- a/modules/gpgpu/src/gpu-parse/parquet/parquet-encoded-page-batch.ts
+++ b/modules/gpgpu/src/gpu-parse/parquet/parquet-encoded-page-batch.ts
@@ -21,6 +21,10 @@ import {
   type ParquetDeltaLengthByteArrayPlan
 } from './parquet-delta-length-byte-array';
 import {
+  parseParquetDeltaByteArrayPlan,
+  type ParquetDeltaByteArrayPlan
+} from './parquet-delta-byte-array';
+import {
   parseParquetPlainByteArrayPlan,
   type ParquetPlainByteArrayPlan
 } from './parquet-plain-byte-array';
@@ -154,6 +158,13 @@ export type GPUParquetValuePlan =
       decodedByteLength: number;
     }>
   | Readonly<{
+      kind: 'rle-boolean';
+      valueCount: number;
+      decodedByteLength: number;
+      runPlan: ParquetRleBitPackedRunPlan;
+      runDescriptors: GPUParquetUploadSection;
+    }>
+  | Readonly<{
       kind: 'plain-byte-array';
       valueCount: number;
       decodedByteLength: number;
@@ -183,6 +194,14 @@ export type GPUParquetValuePlan =
       deltaPlan: ParquetDeltaLengthByteArrayPlan;
       miniBlockDescriptors: GPUParquetUploadSection;
       payload: GPUParquetUploadSection;
+    }>
+  | Readonly<{
+      kind: 'delta-byte-array';
+      valueCount: number;
+      decodedByteLength: number;
+      deltaPlan: ParquetDeltaByteArrayPlan;
+      prefixMiniBlockDescriptors: GPUParquetUploadSection;
+      suffixMiniBlockDescriptors: GPUParquetUploadSection;
     }>
   | Readonly<{
       kind: 'dictionary-fixed' | 'dictionary-byte-array';
@@ -226,6 +245,7 @@ export type CPUParquetPageFallbackPlan = Readonly<{
     | 'unsupported-encoding'
     | 'unsupported-physical-type'
     | 'missing-dictionary'
+    | 'missing-output-capacity'
     | 'variable-dictionary-output';
   detail: string;
   page: ParquetEncodedPage;
@@ -248,6 +268,15 @@ export type GPUParquetEncodedPageBatchPlanOptions = Readonly<{
   minimumGPUByteLength?: number;
   /** Compression codecs retained by loaders.gl and accepted by this adapter. */
   compressionCodecs?: readonly ('SNAPPY' | 'LZ4_RAW')[];
+  /**
+   * Returns an exact decoded byte length for a variable-width page when metadata outside the
+   * encoded payload already provides it. Enables bounded `DELTA_BYTE_ARRAY` reconstruction without
+   * a GPU allocation/readback round trip.
+   */
+  getPageOutputByteLength?: (
+    column: LoadersGLParquetEncodedColumnChunk,
+    page: LoadersGLParquetEncodedPage
+  ) => number | undefined;
   /** Throws instead of returning a mixed plan when any page needs CPU work. */
   requireGPU?: boolean;
 }>;
@@ -305,6 +334,7 @@ export function planGPUParquetEncodedPageBatch(
           pageIndex,
           minimumGPUByteLength,
           compressionCodecs,
+          options.getPageOutputByteLength,
           upload,
           dictionaries[columnIndex],
           dictionaryErrors[columnIndex]
@@ -425,6 +455,7 @@ function planPage(
   pageIndex: number,
   minimumGPUByteLength: number,
   compressionCodecs: ReadonlySet<string>,
+  getPageOutputByteLength: GPUParquetEncodedPageBatchPlanOptions['getPageOutputByteLength'],
   upload: GPUParquetUploadBuilder,
   dictionary: GPUParquetDictionaryPlan | undefined,
   dictionaryError: PlannerError | undefined
@@ -477,6 +508,7 @@ function planPage(
     physicalValueCount,
     sections.decodedValuesByteLength,
     Boolean(compression),
+    getPageOutputByteLength,
     upload,
     dictionary,
     dictionaryError
@@ -607,6 +639,7 @@ function planValues(
   valueCount: number,
   decodedValuesByteLength: number,
   isCompressed: boolean,
+  getPageOutputByteLength: GPUParquetEncodedPageBatchPlanOptions['getPageOutputByteLength'],
   upload: GPUParquetUploadBuilder,
   dictionary: GPUParquetDictionaryPlan | undefined,
   dictionaryError: PlannerError | undefined
@@ -692,6 +725,16 @@ function planValues(
       `Compressed ${encoding} control headers require CPU decompression before GPU planning`
     );
   }
+  if (encoding === 'RLE' && physicalType === 'BOOLEAN') {
+    const runPlan = parseParquetRleBitPackedRunPlan(encoded, 1, valueCount);
+    return Object.freeze({
+      kind: 'rle-boolean' as const,
+      valueCount,
+      decodedByteLength: multiplyUint32(valueCount, 4, 'RLE BOOLEAN output'),
+      runPlan,
+      runDescriptors: upload.add(runPlan.runDescriptors, 'boolean RLE descriptors')
+    });
+  }
   if (encoding === 'DELTA_BINARY_PACKED' && physicalType === 'INT32') {
     const deltaPlan = parseParquetDeltaBinaryPackedPlan(encoded);
     validatePlannedValueCount(deltaPlan.valueCount, valueCount, encoding);
@@ -729,6 +772,32 @@ function planValues(
       payload: upload.add(
         encoded.subarray(deltaPlan.payloadByteOffset),
         'delta length byte-array payload'
+      )
+    });
+  }
+  if (encoding === 'DELTA_BYTE_ARRAY' && physicalType === 'BYTE_ARRAY') {
+    const pageOutputByteLength = getPageOutputByteLength?.(column, page);
+    if (pageOutputByteLength === undefined) {
+      throw makePlannerError(
+        'missing-output-capacity',
+        'DELTA_BYTE_ARRAY requires an exact decoded byte length from getPageOutputByteLength'
+      );
+    }
+    validateUint32(pageOutputByteLength, 'DELTA_BYTE_ARRAY output byte length');
+    const deltaPlan = parseParquetDeltaByteArrayPlan(encoded);
+    validatePlannedValueCount(deltaPlan.prefixLengthPlan.valueCount, valueCount, encoding);
+    return Object.freeze({
+      kind: 'delta-byte-array' as const,
+      valueCount,
+      decodedByteLength: pageOutputByteLength,
+      deltaPlan,
+      prefixMiniBlockDescriptors: upload.add(
+        deltaPlan.prefixLengthPlan.miniBlockDescriptors,
+        'delta byte-array prefix descriptors'
+      ),
+      suffixMiniBlockDescriptors: upload.add(
+        deltaPlan.suffixLengthPlan.miniBlockDescriptors,
+        'delta byte-array suffix descriptors'
       )
     });
   }

--- a/modules/gpgpu/src/gpu-parse/parquet/parquet-rle-framing.ts
+++ b/modules/gpgpu/src/gpu-parse/parquet/parquet-rle-framing.ts
@@ -29,7 +29,7 @@ export function parseParquetDictionaryIndicesPlan(
   return Object.freeze({bitWidth, runPlan, bytesConsumed: runPlan.bytesConsumed});
 }
 
-/** Reads the four-byte little-endian length used by Data Page V1 RLE level/value streams. */
+/** Reads the four-byte little-endian length used by V1 RLE levels and RLE value streams. */
 export function parseParquetLengthPrefixedRleBitPackedRunPlan(
   encoded: Uint8Array,
   bitWidth: number,

--- a/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-delta-byte-array-decoder.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-delta-byte-array-decoder.node.spec.ts
@@ -62,6 +62,11 @@ it('GPUParquetDeltaByteArrayDecoder composes both decoders, scans, and reconstru
     byteLength: 16,
     usage: Buffer.STORAGE
   });
+  const valueLengthHandle = graph.importBuffer({
+    id: 'value-lengths',
+    byteLength: 16,
+    usage: Buffer.STORAGE
+  });
   const outputHandle = graph.importBuffer({id: 'output', byteLength: 16, usage: Buffer.STORAGE});
   const decoder = new GPUParquetDeltaByteArrayDecoder({
     input: graph.createDataView(inputHandle, {format: 'uint32', length: 14}),
@@ -75,6 +80,7 @@ it('GPUParquetDeltaByteArrayDecoder composes both decoders, scans, and reconstru
     }),
     prefixLengths: graph.createDataView(prefixLengthHandle, {format: 'uint32', length: 4}),
     suffixLengths: graph.createDataView(suffixLengthHandle, {format: 'uint32', length: 4}),
+    valueLengths: graph.createDataView(valueLengthHandle, {format: 'uint32', length: 4}),
     valueOffsets: graph.createDataView(valueOffsetHandle, {format: 'uint32', length: 4}),
     output: graph.createDataView(outputHandle, {format: 'uint32', length: 4}),
     encodedByteLength: ENCODED.length,
@@ -87,7 +93,7 @@ it('GPUParquetDeltaByteArrayDecoder composes both decoders, scans, and reconstru
     firstPrefixLength: 0,
     firstSuffixLength: 3
   });
-  const valueLengthHandle = graph.importBuffer({
+  const shaderValueLengthHandle = graph.importBuffer({
     id: 'test-value-lengths',
     byteLength: 16,
     usage: Buffer.STORAGE
@@ -99,7 +105,7 @@ it('GPUParquetDeltaByteArrayDecoder composes both decoders, scans, and reconstru
   });
   const source = getGPUParquetDeltaByteArrayReconstructionShaderSource(
     decoder,
-    graph.createDataView(valueLengthHandle, {format: 'uint32', length: 4}),
+    graph.createDataView(shaderValueLengthHandle, {format: 'uint32', length: 4}),
     graph.createDataView(suffixOffsetHandle, {format: 'uint32', length: 4}),
     {x: 1, y: 1, z: 1}
   );

--- a/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-delta-byte-array-decoder.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-delta-byte-array-decoder.node.spec.ts
@@ -64,7 +64,7 @@ it('GPUParquetDeltaByteArrayDecoder composes both decoders, scans, and reconstru
   });
   const valueLengthHandle = graph.importBuffer({
     id: 'value-lengths',
-    byteLength: 16,
+    byteLength: 32,
     usage: Buffer.STORAGE
   });
   const outputHandle = graph.importBuffer({id: 'output', byteLength: 16, usage: Buffer.STORAGE});
@@ -115,6 +115,18 @@ it('GPUParquetDeltaByteArrayDecoder composes both decoders, scans, and reconstru
   expect(() => decoder.addToGraph(graph)).not.toThrow();
   expect(Boolean(addComputePass.mock.calls.length >= 7)).toBe(true);
   expect(addComputePass.mock.calls.at(-1)?.[0].id).toBe('gpu-parquet-delta-byte-array-reconstruct');
+  expect(
+    () =>
+      new GPUParquetDeltaByteArrayDecoder({
+        ...decoder.props,
+        valueLengths: graph.createDataView(valueLengthHandle, {
+          format: 'uint32',
+          length: 4,
+          byteStride: 8
+        })
+      }),
+    'rejects strided value lengths because the shaders use packed indexing'
+  ).toThrow(/must be packed/);
 });
 
 function makeSupportDevice(): Device {

--- a/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-delta-byte-array-decoder.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-delta-byte-array-decoder.spec.ts
@@ -48,6 +48,10 @@ it('GPUParquetDeltaByteArrayDecoder reconstructs prefix-compressed values', asyn
     byteLength: 16,
     usage: Buffer.STORAGE | Buffer.COPY_SRC
   });
+  const valueLengthsBuffer = device.createBuffer({
+    byteLength: 16,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
   const outputBuffer = device.createBuffer({
     byteLength: 16,
     usage: Buffer.STORAGE | Buffer.COPY_SRC
@@ -59,6 +63,7 @@ it('GPUParquetDeltaByteArrayDecoder reconstructs prefix-compressed values', asyn
   const prefixLengths = importView(graph, prefixLengthsBuffer, 'prefix-lengths', 4);
   const suffixLengths = importView(graph, suffixLengthsBuffer, 'suffix-lengths', 4);
   const valueOffsets = importView(graph, valueOffsetsBuffer, 'value-offsets', 4);
+  const valueLengths = importView(graph, valueLengthsBuffer, 'value-lengths', 4);
   const output = importView(graph, outputBuffer, 'output', 4);
   new GPUParquetDeltaByteArrayDecoder({
     input,
@@ -66,6 +71,7 @@ it('GPUParquetDeltaByteArrayDecoder reconstructs prefix-compressed values', asyn
     suffixMiniBlockDescriptors: suffixDescriptors,
     prefixLengths,
     suffixLengths,
+    valueLengths,
     valueOffsets,
     output,
     encodedByteLength: ENCODED.length,
@@ -86,10 +92,12 @@ it('GPUParquetDeltaByteArrayDecoder reconstructs prefix-compressed values', asyn
     const decodedPrefixLengths = await prefixLengthsBuffer.readAsync();
     const decodedSuffixLengths = await suffixLengthsBuffer.readAsync();
     const decodedValueOffsets = await valueOffsetsBuffer.readAsync();
+    const decodedValueLengths = await valueLengthsBuffer.readAsync();
     const decodedOutput = await outputBuffer.readAsync();
     expect(readUint32(decodedPrefixLengths, 4)).toEqual([0, 2, 3, 0]);
     expect(readUint32(decodedSuffixLengths, 4)).toEqual([3, 1, 4, 3]);
     expect(readUint32(decodedValueOffsets, 4)).toEqual([0, 3, 6, 13]);
+    expect(readUint32(decodedValueLengths, 4)).toEqual([3, 3, 7, 3]);
     expect(new TextDecoder().decode(decodedOutput)).toBe('catcarcartoondog');
   } finally {
     compiled.destroy();
@@ -99,6 +107,7 @@ it('GPUParquetDeltaByteArrayDecoder reconstructs prefix-compressed values', asyn
     prefixLengthsBuffer.destroy();
     suffixLengthsBuffer.destroy();
     valueOffsetsBuffer.destroy();
+    valueLengthsBuffer.destroy();
     outputBuffer.destroy();
   }
 });

--- a/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-encoded-page-batch.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-encoded-page-batch.spec.ts
@@ -244,6 +244,41 @@ it('loaders.gl DELTA_BYTE_ARRAY values execute through the automatic GPU graph',
   }
 });
 
+it('loaders.gl empty DELTA_BYTE_ARRAY values produce an empty GPU graph result', async () => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    return;
+  }
+
+  const plan = planGPUParquetEncodedPageBatch(
+    makeSinglePageBatch(new Uint8Array(0), 'BYTE_ARRAY', 'DELTA_BYTE_ARRAY', 0)
+  );
+  const inputBuffer = createGPUParquetEncodedPageBatchInputBuffer(device, plan);
+  const graph = new GPUCommandGraph(device, {id: 'gpu-parquet-empty-delta-byte-array-test'});
+  const result = addGPUParquetEncodedPageBatchToGraph(graph, plan, inputBuffer);
+  const page = result.pages[0] as GPUParquetDecodedPage;
+  expect(page.values.layout).toBe('byte-array');
+  if (page.values.layout === 'byte-array') {
+    expect(page.values.valueCount).toBe(0);
+    expect(page.values.byteLength).toBe(0);
+    expect(page.values.values.length).toBe(0);
+    expect(page.values.lengths.length).toBe(0);
+    expect(page.values.offsets.length).toBe(0);
+  }
+  const compiled = graph.compile();
+
+  try {
+    const commandEncoder = device.createCommandEncoder({
+      id: 'gpu-parquet-empty-delta-byte-array-encoder'
+    });
+    compiled.encode(commandEncoder, {parameters: undefined});
+    device.submit(commandEncoder.finish());
+  } finally {
+    compiled.destroy();
+    inputBuffer.destroy();
+  }
+});
+
 function makeBatch(
   data: Uint8Array,
   encoding: 'PLAIN' | 'BYTE_STREAM_SPLIT' = 'BYTE_STREAM_SPLIT'

--- a/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-encoded-page-batch.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-encoded-page-batch.spec.ts
@@ -160,7 +160,7 @@ it('loaders.gl RLE BOOLEAN values execute through the automatic GPU graph', asyn
   }
 
   const plan = planGPUParquetEncodedPageBatch(
-    makeSinglePageBatch(Uint8Array.from([8, 1, 8, 0]), 'BOOLEAN', 'RLE', 8)
+    makeSinglePageBatch(Uint8Array.from([4, 0, 0, 0, 8, 1, 8, 0]), 'BOOLEAN', 'RLE', 8)
   );
   const inputBuffer = createGPUParquetEncodedPageBatchInputBuffer(device, plan);
   const graph = new GPUCommandGraph(device, {id: 'gpu-parquet-rle-boolean-batch-test'});

--- a/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-encoded-page-batch.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-encoded-page-batch.spec.ts
@@ -153,6 +153,97 @@ it('loaders.gl encoded pages reuse one byte-array dictionary across GPU pages', 
   }
 });
 
+it('loaders.gl RLE BOOLEAN values execute through the automatic GPU graph', async () => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    return;
+  }
+
+  const plan = planGPUParquetEncodedPageBatch(
+    makeSinglePageBatch(Uint8Array.from([8, 1, 8, 0]), 'BOOLEAN', 'RLE', 8)
+  );
+  const inputBuffer = createGPUParquetEncodedPageBatchInputBuffer(device, plan);
+  const graph = new GPUCommandGraph(device, {id: 'gpu-parquet-rle-boolean-batch-test'});
+  const result = addGPUParquetEncodedPageBatchToGraph(graph, plan, inputBuffer);
+  const page = result.pages[0] as GPUParquetDecodedPage;
+  const readback = createReadbackBuffer(device, 8 * Uint32Array.BYTES_PER_ELEMENT);
+  if (page.values.layout === 'uint32') {
+    addReadbackCopy(graph, page.values.values, readback, 'rle-boolean-values');
+  }
+  const compiled = graph.compile();
+
+  try {
+    const commandEncoder = device.createCommandEncoder({id: 'gpu-parquet-rle-boolean-encoder'});
+    compiled.encode(commandEncoder, {parameters: undefined});
+    device.submit(commandEncoder.finish());
+    const resultData = await readback.readAsync();
+    expect(Array.from(new Uint32Array(resultData.buffer, resultData.byteOffset, 8))).toEqual([
+      1, 1, 1, 1, 0, 0, 0, 0
+    ]);
+  } finally {
+    compiled.destroy();
+    inputBuffer.destroy();
+    readback.destroy();
+  }
+});
+
+it('loaders.gl DELTA_BYTE_ARRAY values execute through the automatic GPU graph', async () => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    return;
+  }
+
+  const encoded = Uint8Array.from([
+    128, 1, 4, 4, 0, 5, 3, 0, 0, 0, 37, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 1, 4, 4, 6, 3, 3, 0,
+    0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 97, 116, 114, 116, 111, 111, 110, 100, 111, 103
+  ]);
+  const plan = planGPUParquetEncodedPageBatch(
+    makeSinglePageBatch(encoded, 'BYTE_ARRAY', 'DELTA_BYTE_ARRAY', 4),
+    {getPageOutputByteLength: () => 16}
+  );
+  const inputBuffer = createGPUParquetEncodedPageBatchInputBuffer(device, plan);
+  const graph = new GPUCommandGraph(device, {id: 'gpu-parquet-delta-byte-array-batch-test'});
+  const result = addGPUParquetEncodedPageBatchToGraph(graph, plan, inputBuffer);
+  const page = result.pages[0] as GPUParquetDecodedPage;
+  const valuesReadback = createReadbackBuffer(device, 16);
+  const lengthsReadback = createReadbackBuffer(device, 16);
+  const offsetsReadback = createReadbackBuffer(device, 16);
+  if (page.values.layout === 'byte-array') {
+    addReadbackCopy(graph, page.values.values, valuesReadback, 'delta-byte-array-values');
+    addReadbackCopy(graph, page.values.lengths, lengthsReadback, 'delta-byte-array-lengths');
+    addReadbackCopy(graph, page.values.offsets, offsetsReadback, 'delta-byte-array-offsets');
+  }
+  const compiled = graph.compile();
+
+  try {
+    const commandEncoder = device.createCommandEncoder({
+      id: 'gpu-parquet-delta-byte-array-encoder'
+    });
+    compiled.encode(commandEncoder, {parameters: undefined});
+    device.submit(commandEncoder.finish());
+    const [valueData, lengthData, offsetData] = await Promise.all([
+      valuesReadback.readAsync(),
+      lengthsReadback.readAsync(),
+      offsetsReadback.readAsync()
+    ]);
+    expect(
+      new TextDecoder().decode(new Uint8Array(valueData.buffer, valueData.byteOffset, 16))
+    ).toBe('catcarcartoondog');
+    expect(Array.from(new Uint32Array(lengthData.buffer, lengthData.byteOffset, 4))).toEqual([
+      3, 3, 7, 3
+    ]);
+    expect(Array.from(new Uint32Array(offsetData.buffer, offsetData.byteOffset, 4))).toEqual([
+      0, 3, 6, 13
+    ]);
+  } finally {
+    compiled.destroy();
+    inputBuffer.destroy();
+    valuesReadback.destroy();
+    lengthsReadback.destroy();
+    offsetsReadback.destroy();
+  }
+});
+
 function makeBatch(
   data: Uint8Array,
   encoding: 'PLAIN' | 'BYTE_STREAM_SPLIT' = 'BYTE_STREAM_SPLIT'
@@ -263,6 +354,59 @@ function makeDictionaryBatch(): ParquetEncodedPageBatch {
           uncompressedByteLength: dictionaryData.byteLength
         },
         pages: [makeDataPage(0, 2, 2), makeDataPage(1, 1, 1)]
+      }
+    ]
+  };
+}
+
+function makeSinglePageBatch(
+  data: Uint8Array,
+  physicalType: string,
+  encoding: string,
+  valueCount: number
+): ParquetEncodedPageBatch {
+  return {
+    shape: 'parquet-encoded-pages',
+    rowGroup: {
+      index: 0,
+      rowOffset: 0,
+      rowCount: valueCount,
+      uncompressedByteLength: data.byteLength,
+      uncompressedSize: data.byteLength,
+      compressedByteLength: data.byteLength,
+      compressedSize: data.byteLength,
+      columns: [],
+      sortingColumns: []
+    },
+    projectedColumns: ['value'],
+    filterColumns: [],
+    columns: [
+      {
+        path: ['value'],
+        physicalType,
+        maxRepetitionLevel: 0,
+        maxDefinitionLevel: 0,
+        compression: 'UNCOMPRESSED',
+        valueCount,
+        pages: [
+          {
+            type: 'data-v2',
+            pageOrdinal: 0,
+            encoding,
+            repetitionLevelEncoding: 'RLE',
+            definitionLevelEncoding: 'RLE',
+            compression: 'UNCOMPRESSED',
+            compressionState: 'decompressed',
+            valueCount,
+            nonNullValueCount: valueCount,
+            data,
+            repetitionLevels: {byteOffset: 0, byteLength: 0},
+            definitionLevels: {byteOffset: 0, byteLength: 0},
+            values: {byteOffset: 0, byteLength: data.byteLength},
+            compressedByteLength: data.byteLength,
+            uncompressedByteLength: data.byteLength
+          }
+        ]
       }
     ]
   };

--- a/modules/gpgpu/test/gpu-parse/parquet/parquet-encoded-page-batch.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/parquet-encoded-page-batch.node.spec.ts
@@ -210,7 +210,7 @@ it('GPU Parquet page planner caches variable dictionaries across data pages', ()
 });
 
 it('GPU Parquet page planner accepts RLE-encoded BOOLEAN values', () => {
-  const data = Uint8Array.from([8, 1, 8, 0]);
+  const data = Uint8Array.from([4, 0, 0, 0, 8, 1, 8, 0]);
   const batch = makeSinglePageBatch(data, 'BOOLEAN', 'RLE', 8);
   const plan = planGPUParquetEncodedPageBatch(batch);
   expect(plan.gpuPageCount).toBe(1);
@@ -219,6 +219,7 @@ it('GPU Parquet page planner accepts RLE-encoded BOOLEAN values', () => {
     expect(plan.pages[0].values.kind).toBe('rle-boolean');
     if (plan.pages[0].values.kind === 'rle-boolean') {
       expect(plan.pages[0].values.runPlan?.runCount).toBe(2);
+      expect(plan.pages[0].values.runPlan?.bytesConsumed).toBe(data.byteLength);
       expect(plan.pages[0].values.decodedByteLength).toBe(32);
     }
   }

--- a/modules/gpgpu/test/gpu-parse/parquet/parquet-encoded-page-batch.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/parquet-encoded-page-batch.node.spec.ts
@@ -249,6 +249,21 @@ it('GPU Parquet page planner uses caller-provided DELTA_BYTE_ARRAY output length
   }
 });
 
+it('GPU Parquet page planner accepts empty DELTA_BYTE_ARRAY pages without capacity metadata', () => {
+  const plan = planGPUParquetEncodedPageBatch(
+    makeSinglePageBatch(new Uint8Array(0), 'BYTE_ARRAY', 'DELTA_BYTE_ARRAY', 0)
+  );
+  expect(plan.gpuPageCount).toBe(1);
+  expect(plan.pages[0].mode).toBe('gpu');
+  if (plan.pages[0].mode === 'gpu') {
+    expect(plan.pages[0].values).toEqual({
+      kind: 'empty-byte-array',
+      valueCount: 0,
+      decodedByteLength: 0
+    });
+  }
+});
+
 function makeSinglePageBatch(
   data: Uint8Array,
   physicalType: string,

--- a/modules/gpgpu/test/gpu-parse/parquet/parquet-encoded-page-batch.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/parquet-encoded-page-batch.node.spec.ts
@@ -209,6 +209,98 @@ it('GPU Parquet page planner caches variable dictionaries across data pages', ()
   }
 });
 
+it('GPU Parquet page planner accepts RLE-encoded BOOLEAN values', () => {
+  const data = Uint8Array.from([8, 1, 8, 0]);
+  const batch = makeSinglePageBatch(data, 'BOOLEAN', 'RLE', 8);
+  const plan = planGPUParquetEncodedPageBatch(batch);
+  expect(plan.gpuPageCount).toBe(1);
+  expect(plan.pages[0].mode).toBe('gpu');
+  if (plan.pages[0].mode === 'gpu') {
+    expect(plan.pages[0].values.kind).toBe('rle-boolean');
+    if (plan.pages[0].values.kind === 'rle-boolean') {
+      expect(plan.pages[0].values.runPlan?.runCount).toBe(2);
+      expect(plan.pages[0].values.decodedByteLength).toBe(32);
+    }
+  }
+});
+
+it('GPU Parquet page planner uses caller-provided DELTA_BYTE_ARRAY output lengths', () => {
+  const data = Uint8Array.from([
+    128, 1, 4, 4, 0, 5, 3, 0, 0, 0, 37, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 1, 4, 4, 6, 3, 3, 0,
+    0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 97, 116, 114, 116, 111, 111, 110, 100, 111, 103
+  ]);
+  const batch = makeSinglePageBatch(data, 'BYTE_ARRAY', 'DELTA_BYTE_ARRAY', 4);
+  const fallbackPlan = planGPUParquetEncodedPageBatch(batch);
+  expect(fallbackPlan.pages[0].mode).toBe('cpu-fallback');
+  if (fallbackPlan.pages[0].mode === 'cpu-fallback') {
+    expect(fallbackPlan.pages[0].reason).toBe('missing-output-capacity');
+  }
+
+  const plan = planGPUParquetEncodedPageBatch(batch, {
+    getPageOutputByteLength: (column, page) =>
+      column.path[0] === 'value' && page.pageOrdinal === 0 ? 16 : undefined
+  });
+  expect(plan.gpuPageCount).toBe(1);
+  expect(plan.pages[0].mode).toBe('gpu');
+  if (plan.pages[0].mode === 'gpu') {
+    expect(plan.pages[0].values.kind).toBe('delta-byte-array');
+    expect(plan.pages[0].values.decodedByteLength).toBe(16);
+  }
+});
+
+function makeSinglePageBatch(
+  data: Uint8Array,
+  physicalType: string,
+  encoding: string,
+  valueCount: number
+): ParquetEncodedPageBatch {
+  return {
+    shape: 'parquet-encoded-pages',
+    rowGroup: {
+      index: 0,
+      rowOffset: 0,
+      rowCount: valueCount,
+      uncompressedByteLength: data.byteLength,
+      uncompressedSize: data.byteLength,
+      compressedByteLength: data.byteLength,
+      compressedSize: data.byteLength,
+      columns: [],
+      sortingColumns: []
+    },
+    projectedColumns: ['value'],
+    filterColumns: [],
+    columns: [
+      {
+        path: ['value'],
+        physicalType,
+        maxRepetitionLevel: 0,
+        maxDefinitionLevel: 0,
+        compression: 'UNCOMPRESSED',
+        valueCount,
+        pages: [
+          {
+            type: 'data-v2',
+            pageOrdinal: 0,
+            encoding,
+            repetitionLevelEncoding: 'RLE',
+            definitionLevelEncoding: 'RLE',
+            compression: 'UNCOMPRESSED',
+            compressionState: 'decompressed',
+            valueCount,
+            nonNullValueCount: valueCount,
+            data,
+            repetitionLevels: {byteOffset: 0, byteLength: 0},
+            definitionLevels: {byteOffset: 0, byteLength: 0},
+            values: {byteOffset: 0, byteLength: data.byteLength},
+            compressedByteLength: data.byteLength,
+            uncompressedByteLength: data.byteLength
+          }
+        ]
+      }
+    ]
+  };
+}
+
 async function makeEncodedPageBatch(useDataPageV2: boolean): Promise<ParquetEncodedPageBatch> {
   const bytes = await ParquetJSWriter.encode(
     {

--- a/website/content/examples/experimental/gpu-parquet-constellation.mdx
+++ b/website/content/examples/experimental/gpu-parquet-constellation.mdx
@@ -21,10 +21,12 @@ exercise page-batch planning and composable value decoders rather than a conveni
 fixture. The fixture is checked in so file generation does not pollute the measured decode paths.
 
 The columns are deliberately uncompressed. That isolates the GPU-suitable column encodings and
-makes the comparison useful: the current generic Snappy/LZ resolver trades parallel performance for
-fully deterministic overlapping-copy semantics, so its descriptor searches and backreference
-chasing can dominate this workload. `readPages()` can still preserve Snappy and LZ4_RAW pages for GPU
-decoding; improving that generic LZ primitive is a separate optimization target.
+makes the comparison useful: the generic Snappy/LZ4_RAW resolver trades parallel performance for
+compact descriptors and fully deterministic overlapping-copy semantics, so descriptor searches
+and irregular backreference chains can dominate this workload. Tests with an LZ4_RAW version of
+this fixture reduced GPU kernel time but increased planning stalls and descriptor upload enough to
+lose the end-to-end comparison. `readPages()` can still preserve Snappy and LZ4_RAW pages for GPU
+decoding, but codec support is intentionally not presented as a universal speedup.
 
 In **GPU command graph** mode, loaders.gl reads page headers and preserves the encoded value
 sections. `planGPUParquetEncodedPageBatch()` validates and packs those sections, and


### PR DESCRIPTION
## Goals

Close small but useful gaps in the loaders.gl encoded-page adapter without growing gpu-parse into a full Parquet parser.

## Changes

- plan and execute Parquet RLE BOOLEAN values through the automatic GPU command graph
- plan and execute bounded DELTA_BYTE_ARRAY pages when callers provide the exact reconstructed byte length
- expose reconstructed DELTA_BYTE_ARRAY lengths as a composable graph output
- keep missing variable-width capacity as an explicit CPU fallback
- document the completed tranche, operation use cases, and the measured LZ4_RAW/Snappy performance boundary
- keep the constellation benchmark focused on encodings where the current GPU path is honest about end-to-end performance

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn test`: 3,260 Node tests passed; 1,940 headless tests passed
- targeted automatic GPU adapter suite: 5 tests passed

## Follow-up

LZ4_RAW remains the stronger codec optimization candidate, but the saved benchmark showed that lower kernel time is currently outweighed by descriptor planning, upload, and main-thread stalls. The next codec work should optimize that generic LZ planning boundary before presenting compressed pages as the primary visual benchmark.
