### PR TITLE
feat(gpgpu): add run-length encoding and unique primitives

### DIFF
--- a/docs/api-reference/experimental/gpu-core/gpu-run-length-encode.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-run-length-encode.md
@@ -4,45 +4,56 @@ import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
 
 ## Overview
 
-`GPURunLengthEncode` turns an ordered `uint32` sequence into one row per contiguous run: the run value, its length, and a scalar count describing the valid output prefix. `GPUUnique` exposes the same ordered-run contract for callers interested primarily in distinct adjacent values.
+`GPURunLengthEncode` (RLE) replaces each contiguous run of equal values with the value and the run length. `GPUUnique` exposes the corresponding distinct adjacent values.
 
-## Motivation
+## What is run-length encoding?
 
-Sorting is only the first half of many GPU grouping pipelines. Once equal keys are adjacent, downstream work needs explicit group boundaries before it can aggregate values, build CSR-style offsets, or emit one record per key. Without a reusable RLE primitive, group-by, histogram-like workflows, graph adjacency construction and columnar dictionary operations each tend to grow their own boundary detection and prefix-scan kernels.
-
-RLE supplies that missing bridge:
+Given ordered values:
 
 ```text
-sort keys
-   ↓
-run-length encode
-   ↓
-unique keys + run lengths / boundaries
-   ↓
-segmented reduction
-   ↓
-grouped aggregates
+input = [2, 2, 2, 5, 5, 9, 9, 9, 9]
 ```
+
+RLE describes the same run structure as:
+
+```text
+values  = [2, 5, 9]
+lengths = [3, 2, 4]
+```
+
+The operation is about **adjacent runs**, not global uniqueness. For example:
+
+```text
+input  = [2, 2, 5, 2]
+values = [2, 5, 2]
+```
+
+If global grouping is desired, sort by key first so equal keys become adjacent.
+
+## Why RLE matters for GPU grouping
+
+Sorting puts equal keys together, but downstream algorithms still need to know where each group starts and ends. RLE turns adjacency into explicit group metadata:
+
+```text
+unsorted keys
+     ↓
+   GPUSort
+     ↓
+[2,2,2,5,5,9,9,9,9]
+     ↓
+GPURunLengthEncode
+     ↓
+values  [2,5,9]
+lengths [3,2,4]
+     ↓
+offset-delimited groups / segmented reduction
+```
+
+For the example, run lengths `[3,2,4]` correspond to offsets `[0,3,5,9]`. Those offsets can describe the same groups to segmented operations and are structurally identical to the offset-delimited representation used by lists and CSR rows.
 
 ## Contract
 
-Input must be an ordered packed `GraphDataView<'uint32'>`. Equal adjacent values form a run. `values` and `lengths` are caller-owned capacity buffers; only the prefix described by `count` is valid.
-
-For:
-
-```text
-[2, 2, 2, 7, 7, 9]
-```
-
-RLE produces:
-
-```text
-values  = [2, 7, 9, ...]
-lengths = [3, 2, 1, ...]
-count   = 3
-```
-
-The operation preserves first-occurrence order. It does not sort the input. Compose it after `GPUSort` when global uniqueness/grouping by key is required.
+Input is an ordered packed `uint32` vector. `values` and `lengths` are caller-owned capacity buffers; only the prefix described by `count` is valid.
 
 ```ts
 new GPURunLengthEncode({
@@ -53,20 +64,30 @@ new GPURunLengthEncode({
 }).addToGraph(graph);
 ```
 
-Empty input writes `count = 0`.
+The operation preserves first-occurrence order and does not sort input. Empty input writes `count = 0`.
 
 ## Composition
 
-The implementation deliberately composes existing graph machinery: one pass identifies run starts, `GPUScan` converts those flags into dense run indices, and a materialization pass publishes run values, lengths and the final count. This keeps run indexing consistent with the same scan substrate used by compaction and segmented layout.
+```text
+sort
+ ↓
+RLE / unique
+ ↓
+run lengths
+ ↓
+offset construction
+ ↓
+GPUSegmentedReduction / GPUSegmentedScan
+ ↓
+grouped results
+```
 
