### PR TITLE
[9.4] Complete example mobile support review fixes

### DIFF
--- a/examples/api/animation/index.html
+++ b/examples/api/animation/index.html
@@ -5,25 +5,33 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import AnimationLoopTemplate from './app.ts';
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]})
-  animationLoop.start();
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]})
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/api/blending/index.html
+++ b/examples/api/blending/index.html
@@ -5,27 +5,35 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgpuAdapter, webgl2Adapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgpuAdapter, webgl2Adapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body></body>

--- a/examples/api/cubemap/index.html
+++ b/examples/api/cubemap/index.html
@@ -5,26 +5,34 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter,]})
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter,]})
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/api/render-bundles/index.html
+++ b/examples/api/render-bundles/index.html
@@ -5,24 +5,32 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter]});
-  animationLoop.start();
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter]});
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/api/texture-3d/index.html
+++ b/examples/api/texture-3d/index.html
@@ -5,25 +5,33 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import AnimationLoopTemplate from './app.ts';
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [/* webgpuAdapter, */ webgl2Adapter]})
-  animationLoop.start();
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [/* webgpuAdapter, */ webgl2Adapter]})
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/api/texture-compressed/index.html
+++ b/examples/api/texture-compressed/index.html
@@ -5,25 +5,33 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgl2Adapter]});
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgl2Adapter]});
+    animationLoop.start();
+  }
 </script>
 <body style="margin: 0"></body>

--- a/examples/api/texture-sampling/index.html
+++ b/examples/api/texture-sampling/index.html
@@ -5,27 +5,35 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgpuAdapter, webgl2Adapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgpuAdapter, webgl2Adapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body></body>

--- a/examples/api/texture-tester/index.html
+++ b/examples/api/texture-tester/index.html
@@ -6,14 +6,19 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -24,8 +29,11 @@
   <body>
     <div id="app"></div>
   </body>
-  <script type="module">
-    import {renderToDOM} from './app.tsx';
-    renderToDOM(document.getElementById('app'));
+  <script type="module" data-luma-example-application>
+    const exampleSupport = await window.lumaExampleSupportPromise;
+    if (exampleSupport.supported) {
+      const {renderToDOM} = await import('./app.tsx');
+      renderToDOM(document.getElementById('app'));
+    }
   </script>
 </html>

--- a/examples/api/video-texture/index.html
+++ b/examples/api/video-texture/index.html
@@ -5,35 +5,43 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgpuAdapter, webgl2Adapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgpuAdapter, webgl2Adapter]
+    });
+    animationLoop.start();
 
-  document.getElementById('use-mediabunny').addEventListener('click', () => {
-    AnimationLoopTemplate.current?.useMediabunny();
-  });
-  document.getElementById('use-camera').addEventListener('click', () => {
-    AnimationLoopTemplate.current?.useCamera();
-  });
+    document.getElementById('use-mediabunny').addEventListener('click', () => {
+      AnimationLoopTemplate.current?.useMediabunny();
+    });
+    document.getElementById('use-camera').addEventListener('click', () => {
+      AnimationLoopTemplate.current?.useCamera();
+    });
+  }
 </script>
 <body>
   <div style="position:fixed;top:12px;left:12px;z-index:1000;display:flex;gap:8px;">

--- a/examples/arrow/arrow-columns/index.html
+++ b/examples/arrow/arrow-columns/index.html
@@ -5,27 +5,35 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgpuAdapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgpuAdapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/arrow/arrow-dggs-polygons/index.html
+++ b/examples/arrow/arrow-dggs-polygons/index.html
@@ -5,27 +5,35 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="dense" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgpuAdapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgpuAdapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/arrow/arrow-filtering/index.html
+++ b/examples/arrow/arrow-filtering/index.html
@@ -5,26 +5,34 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgl2Adapter, webgpuAdapter]
-  });
-  animationLoop.start();
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgl2Adapter, webgpuAdapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body></body>

--- a/examples/arrow/arrow-float64-precision/index.html
+++ b/examples/arrow/arrow-float64-precision/index.html
@@ -5,27 +5,35 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgl2Adapter, webgpuAdapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgl2Adapter, webgpuAdapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body></body>

--- a/examples/arrow/arrow-instancing/index.html
+++ b/examples/arrow/arrow-instancing/index.html
@@ -5,25 +5,33 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgl2Adapter, webgpuAdapter]})
-  animationLoop.start();
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgl2Adapter, webgpuAdapter]})
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/arrow/arrow-lines/index.html
+++ b/examples/arrow/arrow-lines/index.html
@@ -5,28 +5,36 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="dense" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgl2Adapter, webgpuAdapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgl2Adapter, webgpuAdapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/arrow/arrow-mesh-geometry/index.html
+++ b/examples/arrow/arrow-mesh-geometry/index.html
@@ -5,27 +5,35 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="dense" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgl2Adapter, webgpuAdapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgl2Adapter, webgpuAdapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body></body>

--- a/examples/arrow/arrow-particles/index.html
+++ b/examples/arrow/arrow-particles/index.html
@@ -5,27 +5,35 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="dense" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgl2Adapter, webgpuAdapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgl2Adapter, webgpuAdapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body></body>

--- a/examples/arrow/arrow-points/index.html
+++ b/examples/arrow/arrow-points/index.html
@@ -5,27 +5,35 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="dense" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgl2Adapter, webgpuAdapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgl2Adapter, webgpuAdapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body></body>

--- a/examples/arrow/arrow-temporal-starfield/index.html
+++ b/examples/arrow/arrow-temporal-starfield/index.html
@@ -5,28 +5,36 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="dense" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgl2Adapter, webgpuAdapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgl2Adapter, webgpuAdapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/arrow/arrow-text-2d/index.html
+++ b/examples/arrow/arrow-text-2d/index.html
@@ -5,28 +5,36 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="dense" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgl2Adapter, webgpuAdapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgl2Adapter, webgpuAdapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/arrow/arrow-time-columns/index.html
+++ b/examples/arrow/arrow-time-columns/index.html
@@ -5,28 +5,36 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgl2Adapter, webgpuAdapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgl2Adapter, webgpuAdapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/experimental/a-buffer/index.html
+++ b/examples/experimental/a-buffer/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="effects" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -24,16 +29,19 @@
     }
   </style>
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgl2Adapter, webgpuAdapter]
-  });
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgl2Adapter, webgpuAdapter]
+    });
 
-  animationLoop.start();
+    animationLoop.start();
+  }
 </script>
 <body></body>

--- a/examples/experimental/advanced-effects/index.html
+++ b/examples/experimental/advanced-effects/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="effects" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -22,18 +27,21 @@
     canvas { display: block; width: 100vw !important; height: 100vh !important; }
   </style>
 </head>
-<script type="module">
-  import {luma} from '@luma.gl/core';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {luma} = await import('@luma.gl/core');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const device = luma.createDevice({
-    id: 'advanced-effects',
-    adapters: [webgpuAdapter],
-    createCanvasContext: true,
-    featureLevel: 'max'
-  });
-  makeAnimationLoop(AnimationLoopTemplate, {device}).start();
+    const device = luma.createDevice({
+      id: 'advanced-effects',
+      adapters: [webgpuAdapter],
+      createCanvasContext: true,
+      featureLevel: 'max'
+    });
+    makeAnimationLoop(AnimationLoopTemplate, {device}).start();
+  }
 </script>
 <body></body>

--- a/examples/experimental/antialiasing/index.html
+++ b/examples/experimental/antialiasing/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="effects" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -24,17 +29,20 @@
     }
   </style>
 </head>
-<script type="module">
-  import {luma} from '@luma.gl/core';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {luma} = await import('@luma.gl/core');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgpuAdapter, webgl2Adapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgpuAdapter, webgl2Adapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/experimental/bloom/index.html
+++ b/examples/experimental/bloom/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="effects" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -52,33 +57,36 @@
     }
   </style>
 </head>
-<script type="module">
-  import {luma} from '@luma.gl/core';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {luma} = await import('@luma.gl/core');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const requestedDevice = new URLSearchParams(window.location.search).get('device');
-  const adapters =
-    requestedDevice === 'webgl'
-      ? [webgl2Adapter]
-      : requestedDevice === 'webgpu'
-        ? [webgpuAdapter]
-        : [webgpuAdapter, webgl2Adapter];
-  const supportsHighDynamicRange =
-    requestedDevice !== 'webgl' &&
-    typeof window.matchMedia === 'function' &&
-    window.matchMedia('(dynamic-range: high)').matches;
-  const device = luma.createDevice({
-    id: 'bloom',
-    adapters,
-    createCanvasContext: supportsHighDynamicRange
-      ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
-      : true
-  });
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
-  animationLoop.start();
+    const requestedDevice = new URLSearchParams(window.location.search).get('device');
+    const adapters =
+      requestedDevice === 'webgl'
+        ? [webgl2Adapter]
+        : requestedDevice === 'webgpu'
+          ? [webgpuAdapter]
+          : [webgpuAdapter, webgl2Adapter];
+    const supportsHighDynamicRange =
+      requestedDevice !== 'webgl' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(dynamic-range: high)').matches;
+    const device = luma.createDevice({
+      id: 'bloom',
+      adapters,
+      createCanvasContext: supportsHighDynamicRange
+        ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+        : true
+    });
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
+    animationLoop.start();
+  }
 </script>
 <body>
   <aside id="example-panel-container">

--- a/examples/experimental/deferred-rendering/index.html
+++ b/examples/experimental/deferred-rendering/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="effects" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -43,25 +48,28 @@
     #hdr-highlight-value { color: #ffd493; }
   </style>
 </head>
-<script type="module">
-  import {luma} from '@luma.gl/core';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {luma} = await import('@luma.gl/core');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const supportsHighDynamicRange = window.matchMedia('(dynamic-range: high)').matches;
-  const displayMode = supportsHighDynamicRange ? 'WEBGPU · HDR · DISPLAY P3' : 'WEBGPU · SDR';
-  document.title = `Deferred Illumination Lab · ${supportsHighDynamicRange ? 'HDR' : 'SDR'}`;
-  document.getElementById('dynamic-range-status').textContent = displayMode;
-  const device = luma.createDevice({
-    id: 'deferred-rendering',
-    adapters: [webgpuAdapter],
-    createCanvasContext: supportsHighDynamicRange
-      ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
-      : true,
-    featureLevel: 'core'
-  });
-  makeAnimationLoop(AnimationLoopTemplate, {device}).start();
+    const supportsHighDynamicRange = window.matchMedia('(dynamic-range: high)').matches;
+    const displayMode = supportsHighDynamicRange ? 'WEBGPU · HDR · DISPLAY P3' : 'WEBGPU · SDR';
+    document.title = `Deferred Illumination Lab · ${supportsHighDynamicRange ? 'HDR' : 'SDR'}`;
+    document.getElementById('dynamic-range-status').textContent = displayMode;
+    const device = luma.createDevice({
+      id: 'deferred-rendering',
+      adapters: [webgpuAdapter],
+      createCanvasContext: supportsHighDynamicRange
+        ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+        : true,
+      featureLevel: 'core'
+    });
+    makeAnimationLoop(AnimationLoopTemplate, {device}).start();
+  }
 </script>
 <body>
   <aside class="display-status">

--- a/examples/experimental/fluid-foundry/index.html
+++ b/examples/experimental/fluid-foundry/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="simulation" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta charset="UTF-8" />
@@ -34,44 +39,47 @@
   <div id="fluid-foundry-status" style="margin: 24px; font: 14px system-ui; color: #9cdfff">
     Loading Fluid Foundry…
   </div>
-  <script type="module">
-    const status = document.querySelector('#fluid-foundry-status');
+  <script type="module" data-luma-example-application>
+    const exampleSupport = await window.lumaExampleSupportPromise;
+    if (exampleSupport.supported) {
+      const status = document.querySelector('#fluid-foundry-status');
 
-    try {
-      const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: AnimationLoopTemplate}] =
-        await Promise.all([
-          import('@luma.gl/core'),
-          import('@luma.gl/engine'),
-          import('@luma.gl/webgpu'),
-          import('./app.ts')
-        ]);
-      const supportsHighDynamicRange =
-        typeof window.matchMedia === 'function' &&
-        window.matchMedia('(dynamic-range: high)').matches;
-      status.textContent = 'Acquiring WebGPU device…';
-      const device = await luma.createDevice({
-        id: 'fluid-foundry-liquid-metal-press',
-        adapters: [webgpuAdapter],
-        featureLevel: 'best-available',
-        powerPreference: 'high-performance',
-        waitForPageLoad: false,
-        createCanvasContext: supportsHighDynamicRange
-          ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
-          : true
-      });
-      if (device.info.featureLevel !== 'core') {
-        throw new Error('Fluid Foundry requires core WebGPU shader limits.');
+      try {
+        const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: AnimationLoopTemplate}] =
+          await Promise.all([
+            import('@luma.gl/core'),
+            import('@luma.gl/engine'),
+            import('@luma.gl/webgpu'),
+            import('./app.ts')
+          ]);
+        const supportsHighDynamicRange =
+          typeof window.matchMedia === 'function' &&
+          window.matchMedia('(dynamic-range: high)').matches;
+        status.textContent = 'Acquiring WebGPU device…';
+        const device = await luma.createDevice({
+          id: 'fluid-foundry-liquid-metal-press',
+          adapters: [webgpuAdapter],
+          featureLevel: 'best-available',
+          powerPreference: 'high-performance',
+          waitForPageLoad: false,
+          createCanvasContext: supportsHighDynamicRange
+            ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+            : true
+        });
+        if (device.info.featureLevel !== 'core') {
+          throw new Error('Fluid Foundry requires core WebGPU shader limits.');
+        }
+        status.textContent = 'Starting MLS-MPM simulation…';
+        const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
+        await animationLoop.start();
+        status.remove();
+      } catch (error) {
+        console.error('Fluid Foundry failed to start.', error);
+        status.id = 'fluid-foundry-startup-error';
+        status.textContent = error instanceof Error ? error.stack || error.message : String(error);
+        status.style.cssText =
+          'margin:24px;color:#fff;background:#630;padding:16px;white-space:pre-wrap;font:13px/1.45 monospace';
       }
