### PR TITLE
feat(experimental): verify math.gl 5 CRS projection support

### DIFF
--- a/docs/api-reference/experimental/gpu-project.md
+++ b/docs/api-reference/experimental/gpu-project.md
@@ -104,6 +104,11 @@ coordinate system uses meters.
 object with a `project(coordinates)` method can provide the projection. For WGS84-to-Web-Mercator
 applications, `createWebMercatorProjection()` provides a zero-dependency alternative:
 
+With math.gl 5, `Proj4Projection` also accepts compatible CRS definitions from `@math.gl/crs`,
+including PROJJSON objects. Use `checkProj4CRSCompatibility()` when a broader CRS metadata object
+may include unsupported vertical or compound components; CRS metadata by itself does not transform
+coordinates.
+
 ```ts
 import {
   compileProjectionPlan,

--- a/modules/experimental/src/gpu-project/README.md
+++ b/modules/experimental/src/gpu-project/README.md
@@ -66,6 +66,11 @@ compiled.encode(encoder, {parameters: undefined});
 device.submit(encoder.finish());
 ```
 
+With math.gl 5, `from` and `to` can also be compatible CRS definitions from `@math.gl/crs`,
+including PROJJSON objects. `@math.gl/proj4` checks whether each definition is executable by
+proj4js; `gpu-project` then samples that provider on the CPU and evaluates the resulting local
+approximation on the GPU. CRS metadata alone does not perform a transformation.
+
 `bounds` are `[minimumX, minimumY, maximumX, maximumY]` in the source
 coordinate system. `tolerance` is expressed in the destination coordinate
 system's units; when the destination is a meter-based CRS, `0.01` requests a

--- a/modules/experimental/test/gpu-project/projection-plan.node.spec.ts
+++ b/modules/experimental/test/gpu-project/projection-plan.node.spec.ts
@@ -4,6 +4,7 @@
 
 import {readFileSync} from 'node:fs';
 