-The resulting metadata is useful for constructing CSR-style segment offsets and is intended to compose directly with `GPUSegmentedReduction` for GPU group-by pipelines.
+The implementation uses a boundary-detection pass, `GPUScan` to assign dense run indices, then materialization of values, lengths and count.
+
+## GPUUnique
+
+`GPUUnique` answers the simpler question “what are the distinct adjacent run values?” while retaining the same equality and ordering semantics. It should not introduce a second definition of uniqueness. A future optimized path may skip run-length materialization when only values are required.
 
 ## Performance notes
 
-The initial implementation prioritizes a clear reusable contract. Boundary detection and scan are parallel. Run-length materialization may perform additional work around run boundaries; future implementations can specialize length publication using explicit start offsets or subgroup operations without changing the public API.
-
-For unsorted data with few downstream grouped operations, a hash aggregation may be cheaper than sort + RLE. RLE is strongest when keys are already ordered, stable ordering matters, or the resulting run structure is reused by multiple consumers.
-
-## Relationship to GPUUnique
-
-`GPUUnique` is intentionally aligned with RLE rather than inventing a second notion of equality or ordering. A future value-only optimized path may avoid materializing lengths when they are not requested, while retaining the same adjacent-run semantics.
+Boundary detection and scan are parallel. RLE is strongest when keys are already ordered, stable ordering matters, or group structure is reused. For unsorted data used only once, a hash aggregation may be cheaper than sort + RLE.

--- a/docs/api-reference/experimental/gpu-core/gpu-run-length-encode.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-run-length-encode.md
@@ -1,0 +1,72 @@
+import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
+
+# GPURunLengthEncode and GPUUnique
+
+## Overview
+
+`GPURunLengthEncode` turns an ordered `uint32` sequence into one row per contiguous run: the run value, its length, and a scalar count describing the valid output prefix. `GPUUnique` exposes the same ordered-run contract for callers interested primarily in distinct adjacent values.
+
+## Motivation
+
+Sorting is only the first half of many GPU grouping pipelines. Once equal keys are adjacent, downstream work needs explicit group boundaries before it can aggregate values, build CSR-style offsets, or emit one record per key. Without a reusable RLE primitive, group-by, histogram-like workflows, graph adjacency construction and columnar dictionary operations each tend to grow their own boundary detection and prefix-scan kernels.
+
+RLE supplies that missing bridge:
+
+```text
+sort keys
+   ↓
+run-length encode
+   ↓
+unique keys + run lengths / boundaries
+   ↓
+segmented reduction
+   ↓
+grouped aggregates
+```
+
+## Contract
+
+Input must be an ordered packed `GraphDataView<'uint32'>`. Equal adjacent values form a run. `values` and `lengths` are caller-owned capacity buffers; only the prefix described by `count` is valid.
+
+For:
+
+```text
+[2, 2, 2, 7, 7, 9]
+```
+
+RLE produces:
+
+```text
+values  = [2, 7, 9, ...]
+lengths = [3, 2, 1, ...]
+count   = 3
+```
+
+The operation preserves first-occurrence order. It does not sort the input. Compose it after `GPUSort` when global uniqueness/grouping by key is required.
+
+```ts
+new GPURunLengthEncode({
+  input: sortedKeys,
+  values: uniqueKeys,
+  lengths: runLengths,
+  count: runCount
+}).addToGraph(graph);
+```
+
+Empty input writes `count = 0`.
+
+## Composition
+
+The implementation deliberately composes existing graph machinery: one pass identifies run starts, `GPUScan` converts those flags into dense run indices, and a materialization pass publishes run values, lengths and the final count. This keeps run indexing consistent with the same scan substrate used by compaction and segmented layout.
+
+The resulting metadata is useful for constructing CSR-style segment offsets and is intended to compose directly with `GPUSegmentedReduction` for GPU group-by pipelines.
+
+## Performance notes
+
+The initial implementation prioritizes a clear reusable contract. Boundary detection and scan are parallel. Run-length materialization may perform additional work around run boundaries; future implementations can specialize length publication using explicit start offsets or subgroup operations without changing the public API.
+
+For unsorted data with few downstream grouped operations, a hash aggregation may be cheaper than sort + RLE. RLE is strongest when keys are already ordered, stable ordering matters, or the resulting run structure is reused by multiple consumers.
+
+## Relationship to GPUUnique
+
+`GPUUnique` is intentionally aligned with RLE rather than inventing a second notion of equality or ordering. A future value-only optimized path may avoid materializing lengths when they are not requested, while retaining the same adjacent-run semantics.

