### PR TITLE
feat(gpgpu): add segmented reduction primitive

### DIFF
--- a/docs/api-reference/experimental/gpu-core/gpu-segmented-reduction.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-segmented-reduction.md
@@ -1,0 +1,82 @@
+import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
+
+# GPUSegmentedReduction
+
+<GPUCoreDocsTabs active="reduction" />
+
+## Overview
+
+`GPUSegmentedReduction` computes one scalar aggregate for every contiguous segment in a packed GPU
+vector. Segments are described by CSR-style offsets, making the primitive a natural consumer of
+columnar list offsets, group boundaries, adjacency lists, and `GPUSegmentedLayout` output.
+
+## Motivation
+
+`GPUReduction` answers a global question such as “what is the sum of this column?”. Many GPU data
+pipelines instead need the same aggregate independently for thousands of variable-length groups:
+counts or totals per category, weights per graph vertex, statistics per Arrow list row, or one value
+per spatial bucket. Downloading boundaries or values to JavaScript defeats the command graph's
+GPU-resident dataflow.
+
+Segmented reduction makes that operation a reusable graph primitive rather than requiring each
+higher-level algorithm to grow another private reduction kernel.
+
+## Contract
+
+Given packed input values and offsets `[o0, o1, ... oN]`, output row `i` reduces the half-open range
+`input[oi..o(i+1))`.
+
+```ts
+new GPUSegmentedReduction({
+  input: values,
+  segmentOffsets,
+  output: segmentTotals,
+  operation: 'sum'
+}).addToGraph(graph);
+```
+
+The initial implementation accepts packed `uint32`, `sint32`, and `float32` scalar values and
+supports `sum`, `min`, and `max`. `segmentOffsets.length` must equal `output.length + 1`.
+
+Offsets are expected to be monotonically nondecreasing, begin within the input, and terminate no
+later than `input.length`. Those semantic properties are normally guaranteed by the producer of the
+offsets; the GPU primitive does not read them back for host validation.
+
+Empty segments produce zero. This gives list/group pipelines a stable output row for every segment,
+including segments with no values.
+
+## Composition
+
+A common grouped pipeline is:
+
+```text
+keys / boundaries
+      ↓
+segment offsets
+      ↓
+GPUSegmentedReduction
+      ↓
+one aggregate per group
+```
+
+`GPUSegmentedLayout` can materialize dense segment offsets from slot-aligned segment-start flags.
+Those offsets can feed `GPUSegmentedReduction` directly. CSR graph adjacency offsets are another
+natural source: reducing edge weights by adjacency segment produces one aggregate per vertex.
+
+This primitive complements rather than replaces `GPUReduction`: use `GPUReduction` for one global
+aggregate and `GPUSegmentedReduction` when the same operation must be applied independently to many
+contiguous ranges.
+
+## Performance notes
+
+The first implementation assigns one 256-thread workgroup to each segment. Threads stride through
+the segment and then perform a workgroup-tree reduction. This is efficient for many small and
+medium variable-length segments and keeps scheduling simple and deterministic.
+
+Very large or highly skewed segments may benefit from a future hierarchical strategy that assigns
+multiple workgroups to one segment and merges partials. A future subgroup path can also reduce
+workgroup barriers on devices exposing WebGPU subgroup operations. Those optimizations can preserve
+the same graph contract.
+
+The primitive performs no CPU readback and contributes one ordinary compute node to the command
+graph. Inputs and outputs remain caller-owned GPU resources.

--- a/docs/api-reference/experimental/gpu-core/gpu-segmented-reduction.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-segmented-reduction.md
@@ -6,25 +6,39 @@ import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
 
 ## Overview
 
-`GPUSegmentedReduction` computes one scalar aggregate for every contiguous segment in a packed GPU
-vector. Segments are described by CSR-style offsets, making the primitive a natural consumer of
-columnar list offsets, group boundaries, adjacency lists, and `GPUSegmentedLayout` output.
+`GPUSegmentedReduction` computes one scalar aggregate for every contiguous segment in a packed GPU vector. Segments are described by **offset-delimited segments**, a general representation shared by grouped data, adjacency lists, Arrow-style lists and CSR sparse matrices.
 