+import {Proj4Projection} from '@math.gl/proj4';
 import * as experimentalModule from '@luma.gl/experimental';
 import * as projectionModule from '@luma.gl/experimental/gpu-project';
 import {
@@ -119,6 +120,68 @@ describe('dependency-free Web Mercator projection provider', () => {
 });
 
 describe('CPU projection plan compilation', () => {
+  test('accepts math.gl 5 PROJJSON CRS definitions through Proj4Projection', () => {
+    const wgs84: NonNullable<ConstructorParameters<typeof Proj4Projection>[0]['from']> = {
+      type: 'GeographicCRS',
+      name: 'WGS 84',
+      datum: {
+        type: 'GeodeticReferenceFrame',
+        name: 'World Geodetic System 1984',
+        ellipsoid: {
+          name: 'WGS 84',
+          semi_major_axis: 6_378_137,
+          inverse_flattening: 298.257223563
+        }
+      },
+      coordinate_system: {
+        subtype: 'ellipsoidal',
+        axis: [
+          {name: 'Geodetic longitude', abbreviation: 'lon', direction: 'east', unit: 'degree'},
+          {name: 'Geodetic latitude', abbreviation: 'lat', direction: 'north', unit: 'degree'}
+        ]
+      },
+      id: {authority: 'EPSG', code: 4326}
+    };
+    const webMercator: NonNullable<ConstructorParameters<typeof Proj4Projection>[0]['to']> = {
+      type: 'ProjectedCRS',
+      name: 'WGS 84 / Pseudo-Mercator',
+      base_crs: wgs84,
+      conversion: {
+        name: 'Popular Visualisation Pseudo-Mercator',
+        method: {name: 'Popular Visualisation Pseudo Mercator'},
+        parameters: [
+          {name: 'Latitude of natural origin', value: 0, unit: 'degree'},
+          {name: 'Longitude of natural origin', value: 0, unit: 'degree'},
+          {name: 'Scale factor at natural origin', value: 1, unit: 'unity'},
+          {name: 'False easting', value: 0, unit: 'metre'},
+          {name: 'False northing', value: 0, unit: 'metre'}
+        ]
+      },
+      coordinate_system: {
+        subtype: 'Cartesian',
+        axis: [
+          {name: 'Easting', abbreviation: 'E', direction: 'east', unit: 'metre'},
+          {name: 'Northing', abbreviation: 'N', direction: 'north', unit: 'metre'}
+        ]
+      },
+      id: {authority: 'EPSG', code: 3857}
+    };
+    const projection = new Proj4Projection({from: wgs84, to: webMercator});
+    const plan = compileProjectionPlan({
+      projection,
+      bounds: [-122.45, 37.75, -122.4, 37.8],
+      degree: 3,
+      tolerance: 0.01
+    });
+    const coordinate = [-122.4194, 37.7749] as const;
+    const expected = projection.project([...coordinate]);
+    const actual = evaluateProjectionPlan(plan, coordinate);
+
+    expect(plan.maxError).toBeLessThanOrEqual(plan.tolerance);
+    expect(actual[0]).toBeCloseTo(expected[0], 2);
+    expect(actual[1]).toBeCloseTo(expected[1], 2);
+  });
+
   test('accepts object projection providers and preserves their receiver', () => {
     class AffineProjection {
       readonly translation: readonly [number, number] = [12_345, -67_890];

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@math.gl/dggs-geohash": "^4.1.0",
     "@math.gl/dggs-quadkey": "^4.1.0",
     "@math.gl/dggs-s2": "^4.1.0",
+    "@math.gl/proj4": "~5.0.0-alpha.5",
     "@probe.gl/bench": "^4.1.1",
     "@probe.gl/stats": "^4.1.1",
     "@probe.gl/stats-widget": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5265,10 +5265,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@math.gl/core@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@math.gl/core@npm:5.0.0-alpha.5"
+  dependencies:
+    "@math.gl/types": "npm:5.0.0-alpha.5"
+  checksum: 10c0/2a0de21791d4b373b2faed95dba05c62d1355b370a8f82a800f3b7239559e59674a388072eada1199afa1ef38b3388bb0494ddd1239ac8b32ca6d08ce31bd52f
+  languageName: node
+  linkType: hard
+
 "@math.gl/crs@npm:5.0.0-alpha.4":
   version: 5.0.0-alpha.4
   resolution: "@math.gl/crs@npm:5.0.0-alpha.4"
   checksum: 10c0/9e0c540e04e0bcd7b9667f7187c32e252d6032df3c75775fc9758c31cce00fd1da91b45bc5f17a0c17b76a02a706ccb347be95ce5fe4b12169d6373b9c2542eb
+  languageName: node
+  linkType: hard
+
+"@math.gl/crs@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@math.gl/crs@npm:5.0.0-alpha.5"
+  checksum: 10c0/9dae800428e37b7386eda1e4b03acef55f031b3196f3de6772d276502a29234007126d6533de2e1a48f705fa2c6d3bec76812b34ada21ba6afcbb75add554963
   languageName: node
   linkType: hard
 
@@ -5343,6 +5359,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@math.gl/proj4@npm:~5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@math.gl/proj4@npm:5.0.0-alpha.5"
+  dependencies:
+    "@math.gl/core": "npm:5.0.0-alpha.5"
+    "@math.gl/crs": "npm:5.0.0-alpha.5"
+    proj4: "npm:2.21.0"
+  checksum: 10c0/9f6b022b6165f09e714b3670f2bdd728ace349bc739decfd7005b27caa574d6ffa253602bc4d9c6f2d49541fc4d8abb35b6529c799cb9a01521b4f947a46f4c9
+  languageName: node
+  linkType: hard
+
 "@math.gl/sun@npm:^4.1.0":
   version: 4.1.0
   resolution: "@math.gl/sun@npm:4.1.0"
@@ -5361,6 +5388,13 @@ __metadata:
   version: 5.0.0-alpha.4
   resolution: "@math.gl/types@npm:5.0.0-alpha.4"
   checksum: 10c0/f4e0d05803909650e52d12dba30f93d25b5031006a7bb1c0d03650f9c27f82d8b8b920348892e41979ac5c070b920420bf1d4b8aeab2de1e865fdec1b8c68acd
+  languageName: node
+  linkType: hard
+
+"@math.gl/types@npm:5.0.0-alpha.5":
+  version: 5.0.0-alpha.5
+  resolution: "@math.gl/types@npm:5.0.0-alpha.5"
+  checksum: 10c0/b5ce7e8e0d2991dec31728892ace470703d8693991e0117150f7a8caa8c6193db90093ac67ff51056d301686bb9a739236f6bed9545836e86d2f1698bcf73c7d
   languageName: node
   linkType: hard
 
@@ -16419,6 +16453,7 @@ __metadata:
     "@math.gl/dggs-geohash": "npm:^4.1.0"
     "@math.gl/dggs-quadkey": "npm:^4.1.0"
     "@math.gl/dggs-s2": "npm:^4.1.0"
+    "@math.gl/proj4": "npm:~5.0.0-alpha.5"
     "@math.gl/types": "npm:^4.1.0"
     "@probe.gl/bench": "npm:^4.1.1"
     "@probe.gl/stats": "npm:^4.1.1"
@@ -17019,6 +17054,13 @@ __metadata:
   version: 1.1.2
   resolution: "methods@npm:1.1.2"
   checksum: 10c0/bdf7cc72ff0a33e3eede03708c08983c4d7a173f91348b4b1e4f47d4cdbf734433ad971e7d1e8c77247d9e5cd8adb81ea4c67b0a2db526b758b2233d7814b8b2
+  languageName: node
+  linkType: hard
+
+"mgrs@npm:1.0.0":
+  version: 1.0.0
+  resolution: "mgrs@npm:1.0.0"
+  checksum: 10c0/a360853be5a3b4f4734dbf0a193851c08039ccb6077362ab0f890cccd170ef88b59585129757da9fea4d7a313d7dc3ee88f37f594fc1ae3e4e8efc5353144d77
   languageName: node
   linkType: hard
 
@@ -20152,6 +20194,21 @@ __metadata:
   version: 3.0.0
   resolution: "proggy@npm:3.0.0"
   checksum: 10c0/b4265664405e780edf7a164b2424bb59fc7bd3ab917365c88c6540e5f3bedcbbfb1a534da9c6a4a5570f374a41ef6942e9a4e862dc3ea744798b6c7be63e4351
+  languageName: node
+  linkType: hard
+
+"proj4@npm:2.21.0":
+  version: 2.21.0
+  resolution: "proj4@npm:2.21.0"
+  dependencies:
+    mgrs: "npm:1.0.0"
+    wkt-parser: "npm:^1.5.5"
+  peerDependencies:
+    geotiff: "*"
+  peerDependenciesMeta:
+    geotiff:
+      optional: true
+  checksum: 10c0/7a4c5d160492636114ecb3719191734dc2b0094b421b9139466a363e479cd907c63ac35a10277f3b7a4649470c8f02446acd45cc6155829364c2fa0ae2d91aae
   languageName: node
   linkType: hard
 
@@ -23904,6 +23961,13 @@ __metadata:
   version: 2.0.1
   resolution: "wildcard@npm:2.0.1"
   checksum: 10c0/08f70cd97dd9a20aea280847a1fe8148e17cae7d231640e41eb26d2388697cbe65b67fd9e68715251c39b080c5ae4f76d71a9a69fa101d897273efdfb1b58bf7
+  languageName: node
+  linkType: hard
+
+"wkt-parser@npm:^1.5.5":
+  version: 1.5.6
+  resolution: "wkt-parser@npm:1.5.6"
+  checksum: 10c0/67f938ffb6a1721dbc733823677327ff858a0a1f2f0d224e2ecbdf9e879f27764434dd6e44c89a2e94e3d37cc6e5f9874f878e4a1b1e2fd29a1279be38c322ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Verify that GPU Project accepts math.gl 5 Proj4Projection providers backed by PROJJSON CRS definitions.
- Add a WGS84 to Web Mercator integration test against the adaptive GPU projection plan.
- Document the math.gl 5 CRS compatibility boundary while keeping projection execution optional.

## Verification

- `yarn install`
- `yarn lint fix`
- `yarn build`
- Node tests: 3,274 passed.
- Full `yarn test`: Node phase passed; headless phase has one unrelated existing failure in `modules/deck-arrow-layers/test/gpu-graph-deck.spec.ts:613` (resize expected 256, received 128).

## Notes

The existing `.playwright-mcp/` untracked directory was not included.
