### PR TITLE
feat(gpgpu): add generic GPU scatter primitive

### DIFF
--- a/docs/api-reference/experimental/gpu-core/gpu-scatter.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-scatter.md
@@ -1,0 +1,85 @@
+import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
+import {GPUOperationContract} from '@site/src/components/docs/gpu-operation-contract';
+
+# GPUScatter
+
+<GPUCoreDocsTabs active="scatter" />
+
+## Overview
+
+`GPUScatter` writes packed fixed-width rows to destinations selected by packed `uint32` indices.
+
+## Motivation
+
+Scatter is the inverse data-movement primitive to gather. Gather answers “which source row should
+this output row read?” Scatter answers “where should this source row be written?” It is the natural
+building block for prefix-sum pipelines, sparse materialization, partitioning, indexed routing, and
+many graph algorithms that first compute destination offsets and then place payload rows.
+
+Several higher-level `gpu-core` algorithms already contain specialized scatter stages. A standalone
+primitive makes that operation reusable and gives command graphs one common contract for indexed
+row movement instead of duplicating format-specific kernels.
+
+## Concepts
+
+For every source row `i`, scatter performs:
+
+```text
+output[indices[i]] = source[i]
+```
+
+when the destination is in range. Out-of-range destinations are ignored. Source and output must use
+the same packed fixed-width GPU format.
+
+```ts
+new GPUScatter({
+  source,
+  indices,
+  output
+}).addToGraph(graph);
+```
+
+Rows are copied as 32-bit words so floating-point and integer fixed-width formats share one kernel.
+This keeps the primitive about data movement rather than arithmetic interpretation.
+
+## Duplicate destinations
+
+`GPUScatter` deliberately does not impose conflict-resolution semantics. If multiple source rows
+write the same destination, those writes race and the final value is unspecified.
+
+That behavior keeps the primitive cheap and matches the fundamental GPU operation. Workflows that
+need deterministic duplicate handling should first establish unique destinations or use an
+aggregation/reduction primitive.
+
+## When to use it
+
+Use scatter after a stage that has already computed destination indices, for example:
+
+- exclusive scan + scatter for stable compaction
+- bucket offsets + scatter for partitioning
+- group offsets + scatter for grouped materialization
+- sparse index construction
+- graph frontier or adjacency routing
+
+Use gather instead when output order determines which source rows to fetch and no destination
+conflicts are desired.
+
+## Composition
+
+A canonical stable-filter pipeline is:
+
+```text
+predicate → flags → exclusive scan → GPUScatter
+```
+
+The scan produces unique destination indices for selected rows, eliminating scatter conflicts.
+That same pattern underlies compaction and many variable-length GPU algorithms.
+
+## Performance notes
+
+Scatter performs one indexed destination lookup and one fixed-width row copy per input row. The
+initial implementation supports packed rows whose byte length is a multiple of four. It does not
+allocate scratch resources or perform readback.
+
+Arbitrary duplicate-destination reduction is intentionally outside this primitive; adding atomic or
+reduction semantics would change both the type constraints and performance model substantially.

