### PR TITLE
Optimize GPU LZ copy decoding

### DIFF
--- a/docs/api-reference/experimental/gpu-core/gpu-flag-offsets.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-flag-offsets.md
@@ -31,8 +31,10 @@ element `GPUFlagOffsets` and `GPUSegmentOffsets` per depth.
 | `offsets` | at least slot count | Exclusive prefix sum; the dense destination for each slot |
 | `count` | at least 1 | Total set flags in element zero |
 
-An empty input writes `count[0] = 0`. No offset element exists for an empty input. Counts and
-offsets use `uint32` arithmetic, so callers must retain page or batch boundaries before overflow.
+`flags` and `offsets` may be matching `GraphVectorView`s. In that form, the scan carries across
+chunks without repacking their buffers and `count` covers the complete vector. An empty input writes
+`count[0] = 0`. No offset element exists for an empty input. Counts and offsets use `uint32`
+arithmetic, so callers must retain page or batch boundaries before overflow.
 
 ## Usage
 

--- a/docs/api-reference/experimental/gpu-core/gpu-segment-offsets.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-segment-offsets.md
@@ -28,14 +28,15 @@ Use `GPUScan` alone if segment indices are sufficient and list offsets are not n
 | --- | ---: | --- |
 | `elementFlags` | slot count | One when a slot represents a logical element, including nulls |
 | `elementOffsets` | at least slot count | Exclusive dense logical-element offsets |
-| `segmentStartFlags` | slot count | One for starts after the implicit first segment |
+| `segmentStartFlags` | slot count | One for every segment start, including the first |
 | `segmentIndices` | at least slot count | Dense zero-based segment index per slot |
 | `segmentOffsets` | at least slot count + 1 | Logical-element offsets plus a terminal offset |
 | `segmentCount` | at least 1 | Number of segments in element zero |
 
-For non-empty input, `segmentStartFlags[0]` must be zero because segment zero is implicit. Only the
-first `segmentCount + 1` entries of `segmentOffsets` are defined. Empty input writes zero to both
-`segmentOffsets[0]` and `segmentCount[0]`.
+Only the first `segmentCount + 1` entries of `segmentOffsets` are defined. A prefix before the first
+set start flag belongs to no segment, which lets a higher-level format gate absent nested parents
+without inventing an empty child. Empty input writes zero to both `segmentOffsets[0]` and
+`segmentCount[0]`.
 
 ## Usage
 
@@ -66,7 +67,8 @@ compile or submit the graph, or read back counts.
 
 ## Chunking and reuse
 
-Invoke the operation once per durable source page or batch. Each chunk has its own implicit segment
-zero and local offsets; do not concatenate terminal offsets implicitly. A higher-level composer can
-retain those views in a `GraphVectorView`, allowing the command graph to compile once and rebind
-compatible imported page buffers on later executions.
+Pass matching `GraphVectorView` inputs to scan across durable source pages without repacking their
+buffers. Segment indices and element offsets carry across chunks, and the operation publishes one
+global offset stream and count. This is important for repeated formats such as Parquet, where a
+logical row may begin on one page and continue on the next. The command graph can still compile once
+and rebind compatible imported page buffers on later executions.

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -12,6 +12,14 @@ luma.gl largely follows [SEMVER](https://semver.org) conventions. Breaking chang
 
 ## Upgrading to v10.0
 
+**@luma.gl/gpgpu**
+
+- `GPULZByteDecompressor` descriptors now contain five uint32 words per record:
+  `[outputOffset, byteLength, literalSourceOffset, literalPeriod, matchOffset]`. Code that creates
+  descriptor buffers directly must add `literalPeriod` and use `GPU_LZ_BYTE_DESCRIPTOR_WORDS` when
+  allocating and indexing them. Prefer `planGPULZByteDescriptors()` to convert the unchanged
+  four-word parser spans into GPU descriptors.
+
 **@luma.gl/shadertools**
 
 - `ShaderPassPipeline`, `ShaderPassPipelineStep`, and `ShaderPassComputeOptimization` have been

--- a/examples/experimental/gpu-parquet-constellation/app.ts
+++ b/examples/experimental/gpu-parquet-constellation/app.ts
@@ -30,6 +30,7 @@ export const description =
 
 const ROW_COUNT = 600_000;
 const PAGE_SIZE = 65_536;
+const WARMED_DECODE_SAMPLE_COUNT = 3;
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 const UNIFORM_BYTE_LENGTH = 8 * Float32Array.BYTES_PER_ELEMENT;
 const PARQUET_FIXTURES = {
@@ -46,7 +47,7 @@ const INFO_HTML = `<div data-parquet-panel style="display:grid;gap:12px;min-widt
     <label>Decoder <select data-decode-mode><option value="gpu" selected>GPU command graph</option><option value="cpu">CPU on main thread</option></select></label>
     <button type="button" data-run-selected>Decode and display</button>
     <button type="button" data-compare>Compare CPU → GPU</button>
-    <small>The old scene keeps animating during a switch. “Longest frame” exposes main-thread stalls as well as total preparation latency.</small>
+    <small>The old scene keeps animating during a switch. Cold timings expose startup cost; warmed GPU timing follows an unmeasured submission and reports a median.</small>
   </div>
   <div><strong>Measurements</strong><div data-parquet-status style="margin-top:7px">Waiting for WebGPU…</div><div data-parquet-measurements style="margin-top:10px"></div></div>
 </div>`;
@@ -64,9 +65,11 @@ type PreparedScene = {
   gpuDecoder?: {
     compiled: CompiledGPUCommandGraph<undefined>;
     inputBuffer: Buffer;
+    lzCopyDetails: LZCopyDetails;
   };
   uploadByteLength: number;
   decodeGraphNodeCount: number;
+  graphCompileMilliseconds: number;
   decodeExecutionMilliseconds: number;
 };
 
@@ -75,8 +78,17 @@ type DecodeMeasurement = {
   longestFrameMilliseconds: number;
   uploadByteLength: number;
   graphNodeCount: number;
+  graphCompileMilliseconds: number;
   decodeExecutionMilliseconds: number;
   reusedGraphExecutionMilliseconds?: number;
+  lzCopyDetails?: LZCopyDetails;
+};
+
+type LZCopyDetails = {
+  directCopyCount: number;
+  recursiveCopyCount: number;
+  directCopyByteLength: number;
+  recursiveCopyByteLength: number;
 };
 
 type CompressionDetails = {
@@ -322,7 +334,9 @@ export default class GPUParquetConstellationAnimationLoopTemplate extends Animat
         longestFrameMilliseconds: this.longestPreparationFrameMilliseconds,
         uploadByteLength: nextScene.uploadByteLength,
         graphNodeCount: nextScene.decodeGraphNodeCount,
-        decodeExecutionMilliseconds: nextScene.decodeExecutionMilliseconds
+        graphCompileMilliseconds: nextScene.graphCompileMilliseconds,
+        decodeExecutionMilliseconds: nextScene.decodeExecutionMilliseconds,
+        lzCopyDetails: nextScene.gpuDecoder?.lzCopyDetails
       };
       this.destroyScene();
       this.scene = nextScene;
@@ -376,6 +390,7 @@ export default class GPUParquetConstellationAnimationLoopTemplate extends Animat
             buffers,
             PARQUET_CONSTELLATION_COLUMNS.length * ROW_COUNT * UINT32_BYTE_LENGTH,
             0,
+            0,
             decodeExecutionMilliseconds
           );
         } catch (error) {
@@ -403,6 +418,7 @@ export default class GPUParquetConstellationAnimationLoopTemplate extends Animat
         this.compressionDetails = getCompressionDetails(batch.columns);
         this.updateCompressionDetails();
         const plan = planGPUParquetEncodedPageBatch(batch);
+        const lzCopyDetails = getLZCopyDetails(plan.pages);
         if (plan.cpuFallbackPageCount > 0) {
           throw new Error(`${plan.cpuFallbackPageCount} Parquet pages require CPU fallback`);
         }
@@ -438,15 +454,18 @@ export default class GPUParquetConstellationAnimationLoopTemplate extends Animat
             ])
           ) as Record<ParquetConstellationColumn, GraphBufferHandle>;
           this.addDecodedPageCopies(decodeGraph, batch.columns, decoded.pages, destinationHandles);
+          const graphCompileStartedAt = performance.now();
           compiledDecode = decodeGraph.compile();
+          const graphCompileMilliseconds = performance.now() - graphCompileStartedAt;
           const decodeGraphNodeCount = compiledDecode.stats.nodeOrder.length;
           const decodeExecutionMilliseconds = await this.executeGPUDecode(compiledDecode, signal);
           return this.createPreparedScene(
             buffers,
             plan.uploadData.byteLength,
             decodeGraphNodeCount,
+            graphCompileMilliseconds,
             decodeExecutionMilliseconds,
-            {compiled: compiledDecode, inputBuffer}
+            {compiled: compiledDecode, inputBuffer, lzCopyDetails}
           );
         } catch (error) {
           compiledDecode?.destroy();
@@ -535,6 +554,7 @@ export default class GPUParquetConstellationAnimationLoopTemplate extends Animat
     buffers: Record<ParquetConstellationColumn, Buffer>,
     uploadByteLength: number,
     decodeGraphNodeCount: number,
+    graphCompileMilliseconds: number,
     decodeExecutionMilliseconds: number,
     gpuDecoder?: PreparedScene['gpuDecoder']
   ): PreparedScene {
@@ -545,6 +565,7 @@ export default class GPUParquetConstellationAnimationLoopTemplate extends Animat
       gpuDecoder,
       uploadByteLength,
       decodeGraphNodeCount,
+      graphCompileMilliseconds,
       decodeExecutionMilliseconds
     };
   }
@@ -556,16 +577,24 @@ export default class GPUParquetConstellationAnimationLoopTemplate extends Animat
     this.preparationActive = true;
     this.preparationStartedAt = performance.now();
     this.longestPreparationFrameMilliseconds = 0;