--- a/modules/gpgpu/src/gpu-core/gpu-run-length-encode.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-run-length-encode.ts
@@ -1,0 +1,95 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
+import {GPUScan} from './gpu-scan';
+import {createTransientView, getViewBinding, getViewElementOffset, validatePackedUint32View} from './graph-data-view-utils';
+
+const WORKGROUP_SIZE = 256;
+
+export type GPURunLengthEncodeProps = {
+  id?: string;
+  /** Ordered packed uint32 input. Equal adjacent values form one run. */
+  input: GraphDataView<'uint32'>;
+  /** Caller-owned unique run values, capacity >= input.length. */
+  values: GraphDataView<'uint32'>;
+  /** Caller-owned run lengths, capacity >= input.length. */
+  lengths: GraphDataView<'uint32'>;
+  /** Single uint32 receiving the number of valid runs. */
+  count: GraphDataView<'uint32'>;
+};
+
+/** Graph-native run-length encoding for ordered uint32 values. */
+export class GPURunLengthEncode {
+  readonly id: string;
+  readonly input: GraphDataView<'uint32'>;
+  readonly values: GraphDataView<'uint32'>;
+  readonly lengths: GraphDataView<'uint32'>;
+  readonly count: GraphDataView<'uint32'>;
+
+  constructor(props: GPURunLengthEncodeProps) {
+    this.id = props.id ?? 'gpu-run-length-encode';
+    this.input = props.input;
+    this.values = props.values;
+    this.lengths = props.lengths;
+    this.count = props.count;
+    for (const [name, view] of Object.entries({input: this.input, values: this.values, lengths: this.lengths, count: this.count})) {
+      validatePackedUint32View(view, `${this.id} ${name}`);
+    }
+    if (this.values.length < this.input.length || this.lengths.length < this.input.length) {
+      throw new Error(`${this.id} values and lengths must have capacity >= input.length`);
+    }
+    if (this.count.length < 1) throw new Error(`${this.id} count must contain at least one row`);
+    if ([this.values.buffer, this.lengths.buffer, this.count.buffer].includes(this.input.buffer)) {
+      throw new Error(`${this.id} outputs must use separate buffers from input`);
+    }
+  }
+
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    for (const view of [this.input, this.values, this.lengths, this.count]) {
+      if (view.buffer.graph !== graph) throw new Error(`${this.id} views must belong to target graph`);
+    }
+    if (this.input.length === 0) {
+      addEmptyPass(graph, this);
+      return;
+    }
+    const flags = createTransientView(graph, `${this.id}-run-start-flags`, 'uint32', this.input.length);
+    const runIndices = createTransientView(graph, `${this.id}-run-indices`, 'uint32', this.input.length);
+    addFlagsPass(graph, this, flags);
+    new GPUScan({id: `${this.id}-run-index-scan`, input: flags, output: runIndices, mode: 'exclusive'}).addToGraph(graph);
+    addMaterializePass(graph, this, flags, runIndices);
+  }
+}
+
+/** `GPUUnique` is the value-only form of run-length encoding. */
+export class GPUUnique extends GPURunLengthEncode {}
+
+function addFlagsPass<Parameters>(graph: GPUCommandGraph<Parameters>, rle: GPURunLengthEncode, flags: GraphDataView<'uint32'>): void {
+  const source = `const LENGTH: u32 = ${rle.input.length}u; const INPUT_OFFSET: u32 = ${getViewElementOffset(rle.input)}u; const FLAG_OFFSET: u32 = ${getViewElementOffset(flags)}u;
+@group(0) @binding(0) var<storage, read> inputValues: array<u32>;
+@group(0) @binding(1) var<storage, read_write> flags: array<u32>;
+@compute @workgroup_size(${WORKGROUP_SIZE}) fn main(@builtin(global_invocation_id) id: vec3u) { let i=id.x; if(i>=LENGTH){return;} flags[FLAG_OFFSET+i]=select(0u,1u,i==0u || inputValues[INPUT_OFFSET+i]!=inputValues[INPUT_OFFSET+i-1u]); }`;
+  addPass(graph, `${rle.id}-flags`, source, rle.input.length, [{name:'inputValues',view:rle.input,usage:'storage-read'},{name:'flags',view:flags,usage:'storage-write'}]);
+}
+
+function addMaterializePass<Parameters>(graph: GPUCommandGraph<Parameters>, rle: GPURunLengthEncode, flags: GraphDataView<'uint32'>, runIndices: GraphDataView<'uint32'>): void {
+  const source = `const LENGTH:u32=${rle.input.length}u; const INPUT_OFFSET:u32=${getViewElementOffset(rle.input)}u; const FLAG_OFFSET:u32=${getViewElementOffset(flags)}u; const INDEX_OFFSET:u32=${getViewElementOffset(runIndices)}u; const VALUE_OFFSET:u32=${getViewElementOffset(rle.values)}u; const LENGTH_OFFSET:u32=${getViewElementOffset(rle.lengths)}u; const COUNT_OFFSET:u32=${getViewElementOffset(rle.count)}u;
+@group(0) @binding(0) var<storage,read> inputValues:array<u32>; @group(0) @binding(1) var<storage,read> flags:array<u32>; @group(0) @binding(2) var<storage,read> runIndices:array<u32>; @group(0) @binding(3) var<storage,read_write> values:array<u32>; @group(0) @binding(4) var<storage,read_write> lengths:array<u32>; @group(0) @binding(5) var<storage,read_write> count:array<u32>;
+@compute @workgroup_size(${WORKGROUP_SIZE}) fn main(@builtin(global_invocation_id) id:vec3u){let i=id.x;if(i>=LENGTH){return;} let run=runIndices[INDEX_OFFSET+i]; if(flags[FLAG_OFFSET+i]!=0u){values[VALUE_OFFSET+run]=inputValues[INPUT_OFFSET+i];} let isEnd=i+1u==LENGTH || flags[FLAG_OFFSET+i+1u]!=0u; if(isEnd){let start=select(0u, runIndices[INDEX_OFFSET+i], run==0u); var j=i; loop { if(j==0u || flags[FLAG_OFFSET+j]!=0u){break;} j-=1u;} lengths[LENGTH_OFFSET+run]=i-j+1u; if(i+1u==LENGTH){count[COUNT_OFFSET]=run+1u;}}}`;
+  addPass(graph, `${rle.id}-materialize`, source, rle.input.length, [
+    {name:'inputValues',view:rle.input,usage:'storage-read'},{name:'flags',view:flags,usage:'storage-read'},{name:'runIndices',view:runIndices,usage:'storage-read'},
+    {name:'values',view:rle.values,usage:'storage-write'},{name:'lengths',view:rle.lengths,usage:'storage-write'},{name:'count',view:rle.count,usage:'storage-write'}]);
+}
+
+function addEmptyPass<Parameters>(graph: GPUCommandGraph<Parameters>, rle: GPURunLengthEncode): void {
+  const source=`const COUNT_OFFSET:u32=${getViewElementOffset(rle.count)}u; @group(0) @binding(0) var<storage,read_write> count:array<u32>; @compute @workgroup_size(1) fn main(){count[COUNT_OFFSET]=0u;}`;
+  addPass(graph,`${rle.id}-empty`,source,1,[{name:'count',view:rle.count,usage:'storage-write'}]);
+}
+
+type Resource={name:string;view:GraphDataView<'uint32'>;usage:'storage-read'|'storage-write'};
+function addPass<Parameters>(graph:GPUCommandGraph<Parameters>,id:string,source:string,length:number,resources:Resource[]):void{
+  graph.addComputePass({id,workload:{operation:'GPURunLengthEncode',commandCount:1,maximumWorkgroupCount:Math.ceil(length/WORKGROUP_SIZE),maximumInvocationCount:Math.ceil(length/WORKGROUP_SIZE)*WORKGROUP_SIZE,readByteLength:resources.filter(r=>r.usage==='storage-read').length*length*4,writeByteLength:resources.filter(r=>r.usage==='storage-write').length*length*4},resources:resources.map(r=>({buffer:r.view,usage:r.usage})),compile:({device})=>{const computation=new Computation(device,{id,source,shaderLayout:{bindings:resources.map((r,location)=>({name:r.name,type:r.usage==='storage-read'?'read-only-storage':'storage',group:0,location}))}});return{encode:({computePass,getBuffer})=>{const bindings:Record<string,Binding>={};for(const r of resources)bindings[r.name]=getViewBinding(r.view,getBuffer);computation.setBindings(bindings);computation.dispatch(computePass,Math.ceil(length/WORKGROUP_SIZE),1,1);},destroy:()=>computation.destroy()};}});
+}

