### PR TITLE
[9.4] Address example mobile support review feedback

### DIFF
--- a/examples/api/animation/index.html
+++ b/examples/api/animation/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="api/animation" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/api/blending/index.html
+++ b/examples/api/blending/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="api/blending" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/api/cubemap/index.html
+++ b/examples/api/cubemap/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="api/cubemap" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgl2Adapter} from '@luma.gl/webgl';

--- a/examples/api/render-bundles/index.html
+++ b/examples/api/render-bundles/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="api/render-bundles" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/api/texture-3d/index.html
+++ b/examples/api/texture-3d/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="api/texture-3d" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/api/texture-compressed/index.html
+++ b/examples/api/texture-compressed/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="api/texture-compressed" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/api/texture-sampling/index.html
+++ b/examples/api/texture-sampling/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="api/texture-sampling" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/api/texture-tester/index.html
+++ b/examples/api/texture-tester/index.html
@@ -1,6 +1,23 @@
 <!doctype html>
 <html>
   <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="api/texture-tester" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
     <meta charset='UTF-8' />
     <title>Textures</title>
   </head>

--- a/examples/api/video-texture/index.html
+++ b/examples/api/video-texture/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="api/video-texture" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/arrow/arrow-columns/index.html
+++ b/examples/arrow/arrow-columns/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="arrow/arrow-columns" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/arrow/arrow-dggs-polygons/index.html
+++ b/examples/arrow/arrow-dggs-polygons/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="arrow/arrow-dggs-polygons" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="dense" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/arrow/arrow-filtering/index.html
+++ b/examples/arrow/arrow-filtering/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="arrow/arrow-filtering" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgl2Adapter} from '@luma.gl/webgl';

--- a/examples/arrow/arrow-float64-precision/index.html
+++ b/examples/arrow/arrow-float64-precision/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="arrow/arrow-float64-precision" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgl2Adapter} from '@luma.gl/webgl';

--- a/examples/arrow/arrow-instancing/index.html
+++ b/examples/arrow/arrow-instancing/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/instancing" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgl2Adapter} from '@luma.gl/webgl';

--- a/examples/arrow/arrow-lines/index.html
+++ b/examples/arrow/arrow-lines/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="arrow/arrow-lines" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="dense" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgl2Adapter} from '@luma.gl/webgl';

--- a/examples/arrow/arrow-mesh-geometry/index.html
+++ b/examples/arrow/arrow-mesh-geometry/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="arrow/arrow-mesh-geometry" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="dense" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgl2Adapter} from '@luma.gl/webgl';

--- a/examples/arrow/arrow-particles/index.html
+++ b/examples/arrow/arrow-particles/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="arrow/arrow-particles" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="dense" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgl2Adapter} from '@luma.gl/webgl';

--- a/examples/arrow/arrow-points/index.html
+++ b/examples/arrow/arrow-points/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="arrow/arrow-points" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="dense" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgl2Adapter} from '@luma.gl/webgl';

--- a/examples/arrow/arrow-temporal-starfield/index.html
+++ b/examples/arrow/arrow-temporal-starfield/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="arrow/arrow-temporal-starfield" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="dense" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgl2Adapter} from '@luma.gl/webgl';

--- a/examples/arrow/arrow-text-2d/index.html
+++ b/examples/arrow/arrow-text-2d/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="arrow/arrow-text-2d" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="dense" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgl2Adapter} from '@luma.gl/webgl';

--- a/examples/arrow/arrow-time-columns/index.html
+++ b/examples/arrow/arrow-time-columns/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="arrow/arrow-time-columns" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgl2Adapter} from '@luma.gl/webgl';