-    this.setStatus('Reusing the compiled GPU graph for another decode submission…');
+    this.setStatus('Warming the compiled GPU graph before repeated timing…');
     await nextAnimationFrame();
     try {
-      const executionMilliseconds = await this.executeGPUDecode(gpuDecoder.compiled, signal);
+      await this.executeGPUDecode(gpuDecoder.compiled, signal);
+      await nextAnimationFrame();
+      await nextAnimationFrame();
+      const samples: number[] = [];
+      for (let sampleIndex = 0; sampleIndex < WARMED_DECODE_SAMPLE_COUNT; sampleIndex++) {
+        samples.push(await this.executeGPUDecode(gpuDecoder.compiled, signal));
+        await nextAnimationFrame();
+      }
       await nextAnimationFrame();
       signal.throwIfAborted();
       if (preparationVersion !== this.preparationVersion) return;
+      const executionMilliseconds = getMedian(samples);
       measurement.reusedGraphExecutionMilliseconds = executionMilliseconds;
       this.setStatus(
-        `GPU reused its compiled ${measurement.graphNodeCount}-node graph in ${executionMilliseconds.toFixed(1)} ms.`
+        `GPU warmed once, then reused its compiled ${measurement.graphNodeCount}-node graph in a ${executionMilliseconds.toFixed(1)} ms median of ${WARMED_DECODE_SAMPLE_COUNT}.`
       );
       this.updateMeasurements();
     } finally {
@@ -769,12 +798,14 @@ export default class GPUParquetConstellationAnimationLoopTemplate extends Animat
     <table style="width:100%;border-collapse:collapse;text-align:right">
       <thead><tr><th style="text-align:left"></th><th>GPU</th><th>CPU</th></tr></thead>
       <tbody>
-        <tr><th style="text-align:left;font-weight:normal">Preparation latency</th><td>${formatMetric(gpuMeasurement, value => `${value.elapsedMilliseconds.toFixed(1)} ms`)}</td><td>${formatMetric(cpuMeasurement, value => `${value.elapsedMilliseconds.toFixed(1)} ms`)}</td></tr>
-        <tr><th style="text-align:left;font-weight:normal">First decode execution</th><td>${formatMetric(gpuMeasurement, value => `${value.decodeExecutionMilliseconds.toFixed(1)} ms`)}</td><td>${formatMetric(cpuMeasurement, value => `${value.decodeExecutionMilliseconds.toFixed(1)} ms`)}</td></tr>
-        <tr><th style="text-align:left;font-weight:normal">Reused graph execution</th><td>${formatMetric(gpuMeasurement, value => (value.reusedGraphExecutionMilliseconds === undefined ? '—' : `${value.reusedGraphExecutionMilliseconds.toFixed(1)} ms`))}</td><td>n/a</td></tr>
+        <tr><th style="text-align:left;font-weight:normal">Cold preparation</th><td>${formatMetric(gpuMeasurement, value => `${value.elapsedMilliseconds.toFixed(1)} ms`)}</td><td>${formatMetric(cpuMeasurement, value => `${value.elapsedMilliseconds.toFixed(1)} ms`)}</td></tr>
+        <tr><th style="text-align:left;font-weight:normal">Graph compile</th><td>${formatMetric(gpuMeasurement, value => `${value.graphCompileMilliseconds.toFixed(1)} ms`)}</td><td>n/a</td></tr>
+        <tr><th style="text-align:left;font-weight:normal">Cold decode execution</th><td>${formatMetric(gpuMeasurement, value => `${value.decodeExecutionMilliseconds.toFixed(1)} ms`)}</td><td>${formatMetric(cpuMeasurement, value => `${value.decodeExecutionMilliseconds.toFixed(1)} ms`)}</td></tr>
+        <tr><th style="text-align:left;font-weight:normal">Warmed graph median (${WARMED_DECODE_SAMPLE_COUNT})</th><td>${formatMetric(gpuMeasurement, value => (value.reusedGraphExecutionMilliseconds === undefined ? '—' : `${value.reusedGraphExecutionMilliseconds.toFixed(1)} ms`))}</td><td>n/a</td></tr>
         <tr><th style="text-align:left;font-weight:normal">Longest frame</th><td>${formatMetric(gpuMeasurement, value => `${value.longestFrameMilliseconds.toFixed(1)} ms`)}</td><td>${formatMetric(cpuMeasurement, value => `${value.longestFrameMilliseconds.toFixed(1)} ms`)}</td></tr>
         <tr><th style="text-align:left;font-weight:normal">GPU upload</th><td>${formatMetric(gpuMeasurement, value => formatBytes(value.uploadByteLength))}</td><td>${formatMetric(cpuMeasurement, value => formatBytes(value.uploadByteLength))}</td></tr>
         <tr><th style="text-align:left;font-weight:normal">Decode graph nodes</th><td>${formatMetric(gpuMeasurement, value => String(value.graphNodeCount))}</td><td>${formatMetric(cpuMeasurement, value => String(value.graphNodeCount))}</td></tr>
+        <tr><th style="text-align:left;font-weight:normal">Direct / recursive LZ copies</th><td>${formatMetric(gpuMeasurement, value => (value.lzCopyDetails ? `${formatCount(value.lzCopyDetails.directCopyCount)} / ${formatCount(value.lzCopyDetails.recursiveCopyCount)}` : 'n/a'))}</td><td>n/a</td></tr>
       </tbody>
     </table>
     <div style="margin-top:10px;font:11px/1.5 ui-monospace,monospace">4 × BYTE_STREAM_SPLIT FLOAT<br>1 × DELTA_BINARY_PACKED UINT32<br>DataPageV2 · ${this.compressionDetails?.summary ?? 'compression pending'} · dictionary off</div>`;
@@ -812,6 +843,33 @@ function getCompressionDetails(
   }
   const summary = Array.from(codecCounts, ([codec, count]) => `${count} × ${codec}`).join(' · ');
   return {summary, compressedByteLength, uncompressedByteLength};
+}
+
+function getLZCopyDetails(
+  pages: readonly {
+    mode: string;
+    compression?: {
+      directCopyCount: number;
+      recursiveCopyCount: number;
+      directCopyByteLength: number;
+      recursiveCopyByteLength: number;
+    };
+  }[]
+): LZCopyDetails {
+  const details: LZCopyDetails = {
+    directCopyCount: 0,
+    recursiveCopyCount: 0,
+    directCopyByteLength: 0,
+    recursiveCopyByteLength: 0
+  };
+  for (const page of pages) {
+    if (page.mode !== 'gpu' || !page.compression) continue;
+    details.directCopyCount += page.compression.directCopyCount;
+    details.recursiveCopyCount += page.compression.recursiveCopyCount;
+    details.directCopyByteLength += page.compression.directCopyByteLength;
+    details.recursiveCopyByteLength += page.compression.recursiveCopyByteLength;
+  }
+  return details;
 }
 
 function getFloat32Column(
@@ -864,6 +922,11 @@ function nextAnimationFrame(): Promise<void> {
 
 function waitForMilliseconds(milliseconds: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+function getMedian(values: readonly number[]): number {
+  const sortedValues = [...values].sort((left, right) => left - right);
+  return sortedValues[Math.floor(sortedValues.length / 2)];
 }
 
 function formatCount(value: number): string {

--- a/modules/gpgpu/src/gpu-core/gpu-flag-offsets.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-flag-offsets.ts
@@ -4,12 +4,13 @@
 
 import type {Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
-import {GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
+import {GPUCommandGraph, GraphVectorView, type GraphDataView} from './gpu-command-graph';
 import {getBoundedDispatchLayout} from './gpu-dispatch-utils';
-import {GPUScan} from './gpu-scan';
+import {GPUScan, type GPUScanInput} from './gpu-scan';
 import {
   getViewBinding,
   getViewElementOffset,
+  validateMatchingVectorTopology,
   validatePackedUint32View
 } from './graph-data-view-utils';
 
@@ -20,9 +21,9 @@ export type GPUFlagOffsetsProps = {
   /** Prefix for generated graph node IDs. */
   id?: string;
   /** Packed zero-or-one flags. */
-  flags: GraphDataView<'uint32'>;
+  flags: GPUScanInput;
   /** Exclusive dense index for every flag. */
-  offsets: GraphDataView<'uint32'>;
+  offsets: GPUScanInput;
   /** Single uint32 receiving the number of set flags. */
   count: GraphDataView<'uint32'>;
 };
@@ -47,7 +48,7 @@ export class GPUFlagOffsets {
   /** Adds one exclusive scan and one scalar publication pass to a command graph. */
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
     const {flags, offsets, count} = this.props;
-    for (const view of [flags, offsets, count]) {
+    for (const view of [...getChunks(flags), ...getChunks(offsets), count]) {
       if (view.buffer.graph !== graph) {
         throw new Error(`${this.id} views must belong to the target graph`);
       }
@@ -69,6 +70,8 @@ function addCountPass<Parameters>(
   props: Readonly<GPUFlagOffsetsProps>
 ): void {
   const hasValues = props.flags.length > 0;
+  const flagChunk = hasValues ? getLastNonEmptyChunk(props.flags) : undefined;
+  const offsetChunk = hasValues ? getLastNonEmptyChunk(props.offsets) : undefined;
   const dispatchLayout = getBoundedDispatchLayout(
     'GPUFlagOffsetsCount',
     1,
@@ -76,9 +79,9 @@ function addCountPass<Parameters>(
     graph.device.limits.maxComputeWorkgroupsPerDimension
   );
   const source = hasValues
-    ? `const LAST_INDEX: u32 = ${props.flags.length - 1}u;
-const FLAG_OFFSET: u32 = ${getViewElementOffset(props.flags)}u;
-const OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.offsets)}u;
+    ? `const LAST_INDEX: u32 = ${flagChunk!.length - 1}u;
+const FLAG_OFFSET: u32 = ${getViewElementOffset(flagChunk!)}u;
+const OFFSETS_OFFSET: u32 = ${getViewElementOffset(offsetChunk!)}u;
 const COUNT_OFFSET: u32 = ${getViewElementOffset(props.count)}u;
 @group(0) @binding(0) var<storage, read> flags: array<u32>;
 @group(0) @binding(1) var<storage, read> offsets: array<u32>;
@@ -97,8 +100,8 @@ fn main(@builtin(local_invocation_index) localInvocationIndex: u32) {
 }`;
   const resources = hasValues
     ? [
-        {name: 'flags', view: props.flags, usage: 'storage-read' as const},
-        {name: 'offsets', view: props.offsets, usage: 'storage-read' as const},
+        {name: 'flags', view: flagChunk!, usage: 'storage-read' as const},
+        {name: 'offsets', view: offsetChunk!, usage: 'storage-read' as const},
         {name: 'count', view: props.count, usage: 'storage-write' as const}
       ]
     : [{name: 'count', view: props.count, usage: 'storage-write' as const}];