-      status.textContent = 'Starting MLS-MPM simulation…';
-      const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
-      await animationLoop.start();
-      status.remove();
-    } catch (error) {
-      console.error('Fluid Foundry failed to start.', error);
-      status.id = 'fluid-foundry-startup-error';
-      status.textContent = error instanceof Error ? error.stack || error.message : String(error);
-      status.style.cssText =
-        'margin:24px;color:#fff;background:#630;padding:16px;white-space:pre-wrap;font:13px/1.45 monospace';
     }
   </script>
 </body>

--- a/examples/experimental/gpgpu/index.html
+++ b/examples/experimental/gpgpu/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -275,8 +280,11 @@
       <div id="table-status" class="status">Generating Arrow table...</div>
     </section>
   </main>
-  <script type="module">
-    import {initializeGPGPUShowcase} from './src/app.ts';
-    initializeGPGPUShowcase();
+  <script type="module" data-luma-example-application>
+    const exampleSupport = await window.lumaExampleSupportPromise;
+    if (exampleSupport.supported) {
+      const {initializeGPGPUShowcase} = await import('./src/app.ts');
+      initializeGPGPUShowcase();
+    }
   </script>
 </body>

--- a/examples/experimental/gpt-2/index.html
+++ b/examples/experimental/gpt-2/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -27,40 +32,43 @@
   }
 </style>
 <body>
-  <script type="module">
-    import {luma} from '@luma.gl/core';
-    import {makeAnimationLoop} from '@luma.gl/engine';
-    import {webgpuAdapter} from '@luma.gl/webgpu';
-    import AnimationLoopTemplate from './app.ts';
+  <script type="module" data-luma-example-application>
+    const exampleSupport = await window.lumaExampleSupportPromise;
+    if (exampleSupport.supported) {
+      const {luma} = await import('@luma.gl/core');
+      const {makeAnimationLoop} = await import('@luma.gl/engine');
+      const {webgpuAdapter} = await import('@luma.gl/webgpu');
+      const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-    function setDeviceStatus(message) {
-      let deviceStatus = document.getElementById('gpgpu-device');
-      if (!deviceStatus) {
-        deviceStatus = document.createElement('div');
-        deviceStatus.id = 'gpgpu-device';
-        deviceStatus.style.marginBottom = '8px';
-        deviceStatus.style.fontFamily = 'monospace';
-        document.body.prepend(deviceStatus);
+      function setDeviceStatus(message) {
+        let deviceStatus = document.getElementById('gpgpu-device');
+        if (!deviceStatus) {
+          deviceStatus = document.createElement('div');
+          deviceStatus.id = 'gpgpu-device';
+          deviceStatus.style.marginBottom = '8px';
+          deviceStatus.style.fontFamily = 'monospace';
+          document.body.prepend(deviceStatus);
+        }
+        deviceStatus.textContent = message;
       }
-      deviceStatus.textContent = message;
-    }
 
-    document.body.insertAdjacentHTML('afterbegin', AnimationLoopTemplate.info);
-    try {
-      const device = await luma.createDevice({
-        type: 'webgpu',
-        adapters: [webgpuAdapter],
-        createCanvasContext: true
-      });
-      setDeviceStatus(`Device: ${device.type}`);
-      const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-        device
-      });
-      animationLoop.start();
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      setDeviceStatus(`Device: failed to create webgpu (${errorMessage})`);
-      throw error;
+      document.body.insertAdjacentHTML('afterbegin', AnimationLoopTemplate.info);
+      try {
+        const device = await luma.createDevice({
+          type: 'webgpu',
+          adapters: [webgpuAdapter],
+          createCanvasContext: true
+        });
+        setDeviceStatus(`Device: ${device.type}`);
+        const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+          device
+        });
+        animationLoop.start();
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        setDeviceStatus(`Device: failed to create webgpu (${errorMessage})`);
+        throw error;
+      }
     }
   </script>
 </body>

--- a/examples/experimental/gpu-data-analysis/index.html
+++ b/examples/experimental/gpu-data-analysis/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta charset="utf-8" />
@@ -21,8 +26,11 @@
 </head>
 <body style="margin: 0">
   <main id="gpu-data-analysis-app"></main>
-  <script type="module">
-    import {initializeGPUDataAnalysisExample} from './src/app.ts';
-    initializeGPUDataAnalysisExample();
+  <script type="module" data-luma-example-application>
+    const exampleSupport = await window.lumaExampleSupportPromise;
+    if (exampleSupport.supported) {
+      const {initializeGPUDataAnalysisExample} = await import('./src/app.ts');
+      initializeGPUDataAnalysisExample();
+    }
   </script>
 </body>

--- a/examples/experimental/gpu-frustum-culling/index.html
+++ b/examples/experimental/gpu-frustum-culling/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta charset="UTF-8" />
@@ -20,12 +25,15 @@
   <title>GPU Frustum Culling</title>
   <style>body { margin: 0; background: #020617; }</style>
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter]});
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter]});
+    animationLoop.start();
+  }
 </script>
 <body></body>

--- a/examples/experimental/gpu-sort/index.html
+++ b/examples/experimental/gpu-sort/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta charset="utf-8" />
@@ -21,8 +26,11 @@
 </head>
 <body style="margin: 0">
   <main id="gpu-sort-app"></main>
-  <script type="module">
-    import {initializeGPUSortExample} from './src/app.ts';
-    initializeGPUSortExample();
+  <script type="module" data-luma-example-application>
+    const exampleSupport = await window.lumaExampleSupportPromise;
+    if (exampleSupport.supported) {
+      const {initializeGPUSortExample} = await import('./src/app.ts');
+      initializeGPUSortExample();
+    }
   </script>
 </body>

--- a/examples/experimental/gpu-trace-viewer/index.html
+++ b/examples/experimental/gpu-trace-viewer/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta charset="UTF-8" />
@@ -57,22 +62,25 @@
     }
   </style>
 </head>
-<script type="module">
-  import {luma} from '@luma.gl/core';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {luma} = await import('@luma.gl/core');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const forcePortableScan = new URLSearchParams(location.search).get('scan') === 'portable';
-  const device = luma.createDevice({
-    id: 'gpu-trace-viewer',
-    adapters: [webgpuAdapter],
-    createCanvasContext: true,
-    featureLevel: 'max',
-    debugGPUTime: true,
-    _disabledFeatures: forcePortableScan ? {subgroups: true} : undefined
-  });
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
-  animationLoop.start();
+    const forcePortableScan = new URLSearchParams(location.search).get('scan') === 'portable';
+    const device = luma.createDevice({
+      id: 'gpu-trace-viewer',
+      adapters: [webgpuAdapter],
+      createCanvasContext: true,
+      featureLevel: 'max',
+      debugGPUTime: true,
+      _disabledFeatures: forcePortableScan ? {subgroups: true} : undefined
+    });
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
+    animationLoop.start();
+  }
 </script>
 <body><div id="example-panel-host" data-example-panel-host></div></body>

--- a/examples/experimental/html-ui-prism/index.html
+++ b/examples/experimental/html-ui-prism/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="effects" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -24,15 +29,18 @@
     }
   </style>
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgpuAdapter, webgl2Adapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgpuAdapter, webgl2Adapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body></body>

--- a/examples/experimental/lucim-volume-lab/index.html
+++ b/examples/experimental/lucim-volume-lab/index.html
@@ -6,14 +6,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="simulation" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
     <meta charset="UTF-8" />
@@ -84,31 +89,34 @@
       <p id="volume-startup">Preparing a synthetic CT-like phantom and WebGPU graph…</p>
       <div id="example-panel-host" data-example-panel-host></div>
     </aside>
-    <script type="module">
-      const startup = document.querySelector('#volume-startup');
-      try {
-        if (!navigator.gpu) {
-          throw new Error('LuCIM Volume Lab requires a current WebGPU-capable browser.');
+    <script type="module" data-luma-example-application>
+      const exampleSupport = await window.lumaExampleSupportPromise;
+      if (exampleSupport.supported) {
+        const startup = document.querySelector('#volume-startup');
+        try {
+          if (!navigator.gpu) {
+            throw new Error('LuCIM Volume Lab requires a current WebGPU-capable browser.');
+          }
+          const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: AnimationLoopTemplate}] =
+            await Promise.all([
+              import('@luma.gl/core'),
+              import('@luma.gl/engine'),
+              import('@luma.gl/webgpu'),
+              import('./app.ts')
+            ]);
+          const device = await luma.createDevice({
+            id: 'lucim-volume-lab',
+            adapters: [webgpuAdapter],
+            featureLevel: 'best-available',
+            powerPreference: 'high-performance',
+            waitForPageLoad: false,
+            createCanvasContext: true
+          });
+          await makeAnimationLoop(AnimationLoopTemplate, {device}).start();
+        } catch (error) {
+          startup.dataset.state = 'error';
+          startup.textContent = error instanceof Error ? error.message : String(error);
         }
-        const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: AnimationLoopTemplate}] =
-          await Promise.all([
-            import('@luma.gl/core'),
-            import('@luma.gl/engine'),
-            import('@luma.gl/webgpu'),
-            import('./app.ts')
-          ]);
-        const device = await luma.createDevice({
-          id: 'lucim-volume-lab',
-          adapters: [webgpuAdapter],
-          featureLevel: 'best-available',
-          powerPreference: 'high-performance',
-          waitForPageLoad: false,
-          createCanvasContext: true
-        });
-        await makeAnimationLoop(AnimationLoopTemplate, {device}).start();
-      } catch (error) {
-        startup.dataset.state = 'error';
-        startup.textContent = error instanceof Error ? error.message : String(error);
       }
     </script>
   </body>

--- a/examples/experimental/shadow-map/index.html
+++ b/examples/experimental/shadow-map/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="effects" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta charset="UTF-8" />
@@ -20,12 +25,15 @@
   <title>Effects: Shadow Map Quality</title>
   <style>body { margin: 0; background: #0b111a; color-scheme: dark; }</style>
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter]});
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter]});
+    animationLoop.start();
+  }
 </script>
 <body></body>

--- a/examples/experimental/spectral-caustics/index.html
+++ b/examples/experimental/spectral-caustics/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="effects" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta charset="UTF-8" />
@@ -30,23 +35,26 @@
     }
   </style>
 </head>
-<script type="module">
-  import {luma} from '@luma.gl/core';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {luma} = await import('@luma.gl/core');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const supportsHighDynamicRange =
-    typeof window.matchMedia === 'function' &&
-    window.matchMedia('(dynamic-range: high)').matches;
-  const device = luma.createDevice({
-    id: 'spectral-caustics-prism-cathedral',
-    adapters: [webgpuAdapter],
-    createCanvasContext: supportsHighDynamicRange
-      ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
-      : true
-  });
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
-  animationLoop.start();
+    const supportsHighDynamicRange =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(dynamic-range: high)').matches;
+    const device = luma.createDevice({
+      id: 'spectral-caustics-prism-cathedral',
+      adapters: [webgpuAdapter],
+      createCanvasContext: supportsHighDynamicRange
+        ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+        : true
+    });
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
+    animationLoop.start();
+  }
 </script>
 <body></body>

--- a/examples/experimental/text-space-crawl/index.html
+++ b/examples/experimental/text-space-crawl/index.html
@@ -5,26 +5,34 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="dense" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
 <title>luma.gl Text Space Crawl Example</title>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine'
-  import {webgl2Adapter} from '@luma.gl/webgl'
-  import {webgpuAdapter} from '@luma.gl/webgpu'
-  import AnimationLoopTemplate from './app'
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgl2Adapter, webgpuAdapter]})
-  animationLoop.start()
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app');
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgl2Adapter, webgpuAdapter]})
+    animationLoop.start()
+  }
 </script>
 <body>
 </body>

