### PR TITLE
fix(website): keep WebGL fallback without OffscreenCanvas

### DIFF
--- a/website/src/react-luma/store/device-store.tsx
+++ b/website/src/react-luma/store/device-store.tsx
@@ -151,7 +151,6 @@ export async function canCreateDeviceType(type: DeviceType): Promise<boolean> {
   cachedDeviceAvailability[type] ||= (async () => {
     try {
       await createDevice(type);
-      await createPresentationDevice(type);
       return true;
     } catch {
       return false;


### PR DESCRIPTION
## Summary

Keep ordinary WebGL examples available when the optional OffscreenCanvas-backed presentation device cannot be created, as on older iOS Safari versions.

## Changes

- Make device availability probe the primary device only.
- Preserve presentation-device errors for multi-canvas and texture-tester UI.
- Rebased onto the latest master mobile-support contract.

## Verification

- `nvm use`
- `yarn install`
- `yarn lint fix`
- Commit-hook test suite passed on the companion branch
