### PR TITLE
feat(gpgpu): add segmented scan primitive

### DIFF
--- a/docs/api-reference/experimental/gpu-core/gpu-segmented-scan.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-segmented-scan.md
@@ -6,23 +6,45 @@ import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
 
 ## Overview
 
-`GPUSegmentedScan` computes independent prefix sums over variable-length contiguous ranges described by CSR-style offsets.
+`GPUSegmentedScan` computes independent prefix sums over variable-length contiguous ranges described by **offset-delimited segments**.
 
-## Motivation
+## Prefix scans and segmented scans
 
-A global prefix scan is one of the most useful GPU primitives, but many real data structures contain many logical sequences packed into one buffer. Adjacency lists, Arrow list values, grouped rows, spatial buckets and run-length encoded keys all need prefix state to reset at segment boundaries. Without a canonical segmented scan, each higher-level subsystem tends to grow a private scan/reset kernel.
+A prefix scan turns values into running totals. For example, an exclusive scan of:
 
-`GPUSegmentedScan` makes that operation reusable and gives the graph library a direct counterpart to `GPUSegmentedReduction`.
+```text
+input  = [2, 3, 4, 5]
+output = [0, 2, 5, 9]
+```
+
+while the inclusive form is:
+
+```text
+output = [2, 5, 9, 14]
+```
+
+A segmented scan packs several independent sequences into one buffer and resets the running total at each boundary:
+
+```text
+values  = [2, 3 | 4, 5, 6 | 7]
+offsets = [0,   2,        5,   6]
+
+exclusive = [0, 2 | 0, 4, 9 | 0]
+inclusive = [2, 5 | 4, 9,15 | 7]
+```
+
+Segment `s` is `[offsets[s], offsets[s + 1])`. N segments require N+1 offsets; repeated offsets describe empty segments. This general representation also appears in Arrow lists, graph adjacency and CSR matrices, but the segmented API is not matrix-specific.
+
+## Why it matters
+
+Many GPU structures contain thousands of logical lists packed into one allocation. They need local ranks, local allocation positions or prefix weights without launching a separate scan for every list. A canonical segmented scan makes that operation reusable.
 
 ## Contract
 
-The operation consumes packed `uint32` values and packed `uint32` `segmentOffsets`. Offsets use the standard CSR/list convention: segment `s` owns rows in `[segmentOffsets[s], segmentOffsets[s + 1])`. Therefore `segmentOffsets.length - 1` is the number of segments.
-
-The output has the same logical length as the input. Both exclusive and inclusive modes are supported. Empty segments write no rows and are valid.
+The initial operation consumes packed `uint32` values and `segmentOffsets`. The output has the same length as the input and supports `exclusive` and `inclusive` modes.
 
 ```ts
 new GPUSegmentedScan({
-  id: 'neighbor-offsets',
   input: weights,
   segmentOffsets,
   output: prefixWeights,
@@ -30,30 +52,28 @@ new GPUSegmentedScan({
 }).addToGraph(graph);
 ```
 
-For input `[2, 3, 4, 5]` with offsets `[0, 2, 4]`, exclusive output is `[0, 2, 0, 4]`; inclusive output is `[2, 5, 4, 9]`.
+Empty segments are valid and write no rows.
 
 ## Composition
 
-Segmented scan is useful after grouping or topology construction:
-
 ```text
-sort / RLE / CSR construction
-            ↓
-      segmentOffsets
-            ↓
-     GPUSegmentedScan
-            ↓
-per-group offsets / local ranks / allocation positions
+sort / RLE / grouping / sparse construction
+                     ↓
+              segmentOffsets
+                     ↓
+             GPUSegmentedScan
+                     ↓
+       local ranks / offsets / positions
 ```
 
-Together with `GPUSegmentedReduction`, it establishes the basic segmented algebra needed by grouped aggregation, graph adjacency processing, sparse structures and columnar list data.
+Together with `GPUSegmentedReduction`, this establishes the basic segmented algebra needed by grouped aggregation, graph adjacency processing, sparse structures and columnar list data.
 
 ## Performance notes
 