--- a/examples/experimental/virtual-geometry-canyon/index.html
+++ b/examples/experimental/virtual-geometry-canyon/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta charset="UTF-8" />
@@ -23,12 +28,15 @@
     canvas { display: block; width: 100% !important; height: 100% !important; }
   </style>
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter]});
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter]});
+    animationLoop.start();
+  }
 </script>
 <body></body>

--- a/examples/experimental/volumetric-fire-forge/index.html
+++ b/examples/experimental/volumetric-fire-forge/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="simulation" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta charset="UTF-8" />
@@ -36,53 +41,56 @@
     #webgpu-message strong { color: #fff4e5; font-size: 1.2rem; }
   </style>
 </head>
-<script type="module">
-  import {luma} from '@luma.gl/core';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {luma} = await import('@luma.gl/core');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const supportsHighDynamicRange =
-    typeof window.matchMedia === 'function' &&
-    window.matchMedia('(dynamic-range: high)').matches;
+    const supportsHighDynamicRange =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(dynamic-range: high)').matches;
 
-  async function start() {
-    const message = document.getElementById('webgpu-message');
-    if (!navigator.gpu) {
-      message.hidden = false;
-      return;
-    }
-
-    try {
-      let device;
-      try {
-        device = await luma.createDevice({
-          id: 'volumetric-fire-forge',
-          adapters: [webgpuAdapter],
-          createCanvasContext: supportsHighDynamicRange
-            ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
-            : true
-        });
-      } catch (error) {
-        if (!supportsHighDynamicRange) {
-          throw error;
-        }
-        device = await luma.createDevice({
-          id: 'volumetric-fire-forge-sdr-fallback',
-          adapters: [webgpuAdapter],
-          createCanvasContext: true
-        });
+    async function start() {
+      const message = document.getElementById('webgpu-message');
+      if (!navigator.gpu) {
+        message.hidden = false;
+        return;
       }
 
-      const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
-      animationLoop.start();
-    } catch (error) {
-      console.error(error);
-      message.hidden = false;
-    }
-  }
+      try {
+        let device;
+        try {
+          device = await luma.createDevice({
+            id: 'volumetric-fire-forge',
+            adapters: [webgpuAdapter],
+            createCanvasContext: supportsHighDynamicRange
+              ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+              : true
+          });
+        } catch (error) {
+          if (!supportsHighDynamicRange) {
+            throw error;
+          }
+          device = await luma.createDevice({
+            id: 'volumetric-fire-forge-sdr-fallback',
+            adapters: [webgpuAdapter],
+            createCanvasContext: true
+          });
+        }
 
-  start();
+        const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
+        animationLoop.start();
+      } catch (error) {
+        console.error(error);
+        message.hidden = false;
+      }
+    }
+
+    start();
+  }
 </script>
 <body>
   <main id="webgpu-message" hidden>

--- a/examples/experimental/webxr-kaleidoscope/index.html
+++ b/examples/experimental/webxr-kaleidoscope/index.html
@@ -6,14 +6,19 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="effects" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
     <meta charset="UTF-8" />
@@ -164,109 +169,112 @@
     </aside>
     <div class="preview-hint">Drag to orbit · Scroll to move through the portal</div>
 
-    <script type="module">
-      import {luma} from '@luma.gl/core';
-      import {makeAnimationLoop} from '@luma.gl/engine';
-      import {webgl2Adapter} from '@luma.gl/webgl';
-      import {webgpuAdapter} from '@luma.gl/webgpu';
-      import AnimationLoopTemplate from './app.ts';
+    <script type="module" data-luma-example-application>
+      const exampleSupport = await window.lumaExampleSupportPromise;
+      if (exampleSupport.supported) {
+        const {luma} = await import('@luma.gl/core');
+        const {makeAnimationLoop} = await import('@luma.gl/engine');
+        const {webgl2Adapter} = await import('@luma.gl/webgl');
+        const {webgpuAdapter} = await import('@luma.gl/webgpu');
+        const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-      const sceneElement = document.getElementById('scene');
-      const backendStatus = document.getElementById('backend-status');
-      const sessionStatus = document.getElementById('session-status');
-      const switchBackendButton = document.getElementById('switch-backend');
-      let animationLoop = null;
-      let currentDevice = null;
+        const sceneElement = document.getElementById('scene');
+        const backendStatus = document.getElementById('backend-status');
+        const sessionStatus = document.getElementById('session-status');
+        const switchBackendButton = document.getElementById('switch-backend');
+        let animationLoop = null;
+        let currentDevice = null;
 
-      function makeDeviceProps(type, xrCompatible = false) {
-        return {
-          id: `immersive-prism-portal-${type}`,
-          type,
-          adapters: [webgpuAdapter, webgl2Adapter],
-          xrCompatible,
-          createCanvasContext: {container: sceneElement, alphaMode: 'opaque'}
-        };
-      }
-
-      async function createPreferredDevice(type = 'webgpu') {
-        if (type === 'webgl') {
-          return await luma.createDevice(makeDeviceProps('webgl'));
+        function makeDeviceProps(type, xrCompatible = false) {
+          return {
+            id: `immersive-prism-portal-${type}`,
+            type,
+            adapters: [webgpuAdapter, webgl2Adapter],
+            xrCompatible,
+            createCanvasContext: {container: sceneElement, alphaMode: 'opaque'}
+          };
         }
 
-        try {
-          return await luma.createDevice(makeDeviceProps('webgpu', true));
-        } catch {
-          try {
-            return await luma.createDevice(makeDeviceProps('webgpu'));
-          } catch {
+        async function createPreferredDevice(type = 'webgpu') {
+          if (type === 'webgl') {
             return await luma.createDevice(makeDeviceProps('webgl'));
           }
-        }
-      }
 
-      async function startRenderer(type = 'webgpu') {
-        animationLoop?.destroy();
-        currentDevice?.destroy();
-        sceneElement.replaceChildren();
-        sessionStatus.textContent = '';
-
-        currentDevice = await createPreferredDevice(type);
-        animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device: currentDevice});
-        await animationLoop.start();
-
-        if (currentDevice.type === 'webgpu') {
-          const supportsNativeXR = currentDevice.props.xrCompatible && 'XRGPUBinding' in window;
-          backendStatus.textContent = supportsNativeXR
-            ? 'WebGPU · native XR projection layers available when a headset is connected'
-            : 'WebGPU desktop preview · switch to WebGL2 for immersive headset fallback';
-          switchBackendButton.textContent = 'Use WebGL2';
-        } else {
-          backendStatus.textContent = 'WebGL2 · portable stereo and optional AR camera access';
-          switchBackendButton.textContent = 'Use WebGPU';
-        }
-      }
-
-      async function toggleSession(mode) {
-        const application = AnimationLoopTemplate.current;
-        if (!application) {
-          return;
-        }
-
-        try {
-          sessionStatus.dataset.error = 'false';
-          if (application.xrSessionMode === mode) {
-            await application.exitXR();
-            sessionStatus.textContent = 'Returned to the live desktop preview';
-          } else {
-            if (application.xrSession) {
-              await application.exitXR();
+          try {
+            return await luma.createDevice(makeDeviceProps('webgpu', true));
+          } catch {
+            try {
+              return await luma.createDevice(makeDeviceProps('webgpu'));
+            } catch {
+              return await luma.createDevice(makeDeviceProps('webgl'));
             }
-            await application.enterXR(mode);
-            sessionStatus.textContent = `${mode === 'immersive-ar' ? 'AR' : 'VR'} session active`;
           }
-        } catch (error) {
-          sessionStatus.dataset.error = 'true';
-          sessionStatus.textContent = error instanceof Error ? error.message : String(error);
         }
-      }
 
-      document.getElementById('enter-vr').addEventListener('click', () => {
-        void toggleSession('immersive-vr');
-      });
-      document.getElementById('enter-ar').addEventListener('click', () => {
-        void toggleSession('immersive-ar');
-      });
-      switchBackendButton.addEventListener('click', () => {
-        void startRenderer(currentDevice?.type === 'webgpu' ? 'webgl' : 'webgpu').catch(error => {
+        async function startRenderer(type = 'webgpu') {
+          animationLoop?.destroy();
+          currentDevice?.destroy();
+          sceneElement.replaceChildren();
+          sessionStatus.textContent = '';
+
+          currentDevice = await createPreferredDevice(type);
+          animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device: currentDevice});
+          await animationLoop.start();
+
+          if (currentDevice.type === 'webgpu') {
+            const supportsNativeXR = currentDevice.props.xrCompatible && 'XRGPUBinding' in window;
+            backendStatus.textContent = supportsNativeXR
+              ? 'WebGPU · native XR projection layers available when a headset is connected'
+              : 'WebGPU desktop preview · switch to WebGL2 for immersive headset fallback';
+            switchBackendButton.textContent = 'Use WebGL2';
+          } else {
+            backendStatus.textContent = 'WebGL2 · portable stereo and optional AR camera access';
+            switchBackendButton.textContent = 'Use WebGPU';
+          }
+        }
+
+        async function toggleSession(mode) {
+          const application = AnimationLoopTemplate.current;
+          if (!application) {
+            return;
+          }
+
+          try {
+            sessionStatus.dataset.error = 'false';
+            if (application.xrSessionMode === mode) {
+              await application.exitXR();
+              sessionStatus.textContent = 'Returned to the live desktop preview';
+            } else {
+              if (application.xrSession) {
+                await application.exitXR();
+              }
+              await application.enterXR(mode);
+              sessionStatus.textContent = `${mode === 'immersive-ar' ? 'AR' : 'VR'} session active`;
+            }
+          } catch (error) {
+            sessionStatus.dataset.error = 'true';
+            sessionStatus.textContent = error instanceof Error ? error.message : String(error);
+          }
+        }
+
+        document.getElementById('enter-vr').addEventListener('click', () => {
+          void toggleSession('immersive-vr');
+        });
+        document.getElementById('enter-ar').addEventListener('click', () => {
+          void toggleSession('immersive-ar');
+        });
+        switchBackendButton.addEventListener('click', () => {
+          void startRenderer(currentDevice?.type === 'webgpu' ? 'webgl' : 'webgpu').catch(error => {
+            sessionStatus.dataset.error = 'true';
+            sessionStatus.textContent = error instanceof Error ? error.message : String(error);
+          });
+        });
+
+        startRenderer().catch(error => {
           sessionStatus.dataset.error = 'true';
           sessionStatus.textContent = error instanceof Error ? error.message : String(error);
         });
-      });
-
-      startRenderer().catch(error => {
-        sessionStatus.dataset.error = 'true';
-        sessionStatus.textContent = error instanceof Error ? error.message : String(error);
-      });
+      }
     </script>
   </body>
 </html>

--- a/examples/integrations/external-context/index.html
+++ b/examples/integrations/external-context/index.html
@@ -6,14 +6,19 @@
   <meta name="luma-example-backends" content="webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -50,18 +55,21 @@
   <body>
     <div id="status">Connect luma.gl to the MapLibre WebGL context.</div>
     <div id="map-container"></div>
-    <script type="module">
-      import initializeExternalWebGLContext from './app.ts'
+    <script type="module" data-luma-example-application>
+      const exampleSupport = await window.lumaExampleSupportPromise;
+      if (exampleSupport.supported) {
+        const {default: initializeExternalWebGLContext} = await import('./app.ts');
 
-      initializeExternalWebGLContext({
-        container: document.getElementById('map-container')
-      }).catch(error => {
-        const status = document.getElementById('status')
-        if (status) {
-          status.textContent = error.message
-          status.style.background = 'rgba(128, 0, 0, 0.75)'
-        }
-      })
+        initializeExternalWebGLContext({
+          container: document.getElementById('map-container')
+        }).catch(error => {
+          const status = document.getElementById('status')
+          if (status) {
+            status.textContent = error.message
+            status.style.background = 'rgba(128, 0, 0, 0.75)'
+          }
+        })
+      }
     </script>
   </body>
 </html>

--- a/examples/integrations/hello-react/index.html
+++ b/examples/integrations/hello-react/index.html
@@ -6,14 +6,19 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
     <meta charset="UTF-8" />
@@ -28,6 +33,11 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/main.tsx"></script>
+    <script type="module" data-luma-example-application>
+      const exampleSupport = await window.lumaExampleSupportPromise;
+      if (exampleSupport.supported) {
+        await import("/main.tsx");
+      }
+    </script>
   </body>
 </html>

--- a/examples/showcase/algebraic-varieties/index.html
+++ b/examples/showcase/algebraic-varieties/index.html
@@ -6,14 +6,19 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="simulation" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
     <meta charset="UTF-8" />
@@ -79,11 +84,14 @@
         <p>This is numerical root finding, not a proof: fixed sampling can miss tightly clustered roots, and singular or grazing intersections are ill-conditioned. The polynomial value is never treated as a signed-distance field.</p>
       </section>
     </aside>
-    <script type="module">
-      import {makeAnimationLoop} from '@luma.gl/engine';
-      import {webgpuAdapter} from '@luma.gl/webgpu';
-      import AlgebraicVarietiesAnimationLoopTemplate from './app.ts';
-      makeAnimationLoop(AlgebraicVarietiesAnimationLoopTemplate, {adapters: [webgpuAdapter]}).start();
+    <script type="module" data-luma-example-application>
+      const exampleSupport = await window.lumaExampleSupportPromise;
+      if (exampleSupport.supported) {
+        const {makeAnimationLoop} = await import('@luma.gl/engine');
+        const {webgpuAdapter} = await import('@luma.gl/webgpu');
+        const {default: AlgebraicVarietiesAnimationLoopTemplate} = await import('./app.ts');
+        makeAnimationLoop(AlgebraicVarietiesAnimationLoopTemplate, {adapters: [webgpuAdapter]}).start();
+      }
     </script>
   </body>
 </html>

--- a/examples/showcase/billion-point-spatial-atlas/index.html
+++ b/examples/showcase/billion-point-spatial-atlas/index.html
@@ -6,14 +6,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
     <meta charset="UTF-8" />
@@ -54,70 +59,73 @@
     <aside id="atlas-panel-shell" aria-label="Spatial Atlas controls and pipeline inspector">
       <div id="example-panel-host"></div>
     </aside>
-    <script type="module">
-      import {luma} from '@luma.gl/core';
-      import {makeAnimationLoop} from '@luma.gl/engine';
-      import {webgpuAdapter} from '@luma.gl/webgpu';
-      import AnimationLoopTemplate from './app.ts';
+    <script type="module" data-luma-example-application>
+      const exampleSupport = await window.lumaExampleSupportPromise;
+      if (exampleSupport.supported) {
+        const {luma} = await import('@luma.gl/core');
+        const {makeAnimationLoop} = await import('@luma.gl/engine');
+        const {webgpuAdapter} = await import('@luma.gl/webgpu');
+        const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-      const supportsHighDynamicRange =
-        typeof window.matchMedia === 'function' &&
-        window.matchMedia('(dynamic-range: high)').matches;
-      const softwareVisualSmoke =
-        new URLSearchParams(window.location.search).get('visual-smoke') === 'software';
-      // Preserve the full CSS viewport while limiting SwiftShader's render-target workload.
-      const standardCanvasContext = softwareVisualSmoke ? {useDevicePixels: 0.5} : true;
+        const supportsHighDynamicRange =
+          typeof window.matchMedia === 'function' &&
+          window.matchMedia('(dynamic-range: high)').matches;
+        const softwareVisualSmoke =
+          new URLSearchParams(window.location.search).get('visual-smoke') === 'software';
+        // Preserve the full CSS viewport while limiting SwiftShader's render-target workload.
+        const standardCanvasContext = softwareVisualSmoke ? {useDevicePixels: 0.5} : true;
 
-      try {
-        let device;
         try {
-          device = await luma.createDevice({
-            id: 'billion-point-spatial-atlas',
-            adapters: [webgpuAdapter],
-            createCanvasContext: supportsHighDynamicRange
-              ? {
-                  colorFormat: 'rgba16float',
-                  colorSpace: 'display-p3',
-                  toneMapping: 'extended',
-                  ...(softwareVisualSmoke ? {useDevicePixels: 0.5} : {})
-                }
-              : standardCanvasContext
-          });
-        } catch (error) {
-          if (!supportsHighDynamicRange) throw error;
-          device = await luma.createDevice({
-            id: 'billion-point-spatial-atlas-sdr-fallback',
-            adapters: [webgpuAdapter],
-            createCanvasContext: standardCanvasContext
-          });
-        }
+          let device;
+          try {
+            device = await luma.createDevice({
+              id: 'billion-point-spatial-atlas',
+              adapters: [webgpuAdapter],
+              createCanvasContext: supportsHighDynamicRange
+                ? {
+                    colorFormat: 'rgba16float',
+                    colorSpace: 'display-p3',
+                    toneMapping: 'extended',
+                    ...(softwareVisualSmoke ? {useDevicePixels: 0.5} : {})
+                  }
+                : standardCanvasContext
+            });
+          } catch (error) {
+            if (!supportsHighDynamicRange) throw error;
+            device = await luma.createDevice({
+              id: 'billion-point-spatial-atlas-sdr-fallback',
+              adapters: [webgpuAdapter],
+              createCanvasContext: standardCanvasContext
+            });
+          }
 
-        const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
-        const isVisualSmoke = new URLSearchParams(window.location.search).has('visual-smoke');
-        if (isVisualSmoke) {
-          const manualAnimationFrameProvider = {
-            requestAnimationFrame: () => 0,
-            cancelAnimationFrame: () => {}
-          };
-          animationLoop.setProps({animationFrameProvider: manualAnimationFrameProvider});
-          window.addEventListener('spatial-atlas-pause', () => {
+          const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
+          const isVisualSmoke = new URLSearchParams(window.location.search).has('visual-smoke');
+          if (isVisualSmoke) {
+            const manualAnimationFrameProvider = {
+              requestAnimationFrame: () => 0,
+              cancelAnimationFrame: () => {}
+            };
             animationLoop.setProps({animationFrameProvider: manualAnimationFrameProvider});
-          });
-          window.addEventListener('spatial-atlas-redraw', () => animationLoop.redraw());
-          window.spatialAtlasCaptureFrame = () => {
-            const template = animationLoop.getAnimationLoopTemplate();
-            if (!template || typeof template.captureVisualSmokeFrame !== 'function') {
-              throw new Error('Spatial Atlas visual smoke frame is unavailable');
-            }
-            return template.captureVisualSmokeFrame();
-          };
+            window.addEventListener('spatial-atlas-pause', () => {
+              animationLoop.setProps({animationFrameProvider: manualAnimationFrameProvider});
+            });
+            window.addEventListener('spatial-atlas-redraw', () => animationLoop.redraw());
+            window.spatialAtlasCaptureFrame = () => {
+              const template = animationLoop.getAnimationLoopTemplate();
+              if (!template || typeof template.captureVisualSmokeFrame !== 'function') {
+                throw new Error('Spatial Atlas visual smoke frame is unavailable');
+              }
+              return template.captureVisualSmokeFrame();
+            };
+          }
+          await animationLoop.start();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          document.body.innerHTML = '<main data-error role="alert"><h1>WebGPU unavailable</h1><p></p></main>';
+          document.querySelector('[data-error] p').textContent = message;
+          throw error;
         }
-        await animationLoop.start();
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        document.body.innerHTML = '<main data-error role="alert"><h1>WebGPU unavailable</h1><p></p></main>';
-        document.querySelector('[data-error] p').textContent = message;
-        throw error;
       }
     </script>
   </body>

--- a/examples/showcase/dof/index.html
+++ b/examples/showcase/dof/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="effects" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -24,16 +29,19 @@
     }
   </style>
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgpuAdapter, webgl2Adapter]
-  });
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgpuAdapter, webgl2Adapter]
+    });
 
