### PR TITLE
feat(gpgpu): compile GPU command graphs asynchronously

### DIFF
--- a/docs/api-guide/gpu/gpu-data-processing.md
+++ b/docs/api-guide/gpu/gpu-data-processing.md
@@ -65,7 +65,7 @@ execution.
 | --- | --- | --- |
 | Backend support | CPU, WebGL, and WebGPU | WebGPU only |
 | Programming model | Functional operations that produce lazy values | Explicit resources and compute, render, or copy nodes |
-| Execution | `await evaluator.evaluate(device)` | `compile()`, then encode into a caller-owned command encoder |
+| Execution | `await evaluator.evaluate(device)` | Prefer `await compileAsync()`, then encode into a caller-owned command encoder |
 | Submission | Managed by the selected backend | Controlled by the application |
 | Reuse | Materialized results are cached | A compiled workflow can be encoded repeatedly |
 | Temporary memory | Output buffers come from a reusable pool | Graph compilation aliases compatible transients with non-overlapping lifetimes |

--- a/docs/api-reference/core/device.md
+++ b/docs/api-reference/core/device.md
@@ -417,6 +417,16 @@ createRenderPipeline(props: RenderPipelineProps): RenderPipeline
 
 Creates a [`RenderPipeline`](./resources/render-pipeline) (aka program). See [`RenderPipelineProps`](./resources/render-pipeline.md#renderpipelineprops) for available options.
 
+### createRenderPipelineAsync
+
+```typescript
+createRenderPipelineAsync(props: RenderPipelineProps): Promise<RenderPipeline>
+```
+
+Creates a render pipeline through the backend's asynchronous compilation path. On WebGPU this uses
+the native `GPUDevice.createRenderPipelineAsync()` API; synchronous backends return an already
+resolved promise.
+
 ### createComputePipeline
 
 <DocumentationBadges>
@@ -429,6 +439,15 @@ createComputePipeline(props: ComputePipelineProps): ComputePipeline
 ```
 
 Creates a [`ComputePipeline`](./resources/compute-pipeline) (aka program). See [`ComputePipelineProps`](./resources/compute-pipeline.md#computepipelineprops) for available options.
+
+### createComputePipelineAsync
+
+```typescript
+createComputePipelineAsync(props: ComputePipelineProps): Promise<ComputePipeline>
+```
+
+Creates a compute pipeline through the backend's asynchronous compilation path. Start independent
+calls together and await them with `Promise.all()` when minimizing WebGPU preparation latency.
 
 ### createRenderBundleEncoder
 

--- a/docs/api-reference/core/pipeline-factory.md
+++ b/docs/api-reference/core/pipeline-factory.md
@@ -18,7 +18,11 @@ Pipeline creation involves shader compilation and backend-specific linking work.
 import {PipelineFactory} from '@luma.gl/core';
 
 const pipelineFactory = PipelineFactory.getDefaultPipelineFactory(device);
-const pipeline = pipelineFactory.createRenderPipeline({vs, fs, topology: 'triangle-list'});
+const pipeline = await pipelineFactory.createRenderPipelineAsync({
+  vs,
+  fs,
+  topology: 'triangle-list'
+});
 
 // Later, when the caller is done with the pipeline:
 pipelineFactory.release(pipeline);
@@ -53,6 +57,20 @@ Returns a render pipeline. If caching is enabled and an equivalent cached wrappe
 
 Equivalent cache-aware constructor for compute pipelines.
 
+### `createRenderPipelineAsync(props: RenderPipelineProps): Promise<RenderPipeline>`
+
+Uses the backend's asynchronous pipeline creation path and resolves when the render pipeline is
+ready. Use it when pipeline creation is part of an awaitable loading or preparation phase. Multiple
+concurrent requests for equivalent props share the same pending compilation as well as the finished
+cache entry.
+
+### `createComputePipelineAsync(props: ComputePipelineProps): Promise<ComputePipeline>`
+
+WebGPU equivalent of `createRenderPipelineAsync()`. Starting several calls before awaiting them lets
+the browser and driver compile independent pipelines concurrently. On a backend without native
+asynchronous pipeline creation, the device preserves the API by resolving a synchronously created
+pipeline.
+
 ### `release(pipeline: RenderPipeline | ComputePipeline): void`
 
 Releases a previously requested pipeline. When the reference count reaches zero, the pipeline is either destroyed or retained depending on `device.props._destroyPipelines`.
@@ -79,5 +97,5 @@ If an application creates very large numbers of distinct pipelines and cache gro
 
 - `PipelineFactory` hashing is based on pipeline inputs and device type, not just object identity.
 - WebGPU render-pipeline caching tracks immutable descriptor-shaping inputs such as shader sources, entry points, layouts, parameters, topology, buffer layout, and attachment formats.
-- Callers that use `createRenderPipeline()` or `createComputePipeline()` directly should pair those calls with `release()` to avoid leaking cached references.
+- Callers that use any synchronous or asynchronous `create*Pipeline()` method directly should pair each resolved pipeline with `release()` to avoid leaking cached references.
 - The exported `PipelineFactoryProps` type is currently an alias of [`RenderPipelineProps`](/docs/api-reference/core/resources/render-pipeline#renderpipelineprops).

--- a/docs/api-reference/engine/compute/computation.md
+++ b/docs/api-reference/engine/compute/computation.md
@@ -18,7 +18,7 @@ It plays the same role for compute work that [`Model`](/docs/api-reference/engin
 ```typescript
 import {Computation} from '@luma.gl/engine';
 
-const computation = new Computation(device, {
+const computation = await Computation.createAsync(device, {
   source: COMPUTE_SHADER_SOURCE,
   bindings: {
     inputBuffer,
@@ -78,6 +78,13 @@ Current `ShaderInputs` instance.
 ### `constructor(device: Device, props: ComputationProps)`
 
 Creates a computation wrapper for one WebGPU device. Throws on non-WebGPU devices.
+
+### `Computation.createAsync(device: Device, props: ComputationProps): Promise<Computation>`
+
+Creates the same computation through the device's asynchronous compute-pipeline path. Use this in
+an application loading phase, especially when several computations can be started together with
+`Promise.all()`. The returned computation is fully ready to dispatch. `GPUCommandGraph.compileAsync()`
+uses this behavior automatically for computations constructed by graph nodes.
 
 ### `destroy(): void`
 

--- a/docs/api-reference/engine/model.md
+++ b/docs/api-reference/engine/model.md
@@ -26,7 +26,7 @@ import {CubeGeometry, DynamicTexture, Model} from '@luma.gl/engine';
 
 const dynamicTexture = new DynamicTexture(device, {data: loadImageBitmap(url)});
 
-const model = new Model(device, {
+const model = await Model.createAsync(device, {
   vs: GLSL_VERTEX_SHADER,
   fs: GLSL_FRAGMENT_SHADER,
   geometry: new CubeGeometry(),
@@ -127,6 +127,13 @@ Application-owned metadata attached to the model.
 ### `constructor(device: Device, props: ModelProps)`
 
 Creates a render model for one device.
+
+### `Model.createAsync(device: Device, props: ModelProps): Promise<Model>`
+
+Creates the model through the device's asynchronous render-pipeline path and resolves after its
+pipeline and vertex array are ready. Prefer it during WebGPU loading when multiple independent models
+can be created with `Promise.all()`. The `new Model(...)` constructor remains the synchronous
+compatibility path.
 
 ### `destroy(): void`
 

--- a/docs/api-reference/experimental/gpu-core/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-command-graph.md
@@ -9,9 +9,11 @@ import {GPUDataAnalysisExample} from '@site/src/examples';
 ## Overview
 
 `GPUCommandGraph<Parameters>` declares fixed-capacity WebGPU buffer and texture resources plus
-ordered compute, render, and copy nodes. `compile()` returns a `CompiledGPUCommandGraph` that owns
-transient resources and node state but borrows every import. Render nodes can resolve multisampled
-attachments and consume explicitly numbered, frame-scoped swapchain and external-image bindings.
+ordered compute, render, and copy nodes. `compile()` returns a `CompiledGPUCommandGraph` through the
+legacy synchronous pipeline-creation path. `await compileAsync()` prepares independent pipelines in
+parallel where the backend supports it. Both forms return a graph that owns transient resources and
+node state but borrows every import. Render nodes can resolve multisampled attachments and consume
+explicitly numbered, frame-scoped swapchain and external-image bindings.
 
 See [Choosing a GPU Data-Processing API](/docs/api-guide/gpu/gpu-data-processing) for guidance on
 when to use a command graph, portable GPGPU evaluators, or lower-level compute helpers.
@@ -51,17 +53,31 @@ graph.addComputePass({
   compile: ({device}) => makeExecutableNode(device)
 });
 
-const compiled = graph.compile();
+const compiled = await graph.compileAsync();
 const encoding = compiled.encode(device.commandEncoder, {parameters: {time}});
 console.log(encoding.stats.cpuEncodeTimeMilliseconds);
 ```
 
 ## Lifecycle and ownership
 
-A graph definition is mutable until `compile()` is called. Compilation freezes the definition,
+A graph definition is mutable until `compile()` or `compileAsync()` is called. Compilation freezes the definition,
 infers a stable node order, plans transient allocation reuse, creates physical transients, and calls
 each node's `compile` callback once. The returned `CompiledGPUCommandGraph` can then be encoded
 repeatedly with different parameters and compatible imported-resource replacements.
+
+Prefer `compileAsync()` for WebGPU graphs with multiple shader pipelines. It begins every independent
+compute and render pipeline compilation before awaiting completion, and its promise resolves only
+when all node executables are ready to encode. This moves compilation latency behind an explicit
+awaitable preparation boundary and gives the browser and driver an opportunity to compile pipelines
+concurrently. It does not submit commands, execute a warm-up decode, or wait for queue work. Use the
+synchronous `compile()` only when immediate construction is required or when measuring compatibility
+with an older integration.
+
+Node callbacks that construct `Computation` or `Model` instances need no special handling: the graph
+collects their asynchronous pipeline work automatically. A custom node that prepares some other
+asynchronous resource can provide `compileAsync(context)` alongside its required synchronous
+`compile(context)` callback. `compileAsync()` prefers that callback for the node; `compile()` always
+uses the synchronous callback.
 
 Imported buffers, textures, external textures, `GPUData`, and `GPUVector` chunks are borrowed. The
 compiled graph owns only node-created resources, physical transients, and cached texture
@@ -421,7 +437,8 @@ output. A node cannot combine graph-managed attachments with a callback-provided
 ## Node APIs and graph commands
 
 A graph command is a reusable description of GPU work, not a second command queue or a hidden
-submission API. `compile()` prepares node executables once; `encode(commandEncoder, options)`
+submission API. `compile()` or `await compileAsync()` prepares node executables once;
+`encode(commandEncoder, options)`
 records them into the application's existing `CommandEncoder`; the application decides when to
 submit that encoder. This distinction lets analytics, rendering, and explicitly requested
 readback share one dependency-ordered execution without taking ownership of the frame loop.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -25,6 +25,9 @@ Target Release Date: Q3, 2026
 - **Fixed-size-list GPU columns** - First-class `fixed-size-list<float32,768>` formats describe arbitrary fixed-width storage rows without inventing unsupported vertex formats; vectors retain logical table-row counts, flattened element counts, preserved batches, and caller-owned storage.
 - **GPU vector similarity and clustering** - The optional [`@luma.gl/gpgpu/gpu-vector-search`](/docs/api-reference/gpgpu/gpu-vector-search) backend searches ordinary fixed-size-list GPU table columns with exact squared-Euclidean, cosine, and inner-product rankings; GPU-resident linked-selection masks; deterministic bounded top-K output; GPU k-means; and explicitly approximate IVF-flat search. Existing `@luma.gl/arrow` table adapters upload Arrow embedding columns, while source IDs, validity, batch boundaries, ownership, and rendering remain caller-controlled.
 - **GPU command graphs** - Experimental WebGPU command graphs compile explicit buffer hazards, fixed capacities, node resources, and transient-buffer reuse while leaving encoding and submission under application control.
+- **Parallel command-graph preparation** - `await GPUCommandGraph.compileAsync()` starts independent
+  compute and render pipeline compilations together, resolves only when graph-owned pipelines are
+  ready, and leaves command submission and warm-up execution to the application.
 - **Reusable command-graph inspection** - `GPUCommandGraphInspector` collects bounded whole-graph and per-node CPU/GPU timing summaries, compile-time allocation statistics, and device capabilities for application-owned diagnostic UIs.
 - **Flat GPU scene records** - `GPUScene` owns or borrows a fixed-capacity, table-independent draw database with stable IDs, bounds, transforms, grouping, geometry references, command slots, and typed command-graph views. Validated mutation transactions add bounded insert, patch, removal, stable compaction, overflow, move reporting, and exact queue-write costs without introducing a CPU scene hierarchy.
 - **Explicit GPU scene adapters** - `makeGPUSceneFromCPUScene()` maps application-owned hierarchies into ordinary mutable scene records through stable preorder callbacks, while `makeGPUScenePartitionsFromGPUTable()` borrows canonical interleaved records from every preserved table batch without readback, concatenation, or hidden packing. Empty batches retain partition identity, and per-buffer ownership keeps table records borrowed while adapter state is released normally.
@@ -46,6 +49,9 @@ Target Release Date: Q3, 2026
 
 **@luma.gl/engine**
 
+- **Awaitable pipeline creation** - `Computation.createAsync()` and `Model.createAsync()` expose
+  native asynchronous WebGPU pipeline creation for application loading phases, backed by
+  cache-aware asynchronous `Device` and `PipelineFactory` methods.
 - **Pinch-roll orbit controls** - Two-pointer gestures can roll the camera while preserving the
   existing pan, orbit, and zoom interactions.
 

--- a/examples/experimental/gpu-parquet-constellation/app.ts
+++ b/examples/experimental/gpu-parquet-constellation/app.ts
@@ -438,7 +438,7 @@ export default class GPUParquetConstellationAnimationLoopTemplate extends Animat
             ])
           ) as Record<ParquetConstellationColumn, GraphBufferHandle>;
           this.addDecodedPageCopies(decodeGraph, batch.columns, decoded.pages, destinationHandles);
-          compiledDecode = decodeGraph.compile();
+          compiledDecode = await decodeGraph.compileAsync();
           const decodeGraphNodeCount = compiledDecode.stats.nodeOrder.length;
           const decodeExecutionMilliseconds = await this.executeGPUDecode(compiledDecode, signal);
           return this.createPreparedScene(

--- a/examples/experimental/gpu-parquet-constellation/app.ts
+++ b/examples/experimental/gpu-parquet-constellation/app.ts
@@ -795,10 +795,10 @@ export default class GPUParquetConstellationAnimationLoopTemplate extends Animat
     element.innerHTML = `<div style="margin-bottom:9px">
       ${formatBytes(this.parquetBytes?.byteLength ?? 0)} fixture · ${this.fetchMilliseconds.toFixed(1)} ms fetch · ${formatCount(PAGE_SIZE)}-row write batches
     </div>
-    <table style="width:100%;border-collapse:collapse;text-align:right">
+    <table style="width:100%;border-collapse:collapse;text-align:right;font-size:12px;line-height:1.25">
       <thead><tr><th style="text-align:left"></th><th>GPU path</th><th>CPU path</th></tr></thead>
       <tbody>
-        <tr style="border-top:1px solid #334155;border-bottom:1px solid #334155"><th style="padding:5px 0;text-align:left">Parquet → render-ready</th><td style="font-weight:700">${formatMetric(gpuMeasurement, value => `${value.elapsedMilliseconds.toFixed(1)} ms`)}</td><td style="font-weight:700">${formatMetric(cpuMeasurement, value => `${value.elapsedMilliseconds.toFixed(1)} ms`)}</td></tr>
+        <tr><th style="padding:2px 0;text-align:left">Parquet → render-ready</th><td style="font-weight:700">${formatMetric(gpuMeasurement, value => `${value.elapsedMilliseconds.toFixed(1)} ms`)}</td><td style="font-weight:700">${formatMetric(cpuMeasurement, value => `${value.elapsedMilliseconds.toFixed(1)} ms`)}</td></tr>
         <tr><th style="text-align:left;font-weight:normal">Graph + pipeline preparation</th><td>${formatMetric(gpuMeasurement, value => `${value.graphCompileMilliseconds.toFixed(1)} ms`)}</td><td>n/a</td></tr>
         <tr><th style="text-align:left;font-weight:normal">Decode stage (first run)</th><td>${formatMetric(gpuMeasurement, value => `${value.decodeExecutionMilliseconds.toFixed(1)} ms`)}</td><td>${formatMetric(cpuMeasurement, value => `${value.decodeExecutionMilliseconds.toFixed(1)} ms`)}</td></tr>
         <tr><th style="text-align:left;font-weight:normal">GPU decode (warmed median, ${WARMED_DECODE_SAMPLE_COUNT} runs)</th><td>${formatMetric(gpuMeasurement, value => (value.reusedGraphExecutionMilliseconds === undefined ? '—' : `${value.reusedGraphExecutionMilliseconds.toFixed(1)} ms`))}</td><td>n/a</td></tr>

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -784,8 +784,28 @@ or create a device with the 'debug: true' prop.`;
   /** Create a render pipeline (aka program) */
   abstract createRenderPipeline(props: RenderPipelineProps): RenderPipeline;
 
+  /**
+   * Create a render pipeline asynchronously when the backend supports it.
+   *
+   * The default implementation preserves compatibility with synchronous backends. WebGPU
+   * implementations override this method to use `GPUDevice.createRenderPipelineAsync()`.
+   */
+  async createRenderPipelineAsync(props: RenderPipelineProps): Promise<RenderPipeline> {
+    return this.createRenderPipeline(props);
+  }
+
   /** Create a compute pipeline (aka program). WebGPU only. */
   abstract createComputePipeline(props: ComputePipelineProps): ComputePipeline;
+
+  /**
+   * Create a compute pipeline asynchronously when the backend supports it.
+   *
+   * The default implementation preserves compatibility with synchronous backends. WebGPU
+   * implementations override this method to use `GPUDevice.createComputePipelineAsync()`.
+   */
+  async createComputePipelineAsync(props: ComputePipelineProps): Promise<ComputePipeline> {
+    return this.createComputePipeline(props);
+  }
 
   /**
    * Creates an encoder for reusable WebGPU draw commands.

--- a/modules/core/src/factories/pipeline-factory.ts
+++ b/modules/core/src/factories/pipeline-factory.ts
@@ -14,6 +14,36 @@ import type {CoreModuleState} from './core-module-state';
 export type PipelineFactoryProps = RenderPipelineProps;
 
 type CacheItem<ResourceT extends Resource<any>> = {resource: ResourceT; useCount: number};
+type PendingCacheItem<ResourceT extends Resource<any>> = {
+  promise: Promise<ResourceT>;
+  useCount: number;
+};
+
+const asyncCompilationByDevice = new WeakMap<Device, AsyncPipelineCompilation>();
+
+/** Collects pipeline promises started during one synchronous resource-construction phase. */
+export class AsyncPipelineCompilation {
+  private readonly promises: Promise<unknown>[] = [];
+  private closed = false;
+
+  /** @internal Registers work that must finish before the compiled owner can be used. */
+  add(promise: Promise<unknown>): void {
+    if (this.closed) {
+      throw new Error('Cannot add a pipeline after the asynchronous compilation phase has closed');
+    }
+    this.promises.push(promise);
+  }
+
+  /** @internal Stops collecting new pipelines and waits for every registered pipeline in parallel. */
+  async finish(): Promise<void> {
+    this.closed = true;
+    const results = await Promise.allSettled(this.promises);
+    const failure = results.find(result => result.status === 'rejected');
+    if (failure?.status === 'rejected') {
+      throw failure.reason;
+    }
+  }
+}
 
 /**
  * Efficiently creates / caches pipelines
@@ -28,12 +58,46 @@ export class PipelineFactory {
     return moduleData.defaultPipelineFactory;
   }
 
+  /**
+   * Opens a synchronous construction scope that collects asynchronous pipeline work.
+   *
+   * Orchestrators use this while constructing several independent pipeline owners. The scope must
+   * be closed before yielding back to the event loop.
+   *
+   * @internal
+   */
+  static beginAsyncCompilation(device: Device): AsyncPipelineCompilation {
+    if (asyncCompilationByDevice.has(device)) {
+      throw new Error('An asynchronous pipeline compilation scope is already active');
+    }
+    const compilation = new AsyncPipelineCompilation();
+    asyncCompilationByDevice.set(device, compilation);
+    return compilation;
+  }
+
+  /** @internal Returns the construction scope currently collecting pipelines for this device. */
+  static getAsyncCompilation(device: Device): AsyncPipelineCompilation | undefined {
+    return asyncCompilationByDevice.get(device);
+  }
+
+  /** @internal Closes a construction scope before its promises are awaited. */
+  static endAsyncCompilation(device: Device, compilation: AsyncPipelineCompilation): void {
+    if (asyncCompilationByDevice.get(device) !== compilation) {
+      throw new Error('The asynchronous pipeline compilation scope is not active');
+    }
+    asyncCompilationByDevice.delete(device);
+  }
+
   readonly device: Device;
 
   private _hashCounter: number = 0;
   private readonly _hashes: Record<string, number> = {};
   private readonly _renderPipelineCache: Record<string, CacheItem<RenderPipeline>> = {};
   private readonly _computePipelineCache: Record<string, CacheItem<ComputePipeline>> = {};
+  private readonly _pendingRenderPipelineCache: Record<string, PendingCacheItem<RenderPipeline>> =
+    {};
+  private readonly _pendingComputePipelineCache: Record<string, PendingCacheItem<ComputePipeline>> =
+    {};
   private readonly _sharedRenderPipelineCache: Record<string, CacheItem<SharedRenderPipeline>> = {};
 
   get [Symbol.toStringTag](): string {
@@ -100,6 +164,58 @@ export class PipelineFactory {
     return pipeline;
   }
 
+  /**
+   * Asynchronously returns a render pipeline matching the supplied props.
+   *
+   * Concurrent requests for an equivalent pipeline share one pending backend compilation.
+   */
+  async createRenderPipelineAsync(props: RenderPipelineProps): Promise<RenderPipeline> {
+    if (!this.device.props._cachePipelines) {
+      return await this.device.createRenderPipelineAsync(props);
+    }
+
+    const allProps: Required<RenderPipelineProps> = {...RenderPipeline.defaultProps, ...props};
+    const hash = this._hashRenderPipeline(allProps);
+    const cachedItem = this._renderPipelineCache[hash];
+    if (cachedItem) {
+      cachedItem.useCount++;
+      return cachedItem.resource;
+    }
+
+    const pendingItem = this._pendingRenderPipelineCache[hash];
+    if (pendingItem) {
+      pendingItem.useCount++;
+      return await pendingItem.promise;
+    }
+
+    const item: PendingCacheItem<RenderPipeline> = {
+      promise: undefined!,
+      useCount: 1
+    };
+    const sharedRenderPipeline =
+      this.device.type === 'webgl' && this.device.props._sharePipelines
+        ? this.createSharedRenderPipeline(allProps)
+        : undefined;
+    item.promise = this.device
+      .createRenderPipelineAsync({
+        ...allProps,
+        id: allProps.id ? `${allProps.id}-cached` : uid('unnamed-cached'),
+        _sharedRenderPipeline: sharedRenderPipeline
+      })
+      .then(pipeline => {
+        pipeline.hash = hash;
+        this._renderPipelineCache[hash] = {resource: pipeline, useCount: item.useCount};
+        delete this._pendingRenderPipelineCache[hash];
+        return pipeline;
+      })
+      .catch(error => {
+        delete this._pendingRenderPipelineCache[hash];
+        throw error;
+      });
+    this._pendingRenderPipelineCache[hash] = item;
+    return await item.promise;
+  }
+
   /** Return a ComputePipeline matching supplied props. Reuses an equivalent pipeline if already created. */
   createComputePipeline(props: ComputePipelineProps): ComputePipeline {
     if (!this.device.props._cachePipelines) {
@@ -133,6 +249,53 @@ export class PipelineFactory {
     }
 
     return pipeline;
+  }
+
+  /**
+   * Asynchronously returns a compute pipeline matching the supplied props.
+   *
+   * Concurrent requests for an equivalent pipeline share one pending backend compilation.
+   */
+  async createComputePipelineAsync(props: ComputePipelineProps): Promise<ComputePipeline> {
+    if (!this.device.props._cachePipelines) {
+      return await this.device.createComputePipelineAsync(props);
+    }
+
+    const allProps: Required<ComputePipelineProps> = {...ComputePipeline.defaultProps, ...props};
+    const hash = this._hashComputePipeline(allProps);
+    const cachedItem = this._computePipelineCache[hash];
+    if (cachedItem) {
+      cachedItem.useCount++;
+      return cachedItem.resource;
+    }
+
+    const pendingItem = this._pendingComputePipelineCache[hash];
+    if (pendingItem) {
+      pendingItem.useCount++;
+      return await pendingItem.promise;
+    }
+
+    const item: PendingCacheItem<ComputePipeline> = {
+      promise: undefined!,
+      useCount: 1
+    };
+    item.promise = this.device
+      .createComputePipelineAsync({
+        ...allProps,
+        id: allProps.id ? `${allProps.id}-cached` : undefined
+      })
+      .then(pipeline => {
+        pipeline.hash = hash;
+        this._computePipelineCache[hash] = {resource: pipeline, useCount: item.useCount};
+        delete this._pendingComputePipelineCache[hash];
+        return pipeline;
+      })
+      .catch(error => {
+        delete this._pendingComputePipelineCache[hash];
+        throw error;
+      });
+    this._pendingComputePipelineCache[hash] = item;
+    return await item.promise;
   }
 
   release(pipeline: RenderPipeline | ComputePipeline): void {

--- a/modules/core/src/factories/pipeline-factory.ts
+++ b/modules/core/src/factories/pipeline-factory.ts
@@ -19,31 +19,7 @@ type PendingCacheItem<ResourceT extends Resource<any>> = {
   useCount: number;
 };
 
-const asyncCompilationByDevice = new WeakMap<Device, AsyncPipelineCompilation>();
-
-/** Collects pipeline promises started during one synchronous resource-construction phase. */
-export class AsyncPipelineCompilation {
-  private readonly promises: Promise<unknown>[] = [];
-  private closed = false;
-
-  /** @internal Registers work that must finish before the compiled owner can be used. */
-  add(promise: Promise<unknown>): void {
-    if (this.closed) {
-      throw new Error('Cannot add a pipeline after the asynchronous compilation phase has closed');
-    }
-    this.promises.push(promise);
-  }
-
-  /** @internal Stops collecting new pipelines and waits for every registered pipeline in parallel. */
-  async finish(): Promise<void> {
-    this.closed = true;
-    const results = await Promise.allSettled(this.promises);
-    const failure = results.find(result => result.status === 'rejected');
-    if (failure?.status === 'rejected') {
-      throw failure.reason;
-    }
-  }
-}
+const asyncCompilationByDevice = new WeakMap<Device, Promise<unknown>[]>();
 
 /**
  * Efficiently creates / caches pipelines
@@ -66,22 +42,22 @@ export class PipelineFactory {
    *
    * @internal
    */
-  static beginAsyncCompilation(device: Device): AsyncPipelineCompilation {
+  static beginAsyncCompilation(device: Device): Promise<unknown>[] {
     if (asyncCompilationByDevice.has(device)) {
       throw new Error('An asynchronous pipeline compilation scope is already active');
     }
-    const compilation = new AsyncPipelineCompilation();
+    const compilation: Promise<unknown>[] = [];
     asyncCompilationByDevice.set(device, compilation);
     return compilation;
   }
 
   /** @internal Returns the construction scope currently collecting pipelines for this device. */
-  static getAsyncCompilation(device: Device): AsyncPipelineCompilation | undefined {
+  static getAsyncCompilation(device: Device): Promise<unknown>[] | undefined {
     return asyncCompilationByDevice.get(device);
   }
 
   /** @internal Closes a construction scope before its promises are awaited. */
-  static endAsyncCompilation(device: Device, compilation: AsyncPipelineCompilation): void {
+  static endAsyncCompilation(device: Device, compilation: Promise<unknown>[]): void {
     if (asyncCompilationByDevice.get(device) !== compilation) {
       throw new Error('The asynchronous pipeline compilation scope is not active');
     }
@@ -176,51 +152,22 @@ export class PipelineFactory {
 
     const allProps: Required<RenderPipelineProps> = {...RenderPipeline.defaultProps, ...props};
     const hash = this._hashRenderPipeline(allProps);
-    const cachedItem = this._renderPipelineCache[hash];
-    if (cachedItem) {
-      cachedItem.useCount++;
-      return cachedItem.resource;
-    }
-
-    const pendingItem = this._pendingRenderPipelineCache[hash];
-    if (pendingItem) {
-      pendingItem.useCount++;
-      return await pendingItem.promise;
-    }
-
-    const item: PendingCacheItem<RenderPipeline> = {
-      promise: undefined!,
-      useCount: 1
-    };
-    const sharedRenderPipeline =
-      this.device.type === 'webgl' && this.device.props._sharePipelines
-        ? this.createSharedRenderPipeline(allProps)
-        : undefined;
-    item.promise = this.device
-      .createRenderPipelineAsync({
-        ...allProps,
-        id: allProps.id ? `${allProps.id}-cached` : uid('unnamed-cached'),
-        _sharedRenderPipeline: sharedRenderPipeline
-      })
-      .then(pipeline => {
-        delete this._pendingRenderPipelineCache[hash];
-        const cachedItem = this._renderPipelineCache[hash];
-        if (cachedItem) {
-          cachedItem.useCount += item.useCount;
-          pipeline.destroy();
-          this.releaseSharedRenderPipeline(pipeline);
-          return cachedItem.resource;
-        }
-        pipeline.hash = hash;
-        this._renderPipelineCache[hash] = {resource: pipeline, useCount: item.useCount};
-        return pipeline;
-      })
-      .catch(error => {
-        delete this._pendingRenderPipelineCache[hash];
-        throw error;
-      });
-    this._pendingRenderPipelineCache[hash] = item;
-    return await item.promise;
+    return await this._createPipelineAsync(
+      this._renderPipelineCache,
+      this._pendingRenderPipelineCache,
+      hash,
+      () => {
+        const sharedRenderPipeline =
+          this.device.type === 'webgl' && this.device.props._sharePipelines
+            ? this.createSharedRenderPipeline(allProps)
+            : undefined;
+        return this.device.createRenderPipelineAsync({
+          ...allProps,
+          id: allProps.id ? `${allProps.id}-cached` : uid('unnamed-cached'),
+          _sharedRenderPipeline: sharedRenderPipeline
+        });
+      }
+    );
   }
 
   /** Return a ComputePipeline matching supplied props. Reuses an equivalent pipeline if already created. */
@@ -270,45 +217,16 @@ export class PipelineFactory {
 
     const allProps: Required<ComputePipelineProps> = {...ComputePipeline.defaultProps, ...props};
     const hash = this._hashComputePipeline(allProps);
-    const cachedItem = this._computePipelineCache[hash];
-    if (cachedItem) {
-      cachedItem.useCount++;
-      return cachedItem.resource;
-    }
-
-    const pendingItem = this._pendingComputePipelineCache[hash];
-    if (pendingItem) {
-      pendingItem.useCount++;
-      return await pendingItem.promise;
-    }
-
-    const item: PendingCacheItem<ComputePipeline> = {
-      promise: undefined!,
-      useCount: 1
-    };
-    item.promise = this.device
-      .createComputePipelineAsync({
-        ...allProps,
-        id: allProps.id ? `${allProps.id}-cached` : undefined
-      })
-      .then(pipeline => {
-        delete this._pendingComputePipelineCache[hash];
-        const cachedItem = this._computePipelineCache[hash];
-        if (cachedItem) {
-          cachedItem.useCount += item.useCount;
-          pipeline.destroy();
-          return cachedItem.resource;
-        }
-        pipeline.hash = hash;
-        this._computePipelineCache[hash] = {resource: pipeline, useCount: item.useCount};
-        return pipeline;
-      })
-      .catch(error => {
-        delete this._pendingComputePipelineCache[hash];
-        throw error;
-      });
-    this._pendingComputePipelineCache[hash] = item;
-    return await item.promise;
+    return await this._createPipelineAsync(
+      this._computePipelineCache,
+      this._pendingComputePipelineCache,
+      hash,
+      () =>
+        this.device.createComputePipelineAsync({
+          ...allProps,
+          id: allProps.id ? `${allProps.id}-cached` : undefined
+        })
+    );
   }
 
   release(pipeline: RenderPipeline | ComputePipeline): void {
@@ -365,6 +283,48 @@ export class PipelineFactory {
   }
 
   // PRIVATE
+
+  private async _createPipelineAsync<ResourceT extends RenderPipeline | ComputePipeline>(
+    cache: Record<string, CacheItem<ResourceT>>,
+    pendingCache: Record<string, PendingCacheItem<ResourceT>>,
+    hash: string,
+    create: () => Promise<ResourceT>
+  ): Promise<ResourceT> {
+    const cachedItem = cache[hash];
+    if (cachedItem) {
+      cachedItem.useCount++;
+      return cachedItem.resource;
+    }
+    const pendingItem = pendingCache[hash];
+    if (pendingItem) {
+      pendingItem.useCount++;
+      return await pendingItem.promise;
+    }
+
+    const item: PendingCacheItem<ResourceT> = {promise: undefined!, useCount: 1};
+    item.promise = create()
+      .then(pipeline => {
+        delete pendingCache[hash];
+        const synchronousItem = cache[hash];
+        if (synchronousItem) {
+          synchronousItem.useCount += item.useCount;
+          pipeline.destroy();
+          if (pipeline instanceof RenderPipeline) {
+            this.releaseSharedRenderPipeline(pipeline);
+          }
+          return synchronousItem.resource;
+        }
+        pipeline.hash = hash;
+        cache[hash] = {resource: pipeline, useCount: item.useCount};
+        return pipeline;
+      })
+      .catch(error => {
+        delete pendingCache[hash];
+        throw error;
+      });
+    pendingCache[hash] = item;
+    return await item.promise;
+  }
 
   /** Destroy a cached pipeline, removing it from the cache if configured to do so. */
   private _destroyPipeline(pipeline: RenderPipeline | ComputePipeline): boolean {

--- a/modules/core/src/factories/pipeline-factory.ts
+++ b/modules/core/src/factories/pipeline-factory.ts
@@ -203,9 +203,16 @@ export class PipelineFactory {
         _sharedRenderPipeline: sharedRenderPipeline
       })
       .then(pipeline => {
+        delete this._pendingRenderPipelineCache[hash];
+        const cachedItem = this._renderPipelineCache[hash];
+        if (cachedItem) {
+          cachedItem.useCount += item.useCount;
+          pipeline.destroy();
+          this.releaseSharedRenderPipeline(pipeline);
+          return cachedItem.resource;
+        }
         pipeline.hash = hash;
         this._renderPipelineCache[hash] = {resource: pipeline, useCount: item.useCount};
-        delete this._pendingRenderPipelineCache[hash];
         return pipeline;
       })
       .catch(error => {
@@ -285,9 +292,15 @@ export class PipelineFactory {
         id: allProps.id ? `${allProps.id}-cached` : undefined
       })
       .then(pipeline => {
+        delete this._pendingComputePipelineCache[hash];
+        const cachedItem = this._computePipelineCache[hash];
+        if (cachedItem) {
+          cachedItem.useCount += item.useCount;
+          pipeline.destroy();
+          return cachedItem.resource;
+        }
         pipeline.hash = hash;
         this._computePipelineCache[hash] = {resource: pipeline, useCount: item.useCount};
-        delete this._pendingComputePipelineCache[hash];
         return pipeline;
       })
       .catch(error => {

--- a/modules/core/test/factories/pipeline-factory.spec.ts
+++ b/modules/core/test/factories/pipeline-factory.spec.ts
@@ -5,7 +5,14 @@
 import {expect, it} from 'vitest';
 import {getWebGLTestDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
 
-import {luma, PipelineFactory} from '@luma.gl/core';
+import {
+  luma,
+  PipelineFactory,
+  type ComputePipeline,
+  type ComputePipelineProps,
+  type RenderPipeline,
+  type RenderPipelineProps
+} from '@luma.gl/core';
 import {webgl2Adapter, type WebGLDevice} from '@luma.gl/webgl';
 
 const vsSource = /* glsl */ `\
@@ -77,6 +84,21 @@ const webgpuRenderSource = /* wgsl */ `
 
 @fragment fn fragmentAlternateMain() -> @location(0) vec4<f32> {
   return fragmentMain();
+}
+`;
+
+const webgpuComputeSource = /* wgsl */ `
+@compute @workgroup_size(1) fn main() {}
+`;
+
+const webgpuAsyncRenderSource = /* wgsl */ `
+@vertex fn vertexMain(@builtin(vertex_index) vertexIndex: u32) -> @builtin(position) vec4<f32> {
+  let x = f32(i32(vertexIndex) - 1);
+  return vec4<f32>(x, select(-1.0, 1.0, vertexIndex == 2u), 0.0, 1.0);
+}
+
+@fragment fn fragmentMain() -> @location(0) vec4<f32> {
+  return vec4<f32>(1.0);
 }
 `;
 
@@ -357,6 +379,82 @@ it('PipelineFactory#caching with WebGPU attachment formats', async () => {
   shader.destroy();
 
   void 0;
+});
+
+it('PipelineFactory preserves a synchronous compute cache entry when async compilation finishes', async () => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice?.props._cachePipelines) {
+    return;
+  }
+
+  const pipelineFactory = new PipelineFactory(webgpuDevice);
+  const shader = webgpuDevice.createShader({source: webgpuComputeSource});
+  const props: ComputePipelineProps = {shader, shaderLayout: {bindings: []}};
+  const originalCreateComputePipelineAsync =
+    webgpuDevice.createComputePipelineAsync.bind(webgpuDevice);
+  let releaseCompilation!: () => void;
+  const compilationGate = new Promise<void>(resolve => (releaseCompilation = resolve));
+  let discardedPipeline: ComputePipeline | undefined;
+  webgpuDevice.createComputePipelineAsync = async asyncProps => {
+    await compilationGate;
+    discardedPipeline = await originalCreateComputePipelineAsync(asyncProps);
+    return discardedPipeline;
+  };
+
+  try {
+    const asynchronousPipelinePromise = pipelineFactory.createComputePipelineAsync(props);
+    const synchronousPipeline = pipelineFactory.createComputePipeline(props);
+    releaseCompilation();
+    const asynchronousPipeline = await asynchronousPipelinePromise;
+
+    expect(asynchronousPipeline).toBe(synchronousPipeline);
+    expect(discardedPipeline?.destroyed).toBe(true);
+    expect(() => pipelineFactory.release(synchronousPipeline)).not.toThrow();
+    expect(() => pipelineFactory.release(asynchronousPipeline)).not.toThrow();
+  } finally {
+    webgpuDevice.createComputePipelineAsync = originalCreateComputePipelineAsync;
+    shader.destroy();
+  }
+});
+
+it('PipelineFactory preserves a synchronous render cache entry when async compilation finishes', async () => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice?.props._cachePipelines) {
+    return;
+  }
+
+  const pipelineFactory = new PipelineFactory(webgpuDevice);
+  const shader = webgpuDevice.createShader({source: webgpuAsyncRenderSource});
+  const props: RenderPipelineProps = {
+    vs: shader,
+    fs: shader,
+    topology: 'triangle-list'
+  };
+  const originalCreateRenderPipelineAsync =
+    webgpuDevice.createRenderPipelineAsync.bind(webgpuDevice);
+  let releaseCompilation!: () => void;
+  const compilationGate = new Promise<void>(resolve => (releaseCompilation = resolve));
+  let discardedPipeline: RenderPipeline | undefined;
+  webgpuDevice.createRenderPipelineAsync = async asyncProps => {
+    await compilationGate;
+    discardedPipeline = await originalCreateRenderPipelineAsync(asyncProps);
+    return discardedPipeline;
+  };
+
+  try {
+    const asynchronousPipelinePromise = pipelineFactory.createRenderPipelineAsync(props);
+    const synchronousPipeline = pipelineFactory.createRenderPipeline(props);
+    releaseCompilation();
+    const asynchronousPipeline = await asynchronousPipelinePromise;
+
+    expect(asynchronousPipeline).toBe(synchronousPipeline);
+    expect(discardedPipeline?.handle).toBe(null);
+    expect(() => pipelineFactory.release(synchronousPipeline)).not.toThrow();
+    expect(() => pipelineFactory.release(asynchronousPipeline)).not.toThrow();
+  } finally {
+    webgpuDevice.createRenderPipelineAsync = originalCreateRenderPipelineAsync;
+    shader.destroy();
+  }
 });
 
 it('PipelineFactory#caching with explicit WebGPU depth attachments when depth writes are disabled', async () => {

--- a/modules/engine/src/compute/computation.ts
+++ b/modules/engine/src/compute/computation.ts
@@ -77,6 +77,36 @@ export type ComputationProps = Omit<ComputePipelineProps, 'shader'> & {
  * - accepts modules and performs shader transpilation
  */
 export class Computation {
+  /**
+   * Creates a computation while allowing the backend to compile its pipeline asynchronously.
+   *
+   * Use this factory when several independent computations can be prepared together. Calling the
+   * constructor remains the synchronous compatibility path.
+   */
+  static async createAsync(device: Device, props: ComputationProps): Promise<Computation> {
+    const ownsCompilation = !PipelineFactory.getAsyncCompilation(device);
+    const asyncCompilation = ownsCompilation
+      ? PipelineFactory.beginAsyncCompilation(device)
+      : PipelineFactory.getAsyncCompilation(device)!;
+    let computation: Computation;
+    try {
+      computation = new Computation(device, props);
+    } finally {
+      if (ownsCompilation) PipelineFactory.endAsyncCompilation(device, asyncCompilation);
+    }
+    try {
+      if (ownsCompilation) {
+        await asyncCompilation.finish();
+      } else {
+        await computation._pipelineInitialization;
+      }
+      return computation;
+    } catch (error) {
+      computation.destroy();
+      throw error;
+    }
+  }
+
   static defaultProps: Required<ComputationProps> = {
     ...ComputePipeline.defaultProps,
     id: 'unnamed',
@@ -110,7 +140,7 @@ export class Computation {
   bindings: Record<string, Binding> = {};
 
   /** The underlying GPU pipeline. */
-  pipeline: ComputePipeline;
+  pipeline!: ComputePipeline;
   /** Assembled compute shader source */
   source: string;
   /** the underlying compiled compute shader */
@@ -129,6 +159,7 @@ export class Computation {
   private props: Required<ComputationProps>;
 
   private _destroyed = false;
+  private _pipelineInitialization?: Promise<ComputePipeline>;
 
   constructor(device: Device, props: ComputationProps) {
     if (device.type !== 'webgpu') {
@@ -209,7 +240,13 @@ export class Computation {
 
     // Create the pipeline
     // @note order is important
-    this.pipeline = this._updatePipeline();
+    const asyncCompilation = PipelineFactory.getAsyncCompilation(this.device);
+    if (asyncCompilation) {
+      this._pipelineInitialization = this._updatePipelineAsync();
+      asyncCompilation.add(this._pipelineInitialization);
+    } else {
+      this.pipeline = this._updatePipeline();
+    }
 
     // Apply any dynamic settings that will not trigger pipeline change
     if (props.bindings) {
@@ -219,8 +256,8 @@ export class Computation {
 
   destroy(): void {
     if (this._destroyed) return;
-    this.pipelineFactory.release(this.pipeline);
-    this.shaderFactory.release(this.shader);
+    if (this.pipeline) this.pipelineFactory.release(this.pipeline);
+    if (this.shader) this.shaderFactory.release(this.shader);
     this._uniformStore.destroy();
     this._destroyed = true;
   }
@@ -345,35 +382,52 @@ export class Computation {
   }
 
   _updatePipeline(): ComputePipeline {
-    if (this._pipelineNeedsUpdate) {
-      let prevShader: Shader | null = null;
-      if (this.pipeline) {
-        log.log(
-          1,
-          `Model ${this.id}: Recreating pipeline because "${this._pipelineNeedsUpdate}".`
-        )();
-        prevShader = this.shader;
-      }
-
-      this._pipelineNeedsUpdate = false;
-
-      this.shader = this.shaderFactory.createShader({
-        id: `${this.id}-fragment`,
-        stage: 'compute',
-        source: this.source,
-        debugShaders: this.props.debugShaders
-      });
-
-      this.pipeline = this.pipelineFactory.createComputePipeline({
-        ...this.props,
-        shader: this.shader
-      });
-
-      if (prevShader) {
-        this.shaderFactory.release(prevShader);
-      }
+    const update = this._preparePipelineUpdate();
+    if (update) {
+      this.pipeline = this.pipelineFactory.createComputePipeline(update.props);
+      this._finishPipelineUpdate(update.previousShader);
     }
     return this.pipeline;
+  }
+
+  /** Creates or replaces the pipeline through the backend's asynchronous compilation path. */
+  async _updatePipelineAsync(): Promise<ComputePipeline> {
+    const update = this._preparePipelineUpdate();
+    if (update) {
+      try {
+        this.pipeline = await this.pipelineFactory.createComputePipelineAsync(update.props);
+      } catch (error) {
+        this.shaderFactory.release(this.shader);
+        this.shader = update.previousShader!;
+        this._pipelineNeedsUpdate = 'asynchronous pipeline creation failed';
+        throw error;
+      }
+      this._finishPipelineUpdate(update.previousShader);
+    }
+    return this.pipeline;
+  }
+
+  private _preparePipelineUpdate(): {
+    props: ComputePipelineProps;
+    previousShader: Shader | null;
+  } | null {
+    if (!this._pipelineNeedsUpdate) return null;
+    const previousShader = this.pipeline ? this.shader : null;
+    if (this.pipeline) {
+      log.log(1, `Model ${this.id}: Recreating pipeline because "${this._pipelineNeedsUpdate}".`)();
+    }
+    this._pipelineNeedsUpdate = false;
+    this.shader = this.shaderFactory.createShader({
+      id: `${this.id}-fragment`,
+      stage: 'compute',
+      source: this.source,
+      debugShaders: this.props.debugShaders
+    });
+    return {props: {...this.props, shader: this.shader}, previousShader};
+  }
+
+  private _finishPipelineUpdate(previousShader: Shader | null): void {
+    if (previousShader) this.shaderFactory.release(previousShader);
   }
 
   /** Throttle draw call logging */

--- a/modules/engine/src/compute/computation.ts
+++ b/modules/engine/src/compute/computation.ts
@@ -96,7 +96,7 @@ export class Computation {
     }
     try {
       if (ownsCompilation) {
-        await asyncCompilation.finish();
+        await Promise.all(asyncCompilation);
       } else {
         await computation._pipelineInitialization;
       }
@@ -243,7 +243,7 @@ export class Computation {
     const asyncCompilation = PipelineFactory.getAsyncCompilation(this.device);
     if (asyncCompilation) {
       this._pipelineInitialization = this._updatePipelineAsync();
-      asyncCompilation.add(this._pipelineInitialization);
+      asyncCompilation.push(this._pipelineInitialization);
     } else {
       this.pipeline = this._updatePipeline();
     }

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -180,6 +180,31 @@ export type ModelProps = Omit<RenderPipelineProps, 'vs' | 'fs' | 'bindings'> & {
  * - Provides detailed debug logging and optional shader source inspection.
  */
 export class Model {
+  /** Creates a model while allowing the backend to compile its render pipeline asynchronously. */
+  static async createAsync(device: Device, props: ModelProps): Promise<Model> {
+    const ownsCompilation = !PipelineFactory.getAsyncCompilation(device);
+    const asyncCompilation = ownsCompilation
+      ? PipelineFactory.beginAsyncCompilation(device)
+      : PipelineFactory.getAsyncCompilation(device)!;
+    let model: Model;
+    try {
+      model = new Model(device, props);
+    } finally {
+      if (ownsCompilation) PipelineFactory.endAsyncCompilation(device, asyncCompilation);
+    }
+    try {
+      if (ownsCompilation) {
+        await asyncCompilation.finish();
+      } else {
+        await model._pipelineInitialization;
+      }
+      return model;
+    } catch (error) {
+      model.destroy();
+      throw error;
+    }
+  }
+
   static defaultProps: Required<ModelProps> = {
     ...RenderPipeline.defaultProps,
     source: undefined!,
@@ -276,13 +301,13 @@ export class Model {
    * @note not implemented: if bufferLayout is updated, vertex array has to be rebuilt!
    * @todo - allow application to define multiple vertex arrays?
    * */
-  vertexArray: VertexArray;
+  vertexArray!: VertexArray;
 
   /** TransformFeedback, WebGL 2 only. */
   transformFeedback: TransformFeedback | null = null;
 
   /** The underlying GPU "program". @note May be recreated if parameters change */
-  pipeline: RenderPipeline;
+  pipeline!: RenderPipeline;
 
   /** ShaderInputs instance */
   // @ts-expect-error Assigned in function called by constructor
@@ -310,6 +335,7 @@ export class Model {
   /** "Time" of last draw. Monotonically increasing timestamp */
   _lastDrawTimestamp: number = -1;
   private _bindingTable: ShaderBindingDebugRow[] = [];
+  private _pipelineInitialization?: Promise<void>;
 
   get [Symbol.toStringTag](): string {
     return 'Model';
@@ -459,56 +485,47 @@ export class Model {
       props.pipelineFactory || PipelineFactory.getDefaultPipelineFactory(this.device);
     this.shaderFactory = props.shaderFactory || ShaderFactory.getDefaultShaderFactory(this.device);
 
-    // Create the pipeline
-    // @note order is important
-    this.pipeline = this._updatePipeline();
+    const asyncCompilation = PipelineFactory.getAsyncCompilation(this.device);
+    if (asyncCompilation) {
+      this._pipelineInitialization = this._initializePipelineAsync(props);
+      asyncCompilation.add(this._pipelineInitialization);
+    } else {
+      this.pipeline = this._updatePipeline();
+      this._initializePipelineResources(props);
+    }
+  }
 
-    this.vertexArray = device.createVertexArray({
+  private async _initializePipelineAsync(props: ModelProps): Promise<void> {
+    await this._updatePipelineAsync();
+    this._initializePipelineResources(props);
+  }
+
+  private _initializePipelineResources(props: ModelProps): void {
+    this.vertexArray = this.device.createVertexArray({
       shaderLayout: this.pipeline.shaderLayout,
       bufferLayout: this.pipeline.bufferLayout
     });
-
-    // Now we can apply geometry attributes
-    if (this._gpuGeometry) {
-      this._setGeometryAttributes(this._gpuGeometry);
-    }
-
-    // Apply any dynamic settings that will not trigger pipeline change
-    if ('isInstanced' in props) {
-      this.isInstanced = props.isInstanced;
-    }
-
-    if (props.instanceCount) {
-      this.setInstanceCount(props.instanceCount);
-    }
-    if (props.vertexCount) {
-      this.setVertexCount(props.vertexCount);
-    }
-    if (props.indexBuffer) {
-      this.setIndexBuffer(props.indexBuffer);
-    }
-    if (props.attributes) {
-      this.setAttributes(props.attributes);
-    }
-    if (props.constantAttributes) {
-      this.setConstantAttributes(props.constantAttributes);
-    }
-    if (props.bindings) {
-      this.setBindings(props.bindings);
-    }
-    if (props.transformFeedback) {
-      this.transformFeedback = props.transformFeedback;
-    }
+    if (this._gpuGeometry) this._setGeometryAttributes(this._gpuGeometry);
+    if ('isInstanced' in props) this.isInstanced = props.isInstanced;
+    if (props.instanceCount) this.setInstanceCount(props.instanceCount);
+    if (props.vertexCount) this.setVertexCount(props.vertexCount);
+    if (props.indexBuffer) this.setIndexBuffer(props.indexBuffer);
+    if (props.attributes) this.setAttributes(props.attributes);
+    if (props.constantAttributes) this.setConstantAttributes(props.constantAttributes);
+    if (props.bindings) this.setBindings(props.bindings);
+    if (props.transformFeedback) this.transformFeedback = props.transformFeedback;
   }
 
   destroy(): void {
     if (!this._destroyed) {
       // Release pipeline before we destroy the shaders used by the pipeline
-      this.pipelineFactory.release(this.pipeline);
-      // Release the shaders
-      this.shaderFactory.release(this.pipeline.vs);
-      if (this.pipeline.fs && this.pipeline.fs !== this.pipeline.vs) {
-        this.shaderFactory.release(this.pipeline.fs);
+      if (this.pipeline) {
+        this.pipelineFactory.release(this.pipeline);
+        // Release the shaders
+        this.shaderFactory.release(this.pipeline.vs);
+        if (this.pipeline.fs && this.pipeline.fs !== this.pipeline.vs) {
+          this.shaderFactory.release(this.pipeline.fs);
+        }
       }
       this._uniformStore.destroy();
       // TODO - mark resource as managed and destroyIfManaged() ?
@@ -1097,40 +1114,64 @@ export class Model {
 
   /** Update pipeline if needed */
   _updatePipeline(): RenderPipeline {
-    if (this._pipelineNeedsUpdate) {
-      let prevShaderVs: Shader | null = null;
-      let prevShaderFs: Shader | null = null;
-      if (this.pipeline) {
-        log.log(
-          1,
-          `Model ${this.id}: Recreating pipeline because "${this._pipelineNeedsUpdate}".`
-        )();
-        prevShaderVs = this.pipeline.vs;
-        prevShaderFs = this.pipeline.fs;
+    const update = this._preparePipelineUpdate();
+    if (update) {
+      this.pipeline = this.pipelineFactory.createRenderPipeline(update.props);
+      this._finishPipelineUpdate(update);
+    }
+    return this.pipeline;
+  }
+
+  /** Creates or replaces the render pipeline through the backend's asynchronous compilation path. */
+  async _updatePipelineAsync(): Promise<RenderPipeline> {
+    const update = this._preparePipelineUpdate();
+    if (update) {
+      try {
+        this.pipeline = await this.pipelineFactory.createRenderPipelineAsync(update.props);
+      } catch (error) {
+        this._releasePipelineShaders(update.vertexShader, update.fragmentShader);
+        this._pipelineNeedsUpdate = 'asynchronous pipeline creation failed';
+        throw error;
       }
+      this._finishPipelineUpdate(update);
+    }
+    return this.pipeline;
+  }
 
-      this._pipelineNeedsUpdate = false;
+  private _preparePipelineUpdate(): {
+    props: RenderPipelineProps;
+    vertexShader: Shader;
+    fragmentShader: Shader | null;
+    previousVertexShader: Shader | null;
+    previousFragmentShader: Shader | null;
+  } | null {
+    if (!this._pipelineNeedsUpdate) return null;
+    const previousVertexShader = this.pipeline?.vs ?? null;
+    const previousFragmentShader = this.pipeline?.fs ?? null;
+    if (this.pipeline) {
+      log.log(1, `Model ${this.id}: Recreating pipeline because "${this._pipelineNeedsUpdate}".`)();
+    }
+    this._pipelineNeedsUpdate = false;
 
-      const vs = this.shaderFactory.createShader({
-        id: `${this.id}-vertex`,
-        stage: 'vertex',
-        source: this.source || this.vs,
+    const vertexShader = this.shaderFactory.createShader({
+      id: `${this.id}-vertex`,
+      stage: 'vertex',
+      source: this.source || this.vs,
+      debugShaders: this.props.debugShaders
+    });
+    let fragmentShader: Shader | null = null;
+    if (this.source) {
+      fragmentShader = vertexShader;
+    } else if (this.fs) {
+      fragmentShader = this.shaderFactory.createShader({
+        id: `${this.id}-fragment`,
+        stage: 'fragment',
+        source: this.fs,
         debugShaders: this.props.debugShaders
       });
-
-      let fs: Shader | null = null;
-      if (this.source) {
-        fs = vs;
-      } else if (this.fs) {
-        fs = this.shaderFactory.createShader({
-          id: `${this.id}-fragment`,
-          stage: 'fragment',
-          source: this.source || this.fs,
-          debugShaders: this.props.debugShaders
-        });
-      }
-
-      this.pipeline = this.pipelineFactory.createRenderPipeline({
+    }
+    return {
+      props: {
         ...this.props,
         bindings: undefined,
         bufferLayout: this.bufferLayout,
@@ -1139,21 +1180,35 @@ export class Model {
         topology: this.topology,
         parameters: this.parameters,
         bindGroups: undefined,
-        vs,
-        fs
-      });
+        vs: vertexShader,
+        fs: fragmentShader
+      },
+      vertexShader,
+      fragmentShader,
+      previousVertexShader,
+      previousFragmentShader
+    };
+  }
 
-      this._attributeInfos = getAttributeInfosFromLayouts(
-        this.pipeline.shaderLayout,
-        this.bufferLayout
-      );
+  private _finishPipelineUpdate(update: {
+    previousVertexShader: Shader | null;
+    previousFragmentShader: Shader | null;
+  }): void {
+    this._attributeInfos = getAttributeInfosFromLayouts(
+      this.pipeline.shaderLayout,
+      this.bufferLayout
+    );
+    this._releasePipelineShaders(update.previousVertexShader, update.previousFragmentShader);
+  }
 
-      if (prevShaderVs) this.shaderFactory.release(prevShaderVs);
-      if (prevShaderFs && prevShaderFs !== prevShaderVs) {
-        this.shaderFactory.release(prevShaderFs);
-      }
+  private _releasePipelineShaders(
+    vertexShader: Shader | null,
+    fragmentShader: Shader | null
+  ): void {
+    if (vertexShader) this.shaderFactory.release(vertexShader);
+    if (fragmentShader && fragmentShader !== vertexShader) {
+      this.shaderFactory.release(fragmentShader);
     }
-    return this.pipeline;
   }
 
   /** Throttle draw call logging */

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -194,7 +194,7 @@ export class Model {
     }
     try {
       if (ownsCompilation) {
-        await asyncCompilation.finish();
+        await Promise.all(asyncCompilation);
       } else {
         await model._pipelineInitialization;
       }
@@ -488,7 +488,7 @@ export class Model {
     const asyncCompilation = PipelineFactory.getAsyncCompilation(this.device);
     if (asyncCompilation) {
       this._pipelineInitialization = this._initializePipelineAsync(props);
-      asyncCompilation.add(this._pipelineInitialization);
+      asyncCompilation.push(this._pipelineInitialization);
     } else {
       this.pipeline = this._updatePipeline();
       this._initializePipelineResources(props);

--- a/modules/engine/test/compute/computation.spec.ts
+++ b/modules/engine/test/compute/computation.spec.ts
@@ -70,6 +70,15 @@ it('Computation#construct/delete', async () => {
   void 0;
 });
 
+it('Computation.createAsync prepares a WebGPU compute pipeline', async () => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) return;
+
+  const computation = await Computation.createAsync(webgpuDevice, {source});
+  expect(computation.pipeline).toBeDefined();
+  computation.destroy();
+});
+
 it('Computation#compute', async () => {
   const webgpuDevice = await getWebGPUTestDevice();
   if (webgpuDevice) {

--- a/modules/engine/test/lib/model.spec.ts
+++ b/modules/engine/test/lib/model.spec.ts
@@ -337,6 +337,20 @@ it('Model#draw', async () => {
   void 0;
 });
 
+it('Model.createAsync prepares a WebGPU render pipeline and vertex array', async () => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) return;
+
+  const model = await Model.createAsync(webgpuDevice, {
+    id: 'async-webgpu-model',
+    source: DUMMY_WGSL,
+    vertexCount: 1
+  });
+  expect(model.pipeline).toBeDefined();
+  expect(model.vertexArray).toBeDefined();
+  model.destroy();
+});
+
 it('Model#draw skips implicit predraw on WebGPU', async () => {
   const webgpuDevice = await getWebGPUTestDevice();
 

--- a/modules/gpgpu/src/gpu-core/gpu-command-graph-compiler.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-command-graph-compiler.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import {Buffer, Texture, textureFormatDecoder} from '@luma.gl/core';
+import {Buffer, PipelineFactory, Texture, textureFormatDecoder} from '@luma.gl/core';
 import type {Device, TextureFormat} from '@luma.gl/core';
 import type {
   GPUCommandGraphComputeExecutable,
@@ -104,6 +104,15 @@ export type GPUCommandGraphCompilation<Parameters> = {
   preflight: GPUCommandGraphPreflightReport;
 };
 
+type GPUCommandGraphCompilerProps<Parameters> = {
+  device: Device;
+  id: string;
+  buffers: Map<string, GraphBufferHandle>;
+  textures: Map<string, GraphTextureHandle>;
+  externalTextures: Map<string, GraphExternalTextureHandle>;
+  nodes: GPUCommandGraphNode<Parameters>[];
+};
+
 /**
  * Compiles scheduling, transient allocations, and executable node resources.
  *
@@ -114,14 +123,9 @@ export type GPUCommandGraphCompilation<Parameters> = {
  *
  * @internal
  */
-export function compileGPUCommandGraph<Parameters>(props: {
-  device: Device;
-  id: string;
-  buffers: Map<string, GraphBufferHandle>;
-  textures: Map<string, GraphTextureHandle>;
-  externalTextures: Map<string, GraphExternalTextureHandle>;
-  nodes: GPUCommandGraphNode<Parameters>[];
-}): GPUCommandGraphCompilation<Parameters> {
+export function compileGPUCommandGraph<Parameters>(
+  props: GPUCommandGraphCompilerProps<Parameters>
+): GPUCommandGraphCompilation<Parameters> {
   const nodeOrder = getNodeOrder(props.nodes);
   const bufferPlan = getBufferTransientAllocationPlan(nodeOrder, props.buffers.values());
   const texturePlan = getTextureTransientAllocationPlan(nodeOrder, props.textures.values());
@@ -166,6 +170,117 @@ export function compileGPUCommandGraph<Parameters>(props: {
     throw error;
   }
 
+  return finishGPUCommandGraphCompilation(
+    props,
+    nodeOrder,
+    compiledNodes,
+    transientBuffers,
+    transientTextures,
+    bufferPlan,
+    texturePlan
+  );
+}
+
+/**
+ * Compiles graph node resources concurrently through their asynchronous compilation callbacks.
+ *
+ * Scheduling and transient allocation remain deterministic and synchronous. All node compilation
+ * promises are started before any is awaited, allowing WebGPU pipeline compilation to overlap.
+ * Nodes without an asynchronous callback retain their synchronous compatibility path.
+ *
+ * @internal
+ */
+export async function compileGPUCommandGraphAsync<Parameters>(
+  props: GPUCommandGraphCompilerProps<Parameters>
+): Promise<GPUCommandGraphCompilation<Parameters>> {
+  const nodeOrder = getNodeOrder(props.nodes);
+  const bufferPlan = getBufferTransientAllocationPlan(nodeOrder, props.buffers.values());
+  const texturePlan = getTextureTransientAllocationPlan(nodeOrder, props.textures.values());
+  const transientBuffers = new Map<GraphBufferHandle, Buffer>();
+  const transientTextures = new Map<GraphTextureHandle, Texture>();
+
+  try {
+    for (const allocation of bufferPlan) {
+      allocation.buffer = props.device.createBuffer({
+        id: `${props.id}-transient-buffer-${bufferPlan.indexOf(allocation)}`,
+        byteLength: allocation.byteLength,
+        usage: allocation.usage
+      });
+      for (const handle of allocation.handles) {
+        transientBuffers.set(handle, allocation.buffer);
+      }
+    }
+    for (const allocation of texturePlan) {
+      allocation.texture = props.device.createTexture({
+        ...allocation.descriptor,
+        id: `${props.id}-transient-texture-${texturePlan.indexOf(allocation)}`
+      });
+      for (const handle of allocation.handles) {
+        transientTextures.set(handle, allocation.texture);
+      }
+    }
+
+    const asyncPipelineCompilation = PipelineFactory.beginAsyncCompilation(props.device);
+    const nodeCompilationPromises = nodeOrder.map(async node => ({
+      node,
+      executable: node.compileAsync
+        ? await node.compileAsync({device: props.device})
+        : node.compile({device: props.device})
+    }));
+    PipelineFactory.endAsyncCompilation(props.device, asyncPipelineCompilation);
+    const [results, pipelineResult] = await Promise.all([
+      Promise.allSettled(nodeCompilationPromises),
+      asyncPipelineCompilation.finish().then(
+        () => ({status: 'fulfilled' as const}),
+        reason => ({status: 'rejected' as const, reason})
+      )
+    ]);
+    const compiledNodes: CompiledNode<Parameters>[] = [];
+    let compilationError: unknown =
+      pipelineResult.status === 'rejected' ? pipelineResult.reason : undefined;
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        compiledNodes.push(result.value);
+      } else {
+        compilationError ??= result.reason;
+      }
+    }
+    if (compilationError) {
+      for (const compiledNode of compiledNodes) {
+        compiledNode.executable.destroy?.();
+      }
+      throw compilationError;
+    }
+
+    return finishGPUCommandGraphCompilation(
+      props,
+      nodeOrder,
+      compiledNodes,
+      transientBuffers,
+      transientTextures,
+      bufferPlan,
+      texturePlan
+    );
+  } catch (error) {
+    for (const allocation of bufferPlan) {
+      allocation.buffer?.destroy();
+    }
+    for (const allocation of texturePlan) {
+      allocation.texture?.destroy();
+    }
+    throw error;
+  }
+}
+
+function finishGPUCommandGraphCompilation<Parameters>(
+  props: GPUCommandGraphCompilerProps<Parameters>,
+  nodeOrder: GPUCommandGraphNode<Parameters>[],
+  compiledNodes: CompiledNode<Parameters>[],
+  transientBuffers: Map<GraphBufferHandle, Buffer>,
+  transientTextures: Map<GraphTextureHandle, Texture>,
+  bufferPlan: BufferTransientAllocation[],
+  texturePlan: TextureTransientAllocation[]
+): GPUCommandGraphCompilation<Parameters> {
   const logicalBuffers = Array.from(props.buffers.values());
   const importedBuffers = logicalBuffers.filter(buffer => !buffer.transient);
   const logicalTransientBuffers = logicalBuffers.filter(buffer => buffer.transient);

--- a/modules/gpgpu/src/gpu-core/gpu-command-graph-compiler.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-command-graph-compiler.ts
@@ -228,16 +228,14 @@ export async function compileGPUCommandGraphAsync<Parameters>(
         : node.compile({device: props.device})
     }));
     PipelineFactory.endAsyncCompilation(props.device, asyncPipelineCompilation);
-    const [results, pipelineResult] = await Promise.all([
+    const [results, pipelineResults] = await Promise.all([
       Promise.allSettled(nodeCompilationPromises),
-      asyncPipelineCompilation.finish().then(
-        () => ({status: 'fulfilled' as const}),
-        reason => ({status: 'rejected' as const, reason})
-      )
+      Promise.allSettled(asyncPipelineCompilation)
     ]);
     const compiledNodes: CompiledNode<Parameters>[] = [];
+    const pipelineFailure = pipelineResults.find(result => result.status === 'rejected');
     let compilationError: unknown =
-      pipelineResult.status === 'rejected' ? pipelineResult.reason : undefined;
+      pipelineFailure?.status === 'rejected' ? pipelineFailure.reason : undefined;
     for (const result of results) {
       if (result.status === 'fulfilled') {
         compiledNodes.push(result.value);

--- a/modules/gpgpu/src/gpu-core/gpu-command-graph-types.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-command-graph-types.ts
@@ -611,6 +611,10 @@ export type GPUCommandGraphComputeNode<Parameters> = GPUCommandGraphNodeBase<
   type: 'compute';
   /** Creates reusable node resources and the encode callback. */
   compile: (context: GPUCommandGraphCompileContext) => GPUCommandGraphComputeExecutable<Parameters>;
+  /** Creates reusable node resources through asynchronous backend compilation when available. */
+  compileAsync?: (
+    context: GPUCommandGraphCompileContext
+  ) => Promise<GPUCommandGraphComputeExecutable<Parameters>>;
 };
 
 /** Render node compiled once and encoded into a graph-owned render pass. */
@@ -623,6 +627,10 @@ export type GPUCommandGraphRenderNode<Parameters> = GPUCommandGraphNodeBase<
   attachments?: GraphRenderPassAttachments;
   /** Creates reusable node resources and the encode callback. */
   compile: (context: GPUCommandGraphCompileContext) => GPUCommandGraphRenderExecutable<Parameters>;
+  /** Creates reusable node resources through asynchronous backend compilation when available. */
+  compileAsync?: (
+    context: GPUCommandGraphCompileContext
+  ) => Promise<GPUCommandGraphRenderExecutable<Parameters>>;
 };
 
 /** Copy or pass-independent node compiled once and encoded directly on the command encoder. */
@@ -633,6 +641,10 @@ export type GPUCommandGraphCopyNode<Parameters> = GPUCommandGraphNodeBase<
   type: 'copy';
   /** Creates reusable node resources and the encode callback. */
   compile: (context: GPUCommandGraphCompileContext) => GPUCommandGraphCopyExecutable<Parameters>;
+  /** Creates reusable node resources through asynchronous backend compilation when available. */
+  compileAsync?: (
+    context: GPUCommandGraphCompileContext
+  ) => Promise<GPUCommandGraphCopyExecutable<Parameters>>;
 };
 
 /** Any node accepted by a `GPUCommandGraph`. */

--- a/modules/gpgpu/src/gpu-core/gpu-command-graph.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-command-graph.ts
@@ -25,6 +25,7 @@ import {
 } from '@luma.gl/gpgpu/gpu-data';
 import {
   compileGPUCommandGraph,
+  compileGPUCommandGraphAsync,
   getBufferHandle,
   getTextureHandle,
   isGraphBufferUse,
@@ -926,6 +927,34 @@ export class GPUCommandGraph<Parameters = void> {
     this.compiled = true;
     return new CompiledGPUCommandGraph(
       compileGPUCommandGraph({
+        device: this.device,
+        id: this.id,
+        buffers: this.buffers,
+        textures: this.textures,
+        externalTextures: this.externalTextures,
+        nodes: this.nodes
+      })
+    );
+  }
+
+  /**
+   * Compiles graph resources with asynchronous backend pipeline creation.
+   *
+   * Every node's asynchronous compile callback is started before compilation waits for any one
+   * node. This lets independent WebGPU pipelines compile concurrently. Nodes that do not provide
+   * an asynchronous callback use their existing synchronous compile callback.
+   *
+   * Compilation freezes this graph immediately. A graph can be compiled only once, including when
+   * asynchronous compilation rejects.
+   *
+   * @returns An executable graph whose pipelines are ready before the promise resolves.
+   */
+  async compileAsync(): Promise<CompiledGPUCommandGraph<Parameters>> {
+    this.assertMutable();
+    assertDeviceAvailable(this.device, 'compilation');
+    this.compiled = true;
+    return new CompiledGPUCommandGraph(
+      await compileGPUCommandGraphAsync({
         device: this.device,
         id: this.id,
         buffers: this.buffers,

--- a/modules/gpgpu/test/gpu-core/gpu-command-graph-async.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-command-graph-async.spec.ts
@@ -1,0 +1,54 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {ComputePipelineProps} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph} from '@luma.gl/gpgpu/gpu-core';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import {expect, test} from 'vitest';
+
+test('GPUCommandGraph#compileAsync starts graph-owned pipelines in parallel', async () => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return;
+
+  const originalCreateComputePipelineAsync = device.createComputePipelineAsync.bind(device);
+  let startedPipelineCount = 0;
+  let releasePipelines!: () => void;
+  const pipelineGate = new Promise<void>(resolve => {
+    releasePipelines = resolve;
+  });
+  device.createComputePipelineAsync = async (props: ComputePipelineProps) => {
+    startedPipelineCount++;
+    await pipelineGate;
+    return await originalCreateComputePipelineAsync(props);
+  };
+
+  const graph = new GPUCommandGraph(device, {id: 'async-pipeline-compilation'});
+  for (const suffix of ['first', 'second']) {
+    graph.addComputePass({
+      id: suffix,
+      compile: ({device: compileDevice}) => {
+        const computation = new Computation(compileDevice, {
+          id: `async-${suffix}`,
+          source: `@compute @workgroup_size(1) fn main() { let ${suffix} = 1u; }`
+        });
+        return {
+          encode: ({computePass}) => computation.dispatch(computePass, 1),
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+  }
+
+  try {
+    const compilationPromise = graph.compileAsync();
+    await Promise.resolve();
+    expect(startedPipelineCount).toBe(2);
+    releasePipelines();
+    const compiled = await compilationPromise;
+    compiled.destroy();
+  } finally {
+    device.createComputePipelineAsync = originalCreateComputePipelineAsync;
+  }
+});

--- a/modules/gpgpu/test/gpu-core/gpu-command-graph-passes.node.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-command-graph-passes.node.spec.ts
@@ -110,6 +110,41 @@ describe('GPUCommandGraphEncoding constructor compatibility', () => {
   });
 });
 
+describe('GPUCommandGraph asynchronous compilation', () => {
+  test('starts independent node compilation concurrently and preserves scheduled order', async () => {
+    const device = new NullDevice({id: 'async-compilation-device'});
+    Object.defineProperty(device, 'type', {value: 'webgpu'});
+    const graph = new GPUCommandGraph(device, {id: 'parallel-async-compilation'});
+    const startedNodes: string[] = [];
+    let releaseCompilation!: () => void;
+    const compilationGate = new Promise<void>(resolve => {
+      releaseCompilation = resolve;
+    });
+
+    for (const id of ['first', 'second', 'third']) {
+      graph.addComputePass({
+        id,
+        compile: () => ({encode: () => {}}),
+        compileAsync: async () => {
+          startedNodes.push(id);
+          await compilationGate;
+          return {encode: () => {}};
+        }
+      });
+    }
+
+    const compilationPromise = graph.compileAsync();
+    await Promise.resolve();
+    expect(startedNodes).toEqual(['first', 'second', 'third']);
+
+    releaseCompilation();
+    const compiled = await compilationPromise;
+    expect(compiled.stats.nodeOrder).toEqual(['first', 'second', 'third']);
+    compiled.destroy();
+    device.destroy();
+  });
+});
+
 describe('GPUCommandGraph compute-pass coalescing', () => {
   test('coalesces consecutive compute nodes while preserving node order and debug groups', () => {
     const fixture = createComputePassFixture('consecutive-compute-nodes');

--- a/modules/webgpu/src/adapter/resources/webgpu-compute-pipeline.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-compute-pipeline.ts
@@ -20,6 +20,28 @@ const EMPTY_BIND_GROUPS: BindingsByGroup = {};
 
 /** Creates a new compute pipeline when parameters change */
 export class WebGPUComputePipeline extends ComputePipeline {
+  /** Creates the native pipeline through WebGPU's asynchronous compilation entry point. */
+  static async createAsync(
+    device: WebGPUDevice,
+    props: ComputePipelineProps
+  ): Promise<WebGPUComputePipeline> {
+    if (props.handle) {
+      return new WebGPUComputePipeline(device, props);
+    }
+    const allProps: Required<ComputePipelineProps> = {...ComputePipeline.defaultProps, ...props};
+    const webgpuShader = allProps.shader as WebGPUShader;
+    const handle = await device.handle.createComputePipelineAsync({
+      label: allProps.id,
+      compute: {
+        module: webgpuShader.handle,
+        entryPoint: allProps.entryPoint,
+        constants: allProps.constants
+      },
+      layout: 'auto'
+    });
+    return new WebGPUComputePipeline(device, {...allProps, handle});
+  }
+
   readonly device: WebGPUDevice;
   readonly handle: GPUComputePipeline;
 

--- a/modules/webgpu/src/adapter/resources/webgpu-render-pipeline.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-render-pipeline.ts
@@ -22,8 +22,31 @@ import type {WebGPURenderPass} from './webgpu-render-pass';
 
 /** Creates a new render pipeline when parameters change */
 export class WebGPURenderPipeline extends RenderPipeline {
+  /** Creates the native pipeline through WebGPU's asynchronous compilation entry point. */
+  static async createAsync(
+    device: WebGPUDevice,
+    props: RenderPipelineProps
+  ): Promise<WebGPURenderPipeline> {
+    if (props.handle) {
+      return new WebGPURenderPipeline(device, props);
+    }
+    const pipeline = new WebGPURenderPipeline(device, props, true);
+    // The deferred constructor always creates the descriptor.
+    const descriptor = pipeline.descriptor!;
+    try {
+      pipeline.handle = await device.handle.createRenderPipelineAsync(descriptor);
+    } catch (error) {
+      pipeline.linkStatus = 'error';
+      pipeline.destroy();
+      throw error;
+    }
+    pipeline.handle.label = pipeline.props.id;
+    pipeline.linkStatus = 'success';
+    return pipeline;
+  }
+
   readonly device: WebGPUDevice;
-  readonly handle: GPURenderPipeline;
+  handle!: GPURenderPipeline;
   readonly descriptor: GPURenderPipelineDescriptor | null;
 
   readonly vs: WebGPUShader;
@@ -37,7 +60,7 @@ export class WebGPURenderPipeline extends RenderPipeline {
     return 'WebGPURenderPipeline';
   }
 
-  constructor(device: WebGPUDevice, props: RenderPipelineProps) {
+  constructor(device: WebGPUDevice, props: RenderPipelineProps, deferPipelineCreation = false) {
     super(device, props);
     this.device = device;
     if (!this.shaderLayout) {
@@ -57,17 +80,24 @@ export class WebGPURenderPipeline extends RenderPipeline {
       log.probe(1, JSON.stringify(descriptor, null, 2))();
       log.groupEnd(1)();
 
-      this.device.pushErrorScope('validation');
-      this.handle = this.device.handle.createRenderPipeline(descriptor);
-      validationPromise = this.device.popErrorScope((error: GPUError) => {
-        this.linkStatus = 'error';
-        this.device.reportError(new Error(`${this} creation failed:\n"${error.message}"`), this)();
-        this.device.debug();
-      });
+      if (!deferPipelineCreation) {
+        this.device.pushErrorScope('validation');
+        this.handle = this.device.handle.createRenderPipeline(descriptor);
+        validationPromise = this.device.popErrorScope((error: GPUError) => {
+          this.linkStatus = 'error';
+          this.device.reportError(
+            new Error(`${this} creation failed:\n"${error.message}"`),
+            this
+          )();
+          this.device.debug();
+        });
+      }
     }
     this.descriptor = descriptor;
-    this.handle.label = this.props.id;
-    this.linkStatus = validationPromise ? 'pending' : 'success';
+    if (this.handle) {
+      this.handle.label = this.props.id;
+    }
+    this.linkStatus = validationPromise || deferPipelineCreation ? 'pending' : 'success';
     validationPromise?.then(() => {
       if (this.linkStatus !== 'error') {
         this.linkStatus = 'success';

--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -221,12 +221,24 @@ export class WebGPUDevice extends Device {
     return new WebGPURenderPipeline(this, props);
   }
 
+  override async createRenderPipelineAsync(
+    props: RenderPipelineProps
+  ): Promise<WebGPURenderPipeline> {
+    return await WebGPURenderPipeline.createAsync(this, props);
+  }
+
   createFramebuffer(props: FramebufferProps): WebGPUFramebuffer {
     return new WebGPUFramebuffer(this, props);
   }
 
   createComputePipeline(props: ComputePipelineProps): WebGPUComputePipeline {
     return new WebGPUComputePipeline(this, props);
+  }
+
+  override async createComputePipelineAsync(
+    props: ComputePipelineProps
+  ): Promise<WebGPUComputePipeline> {
+    return await WebGPUComputePipeline.createAsync(this, props);
   }
 
   /** Creates an encoder for reusable WebGPU draw commands. */

--- a/test/size/bundle-size.config.mjs
+++ b/test/size/bundle-size.config.mjs
@@ -8,7 +8,7 @@ export const BUNDLE_SIZE_FIXTURES = [
     label: '`@luma.gl/core`',
     entry: 'modules/core/src/index.ts',
     external: [],
-    maximum: {minified: 100_000, gzip: 28_500, brotli: 25_000},
+    maximum: {minified: 101_000, gzip: 28_500, brotli: 25_000},
     targetGzip: 24_000
   },
   {

--- a/website/content/examples/experimental/gpu-parquet-constellation.mdx
+++ b/website/content/examples/experimental/gpu-parquet-constellation.mdx
@@ -45,7 +45,8 @@ populates both measurement columns. Use **Compare CPU → GPU** to repeat the fu
 the fixture is built. **Preparation latency** includes page access,
 planning, decoding, buffer creation, and render-graph preparation. **First decode execution** narrows
 that down to the CPU source read and decode, or to GPU command submission through queue completion
-after compilation. The GPU path retains its compiled graph and immutable input buffer, so the
+after `await graph.compileAsync()` has prepared the graph's independent pipelines in parallel. The
+GPU path retains its compiled graph and immutable input buffer, so the
 comparison immediately submits it again and reports **Reused graph execution** separately. Selecting
 GPU and choosing **Decode and display** also reuses the graph. **Longest frame** records the largest
 animation gap while the old constellation remains active, making main-thread stalls visible. Results


### PR DESCRIPTION
## Goals

- Move WebGPU pipeline compilation out of measured command-graph execution.
- Compile independent graph pipelines concurrently instead of serially.
- Preserve synchronous construction and compilation APIs for compatibility.

## Changes

- Add asynchronous render/compute pipeline creation to `Device`, with native WebGPU
  `create*PipelineAsync` implementations and compatible fallbacks.
- Add pending-pipeline deduplication and compilation scopes to `PipelineFactory`.
- Add `Computation.createAsync()`, `Model.createAsync()`, and deferred construction support inside
  an async graph compilation scope.
- Add `GPUCommandGraph.compileAsync()`; it starts all node compilation callbacks and collected
  pipelines before awaiting them, then returns a fully ready reusable graph.
- Update the GPU Parquet example to prepare its decode graph asynchronously before timing decode
  execution, and make its CPU/GPU table compact and explicit about the compared work.
- Document API behavior, use cases, error semantics, and the distinction between preparation and
  execution.
- Consolidate render and compute pending-cache logic after review, including safe mixed sync/async
  cache races.

## Verification

- `nvm use`
- `yarn install` (earlier on this worktree)
- `yarn lint fix`
- `yarn build`
- `yarn test`: 409 Node files passed with 3,271 tests; 297 headless files passed with 1,953 tests.
- `yarn bundle-size`: all fixtures pass. The intentional async core API adds 404 gzip bytes and
  required a 1 KB increase to the core minified ceiling; gzip, Brotli, and combined ceilings remain
  unchanged.
- The GPU Parquet Constellation example was run in Chrome and populated GPU/CPU results using the
  asynchronously prepared decode graph.

## Compatibility and risk

- Existing synchronous APIs are unchanged.
- WebGL and other devices use the default Promise-wrapped synchronous fallback.
- The graph remains immutable as soon as `compileAsync()` is called and is not exposed until every
  node and pipeline is ready.
- Equivalent concurrent async requests share one backend compilation. If a synchronous request
  wins while that compilation is pending, the async callers adopt the synchronous cached resource
  and discard the duplicate without leaking shared WebGL program ownership.