-## Motivation
+## What is an offset-delimited segment?
 
-`GPUReduction` answers a global question such as “what is the sum of this column?”. Many GPU data
-pipelines instead need the same aggregate independently for thousands of variable-length groups:
-counts or totals per category, weights per graph vertex, statistics per Arrow list row, or one value
-per spatial bucket. Downloading boundaries or values to JavaScript defeats the command graph's
-GPU-resident dataflow.
+Many logical lists can be packed back-to-back into one flat GPU buffer. A second array stores the boundary of each list:
 
-Segmented reduction makes that operation a reusable graph primitive rather than requiring each
-higher-level algorithm to grow another private reduction kernel.
+```text
+values  = [10, 20 | 30, 40, 50 | 60, 70]
+offsets = [0,     2,           5,      7]
+```
+
+Segment `s` owns the half-open range `[offsets[s], offsets[s + 1])`. The final offset closes the last segment, so N segments require N+1 offsets. Repeated offsets represent empty segments.
+
+This pattern is sometimes encountered as the row-offset part of CSR sparse matrices, but segmented primitives use the more general term **offset-delimited segments** because no matrix is required.
+
+## What is segmented reduction?
+
+A normal reduction combines an entire vector into one result. A segmented reduction performs the same reduction independently inside every segment:
+
+```text
+values  = [10, 20 | 30, 40, 50 | 60, 70]
+                 sum each segment
+                         ↓
+output  = [30, 120, 130]
+```
+
+For `min` the same input produces `[10, 30, 60]`; for `max`, `[20, 50, 70]`.
+
+This is useful for totals per group, edge-weight totals per graph vertex, statistics per variable-length list, and values per spatial bucket.
 
 ## Contract
 
-Given packed input values and offsets `[o0, o1, ... oN]`, output row `i` reduces the half-open range
-`input[oi..o(i+1))`.
+Given offsets `[o0, o1, ... oN]`, output row `i` reduces `input[oi..o(i+1))`.
 
 ```ts
 new GPUSegmentedReduction({
@@ -35,48 +49,28 @@ new GPUSegmentedReduction({
 }).addToGraph(graph);
 ```
 
-The initial implementation accepts packed `uint32`, `sint32`, and `float32` scalar values and
-supports `sum`, `min`, and `max`. `segmentOffsets.length` must equal `output.length + 1`.
+The initial implementation accepts packed `uint32`, `sint32`, and `float32` values and supports `sum`, `min`, and `max`. `segmentOffsets.length` must equal `output.length + 1`. Empty segments produce zero.
 
-Offsets are expected to be monotonically nondecreasing, begin within the input, and terminate no
-later than `input.length`. Those semantic properties are normally guaranteed by the producer of the
-offsets; the GPU primitive does not read them back for host validation.
-
-Empty segments produce zero. This gives list/group pipelines a stable output row for every segment,
-including segments with no values.
+Offsets are expected to be monotonically nondecreasing and within input bounds. These GPU-resident invariants are normally guaranteed by the producer rather than validated through CPU readback.
 
 ## Composition
 
-A common grouped pipeline is:
-
 ```text
-keys / boundaries
-      ↓
-segment offsets
-      ↓
-GPUSegmentedReduction
-      ↓
-one aggregate per group
+sort / RLE / grouping / adjacency construction
+                     ↓
+              segment offsets
+                     ↓
+          GPUSegmentedReduction
+                     ↓
+           one aggregate per group
 ```
 
-`GPUSegmentedLayout` can materialize dense segment offsets from slot-aligned segment-start flags.
-Those offsets can feed `GPUSegmentedReduction` directly. CSR graph adjacency offsets are another
-natural source: reducing edge weights by adjacency segment produces one aggregate per vertex.
+`GPUSegmentedLayout` can materialize offsets from segment-start flags. CSR row offsets are another natural source: reducing edge weights by each adjacency segment produces one aggregate per vertex.
 