-The first implementation deliberately establishes the API contract before optimizing the execution strategy. It assigns one workgroup to each segment and currently uses one lane to scan that segment serially. This is appropriate only as a correctness baseline and for small segments.
+The first implementation establishes the API before optimizing execution: one workgroup is assigned per segment and one lane currently scans that segment serially. This is a correctness baseline and is appropriate only for small segments.
 
-The intended optimized implementation should use parallel workgroup scans for medium segments, subgroup collectives when available, and a hierarchical strategy for segments larger than one workgroup. Highly skewed segment distributions require special care because one-workgroup-per-segment scheduling can leave the GPU underutilized. These optimizations do not require changing the CSR-style API.
+The intended optimized implementation uses parallel workgroup scans for medium segments, subgroup collectives when available, and hierarchical strategies for very large segments. Highly skewed segment distributions require strategy selection to avoid poor GPU utilization. None of those optimizations requires changing the offset-delimited contract.
 
 ## Limitations
 
-The initial primitive supports `uint32` addition only. General scalar formats and operators can follow once the execution strategy is established. Input/output aliasing is intentionally rejected in the first implementation. Offsets are assumed to be monotonic and within input bounds; validation of GPU-resident offset contents is left to producers rather than requiring readback.
+The initial primitive supports `uint32` addition only. Input/output aliasing is rejected. Offsets are assumed monotonic and within input bounds; producers establish those GPU-resident invariants without requiring readback.

--- a/docs/api-reference/experimental/gpu-core/gpu-segmented-scan.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-segmented-scan.md
@@ -1,0 +1,59 @@
+import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
+
+# GPUSegmentedScan
+
+<GPUCoreDocsTabs active="scan" />
+
+## Overview
+
+`GPUSegmentedScan` computes independent prefix sums over variable-length contiguous ranges described by CSR-style offsets.
+
+## Motivation
+
+A global prefix scan is one of the most useful GPU primitives, but many real data structures contain many logical sequences packed into one buffer. Adjacency lists, Arrow list values, grouped rows, spatial buckets and run-length encoded keys all need prefix state to reset at segment boundaries. Without a canonical segmented scan, each higher-level subsystem tends to grow a private scan/reset kernel.
+
+`GPUSegmentedScan` makes that operation reusable and gives the graph library a direct counterpart to `GPUSegmentedReduction`.
+
+## Contract
+
+The operation consumes packed `uint32` values and packed `uint32` `segmentOffsets`. Offsets use the standard CSR/list convention: segment `s` owns rows in `[segmentOffsets[s], segmentOffsets[s + 1])`. Therefore `segmentOffsets.length - 1` is the number of segments.
+
+The output has the same logical length as the input. Both exclusive and inclusive modes are supported. Empty segments write no rows and are valid.
+
+```ts
+new GPUSegmentedScan({
+  id: 'neighbor-offsets',
+  input: weights,
+  segmentOffsets,
+  output: prefixWeights,
+  mode: 'exclusive'
+}).addToGraph(graph);
+```
+
+For input `[2, 3, 4, 5]` with offsets `[0, 2, 4]`, exclusive output is `[0, 2, 0, 4]`; inclusive output is `[2, 5, 4, 9]`.
+
+## Composition
+
+Segmented scan is useful after grouping or topology construction:
+
+```text
+sort / RLE / CSR construction
+            ↓
+      segmentOffsets
+            ↓
+     GPUSegmentedScan
+            ↓
+per-group offsets / local ranks / allocation positions
+```
+
+Together with `GPUSegmentedReduction`, it establishes the basic segmented algebra needed by grouped aggregation, graph adjacency processing, sparse structures and columnar list data.
+
+## Performance notes
+
+The first implementation deliberately establishes the API contract before optimizing the execution strategy. It assigns one workgroup to each segment and currently uses one lane to scan that segment serially. This is appropriate only as a correctness baseline and for small segments.
+
+The intended optimized implementation should use parallel workgroup scans for medium segments, subgroup collectives when available, and a hierarchical strategy for segments larger than one workgroup. Highly skewed segment distributions require special care because one-workgroup-per-segment scheduling can leave the GPU underutilized. These optimizations do not require changing the CSR-style API.
+
+## Limitations
+
+The initial primitive supports `uint32` addition only. General scalar formats and operators can follow once the execution strategy is established. Input/output aliasing is intentionally rejected in the first implementation. Offsets are assumed to be monotonic and within input bounds; validation of GPU-resident offset contents is left to producers rather than requiring readback.