--- a/examples/experimental/a-buffer/index.html
+++ b/examples/experimental/a-buffer/index.html
@@ -1,5 +1,22 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/a-buffer" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="effects" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
   <style>
     body {
       margin: 0;

--- a/examples/experimental/advanced-effects/index.html
+++ b/examples/experimental/advanced-effects/index.html
@@ -1,5 +1,22 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/advanced-effects" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="effects" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
   <style>
     html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; background: #030712; color-scheme: dark; }
     canvas { display: block; width: 100vw !important; height: 100vh !important; }

--- a/examples/experimental/antialiasing/index.html
+++ b/examples/experimental/antialiasing/index.html
@@ -1,5 +1,22 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/antialiasing" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="effects" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
   <style>
     body {
       background: black;

--- a/examples/experimental/bloom/index.html
+++ b/examples/experimental/bloom/index.html
@@ -1,5 +1,20 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/bloom" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="effects" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
     html,

--- a/examples/experimental/deferred-rendering/index.html
+++ b/examples/experimental/deferred-rendering/index.html
@@ -1,5 +1,22 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/deferred-rendering" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="effects" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
   <meta charset="utf-8" />
   <title>Deferred Illumination Lab</title>
   <style>

--- a/examples/experimental/fluid-foundry/index.html
+++ b/examples/experimental/fluid-foundry/index.html
@@ -1,5 +1,20 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/fluid-foundry" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="simulation" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Fluid Foundry: Liquid Metal Press</title>

--- a/examples/experimental/gpgpu/index.html
+++ b/examples/experimental/gpgpu/index.html
@@ -1,5 +1,22 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/gpgpu" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
   <style>
     :root {
       color-scheme: light;

--- a/examples/experimental/gpt-2/index.html
+++ b/examples/experimental/gpt-2/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/gpt-2" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <style>
   html,
   body {

--- a/examples/experimental/gpu-data-analysis/index.html
+++ b/examples/experimental/gpu-data-analysis/index.html
@@ -1,5 +1,20 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/gpu-data-analysis" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Graph-native GPU data analysis</title>

--- a/examples/experimental/gpu-frustum-culling/index.html
+++ b/examples/experimental/gpu-frustum-culling/index.html
@@ -1,5 +1,20 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/gpu-frustum-culling" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>GPU Frustum Culling</title>

--- a/examples/experimental/gpu-graph-explorer/app.ts
+++ b/examples/experimental/gpu-graph-explorer/app.ts
@@ -152,6 +152,7 @@ export default class GPUGraphExplorerAnimationLoopTemplate extends AnimationLoop
   private dragging = false;
   private lastPointer: [number, number] | null = null;
   private canvas: HTMLCanvasElement | null = null;
+  private canvasTouchAction = '';
   private statusElement: HTMLElement | null = null;
   private graphSizeElement: HTMLElement | null = null;
   private controlsRoot: HTMLElement | null = null;
@@ -433,6 +434,7 @@ export default class GPUGraphExplorerAnimationLoopTemplate extends AnimationLoop
   override async onInitialize({canvas}: AnimationProps): Promise<void> {
     if (canvas instanceof HTMLCanvasElement) {
       this.canvas = canvas;
+      this.canvasTouchAction = canvas.style.touchAction;
       canvas.style.cursor = 'grab';
       canvas.style.touchAction = 'none';
       canvas.addEventListener('pointerdown', this.handlePointerDown);
@@ -527,6 +529,7 @@ export default class GPUGraphExplorerAnimationLoopTemplate extends AnimationLoop
     this.pendingPick = null;
     this.pendingPickSession = null;
     if (this.canvas) {
+      this.canvas.style.touchAction = this.canvasTouchAction;
       this.canvas.removeEventListener('pointerdown', this.handlePointerDown);
       this.canvas.removeEventListener('pointermove', this.handlePointerMove);
       this.canvas.removeEventListener('pointerup', this.handlePointerUp);

--- a/examples/experimental/gpu-sort/index.html
+++ b/examples/experimental/gpu-sort/index.html
@@ -1,5 +1,20 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/gpu-sort" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Graph-native GPU sort</title>

--- a/examples/experimental/gpu-trace-scene/app.ts
+++ b/examples/experimental/gpu-trace-scene/app.ts
@@ -97,6 +97,7 @@ export default class GPUTraceSceneAnimationLoopTemplate extends AnimationLoopTem
   private inspectorPanel: GPUCommandGraphInspectorPanel | null = null;
   private controls: HTMLElement | null = null;
   private canvas: HTMLCanvasElement | null = null;
+  private canvasTouchAction = '';
   private traceDuration = 240;
   private timeMinimum = 0;
   private timeMaximum = 240;
@@ -164,6 +165,7 @@ export default class GPUTraceSceneAnimationLoopTemplate extends AnimationLoopTem
   override async onInitialize({canvas}: AnimationProps): Promise<void> {
     if (canvas instanceof HTMLCanvasElement) {
       this.canvas = canvas;
+      this.canvasTouchAction = canvas.style.touchAction;
       canvas.style.touchAction = 'none';
       canvas.addEventListener('click', this.handleClick);
       canvas.addEventListener('wheel', this.handleWheel, {passive: false});
@@ -205,6 +207,7 @@ export default class GPUTraceSceneAnimationLoopTemplate extends AnimationLoopTem
   }
 
   override onFinalize(): void {
+    if (this.canvas) this.canvas.style.touchAction = this.canvasTouchAction;
     this.canvas?.removeEventListener('click', this.handleClick);
     this.canvas?.removeEventListener('wheel', this.handleWheel);
     this.panels.finalize();

--- a/examples/experimental/gpu-trace-viewer/index.html
+++ b/examples/experimental/gpu-trace-viewer/index.html
@@ -1,5 +1,20 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/gpu-trace-viewer" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>GPU Hierarchical Trace Viewer</title>

--- a/examples/experimental/html-ui-prism/app.ts
+++ b/examples/experimental/html-ui-prism/app.ts
@@ -108,6 +108,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   });
   private readonly settingsPanel: ExampleSettingsPanelManager;
   private readonly canvas: HTMLInCanvasElement;
+  private readonly canvasTouchAction: string;
   private readonly supported: boolean;
   private activeFaceId: PrismFaceId = 'info';
   private dragPointerId: number | null = null;
@@ -131,6 +132,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     super();
     this.canvas = device.getDefaultCanvasContext().canvas as HTMLCanvasElement;
     activePrismByCanvas.get(this.canvas)?.deactivateForReplacement();
+    this.canvasTouchAction = this.canvas.style.touchAction;
     activePrismByCanvas.set(this.canvas, this);
 
     this.supported = HTMLTexture.isSupported(device, this.canvas);
@@ -170,6 +172,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       return;
     }
     this.finalized = true;
+    this.canvas.style.touchAction = this.canvasTouchAction;
     this.settingsPanel.finalize();
     this.prismFaces.forEach(face => {
       renderExamplePanel(face.panelHostElement, null);

--- a/examples/experimental/html-ui-prism/index.html
+++ b/examples/experimental/html-ui-prism/index.html
@@ -1,5 +1,22 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/html-ui-prism" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="effects" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
   <style>
     body {
       background: #0d1117;

--- a/examples/experimental/lucim-volume-lab/index.html
+++ b/examples/experimental/lucim-volume-lab/index.html
@@ -1,6 +1,21 @@
 <!doctype html>
 <html lang="en">
   <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/lucim-volume-lab" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="simulation" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#020914" />

--- a/examples/experimental/shadow-map/index.html
+++ b/examples/experimental/shadow-map/index.html
@@ -1,5 +1,20 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/shadow-map" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="effects" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Effects: Shadow Map Quality</title>

--- a/examples/experimental/spectral-caustics/index.html
+++ b/examples/experimental/spectral-caustics/index.html
@@ -1,5 +1,20 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/spectral-caustics" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="effects" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spectral Caustics: Prism Cathedral</title>

--- a/examples/experimental/text-space-crawl/index.html
+++ b/examples/experimental/text-space-crawl/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/text-space-crawl" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="dense" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <title>luma.gl Text Space Crawl Example</title>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine'

--- a/examples/experimental/virtual-geometry-canyon/app.ts
+++ b/examples/experimental/virtual-geometry-canyon/app.ts
@@ -99,6 +99,7 @@ export default class VirtualGeometryCanyonAnimationLoopTemplate extends Animatio
   private graphResources: CanyonGraphResources | null = null;
   private readonly windAudio = new CanyonWindAudio();
   private canvas: HTMLCanvasElement | null = null;
+  private canvasTouchAction = '';
   private frameIndex = 0;
   private lastFrameTimeMilliseconds: number | null = null;
   private routeTimeSeconds = 0;
@@ -195,6 +196,7 @@ export default class VirtualGeometryCanyonAnimationLoopTemplate extends Animatio
       return;
     }
     this.canvas = canvas;
+    this.canvasTouchAction = canvas.style.touchAction;
     canvas.style.cursor = 'grab';
     canvas.style.touchAction = 'none';
     canvas.addEventListener('pointerdown', this.handlePointerDown);
@@ -262,6 +264,7 @@ export default class VirtualGeometryCanyonAnimationLoopTemplate extends Animatio
 
   override onFinalize(): void {
     if (this.canvas) {
+      this.canvas.style.touchAction = this.canvasTouchAction;
       this.canvas.removeEventListener('pointerdown', this.handlePointerDown);
       this.canvas.removeEventListener('pointermove', this.handlePointerMove);
       this.canvas.removeEventListener('pointerup', this.handlePointerUp);

--- a/examples/experimental/virtual-geometry-canyon/index.html
+++ b/examples/experimental/virtual-geometry-canyon/index.html
@@ -1,5 +1,20 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/virtual-geometry-canyon" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Virtual Geometry Canyon</title>

--- a/examples/experimental/volumetric-fire-forge/index.html
+++ b/examples/experimental/volumetric-fire-forge/index.html
@@ -1,5 +1,20 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/volumetric-fire-forge" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="simulation" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Volumetric Fire Forge</title>

--- a/examples/experimental/webxr-kaleidoscope/index.html
+++ b/examples/experimental/webxr-kaleidoscope/index.html
@@ -1,6 +1,21 @@
 <!doctype html>
 <html lang="en">
   <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/webxr-kaleidoscope" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="effects" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WebXR: Immersive Prism Portal | luma.gl</title>

--- a/examples/integrations/external-context/index.html
+++ b/examples/integrations/external-context/index.html
@@ -1,6 +1,23 @@
 <!doctype html>
 <html>
   <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="integrations/external-context" />
+  <meta name="luma-example-backends" content="webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
     <style>
       html,
       body,

--- a/examples/integrations/hello-react/index.html
+++ b/examples/integrations/hello-react/index.html
@@ -1,6 +1,21 @@
 <!doctype html>
 <html lang="en">
   <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="integrations/hello-react" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>luma.gl - React Spinning Cube Example</title>

--- a/examples/showcase/algebraic-varieties/index.html
+++ b/examples/showcase/algebraic-varieties/index.html
@@ -1,6 +1,21 @@
 <!doctype html>
 <html lang="en">
   <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/algebraic-varieties" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="simulation" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Algebraic Varieties · luma.gl</title>

--- a/examples/showcase/billion-point-spatial-atlas/app.ts
+++ b/examples/showcase/billion-point-spatial-atlas/app.ts
@@ -216,6 +216,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
   private resources: AtlasResources | null = null;
   private animationLoop: AnimationProps['animationLoop'] | null = null;
   private canvas: HTMLCanvasElement | null = null;
+  private canvasTouchAction = '';
   private canvasContainer: HTMLElement | null = null;
   private canvasContainerPosition = '';
   private navigationOverlay: HTMLDivElement | null = null;
@@ -350,6 +351,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     this.animationLoop = animationLoop;
     if (canvas instanceof HTMLCanvasElement) {
       this.canvas = canvas;
+      this.canvasTouchAction = canvas.style.touchAction;
       canvas.style.cursor = 'crosshair';
       canvas.style.touchAction = 'none';
       canvas.tabIndex = 0;
@@ -547,6 +549,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     this.lidarLoadAbortController?.abort();
     if (this.lidarPublishTimer) clearTimeout(this.lidarPublishTimer);
     if (this.canvas) {
+      this.canvas.style.touchAction = this.canvasTouchAction;
       this.canvas.removeEventListener('pointerdown', this.handlePointerDown);
       this.canvas.removeEventListener('pointermove', this.handlePointerMove);
       this.canvas.removeEventListener('pointerleave', this.handlePointerLeave);

--- a/examples/showcase/billion-point-spatial-atlas/index.html
+++ b/examples/showcase/billion-point-spatial-atlas/index.html
@@ -1,6 +1,21 @@
 <!doctype html>
 <html lang="en">
   <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/billion-point-spatial-atlas" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="data:," />

--- a/examples/showcase/dof/index.html
+++ b/examples/showcase/dof/index.html
@@ -1,5 +1,22 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/dof" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="effects" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
   <style>
     body {
       margin: 0;

--- a/examples/showcase/gaussian-splats/index.html
+++ b/examples/showcase/gaussian-splats/index.html
@@ -1,6 +1,21 @@
 <!doctype html>
 <html lang="en">
   <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/gaussian-splats" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta

--- a/examples/showcase/globe/index.html
+++ b/examples/showcase/globe/index.html
@@ -1,5 +1,22 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/globe" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="dense" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
   <script type="module">
     import {luma} from '@luma.gl/core';
     import {makeAnimationLoop} from '@luma.gl/engine';

--- a/examples/showcase/gltf/index.html
+++ b/examples/showcase/gltf/index.html
@@ -1,5 +1,20 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/gltf" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>glTF Animation Studio</title>

--- a/examples/showcase/instancing/index.html
+++ b/examples/showcase/instancing/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/instancing" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {luma} from '@luma.gl/core';
   import {makeAnimationLoop} from '@luma.gl/engine';

--- a/examples/showcase/lightstorm-megacity/index.html
+++ b/examples/showcase/lightstorm-megacity/index.html
@@ -1,5 +1,20 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/lightstorm-megacity" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Lightstorm Megacity</title>

--- a/examples/showcase/llm-network/index.html
+++ b/examples/showcase/llm-network/index.html
@@ -1,6 +1,21 @@
 <!doctype html>
 <html lang="en">
   <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/llm-network" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="dense" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#07101a" />

--- a/examples/showcase/million-row-crossfilter/index.html
+++ b/examples/showcase/million-row-crossfilter/index.html
@@ -1,6 +1,21 @@
 <!doctype html>
 <html lang="en">
   <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/million-row-crossfilter" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#050812" />

--- a/examples/showcase/packet-spraying/index.html
+++ b/examples/showcase/packet-spraying/index.html
@@ -1,5 +1,20 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/packet-spraying" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="effects" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <script type="module">
     import {luma} from '@luma.gl/core';

--- a/examples/showcase/persistence/index.html
+++ b/examples/showcase/persistence/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/persistence" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="effects" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/showcase/postprocessing/index.html
+++ b/examples/showcase/postprocessing/index.html
@@ -1,5 +1,20 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/postprocessing" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="effects" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Effects: Image Processing</title>

--- a/examples/showcase/quantum-state-studio/index.html
+++ b/examples/showcase/quantum-state-studio/index.html
@@ -1,6 +1,21 @@
 <!doctype html>
 <html lang="en">
   <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/quantum-state-studio" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#040819" />

--- a/examples/showcase/raster-lab/index.html
+++ b/examples/showcase/raster-lab/index.html
@@ -1,6 +1,21 @@
 <!doctype html>
 <html lang="en">
   <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/raster-lab" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="large-data" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#071016" />

--- a/examples/showcase/scene/index.html
+++ b/examples/showcase/scene/index.html
@@ -1,6 +1,21 @@
 <!doctype html>
 <html lang="en">
   <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/scene-playground" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="effects" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#070913" />

--- a/examples/showcase/scene/playground.html
+++ b/examples/showcase/scene/playground.html
@@ -1,6 +1,21 @@
 <!doctype html>
 <html lang="en">
   <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="experimental/scene-playground" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="effects" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#090b13" />

--- a/examples/showcase/tempest-ocean/index.html
+++ b/examples/showcase/tempest-ocean/index.html
@@ -1,5 +1,20 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/tempest-ocean" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="simulation" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tempest Ocean: Spectral Stormfront</title>

--- a/examples/showcase/vector-field-lab/index.html
+++ b/examples/showcase/vector-field-lab/index.html
@@ -1,6 +1,21 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="showcase/vector-field-lab" />
+  <meta name="luma-example-backends" content="webgpu" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="simulation" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Vector Field Lab · luma.gl</title>

--- a/examples/tutorials/hello-cube/index.html
+++ b/examples/tutorials/hello-cube/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="tutorials/hello-cube" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/tutorials/hello-gltf/index.html
+++ b/examples/tutorials/hello-gltf/index.html
@@ -1,5 +1,22 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="tutorials/hello-gltf" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
   <script type="module">
     import {makeAnimationLoop} from '@luma.gl/engine';
     import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/tutorials/hello-instanced-cubes/index.html
+++ b/examples/tutorials/hello-instanced-cubes/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="tutorials/instanced-cubes" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="reduced" />
+  <meta name="luma-example-mobile-profile" content="dense" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {webgpuAdapter} from '@luma.gl/webgpu';
   import {webgl2Adapter} from '@luma.gl/webgl';

--- a/examples/tutorials/hello-instancing/index.html
+++ b/examples/tutorials/hello-instancing/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="tutorials/hello-instancing" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {webgl2Adapter} from '@luma.gl/webgl';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/tutorials/hello-triangle-geometry/index.html
+++ b/examples/tutorials/hello-triangle-geometry/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="tutorials/hello-triangle-geometry" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgl2Adapter} from '@luma.gl/webgl';

--- a/examples/tutorials/hello-triangle/index.html
+++ b/examples/tutorials/hello-triangle/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="tutorials/hello-triangle" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/tutorials/hello-two-cubes/index.html
+++ b/examples/tutorials/hello-two-cubes/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="tutorials/two-cubes" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {webgpuAdapter} from '@luma.gl/webgpu';
   import {webgl2Adapter} from '@luma.gl/webgl';

--- a/examples/tutorials/lighting/index.html
+++ b/examples/tutorials/lighting/index.html
@@ -1,5 +1,22 @@
 <!doctype html>
 <head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="tutorials/lighting" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
   <style>
     body {
       background: black;

--- a/examples/tutorials/shader-hooks/index.html
+++ b/examples/tutorials/shader-hooks/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="tutorials/shader-hooks" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {webgl2Adapter} from '@luma.gl/webgl';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/tutorials/shader-modules/index.html
+++ b/examples/tutorials/shader-modules/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="tutorials/shader-modules" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {webgl2Adapter} from '@luma.gl/webgl';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/tutorials/shader-plugins/index.html
+++ b/examples/tutorials/shader-plugins/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="tutorials/shader-plugins" />
+  <meta name="luma-example-backends" content="webgpu,webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {webgl2Adapter} from '@luma.gl/webgl';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/examples/tutorials/transform-feedback/index.html
+++ b/examples/tutorials/transform-feedback/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="tutorials/transform-feedback" />
+  <meta name="luma-example-backends" content="webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgl2Adapter} from '@luma.gl/webgl';

--- a/examples/tutorials/transform/index.html
+++ b/examples/tutorials/transform/index.html
@@ -1,4 +1,22 @@
 <!doctype html>
+<head>
+  <!-- luma-example-support -->
+  <meta name="luma-example-id" content="tutorials/transform" />
+  <meta name="luma-example-backends" content="webgl2" />
+  <meta name="luma-example-mobile" content="full" />
+  <meta name="luma-example-mobile-profile" content="standard" />
+  <script type="module" data-luma-example-support-bootstrap>
+    import {installStandaloneExampleSupport} from '../../example-support.ts';
+    const exampleSupport = installStandaloneExampleSupport();
+    if (!exampleSupport.supported) {
+      document
+        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
+        .forEach(script => script.remove());
+    }
+  </script>
+  <!-- /luma-example-support -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgpuAdapter} from '@luma.gl/webgpu';

--- a/test/examples/example-catalog-metadata.node.spec.ts
+++ b/test/examples/example-catalog-metadata.node.spec.ts
@@ -236,6 +236,16 @@ describe('live example catalog metadata', () => {
         EXAMPLE_SUPPORT_REGISTRY[canonicalId],
         `${relativeFile} requires a sidecar support definition`
       ).toBeDefined();
+      const standaloneHtml = readFileSync(
+        path.join(process.cwd(), 'examples', relativeFile),
+        'utf8'
+      );
+      expect(standaloneHtml, `${relativeFile} requires the standalone support bootstrap`).toContain(
+        'data-luma-example-support-bootstrap'
+      );
+      expect(standaloneHtml, `${relativeFile} requires its canonical example identifier`).toContain(
+        `<meta name="luma-example-id" content="${canonicalId}" />`
+      );
     }
   });
 


### PR DESCRIPTION
#### Background
Follow-up to #3198, which merged while its automated review was still running. This addresses both review findings from that PR.

#### Change List
- Commit the generated mobile-support bootstrap and metadata into all 75 standalone example HTML pages.
- Add regression assertions for standalone bootstrap installation and canonical example IDs.
- Restore each shared canvas's previous `touchAction` value when the five affected examples finalize.

#### Verification
- `nvm use`
- `yarn lint fix`
- `yarn build`
- `yarn examples:typecheck`
- `yarn website:build`
- `(cd website && yarn build)`
- `yarn test-node`: 2,932 passed, 3 skipped
- `yarn test`: node suite passed; headless suite passed 1,812 tests and reproduced the same six unrelated WebGPU failures in untouched DGGS, raster, splats, and scene-renderer tests.