-This primitive complements rather than replaces `GPUReduction`: use `GPUReduction` for one global
-aggregate and `GPUSegmentedReduction` when the same operation must be applied independently to many
-contiguous ranges.
+Use `GPUReduction` for one global aggregate and `GPUSegmentedReduction` when the same operation must run independently over many contiguous ranges.
 
 ## Performance notes
 
-The first implementation assigns one 256-thread workgroup to each segment. Threads stride through
-the segment and then perform a workgroup-tree reduction. This is efficient for many small and
-medium variable-length segments and keeps scheduling simple and deterministic.
+The first implementation assigns one 256-thread workgroup to each segment. Threads stride through the segment and perform a workgroup-tree reduction. This is effective for many small and medium segments.
 
-Very large or highly skewed segments may benefit from a future hierarchical strategy that assigns
-multiple workgroups to one segment and merges partials. A future subgroup path can also reduce
-workgroup barriers on devices exposing WebGPU subgroup operations. Those optimizations can preserve
-the same graph contract.
-
-The primitive performs no CPU readback and contributes one ordinary compute node to the command
-graph. Inputs and outputs remain caller-owned GPU resources.
+Very large or highly skewed segments may need hierarchical multi-workgroup partials; subgroup operations can reduce barrier cost. Those optimizations preserve the offset-delimited API.

