### PR TITLE
fix(website): serialize example transitions

### DIFF
--- a/test/examples/example-lifecycle.node.spec.ts
+++ b/test/examples/example-lifecycle.node.spec.ts
@@ -77,6 +77,25 @@ describe('example lifecycle', () => {
     await waitForLifecycleQueue();
     expect(events).toEqual(['start first', 'stop first']);
   });
+
+  it('reports startup errors before stopping the failed session', async () => {
+    const events: string[] = [];
+    startExclusiveExample({
+      start: () => {
+        events.push('start');
+        throw new Error('startup failed');
+      },
+      stop: () => {
+        events.push('stop');
+      },
+      onError: error => {
+        events.push(`error: ${(error as Error).message}`);
+      }
+    });
+
+    await waitForLifecycleQueue();
+    expect(events).toEqual(['start', 'error: startup failed', 'stop']);
+  });
 });
 
 async function waitForLifecycleQueue(): Promise<void> {

--- a/test/examples/example-lifecycle.node.spec.ts
+++ b/test/examples/example-lifecycle.node.spec.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {describe, expect, it} from 'vitest';
+import {startExclusiveExample} from '../../website/src/react-luma/utils/example-lifecycle';
+
+describe('example lifecycle', () => {
+  it('stops the active example before starting the next one', async () => {
+    const events: string[] = [];
+    const errors: unknown[] = [];
+    const stopFirst = startExclusiveExample({
+      start: () => {
+        events.push('start first');
+      },
+      stop: () => {
+        events.push('stop first');
+      },
+      onError: error => errors.push(error)
+    });
+    const stopSecond = startExclusiveExample({
+      start: () => {
+        events.push('start second');
+      },
+      stop: () => {
+        events.push('stop second');
+      },
+      onError: error => errors.push(error)
+    });
+
+    await waitForLifecycleQueue();
+    expect(events).toEqual(['start first', 'stop first', 'start second']);
+    expect(errors).toEqual([]);
+
+    stopFirst();
+    stopSecond();
+    await waitForLifecycleQueue();
+    expect(events).toEqual(['start first', 'stop first', 'start second', 'stop second']);
+  });
+
+  it('does not start a session that is stopped while waiting', async () => {
+    const events: string[] = [];
+    let finishStart: (() => void) | undefined;
+    const startBarrier = new Promise<void>(resolve => {
+      finishStart = resolve;
+    });
+    const stopFirst = startExclusiveExample({
+      start: async () => {
+        events.push('start first');
+        await startBarrier;
+      },
+      stop: () => {
+        events.push('stop first');
+      },
+      onError: error => {
+        throw error;
+      }
+    });
+    const stopSecond = startExclusiveExample({
+      start: () => {
+        events.push('start second');
+      },
+      stop: () => {
+        events.push('stop second');
+      },
+      onError: error => {
+        throw error;
+      }
+    });
+    stopSecond();
+
+    await Promise.resolve();
+    finishStart!();
+    await waitForLifecycleQueue();
+    expect(events).toEqual(['start first']);
+
+    stopFirst();
+    await waitForLifecycleQueue();
+    expect(events).toEqual(['start first', 'stop first']);
+  });
+});
+
+async function waitForLifecycleQueue(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0));
+  await new Promise(resolve => setTimeout(resolve, 0));
+}

--- a/test/examples/gpgpu-responsive-website.node.spec.ts
+++ b/test/examples/gpgpu-responsive-website.node.spec.ts
@@ -11,6 +11,10 @@ const LUMA_EXAMPLE_PATH = path.join(
   process.cwd(),
   'website/src/react-luma/components/luma-example.tsx'
 );
+const EXAMPLE_LIFECYCLE_PATH = path.join(
+  process.cwd(),
+  'website/src/react-luma/utils/example-lifecycle.ts'
+);
 const EXAMPLE_CATALOG_PATH = path.join(process.cwd(), 'website/src/components/examples-index.tsx');
 const EXAMPLE_CARD_PATH = path.join(process.cwd(), 'website/src/components/example-card.tsx');
 const HOMEPAGE_SOURCE_PATH = path.join(process.cwd(), 'website/src/pages/index.jsx');