-  animationLoop.start();
+    animationLoop.start();
+  }
 </script>
 <body></body>

--- a/examples/showcase/gaussian-splats/index.html
+++ b/examples/showcase/gaussian-splats/index.html
@@ -6,14 +6,19 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
     <meta charset="UTF-8" />
@@ -83,64 +88,67 @@
       <h1>Chromatic Observatory</h1>
       <div id="gaussian-splats-panel-container"></div>
     </aside>
-    <script type="module">
-      import {luma} from '@luma.gl/core';
-      import {makeAnimationLoop} from '@luma.gl/engine';
-      import {webgl2Adapter} from '@luma.gl/webgl';
-      import {webgpuAdapter} from '@luma.gl/webgpu';
-      import AnimationLoopTemplate, {makeGaussianSplatInfoHtml} from './app.ts';
+    <script type="module" data-luma-example-application>
+      const exampleSupport = await window.lumaExampleSupportPromise;
+      if (exampleSupport.supported) {
+        const {luma} = await import('@luma.gl/core');
+        const {makeAnimationLoop} = await import('@luma.gl/engine');
+        const {webgl2Adapter} = await import('@luma.gl/webgl');
+        const {webgpuAdapter} = await import('@luma.gl/webgpu');
+        const {default: AnimationLoopTemplate, makeGaussianSplatInfoHtml} = await import('./app.ts');
 
-      window.__lumaGaussianSplatsLocalLoadersRoot = import.meta.env.VITE_LOADERS_GL_ROOT || '';
-      document.getElementById('gaussian-splats-panel-container').innerHTML =
-        makeGaussianSplatInfoHtml();
+        window.__lumaGaussianSplatsLocalLoadersRoot = import.meta.env.VITE_LOADERS_GL_ROOT || '';
+        document.getElementById('gaussian-splats-panel-container').innerHTML =
+          makeGaussianSplatInfoHtml();
 
-      try {
-        const requestedDevice = new URLSearchParams(window.location.search).get('device');
-        const adapters =
-          requestedDevice === 'webgl' || requestedDevice === 'webgl2'
-            ? [webgl2Adapter]
-            : requestedDevice === 'webgpu'
-              ? [webgpuAdapter]
-              : [webgpuAdapter, webgl2Adapter];
-        const deviceOptions = {
-          id: 'gaussian-splats',
-          adapters,
-          createCanvasContext: true
-        };
-        const prefersHighDynamicRange =
-          requestedDevice !== 'webgl' &&
-          requestedDevice !== 'webgl2' &&
-          window.matchMedia('(dynamic-range: high)').matches;
-        let device;
-        if (prefersHighDynamicRange) {
-          try {
-            device = await luma.createDevice({
-              ...deviceOptions,
-              adapters: [webgpuAdapter],
-              createCanvasContext: {
-                colorFormat: 'rgba16float',
-                colorSpace: 'display-p3',
-                toneMapping: 'extended'
-              }
-            });
-          } catch {
+        try {
+          const requestedDevice = new URLSearchParams(window.location.search).get('device');
+          const adapters =
+            requestedDevice === 'webgl' || requestedDevice === 'webgl2'
+              ? [webgl2Adapter]
+              : requestedDevice === 'webgpu'
+                ? [webgpuAdapter]
+                : [webgpuAdapter, webgl2Adapter];
+          const deviceOptions = {
+            id: 'gaussian-splats',
+            adapters,
+            createCanvasContext: true
+          };
+          const prefersHighDynamicRange =
+            requestedDevice !== 'webgl' &&
+            requestedDevice !== 'webgl2' &&
+            window.matchMedia('(dynamic-range: high)').matches;
+          let device;
+          if (prefersHighDynamicRange) {
+            try {
+              device = await luma.createDevice({
+                ...deviceOptions,
+                adapters: [webgpuAdapter],
+                createCanvasContext: {
+                  colorFormat: 'rgba16float',
+                  colorSpace: 'display-p3',
+                  toneMapping: 'extended'
+                }
+              });
+            } catch {
+              device = await luma.createDevice(deviceOptions);
+            }
+          } else {
             device = await luma.createDevice(deviceOptions);
           }
-        } else {
-          device = await luma.createDevice(deviceOptions);
+          const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+            device,
+            autoResizeViewport: true
+          });
+          await animationLoop.start();
+        } catch (error) {
+          const errorElement = document.createElement('div');
+          errorElement.id = 'gaussian-splats-error';
+          errorElement.setAttribute('role', 'alert');
+          errorElement.textContent =
+            error instanceof Error ? error.message : 'Unable to initialize Gaussian splat rendering.';
+          document.body.append(errorElement);
         }
-        const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-          device,
-          autoResizeViewport: true
-        });
-        await animationLoop.start();
-      } catch (error) {
-        const errorElement = document.createElement('div');
-        errorElement.id = 'gaussian-splats-error';
-        errorElement.setAttribute('role', 'alert');
-        errorElement.textContent =
-          error instanceof Error ? error.message : 'Unable to initialize Gaussian splat rendering.';
-        document.body.append(errorElement);
       }
     </script>
   </body>

--- a/examples/showcase/globe/index.html
+++ b/examples/showcase/globe/index.html
@@ -5,45 +5,53 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="dense" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <script type="module">
-    import {luma} from '@luma.gl/core';
-    import {makeAnimationLoop} from '@luma.gl/engine';
-    import {webgpuAdapter} from '@luma.gl/webgpu';
-    import {webgl2Adapter} from '@luma.gl/webgl';
-    import AnimationLoopTemplate from './app.ts';
+  <script type="module" data-luma-example-application>
+    const exampleSupport = await window.lumaExampleSupportPromise;
+    if (exampleSupport.supported) {
+      const {luma} = await import('@luma.gl/core');
+      const {makeAnimationLoop} = await import('@luma.gl/engine');
+      const {webgpuAdapter} = await import('@luma.gl/webgpu');
+      const {webgl2Adapter} = await import('@luma.gl/webgl');
+      const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-    const requestedDevice = new URLSearchParams(window.location.search).get('device');
-    const adapters =
-      requestedDevice === 'webgl'
-        ? [webgl2Adapter]
-        : requestedDevice === 'webgpu'
-          ? [webgpuAdapter]
-          : [webgpuAdapter, webgl2Adapter];
-    const supportsHighDynamicRange =
-      requestedDevice !== 'webgl' &&
-      typeof window.matchMedia === 'function' &&
-      window.matchMedia('(dynamic-range: high)').matches;
-    const device = luma.createDevice({
-      id: 'globe',
-      adapters,
-      createCanvasContext: supportsHighDynamicRange
-        ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
-        : true
-    });
-    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
-    animationLoop.start();
+      const requestedDevice = new URLSearchParams(window.location.search).get('device');
+      const adapters =
+        requestedDevice === 'webgl'
+          ? [webgl2Adapter]
+          : requestedDevice === 'webgpu'
+            ? [webgpuAdapter]
+            : [webgpuAdapter, webgl2Adapter];
+      const supportsHighDynamicRange =
+        requestedDevice !== 'webgl' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia('(dynamic-range: high)').matches;
+      const device = luma.createDevice({
+        id: 'globe',
+        adapters,
+        createCanvasContext: supportsHighDynamicRange
+          ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+          : true
+      });
+      const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
+      animationLoop.start();
+    }
   </script>
   <style>
     html,