--- a/modules/gpgpu/test/gpu-core/gpu-run-length-encode.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-run-length-encode.spec.ts
@@ -1,0 +1,33 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {describe, expect, it} from 'vitest';
+import {GPUCommandGraph} from '../../src/gpu-core/gpu-command-graph';
+import {GPURunLengthEncode} from '../../src/gpu-core/gpu-run-length-encode';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+describe('GPURunLengthEncode', () => {
+  it('validates output capacity', async () => {
+    const device = await getWebGPUTestDevice();
+    if (!device) return;
+    const graph = new GPUCommandGraph(device);
+    const input = graph.createDataView(graph.createBuffer({byteLength: 24}), {format: 'uint32', length: 6});
+    const values = graph.createDataView(graph.createBuffer({byteLength: 8}), {format: 'uint32', length: 2});
+    const lengths = graph.createDataView(graph.createBuffer({byteLength: 24}), {format: 'uint32', length: 6});
+    const count = graph.createDataView(graph.createBuffer({byteLength: 4}), {format: 'uint32', length: 1});
+    expect(() => new GPURunLengthEncode({input, values, lengths, count})).toThrow(/capacity/);
+  });
+
+  it('adds graph nodes for ordered run encoding', async () => {
+    const device = await getWebGPUTestDevice();
+    if (!device) return;
+    const graph = new GPUCommandGraph(device);
+    const input = graph.createDataView(graph.createBuffer({byteLength: 24}), {format: 'uint32', length: 6});
+    const values = graph.createDataView(graph.createBuffer({byteLength: 24}), {format: 'uint32', length: 6});
+    const lengths = graph.createDataView(graph.createBuffer({byteLength: 24}), {format: 'uint32', length: 6});
+    const count = graph.createDataView(graph.createBuffer({byteLength: 4}), {format: 'uint32', length: 1});
+    new GPURunLengthEncode({input, values, lengths, count}).addToGraph(graph);
+    expect(graph).toBeDefined();
+  });
+});