--- a/modules/gpgpu/src/gpu-core/gpu-segmented-scan.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-segmented-scan.ts
@@ -1,0 +1,68 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
+import {getViewBinding, getViewElementOffset, validatePackedUint32View} from './graph-data-view-utils';
+
+const WORKGROUP_SIZE = 256;
+
+export type GPUSegmentedScanMode = 'exclusive' | 'inclusive';
+
+export type GPUSegmentedScanProps = {
+  id?: string;
+  /** Packed uint32 values. */
+  input: GraphDataView<'uint32'>;
+  /** CSR-style offsets, one per segment plus a terminal offset. */
+  segmentOffsets: GraphDataView<'uint32'>;
+  /** Caller-owned packed uint32 output with the same length as input. */
+  output: GraphDataView<'uint32'>;
+  mode?: GPUSegmentedScanMode;
+};
+
+/** Performs an independent uint32 prefix sum inside every CSR-style segment. */
+export class GPUSegmentedScan {
+  readonly id: string;
+  readonly input: GraphDataView<'uint32'>;
+  readonly segmentOffsets: GraphDataView<'uint32'>;
+  readonly output: GraphDataView<'uint32'>;
+  readonly mode: GPUSegmentedScanMode;
+
+  constructor(props: GPUSegmentedScanProps) {
+    this.id = props.id ?? 'gpu-segmented-scan';
+    this.input = props.input;
+    this.segmentOffsets = props.segmentOffsets;
+    this.output = props.output;
+    this.mode = props.mode ?? 'exclusive';
+    validatePackedUint32View(this.input, `${this.id} input`);
+    validatePackedUint32View(this.segmentOffsets, `${this.id} segmentOffsets`);
+    validatePackedUint32View(this.output, `${this.id} output`);
+    if (this.output.length !== this.input.length) throw new Error(`${this.id} output length must match input length`);
+    if (this.segmentOffsets.length < 1) throw new Error(`${this.id} segmentOffsets must contain at least the terminal offset`);
+    if (!['exclusive', 'inclusive'].includes(this.mode)) throw new Error(`${this.id} mode must be exclusive or inclusive`);
+    if (this.output.buffer === this.input.buffer || this.output.buffer === this.segmentOffsets.buffer) throw new Error(`${this.id} output must use a separate buffer`);
+  }
+
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    for (const view of [this.input, this.segmentOffsets, this.output]) {
+      if (view.buffer.graph !== graph) throw new Error(`${this.id} views must belong to target graph`);
+    }
+    const segmentCount = this.segmentOffsets.length - 1;
+    if (segmentCount === 0) return;
+    const source = makeShaderSource(this);
+    graph.addComputePass({
+      id: this.id,
+      workload: {operation:'GPUSegmentedScan',commandCount:1,maximumWorkgroupCount:segmentCount,maximumInvocationCount:segmentCount*WORKGROUP_SIZE,readByteLength:this.input.length*4+this.segmentOffsets.length*4,writeByteLength:this.output.length*4},
+      resources:[{buffer:this.input,usage:'storage-read'},{buffer:this.segmentOffsets,usage:'storage-read'},{buffer:this.output,usage:'storage-write'}],
+      compile:({device})=>{const computation=new Computation(device,{id:this.id,source,shaderLayout:{bindings:[{name:'inputValues',type:'read-only-storage',group:0,location:0},{name:'segmentOffsets',type:'read-only-storage',group:0,location:1},{name:'outputValues',type:'storage',group:0,location:2}]}});return{encode:({computePass,getBuffer})=>{const bindings:Record<string,Binding>={inputValues:getViewBinding(this.input,getBuffer),segmentOffsets:getViewBinding(this.segmentOffsets,getBuffer),outputValues:getViewBinding(this.output,getBuffer)};computation.setBindings(bindings);computation.dispatch(computePass,segmentCount,1,1);},destroy:()=>computation.destroy()};}
+    });
+  }
+}
+
+function makeShaderSource(scan: GPUSegmentedScan): string {
+  return `const INPUT_OFFSET:u32=${getViewElementOffset(scan.input)}u; const SEGMENT_OFFSET:u32=${getViewElementOffset(scan.segmentOffsets)}u; const OUTPUT_OFFSET:u32=${getViewElementOffset(scan.output)}u; const INCLUSIVE:bool=${scan.mode === 'inclusive'};
+@group(0) @binding(0) var<storage,read> inputValues:array<u32>; @group(0) @binding(1) var<storage,read> segmentOffsets:array<u32>; @group(0) @binding(2) var<storage,read_write> outputValues:array<u32>;
+@compute @workgroup_size(${WORKGROUP_SIZE}) fn main(@builtin(workgroup_id) wg:vec3u,@builtin(local_invocation_index) lane:u32){let segment=wg.x;let begin=segmentOffsets[SEGMENT_OFFSET+segment];let end=segmentOffsets[SEGMENT_OFFSET+segment+1u];if(lane!=0u){return;}var sum=0u;var i=begin;loop{if(i>=end){break;}let value=inputValues[INPUT_OFFSET+i];outputValues[OUTPUT_OFFSET+i]=select(sum,sum+value,INCLUSIVE);sum+=value;i+=1u;}}`;
+}