--- a/examples/showcase/gltf/index.html
+++ b/examples/showcase/gltf/index.html
@@ -5,46 +5,54 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>glTF Animation Studio</title>
-  <script type="module">
-    import {luma} from '@luma.gl/core';
-    import {makeAnimationLoop} from '@luma.gl/engine';
-    import {webgpuAdapter} from '@luma.gl/webgpu';
-    import {webgl2Adapter} from '@luma.gl/webgl';
-    import AnimationLoopTemplate from './app.ts';
+  <script type="module" data-luma-example-application>
+    const exampleSupport = await window.lumaExampleSupportPromise;
+    if (exampleSupport.supported) {
+      const {luma} = await import('@luma.gl/core');
+      const {makeAnimationLoop} = await import('@luma.gl/engine');
+      const {webgpuAdapter} = await import('@luma.gl/webgpu');
+      const {webgl2Adapter} = await import('@luma.gl/webgl');
+      const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-    const requestedDevice = new URLSearchParams(window.location.search).get('device');
-    const adapters =
-      requestedDevice === 'webgl'
-        ? [webgl2Adapter]
-        : requestedDevice === 'webgpu'
-          ? [webgpuAdapter]
-          : [webgpuAdapter, webgl2Adapter];
-    const supportsHighDynamicRange =
-      requestedDevice !== 'webgl' &&
-      typeof window.matchMedia === 'function' &&
-      window.matchMedia('(dynamic-range: high)').matches;
-    const device = luma.createDevice({
-      id: 'gltf',
-      adapters,
-      createCanvasContext: supportsHighDynamicRange
-        ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
-        : true
-    });
-    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
-    animationLoop.start();
+      const requestedDevice = new URLSearchParams(window.location.search).get('device');
+      const adapters =
+        requestedDevice === 'webgl'
+          ? [webgl2Adapter]
+          : requestedDevice === 'webgpu'
+            ? [webgpuAdapter]
+            : [webgpuAdapter, webgl2Adapter];
+      const supportsHighDynamicRange =
+        requestedDevice !== 'webgl' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia('(dynamic-range: high)').matches;
+      const device = luma.createDevice({
+        id: 'gltf',
+        adapters,
+        createCanvasContext: supportsHighDynamicRange
+          ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+          : true
+      });
+      const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
+      animationLoop.start();
+    }
   </script>
   <style>
     html,

--- a/examples/showcase/instancing/index.html
+++ b/examples/showcase/instancing/index.html
@@ -5,45 +5,53 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {luma} from '@luma.gl/core';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {luma} = await import('@luma.gl/core');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const requestedDevice = new URLSearchParams(window.location.search).get('device');
-  const adapters =
-    requestedDevice === 'webgl'
-      ? [webgl2Adapter]
-      : requestedDevice === 'webgpu'
-        ? [webgpuAdapter]
-        : [webgpuAdapter, webgl2Adapter];
-  const supportsHighDynamicRange =
-    requestedDevice !== 'webgl' &&
-    typeof window.matchMedia === 'function' &&
-    window.matchMedia('(dynamic-range: high)').matches;
-  const device = luma.createDevice({
-    id: 'instancing',
-    adapters,
-    createCanvasContext: supportsHighDynamicRange
-      ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
-      : true
-  });
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
-  animationLoop.start();
+    const requestedDevice = new URLSearchParams(window.location.search).get('device');
+    const adapters =
+      requestedDevice === 'webgl'
+        ? [webgl2Adapter]
+        : requestedDevice === 'webgpu'
+          ? [webgpuAdapter]
+          : [webgpuAdapter, webgl2Adapter];
+    const supportsHighDynamicRange =
+      requestedDevice !== 'webgl' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(dynamic-range: high)').matches;
+    const device = luma.createDevice({
+      id: 'instancing',
+      adapters,
+      createCanvasContext: supportsHighDynamicRange
+        ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+        : true
+    });
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/showcase/lightstorm-megacity/index.html
+++ b/examples/showcase/lightstorm-megacity/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta charset="UTF-8" />
@@ -23,37 +28,40 @@
     canvas { display: block; width: 100vw !important; height: 100vh !important; }
   </style>
 </head>
-<script type="module">
-  import {luma} from '@luma.gl/core';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {luma} = await import('@luma.gl/core');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const supportsHighDynamicRange =
-    typeof window.matchMedia === 'function' &&
-    window.matchMedia('(dynamic-range: high)').matches;
+    const supportsHighDynamicRange =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(dynamic-range: high)').matches;
 
-  let device;
-  try {
-    device = await luma.createDevice({
-      id: 'lightstorm-megacity',
-      adapters: [webgpuAdapter],
-      createCanvasContext: supportsHighDynamicRange
-        ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
-        : true
-    });
-  } catch (error) {
-    if (!supportsHighDynamicRange) {
-      throw error;
+    let device;
+    try {
+      device = await luma.createDevice({
+        id: 'lightstorm-megacity',
+        adapters: [webgpuAdapter],
+        createCanvasContext: supportsHighDynamicRange
+          ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+          : true
+      });
+    } catch (error) {
+      if (!supportsHighDynamicRange) {
+        throw error;
+      }
+      device = await luma.createDevice({
+        id: 'lightstorm-megacity-sdr-fallback',
+        adapters: [webgpuAdapter],
+        createCanvasContext: true
+      });
     }
-    device = await luma.createDevice({
-      id: 'lightstorm-megacity-sdr-fallback',
-      adapters: [webgpuAdapter],
-      createCanvasContext: true
-    });
-  }
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
+    animationLoop.start();
+  }
 </script>
 <body></body>

--- a/examples/showcase/llm-network/index.html
+++ b/examples/showcase/llm-network/index.html
@@ -6,14 +6,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="dense" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
     <meta charset="UTF-8" />
@@ -27,32 +32,35 @@
     <main id="llm-network-startup" aria-live="polite">
       <section><p>luma.gl · visual transformer tour</p><h1>Inside a Transformer</h1><span data-startup-status>Compiling the network visualization…</span></section>
     </main>
-    <script type="module">
-      const startup = document.querySelector('#llm-network-startup');
-      const status = document.querySelector('[data-startup-status]');
-      try {
-        if (!navigator.gpu) throw new Error('This showcase requires WebGPU in a recent browser.');
-        const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: LLMNetwork}] =
-          await Promise.all([
-            import('@luma.gl/core'),
-            import('@luma.gl/engine'),
-            import('@luma.gl/webgpu'),
-            import('./app.ts')
-          ]);
-        const device = await luma.createDevice({
-          id: 'llm-network',
-          adapters: [webgpuAdapter],
-          featureLevel: 'best-available',
-          powerPreference: 'high-performance',
-          waitForPageLoad: false,
-          createCanvasContext: true
-        });
-        await makeAnimationLoop(LLMNetwork, {device}).start();
-        startup.remove();
-      } catch (error) {
-        console.error('Inside a Transformer failed to start.', error);
-        status.textContent = error instanceof Error ? error.message : String(error);
-        status.dataset.state = 'error';
+    <script type="module" data-luma-example-application>
+      const exampleSupport = await window.lumaExampleSupportPromise;
+      if (exampleSupport.supported) {
+        const startup = document.querySelector('#llm-network-startup');
+        const status = document.querySelector('[data-startup-status]');
+        try {
+          if (!navigator.gpu) throw new Error('This showcase requires WebGPU in a recent browser.');
+          const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: LLMNetwork}] =
+            await Promise.all([
+              import('@luma.gl/core'),
+              import('@luma.gl/engine'),
+              import('@luma.gl/webgpu'),
+              import('./app.ts')
+            ]);
+          const device = await luma.createDevice({
+            id: 'llm-network',
+            adapters: [webgpuAdapter],
+            featureLevel: 'best-available',
+            powerPreference: 'high-performance',
+            waitForPageLoad: false,
+            createCanvasContext: true
+          });
+          await makeAnimationLoop(LLMNetwork, {device}).start();
+          startup.remove();
+        } catch (error) {
+          console.error('Inside a Transformer failed to start.', error);
+          status.textContent = error instanceof Error ? error.message : String(error);
+          status.dataset.state = 'error';
+        }
       }
     </script>
   </body>

--- a/examples/showcase/million-row-crossfilter/index.html
+++ b/examples/showcase/million-row-crossfilter/index.html
@@ -6,14 +6,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
     <meta charset="UTF-8" />
@@ -104,40 +109,43 @@
         <p class="startup-status" data-startup-status>Preparing one million GPU-resident rows…</p>
       </section>
     </main>
-    <script type="module">
-      const startup = document.querySelector('#crossfilter-startup');
-      const status = document.querySelector('[data-startup-status]');
+    <script type="module" data-luma-example-application>
+      const exampleSupport = await window.lumaExampleSupportPromise;
+      if (exampleSupport.supported) {
+        const startup = document.querySelector('#crossfilter-startup');
+        const status = document.querySelector('[data-startup-status]');
 
-      try {
-        if (!navigator.gpu) {
-          throw new Error('This browser does not expose WebGPU. Try a recent Chromium browser.');
+        try {
+          if (!navigator.gpu) {
+            throw new Error('This browser does not expose WebGPU. Try a recent Chromium browser.');
+          }
+
+          const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: AnimationLoopTemplate}] =
+            await Promise.all([
+              import('@luma.gl/core'),
+              import('@luma.gl/engine'),
+              import('@luma.gl/webgpu'),
+              import('./app.ts')
+            ]);
+
+          status.textContent = 'Acquiring a high-performance WebGPU device…';
+          const device = await luma.createDevice({
+            id: 'million-row-crossfilter',
+            adapters: [webgpuAdapter],
+            featureLevel: 'best-available',
+            powerPreference: 'high-performance',
+            waitForPageLoad: false,
+            createCanvasContext: true
+          });
+
+          status.textContent = 'Compiling the linked-view command graph…';
+          await makeAnimationLoop(AnimationLoopTemplate, {device}).start();
+          startup.remove();
+        } catch (error) {
+          console.error('Million-Row Crossfilter Explorer failed to start.', error);
+          status.dataset.state = 'error';
+          status.textContent = error instanceof Error ? error.message : String(error);
         }
-
-        const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: AnimationLoopTemplate}] =
-          await Promise.all([
-            import('@luma.gl/core'),
-            import('@luma.gl/engine'),
-            import('@luma.gl/webgpu'),
-            import('./app.ts')
-          ]);
-
-        status.textContent = 'Acquiring a high-performance WebGPU device…';
-        const device = await luma.createDevice({
-          id: 'million-row-crossfilter',
-          adapters: [webgpuAdapter],
-          featureLevel: 'best-available',
-          powerPreference: 'high-performance',
-          waitForPageLoad: false,
-          createCanvasContext: true
-        });
-
-        status.textContent = 'Compiling the linked-view command graph…';
-        await makeAnimationLoop(AnimationLoopTemplate, {device}).start();
-        startup.remove();
-      } catch (error) {
-        console.error('Million-Row Crossfilter Explorer failed to start.', error);
-        status.dataset.state = 'error';
-        status.textContent = error instanceof Error ? error.message : String(error);
       }
     </script>
   </body>