### PR DESCRIPTION
#### Background

The GPU graph library already has sorting, scans, compaction and segmented layout, but lacks the canonical bridge from ordered keys to explicit groups. Once equal keys are adjacent, higher-level group-by, CSR construction and columnar workflows need reusable run boundaries rather than another private boundary-detection kernel.

This PR adds `GPURunLengthEncode` and an aligned `GPUUnique` surface as the next primitive-completeness item in the Jarnevon roadmap.

#### Change List
- add graph-native run-length encoding for ordered packed uint32 values
- emit caller-owned run values and run lengths plus a scalar valid-run count
- define `GPUUnique` with the same adjacent-run equality/ordering semantics
- compose run-start detection with existing `GPUScan`
- handle empty inputs by publishing count zero
- add validation tests
- add API documentation covering motivation, contract, composition, performance and relationship to sorting/segmented reduction

#### Motivation

This establishes the reusable pipeline:

`sort -> RLE/unique -> segmented reduction -> grouped aggregates`

It also provides useful metadata for CSR-style offsets, graph adjacency construction and columnar dictionary/group operations.

#### Semantics

Input is ordered but not implicitly sorted. Equal adjacent uint32 values form one run. Only the prefixes of `values` and `lengths` described by `count` are valid. First-occurrence order is preserved.

#### Performance model

The initial implementation prioritizes composability: a parallel boundary pass produces flags, `GPUScan` assigns dense run indices, and a materialization pass publishes values/lengths/count. Later work can optimize length publication or add subgroup specialization without changing the contract.

#### Follow-ups
- public export/docs navigation integration
- optimize `GPUUnique` to avoid materializing lengths when unnecessary
- expose/build CSR-style segment offsets directly from run metadata
- compose with `GPUSegmentedReduction` for a canonical group-by helper
- migrate from `Computation` to `Kernel` when the lightweight Kernel PR lands

Draft while export integration and CI are completed.