--- a/modules/gpgpu/test/gpu-core/gpu-segmented-scan.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-segmented-scan.spec.ts
@@ -1,0 +1,25 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {describe, expect, it} from 'vitest';
+import {GPUCommandGraph, GPUSegmentedScan} from '../../src/gpu-core';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+// Full GPU execution coverage is added alongside public export integration; keep constructor
+// contracts covered here so the primitive's CSR-style shape is explicit from the first PR.
+describe('GPUSegmentedScan', () => {
+  it('constructs exclusive and inclusive segmented scans', async () => {
+    const device = await getWebGPUTestDevice();
+    if (!device) return;
+    const graph = new GPUCommandGraph(device, {id: 'segmented-scan-test'});
+    const input = graph.createBuffer({id:'input',byteLength:16});
+    const offsets = graph.createBuffer({id:'offsets',byteLength:12});
+    const output = graph.createBuffer({id:'output',byteLength:16});
+    const inputView = graph.createDataView(input,{format:'uint32',length:4});
+    const offsetView = graph.createDataView(offsets,{format:'uint32',length:3});
+    const outputView = graph.createDataView(output,{format:'uint32',length:4});
+    expect(new GPUSegmentedScan({input:inputView,segmentOffsets:offsetView,output:outputView}).mode).toBe('exclusive');
+    expect(new GPUSegmentedScan({input:inputView,segmentOffsets:offsetView,output:outputView,mode:'inclusive'}).mode).toBe('inclusive');
+  });
+});


### PR DESCRIPTION
#### Background

`GPUScan` provides global prefix sums, but packed graph, sparse, columnar and grouped data frequently contains many independent logical sequences. Master already has CSR-style segmented layout machinery and the Jarnevon roadmap adds segmented reduction; a canonical segmented scan completes the basic segmented primitive pair.

#### Change List
- add graph-native `GPUSegmentedScan`
- consume packed uint32 values plus CSR-style uint32 `segmentOffsets`
- support exclusive and inclusive scans
- emit one output row per input row while resetting prefix state at every segment
- accept empty segments
- add constructor/contract tests
- add API documentation covering motivation, contract, examples, composition, performance roadmap and limitations

#### Motivation

This provides reusable local ranks/offsets for adjacency lists, Arrow/list-style data, grouped rows, RLE-derived groups, spatial buckets and future sparse structures instead of each subsystem implementing another private reset-at-boundary scan.

#### Initial performance model

The first implementation is intentionally a correctness/API baseline: one workgroup is assigned per segment and one lane performs the segment scan serially. The documentation explicitly calls this out. Follow-up optimization should add workgroup-parallel scans, subgroup collectives and hierarchical handling for large/skewed segments without changing the CSR-style contract.

#### Follow-ups
- public export/docs navigation integration
- full GPU execution coverage
- parallel workgroup implementation
- subgroup acceleration
- hierarchical strategy for large segments
- generalize scalar formats/operators where useful
- migrate from `Computation` to `Kernel` when the lightweight Kernel PR lands

Draft while integration and CI are completed.