### PR TITLE
[9.4] Support namespace imports in standalone gate generator

### DIFF
--- a/scripts/examples/standalone-module-imports.mjs
+++ b/scripts/examples/standalone-module-imports.mjs
@@ -1,0 +1,44 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+/** Converts top-level ESM imports into conditional-friendly dynamic imports. */
+export function transformStaticImports(source) {
+  return source.replace(
+    /(^[ \t]*)import\s+(.+?)\s+from\s+(["'])([^"']+)\3;?[ \t]*$/gm,
+    (statement, indentation, bindings, quote, moduleSource) =>
+      makeDynamicImport(indentation, bindings, `${quote}${moduleSource}${quote}`)
+  );
+}
+
+function makeDynamicImport(indentation, bindings, moduleSource) {
+  const namespaceImport = bindings.match(/^\*\s+as\s+([$\w]+)$/);
+  if (namespaceImport) {
+    return `${indentation}const ${namespaceImport[1]} = await import(${moduleSource});`;
+  }
+
+  const defaultAndNamespaceImport = bindings.match(/^([$\w]+)\s*,\s*\*\s+as\s+([$\w]+)$/);
+  if (defaultAndNamespaceImport) {
+    const [, defaultBinding, namespaceBinding] = defaultAndNamespaceImport;
+    return `${indentation}const ${namespaceBinding} = await import(${moduleSource});
+${indentation}const {default: ${defaultBinding}} = ${namespaceBinding};`;
+  }
+
+  const defaultAndNamedImport = bindings.match(/^([$\w]+)\s*,\s*(\{.*\})$/);
+  if (defaultAndNamedImport) {
+    const [, defaultBinding, namedBindings] = defaultAndNamedImport;
+    return `${indentation}const {default: ${defaultBinding}, ${normalizeNamedBindings(namedBindings)}} = await import(${moduleSource});`;
+  }
+
+  if (bindings.startsWith('{')) {
+    return `${indentation}const {${normalizeNamedBindings(bindings)}} = await import(${moduleSource});`;
+  }
+
+  return `${indentation}const {default: ${bindings}} = await import(${moduleSource});`;
+}
+
+function normalizeNamedBindings(bindings) {
+  return bindings
+    .replace(/^\{\s*|\s*\}$/g, '')
+    .replace(/([$\w]+)\s+as\s+([$\w]+)/g, '$1: $2');
+}

--- a/scripts/examples/synchronize-mobile-support-metadata.mjs
+++ b/scripts/examples/synchronize-mobile-support-metadata.mjs
@@ -4,6 +4,7 @@
 
 import {readFileSync, readdirSync, statSync, writeFileSync} from 'node:fs';
 import path from 'node:path';
+import {transformStaticImports} from './standalone-module-imports.mjs';
 
 const REPOSITORY_ROOT = process.cwd();
 const EXAMPLE_DIRECTORY = path.join(REPOSITORY_ROOT, 'examples');
@@ -124,20 +125,6 @@ ${tagIndentation}  if (exampleSupport.supported) {
 ${gatedSource}
 ${tagIndentation}  }
 ${tagIndentation}</script>`;
-    }
-  );
-}
-
-function transformStaticImports(source) {
-  return source.replace(
-    /(^[ \t]*)import\s+(.+?)\s+from\s+(["'])([^"']+)\3;?[ \t]*$/gm,
-    (statement, indentation, bindings, quote, moduleSource) => {
-      const destructuredBindings = bindings.startsWith('{')
-        ? bindings
-        : bindings.includes(', {')
-          ? `{default: ${bindings.replace(', {', ', ').replace(/}$/, '')}}`
-          : `{default: ${bindings}}`;
-      return `${indentation}const ${destructuredBindings} = await import(${quote}${moduleSource}${quote});`;
     }
   );
 }

--- a/test/examples/example-catalog-metadata.node.spec.ts
+++ b/test/examples/example-catalog-metadata.node.spec.ts
@@ -8,6 +8,7 @@ import path from 'node:path';
 import {describe, expect, test} from 'vitest';
 import {parse} from 'yaml';
 import {EXAMPLE_SUPPORT_REGISTRY} from '../../examples/example-support-registry';
+import {transformStaticImports} from '../../scripts/examples/standalone-module-imports.mjs';
 
 type ExampleSidebarEntry =
   | string
@@ -59,6 +60,21 @@ const LIVE_EXAMPLES = readLiveExamples();
 const requireCommonJSModule = createRequire(import.meta.url);
 
 describe('live example catalog metadata', () => {
+  test('rewrites namespace, aliased, and combined imports as valid dynamic imports', () => {
+    expect(transformStaticImports("import * as arrow from 'apache-arrow';")).toBe(
+      "const arrow = await import('apache-arrow');"
+    );
+    expect(transformStaticImports("import {Table as ArrowTable} from 'apache-arrow';")).toBe(
+      "const {Table: ArrowTable} = await import('apache-arrow');"
+    );
+    expect(transformStaticImports("import arrow, * as arrowNamespace from 'apache-arrow';")).toBe(
+      "const arrowNamespace = await import('apache-arrow');\nconst {default: arrow} = arrowNamespace;"
+    );
+    expect(
+      transformStaticImports("import Table, {makeTable as createTable} from 'apache-arrow';")
+    ).toBe("const {default: Table, makeTable: createTable} = await import('apache-arrow');");
+  });
+
   test('features MRC packet spraying in the visible showcase gallery', () => {
     expect(LIVE_EXAMPLES.find(({id}) => id === 'showcase/packet-spraying')).toMatchObject({
       id: 'showcase/packet-spraying',


### PR DESCRIPTION
## Summary

Addresses the remaining inline review comment from #3202, which merged before the fix commit was pushed.

- Extracts the standalone static-to-dynamic import transformer into a tested helper.
- Correctly rewrites namespace imports, aliased named imports, default-plus-namespace imports, and default-plus-aliased-named imports.
- Adds focused regression coverage using the repository-preferred `import * as arrow from 'apache-arrow'` form.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn test-node`: 2,933 passed, 3 skipped
- `yarn test`: node suite passes; headless reproduces the same six unrelated local WebGPU failures, with 1,812 browser tests passing and 23 skipped
- `yarn examples:synchronize-mobile-support` remains idempotent

Follow-up to #3202.