--- a/examples/showcase/packet-spraying/index.html
+++ b/examples/showcase/packet-spraying/index.html
@@ -5,44 +5,52 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="effects" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script type="module">
-    import {luma} from '@luma.gl/core';
-    import {makeAnimationLoop} from '@luma.gl/engine';
-    import {webgl2Adapter} from '@luma.gl/webgl';
-    import {webgpuAdapter} from '@luma.gl/webgpu';
-    import AnimationLoopTemplate from './app.ts';
+  <script type="module" data-luma-example-application>
+    const exampleSupport = await window.lumaExampleSupportPromise;
+    if (exampleSupport.supported) {
+      const {luma} = await import('@luma.gl/core');
+      const {makeAnimationLoop} = await import('@luma.gl/engine');
+      const {webgl2Adapter} = await import('@luma.gl/webgl');
+      const {webgpuAdapter} = await import('@luma.gl/webgpu');
+      const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-    const requestedDevice = new URLSearchParams(window.location.search).get('device');
-    const adapters =
-      requestedDevice === 'webgl'
-        ? [webgl2Adapter]
-        : requestedDevice === 'webgpu'
-          ? [webgpuAdapter]
-          : [webgpuAdapter, webgl2Adapter];
-    const supportsHighDynamicRange =
-      requestedDevice !== 'webgl' &&
-      typeof window.matchMedia === 'function' &&
-      window.matchMedia('(dynamic-range: high)').matches;
-    const device = luma.createDevice({
-      id: 'packet-spraying',
-      adapters,
-      createCanvasContext: supportsHighDynamicRange
-        ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
-        : true
-    });
-    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
-    animationLoop.start();
+      const requestedDevice = new URLSearchParams(window.location.search).get('device');
+      const adapters =
+        requestedDevice === 'webgl'
+          ? [webgl2Adapter]
+          : requestedDevice === 'webgpu'
+            ? [webgpuAdapter]
+            : [webgpuAdapter, webgl2Adapter];
+      const supportsHighDynamicRange =
+        requestedDevice !== 'webgl' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia('(dynamic-range: high)').matches;
+      const device = luma.createDevice({
+        id: 'packet-spraying',
+        adapters,
+        createCanvasContext: supportsHighDynamicRange
+          ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+          : true
+      });
+      const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
+      animationLoop.start();
+    }
   </script>
   <style>
     html,

--- a/examples/showcase/persistence/index.html
+++ b/examples/showcase/persistence/index.html
@@ -5,25 +5,33 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="effects" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import AnimationLoopTemplate from './app.ts';
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [/* webgpuAdapter, */ webgl2Adapter]})
-  animationLoop.start();
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [/* webgpuAdapter, */ webgl2Adapter]})
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/showcase/postprocessing/index.html
+++ b/examples/showcase/postprocessing/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="effects" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta charset="UTF-8" />
@@ -39,22 +44,25 @@
     }
   </style>
 </head>
-<script type="module">
-  import {luma} from '@luma.gl/core';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {luma} = await import('@luma.gl/core');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const requestedDevice = new URLSearchParams(window.location.search).get('device');
-  const adapters =
-    requestedDevice === 'webgl'
-      ? [webgl2Adapter]
-      : requestedDevice === 'webgpu'
-        ? [webgpuAdapter]
-        : [webgpuAdapter, webgl2Adapter];
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters});
-  animationLoop.start();
+    const requestedDevice = new URLSearchParams(window.location.search).get('device');
+    const adapters =
+      requestedDevice === 'webgl'
+        ? [webgl2Adapter]
+        : requestedDevice === 'webgpu'
+          ? [webgpuAdapter]
+          : [webgpuAdapter, webgl2Adapter];
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters});
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/showcase/quantum-state-studio/index.html
+++ b/examples/showcase/quantum-state-studio/index.html
@@ -6,14 +6,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
     <meta charset="UTF-8" />
@@ -27,38 +32,41 @@
     <main id="quantum-startup" aria-live="polite">
       <section><p>luma.gl · WebGPU</p><h1>Quantum State Studio</h1><span data-startup-status>Acquiring the GPU and compiling state evolution…</span></section>
     </main>
-    <script type="module">
-      const startup = document.querySelector('#quantum-startup');
-      const status = document.querySelector('[data-startup-status]');
-      try {
-        if (!navigator.gpu) throw new Error('This showcase requires WebGPU in a recent browser.');
-        const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: QuantumStateStudio}] =
-          await Promise.all([
-            import('@luma.gl/core'),
-            import('@luma.gl/engine'),
-            import('@luma.gl/webgpu'),
-            import('./app.ts')
-          ]);
-        const supportsHighDynamicRange =
-          typeof window.matchMedia === 'function' &&
-          window.matchMedia('(dynamic-range: high)').matches;
-        const device = await luma.createDevice({
-          id: 'quantum-state-studio',
-          adapters: [webgpuAdapter],
-          featureLevel: 'best-available',
-          powerPreference: 'high-performance',
-          waitForPageLoad: false,
-          createCanvasContext: supportsHighDynamicRange
-            ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
-            : true
-        });
-        status.textContent = 'Building the GPU-resident circuit history…';
-        await makeAnimationLoop(QuantumStateStudio, {device}).start();
-        startup.remove();
-      } catch (error) {
-        console.error('Quantum State Studio failed to start.', error);
-        status.textContent = error instanceof Error ? error.message : String(error);
-        status.dataset.state = 'error';
+    <script type="module" data-luma-example-application>
+      const exampleSupport = await window.lumaExampleSupportPromise;
+      if (exampleSupport.supported) {
+        const startup = document.querySelector('#quantum-startup');
+        const status = document.querySelector('[data-startup-status]');
+        try {
+          if (!navigator.gpu) throw new Error('This showcase requires WebGPU in a recent browser.');
+          const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: QuantumStateStudio}] =
+            await Promise.all([
+              import('@luma.gl/core'),
+              import('@luma.gl/engine'),
+              import('@luma.gl/webgpu'),
+              import('./app.ts')
+            ]);
+          const supportsHighDynamicRange =
+            typeof window.matchMedia === 'function' &&
+            window.matchMedia('(dynamic-range: high)').matches;
+          const device = await luma.createDevice({
+            id: 'quantum-state-studio',
+            adapters: [webgpuAdapter],
+            featureLevel: 'best-available',
+            powerPreference: 'high-performance',
+            waitForPageLoad: false,
+            createCanvasContext: supportsHighDynamicRange
+              ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+              : true
+          });
+          status.textContent = 'Building the GPU-resident circuit history…';
+          await makeAnimationLoop(QuantumStateStudio, {device}).start();
+          startup.remove();
+        } catch (error) {
+          console.error('Quantum State Studio failed to start.', error);
+          status.textContent = error instanceof Error ? error.message : String(error);
+          status.dataset.state = 'error';
+        }
       }
     </script>
   </body>

--- a/examples/showcase/raster-lab/index.html
+++ b/examples/showcase/raster-lab/index.html
@@ -6,14 +6,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="large-data" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
     <meta charset="UTF-8" />
@@ -98,39 +103,42 @@
         <p class="startup-status" data-raster-startup-status>Preparing synthetic satellite bands…</p>
       </section>
     </main>
-    <script type="module">
-      const startup = document.querySelector('#raster-startup');
-      const status = document.querySelector('[data-raster-startup-status]');
+    <script type="module" data-luma-example-application>
+      const exampleSupport = await window.lumaExampleSupportPromise;
+      if (exampleSupport.supported) {
+        const startup = document.querySelector('#raster-startup');
+        const status = document.querySelector('[data-raster-startup-status]');
 
-      try {
-        if (!navigator.gpu) {
-          throw new Error('WebGPU is unavailable. Try a recent Chromium browser with GPU access.');
+        try {
+          if (!navigator.gpu) {
+            throw new Error('WebGPU is unavailable. Try a recent Chromium browser with GPU access.');
+          }
+
+          const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: AnimationLoopTemplate}] =
+            await Promise.all([
+              import('@luma.gl/core'),
+              import('@luma.gl/engine'),
+              import('@luma.gl/webgpu'),
+              import('./app.ts')
+            ]);
+
+          status.textContent = 'Acquiring a WebGPU device for resident raster analysis…';
+          const device = await luma.createDevice({
+            id: 'gpu-raster-satellite-raster-lab',
+            adapters: [webgpuAdapter],
+            featureLevel: 'best-available',
+            powerPreference: 'high-performance',
+            waitForPageLoad: false,
+            createCanvasContext: true
+          });
+
+          status.textContent = 'Compiling NDVI and validity-aware histogram passes…';
+          await makeAnimationLoop(AnimationLoopTemplate, {device}).start();
+          startup.remove();
+        } catch (error) {
+          status.dataset.state = 'error';
+          status.textContent = error instanceof Error ? error.message : String(error);
         }
-
-        const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: AnimationLoopTemplate}] =
-          await Promise.all([
-            import('@luma.gl/core'),
-            import('@luma.gl/engine'),
-            import('@luma.gl/webgpu'),
-            import('./app.ts')
-          ]);
-
-        status.textContent = 'Acquiring a WebGPU device for resident raster analysis…';
-        const device = await luma.createDevice({
-          id: 'gpu-raster-satellite-raster-lab',
-          adapters: [webgpuAdapter],
-          featureLevel: 'best-available',
-          powerPreference: 'high-performance',
-          waitForPageLoad: false,
-          createCanvasContext: true
-        });
-
-        status.textContent = 'Compiling NDVI and validity-aware histogram passes…';
-        await makeAnimationLoop(AnimationLoopTemplate, {device}).start();
-        startup.remove();
-      } catch (error) {
-        status.dataset.state = 'error';
-        status.textContent = error instanceof Error ? error.message : String(error);
       }
     </script>
   </body>

--- a/examples/showcase/scene/index.html
+++ b/examples/showcase/scene/index.html
@@ -6,14 +6,19 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="effects" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
     <meta charset="UTF-8" />
@@ -346,27 +351,30 @@
         }
       }
     </style>
-    <script type="module">
-      import {makeAnimationLoop} from '@luma.gl/engine';
-      import {luma} from '@luma.gl/core';
-      import {webgpuAdapter} from '@luma.gl/webgpu';
-      import {webgl2Adapter} from '@luma.gl/webgl';
-      import ANARIShowcase from './app.ts';
+    <script type="module" data-luma-example-application>
+      const exampleSupport = await window.lumaExampleSupportPromise;
+      if (exampleSupport.supported) {
+        const {makeAnimationLoop} = await import('@luma.gl/engine');
+        const {luma} = await import('@luma.gl/core');
+        const {webgpuAdapter} = await import('@luma.gl/webgpu');
+        const {webgl2Adapter} = await import('@luma.gl/webgl');
+        const {default: ANARIShowcase} = await import('./app.ts');
 
-      const forceWebGL = new URLSearchParams(window.location.search).get('backend') === 'webgl';
-      const supportsHighDynamicRange =
-        !forceWebGL && window.matchMedia('(dynamic-range: high)').matches;
-      const device = await luma.createDevice({
-        id: 'anari-showcase',
-        adapters: forceWebGL ? [webgl2Adapter] : [webgpuAdapter, webgl2Adapter],
-        createCanvasContext: supportsHighDynamicRange
-          ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
-          : true
-      });
-      const animationLoop = makeAnimationLoop(ANARIShowcase, {
-        device
-      });
-      animationLoop.start();
+        const forceWebGL = new URLSearchParams(window.location.search).get('backend') === 'webgl';
+        const supportsHighDynamicRange =
+          !forceWebGL && window.matchMedia('(dynamic-range: high)').matches;
+        const device = await luma.createDevice({
+          id: 'anari-showcase',
+          adapters: forceWebGL ? [webgl2Adapter] : [webgpuAdapter, webgl2Adapter],
+          createCanvasContext: supportsHighDynamicRange
+            ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+            : true
+        });
+        const animationLoop = makeAnimationLoop(ANARIShowcase, {
+          device
+        });
+        animationLoop.start();
+      }
     </script>
   </head>
   <body>

--- a/examples/showcase/scene/playground.html
+++ b/examples/showcase/scene/playground.html
@@ -6,14 +6,19 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="effects" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
     <meta charset="UTF-8" />
@@ -522,26 +527,29 @@
         }
       }
     </style>