--- a/modules/gpgpu/src/gpu-core/gpu-scatter.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-scatter.ts
@@ -1,0 +1,186 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {
+  getGPUVectorFormatInfo,
+  isValueListGPUVectorFormat,
+  isVertexListGPUVectorFormat,
+  type GPUVectorFormat
+} from '@luma.gl/gpgpu/gpu-data';
+import {GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
+import {getBoundedDispatchLayout, getBoundedInvocationIndexSource} from './gpu-dispatch-utils';
+import {getViewBinding, getViewElementOffset, validatePackedUint32View} from './graph-data-view-utils';
+
+const SCATTER_WORKGROUP_SIZE = 256;
+const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
+
+/** Fixed-width graph data formats accepted by {@link GPUScatter}. */
+export type GPUScatterFormat = Exclude<
+  GPUVectorFormat,
+  `vertex-list<${string}>` | `value-list<${string}>`
+>;
+
+/** Properties for one graph-native indexed scatter. */
+export type GPUScatterProps<T extends GPUScatterFormat = GPUScatterFormat> = {
+  /** Prefix for the generated graph node. */
+  id?: string;
+  /** Packed fixed-width source rows. */
+  source: GraphDataView<T>;
+  /** Packed uint32 destination-row indices. */
+  indices: GraphDataView<'uint32'>;
+  /** Caller-owned packed destination with the same format as source. */
+  output: GraphDataView<T>;
+};
+
+/**
+ * Scatters packed fixed-width rows through uint32 destination indices.
+ *
+ * Each source row `i` is written to `output[indices[i]]`. Out-of-range destination indices are
+ * ignored. Duplicate destination indices are intentionally unordered: if multiple invocations write
+ * the same output row, the final value is unspecified. Callers that need deterministic conflict
+ * handling should pre-aggregate or otherwise ensure unique destination indices.
+ *
+ * Rows are copied as 32-bit words so float and integer formats share one kernel. Row byte length must
+ * therefore be a multiple of four.
+ */
+export class GPUScatter<T extends GPUScatterFormat = GPUScatterFormat> {
+  readonly id: string;
+  readonly source: GraphDataView<T>;
+  readonly indices: GraphDataView<'uint32'>;
+  readonly output: GraphDataView<T>;
+  readonly wordsPerRow: number;
+
+  constructor(props: GPUScatterProps<T>) {
+    this.id = props.id ?? 'gpu-scatter';
+    this.source = props.source;
+    this.indices = props.indices;
+    this.output = props.output;
+
+    validateScatterView(this.source, `${this.id} source`);
+    validatePackedUint32View(this.indices, `${this.id} indices`);
+    validateScatterView(this.output, `${this.id} output`);
+
+    if (this.source.format !== this.output.format) {
+      throw new Error(`${this.id} source and output must use the same format`);
+    }
+    if (this.source.length < this.indices.length) {
+      throw new Error(`${this.id} source must contain at least indices.length rows`);
+    }
+    if (this.output.buffer === this.source.buffer || this.output.buffer === this.indices.buffer) {
+      throw new Error(`${this.id} output must use a separate buffer`);
+    }
+
+    this.wordsPerRow = this.source.rowByteLength / UINT32_BYTE_LENGTH;
+  }
+
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    for (const view of [this.source, this.indices, this.output]) {
+      if (view.buffer.graph !== graph) {
+        throw new Error(`${this.id} views must belong to the target graph`);
+      }
+    }
+    if (this.indices.length === 0) {
+      return;
+    }
+
+    const dispatchLayout = getBoundedDispatchLayout(
+      'GPUScatter',
+      this.indices.length,
+      SCATTER_WORKGROUP_SIZE,
+      graph.device.limits.maxComputeWorkgroupsPerDimension
+    );
+    const source = makeShaderSource(this, dispatchLayout);
+
+    graph.addComputePass({
+      id: this.id,
+      workload: {
+        operation: 'GPUScatter',
+        commandCount: 1,
+        maximumWorkgroupCount: dispatchLayout.x * dispatchLayout.y * dispatchLayout.z,
+        maximumInvocationCount:
+          dispatchLayout.x * dispatchLayout.y * dispatchLayout.z * SCATTER_WORKGROUP_SIZE,
+        readByteLength: this.indices.length * (UINT32_BYTE_LENGTH + this.source.rowByteLength),
+        writeByteLength: this.indices.length * this.output.rowByteLength
+      },
+      resources: [
+        {buffer: this.source, usage: 'storage-read'},
+        {buffer: this.indices, usage: 'storage-read'},
+        {buffer: this.output, usage: 'storage-write'}
+      ],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: this.id,
+          source,
+          shaderLayout: {
+            bindings: [
+              {name: 'sourceWords', type: 'read-only-storage', group: 0, location: 0},
+              {name: 'indices', type: 'read-only-storage', group: 0, location: 1},
+              {name: 'outputWords', type: 'storage', group: 0, location: 2}
+            ]
+          }
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            const bindings: Record<string, Binding> = {
+              sourceWords: getViewBinding(this.source, getBuffer),
+              indices: getViewBinding(this.indices, getBuffer),
+              outputWords: getViewBinding(this.output, getBuffer)
+            };
+            computation.setBindings(bindings);
+            computation.dispatch(computePass, dispatchLayout.x, dispatchLayout.y, dispatchLayout.z);
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+  }
+}
+
+function validateScatterView(view: GraphDataView, name: string): void {
+  if (isVertexListGPUVectorFormat(view.format) || isValueListGPUVectorFormat(view.format)) {
+    throw new Error(`${name} must use a fixed-width GPU data format`);
+  }
+  const formatInfo = getGPUVectorFormatInfo(view.format);
+  if (
+    view.byteStride !== formatInfo.byteLength ||
+    view.rowByteLength !== formatInfo.byteLength ||
+    view.byteOffset % UINT32_BYTE_LENGTH !== 0 ||
+    view.rowByteLength % UINT32_BYTE_LENGTH !== 0
+  ) {
+    throw new Error(`${name} must be packed, uint32-aligned GPU data with 32-bit-word rows`);
+  }
+}
+
+function makeShaderSource(
+  scatter: GPUScatter,
+  dispatchLayout: ReturnType<typeof getBoundedDispatchLayout>
+): string {
+  return `const INDEX_COUNT: u32 = ${scatter.indices.length}u;
+const OUTPUT_LENGTH: u32 = ${scatter.output.length}u;
+const WORDS_PER_ROW: u32 = ${scatter.wordsPerRow}u;
+const SOURCE_OFFSET: u32 = ${getViewElementOffset(scatter.source)}u;
+const INDEX_OFFSET: u32 = ${getViewElementOffset(scatter.indices)}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(scatter.output)}u;
+@group(0) @binding(0) var<storage, read> sourceWords: array<u32>;
+@group(0) @binding(1) var<storage, read> indices: array<u32>;
+@group(0) @binding(2) var<storage, read_write> outputWords: array<u32>;
+@compute @workgroup_size(${SCATTER_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3u,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getBoundedInvocationIndexSource(dispatchLayout, SCATTER_WORKGROUP_SIZE)}
+  if (index >= INDEX_COUNT) { return; }
+  let destinationIndex = indices[INDEX_OFFSET + index];
+  if (destinationIndex >= OUTPUT_LENGTH) { return; }
+
+  let sourceBase = SOURCE_OFFSET + index * WORDS_PER_ROW;
+  let outputBase = OUTPUT_OFFSET + destinationIndex * WORDS_PER_ROW;
+  for (var word = 0u; word < WORDS_PER_ROW; word++) {
+    outputWords[outputBase + word] = sourceWords[sourceBase + word];
+  }
+}`;
+}

--- a/modules/gpgpu/test/gpu-core/gpu-scatter.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-scatter.spec.ts
@@ -1,0 +1,89 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {expect, it} from 'vitest';
+import {Buffer, type Device} from '@luma.gl/core';
+import {GPUCommandGraph, GPUScatter} from '@luma.gl/gpgpu/gpu-core';
+import {GPUData} from '@luma.gl/gpgpu/gpu-data';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+it('GPUScatter scatters fixed-width float rows and ignores invalid destinations', async () => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return;
+
+  const sourceData = new Float32Array([
+    1, 2, 3,
+    4, 5, 6,
+    7, 8, 9
+  ]);
+  const indicesData = new Uint32Array([2, 0, 99]);
+  const sourceBuffer = device.createBuffer({data: sourceData, usage: Buffer.STORAGE});
+  const indicesBuffer = device.createBuffer({data: indicesData, usage: Buffer.STORAGE});
+  const outputBuffer = device.createBuffer({
+    byteLength: 4 * 3 * Float32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+  outputBuffer.write(new Float32Array(12));
+
+  const graph = new GPUCommandGraph(device, {id: 'scatter-graph'});
+  const source = graph.importGPUData(
+    'source',
+    new GPUData({buffer: sourceBuffer, format: 'float32x3', length: 3, ownsBuffer: false})
+  );
+  const indices = graph.importGPUData(
+    'indices',
+    new GPUData({buffer: indicesBuffer, format: 'uint32', length: 3, ownsBuffer: false})
+  );
+  const output = graph.importGPUData(
+    'output',
+    new GPUData({buffer: outputBuffer, format: 'float32x3', length: 4, ownsBuffer: false})
+  );
+
+  new GPUScatter({source, indices, output}).addToGraph(graph);
+  const compiled = graph.compile();
+  try {
+    const encoder = device.createCommandEncoder({id: 'scatter'});
+    compiled.encode(encoder, {parameters: undefined});
+    device.submit(encoder.finish());
+
+    const bytes = await outputBuffer.readAsync();
+    expect(Array.from(new Float32Array(bytes.buffer, bytes.byteOffset, 12))).toEqual([
+      4, 5, 6,
+      0, 0, 0,
+      1, 2, 3,
+      0, 0, 0
+    ]);
+  } finally {
+    compiled.destroy();
+    sourceBuffer.destroy();
+    indicesBuffer.destroy();
+    outputBuffer.destroy();
+  }
+});
+
+it('GPUScatter rejects duplicate-buffer output aliases', async () => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return;
+  const dataBuffer = device.createBuffer({
+    data: new Uint32Array([1, 2]),
+    usage: Buffer.STORAGE
+  });
+  const indexBuffer = device.createBuffer({
+    data: new Uint32Array([1, 0]),
+    usage: Buffer.STORAGE
+  });
+  const graph = new GPUCommandGraph(device, {id: 'scatter-validation'});
+  const data = graph.importGPUData(
+    'data',
+    new GPUData({buffer: dataBuffer, format: 'uint32', length: 2, ownsBuffer: false})
+  );
+  const indices = graph.importGPUData(
+    'indices',
+    new GPUData({buffer: indexBuffer, format: 'uint32', length: 2, ownsBuffer: false})
+  );
+
+  expect(() => new GPUScatter({source: data, indices, output: data})).toThrow(/separate buffer/);
+  dataBuffer.destroy();
+  indexBuffer.destroy();
+});


### PR DESCRIPTION
#### Background

`gpu-core` already has specialized scatter stages in compaction and chunked indexed routing, but there is no small general-purpose graph primitive corresponding to gather: scatter fixed-width rows through a uint32 destination-index vector.

This is the next primitive-completeness item in the GPU graph roadmap.

#### Change List
- add graph-native `GPUScatter` for packed fixed-width GPU rows
- accept packed uint32 destination indices
- ignore out-of-range destinations
- explicitly document duplicate destination indices as unordered/unspecified
- copy row bits as 32-bit words so float/integer fixed-width formats share one kernel
- add WebGPU coverage using `float32x3` rows
- reject source/output buffer aliasing

#### Semantics
For each index `i`, the primitive performs `output[indices[i]] = source[i]` when the destination is in range. If multiple source rows target the same destination, the final value is unspecified; deterministic conflict handling belongs in a higher-level reduction/aggregation primitive.

#### Follow-ups
- public export/docs integration
- evaluate reuse from existing specialized scatter paths
- move implementation from `Computation` to `Kernel` once the lightweight engine kernel PR lands

Draft while export/docs/CI integration is completed.