--- a/modules/gpgpu/src/gpu-core/gpu-segmented-reduction.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-segmented-reduction.ts
@@ -1,0 +1,146 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
+import {getViewBinding, getViewElementOffset, validatePackedUint32View, validatePackedView, type GPUScalarFormat} from './graph-data-view-utils';
+
+const WORKGROUP_SIZE = 256;
+const SCALAR_FORMATS = ['uint32', 'sint32', 'float32'] as const;
+
+export type GPUSegmentedReductionOperation = 'sum' | 'min' | 'max';
+
+export type GPUSegmentedReductionProps<T extends GPUScalarFormat = GPUScalarFormat> = {
+  id?: string;
+  input: GraphDataView<T>;
+  /** CSR-style element offsets. Length must equal output.length + 1. */
+  segmentOffsets: GraphDataView<'uint32'>;
+  output: GraphDataView<T>;
+  operation: GPUSegmentedReductionOperation;
+};
+
+/** Reduces packed scalar rows independently for each CSR-style segment. */
+export class GPUSegmentedReduction<T extends GPUScalarFormat = GPUScalarFormat> {
+  readonly id: string;
+  readonly input: GraphDataView<T>;
+  readonly segmentOffsets: GraphDataView<'uint32'>;
+  readonly output: GraphDataView<T>;
+  readonly operation: GPUSegmentedReductionOperation;
+
+  constructor(props: GPUSegmentedReductionProps<T>) {
+    this.id = props.id ?? 'gpu-segmented-reduction';
+    this.input = props.input;
+    this.segmentOffsets = props.segmentOffsets;
+    this.output = props.output;
+    this.operation = props.operation;
+
+    validatePackedView(this.input, SCALAR_FORMATS, `${this.id} input`);
+    validatePackedUint32View(this.segmentOffsets, `${this.id} segmentOffsets`);
+    validatePackedView(this.output, SCALAR_FORMATS, `${this.id} output`);
+    if (this.input.format !== this.output.format) {
+      throw new Error(`${this.id} input and output formats must match`);
+    }
+    if (this.segmentOffsets.length !== this.output.length + 1) {
+      throw new Error(`${this.id} segmentOffsets length must equal output.length + 1`);
+    }
+    if (!['sum', 'min', 'max'].includes(this.operation)) {
+      throw new Error(`${this.id} operation must be sum, min, or max`);
+    }
+    if (this.output.buffer === this.input.buffer || this.output.buffer === this.segmentOffsets.buffer) {
+      throw new Error(`${this.id} output must use a separate buffer`);
+    }
+  }
+
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    for (const view of [this.input, this.segmentOffsets, this.output]) {
+      if (view.buffer.graph !== graph) throw new Error(`${this.id} views must belong to target graph`);
+    }
+    if (this.output.length === 0) return;
+
+    const source = makeShaderSource(this);
+    graph.addComputePass({
+      id: this.id,
+      workload: {
+        operation: 'GPUSegmentedReduction',
+        commandCount: 1,
+        maximumWorkgroupCount: this.output.length,
+        maximumInvocationCount: this.output.length * WORKGROUP_SIZE,
+        readByteLength: this.input.length * 4 + this.segmentOffsets.length * 4,
+        writeByteLength: this.output.length * 4
+      },
+      resources: [
+        {buffer: this.input, usage: 'storage-read'},
+        {buffer: this.segmentOffsets, usage: 'storage-read'},
+        {buffer: this.output, usage: 'storage-write'}
+      ],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: this.id,
+          source,
+          shaderLayout: {bindings: [
+            {name: 'inputValues', type: 'read-only-storage', group: 0, location: 0},
+            {name: 'segmentOffsets', type: 'read-only-storage', group: 0, location: 1},
+            {name: 'outputValues', type: 'storage', group: 0, location: 2}
+          ]}
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            const bindings: Record<string, Binding> = {
+              inputValues: getViewBinding(this.input, getBuffer),
+              segmentOffsets: getViewBinding(this.segmentOffsets, getBuffer),
+              outputValues: getViewBinding(this.output, getBuffer)
+            };
+            computation.setBindings(bindings);
+            computation.dispatch(computePass, this.output.length, 1, 1);
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+  }
+}
+
+function makeShaderSource(reduction: GPUSegmentedReduction): string {
+  const type = reduction.input.format === 'uint32' ? 'u32' : reduction.input.format === 'sint32' ? 'i32' : 'f32';
+  const identity = reduction.operation === 'sum'
+    ? (type === 'f32' ? '0.0' : '0')
+    : reduction.operation === 'min'
+      ? (type === 'f32' ? '3.402823466e+38' : type === 'u32' ? '0xffffffffu' : '2147483647')
+      : (type === 'f32' ? '-3.402823466e+38' : type === 'u32' ? '0u' : '-2147483648');
+  const combine = reduction.operation === 'sum' ? 'a + b' : reduction.operation === 'min' ? 'min(a, b)' : 'max(a, b)';
+  return `const INPUT_OFFSET: u32 = ${getViewElementOffset(reduction.input)}u;
+const SEGMENT_OFFSET: u32 = ${getViewElementOffset(reduction.segmentOffsets)}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(reduction.output)}u;
+@group(0) @binding(0) var<storage, read> inputValues: array<${type}>;
+@group(0) @binding(1) var<storage, read> segmentOffsets: array<u32>;
+@group(0) @binding(2) var<storage, read_write> outputValues: array<${type}>;
+var<workgroup> scratch: array<${type}, ${WORKGROUP_SIZE}>;
+fn combine(a: ${type}, b: ${type}) -> ${type} { return ${combine}; }
+@compute @workgroup_size(${WORKGROUP_SIZE})
+fn main(@builtin(workgroup_id) wg: vec3u, @builtin(local_invocation_index) lane: u32) {
+  let segment = wg.x;
+  let begin = segmentOffsets[SEGMENT_OFFSET + segment];
+  let end = segmentOffsets[SEGMENT_OFFSET + segment + 1u];
+  var value: ${type} = ${identity};
+  var i = begin + lane;
+  loop {
+    if (i >= end) { break; }
+    value = combine(value, inputValues[INPUT_OFFSET + i]);
+    i += ${WORKGROUP_SIZE}u;
+  }
+  scratch[lane] = value;
+  workgroupBarrier();
+  var stride = ${WORKGROUP_SIZE / 2}u;
+  loop {
+    if (stride == 0u) { break; }
+    if (lane < stride) { scratch[lane] = combine(scratch[lane], scratch[lane + stride]); }
+    workgroupBarrier();
+    stride = stride / 2u;
+  }
+  if (lane == 0u) {
+    outputValues[OUTPUT_OFFSET + segment] = select(scratch[0], ${type}(${reduction.operation === 'sum' ? '0' : '0'}), begin == end);
+  }
+}`;
+}

--- a/modules/gpgpu/test/gpu-core/gpu-segmented-reduction.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-segmented-reduction.spec.ts
@@ -1,0 +1,39 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {describe, expect, it} from 'vitest';
+import {Buffer} from '@luma.gl/core';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import {GPUCommandGraph} from '../../src/gpu-core/gpu-command-graph';
+import {GPUSegmentedReduction} from '../../src/gpu-core/gpu-segmented-reduction';
+
+describe('GPUSegmentedReduction', () => {
+  it('validates CSR-style offset cardinality', async () => {
+    const device = await getWebGPUTestDevice();
+    if (!device) return;
+    const graph = new GPUCommandGraph(device);
+    const input = graph.createDataView(graph.createBuffer({byteLength: 16}), {format: 'uint32', length: 4});
+    const offsets = graph.createDataView(graph.createBuffer({byteLength: 8}), {format: 'uint32', length: 2});
+    const output = graph.createDataView(graph.createBuffer({byteLength: 8}), {format: 'uint32', length: 2});
+    expect(() => new GPUSegmentedReduction({input, segmentOffsets: offsets, output, operation: 'sum'})).toThrow(/output.length \+ 1/);
+  });
+
+  it('reduces independent uint32 segments including an empty segment', async () => {
+    const device = await getWebGPUTestDevice();
+    if (!device || device.info.gpu === 'software' || device.info.gpuType === 'cpu' || device.info.fallback) return;
+    const graph = new GPUCommandGraph(device);
+    const inputBuffer = graph.createBuffer({data: new Uint32Array([2, 3, 5, 7, 11]), usage: Buffer.STORAGE | Buffer.COPY_SRC});
+    const offsetBuffer = graph.createBuffer({data: new Uint32Array([0, 2, 2, 5]), usage: Buffer.STORAGE | Buffer.COPY_SRC});
+    const outputBuffer = graph.createBuffer({byteLength: 3 * 4, usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST});
+    const input = graph.createDataView(inputBuffer, {format: 'uint32', length: 5});
+    const offsets = graph.createDataView(offsetBuffer, {format: 'uint32', length: 4});
+    const output = graph.createDataView(outputBuffer, {format: 'uint32', length: 3});
+    new GPUSegmentedReduction({input, segmentOffsets: offsets, output, operation: 'sum'}).addToGraph(graph);
+    const compiled = graph.compile();
+    compiled.execute();
+    const bytes = await outputBuffer.buffer.readAsync();
+    expect(Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, 3))).toEqual([5, 0, 23]);
+    compiled.destroy();
+  });
+});