-    <script type="module">
-      import {luma} from '@luma.gl/core';
-      import {makeAnimationLoop} from '@luma.gl/engine';
-      import {webgl2Adapter} from '@luma.gl/webgl';
-      import {webgpuAdapter} from '@luma.gl/webgpu';
-      import ANARIPlayground from './playground.ts';
+    <script type="module" data-luma-example-application>
+      const exampleSupport = await window.lumaExampleSupportPromise;
+      if (exampleSupport.supported) {
+        const {luma} = await import('@luma.gl/core');
+        const {makeAnimationLoop} = await import('@luma.gl/engine');
+        const {webgl2Adapter} = await import('@luma.gl/webgl');
+        const {webgpuAdapter} = await import('@luma.gl/webgpu');
+        const {default: ANARIPlayground} = await import('./playground.ts');
 
-      const forceWebGL = new URLSearchParams(window.location.search).get('backend') === 'webgl';
-      const supportsHighDynamicRange =
-        !forceWebGL && window.matchMedia('(dynamic-range: high)').matches;
-      const canvas = document.getElementById('playground-canvas');
-      const canvasProperties = supportsHighDynamicRange
-        ? {canvas, colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
-        : {canvas};
-      const device = await luma.createDevice({
-        id: 'anari-json-playground',
-        adapters: forceWebGL ? [webgl2Adapter] : [webgpuAdapter, webgl2Adapter],
-        createCanvasContext: canvasProperties
-      });
-      makeAnimationLoop(ANARIPlayground, {device}).start();
+        const forceWebGL = new URLSearchParams(window.location.search).get('backend') === 'webgl';
+        const supportsHighDynamicRange =
+          !forceWebGL && window.matchMedia('(dynamic-range: high)').matches;
+        const canvas = document.getElementById('playground-canvas');
+        const canvasProperties = supportsHighDynamicRange
+          ? {canvas, colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+          : {canvas};
+        const device = await luma.createDevice({
+          id: 'anari-json-playground',
+          adapters: forceWebGL ? [webgl2Adapter] : [webgpuAdapter, webgl2Adapter],
+          createCanvasContext: canvasProperties
+        });
+        makeAnimationLoop(ANARIPlayground, {device}).start();
+      }
     </script>
   </head>
   <body>

--- a/examples/showcase/tempest-ocean/index.html
+++ b/examples/showcase/tempest-ocean/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="simulation" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta charset="UTF-8" />
@@ -39,44 +44,47 @@
   <div id="tempest-ocean-status" style="margin: 24px; font: 14px system-ui; color: #bfe9ff">
     Loading Tempest Ocean…
   </div>
-  <script type="module">
-    const status = document.querySelector('#tempest-ocean-status');
+  <script type="module" data-luma-example-application>
+    const exampleSupport = await window.lumaExampleSupportPromise;
+    if (exampleSupport.supported) {
+      const status = document.querySelector('#tempest-ocean-status');
 
-    try {
-      const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: AnimationLoopTemplate}] =
-        await Promise.all([
-          import('@luma.gl/core'),
-          import('@luma.gl/engine'),
-          import('@luma.gl/webgpu'),
-          import('./app.ts')
-        ]);
-      const supportsHighDynamicRange =
-        typeof window.matchMedia === 'function' &&
-        window.matchMedia('(dynamic-range: high)').matches;
-      status.textContent = 'Acquiring WebGPU device…';
-      const device = await luma.createDevice({
-        id: 'tempest-ocean-spectral-stormfront',
-        adapters: [webgpuAdapter],
-        featureLevel: 'best-available',
-        powerPreference: 'high-performance',
-        waitForPageLoad: false,
-        createCanvasContext: supportsHighDynamicRange
-          ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
-          : true
-      });
-      if (device.info.featureLevel !== 'core') {
-        throw new Error('Tempest Ocean requires core WebGPU shader limits.');
+      try {
+        const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: AnimationLoopTemplate}] =
+          await Promise.all([
+            import('@luma.gl/core'),
+            import('@luma.gl/engine'),
+            import('@luma.gl/webgpu'),
+            import('./app.ts')
+          ]);
+        const supportsHighDynamicRange =
+          typeof window.matchMedia === 'function' &&
+          window.matchMedia('(dynamic-range: high)').matches;
+        status.textContent = 'Acquiring WebGPU device…';
+        const device = await luma.createDevice({
+          id: 'tempest-ocean-spectral-stormfront',
+          adapters: [webgpuAdapter],
+          featureLevel: 'best-available',
+          powerPreference: 'high-performance',
+          waitForPageLoad: false,
+          createCanvasContext: supportsHighDynamicRange
+            ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+            : true
+        });
+        if (device.info.featureLevel !== 'core') {
+          throw new Error('Tempest Ocean requires core WebGPU shader limits.');
+        }
+        status.textContent = 'Starting spectral ocean simulation…';
+        const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
+        await animationLoop.start();
+        status.remove();
+      } catch (error) {
+        console.error('Tempest Ocean failed to start.', error);
+        status.id = 'tempest-ocean-startup-error';
+        status.textContent = error instanceof Error ? error.stack || error.message : String(error);
+        status.style.cssText =
+          'margin:24px;color:#fff;background:#630;padding:16px;white-space:pre-wrap;font:13px/1.45 monospace';
       }
-      status.textContent = 'Starting spectral ocean simulation…';
-      const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
-      await animationLoop.start();
-      status.remove();
-    } catch (error) {
-      console.error('Tempest Ocean failed to start.', error);
-      status.id = 'tempest-ocean-startup-error';
-      status.textContent = error instanceof Error ? error.stack || error.message : String(error);
-      status.style.cssText =
-        'margin:24px;color:#fff;background:#630;padding:16px;white-space:pre-wrap;font:13px/1.45 monospace';
     }
   </script>
 </body>

--- a/examples/showcase/vector-field-lab/index.html
+++ b/examples/showcase/vector-field-lab/index.html
@@ -6,14 +6,19 @@
   <meta name="luma-example-backends" content="webgpu" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="simulation" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta charset="UTF-8" />
@@ -50,24 +55,27 @@
     <div data-field-panel-label class="panel-label">Flow topology</div>
     <div data-field-probe class="field-probe"></div>
   </div>
-  <script type="module">
-    const status = document.querySelector('#vector-field-status');
-    try {
-      const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: AnimationLoopTemplate}] = await Promise.all([
-        import('@luma.gl/core'), import('@luma.gl/engine'), import('@luma.gl/webgpu'), import('./app.ts')
-      ]);
-      const device = await luma.createDevice({
-        id:'vector-field-lab', adapters:[webgpuAdapter], featureLevel:'best-available',
-        powerPreference:'high-performance', waitForPageLoad:false, createCanvasContext:true
-      });
-      if (device.info.featureLevel !== 'core') throw new Error('Vector Field Lab requires core WebGPU.');
-      const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
-      await animationLoop.start();
-      status.remove();
-    } catch (error) {
-      console.error(error);
-      status.textContent = error instanceof Error ? error.stack || error.message : String(error);
-      status.style.cssText = 'position:fixed;inset:24px;color:#fff;background:#630;padding:16px;white-space:pre-wrap;font:13px/1.45 monospace;z-index:10';
+  <script type="module" data-luma-example-application>
+    const exampleSupport = await window.lumaExampleSupportPromise;
+    if (exampleSupport.supported) {
+      const status = document.querySelector('#vector-field-status');
+      try {
+        const [{luma}, {makeAnimationLoop}, {webgpuAdapter}, {default: AnimationLoopTemplate}] = await Promise.all([
+          import('@luma.gl/core'), import('@luma.gl/engine'), import('@luma.gl/webgpu'), import('./app.ts')
+        ]);
+        const device = await luma.createDevice({
+          id:'vector-field-lab', adapters:[webgpuAdapter], featureLevel:'best-available',
+          powerPreference:'high-performance', waitForPageLoad:false, createCanvasContext:true
+        });
+        if (device.info.featureLevel !== 'core') throw new Error('Vector Field Lab requires core WebGPU.');
+        const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
+        await animationLoop.start();
+        status.remove();
+      } catch (error) {
+        console.error(error);
+        status.textContent = error instanceof Error ? error.stack || error.message : String(error);
+        status.style.cssText = 'position:fixed;inset:24px;color:#fff;background:#630;padding:16px;white-space:pre-wrap;font:13px/1.45 monospace;z-index:10';
+      }
     }
   </script>
 </body>

--- a/examples/tutorials/hello-cube/index.html
+++ b/examples/tutorials/hello-cube/index.html
@@ -5,25 +5,33 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import AnimationLoopTemplate from './app.ts';
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]});
-  animationLoop.start();
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]});
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/tutorials/hello-gltf/index.html
+++ b/examples/tutorials/hello-gltf/index.html
@@ -5,25 +5,33 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <script type="module">
-    import {makeAnimationLoop} from '@luma.gl/engine';
-    import {webgpuAdapter} from '@luma.gl/webgpu';
-    import {webgl2Adapter} from '@luma.gl/webgl';
-    import AnimationLoopTemplate from './app.ts';
-    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]});
-    animationLoop.start();
+  <script type="module" data-luma-example-application>
+    const exampleSupport = await window.lumaExampleSupportPromise;
+    if (exampleSupport.supported) {
+      const {makeAnimationLoop} = await import('@luma.gl/engine');
+      const {webgpuAdapter} = await import('@luma.gl/webgpu');
+      const {webgl2Adapter} = await import('@luma.gl/webgl');
+      const {default: AnimationLoopTemplate} = await import('./app.ts');
+      const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]});
+      animationLoop.start();
+    }
   </script>
   <style>
     body {

--- a/examples/tutorials/hello-instanced-cubes/index.html
+++ b/examples/tutorials/hello-instanced-cubes/index.html
@@ -5,26 +5,34 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="reduced" />
   <meta name="luma-example-mobile-profile" content="dense" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]});
-  animationLoop.start({canvas: 'canvas'});
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]});
+    animationLoop.start({canvas: 'canvas'});
+  }
 </script>
 <body>
 </body>

--- a/examples/tutorials/hello-instancing/index.html
+++ b/examples/tutorials/hello-instancing/index.html
@@ -5,26 +5,34 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  luma.registerAdapters([webgl2Adapter]);
-  makeAnimationLoop(AnimationLoopTemplate).start();
+    luma.registerAdapters([webgl2Adapter]);
+    makeAnimationLoop(AnimationLoopTemplate).start();
+  }
 </script>
 <body>
 </body>

--- a/examples/tutorials/hello-triangle-geometry/index.html
+++ b/examples/tutorials/hello-triangle-geometry/index.html
@@ -5,25 +5,33 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]}).start();
+    makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]}).start();
+  }
 </script>
 <body>
 </body>

--- a/examples/tutorials/hello-triangle/index.html
+++ b/examples/tutorials/hello-triangle/index.html
@@ -5,26 +5,34 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]});
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]});
+    animationLoop.start();
+  }
 </script>
 <body style="margin: 0;">
 </body>

--- a/examples/tutorials/hello-two-cubes/index.html
+++ b/examples/tutorials/hello-two-cubes/index.html
@@ -5,26 +5,34 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]});
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]});
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/tutorials/lighting/index.html
+++ b/examples/tutorials/lighting/index.html
@@ -5,14 +5,19 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -30,13 +35,17 @@
     }
   </style>
 </head>
-<script type="module">
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]});
-  animationLoop.start();</script>
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]});
+    animationLoop.start();
+  }
+</script>
 <body>
 </body>

--- a/examples/tutorials/shader-hooks/index.html
+++ b/examples/tutorials/shader-hooks/index.html
@@ -5,27 +5,35 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {luma} from '@luma.gl/core';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {luma} = await import('@luma.gl/core');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [/* webgpuAdapter, */ webgl2Adapter]});
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [/* webgpuAdapter, */ webgl2Adapter]});
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/tutorials/shader-modules/index.html
+++ b/examples/tutorials/shader-modules/index.html
@@ -5,27 +5,35 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {luma} from '@luma.gl/core';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {luma} = await import('@luma.gl/core');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [/* webgpuAdapter, */ webgl2Adapter]});
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [/* webgpuAdapter, */ webgl2Adapter]});
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/tutorials/shader-plugins/index.html
+++ b/examples/tutorials/shader-plugins/index.html
@@ -5,28 +5,36 @@
   <meta name="luma-example-backends" content="webgpu,webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import AnimationLoopTemplate from './app.ts';
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgpuAdapter, webgl2Adapter]
-  });
-  animationLoop.start();
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgpuAdapter, webgl2Adapter]
+    });
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/tutorials/transform-feedback/index.html
+++ b/examples/tutorials/transform-feedback/index.html
@@ -5,25 +5,33 @@
   <meta name="luma-example-backends" content="webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import AnimationLoopTemplate from './app.ts';
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgl2Adapter]});
-  animationLoop.start();
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgl2Adapter]});
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/examples/tutorials/transform/index.html
+++ b/examples/tutorials/transform/index.html
@@ -5,25 +5,33 @@
   <meta name="luma-example-backends" content="webgl2" />
   <meta name="luma-example-mobile" content="full" />
   <meta name="luma-example-mobile-profile" content="standard" />
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import AnimationLoopTemplate from './app.ts';
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [/*webgpuAdapter,*/ webgl2Adapter]});
-  animationLoop.start();
+<script type="module" data-luma-example-application>
+  const exampleSupport = await window.lumaExampleSupportPromise;
+  if (exampleSupport.supported) {
+    const {makeAnimationLoop} = await import('@luma.gl/engine');
+    const {webgpuAdapter} = await import('@luma.gl/webgpu');
+    const {webgl2Adapter} = await import('@luma.gl/webgl');
+    const {default: AnimationLoopTemplate} = await import('./app.ts');
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [/*webgpuAdapter,*/ webgl2Adapter]});
+    animationLoop.start();
+  }
 </script>
 <body>
 </body>

--- a/scripts/examples/synchronize-mobile-support-metadata.mjs
+++ b/scripts/examples/synchronize-mobile-support-metadata.mjs
@@ -8,6 +8,8 @@ import path from 'node:path';
 const REPOSITORY_ROOT = process.cwd();
 const EXAMPLE_DIRECTORY = path.join(REPOSITORY_ROOT, 'examples');
 const SUPPORT_BLOCK_PATTERN = /\n?\s*<!-- luma-example-support -->[\s\S]*?<!-- \/luma-example-support -->\n?/;
