### PR TITLE
fix(examples): reserve touch gestures on mobile canvases

### DIFF
--- a/examples/experimental/gpu-graph-explorer/app.ts
+++ b/examples/experimental/gpu-graph-explorer/app.ts
@@ -434,6 +434,7 @@ export default class GPUGraphExplorerAnimationLoopTemplate extends AnimationLoop
     if (canvas instanceof HTMLCanvasElement) {
       this.canvas = canvas;
       canvas.style.cursor = 'grab';
+      canvas.style.touchAction = 'none';
       canvas.addEventListener('pointerdown', this.handlePointerDown);
       canvas.addEventListener('pointermove', this.handlePointerMove);
       canvas.addEventListener('pointerup', this.handlePointerUp);

--- a/examples/experimental/gpu-trace-scene/app.ts
+++ b/examples/experimental/gpu-trace-scene/app.ts
@@ -164,6 +164,7 @@ export default class GPUTraceSceneAnimationLoopTemplate extends AnimationLoopTem
   override async onInitialize({canvas}: AnimationProps): Promise<void> {
     if (canvas instanceof HTMLCanvasElement) {
       this.canvas = canvas;
+      canvas.style.touchAction = 'none';
       canvas.addEventListener('click', this.handleClick);
       canvas.addEventListener('wheel', this.handleWheel, {passive: false});
     }

--- a/examples/experimental/html-ui-prism/app.ts
+++ b/examples/experimental/html-ui-prism/app.ts
@@ -235,6 +235,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     HTMLTexture.configureCanvas(this.canvas);
     this.canvas.style.background = '#0d1117';
     this.canvas.style.cursor = 'grab';
+    this.canvas.style.touchAction = 'none';
     this.canvas.style.overflow = 'visible';
     this.canvas.style.position = 'relative';
     this.styleElement = document.createElement('style');

--- a/examples/experimental/virtual-geometry-canyon/app.ts
+++ b/examples/experimental/virtual-geometry-canyon/app.ts
@@ -196,6 +196,7 @@ export default class VirtualGeometryCanyonAnimationLoopTemplate extends Animatio
     }
     this.canvas = canvas;
     canvas.style.cursor = 'grab';
+    canvas.style.touchAction = 'none';
     canvas.addEventListener('pointerdown', this.handlePointerDown);
     canvas.addEventListener('pointermove', this.handlePointerMove);
     canvas.addEventListener('pointerup', this.handlePointerUp);

--- a/examples/showcase/billion-point-spatial-atlas/app.ts
+++ b/examples/showcase/billion-point-spatial-atlas/app.ts
@@ -351,6 +351,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     if (canvas instanceof HTMLCanvasElement) {
       this.canvas = canvas;
       canvas.style.cursor = 'crosshair';
+      canvas.style.touchAction = 'none';
       canvas.tabIndex = 0;
       canvas.setAttribute('role', 'img');
       canvas.setAttribute(


### PR DESCRIPTION
## Summary

Make custom pointer-driven examples usable on iPhone by reserving touch gestures for canvas interaction.

## Changes

- Set `touch-action: none` on the canvases used by five custom gesture handlers.
- Cover GPU graph explorer, GPU trace scene, HTML UI prism, virtual geometry canyon, and billion-point spatial atlas.
- Rebased onto the latest master mobile-support contract.

## Verification

- `nvm use`
- `yarn install`
- `yarn lint fix`
- Commit-hook test suite passed