@@ -117,23 +121,18 @@ describe('responsive GPGPU website examples', () => {
   });
 
   test('serializes template finalization after asynchronous initialization', () => {
-    const lifecycleSource = readFileSync(LUMA_EXAMPLE_PATH, 'utf8');
-    const cleanupOffset = lifecycleSource.lastIndexOf('return () => {\n      isCancelled = true;');
-    const queuedCleanupOffset = lifecycleSource.indexOf(
-      'currentLumaExampleTask = currentLumaExampleTask',
-      cleanupOffset
+    const exampleSource = readFileSync(LUMA_EXAMPLE_PATH, 'utf8');
+    const lifecycleSource = readFileSync(EXAMPLE_LIFECYCLE_PATH, 'utf8');
+    const stopPreviousOffset = lifecycleSource.indexOf(
+      'await stopExampleSession(activeExampleSession)'
     );
-    const serializedDestroyOffset = lifecycleSource.indexOf(
-      'animationLoop.destroy()',
-      queuedCleanupOffset
-    );
-    const immediateCleanupSource = lifecycleSource.slice(cleanupOffset, queuedCleanupOffset);
+    const startNextOffset = lifecycleSource.indexOf('await session.start()');
 
-    expect(cleanupOffset).toBeGreaterThan(0);
-    expect(queuedCleanupOffset).toBeGreaterThan(cleanupOffset);
-    expect(serializedDestroyOffset).toBeGreaterThan(queuedCleanupOffset);
-    expect(immediateCleanupSource).not.toContain('animationLoop?.stop()');
-    expect(immediateCleanupSource).toContain('canvasContainer.replaceChildren()');
+    expect(exampleSource).toContain('startExclusiveExample({');
+    expect(exampleSource).toContain('canvasContainer.replaceChildren()');
+    expect(exampleSource).toContain('animationLoop.destroy()');
+    expect(stopPreviousOffset).toBeGreaterThan(0);
+    expect(startNextOffset).toBeGreaterThan(stopPreviousOffset);
   });
 
   test('keeps DOM-only compute examples from inserting presentation canvases into the page', () => {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -223,6 +223,14 @@ module.exports = {
       }
       return plugin;
     }),
+    function exampleNavigationLifecycle() {
+      return {
+        name: 'example-navigation-lifecycle',
+        getClientModules() {
+          return [path.resolve(__dirname, 'src/client-modules/example-navigation.ts')];
+        }
+      };
+    },
     [
       '@signalwire/docusaurus-plugin-llms-txt',
       {

--- a/website/src/client-modules/example-navigation.ts
+++ b/website/src/client-modules/example-navigation.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {ClientModule} from '@docusaurus/types';
+import {
+  EXAMPLE_NAVIGATION_END_EVENT,
+  EXAMPLE_NAVIGATION_START_EVENT
+} from '../react-luma/utils/example-lifecycle';
+
+const EXAMPLE_ROUTE_PATTERN = /(?:^|\/)examples(?:\/|$)/;
+
+const exampleNavigationClientModule: ClientModule = {
+  onRouteUpdate({location, previousLocation}) {
+    if (!previousLocation || location.pathname === previousLocation.pathname) {
+      return;
+    }
+
+    if (isExampleRoute(previousLocation.pathname)) {
+      window.dispatchEvent(new Event(EXAMPLE_NAVIGATION_START_EVENT));
+    }
+  },
+  onRouteDidUpdate() {
+    window.dispatchEvent(new Event(EXAMPLE_NAVIGATION_END_EVENT));
+  }
+};
+
+export default exampleNavigationClientModule;
+
+function isExampleRoute(pathname: string): boolean {
+  return EXAMPLE_ROUTE_PATTERN.test(pathname);
+}

--- a/website/src/custom.css
+++ b/website/src/custom.css
@@ -2573,6 +2573,60 @@ html[data-theme="dark"] .markdown .docs-arrow-structure__detail {
   padding-bottom: 0.5rem;
 }
 
+/* Loading surfaces cover stale shared-canvas pixels until the next example renders. */
+.luma-example-loading,
+.luma-example-navigation-loading {
+  position: absolute;
+  inset: 0;
+  z-index: 40;
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 0.7rem;
+  padding: 2rem;
+  background:
+    radial-gradient(ellipse at 50% 42%, rgba(14, 165, 233, 0.16), transparent 28rem),
+    #07101d;
+  color: #f1f5f9;
+  text-align: center;
+}
+
+.luma-example-navigation-loading {
+  position: fixed;
+  z-index: 1000;
+}
+
+.luma-example-loading--embedded {
+  border-radius: inherit;
+}
+
+.luma-example-loading strong,
+.luma-example-navigation-loading strong {
+  font-size: 1.08rem;
+  letter-spacing: -0.01em;
+}
+
+.luma-example-loading > span:last-child,
+.luma-example-navigation-loading > span:last-child {
+  color: #aebed0;
+  font-size: 0.86rem;
+}
+
+.luma-example-loading-spinner {
+  width: 2rem;
+  height: 2rem;
+  border: 3px solid rgba(125, 211, 252, 0.24);
+  border-top-color: #7dd3fc;
+  border-radius: 50%;
+  animation: luma-example-loading-spin 800ms linear infinite;
+}
+
+@keyframes luma-example-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* Premium example navigation is scoped to the examples plugin route shell only. */
 body:has([data-luma-example-route]) .theme-doc-sidebar-container {
   --luma-example-sidebar-accent: #0369a1;
@@ -2666,6 +2720,10 @@ html[data-theme="dark"]
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .luma-example-loading-spinner {
+    animation: none;
+  }
+
   body:has([data-luma-example-route]) .theme-doc-sidebar-container .menu__link {
     transition: none;
   }

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -5,6 +5,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import {
   DeviceTabs,
   ExampleHeader,
+  ExampleLoadingIndicator,
   ExamplePage,
   getCanvasContainer,
   InfoBox,
@@ -24,6 +25,7 @@ import type {GPGPUShowcaseHandle} from '../../examples/v10/gpgpu/src/app';
 import type {ExternalWebGLContextHandle} from '../../examples/integrations/external-context/app';
 import type {GaussianSplatSourceCatalogEntry} from '../../examples/showcase/gaussian-splats/local-loaders';
 import {getErrorMessage, logError} from './react-luma/utils/error-utils';
+import {startExclusiveExample} from './react-luma/utils/example-lifecycle';
 
 const exampleConfig = {};
 
@@ -357,45 +359,49 @@ function DeckArrowLayerCanvas({
     if (!(deviceCanvas instanceof HTMLCanvasElement)) {
       throw new Error('Website Deck examples require the shared device canvas to be an HTMLCanvasElement');
     }
-    Object.assign(deviceCanvas.style, {
-      display: 'block',
-      position: 'absolute',
-      inset: '0',
-      width: '100%',
-      height: '100%'
-    });
-    container.replaceChildren(deviceCanvas);
-
     let isFinalized = false;
     let deck: DeckExampleHandle | null = null;
-    void device.lost.then(loss => {
-      if (!isFinalized && loss.reason !== 'destroyed') {
-        setErrorMessage(loss.message || 'The graphics device was lost while this example ran.');
-        setRuntimeState('failed');
-      }
-    });
-    void Promise.resolve(createDeck(container, {device}))
-      .then(createdDeck => {
-        if (isFinalized) {
-          createdDeck.finalize();
-          return;
+    const stopExclusiveExample = startExclusiveExample({
+      start: async () => {
+        Object.assign(deviceCanvas.style, {
+          display: 'block',
+          position: 'absolute',
+          inset: '0',
+          width: '100%',
+          height: '100%'
+        });
+        container.replaceChildren(deviceCanvas);
+        void device.lost.then(loss => {
+          if (!isFinalized && loss.reason !== 'destroyed') {
+            setErrorMessage(loss.message || 'The graphics device was lost while this example ran.');
+            setRuntimeState('failed');
+          }
+        });
+        deck = await createDeck(container, {device});
+        if (!isFinalized) {
+          setRuntimeState('running');
         }
-        deck = createdDeck;
-        setRuntimeState('running');
-      })
-      .catch(error => {
+      },
+      stop: () => {
+        isFinalized = true;
+        deck?.finalize();
+        deck = null;
+        container.replaceChildren();
+        getCanvasContainer().appendChild(deviceCanvas);
+      },
+      onError: error => {
         if (!isFinalized) {
           setErrorMessage(getErrorMessage(error));
           setRuntimeState('failed');
           logError(`Failed to initialize ${panel.id} Deck example`, error);
         }
-      });
+      }
+    });
 
     return () => {
       isFinalized = true;
-      deck?.finalize();
       container.replaceChildren();
-      getCanvasContainer().appendChild(deviceCanvas);
+      stopExclusiveExample();
     };
   }, [createDeck, device, panel.id]);
 
@@ -403,6 +409,7 @@ function DeckArrowLayerCanvas({
     <div data-luma-example-state={runtimeState} style={{position: 'absolute', inset: 0}}>
       <div ref={containerRef} style={{position: 'absolute', inset: 0, overflow: 'hidden'}} />
       <DeckArrowLayerPanel {...panel} />
+      {runtimeState === 'loading' ? <ExampleLoadingIndicator /> : null}
       {errorMessage ? (
         <div role="alert" style={{position: 'absolute', inset: 20, zIndex: 30}}>
           {errorMessage}
@@ -1231,6 +1238,7 @@ export const ArrowDggsPolygonsExample: React.FC = props => (
 
 export const GPGPUExample: React.FC = () => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
   const deviceType = useStore(store => store.deviceType);
   const device = useStore(store => store.device);
 
@@ -1239,31 +1247,41 @@ export const GPGPUExample: React.FC = () => {
       return;
     }
 
-    let isCancelled = false;
     let handle: GPGPUShowcaseHandle | null = null;
     setErrorMessage(null);
-    void loadGPGPUShowcaseExample()
-      .then(({initializeGPGPUShowcase}) => {
+    setIsRunning(false);
+    let isCancelled = false;
+    const stopExclusiveExample = startExclusiveExample({
+      start: async () => {
+        const {initializeGPGPUShowcase} = await loadGPGPUShowcaseExample();
         if (!isCancelled) {
           handle = initializeGPGPUShowcase({device});
+          setIsRunning(true);
         }
-      })
-      .catch(error => {
+      },
+      stop: () => {
+        isCancelled = true;
+        setIsRunning(false);
+        handle?.destroy();
+        handle = null;
+      },
+      onError: error => {
         if (!isCancelled) {
           setErrorMessage(getErrorMessage(error));
           logError('Failed to initialize GPGPU example', error);
         }
-      });
+      }
+    });
 
     return () => {
       isCancelled = true;
-      handle?.destroy();
+      stopExclusiveExample();
     };
   }, [deviceType, device]);
 
   return (
     <ExamplePage
-      runtimeState={errorMessage ? 'failed' : 'running'}
+      runtimeState={errorMessage ? 'failed' : isRunning ? 'running' : 'loading'}
       style={{background: '#f7f8fb', overflow: 'hidden'}}
     >
       <style>{GPGPU_EXAMPLE_STYLE}</style>
@@ -1336,26 +1354,36 @@ export const GPGPUExample: React.FC = () => {
 /** Docusaurus wrapper for the graph-native paired GPU sort example. */
 export const GPUSortExample: React.FC<WebsiteExampleProps> = ({embeddedHeight, ...props}) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
 
   useEffect(() => {
     let isCancelled = false;
     let handle: GPUSortExampleHandle | null = null;
-    void loadGPUSortExample()
-      .then(({initializeGPUSortExample}) => {
+    const stopExclusiveExample = startExclusiveExample({
+      start: async () => {
+        const {initializeGPUSortExample} = await loadGPUSortExample();
         if (!isCancelled) {
           handle = initializeGPUSortExample();
+          setIsRunning(true);
         }
-      })
-      .catch(error => {
+      },
+      stop: () => {
+        isCancelled = true;
+        setIsRunning(false);
+        handle?.destroy();
+        handle = null;
+      },
+      onError: error => {
         if (!isCancelled) {
           setErrorMessage(getErrorMessage(error));
           logError('Failed to initialize GPU sort example', error);
         }
-      });
+      }
+    });
 
     return () => {
       isCancelled = true;
-      handle?.destroy();
+      stopExclusiveExample();
     };
   }, []);
 
@@ -1363,7 +1391,7 @@ export const GPUSortExample: React.FC<WebsiteExampleProps> = ({embeddedHeight, .
     <ExamplePage
       {...props}
       embeddedHeight={embeddedHeight ?? (props.embedded ? 720 : undefined)}
-      runtimeState={errorMessage ? 'failed' : 'running'}
+      runtimeState={errorMessage ? 'failed' : isRunning ? 'running' : 'loading'}
       style={{background: '#f7f8fb', overflow: 'auto', ...props.style}}
     >
       <main id="gpu-sort-app" />
@@ -1382,25 +1410,35 @@ export const GPUDataAnalysisExample: React.FC<WebsiteExampleProps> = ({
   ...props
 }) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
 
   useEffect(() => {
     let isCancelled = false;
     let handle: GPUDataAnalysisExampleHandle | null = null;
-    void loadGPUDataAnalysisExample()
-      .then(({initializeGPUDataAnalysisExample}) => {
+    const stopExclusiveExample = startExclusiveExample({
+      start: async () => {
+        const {initializeGPUDataAnalysisExample} = await loadGPUDataAnalysisExample();
         if (!isCancelled) {
           handle = initializeGPUDataAnalysisExample();
+          setIsRunning(true);
         }
-      })
-      .catch(error => {
+      },
+      stop: () => {
+        isCancelled = true;
+        setIsRunning(false);
+        handle?.destroy();
+        handle = null;
+      },
+      onError: error => {
         if (!isCancelled) {
           setErrorMessage(getErrorMessage(error));
           logError('Failed to initialize GPU data-analysis example', error);
         }
-      });
+      }
+    });
     return () => {
       isCancelled = true;
-      handle?.destroy();
+      stopExclusiveExample();
     };
   }, []);
 
@@ -1408,7 +1446,7 @@ export const GPUDataAnalysisExample: React.FC<WebsiteExampleProps> = ({
     <ExamplePage
       {...props}
       embeddedHeight={embeddedHeight ?? (props.embedded ? 720 : undefined)}
-      runtimeState={errorMessage ? 'failed' : 'running'}
+      runtimeState={errorMessage ? 'failed' : isRunning ? 'running' : 'loading'}
       style={{background: '#f6f8fb', overflow: 'auto', ...props.style}}
     >
       <main id="gpu-data-analysis-app" />
@@ -2309,6 +2347,7 @@ export const RenderBundlesExample: React.FC<WebsiteExampleProps> = props => (
 export const ExternalContextExample: React.FC = () => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -2317,32 +2356,42 @@ export const ExternalContextExample: React.FC = () => {
     let isCancelled = false;
     let exampleHandle: ExternalWebGLContextHandle | null = null;
 
-    loadExternalContextExample()
-      .then(({default: initializeExternalWebGLContext}) =>
-        initializeExternalWebGLContext({container})
-      )
-      .then(instance => {
+    const stopExclusiveExample = startExclusiveExample({
+      start: async () => {
+        const {default: initializeExternalWebGLContext} = await loadExternalContextExample();
+        const instance = await initializeExternalWebGLContext({container});
         if (isCancelled) {
           instance.destroy();
           return;
         }
         exampleHandle = instance;
-      })
-      .catch(caughtError => {
+        setIsRunning(true);
+      },
+      stop: () => {
+        isCancelled = true;
+        setIsRunning(false);
+        exampleHandle?.destroy();
+        exampleHandle = null;
+      },
+      onError: caughtError => {
         if (!isCancelled) {
           logError('External WebGL context example failed', caughtError);
           setError(getErrorMessage(caughtError));
         }
-      });
+      }
+    });
 
     return () => {
       isCancelled = true;
-      exampleHandle?.destroy();
+      stopExclusiveExample();
     };
   }, []);
 
   return (
-    <ExamplePage runtimeState={error ? 'failed' : 'running'} style={{minHeight: '640px'}}>
+    <ExamplePage
+      runtimeState={error ? 'failed' : isRunning ? 'running' : 'loading'}
+      style={{minHeight: '640px'}}
+    >
       <div
         className="integration-example-page"
         style={{position: 'relative', width: '100%', minHeight: '640px'}}

--- a/website/src/react-luma/components/luma-example.tsx
+++ b/website/src/react-luma/components/luma-example.tsx
@@ -22,8 +22,13 @@ import {
 } from '../utils/hdr-screenshot-capture';
 import {getMobileExamplePixelRatio} from '../utils/mobile-example-pixel-ratio';
 import {
-  getExampleMobileQuality,
+  EXAMPLE_NAVIGATION_END_EVENT,
+  EXAMPLE_NAVIGATION_START_EVENT,
+  startExclusiveExample
+} from '../utils/example-lifecycle';
+import {
   getExampleMobileLabel,
+  getExampleMobileQuality,
   getExampleMobileUnsupportedReason,
   getExampleRuntimeEnvironment,
   type ExampleMobileMode,
@@ -43,8 +48,6 @@ import {
   type DeviceType,
   useStore
 } from '../store/device-store';
-
-let currentLumaExampleTask: Promise<void> = Promise.resolve();
 
 export type {HDRScreenshotCapture} from '../utils/hdr-screenshot-capture';
 
@@ -213,13 +216,18 @@ export const ExampleStage: FC<ExampleStageProps> = (props: ExampleStageProps) =>
 
 export const ExamplePage: FC<ExamplePageProps> = (props: ExamplePageProps) => {
   const [isImmersive, setIsImmersive] = useState(true);
+  const [isNavigationPending, setIsNavigationPending] = useState(false);
   const supportDefinition = useResolvedExampleSupportDefinition(props);
   const runtimeEnvironment = useExampleRuntimeEnvironment();
   const mobileUnsupportedReason = getExampleMobileUnsupportedReason(
     supportDefinition,
     runtimeEnvironment
   );
-  const runtimeState = mobileUnsupportedReason ? 'unsupported' : props.runtimeState || 'running';
+  const runtimeState = mobileUnsupportedReason
+    ? 'unsupported'
+    : isNavigationPending
+      ? 'loading'
+      : props.runtimeState || 'running';
   const embeddedHeight = props.embeddedHeight ?? 560;
   const embeddedStyle: CSSProperties | undefined = props.embedded
     ? {
@@ -227,6 +235,17 @@ export const ExamplePage: FC<ExamplePageProps> = (props: ExamplePageProps) => {
         minHeight: embeddedHeight === 'auto' ? 0 : embeddedHeight
       }
     : undefined;
+
+  useEffect(() => {
+    const handleNavigationStart = () => setIsNavigationPending(true);
+    const handleNavigationEnd = () => setIsNavigationPending(false);
+    window.addEventListener(EXAMPLE_NAVIGATION_START_EVENT, handleNavigationStart);
+    window.addEventListener(EXAMPLE_NAVIGATION_END_EVENT, handleNavigationEnd);
+    return () => {
+      window.removeEventListener(EXAMPLE_NAVIGATION_START_EVENT, handleNavigationStart);
+      window.removeEventListener(EXAMPLE_NAVIGATION_END_EVENT, handleNavigationEnd);
+    };
+  }, []);
 
   return (
     <div
@@ -257,9 +276,12 @@ export const ExamplePage: FC<ExamplePageProps> = (props: ExamplePageProps) => {
           message={mobileUnsupportedReason}
           state="unsupported"
         />
-      ) : (
+      ) : isNavigationPending ? null : (
         props.children
       )}
+      {runtimeState === 'loading' && !isNavigationPending ? (
+        <ExampleLoadingIndicator embedded={props.embedded} />
+      ) : null}
       {!props.embedded ? (
         <button
           data-luma-example-fullscreen-toggle=""
@@ -665,53 +687,57 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
       }
     };
 
-    currentLumaExampleTask = currentLumaExampleTask
-      .then(() => {
-        if (isCancelled) {
-          return;
+    const stopExclusiveExample = startExclusiveExample({
+      start: asyncCreateLoop,
+      stop: () => {
+        isCancelled = true;
+        captureController?.finalize();
+        removeBrowserCaptureFunction();
+        window.removeEventListener('resize', updateMobileDrawingBufferResolution);
+        // Never leave the shared canvas showing the outgoing example while teardown is queued.
+        canvasContainer.replaceChildren();
+
+        if (animationLoop) {
+          // destroy() synchronously finalizes the template after start() has settled.
+          if (!effectiveDevice.isLost) {
+            effectiveDevice.submit();
+          }
+          animationLoop.destroy();
+          animationLoop = null;
         }
 
-        return asyncCreateLoop();
-      })
-      .catch(error => {
+        clearActiveCpuHotspotProfilerDevice(effectiveDevice);
+        defaultCanvasContext.setProps({useDevicePixels: previousUseDevicePixels});
+        if (deviceCanvas instanceof HTMLCanvasElement) {
+          delete deviceCanvas.dataset.lumaExamplePixelRatio;
+        }
+        getCanvasContainer().appendChild(deviceCanvas as HTMLCanvasElement);
+      },
+      onError: error => {
         if (!isCancelled) {
           setStartupErrorMessage(getErrorMessage(error));
           setHasRendered(false);
           logError(`Example startup failed for ${effectiveDeviceType}`, error);
         }
-      });
+      }
+    });
+
+    let hasRequestedStop = false;
+    const stopExample = () => {
+      if (hasRequestedStop) {
+        return;
+      }
+      hasRequestedStop = true;
+      isCancelled = true;
+      canvasContainer.replaceChildren();
+      window.removeEventListener(EXAMPLE_NAVIGATION_START_EVENT, stopExample);
+      stopExclusiveExample();
+    };
+    window.addEventListener(EXAMPLE_NAVIGATION_START_EVENT, stopExample);
 
     return () => {
-      isCancelled = true;
-      captureController?.finalize();
-      removeBrowserCaptureFunction();
-      window.removeEventListener('resize', updateMobileDrawingBufferResolution);
-      // Route transitions must stop displaying the outgoing example immediately, even when its
-      // asynchronous initialization is still ahead of cleanup in the serialized task queue.
-      canvasContainer.replaceChildren();
-
-      currentLumaExampleTask = currentLumaExampleTask
-        .then(() => {
-          if (animationLoop) {
-            // destroy() synchronously finalizes the template, so it must remain serialized after
-            // animationLoop.start() and its asynchronous onInitialize() have settled.
-            if (!effectiveDevice.isLost) {
-              effectiveDevice.submit();
-            }
-            animationLoop.destroy();
-            animationLoop = null;
-          }
-
-          clearActiveCpuHotspotProfilerDevice(effectiveDevice);
-          defaultCanvasContext.setProps({useDevicePixels: previousUseDevicePixels});
-          if (deviceCanvas instanceof HTMLCanvasElement) {
-            delete deviceCanvas.dataset.lumaExamplePixelRatio;
-          }
-          getCanvasContainer().appendChild(deviceCanvas as HTMLCanvasElement);
-        })
-        .catch(error => {
-          logError(`Example cleanup failed for ${effectiveDeviceType}`, error);
-        });
+      window.removeEventListener(EXAMPLE_NAVIGATION_START_EVENT, stopExample);
+      stopExample();
     };
   }, [
     effectiveDeviceType,
@@ -970,6 +996,21 @@ function ExampleStatusMessage({
         </strong>
         <span>{message}</span>
       </div>
+    </div>
+  );
+}
+
+export function ExampleLoadingIndicator({embedded}: {embedded?: boolean}): React.JSX.Element {
+  return (
+    <div
+      className={`luma-example-loading${embedded ? ' luma-example-loading--embedded' : ''}`}
+      data-luma-example-status="loading"
+      role="status"
+      aria-live="polite"
+    >
+      <span className="luma-example-loading-spinner" aria-hidden="true" />
+      <strong>Loading example</strong>
+      <span>Preparing GPU resources…</span>
     </div>
   );
 }

--- a/website/src/react-luma/index.ts
+++ b/website/src/react-luma/index.ts
@@ -20,7 +20,7 @@ export {
 } from './components/device-info';
 
 // Examples
-export {ExamplePage, ExampleStage} from './components/luma-example';
+export {ExampleLoadingIndicator, ExamplePage, ExampleStage} from './components/luma-example';
 export {ExampleHeader} from './components/luma-example';
 export type {
   ExampleDisplayProps,

--- a/website/src/react-luma/utils/example-lifecycle.ts
+++ b/website/src/react-luma/utils/example-lifecycle.ts
@@ -49,8 +49,9 @@ export function startExclusiveExample(example: ExclusiveExample): () => void {
     try {
       await session.start();
     } catch (error) {
+      session.onError(error);
       await stopExampleSession(session);
-      throw error;
+      return;
     }
 
     if (session.stopRequested) {

--- a/website/src/react-luma/utils/example-lifecycle.ts
+++ b/website/src/react-luma/utils/example-lifecycle.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export const EXAMPLE_NAVIGATION_START_EVENT = 'luma-example-navigation-start';
+export const EXAMPLE_NAVIGATION_END_EVENT = 'luma-example-navigation-end';
+
+export type ExclusiveExample = {
+  start: () => Promise<void> | void;
+  stop: () => Promise<void> | void;
+  onError: (error: unknown) => void;
+};
+
+type ExclusiveExampleSession = ExclusiveExample & {
+  started: boolean;
+  stopRequested: boolean;
+  stopped: boolean;
+};
+
+let activeExampleSession: ExclusiveExampleSession | null = null;
+let exampleLifecycleTask: Promise<void> = Promise.resolve();
+
+/**
+ * Starts an example after the previous example has completely stopped.
+ *
+ * The returned function is idempotent and requests teardown. A session also stops when another
+ * session starts, which protects the GPU if two example pages overlap during a route transition.
+ */
+export function startExclusiveExample(example: ExclusiveExample): () => void {
+  const session: ExclusiveExampleSession = {
+    ...example,
+    started: false,
+    stopRequested: false,
+    stopped: false
+  };
+
+  const startTask = enqueueExampleLifecycleTask(async () => {
+    if (session.stopRequested) {
+      return;
+    }
+    if (activeExampleSession) {
+      await stopExampleSession(activeExampleSession);
+    }
+    if (session.stopRequested) {
+      return;
+    }
+
+    activeExampleSession = session;
+    session.started = true;
+    try {
+      await session.start();
+    } catch (error) {
+      await stopExampleSession(session);
+      throw error;
+    }
+
+    if (session.stopRequested) {
+      await stopExampleSession(session);
+    }
+  });
+  void startTask.catch(session.onError);
+
+  return () => {
+    if (session.stopRequested) {
+      return;
+    }
+    session.stopRequested = true;
+    const stopTask = enqueueExampleLifecycleTask(() => stopExampleSession(session));
+    void stopTask.catch(session.onError);
+  };
+}
+
+async function stopExampleSession(session: ExclusiveExampleSession): Promise<void> {
+  if (session.stopped) {
+    return;
+  }
+
+  session.stopped = true;
+  if (activeExampleSession === session) {
+    activeExampleSession = null;
+  }
+  if (!session.started) {
+    return;
+  }
+  try {
+    await session.stop();
+  } catch (error) {
+    session.onError(error);
+  }
+}
+
+function enqueueExampleLifecycleTask(task: () => Promise<void> | void): Promise<void> {
+  const queuedTask = exampleLifecycleTask.then(task);
+  exampleLifecycleTask = queuedTask.catch(() => {});
+  return queuedTask;
+}

--- a/website/src/theme/Root.tsx
+++ b/website/src/theme/Root.tsx
@@ -1,9 +1,42 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
+import {
+  EXAMPLE_NAVIGATION_END_EVENT,
+  EXAMPLE_NAVIGATION_START_EVENT
+} from '../react-luma/utils/example-lifecycle';
 
 type RootProps = {
   children: React.ReactNode;
 };
 
 export default function Root(props: RootProps) {
-  return <>{props.children}</>;
+  const [isExampleNavigationPending, setIsExampleNavigationPending] = useState(false);
+
+  useEffect(() => {
+    const handleNavigationStart = () => setIsExampleNavigationPending(true);
+    const handleNavigationEnd = () => setIsExampleNavigationPending(false);
+    window.addEventListener(EXAMPLE_NAVIGATION_START_EVENT, handleNavigationStart);
+    window.addEventListener(EXAMPLE_NAVIGATION_END_EVENT, handleNavigationEnd);
+    return () => {
+      window.removeEventListener(EXAMPLE_NAVIGATION_START_EVENT, handleNavigationStart);
+      window.removeEventListener(EXAMPLE_NAVIGATION_END_EVENT, handleNavigationEnd);
+    };
+  }, []);
+
+  return (
+    <>
+      {props.children}
+      {isExampleNavigationPending ? (
+        <div
+          className="luma-example-navigation-loading"
+          data-luma-example-navigation-loading=""
+          role="status"
+          aria-live="polite"
+        >
+          <span className="luma-example-loading-spinner" aria-hidden="true" />
+          <strong>Loading example</strong>
+          <span>Stopping the previous GPU work and preparing the next scene…</span>
+        </div>
+      ) : null}
+    </>
+  );
 }


### PR DESCRIPTION
## Goals

- Show an immediate, unambiguous loading state while switching examples.
- Prevent stale pixels from the previous shared canvas from appearing in the next example.
- Ensure GPU examples are stopped before another example starts.

## Changes

- Added an exclusive example lifecycle coordinator shared by animation-loop, Deck, GPGPU, GPU analysis, and external-context examples.
- Added Docusaurus route lifecycle handling that stops outgoing GPU work as soon as navigation begins.
- Added route-level and first-frame loading indicators with reduced-motion support.
- Updated existing lifecycle contract coverage and added focused queue/cancellation tests.

## Verification

- `yarn lint fix`
- Pre-commit `test-fast`: 410 test files passed, 1 skipped; 3272 tests passed, 7 skipped.
- Focused lifecycle and website contract tests: 9 passed.

## Known local environment limitations

- `yarn website:build` reaches Docusaurus client compilation but is blocked by missing optional `compress-utils` codec modules in the local install.
- The website TypeScript command reports existing cross-example/API errors, including the current `mobileQuality` mismatch on `master`; no new lifecycle-specific TypeScript error was reported.