@@ -142,14 +145,37 @@ fn main(@builtin(local_invocation_index) localInvocationIndex: u32) {
 }
 
 function validateConfiguration(props: Readonly<GPUFlagOffsetsProps>): void {
-  for (const [name, view] of Object.entries({
-    flags: props.flags,
-    offsets: props.offsets,
-    count: props.count
-  })) {
-    validatePackedUint32View(view, `${props.id} ${name}`);
+  for (const view of getChunks(props.flags)) {
+    validatePackedUint32View(view, `${props.id} flags`);
   }
-  if (props.offsets.length < props.flags.length || props.count.length < 1) {
+  for (const view of getChunks(props.offsets)) {
+    validatePackedUint32View(view, `${props.id} offsets`);
+  }
+  validatePackedUint32View(props.count, `${props.id} count`);
+  const flagsAreVector = props.flags instanceof GraphVectorView;
+  if (flagsAreVector !== props.offsets instanceof GraphVectorView) {
+    throw new Error(`${props.id} flags and offsets must both be data views or vector views`);
+  }
+  if (props.flags instanceof GraphVectorView && props.offsets instanceof GraphVectorView) {
+    validateMatchingVectorTopology(props.flags, props.offsets, `${props.id} offsets`);
+  } else if (props.offsets.length < props.flags.length) {
+    throw new Error(`${props.id} offsets must contain at least flags.length rows`);
+  }
+  if (props.count.length < 1) {
     throw new Error(`${props.id} result views are too short`);
   }
+}
+
+function getChunks(input: GPUScanInput): readonly GraphDataView<'uint32'>[] {
+  return input instanceof GraphVectorView ? input.data : [input];
+}
+
+function getLastNonEmptyChunk(input: GPUScanInput): GraphDataView<'uint32'> {
+  const chunks = getChunks(input);
+  for (let chunkIndex = chunks.length - 1; chunkIndex >= 0; chunkIndex--) {
+    if (chunks[chunkIndex].length > 0) {
+      return chunks[chunkIndex];
+    }
+  }
+  throw new Error('Non-empty GPUFlagOffsets input requires a non-empty chunk');
 }

--- a/modules/gpgpu/src/gpu-core/gpu-lz-byte-decompressor.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-lz-byte-decompressor.ts
@@ -16,14 +16,133 @@ import {
   validatePackedUint32View
 } from './graph-data-view-utils';
 
-export const GPU_LZ_BYTE_DESCRIPTOR_WORDS = 4;
+export const GPU_LZ_BYTE_DESCRIPTOR_WORDS = 5;
 export const GPU_LZ_BYTE_WORKGROUP_SIZE = 256;
+
+/** CPU result for compact LZ spans annotated with direct compressed-input provenance. */
+export type GPULZByteDescriptorPlan = Readonly<{
+  descriptors: Uint32Array;
+  descriptorCount: number;
+  directCopyCount: number;
+  recursiveCopyCount: number;
+  directCopyByteLength: number;
+  recursiveCopyByteLength: number;
+}>;
+
+/**
+ * Converts `[outputOffset, byteLength, literalSourceOffset, matchOffset]` spans into GPU records.
+ *
+ * A copy becomes a direct compressed-input gather when its source cycle is contained by one prior
+ * direct descriptor. Other copies retain their compact backreference. Planning remains one record
+ * per input span and never materializes byte-level provenance, keeping CPU work and upload size
+ * bounded while removing descriptor recursion from the common literal-followed-by-copy pattern.
+ */
+export function planGPULZByteDescriptors(spans: readonly number[]): GPULZByteDescriptorPlan {
+  if (spans.length % 4 !== 0) {
+    throw new Error('LZ byte spans must contain four words per record');
+  }
+  const descriptors: number[] = [];
+  let directCopyCount = 0;
+  let recursiveCopyCount = 0;
+  let directCopyByteLength = 0;
+  let recursiveCopyByteLength = 0;
+  for (let spanOffset = 0; spanOffset < spans.length; spanOffset += 4) {
+    const outputOffset = spans[spanOffset];
+    const byteLength = spans[spanOffset + 1];
+    const literalSourceOffset = spans[spanOffset + 2];
+    const matchOffset = spans[spanOffset + 3];
+    if (matchOffset === 0) {
+      descriptors.push(outputOffset, byteLength, literalSourceOffset, 0, 0);
+      continue;
+    }
+    const directCopy = findDirectCopy(
+      descriptors,
+      outputOffset - matchOffset,
+      byteLength,
+      matchOffset
+    );
+    if (directCopy) {
+      descriptors.push(
+        outputOffset,
+        byteLength,
+        directCopy.literalSourceOffset,
+        directCopy.literalPeriod,
+        0
+      );
+      directCopyCount++;
+      directCopyByteLength += byteLength;
+    } else {
+      descriptors.push(outputOffset, byteLength, 0, 0, matchOffset);
+      recursiveCopyCount++;
+      recursiveCopyByteLength += byteLength;
+    }
+  }
+  return Object.freeze({
+    descriptors: Uint32Array.from(descriptors),
+    descriptorCount: descriptors.length / GPU_LZ_BYTE_DESCRIPTOR_WORDS,
+    directCopyCount,
+    recursiveCopyCount,
+    directCopyByteLength,
+    recursiveCopyByteLength
+  });
+}
+
+function findDirectCopy(
+  descriptors: readonly number[],
+  sourceOutputOffset: number,
+  byteLength: number,
+  matchOffset: number
+): {literalSourceOffset: number; literalPeriod: number} | undefined {
+  const descriptorIndex = findContainingDescriptor(descriptors, sourceOutputOffset);
+  if (descriptorIndex < 0) return undefined;
+  const descriptorOffset = descriptorIndex * GPU_LZ_BYTE_DESCRIPTOR_WORDS;
+  const descriptorOutputOffset = descriptors[descriptorOffset];
+  const descriptorByteLength = descriptors[descriptorOffset + 1];
+  const literalSourceOffset = descriptors[descriptorOffset + 2];
+  const literalPeriod = descriptors[descriptorOffset + 3];
+  const sourceMatchOffset = descriptors[descriptorOffset + 4];
+  if (sourceMatchOffset !== 0) return undefined;
+  const relativeSourceOffset = sourceOutputOffset - descriptorOutputOffset;
+  const sourceCycleLength = Math.min(byteLength, matchOffset);
+  if (relativeSourceOffset + sourceCycleLength > descriptorByteLength) return undefined;
+  if (literalPeriod === 0) {
+    return {
+      literalSourceOffset: literalSourceOffset + relativeSourceOffset,
+      literalPeriod: byteLength > matchOffset ? matchOffset : 0
+    };
+  }
+  const literalPhase = relativeSourceOffset % literalPeriod;
+  const repeatsSourceCycle = byteLength > matchOffset;
+  if (literalPhase !== 0 || (repeatsSourceCycle && matchOffset % literalPeriod !== 0)) {
+    return undefined;
+  }
+  return {literalSourceOffset, literalPeriod};
+}
+
+function findContainingDescriptor(descriptors: readonly number[], outputOffset: number): number {
+  let lowerIndex = 0;
+  let upperIndex = descriptors.length / GPU_LZ_BYTE_DESCRIPTOR_WORDS;
+  while (lowerIndex < upperIndex) {
+    const middleIndex = lowerIndex + Math.floor((upperIndex - lowerIndex) / 2);
+    if (descriptors[middleIndex * GPU_LZ_BYTE_DESCRIPTOR_WORDS] <= outputOffset) {
+      lowerIndex = middleIndex + 1;
+    } else {
+      upperIndex = middleIndex;
+    }
+  }
+  const descriptorIndex = lowerIndex - 1;
+  if (descriptorIndex < 0) return -1;
+  const descriptorOffset = descriptorIndex * GPU_LZ_BYTE_DESCRIPTOR_WORDS;
+  return outputOffset < descriptors[descriptorOffset] + descriptors[descriptorOffset + 1]
+    ? descriptorIndex
+    : -1;
+}
 
 export type GPULZByteDecompressorProps = {
   id?: string;
   /** Compressed bytes packed into little-endian uint32 words. */
   input: GraphDataView<'uint32'>;
-  /** Sorted `[outputOffset, byteLength, literalSourceOffset, matchOffset]` records. */
+  /** Sorted `[outputOffset, byteLength, literalSourceOffset, literalPeriod, matchOffset]` records. */
   descriptors: GraphDataView<'uint32'>;
   /** Decompressed bytes packed into little-endian uint32 words. */
   output: GraphDataView<'uint32'>;
@@ -35,10 +154,11 @@ export type GPULZByteDecompressorProps = {
 /**
  * Expands literal and LZ backreference spans into a packed byte buffer.
  *
- * A zero `matchOffset` marks a literal span and uses `literalSourceOffset`. A nonzero
- * `matchOffset` marks a copy from the already-defined output prefix. Each invocation owns one
- * complete output word and recursively resolves backreferences to literals, so overlapping copies
- * are deterministic without global barriers or byte-level write races.
+ * A zero `matchOffset` gathers compressed literal bytes directly; a nonzero `literalPeriod`
+ * repeats that source range for a resolved overlapping copy. A nonzero `matchOffset` retains a
+ * copy whose provenance crosses descriptor boundaries. Each invocation owns one complete output
+ * word and only recursively resolves those remaining backreferences, so overlapping copies are
+ * deterministic without global barriers or byte-level write races.
  */
 export class GPULZByteDecompressor {
   readonly id: string;
@@ -97,7 +217,7 @@ fn findDescriptor(outputByteIndex: u32) -> u32 {
   while (lowerDescriptorIndex < upperDescriptorIndex) {
     let middleDescriptorIndex = lowerDescriptorIndex +
       (upperDescriptorIndex - lowerDescriptorIndex) / 2u;
-    let descriptorOutputOffset = descriptors[DESCRIPTOR_OFFSET + middleDescriptorIndex * 4u];
+    let descriptorOutputOffset = descriptors[DESCRIPTOR_OFFSET + middleDescriptorIndex * 5u];
     if (descriptorOutputOffset <= outputByteIndex) {
       lowerDescriptorIndex = middleDescriptorIndex + 1u;
     } else {
@@ -106,18 +226,24 @@ fn findDescriptor(outputByteIndex: u32) -> u32 {
   }
   return lowerDescriptorIndex - 1u;
 }
-fn resolveLiteralByte(outputByteIndex: u32) -> u32 {
+fn resolveLiteralByte(outputByteIndex: u32, initialDescriptorIndex: u32) -> u32 {
   var sourceOutputByteIndex = outputByteIndex;
+  var sourceDescriptorIndex = initialDescriptorIndex;
   for (var depth = 0u; depth < DESCRIPTOR_COUNT; depth++) {
-    let descriptorIndex = DESCRIPTOR_OFFSET + findDescriptor(sourceOutputByteIndex) * 4u;
+    let descriptorIndex = DESCRIPTOR_OFFSET + sourceDescriptorIndex * 5u;
     let descriptorOutputOffset = descriptors[descriptorIndex];
     let literalSourceOffset = descriptors[descriptorIndex + 2u];
-    let matchOffset = descriptors[descriptorIndex + 3u];
-    let relativeByteIndex = sourceOutputByteIndex - descriptorOutputOffset;
+    let literalPeriod = descriptors[descriptorIndex + 3u];
+    let matchOffset = descriptors[descriptorIndex + 4u];
+    var relativeByteIndex = sourceOutputByteIndex - descriptorOutputOffset;
     if (matchOffset == 0u) {
+      if (literalPeriod != 0u) {
+        relativeByteIndex %= literalPeriod;
+      }
       return readInputByte(literalSourceOffset + relativeByteIndex);
     }
     sourceOutputByteIndex = descriptorOutputOffset - matchOffset + relativeByteIndex % matchOffset;
+    sourceDescriptorIndex = findDescriptor(sourceOutputByteIndex);
   }
   return 0u;
 }
@@ -130,10 +256,15 @@ fn main(
   let outputWordIndex = index;
   if (outputWordIndex >= OUTPUT_WORD_COUNT) { return; }
   var outputWord = 0u;
+  var descriptorIndex = findDescriptor(outputWordIndex * 4u);
   for (var byteLane = 0u; byteLane < 4u; byteLane++) {
     let outputByteIndex = outputWordIndex * 4u + byteLane;
     if (outputByteIndex < OUTPUT_BYTE_LENGTH) {
-      outputWord |= resolveLiteralByte(outputByteIndex) << (byteLane * 8u);
+      if (descriptorIndex + 1u < DESCRIPTOR_COUNT &&
+          descriptors[DESCRIPTOR_OFFSET + (descriptorIndex + 1u) * 5u] <= outputByteIndex) {
+        descriptorIndex += 1u;
+      }
+      outputWord |= resolveLiteralByte(outputByteIndex, descriptorIndex) << (byteLane * 8u);
     }
   }
   outputWords[OUTPUT_OFFSET + outputWordIndex] = outputWord;

--- a/modules/gpgpu/src/gpu-core/gpu-lz-byte-decompressor.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-lz-byte-decompressor.ts
@@ -30,7 +30,9 @@ export type GPULZByteDescriptorPlan = Readonly<{
 }>;
 
 /**
- * Converts `[outputOffset, byteLength, literalSourceOffset, matchOffset]` spans into GPU records.
+ * Converts four-word `[outputOffset, byteLength, literalSourceOffset, matchOffset]` spans into
+ * five-word `[outputOffset, byteLength, literalSourceOffset, literalPeriod, matchOffset]` GPU
+ * records. Use `GPU_LZ_BYTE_DESCRIPTOR_WORDS` when allocating or indexing the returned records.
  *
  * A copy becomes a direct compressed-input gather when its source cycle is contained by one prior
  * direct descriptor. Other copies retain their compact backreference. Planning remains one record

--- a/modules/gpgpu/src/gpu-core/gpu-segment-offsets.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-segment-offsets.ts
@@ -4,12 +4,13 @@
 
 import type {Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
-import {GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
+import {GPUCommandGraph, GraphVectorView, type GraphDataView} from './gpu-command-graph';
 import {getBoundedDispatchLayout, getBoundedInvocationIndexSource} from './gpu-dispatch-utils';
-import {GPUScan} from './gpu-scan';
+import {GPUScan, type GPUScanInput} from './gpu-scan';
 import {
   getViewBinding,
   getViewElementOffset,
+  validateMatchingVectorTopology,
   validatePackedUint32View
 } from './graph-data-view-utils';
 
@@ -19,13 +20,13 @@ const WORKGROUP_SIZE = 256;
 export type GPUSegmentOffsetsProps = {
   id?: string;
   /** Zero-or-one flags for logical elements, including null elements. */
-  elementFlags: GraphDataView<'uint32'>;
+  elementFlags: GPUScanInput;
   /** Exclusive dense logical-element offsets, normally produced by {@link GPUFlagOffsets}. */
-  elementOffsets: GraphDataView<'uint32'>;
-  /** One when a slot starts a segment after the implicit first segment. */
-  segmentStartFlags: GraphDataView<'uint32'>;
+  elementOffsets: GPUScanInput;
+  /** One when a slot starts a segment, including the first segment. */
+  segmentStartFlags: GPUScanInput;
   /** Dense zero-based segment index for every slot. */
-  segmentIndices: GraphDataView<'uint32'>;
+  segmentIndices: GPUScanInput;
   /** Logical-element offset for every segment plus one terminal offset. */
   segmentOffsets: GraphDataView<'uint32'>;
   /** Single uint32 receiving the number of segments. */
@@ -51,10 +52,14 @@ export class GPUSegmentOffsets {
 
   /** Adds a segment-index scan followed by segment-offset and count publication passes. */
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
-    for (const view of Object.values(this.props).filter(
-      (value): value is GraphDataView<'uint32'> =>
-        typeof value === 'object' && value !== null && 'buffer' in value
-    )) {
+    for (const view of [
+      ...getChunks(this.props.elementFlags),
+      ...getChunks(this.props.elementOffsets),
+      ...getChunks(this.props.segmentStartFlags),
+      ...getChunks(this.props.segmentIndices),
+      this.props.segmentOffsets,
+      this.props.segmentCount
+    ]) {
       if (view.buffer.graph !== graph) {
         throw new Error(`${this.id} views must belong to the target graph`);
       }
@@ -67,9 +72,24 @@ export class GPUSegmentOffsets {
       id: `${this.id}-segment-indices`,
       input: this.props.segmentStartFlags,
       output: this.props.segmentIndices,
-      mode: 'inclusive'
+      mode: 'exclusive'
     }).addToGraph(graph);
-    addSegmentOffsetsPass(graph, this.props);
+    const elementFlagChunks = getChunks(this.props.elementFlags);
+    const elementOffsetChunks = getChunks(this.props.elementOffsets);
+    const segmentStartFlagChunks = getChunks(this.props.segmentStartFlags);
+    const segmentIndexChunks = getChunks(this.props.segmentIndices);
+    for (let chunkIndex = 0; chunkIndex < elementFlagChunks.length; chunkIndex++) {
+      if (elementFlagChunks[chunkIndex].length > 0) {
+        addSegmentOffsetsPass(graph, {
+          ...this.props,
+          id: `${this.id}-chunk-${chunkIndex}`,
+          elementFlags: elementFlagChunks[chunkIndex],
+          elementOffsets: elementOffsetChunks[chunkIndex],
+          segmentStartFlags: segmentStartFlagChunks[chunkIndex],
+          segmentIndices: segmentIndexChunks[chunkIndex]
+        });
+      }
+    }
     addSegmentCountPass(graph, this.props);
   }
 }
@@ -102,20 +122,23 @@ fn main(@builtin(local_invocation_index) localInvocationIndex: u32) {
 
 function addSegmentOffsetsPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
-  props: Readonly<GPUSegmentOffsetsProps>
+  props: Readonly<GPUSegmentOffsetsProps> & {
+    elementFlags: GraphDataView<'uint32'>;
+    elementOffsets: GraphDataView<'uint32'>;
+    segmentStartFlags: GraphDataView<'uint32'>;
+    segmentIndices: GraphDataView<'uint32'>;
+  }
 ): void {
   const length = props.elementFlags.length;
   const source = `const LENGTH: u32 = ${length}u;
-const ELEMENT_FLAG_OFFSET: u32 = ${getViewElementOffset(props.elementFlags)}u;
 const ELEMENT_OFFSET: u32 = ${getViewElementOffset(props.elementOffsets)}u;
 const SEGMENT_START_OFFSET: u32 = ${getViewElementOffset(props.segmentStartFlags)}u;
 const SEGMENT_INDEX_OFFSET: u32 = ${getViewElementOffset(props.segmentIndices)}u;
 const SEGMENT_OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.segmentOffsets)}u;
 @group(0) @binding(0) var<storage, read> segmentStartFlags: array<u32>;
 @group(0) @binding(1) var<storage, read> segmentIndices: array<u32>;
-@group(0) @binding(2) var<storage, read> elementFlags: array<u32>;
-@group(0) @binding(3) var<storage, read> elementOffsets: array<u32>;
-@group(0) @binding(4) var<storage, read_write> segmentOffsets: array<u32>;
+@group(0) @binding(2) var<storage, read> elementOffsets: array<u32>;
+@group(0) @binding(3) var<storage, read_write> segmentOffsets: array<u32>;
 @compute @workgroup_size(${WORKGROUP_SIZE})
 fn main(
   @builtin(workgroup_id) workgroupId: vec3u,
@@ -131,21 +154,14 @@ fn main(
     WORKGROUP_SIZE
   )}
   if (index >= LENGTH) { return; }
-  if (index == 0u) { segmentOffsets[SEGMENT_OFFSETS_OFFSET] = 0u; }
   if (segmentStartFlags[SEGMENT_START_OFFSET + index] != 0u) {
     segmentOffsets[SEGMENT_OFFSETS_OFFSET + segmentIndices[SEGMENT_INDEX_OFFSET + index]] =
       elementOffsets[ELEMENT_OFFSET + index];
-  }
-  if (index + 1u == LENGTH) {
-    let elementCount = elementOffsets[ELEMENT_OFFSET + index] + elementFlags[ELEMENT_FLAG_OFFSET + index];
-    let count = segmentIndices[SEGMENT_INDEX_OFFSET + index] + 1u;
-    segmentOffsets[SEGMENT_OFFSETS_OFFSET + count] = elementCount;
   }
 }`;
   addPass(graph, `${props.id}-publish`, 'GPUSegmentOffsetsPublish', source, length, [
     {name: 'segmentStartFlags', view: props.segmentStartFlags, usage: 'storage-read'},
     {name: 'segmentIndices', view: props.segmentIndices, usage: 'storage-read'},
-    {name: 'elementFlags', view: props.elementFlags, usage: 'storage-read'},
     {name: 'elementOffsets', view: props.elementOffsets, usage: 'storage-read'},
     {name: 'segmentOffsets', view: props.segmentOffsets, usage: 'storage-write'}
   ]);
@@ -155,18 +171,39 @@ function addSegmentCountPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   props: Readonly<GPUSegmentOffsetsProps>
 ): void {
-  const source = `const LAST_INDEX: u32 = ${props.elementFlags.length - 1}u;
-const SEGMENT_INDEX_OFFSET: u32 = ${getViewElementOffset(props.segmentIndices)}u;
+  const elementFlagChunk = getLastNonEmptyChunk(props.elementFlags);
+  const elementOffsetChunk = getLastNonEmptyChunk(props.elementOffsets);
+  const segmentStartFlagChunk = getLastNonEmptyChunk(props.segmentStartFlags);
+  const segmentIndexChunk = getLastNonEmptyChunk(props.segmentIndices);
+  const source = `const LAST_INDEX: u32 = ${elementFlagChunk.length - 1}u;
+const ELEMENT_FLAG_OFFSET: u32 = ${getViewElementOffset(elementFlagChunk)}u;
+const ELEMENT_OFFSET: u32 = ${getViewElementOffset(elementOffsetChunk)}u;
+const SEGMENT_START_OFFSET: u32 = ${getViewElementOffset(segmentStartFlagChunk)}u;
+const SEGMENT_INDEX_OFFSET: u32 = ${getViewElementOffset(segmentIndexChunk)}u;
+const SEGMENT_OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.segmentOffsets)}u;
 const SEGMENT_COUNT_OFFSET: u32 = ${getViewElementOffset(props.segmentCount)}u;
-@group(0) @binding(0) var<storage, read> segmentIndices: array<u32>;
-@group(0) @binding(1) var<storage, read_write> segmentCount: array<u32>;
+@group(0) @binding(0) var<storage, read> elementFlags: array<u32>;
+@group(0) @binding(1) var<storage, read> elementOffsets: array<u32>;
+@group(0) @binding(2) var<storage, read> segmentStartFlags: array<u32>;
+@group(0) @binding(3) var<storage, read> segmentIndices: array<u32>;
+@group(0) @binding(4) var<storage, read_write> segmentOffsets: array<u32>;
+@group(0) @binding(5) var<storage, read_write> segmentCount: array<u32>;
 @compute @workgroup_size(${WORKGROUP_SIZE})
 fn main(@builtin(local_invocation_index) localInvocationIndex: u32) {
   if (localInvocationIndex > 0u) { return; }
-  segmentCount[SEGMENT_COUNT_OFFSET] = segmentIndices[SEGMENT_INDEX_OFFSET + LAST_INDEX] + 1u;
+  let count = segmentIndices[SEGMENT_INDEX_OFFSET + LAST_INDEX] +
+    segmentStartFlags[SEGMENT_START_OFFSET + LAST_INDEX];
+  let elementCount = elementOffsets[ELEMENT_OFFSET + LAST_INDEX] +
+    elementFlags[ELEMENT_FLAG_OFFSET + LAST_INDEX];
+  segmentOffsets[SEGMENT_OFFSETS_OFFSET + count] = elementCount;
+  segmentCount[SEGMENT_COUNT_OFFSET] = count;
 }`;
   addPass(graph, `${props.id}-count`, 'GPUSegmentOffsetsCount', source, 1, [
-    {name: 'segmentIndices', view: props.segmentIndices, usage: 'storage-read'},
+    {name: 'elementFlags', view: elementFlagChunk, usage: 'storage-read'},
+    {name: 'elementOffsets', view: elementOffsetChunk, usage: 'storage-read'},
+    {name: 'segmentStartFlags', view: segmentStartFlagChunk, usage: 'storage-read'},
+    {name: 'segmentIndices', view: segmentIndexChunk, usage: 'storage-read'},
+    {name: 'segmentOffsets', view: props.segmentOffsets, usage: 'storage-write'},
     {name: 'segmentCount', view: props.segmentCount, usage: 'storage-write'}
   ]);
 }
@@ -229,22 +266,44 @@ function addPass<Parameters>(
 
 function validateConfiguration(props: Readonly<GPUSegmentOffsetsProps>): void {
   const slotCount = props.elementFlags.length;
-  for (const [name, view] of Object.entries({
+  for (const [name, input] of Object.entries({
     elementFlags: props.elementFlags,
     elementOffsets: props.elementOffsets,
     segmentStartFlags: props.segmentStartFlags,
-    segmentIndices: props.segmentIndices,
-    segmentOffsets: props.segmentOffsets,
-    segmentCount: props.segmentCount
+    segmentIndices: props.segmentIndices
   })) {
-    validatePackedUint32View(view, `${props.id} ${name}`);
+    for (const view of getChunks(input)) {
+      validatePackedUint32View(view, `${props.id} ${name}`);
+    }
   }
-  for (const view of [props.elementOffsets, props.segmentStartFlags, props.segmentIndices]) {
-    if (view.length < slotCount) {
+  validatePackedUint32View(props.segmentOffsets, `${props.id} segmentOffsets`);
+  validatePackedUint32View(props.segmentCount, `${props.id} segmentCount`);
+  const elementFlagsAreVector = props.elementFlags instanceof GraphVectorView;
+  for (const input of [props.elementOffsets, props.segmentStartFlags, props.segmentIndices]) {
+    if (elementFlagsAreVector !== input instanceof GraphVectorView) {
+      throw new Error(`${props.id} slot-aligned inputs must use the same view kind`);
+    }
+    if (props.elementFlags instanceof GraphVectorView && input instanceof GraphVectorView) {
+      validateMatchingVectorTopology(props.elementFlags, input, `${props.id} slot-aligned inputs`);
+    } else if (input.length < slotCount) {
       throw new Error(`${props.id} slot-aligned views must cover every element flag`);
     }
   }
   if (props.segmentOffsets.length < slotCount + 1 || props.segmentCount.length < 1) {
     throw new Error(`${props.id} result views are too short`);
   }
+}
+
+function getChunks(input: GPUScanInput): readonly GraphDataView<'uint32'>[] {
+  return input instanceof GraphVectorView ? input.data : [input];
+}
+
+function getLastNonEmptyChunk(input: GPUScanInput): GraphDataView<'uint32'> {
+  const chunks = getChunks(input);
+  for (let chunkIndex = chunks.length - 1; chunkIndex >= 0; chunkIndex--) {
+    if (chunks[chunkIndex].length > 0) {
+      return chunks[chunkIndex];
+    }
+  }
+  throw new Error('Non-empty GPUSegmentOffsets input requires a non-empty chunk');
 }

--- a/modules/gpgpu/src/gpu-core/index.ts
+++ b/modules/gpgpu/src/gpu-core/index.ts
@@ -137,9 +137,13 @@ export {
   GPULZByteDecompressor,
   GPU_LZ_BYTE_DESCRIPTOR_WORDS,
   GPU_LZ_BYTE_WORKGROUP_SIZE,
-  getGPULZByteDecompressorShaderSource
+  getGPULZByteDecompressorShaderSource,
+  planGPULZByteDescriptors
 } from './gpu-lz-byte-decompressor';
-export type {GPULZByteDecompressorProps} from './gpu-lz-byte-decompressor';
+export type {
+  GPULZByteDecompressorProps,
+  GPULZByteDescriptorPlan
+} from './gpu-lz-byte-decompressor';
 export {
   runGPUWorkgroupScanBenchmark,
   summarizeGPUWorkgroupScanBenchmarkSamples

--- a/modules/gpgpu/src/gpu-parse/README.md
+++ b/modules/gpgpu/src/gpu-parse/README.md
@@ -163,15 +163,16 @@ An all-null page has zero physical values and therefore a known empty result. Th
   Parquet definition/repetition levels into binary flags, then composes `GPUSegmentedLayout`.
 - Use `GPUParquetNestedColumnLayout` when one column has multiple requested schema depths or page
   chunks must remain explicit. It accepts matching definition/repetition `GraphVectorView`s, scans
-  leaf validity once per page, and composes `GPUFlagOffsets` plus `GPUSegmentOffsets` per depth.
+  leaf validity across the vector, and composes chunk-aware `GPUFlagOffsets` plus
+  `GPUSegmentOffsets` per depth.
   Required, optional, list, and nested-list layouts differ only in their schema-derived definition
-  and repetition thresholds. Returned vectors retain page-local offsets and can feed later graph
-  nodes without readback.
+  and repetition thresholds. Slot-aligned vectors retain page topology, while dense indices and one
+  global list-offset stream carry through page boundaries so a repeated row is never split.
 
 The nested operation allocates public results as graph transients with storage and copy-source
 usage. Keep them transient when the consumer is in the same graph. If results must outlive the
 compiled graph, copy selected chunks to imported caller-owned buffers and wrap those buffers as
-`GPUData`/`GPUVector` in the adapter; do not concatenate page terminals implicitly.
+`GPUData`/`GPUVector` in the adapter. The global list-offset stream already contains its terminal.
 
 ### Compression
 

--- a/modules/gpgpu/src/gpu-parse/compression/lz4-raw-plan.ts
+++ b/modules/gpgpu/src/gpu-parse/compression/lz4-raw-plan.ts
@@ -2,13 +2,19 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-export const LZ4_RAW_DESCRIPTOR_WORDS = 4;
+import {GPU_LZ_BYTE_DESCRIPTOR_WORDS, planGPULZByteDescriptors} from '@luma.gl/gpgpu/gpu-core';
+
+export const LZ4_RAW_DESCRIPTOR_WORDS = GPU_LZ_BYTE_DESCRIPTOR_WORDS;
 
 /** CPU-parsed LZ4_RAW sequence control data for GPU upload. */
 export type LZ4RawDecompressionPlan = {
-  /** Generic `[outputOffset, byteLength, literalSourceOffset, matchOffset]` LZ spans. */
+  /** GPU LZ descriptors with direct compressed-input provenance where tractable. */
   descriptors: Uint32Array;
   descriptorCount: number;
+  directCopyCount: number;
+  recursiveCopyCount: number;
+  directCopyByteLength: number;
+  recursiveCopyByteLength: number;
   compressedByteLength: number;
   outputByteLength: number;
 };
@@ -54,8 +60,7 @@ export function parseLZ4RawDecompressionPlan(compressed: Uint8Array): LZ4RawDeco
     outputByteOffset = addOutputLength(outputByteOffset, literalLength + matchLength);
   }
   return Object.freeze({
-    descriptors: Uint32Array.from(descriptors),
-    descriptorCount: descriptors.length / LZ4_RAW_DESCRIPTOR_WORDS,
+    ...planGPULZByteDescriptors(descriptors),
     compressedByteLength: compressed.length,
     outputByteLength: outputByteOffset
   });

--- a/modules/gpgpu/src/gpu-parse/compression/snappy-plan.ts
+++ b/modules/gpgpu/src/gpu-parse/compression/snappy-plan.ts
@@ -2,15 +2,19 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import {GPU_LZ_BYTE_DESCRIPTOR_WORDS} from '@luma.gl/gpgpu/gpu-core';
+import {GPU_LZ_BYTE_DESCRIPTOR_WORDS, planGPULZByteDescriptors} from '@luma.gl/gpgpu/gpu-core';
 
 export const SNAPPY_DESCRIPTOR_WORDS = GPU_LZ_BYTE_DESCRIPTOR_WORDS;
 
 /** CPU-parsed raw Snappy block control data for GPU upload. */
 export type SnappyDecompressionPlan = {
-  /** Generic `[outputOffset, byteLength, literalSourceOffset, matchOffset]` LZ spans. */
+  /** GPU LZ descriptors with direct compressed-input provenance where tractable. */
   descriptors: Uint32Array;
   descriptorCount: number;
+  directCopyCount: number;
+  recursiveCopyCount: number;
+  directCopyByteLength: number;
+  recursiveCopyByteLength: number;
   compressedByteLength: number;
   outputByteLength: number;
 };
@@ -50,8 +54,7 @@ export function parseSnappyDecompressionPlan(compressed: Uint8Array): SnappyDeco
     throw new Error('Snappy decoded length does not match the preamble');
   }
   return Object.freeze({
-    descriptors: Uint32Array.from(descriptors),
-    descriptorCount: descriptors.length / SNAPPY_DESCRIPTOR_WORDS,
+    ...planGPULZByteDescriptors(descriptors),
     compressedByteLength: compressed.length,
     outputByteLength
   });

--- a/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-nested-column-layout.ts
+++ b/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-nested-column-layout.ts
@@ -71,9 +71,9 @@ export type GPUParquetNestedColumnDepthLayout = Readonly<{
 export type GPUParquetNestedColumnLayoutResult = Readonly<{
   /** Leaf presence flags aligned with encoded level slots. */
   validity: GraphVectorView<'uint32'>;
-  /** Exclusive dense physical-value indices aligned with encoded level slots. */
+  /** Page-local exclusive physical-value indices aligned with encoded level slots. */
   valueOffsets: GraphVectorView<'uint32'>;
-  /** One non-null value count for the complete chunked column. */
+  /** One non-null value count per input page chunk, including empty chunks. */
   nonNullValueCounts: GraphVectorView<'uint32'>;
   /** One result for every requested schema depth, in input order. */
   depths: readonly GPUParquetNestedColumnDepthLayout[];
@@ -82,8 +82,9 @@ export type GPUParquetNestedColumnLayoutResult = Readonly<{
 /**
  * Materializes a required, optional, list, or nested-list Parquet column without CPU readback.
  *
- * The operation preserves the input `GraphVectorView` page topology for slot-aligned streams while
- * scans carry offsets across page boundaries. Each requested schema depth receives one global
+ * The operation preserves the input `GraphVectorView` page topology for slot-aligned streams.
+ * Leaf value offsets and counts restart for each page so that they index the page-sized decoded
+ * value chunks emitted by Parquet readers. Each requested schema depth instead receives one global
  * list-offset stream, so a repeated row that begins on one page and continues on the next remains
  * one row. Returned transient views can be connected directly to later graph nodes; adapters that
  * require durable `GPUData`/`GPUVector` objects should copy chosen views into caller-owned buffers.
@@ -107,11 +108,16 @@ export class GPUParquetNestedColumnLayout {
     const {definitionLevels, repetitionLevels} = this.props;
     const validity = createOutputVector(graph, `${this.id}-validity`, definitionLevels);
     const valueOffsets = createOutputVector(graph, `${this.id}-value-offsets`, definitionLevels);
-    const nonNullValueCount = createTransientView(
-      graph,
-      `${this.id}-non-null-value-count`,
-      'uint32',
-      1
+    const nonNullValueCounts = makeVector(
+      `${this.id}-non-null-value-counts`,
+      definitionLevels.data.map((_, chunkIndex) =>
+        createTransientView(
+          graph,
+          `${this.id}-non-null-value-count-chunk-${chunkIndex}`,
+          'uint32',
+          1
+        )
+      )
     );
     const depthOutputs = this.props.depths.map(depth => ({
       elementFlags: createOutputVector(
@@ -184,12 +190,14 @@ export class GPUParquetNestedColumnLayout {
       }
     }
 
-    new GPUFlagOffsets({
-      id: `${this.id}-leaf-values`,
-      flags: validity,
-      offsets: valueOffsets,
-      count: nonNullValueCount
-    }).addToGraph(graph);
+    for (let chunkIndex = 0; chunkIndex < validity.data.length; chunkIndex++) {
+      new GPUFlagOffsets({
+        id: `${this.id}-leaf-values-chunk-${chunkIndex}`,
+        flags: validity.data[chunkIndex],
+        offsets: valueOffsets.data[chunkIndex],
+        count: nonNullValueCounts.data[chunkIndex]
+      }).addToGraph(graph);
+    }
     for (let depthIndex = 0; depthIndex < this.props.depths.length; depthIndex++) {
       const depth = this.props.depths[depthIndex];
       const output = depthOutputs[depthIndex];
@@ -213,7 +221,7 @@ export class GPUParquetNestedColumnLayout {
     return Object.freeze({
       validity,
       valueOffsets,
-      nonNullValueCounts: makeVector(`${this.id}-non-null-value-counts`, [nonNullValueCount]),
+      nonNullValueCounts,
       depths: Object.freeze(
         this.props.depths.map((depth, depthIndex) => {
           const output = depthOutputs[depthIndex];

--- a/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-nested-column-layout.ts
+++ b/modules/gpgpu/src/gpu-parse/parquet/gpu-parquet-nested-column-layout.ts
@@ -61,9 +61,9 @@ export type GPUParquetNestedColumnDepthLayout = Readonly<{
   rowStartFlags: GraphVectorView<'uint32'>;
   rowIndices: GraphVectorView<'uint32'>;
   listOffsets: GraphVectorView<'uint32'>;
-  /** One scalar count chunk per source page. */
+  /** One scalar count for the complete chunked column. */
   elementCounts: GraphVectorView<'uint32'>;
-  /** One scalar count chunk per source page. */
+  /** One scalar count for the complete chunked column. */
   rowCounts: GraphVectorView<'uint32'>;
 }>;
 
@@ -73,7 +73,7 @@ export type GPUParquetNestedColumnLayoutResult = Readonly<{
   validity: GraphVectorView<'uint32'>;
   /** Exclusive dense physical-value indices aligned with encoded level slots. */
   valueOffsets: GraphVectorView<'uint32'>;
-  /** One non-null value count per source page. */
+  /** One non-null value count for the complete chunked column. */
   nonNullValueCounts: GraphVectorView<'uint32'>;
   /** One result for every requested schema depth, in input order. */
   depths: readonly GPUParquetNestedColumnDepthLayout[];
@@ -82,11 +82,11 @@ export type GPUParquetNestedColumnLayoutResult = Readonly<{
 /**
  * Materializes a required, optional, list, or nested-list Parquet column without CPU readback.
  *
- * The operation preserves the input `GraphVectorView` page topology. Leaf validity is classified
- * and scanned once per page, while each requested schema depth receives its own logical-element
- * and segment offsets. Returned transient views can be connected directly to later graph nodes;
- * adapters that require durable `GPUData`/`GPUVector` objects should copy chosen views into
- * caller-owned buffers and retain the same chunk order.
+ * The operation preserves the input `GraphVectorView` page topology for slot-aligned streams while
+ * scans carry offsets across page boundaries. Each requested schema depth receives one global
+ * list-offset stream, so a repeated row that begins on one page and continues on the next remains
+ * one row. Returned transient views can be connected directly to later graph nodes; adapters that
+ * require durable `GPUData`/`GPUVector` objects should copy chosen views into caller-owned buffers.
  *
  * Compile the completed command graph once and rebind imported input buffers for later batches
  * with the same page sizes. The operation performs no allocation, parsing, submission, or mapping
@@ -102,20 +102,51 @@ export class GPUParquetNestedColumnLayout {
     validateConfiguration(this.props);
   }
 
-  /** Adds page-local classifiers and generic offset operations, then returns composable views. */
+  /** Adds page classifiers and chunk-spanning generic offset operations. */
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): GPUParquetNestedColumnLayoutResult {
     const {definitionLevels, repetitionLevels} = this.props;
-    const validityChunks: GraphDataView<'uint32'>[] = [];
-    const valueOffsetChunks: GraphDataView<'uint32'>[] = [];
-    const nonNullValueCountChunks: GraphDataView<'uint32'>[] = [];
-    const depthChunks = this.props.depths.map(() => ({
-      elementFlags: [] as GraphDataView<'uint32'>[],
-      elementOffsets: [] as GraphDataView<'uint32'>[],
-      rowStartFlags: [] as GraphDataView<'uint32'>[],
-      rowIndices: [] as GraphDataView<'uint32'>[],
-      listOffsets: [] as GraphDataView<'uint32'>[],
-      elementCounts: [] as GraphDataView<'uint32'>[],
-      rowCounts: [] as GraphDataView<'uint32'>[]
+    const validity = createOutputVector(graph, `${this.id}-validity`, definitionLevels);
+    const valueOffsets = createOutputVector(graph, `${this.id}-value-offsets`, definitionLevels);
+    const nonNullValueCount = createTransientView(
+      graph,
+      `${this.id}-non-null-value-count`,
+      'uint32',
+      1
+    );
+    const depthOutputs = this.props.depths.map(depth => ({
+      elementFlags: createOutputVector(
+        graph,
+        `${this.id}-${depth.name}-element-flags`,
+        definitionLevels
+      ),
+      elementOffsets: createOutputVector(
+        graph,
+        `${this.id}-${depth.name}-element-offsets`,
+        definitionLevels
+      ),
+      rowStartFlags: createOutputVector(
+        graph,
+        `${this.id}-${depth.name}-row-start-flags`,
+        definitionLevels
+      ),
+      rowIndices: createOutputVector(
+        graph,
+        `${this.id}-${depth.name}-row-indices`,
+        definitionLevels
+      ),
+      listOffsets: createTransientView(
+        graph,
+        `${this.id}-${depth.name}-list-offsets`,
+        'uint32',
+        definitionLevels.length + 1
+      ),
+      elementCount: createTransientView(
+        graph,
+        `${this.id}-${depth.name}-element-count`,
+        'uint32',
+        1
+      ),
+      rowCount: createTransientView(graph, `${this.id}-${depth.name}-row-count`, 'uint32', 1)
     }));
 
     for (let chunkIndex = 0; chunkIndex < definitionLevels.data.length; chunkIndex++) {
@@ -127,133 +158,76 @@ export class GPUParquetNestedColumnLayout {
       ) {
         throw new Error(`${this.id} inputs must belong to the target graph`);
       }
-      const chunkId = `${this.id}-chunk-${chunkIndex}`;
       const slotCount = definitionLevelChunk.length;
-      const validity = createTransientView(graph, `${chunkId}-validity`, 'uint32', slotCount);
-      const valueOffsets = createTransientView(
-        graph,
-        `${chunkId}-value-offsets`,
-        'uint32',
-        slotCount
-      );
-      const nonNullValueCount = createTransientView(
-        graph,
-        `${chunkId}-non-null-value-count`,
-        'uint32',
-        1
-      );
-      validityChunks.push(validity);
-      valueOffsetChunks.push(valueOffsets);
-      nonNullValueCountChunks.push(nonNullValueCount);
+      const chunkId = `${this.id}-chunk-${chunkIndex}`;
 
       for (let depthIndex = 0; depthIndex < this.props.depths.length; depthIndex++) {
         const depth = this.props.depths[depthIndex];
-        const output = depthChunks[depthIndex];
+        const output = depthOutputs[depthIndex];
         const depthId = `${chunkId}-${depth.name}`;
-        const elementFlags = createTransientView(
-          graph,
-          `${depthId}-element-flags`,
-          'uint32',
-          slotCount
-        );
-        const elementOffsets = createTransientView(
-          graph,
-          `${depthId}-element-offsets`,
-          'uint32',
-          slotCount
-        );
-        const rowStartFlags = createTransientView(
-          graph,
-          `${depthId}-row-start-flags`,
-          'uint32',
-          slotCount
-        );
-        const rowIndices = createTransientView(
-          graph,
-          `${depthId}-row-indices`,
-          'uint32',
-          slotCount
-        );
-        const listOffsets = createTransientView(
-          graph,
-          `${depthId}-list-offsets`,
-          'uint32',
-          slotCount + 1
-        );
-        const elementCount = createTransientView(graph, `${depthId}-element-count`, 'uint32', 1);
-        const rowCount = createTransientView(graph, `${depthId}-row-count`, 'uint32', 1);
-        output.elementFlags.push(elementFlags);
-        output.elementOffsets.push(elementOffsets);
-        output.rowStartFlags.push(rowStartFlags);
-        output.rowIndices.push(rowIndices);
-        output.listOffsets.push(listOffsets);
-        output.elementCounts.push(elementCount);
-        output.rowCounts.push(rowCount);
 
         if (slotCount > 0) {
           addClassifyPass(graph, {
             id: `${depthId}-classify`,
             definitionLevels: definitionLevelChunk,
             repetitionLevels: repetitionLevelChunk,
-            validity: depthIndex === 0 ? validity : undefined,
-            elementFlags,
-            rowStartFlags,
+            validity: depthIndex === 0 ? validity.data[chunkIndex] : undefined,
+            elementFlags: output.elementFlags.data[chunkIndex],
+            rowStartFlags: output.rowStartFlags.data[chunkIndex],
             maxDefinitionLevel: this.props.maxDefinitionLevel,
             elementDefinitionLevel: depth.elementDefinitionLevel,
+            rowDefinitionLevel:
+              depthIndex === 0 ? 0 : this.props.depths[depthIndex - 1].elementDefinitionLevel,
             rowStartRepetitionLevel: depth.rowStartRepetitionLevel
           });
         }
-        if (depthIndex === 0) {
-          new GPUFlagOffsets({
-            id: `${chunkId}-leaf-values`,
-            flags: validity,
-            offsets: valueOffsets,
-            count: nonNullValueCount
-          }).addToGraph(graph);
-        }
-        new GPUFlagOffsets({
-          id: `${depthId}-elements`,
-          flags: elementFlags,
-          offsets: elementOffsets,
-          count: elementCount
-        }).addToGraph(graph);
-        new GPUSegmentOffsets({
-          id: `${depthId}-rows`,
-          elementFlags,
-          elementOffsets,
-          segmentStartFlags: rowStartFlags,
-          segmentIndices: rowIndices,
-          segmentOffsets: listOffsets,
-          segmentCount: rowCount
-        }).addToGraph(graph);
       }
     }
 
+    new GPUFlagOffsets({
+      id: `${this.id}-leaf-values`,
+      flags: validity,
+      offsets: valueOffsets,
+      count: nonNullValueCount
+    }).addToGraph(graph);
+    for (let depthIndex = 0; depthIndex < this.props.depths.length; depthIndex++) {
+      const depth = this.props.depths[depthIndex];
+      const output = depthOutputs[depthIndex];
+      new GPUFlagOffsets({
+        id: `${this.id}-${depth.name}-elements`,
+        flags: output.elementFlags,
+        offsets: output.elementOffsets,
+        count: output.elementCount
+      }).addToGraph(graph);
+      new GPUSegmentOffsets({
+        id: `${this.id}-${depth.name}-rows`,
+        elementFlags: output.elementFlags,
+        elementOffsets: output.elementOffsets,
+        segmentStartFlags: output.rowStartFlags,
+        segmentIndices: output.rowIndices,
+        segmentOffsets: output.listOffsets,
+        segmentCount: output.rowCount
+      }).addToGraph(graph);
+    }
+
     return Object.freeze({
-      validity: makeVector(`${this.id}-validity`, validityChunks),
-      valueOffsets: makeVector(`${this.id}-value-offsets`, valueOffsetChunks),
-      nonNullValueCounts: makeVector(`${this.id}-non-null-value-counts`, nonNullValueCountChunks),
+      validity,
+      valueOffsets,
+      nonNullValueCounts: makeVector(`${this.id}-non-null-value-counts`, [nonNullValueCount]),
       depths: Object.freeze(
         this.props.depths.map((depth, depthIndex) => {
-          const chunks = depthChunks[depthIndex];
+          const output = depthOutputs[depthIndex];
           return Object.freeze({
             name: depth.name,
-            elementFlags: makeVector(`${this.id}-${depth.name}-element-flags`, chunks.elementFlags),
-            elementOffsets: makeVector(
-              `${this.id}-${depth.name}-element-offsets`,
-              chunks.elementOffsets
-            ),
-            rowStartFlags: makeVector(
-              `${this.id}-${depth.name}-row-start-flags`,
-              chunks.rowStartFlags
-            ),
-            rowIndices: makeVector(`${this.id}-${depth.name}-row-indices`, chunks.rowIndices),
-            listOffsets: makeVector(`${this.id}-${depth.name}-list-offsets`, chunks.listOffsets),
-            elementCounts: makeVector(
-              `${this.id}-${depth.name}-element-counts`,
-              chunks.elementCounts
-            ),
-            rowCounts: makeVector(`${this.id}-${depth.name}-row-counts`, chunks.rowCounts)
+            elementFlags: output.elementFlags,
+            elementOffsets: output.elementOffsets,
+            rowStartFlags: output.rowStartFlags,
+            rowIndices: output.rowIndices,
+            listOffsets: makeVector(`${this.id}-${depth.name}-list-offsets`, [output.listOffsets]),
+            elementCounts: makeVector(`${this.id}-${depth.name}-element-counts`, [
+              output.elementCount
+            ]),
+            rowCounts: makeVector(`${this.id}-${depth.name}-row-counts`, [output.rowCount])
           });
         })
       )
@@ -270,6 +244,7 @@ type ClassifyPassProps = {
   rowStartFlags: GraphDataView<'uint32'>;
   maxDefinitionLevel: number;
   elementDefinitionLevel: number;
+  rowDefinitionLevel: number;
   rowStartRepetitionLevel: number;
 };
 
@@ -297,6 +272,7 @@ function addClassifyPass<Parameters>(
   const source = `const LENGTH: u32 = ${length}u;
 const MAX_DEFINITION_LEVEL: u32 = ${props.maxDefinitionLevel}u;
 const ELEMENT_DEFINITION_LEVEL: u32 = ${props.elementDefinitionLevel}u;
+const ROW_DEFINITION_LEVEL: u32 = ${props.rowDefinitionLevel}u;
 const ROW_START_REPETITION_LEVEL: u32 = ${props.rowStartRepetitionLevel}u;
 const DEFINITION_OFFSET: u32 = ${getViewElementOffset(props.definitionLevels)}u;
 const REPETITION_OFFSET: u32 = ${getViewElementOffset(props.repetitionLevels)}u;
@@ -321,7 +297,8 @@ fn main(
   rowStartFlags[ROW_START_OFFSET + index] = select(
     0u,
     1u,
-    index > 0u && repetitionLevels[REPETITION_OFFSET + index] <= ROW_START_REPETITION_LEVEL
+    definitionLevel >= ROW_DEFINITION_LEVEL &&
+      repetitionLevels[REPETITION_OFFSET + index] <= ROW_START_REPETITION_LEVEL
   );
 }`;
   const resources = [
@@ -389,6 +366,17 @@ function makeVector(
     rowByteLength: Uint32Array.BYTES_PER_ELEMENT,
     data
   });
+}
+
+function createOutputVector<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  id: string,
+  template: GraphVectorView<'uint32'>
+): GraphVectorView<'uint32'> {
+  const chunks = template.data.map((chunk, chunkIndex) =>
+    createTransientView(graph, `${id}-chunk-${chunkIndex}`, 'uint32', chunk.length)
+  );
+  return makeVector(id, chunks);
 }
 
 function validateConfiguration(props: Readonly<GPUParquetNestedColumnLayoutProps>): void {

--- a/modules/gpgpu/src/gpu-parse/parquet/parquet-encoded-page-batch.ts
+++ b/modules/gpgpu/src/gpu-parse/parquet/parquet-encoded-page-batch.ts
@@ -110,6 +110,14 @@ export type GPUParquetCompressionPlan = Readonly<{
   input: GPUParquetUploadSection;
   descriptors: GPUParquetUploadSection;
   descriptorCount: number;
+  /** Match/copy descriptors resolved to compressed-input gathers during CPU planning. */
+  directCopyCount: number;
+  /** Match/copy descriptors that still require output-prefix recursion on the GPU. */
+  recursiveCopyCount: number;
+  /** Decoded bytes covered by direct copy descriptors. */
+  directCopyByteLength: number;
+  /** Decoded bytes covered by recursive copy descriptors. */
+  recursiveCopyByteLength: number;
   outputByteLength: number;
 }>;
 
@@ -613,6 +621,10 @@ function planCompression(
       input,
       descriptors: upload.add(plan.descriptors, 'snappy descriptors'),
       descriptorCount: plan.descriptorCount,
+      directCopyCount: plan.directCopyCount,
+      recursiveCopyCount: plan.recursiveCopyCount,
+      directCopyByteLength: plan.directCopyByteLength,
+      recursiveCopyByteLength: plan.recursiveCopyByteLength,
       outputByteLength
     });
   }
@@ -628,6 +640,10 @@ function planCompression(
       input,
       descriptors: upload.add(plan.descriptors, 'lz4 descriptors'),
       descriptorCount: plan.descriptorCount,
+      directCopyCount: plan.directCopyCount,
+      recursiveCopyCount: plan.recursiveCopyCount,
+      directCopyByteLength: plan.directCopyByteLength,
+      recursiveCopyByteLength: plan.recursiveCopyByteLength,
       outputByteLength
     });
   }

--- a/modules/gpgpu/test/gpu-parse/compression/gpu-lz4-raw-decompressor.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/compression/gpu-lz4-raw-decompressor.node.spec.ts
@@ -9,15 +9,18 @@ import {
   getGPULZ4RawShaderSource,
   parseLZ4RawDecompressionPlan
 } from '@luma.gl/gpgpu/gpu-parse';
-import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
+import {GPUCommandGraph, planGPULZByteDescriptors} from '@luma.gl/gpgpu/gpu-core';
 import {WgslReflect} from 'wgsl_reflect';
 
 const COMPRESSED = Uint8Array.from([0x14, 65, 1, 0, 0x50, 66, 67, 68, 69, 70]);
 
 it('parseLZ4RawDecompressionPlan describes literals and overlapping matches', () => {
   const plan = parseLZ4RawDecompressionPlan(COMPRESSED);
-  expect(Array.from(plan.descriptors)).toEqual([0, 1, 1, 0, 1, 8, 0, 1, 9, 5, 5, 0]);
+  expect(Array.from(plan.descriptors)).toEqual([0, 1, 1, 0, 0, 1, 8, 1, 1, 0, 9, 5, 5, 0, 0]);
   expect(plan.descriptorCount).toBe(3);
+  expect(plan.directCopyCount).toBe(1);
+  expect(plan.recursiveCopyCount).toBe(0);
+  expect(plan.directCopyByteLength).toBe(8);
   expect(plan.compressedByteLength).toBe(10);
   expect(plan.outputByteLength).toBe(14);
   expect(() => parseLZ4RawDecompressionPlan(Uint8Array.from([0x10, 65, 0, 0]))).toThrow(
@@ -28,18 +31,27 @@ it('parseLZ4RawDecompressionPlan describes literals and overlapping matches', ()
   );
 });
 
-it('GPULZ4RawDecompressor emits recursive literal resolution WGSL', () => {
+it('planGPULZByteDescriptors retains copies that cross direct descriptors', () => {
+  const plan = planGPULZByteDescriptors([0, 2, 10, 0, 2, 2, 20, 0, 4, 8, 0, 4]);
+  expect(plan.descriptorCount).toBe(3);
+  expect(plan.directCopyCount).toBe(0);
+  expect(plan.recursiveCopyCount).toBe(1);
+  expect(plan.recursiveCopyByteLength).toBe(8);
+  expect(Array.from(plan.descriptors.slice(10))).toEqual([4, 8, 0, 0, 4]);
+});
+
+it('GPULZ4RawDecompressor emits direct and recursive literal resolution WGSL', () => {
   const graph = new GPUCommandGraph(makeSupportDevice());
   const inputHandle = graph.importBuffer({id: 'input', byteLength: 12, usage: Buffer.STORAGE});
   const descriptorHandle = graph.importBuffer({
     id: 'descriptors',
-    byteLength: 48,
+    byteLength: 60,
     usage: Buffer.STORAGE
   });
   const outputHandle = graph.importBuffer({id: 'output', byteLength: 16, usage: Buffer.STORAGE});
   const decompressor = new GPULZ4RawDecompressor({
     input: graph.createDataView(inputHandle, {format: 'uint32', length: 3}),
-    descriptors: graph.createDataView(descriptorHandle, {format: 'uint32', length: 12}),
+    descriptors: graph.createDataView(descriptorHandle, {format: 'uint32', length: 15}),
     output: graph.createDataView(outputHandle, {format: 'uint32', length: 4}),
     compressedByteLength: 10,
     outputByteLength: 14,
@@ -47,6 +59,7 @@ it('GPULZ4RawDecompressor emits recursive literal resolution WGSL', () => {
   });
   const source = getGPULZ4RawShaderSource(decompressor, {x: 1, y: 1, z: 1});
   expect(new WgslReflect(source).entry.compute.map(entry => entry.name)).toEqual(['main']);
+  expect(source).toMatch(/literalPeriod != 0u/);
   expect(source).toMatch(/relativeByteIndex % matchOffset/);
   expect(source).toMatch(/depth < DESCRIPTOR_COUNT/);
   expect(() => decompressor.addToGraph(graph)).not.toThrow();

--- a/modules/gpgpu/test/gpu-parse/compression/gpu-snappy-decompressor.node.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/compression/gpu-snappy-decompressor.node.spec.ts
@@ -10,7 +10,9 @@ it('parseSnappyDecompressionPlan parses literals and overlapping copies', () => 
   const plan = parseSnappyDecompressionPlan(compressed);
   expect(plan.outputByteLength).toBe(10);
   expect(plan.descriptorCount).toBe(3);
-  expect(Array.from(plan.descriptors)).toEqual([0, 3, 2, 0, 3, 6, 0, 3, 9, 1, 9, 0]);
+  expect(plan.directCopyCount).toBe(1);
+  expect(plan.recursiveCopyCount).toBe(0);
+  expect(Array.from(plan.descriptors)).toEqual([0, 3, 2, 0, 0, 3, 6, 2, 3, 0, 9, 1, 9, 0, 0]);
   expect(() => parseSnappyDecompressionPlan(Uint8Array.from([2, 0, 65]))).toThrow(/does not match/);
   expect(() => parseSnappyDecompressionPlan(Uint8Array.from([4, 2, 1, 0]))).toThrow(
     /outside the decoded prefix/

--- a/modules/gpgpu/test/gpu-parse/compression/gpu-snappy-decompressor.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/compression/gpu-snappy-decompressor.spec.ts
@@ -42,7 +42,10 @@ it('GPUSnappyDecompressor resolves raw Snappy backreferences', async () => {
   );
   new GPUSnappyDecompressor({
     input: graph.createDataView(inputHandle, {format: 'uint32', length: 3}),
-    descriptors: graph.createDataView(descriptorHandle, {format: 'uint32', length: 12}),
+    descriptors: graph.createDataView(descriptorHandle, {
+      format: 'uint32',
+      length: plan.descriptors.length
+    }),
     output: graph.createDataView(outputHandle, {format: 'uint32', length: 3}),
     compressedByteLength: plan.compressedByteLength,
     outputByteLength: plan.outputByteLength,

--- a/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-nested-column-layout.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-nested-column-layout.spec.ts
@@ -43,12 +43,12 @@ it('GPUParquetNestedColumnLayout preserves page chunks and materializes two dept
   };
   const definitionLevels = importChunks('definition-levels', [
     Uint32Array.from([3, 3, 2, 3, 1, 3]),
-    Uint32Array.from([3, 2]),
+    Uint32Array.from([3, 0, 3, 2]),
     new Uint32Array(0)
   ]);
   const repetitionLevels = importChunks('repetition-levels', [
     Uint32Array.from([0, 2, 1, 0, 0, 1]),
-    Uint32Array.from([0, 1]),
+    Uint32Array.from([2, 0, 0, 0]),
     new Uint32Array(0)
   ]);
   const result = new GPUParquetNestedColumnLayout({
@@ -61,8 +61,8 @@ it('GPUParquetNestedColumnLayout preserves page chunks and materializes two dept
     ]
   }).addToGraph(graph);
 
-  expect(result.validity.data.map(chunk => chunk.length)).toEqual([6, 2, 0]);
-  expect(result.depths[0].listOffsets.data.map(chunk => chunk.length)).toEqual([7, 3, 1]);
+  expect(result.validity.data.map(chunk => chunk.length)).toEqual([6, 4, 0]);
+  expect(result.depths[0].listOffsets.data.map(chunk => chunk.length)).toEqual([11]);
 
   const readbacks = new Map<GraphDataView<'uint32'>, Buffer>();
   const addReadback = (id: string, view: GraphDataView<'uint32'>) => {
@@ -118,22 +118,20 @@ it('GPUParquetNestedColumnLayout preserves page chunks and materializes two dept
       return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, view.length));
     };
     expect(await read(result.validity.data[0])).toEqual([1, 1, 0, 1, 0, 1]);
-    expect(await read(result.validity.data[1])).toEqual([1, 0]);
+    expect(await read(result.validity.data[1])).toEqual([1, 0, 1, 0]);
     expect(await read(result.valueOffsets.data[0])).toEqual([0, 1, 2, 2, 3, 3]);
-    expect(await read(result.nonNullValueCounts.data[0])).toEqual([4]);
-    expect((await read(result.depths[0].listOffsets.data[0])).slice(0, 4)).toEqual([0, 3, 4, 6]);
-    expect(await read(result.depths[0].elementCounts.data[0])).toEqual([6]);
-    expect(await read(result.depths[0].rowCounts.data[0])).toEqual([3]);
-    expect((await read(result.depths[1].listOffsets.data[0])).slice(0, 6)).toEqual([
-      0, 2, 3, 4, 4, 5
+    expect(await read(result.valueOffsets.data[1])).toEqual([4, 5, 5, 6]);
+    expect(await read(result.nonNullValueCounts.data[0])).toEqual([6]);
+    expect((await read(result.depths[0].listOffsets.data[0])).slice(0, 7)).toEqual([
+      0, 3, 4, 7, 7, 8, 9
     ]);
-    expect(await read(result.depths[1].elementCounts.data[0])).toEqual([5]);
-    expect(await read(result.depths[1].rowCounts.data[0])).toEqual([5]);
-    expect((await read(result.depths[1].listOffsets.data[1])).slice(0, 3)).toEqual([0, 1, 2]);
-    expect(await read(result.nonNullValueCounts.data[2])).toEqual([0]);
-    expect(await read(result.depths[0].listOffsets.data[2])).toEqual([0]);
-    expect(await read(result.depths[0].elementCounts.data[2])).toEqual([0]);
-    expect(await read(result.depths[0].rowCounts.data[2])).toEqual([0]);
+    expect(await read(result.depths[0].elementCounts.data[0])).toEqual([9]);
+    expect(await read(result.depths[0].rowCounts.data[0])).toEqual([6]);
+    expect((await read(result.depths[1].listOffsets.data[0])).slice(0, 8)).toEqual([
+      0, 2, 3, 4, 4, 6, 7, 8
+    ]);
+    expect(await read(result.depths[1].elementCounts.data[0])).toEqual([8]);
+    expect(await read(result.depths[1].rowCounts.data[0])).toEqual([7]);
   } finally {
     compiled.destroy();
     for (const buffer of buffers) {

--- a/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-nested-column-layout.spec.ts
+++ b/modules/gpgpu/test/gpu-parse/parquet/gpu-parquet-nested-column-layout.spec.ts
@@ -62,6 +62,7 @@ it('GPUParquetNestedColumnLayout preserves page chunks and materializes two dept
   }).addToGraph(graph);
 
   expect(result.validity.data.map(chunk => chunk.length)).toEqual([6, 4, 0]);
+  expect(result.nonNullValueCounts.data.map(chunk => chunk.length)).toEqual([1, 1, 1]);
   expect(result.depths[0].listOffsets.data.map(chunk => chunk.length)).toEqual([11]);
 
   const readbacks = new Map<GraphDataView<'uint32'>, Buffer>();
@@ -120,8 +121,10 @@ it('GPUParquetNestedColumnLayout preserves page chunks and materializes two dept
     expect(await read(result.validity.data[0])).toEqual([1, 1, 0, 1, 0, 1]);
     expect(await read(result.validity.data[1])).toEqual([1, 0, 1, 0]);
     expect(await read(result.valueOffsets.data[0])).toEqual([0, 1, 2, 2, 3, 3]);
-    expect(await read(result.valueOffsets.data[1])).toEqual([4, 5, 5, 6]);
-    expect(await read(result.nonNullValueCounts.data[0])).toEqual([6]);
+    expect(await read(result.valueOffsets.data[1])).toEqual([0, 1, 1, 2]);
+    expect(await read(result.nonNullValueCounts.data[0])).toEqual([4]);
+    expect(await read(result.nonNullValueCounts.data[1])).toEqual([2]);
+    expect(await read(result.nonNullValueCounts.data[2])).toEqual([0]);
     expect((await read(result.depths[0].listOffsets.data[0])).slice(0, 7)).toEqual([
       0, 3, 4, 7, 7, 8, 9
     ]);

--- a/website/content/examples/experimental/gpu-parquet-constellation.mdx
+++ b/website/content/examples/experimental/gpu-parquet-constellation.mdx
@@ -42,12 +42,16 @@ loaders.gl worker, trading worker startup, memory, and transfer costs against ma
 
 The initial load automatically prepares CPU and GPU results, leaves the GPU scene active, and
 populates both measurement columns. Use **Compare CPU → GPU** to repeat the full comparison after
-the fixture is built. **Preparation latency** includes page access,
-planning, decoding, buffer creation, and render-graph preparation. **First decode execution** narrows
-that down to the CPU source read and decode, or to GPU command submission through queue completion
-after compilation. The GPU path retains its compiled graph and immutable input buffer, so the
-comparison immediately submits it again and reports **Reused graph execution** separately. Selecting
-GPU and choosing **Decode and display** also reuses the graph. **Longest frame** records the largest
-animation gap while the old constellation remains active, making main-thread stalls visible. Results
-depend on the browser, GPU, row count, and whether shader pipelines are warm; they are an experiment,
-not a fixed performance claim.
+the fixture is built. **Cold preparation** includes page access, planning, decoding, buffer creation,
+and render-graph preparation. **Graph compile** isolates the synchronous luma.gl graph compilation,
+transient allocation, shader creation, and WebGPU pipeline creation calls. A browser or driver may
+still finish pipeline compilation lazily, so **Cold decode execution** reports the first GPU command
+submission through queue completion separately. The timing uses an asynchronous
+`GPUQueue.onSubmittedWorkDone()` wait rather than blocking or polling the JavaScript thread.
+
+The GPU path retains its compiled graph and immutable input buffer. It submits one unmeasured
+warm-up, yields two animation frames, then reports the median of three subsequent submissions as
+**Warmed graph median**. Selecting GPU and choosing **Decode and display** repeats that protocol.
+**Longest frame** records the largest animation gap while the old constellation remains active,
+making main-thread stalls visible. Results depend on the browser, GPU, row count, and cache state;
+they are an experiment, not a fixed performance claim.


### PR DESCRIPTION
## Goals

- Reduce LZ4_RAW and Snappy GPU decompression recursion for common literal-followed-by-copy streams.
- Address both P1 nested-layout findings from #3199.

## Changes

- Add a generic `planGPULZByteDescriptors()` pass that rewrites tractable copies as direct compressed-input gathers with an optional repeat period.
- Keep one bounded descriptor per parsed span and retain recursive backreferences only when provenance crosses descriptor boundaries.
- Reuse the current descriptor across the four output-byte lanes instead of binary-searching from scratch for every byte.
- Publish direct/recursive copy coverage in Parquet compression plans.
- Extend `GPUFlagOffsets` and `GPUSegmentOffsets` across matching `GraphVectorView` chunks.
- Gate nested child row starts on parent presence and preserve a single logical row across Parquet page boundaries.
- Update operation documentation and WebGPU/parser tests.

## Verification

- `yarn lint fix`
- `yarn build`
- focused node parser tests (4 passed)
- focused headless WebGPU tests for LZ4_RAW, Snappy, and nested Parquet layout (3 passed)
- commit hooks: full node suite (409 files passed, 1 skipped; 3270 tests passed, 7 skipped)

## Follow-up to #3199

#3199 merged while this branch was being prepared. The first commit directly fixes both open P1 review findings from that PR; the second commit is the LZ optimization tranche.