+const DEFERRED_MODULE_TYPE = 'application/luma-example-module';
+const APPLICATION_SCRIPT_ATTRIBUTE = 'data-luma-example-application';
 const CATALOG_ALIASES = new Map([
   ['arrow/arrow-instancing', 'showcase/instancing'],
   ['showcase/scene', 'experimental/scene-playground'],
@@ -26,6 +28,7 @@ for (const relativeHtmlFile of htmlFiles) {
   const supportBlock = makeSupportBlock(catalogId, definition);
   const absoluteHtmlFile = path.join(EXAMPLE_DIRECTORY, relativeHtmlFile);
   let html = readFileSync(absoluteHtmlFile, 'utf8').replace(SUPPORT_BLOCK_PATTERN, '\n');
+  html = gateApplicationModuleScripts(html);
 
   if (!/<meta\s+name=["']viewport["']/i.test(html)) {
     const viewport = '  <meta name="viewport" content="width=device-width, initial-scale=1.0" />\n';
@@ -71,16 +74,83 @@ function makeSupportBlock(catalogId, definition) {
   <meta name="luma-example-backends" content="${definition.backends.join(',')}" />
   <meta name="luma-example-mobile" content="${definition.mobile}" />
   <meta name="luma-example-mobile-profile" content="${definition.mobileProfile}" />${unsupportedReasonMeta}
+  <script data-luma-example-support-promise>
+    window.lumaExampleSupportPromise = new Promise(resolve => {
+      window.addEventListener('luma-example-support-ready', event => resolve(event.detail), {
+        once: true
+      });
+    });
+  </script>
   <script type="module" data-luma-example-support-bootstrap>
     import {installStandaloneExampleSupport} from '../../example-support.ts';
     const exampleSupport = installStandaloneExampleSupport();
-    if (!exampleSupport.supported) {
-      document
-        .querySelectorAll('script[type="module"]:not([data-luma-example-support-bootstrap])')
-        .forEach(script => script.remove());
-    }
+    window.dispatchEvent(
+      new CustomEvent('luma-example-support-ready', {detail: exampleSupport})
+    );
   </script>
   <!-- /luma-example-support -->`;
+}
+
+function gateApplicationModuleScripts(html) {
+  return html.replace(
+    /^([ \t]*)<script\b([^>]*)>([\s\S]*?)<\/script>/gim,
+    (script, tagIndentation, attributes, source) => {
+      const type = attributes.match(/\btype=(["'])(.*?)\1/i)?.[2];
+      if (
+        (type !== 'module' && type !== DEFERRED_MODULE_TYPE) ||
+        attributes.includes(APPLICATION_SCRIPT_ATTRIBUTE)
+      ) {
+        return script;
+      }
+
+      const sourceAttribute = attributes.match(/\bsrc=(["'])(.*?)\1/i);
+      const applicationSource = sourceAttribute
+        ? `await import(${JSON.stringify(sourceAttribute[2])});`
+        : transformStaticImports(source);
+      if (/^\s*import\s/m.test(applicationSource)) {
+        throw new Error('Standalone application scripts must use one-line static imports.');
+      }
+
+      const applicationAttributes = attributes
+        .replace(/\s*\bsrc=(["'])(.*?)\1/i, '')
+        .replace(
+          /\btype=(["'])(?:module|application\/luma-example-module)\1/i,
+          'type="module"'
+        );
+      const gatedSource = indentApplicationSource(applicationSource, `${tagIndentation}    `);
+      return `${tagIndentation}<script${applicationAttributes} ${APPLICATION_SCRIPT_ATTRIBUTE}>
+${tagIndentation}  const exampleSupport = await window.lumaExampleSupportPromise;
+${tagIndentation}  if (exampleSupport.supported) {
+${gatedSource}
+${tagIndentation}  }
+${tagIndentation}</script>`;
+    }
+  );
+}
+
+function transformStaticImports(source) {
+  return source.replace(
+    /(^[ \t]*)import\s+(.+?)\s+from\s+(["'])([^"']+)\3;?[ \t]*$/gm,
+    (statement, indentation, bindings, quote, moduleSource) => {
+      const destructuredBindings = bindings.startsWith('{')
+        ? bindings
+        : bindings.includes(', {')
+          ? `{default: ${bindings.replace(', {', ', ').replace(/}$/, '')}}`
+          : `{default: ${bindings}}`;
+      return `${indentation}const ${destructuredBindings} = await import(${quote}${moduleSource}${quote});`;
+    }
+  );
+}
+
+function indentApplicationSource(source, indentation) {
+  const lines = source.replace(/^\s*\n/, '').replace(/\n\s*$/, '').split('\n');
+  const indentationLengths = lines
+    .filter(line => line.trim())
+    .map(line => line.match(/^\s*/)[0].length);
+  const minimumIndentation = Math.min(...indentationLengths);
+  return lines
+    .map(line => `${indentation}${line.slice(minimumIndentation)}`.trimEnd())
+    .join('\n');
 }
 
 function escapeHtmlAttribute(value) {

--- a/test/examples/example-catalog-metadata.node.spec.ts
+++ b/test/examples/example-catalog-metadata.node.spec.ts
@@ -243,6 +243,27 @@ describe('live example catalog metadata', () => {
       expect(standaloneHtml, `${relativeFile} requires the standalone support bootstrap`).toContain(
         'data-luma-example-support-bootstrap'
       );
+      expect(
+        standaloneHtml.match(/<script[^>]*type="module"/g),
+        `${relativeFile} must have a support bootstrap and gated application module`
+      ).toHaveLength(2);
+      expect(
+        standaloneHtml,
+        `${relativeFile} must gate its application module until support is known`
+      ).toContain('data-luma-example-application');
+      const applicationSource = standaloneHtml.match(
+        /<script[^>]*data-luma-example-application[^>]*>([\s\S]*?)<\/script>/
+      )?.[1];
+      expect(applicationSource, `${relativeFile} must await its support preflight`).toContain(
+        'await window.lumaExampleSupportPromise'
+      );
+      expect(applicationSource, `${relativeFile} must defer its application imports`).toContain(
+        'import('
+      );
+      expect(
+        applicationSource,
+        `${relativeFile} must not statically import application code`
+      ).not.toMatch(/^\s*import\s/m);
       expect(standaloneHtml, `${relativeFile} requires its canonical example identifier`).toContain(
         `<meta name="luma-example-id" content="${canonicalId}" />`
       );

--- a/test/examples/webxr-kaleidoscope.node.spec.ts
+++ b/test/examples/webxr-kaleidoscope.node.spec.ts
@@ -367,9 +367,9 @@ describe('immersive WebGPU and WebGL2 prism portal', () => {
       dependencies: Record<string, string>;
     };
 
-    expect(standaloneSource).toContain("import {luma} from '@luma.gl/core'");
-    expect(standaloneSource).toContain("import {webgpuAdapter} from '@luma.gl/webgpu'");
-    expect(standaloneSource).toContain("import {webgl2Adapter} from '@luma.gl/webgl'");
+    expect(standaloneSource).toContain("const {luma} = await import('@luma.gl/core')");
+    expect(standaloneSource).toContain("const {webgpuAdapter} = await import('@luma.gl/webgpu')");
+    expect(standaloneSource).toContain("const {webgl2Adapter} = await import('@luma.gl/webgl')");
     expect(standaloneSource).toContain("luma.createDevice(makeDeviceProps('webgpu', true))");
     expect(standaloneSource).toContain(
       'makeAnimationLoop(AnimationLoopTemplate, {device: currentDevice})'

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -670,6 +670,7 @@ export const TempestOceanExample: React.FC<WebsiteExampleProps> = props => (
 
 export const GPGPUExample: React.FC<WebsiteExampleProps> = ({embeddedHeight, ...props}) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [hasInitialized, setHasInitialized] = useState(false);
 
   useEffect(() => {
     let isCancelled = false;
@@ -678,6 +679,7 @@ export const GPGPUExample: React.FC<WebsiteExampleProps> = ({embeddedHeight, ...
       .then(({initializeGPGPUShowcase}) => {
         if (!isCancelled) {
           handle = initializeGPGPUShowcase();
+          setHasInitialized(true);
         }
       })
       .catch(error => {
@@ -697,7 +699,7 @@ export const GPGPUExample: React.FC<WebsiteExampleProps> = ({embeddedHeight, ...
     <ExamplePage
       {...props}
       embeddedHeight={embeddedHeight ?? (props.embedded ? 720 : undefined)}
-      runtimeState={errorMessage ? 'failed' : 'running'}
+      runtimeState={errorMessage ? 'failed' : hasInitialized ? 'running' : 'loading'}
       style={{background: '#f7f8fb', overflow: 'hidden', ...props.style}}
     >
       <style>{GPGPU_EXAMPLE_STYLE}</style>
@@ -768,6 +770,7 @@ export const GPGPUExample: React.FC<WebsiteExampleProps> = ({embeddedHeight, ...
 /** Docusaurus wrapper for the graph-native paired GPU sort example. */
 export const GPUSortExample: React.FC<WebsiteExampleProps> = ({embeddedHeight, ...props}) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [hasInitialized, setHasInitialized] = useState(false);
 
   useEffect(() => {
     let isCancelled = false;
@@ -776,6 +779,7 @@ export const GPUSortExample: React.FC<WebsiteExampleProps> = ({embeddedHeight, .
       .then(({initializeGPUSortExample}) => {
         if (!isCancelled) {
           handle = initializeGPUSortExample();
+          setHasInitialized(true);
         }
       })
       .catch(error => {
@@ -795,7 +799,7 @@ export const GPUSortExample: React.FC<WebsiteExampleProps> = ({embeddedHeight, .
     <ExamplePage
       {...props}
       embeddedHeight={embeddedHeight ?? (props.embedded ? 720 : undefined)}
-      runtimeState={errorMessage ? 'failed' : 'running'}
+      runtimeState={errorMessage ? 'failed' : hasInitialized ? 'running' : 'loading'}
       style={{background: '#f7f8fb', overflow: 'auto', ...props.style}}
     >
       <main id="gpu-sort-app" />
@@ -814,6 +818,7 @@ export const GPUDataAnalysisExample: React.FC<WebsiteExampleProps> = ({
   ...props
 }) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [hasInitialized, setHasInitialized] = useState(false);
 
   useEffect(() => {
     let isCancelled = false;
@@ -822,6 +827,7 @@ export const GPUDataAnalysisExample: React.FC<WebsiteExampleProps> = ({
       .then(({initializeGPUDataAnalysisExample}) => {
         if (!isCancelled) {
           handle = initializeGPUDataAnalysisExample();
+          setHasInitialized(true);
         }
       })
       .catch(error => {
@@ -840,7 +846,7 @@ export const GPUDataAnalysisExample: React.FC<WebsiteExampleProps> = ({
     <ExamplePage
       {...props}
       embeddedHeight={embeddedHeight ?? (props.embedded ? 720 : undefined)}
-      runtimeState={errorMessage ? 'failed' : 'running'}
+      runtimeState={errorMessage ? 'failed' : hasInitialized ? 'running' : 'loading'}
       style={{background: '#f6f8fb', overflow: 'auto', ...props.style}}
     >
       <main id="gpu-data-analysis-app" />

--- a/website/src/react-luma/components/luma-example.tsx
+++ b/website/src/react-luma/components/luma-example.tsx
@@ -960,7 +960,7 @@ function ExampleStatusMessage({
       <div style={{maxWidth: 620}}>
         <strong style={{display: 'block', fontSize: 18, marginBottom: 8}}>
           {state === 'unsupported'
-            ? 'This example does not support this mobile device.'
+            ? 'This example is not supported in the current environment.'
             : 'This example could not start on the selected GPU.'}
         </strong>
         <span>{message}</span>


### PR DESCRIPTION
## Summary

Addresses the three automated review findings that landed on #3200 after it had already merged.

- Gates all 75 standalone application entry points behind the support preflight using conditional dynamic imports, so unsupported examples never schedule application imports.
- Preserves Vite development and production bundling; the generated support promise is established synchronously, and application modules await it before importing their code.
- Keeps the GPGPU, GPU Sort, and GPU Data Analysis website wrappers in `loading` until their async initializers return a handle.
- Uses device-neutral unsupported-environment messaging.
- Adds catalog regression coverage for the support bootstrap, gated application module, awaited preflight, and absence of static application imports.

## Verification

- `nvm use`
- `yarn install` (already current from the preceding backport work)
- `yarn lint fix`
- `yarn build`
- `yarn examples:typecheck`
- `yarn test-node`: 2,932 passed, 3 skipped
- `yarn website:build`
- `(cd website && yarn build)`
- Representative Vite production builds for scene, GPU Sort, Gaussian Splats, Fluid Foundry, Hello React, WebXR Kaleidoscope, and Animation all bundle the gated dynamic application entries.
- Full `yarn test`: node suite passes; headless reports the same six unrelated local WebGPU failures seen before these changes (DGGS ×2, raster band math, scene-renderer lighting, and splat renderer ×2), with 1,812 browser tests passing and 23 skipped.

Follow-up to #3200 and #3198.