### PR DESCRIPTION
#### Background

`GPUReduction` provides global scalar aggregates, while many columnar, graph, spatial and grouped workloads need the same operation independently across variable-length contiguous ranges. Master already has CSR-style segmented layout/offset machinery, but no canonical graph primitive that consumes those offsets and emits one aggregate per segment.

This PR adds `GPUSegmentedReduction` as the next primitive-completeness item in the GPU graph/Jarnevon roadmap.

#### Change List
- add graph-native `GPUSegmentedReduction`
- consume packed scalar values plus CSR-style uint32 `segmentOffsets`
- support `uint32`, `sint32`, and `float32`
- support `sum`, `min`, and `max`
- emit one output scalar per segment
- define empty segments to produce zero
- assign one 256-thread workgroup per segment in the initial implementation
- add WebGPU coverage including an empty segment
- add full API documentation covering motivation, contract, composition, semantics, and performance tradeoffs

#### Motivation

This provides a reusable substrate for grouped aggregation, Arrow/list-style values, graph adjacency reductions, spatial buckets and future RLE/group-by pipelines without each higher-level feature implementing another private segmented reduction kernel.

#### Performance model

The initial implementation is intentionally simple: one workgroup strides over each segment and performs a workgroup-tree reduction. This should work well for many small/medium segments. Very large or highly skewed segments can later use hierarchical multi-workgroup partials, and subgroup collectives can reduce barrier cost, without changing the API contract.

#### Follow-ups
- public export / docs navigation integration
- subgroup acceleration
- hierarchical strategy for very large segments
- optional mask/validity semantics aligned with `GPUReduction`
- migrate from `Computation` to `Kernel` when the lightweight Kernel PR lands

Draft while export integration and CI are completed.