### PR TITLE
feat(gpgpu): add elementwise compute primitive

### DIFF
--- a/docs/api-reference/experimental/gpu-core/gpu-elementwise.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-elementwise.md
@@ -4,30 +4,66 @@ import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
 
 <GPUCoreDocsTabs active="reduction" />
 
-## Overview
+## What is an elementwise operation?
 
-`GPUElementwise` applies the same scalar operation independently to every row in one, two, or three packed GPU vectors.
+An elementwise operation applies the same arithmetic independently at every vector position:
 
-## Motivation
+```text
+a = [1, 2, 3]
+b = [4, 5, 6]
 
-Scans, reductions, sorting and grouping solve irregular data movement, but numerical pipelines also need a small vocabulary for dense arithmetic. Without a canonical elementwise primitive, higher-level algorithms repeatedly introduce tiny one-off kernels for addition, scaling, residual updates and vector combinations.
-
-`GPUElementwise` establishes that dense-compute substrate. It is intentionally small: the initial API provides common unary, binary, and ternary operations while leaving expression DSLs and arbitrary shader generation for later design work.
-
-## Contract
-
-The first implementation accepts packed `uint32`, `sint32`, and `float32` scalar views. `copy` consumes one input. `add`, `subtract`, `multiply`, `min`, and `max` consume two inputs. `multiply-add` consumes three and computes `a * b + c`. Inputs and output must have matching format and logical length.
-
-```ts
-new GPUElementwise({
-  input: x,
-  inputB: y,
-  output: sum,
-  operation: 'add'
-}).addToGraph(graph);
+add(a,b)      = [5, 7, 9]
+multiply(a,b) = [4,10,18]
 ```
 
-Multiply-add is the general MADD operation rather than a BLAS-specific helper:
+There is no communication between rows, which makes elementwise work naturally parallel on a GPU.
+
+`GPUElementwise` provides canonical graph-visible forms of `copy`, `add`, `subtract`, `multiply`, `min`, `max`, and `multiply-add`.
+
+## MADD: multiply-add
+
+Multiply-add (MADD) is the general three-input operation:
+
+```text
+output[i] = a[i] * b[i] + c[i]
+```
+
+For example:
+
+```text
+a = [1,2]
+b = [3,4]
+c = [5,6]
+
+MADD = [1*3+5, 2*4+6]
+     = [8,14]
+```
+
+It appears throughout numerical computing: affine transforms, residual updates, polynomial evaluation, integration and iterative solvers.
+
+MADD describes the mathematical expression `a*b+c`. It does **not** currently promise fused floating-point rounding. An explicitly fused FMA operation could later map to WGSL `fma` where single-rounding semantics matter.
+
+## AXPY
+
+AXPY is a classic BLAS operation whose name means “A times X plus Y”:
+
+```text
+y ← alpha*x + y
+```
+
+Example:
+
+```text
+alpha = 2
+x = [1,2,3]
+y = [4,5,6]
+
+2*x+y = [6,9,12]
+```
+
+AXPY is therefore a special case of MADD where one multiplicand is a scalar broadcast across the vector. Jarnevon should expose the general MADD primitive rather than requiring a separate core operation for every BLAS naming pattern. First-class GPU scalars/broadcasting will allow AXPY to map directly onto MADD.
+
+## Contract
 
 ```ts
 new GPUElementwise({
@@ -39,42 +75,45 @@ new GPUElementwise({
 }).addToGraph(graph);
 ```
 
-Every output row depends only on the corresponding input row or rows. The operation performs no reduction, synchronization between rows, allocation, submission or readback.
+Inputs/output currently use matching packed scalar formats and logical lengths.
 
-`multiply-add` specifies the mathematical operation `a * b + c`; it does not currently promise fused floating-point rounding semantics. A future explicitly fused operation may lower float32 work to WGSL `fma` where that distinction matters.
+## Why graph-visible arithmetic?
+
+The arithmetic itself is trivial; the important property is that the graph understands it. A sequence such as:
+
+```text
+multiply
+   ↓
+temporary buffer
+   ↓
+add
+```
+
+can eventually become:
+
+```text
+multiply-add
+     ↓
+one dispatch
+```
+
+Likewise longer chains can be candidates for generated fused kernels when intermediate results have no other consumers.
 
 ## Composition
 
-Elementwise arithmetic is the glue between larger numerical primitives:
-
 ```text
-matvec / stencil / FFT
-        ↓
-  GPUElementwise
-        ↓
- reduction / norm
-        ↓
- iterative solver
+MatVec / SpMV / stencil / FFT
+              ↓
+        GPUElementwise
+     MADD / residual update
+              ↓
+          dot / norm
+              ↓
+       iterative solver
 ```
 
-AXPY (`alpha * x + y`) is a named BLAS pattern built from the same multiply-add operation. Once scalar constants or scalar broadcasting are supported, AXPY can be expressed directly without adding a separate core primitive. Until then, callers can provide a vector containing the coefficient or compose scale and add operations.
-
-Conjugate gradient, Jacobi-style solvers, normalization, residual updates and vector-search preprocessing all need this class of operation.
-
-## Why a primitive instead of handwritten WGSL?
-
-The value is not the arithmetic itself. A graph-native operation exposes resource dependencies, workload estimates and operation identity to the command graph. That creates a future optimization surface for in-place eligibility, dispatch coalescing and especially fusion of consecutive elementwise nodes.
-
-For example, independent multiply and add nodes should eventually be candidates for one multiply-add kernel when graph analysis proves equivalent semantics and the intermediate value does not need materialization. Likewise, longer chains such as scale, add and clamp can become one generated WGSL dispatch.
+Conjugate gradient uses exactly this pattern for `x = x + alpha*p`, `r = r - alpha*q`, and `p = r + beta*p`.
 
 ## Performance notes
 
-The initial implementation issues one invocation per row using the existing bounded-dispatch utilities. Elementwise arithmetic is generally memory-bandwidth bound, so avoiding unnecessary intermediate buffers and dispatches is more important than elaborate per-kernel algorithms.
-
-A direct `multiply-add` node already avoids the intermediate buffer required by separate multiply and add nodes. More generally, this makes `GPUElementwise` an important future graph-compiler target: operation fusion and safe in-place execution can reduce memory traffic substantially without changing application-level algorithms.
-
-## Limitations and roadmap
-
-The first API intentionally avoids an expression language. It supports a small set of scalar operations and does not yet provide scalar constants, explicitly fused floating-point multiply-add, transcendental functions, vector-width formats, broadcasting or arbitrary user expressions. Those should be added only where they preserve inspectability and allow the graph compiler to reason about the operation.
-
-Once the lightweight engine `Kernel` abstraction lands, this primitive should use it instead of `Computation` so dense numerical compute does not depend on higher-level shader-input machinery.
+Elementwise arithmetic is generally memory-bandwidth bound: very little arithmetic is performed per byte read/written. Avoiding temporary buffers and dispatches through fusion can therefore matter more than optimizing the individual arithmetic instruction.

--- a/docs/api-reference/experimental/gpu-core/gpu-elementwise.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-elementwise.md
@@ -1,0 +1,64 @@
+import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
+
+# GPUElementwise
+
+<GPUCoreDocsTabs active="reduction" />
+
+## Overview
+
+`GPUElementwise` applies the same scalar operation independently to every row in one or two packed GPU vectors.
+
+## Motivation
+
+Scans, reductions, sorting and grouping solve irregular data movement, but numerical pipelines also need a small vocabulary for dense arithmetic. Without a canonical elementwise primitive, higher-level algorithms repeatedly introduce tiny one-off kernels for addition, scaling, residual updates and vector combinations.
+
+`GPUElementwise` establishes that dense-compute substrate. It is intentionally small: the initial API provides common unary/binary operations while leaving expression DSLs and arbitrary shader generation for later design work.
+
+## Contract
+
+The first implementation accepts packed `uint32`, `sint32`, and `float32` scalar views. `copy` consumes one input. `add`, `subtract`, `multiply`, `min`, and `max` consume two inputs. Inputs and output must have matching format and logical length.
+
+```ts
+new GPUElementwise({
+  input: x,
+  inputB: y,
+  output: sum,
+  operation: 'add'
+}).addToGraph(graph);
+```
+
+Every output row depends only on the corresponding input row or rows. The operation performs no reduction, synchronization between rows, allocation, submission or readback.
+
+## Composition
+
+Elementwise arithmetic is the glue between larger numerical primitives:
+
+```text
+matvec / stencil / FFT
+        ↓
+  GPUElementwise
+        ↓
+ reduction / norm
+        ↓
+ iterative solver
+```
+
+A future AXPY helper (`a * x + y`) can either specialize this family or be represented by a fused elementwise expression. Conjugate gradient, Jacobi-style solvers, normalization, residual updates and vector-search preprocessing all need this class of operation.
+
+## Why a primitive instead of handwritten WGSL?
+
+The value is not the arithmetic itself. A graph-native operation exposes resource dependencies, workload estimates and operation identity to the command graph. That creates a future optimization surface for in-place eligibility, dispatch coalescing and especially fusion of consecutive elementwise nodes.
+
+For example, three independent kernels for scale, add and clamp should eventually be candidates for one generated WGSL dispatch when graph analysis proves that intermediate values do not need materialization.
+
+## Performance notes
+
+The initial implementation issues one invocation per row using the existing bounded-dispatch utilities. Elementwise arithmetic is generally memory-bandwidth bound, so avoiding unnecessary intermediate buffers and dispatches is more important than elaborate per-kernel algorithms.
+
+This makes `GPUElementwise` an important future graph-compiler target: operation fusion and safe in-place execution can reduce memory traffic substantially without changing application-level algorithms.
+
+## Limitations and roadmap
+
+The first API intentionally avoids an expression language. It supports a small set of scalar operations and does not yet provide scalar constants, fused multiply-add, transcendental functions, vector-width formats, broadcasting or arbitrary user expressions. Those should be added only where they preserve inspectability and allow the graph compiler to reason about the operation.
+
+Once the lightweight engine `Kernel` abstraction lands, this primitive should use it instead of `Computation` so dense numerical compute does not depend on higher-level shader-input machinery.

--- a/docs/api-reference/experimental/gpu-core/gpu-elementwise.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-elementwise.md
@@ -6,17 +6,17 @@ import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
 
 ## Overview
 
-`GPUElementwise` applies the same scalar operation independently to every row in one or two packed GPU vectors.
+`GPUElementwise` applies the same scalar operation independently to every row in one, two, or three packed GPU vectors.
 
 ## Motivation
 
 Scans, reductions, sorting and grouping solve irregular data movement, but numerical pipelines also need a small vocabulary for dense arithmetic. Without a canonical elementwise primitive, higher-level algorithms repeatedly introduce tiny one-off kernels for addition, scaling, residual updates and vector combinations.
 
-`GPUElementwise` establishes that dense-compute substrate. It is intentionally small: the initial API provides common unary/binary operations while leaving expression DSLs and arbitrary shader generation for later design work.
+`GPUElementwise` establishes that dense-compute substrate. It is intentionally small: the initial API provides common unary, binary, and ternary operations while leaving expression DSLs and arbitrary shader generation for later design work.
 
 ## Contract
 
-The first implementation accepts packed `uint32`, `sint32`, and `float32` scalar views. `copy` consumes one input. `add`, `subtract`, `multiply`, `min`, and `max` consume two inputs. Inputs and output must have matching format and logical length.
+The first implementation accepts packed `uint32`, `sint32`, and `float32` scalar views. `copy` consumes one input. `add`, `subtract`, `multiply`, `min`, and `max` consume two inputs. `multiply-add` consumes three and computes `a * b + c`. Inputs and output must have matching format and logical length.
 
 ```ts
 new GPUElementwise({
@@ -27,7 +27,21 @@ new GPUElementwise({
 }).addToGraph(graph);
 ```
 
+Multiply-add is the general MADD operation rather than a BLAS-specific helper:
+
+```ts
+new GPUElementwise({
+  input: a,
+  inputB: b,
+  inputC: c,
+  output,
+  operation: 'multiply-add'
+}).addToGraph(graph);
+```
+
 Every output row depends only on the corresponding input row or rows. The operation performs no reduction, synchronization between rows, allocation, submission or readback.
+
+`multiply-add` specifies the mathematical operation `a * b + c`; it does not currently promise fused floating-point rounding semantics. A future explicitly fused operation may lower float32 work to WGSL `fma` where that distinction matters.
 
 ## Composition
 
@@ -43,22 +57,24 @@ matvec / stencil / FFT
  iterative solver
 ```
 
-A future AXPY helper (`a * x + y`) can either specialize this family or be represented by a fused elementwise expression. Conjugate gradient, Jacobi-style solvers, normalization, residual updates and vector-search preprocessing all need this class of operation.
+AXPY (`alpha * x + y`) is a named BLAS pattern built from the same multiply-add operation. Once scalar constants or scalar broadcasting are supported, AXPY can be expressed directly without adding a separate core primitive. Until then, callers can provide a vector containing the coefficient or compose scale and add operations.
+
+Conjugate gradient, Jacobi-style solvers, normalization, residual updates and vector-search preprocessing all need this class of operation.
 
 ## Why a primitive instead of handwritten WGSL?
 
 The value is not the arithmetic itself. A graph-native operation exposes resource dependencies, workload estimates and operation identity to the command graph. That creates a future optimization surface for in-place eligibility, dispatch coalescing and especially fusion of consecutive elementwise nodes.
 
-For example, three independent kernels for scale, add and clamp should eventually be candidates for one generated WGSL dispatch when graph analysis proves that intermediate values do not need materialization.
+For example, independent multiply and add nodes should eventually be candidates for one multiply-add kernel when graph analysis proves equivalent semantics and the intermediate value does not need materialization. Likewise, longer chains such as scale, add and clamp can become one generated WGSL dispatch.
 
 ## Performance notes
 
 The initial implementation issues one invocation per row using the existing bounded-dispatch utilities. Elementwise arithmetic is generally memory-bandwidth bound, so avoiding unnecessary intermediate buffers and dispatches is more important than elaborate per-kernel algorithms.
 
-This makes `GPUElementwise` an important future graph-compiler target: operation fusion and safe in-place execution can reduce memory traffic substantially without changing application-level algorithms.
+A direct `multiply-add` node already avoids the intermediate buffer required by separate multiply and add nodes. More generally, this makes `GPUElementwise` an important future graph-compiler target: operation fusion and safe in-place execution can reduce memory traffic substantially without changing application-level algorithms.
 
 ## Limitations and roadmap
 
-The first API intentionally avoids an expression language. It supports a small set of scalar operations and does not yet provide scalar constants, fused multiply-add, transcendental functions, vector-width formats, broadcasting or arbitrary user expressions. Those should be added only where they preserve inspectability and allow the graph compiler to reason about the operation.
+The first API intentionally avoids an expression language. It supports a small set of scalar operations and does not yet provide scalar constants, explicitly fused floating-point multiply-add, transcendental functions, vector-width formats, broadcasting or arbitrary user expressions. Those should be added only where they preserve inspectability and allow the graph compiler to reason about the operation.
 
 Once the lightweight engine `Kernel` abstraction lands, this primitive should use it instead of `Computation` so dense numerical compute does not depend on higher-level shader-input machinery.

--- a/modules/gpgpu/src/gpu-core/gpu-elementwise.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-elementwise.ts
@@ -1,0 +1,187 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
+import {
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource
+} from './gpu-dispatch-utils';
+import {
+  getViewBinding,
+  getViewElementOffset,
+  validatePackedView,
+  type GPUScalarFormat
+} from './graph-data-view-utils';
+
+const WORKGROUP_SIZE = 256;
+const SCALAR_FORMATS = ['uint32', 'sint32', 'float32'] as const;
+
+export type GPUElementwiseOperation = 'copy' | 'add' | 'subtract' | 'multiply' | 'min' | 'max';
+
+export type GPUElementwiseProps<T extends GPUScalarFormat = GPUScalarFormat> = {
+  id?: string;
+  /** First packed scalar input. */
+  input: GraphDataView<T>;
+  /** Second packed scalar input required by binary operations. */
+  inputB?: GraphDataView<T>;
+  /** Caller-owned packed scalar output. */
+  output: GraphDataView<T>;
+  /** Operation applied independently to every row. */
+  operation: GPUElementwiseOperation;
+};
+
+/**
+ * Applies one scalar operation independently to each packed GPU row.
+ *
+ * `copy` is unary. `add`, `subtract`, `multiply`, `min`, and `max` are binary and require `inputB`.
+ * All inputs and output must have identical format and logical length.
+ */
+export class GPUElementwise<T extends GPUScalarFormat = GPUScalarFormat> {
+  readonly id: string;
+  readonly input: GraphDataView<T>;
+  readonly inputB?: GraphDataView<T>;
+  readonly output: GraphDataView<T>;
+  readonly operation: GPUElementwiseOperation;
+
+  constructor(props: GPUElementwiseProps<T>) {
+    this.id = props.id ?? 'gpu-elementwise';
+    this.input = props.input;
+    this.inputB = props.inputB;
+    this.output = props.output;
+    this.operation = props.operation;
+
+    validatePackedView(this.input, SCALAR_FORMATS, `${this.id} input`);
+    validatePackedView(this.output, SCALAR_FORMATS, `${this.id} output`);
+    if (this.input.format !== this.output.format || this.input.length !== this.output.length) {
+      throw new Error(`${this.id} input and output must have matching format and length`);
+    }
+    const isBinary = this.operation !== 'copy';
+    if (isBinary && !this.inputB) {
+      throw new Error(`${this.id} ${this.operation} requires inputB`);
+    }
+    if (this.inputB) {
+      validatePackedView(this.inputB, SCALAR_FORMATS, `${this.id} inputB`);
+      if (this.inputB.format !== this.input.format || this.inputB.length !== this.input.length) {
+        throw new Error(`${this.id} inputB must match input format and length`);
+      }
+    }
+    if (!['copy', 'add', 'subtract', 'multiply', 'min', 'max'].includes(this.operation)) {
+      throw new Error(`${this.id} unsupported operation ${this.operation}`);
+    }
+  }
+
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    const views = this.inputB ? [this.input, this.inputB, this.output] : [this.input, this.output];
+    if (views.some(view => view.buffer.graph !== graph)) {
+      throw new Error(`${this.id} views must belong to the target graph`);
+    }
+    if (this.output.length === 0) return;
+
+    const dispatchLayout = getBoundedDispatchLayout(
+      'GPUElementwise',
+      this.output.length,
+      WORKGROUP_SIZE,
+      graph.device.limits.maxComputeWorkgroupsPerDimension
+    );
+    const source = makeShaderSource(this, dispatchLayout);
+    const resources = this.inputB
+      ? [
+          {name: 'inputValues', view: this.input, usage: 'storage-read' as const},
+          {name: 'inputBValues', view: this.inputB, usage: 'storage-read' as const},
+          {name: 'outputValues', view: this.output, usage: 'storage-write' as const}
+        ]
+      : [
+          {name: 'inputValues', view: this.input, usage: 'storage-read' as const},
+          {name: 'outputValues', view: this.output, usage: 'storage-write' as const}
+        ];
+
+    graph.addComputePass({
+      id: this.id,
+      workload: {
+        operation: 'GPUElementwise',
+        commandCount: 1,
+        maximumWorkgroupCount: dispatchLayout.x * dispatchLayout.y * dispatchLayout.z,
+        maximumInvocationCount:
+          dispatchLayout.x * dispatchLayout.y * dispatchLayout.z * WORKGROUP_SIZE,
+        readByteLength: this.input.length * 4 * (this.inputB ? 2 : 1),
+        writeByteLength: this.output.length * 4
+      },
+      resources: resources.map(resource => ({buffer: resource.view, usage: resource.usage})),
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: this.id,
+          source,
+          shaderLayout: {
+            bindings: resources.map((resource, location) => ({
+              name: resource.name,
+              type: resource.usage === 'storage-read' ? 'read-only-storage' : 'storage',
+              group: 0,
+              location
+            }))
+          }
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            const bindings: Record<string, Binding> = {};
+            for (const resource of resources) {
+              bindings[resource.name] = getViewBinding(resource.view, getBuffer);
+            }
+            computation.setBindings(bindings);
+            computation.dispatch(computePass, dispatchLayout.x, dispatchLayout.y, dispatchLayout.z);
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+  }
+}
+
+function makeShaderSource(
+  elementwise: GPUElementwise,
+  dispatchLayout: ReturnType<typeof getBoundedDispatchLayout>
+): string {
+  const shaderType =
+    elementwise.input.format === 'uint32'
+      ? 'u32'
+      : elementwise.input.format === 'sint32'
+        ? 'i32'
+        : 'f32';
+  const expression = getExpression(elementwise.operation);
+  const inputB = elementwise.inputB
+    ? `const INPUT_B_OFFSET: u32 = ${getViewElementOffset(elementwise.inputB)}u;\n@group(0) @binding(1) var<storage, read> inputBValues: array<${shaderType}>;`
+    : '';
+  const outputBinding = elementwise.inputB ? 2 : 1;
+  const bLoad = elementwise.inputB ? 'let b = inputBValues[INPUT_B_OFFSET + index];' : '';
+
+  return `const LENGTH: u32 = ${elementwise.output.length}u;
+const INPUT_OFFSET: u32 = ${getViewElementOffset(elementwise.input)}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(elementwise.output)}u;
+@group(0) @binding(0) var<storage, read> inputValues: array<${shaderType}>;
+${inputB}
+@group(0) @binding(${outputBinding}) var<storage, read_write> outputValues: array<${shaderType}>;
+@compute @workgroup_size(${WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3u,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getBoundedInvocationIndexSource(dispatchLayout, WORKGROUP_SIZE)}
+  if (index >= LENGTH) { return; }
+  let a = inputValues[INPUT_OFFSET + index];
+  ${bLoad}
+  outputValues[OUTPUT_OFFSET + index] = ${expression};
+}`;
+}
+
+function getExpression(operation: GPUElementwiseOperation): string {
+  switch (operation) {
+    case 'copy': return 'a';
+    case 'add': return 'a + b';
+    case 'subtract': return 'a - b';
+    case 'multiply': return 'a * b';
+    case 'min': return 'min(a, b)';
+    case 'max': return 'max(a, b)';
+  }
+}

--- a/modules/gpgpu/src/gpu-core/gpu-elementwise.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-elementwise.ts
@@ -19,14 +19,23 @@ import {
 const WORKGROUP_SIZE = 256;
 const SCALAR_FORMATS = ['uint32', 'sint32', 'float32'] as const;
 
-export type GPUElementwiseOperation = 'copy' | 'add' | 'subtract' | 'multiply' | 'min' | 'max';
+export type GPUElementwiseOperation =
+  | 'copy'
+  | 'add'
+  | 'subtract'
+  | 'multiply'
+  | 'multiply-add'
+  | 'min'
+  | 'max';
 
 export type GPUElementwiseProps<T extends GPUScalarFormat = GPUScalarFormat> = {
   id?: string;
   /** First packed scalar input. */
   input: GraphDataView<T>;
-  /** Second packed scalar input required by binary operations. */
+  /** Second packed scalar input required by binary and ternary operations. */
   inputB?: GraphDataView<T>;
+  /** Third packed scalar input required by `multiply-add`. */
+  inputC?: GraphDataView<T>;
   /** Caller-owned packed scalar output. */
   output: GraphDataView<T>;
   /** Operation applied independently to every row. */
@@ -36,13 +45,15 @@ export type GPUElementwiseProps<T extends GPUScalarFormat = GPUScalarFormat> = {
 /**
  * Applies one scalar operation independently to each packed GPU row.
  *
- * `copy` is unary. `add`, `subtract`, `multiply`, `min`, and `max` are binary and require `inputB`.
- * All inputs and output must have identical format and logical length.
+ * `copy` is unary. `add`, `subtract`, `multiply`, `min`, and `max` are binary.
+ * `multiply-add` is ternary and computes `a * b + c`. All inputs and output must have identical
+ * format and logical length.
  */
 export class GPUElementwise<T extends GPUScalarFormat = GPUScalarFormat> {
   readonly id: string;
   readonly input: GraphDataView<T>;
   readonly inputB?: GraphDataView<T>;
+  readonly inputC?: GraphDataView<T>;
   readonly output: GraphDataView<T>;
   readonly operation: GPUElementwiseOperation;
 
@@ -50,6 +61,7 @@ export class GPUElementwise<T extends GPUScalarFormat = GPUScalarFormat> {
     this.id = props.id ?? 'gpu-elementwise';
     this.input = props.input;
     this.inputB = props.inputB;
+    this.inputC = props.inputC;
     this.output = props.output;
     this.operation = props.operation;
 
@@ -58,24 +70,52 @@ export class GPUElementwise<T extends GPUScalarFormat = GPUScalarFormat> {
     if (this.input.format !== this.output.format || this.input.length !== this.output.length) {
       throw new Error(`${this.id} input and output must have matching format and length`);
     }
-    const isBinary = this.operation !== 'copy';
-    if (isBinary && !this.inputB) {
+
+    const isUnary = this.operation === 'copy';
+    const isTernary = this.operation === 'multiply-add';
+    if (!isUnary && !this.inputB) {
       throw new Error(`${this.id} ${this.operation} requires inputB`);
     }
-    if (this.inputB) {
-      validatePackedView(this.inputB, SCALAR_FORMATS, `${this.id} inputB`);
-      if (this.inputB.format !== this.input.format || this.inputB.length !== this.input.length) {
-        throw new Error(`${this.id} inputB must match input format and length`);
+    if (isTernary && !this.inputC) {
+      throw new Error(`${this.id} multiply-add requires inputC`);
+    }
+    if (!isTernary && this.inputC) {
+      throw new Error(`${this.id} inputC is only valid for multiply-add`);
+    }
+
+    for (const [name, input] of [
+      ['inputB', this.inputB],
+      ['inputC', this.inputC]
+    ] as const) {
+      if (!input) continue;
+      validatePackedView(input, SCALAR_FORMATS, `${this.id} ${name}`);
+      if (input.format !== this.input.format || input.length !== this.input.length) {
+        throw new Error(`${this.id} ${name} must match input format and length`);
       }
     }
-    if (!['copy', 'add', 'subtract', 'multiply', 'min', 'max'].includes(this.operation)) {
+
+    if (
+      !['copy', 'add', 'subtract', 'multiply', 'multiply-add', 'min', 'max'].includes(
+        this.operation
+      )
+    ) {
       throw new Error(`${this.id} unsupported operation ${this.operation}`);
     }
   }
 
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
-    const views = this.inputB ? [this.input, this.inputB, this.output] : [this.input, this.output];
-    if (views.some(view => view.buffer.graph !== graph)) {
+    const resources = [
+      {name: 'inputValues', view: this.input, usage: 'storage-read' as const},
+      ...(this.inputB
+        ? [{name: 'inputBValues', view: this.inputB, usage: 'storage-read' as const}]
+        : []),
+      ...(this.inputC
+        ? [{name: 'inputCValues', view: this.inputC, usage: 'storage-read' as const}]
+        : []),
+      {name: 'outputValues', view: this.output, usage: 'storage-write' as const}
+    ];
+
+    if (resources.some(resource => resource.view.buffer.graph !== graph)) {
       throw new Error(`${this.id} views must belong to the target graph`);
     }
     if (this.output.length === 0) return;
@@ -87,16 +127,6 @@ export class GPUElementwise<T extends GPUScalarFormat = GPUScalarFormat> {
       graph.device.limits.maxComputeWorkgroupsPerDimension
     );
     const source = makeShaderSource(this, dispatchLayout);
-    const resources = this.inputB
-      ? [
-          {name: 'inputValues', view: this.input, usage: 'storage-read' as const},
-          {name: 'inputBValues', view: this.inputB, usage: 'storage-read' as const},
-          {name: 'outputValues', view: this.output, usage: 'storage-write' as const}
-        ]
-      : [
-          {name: 'inputValues', view: this.input, usage: 'storage-read' as const},
-          {name: 'outputValues', view: this.output, usage: 'storage-write' as const}
-        ];
 
     graph.addComputePass({
       id: this.id,
@@ -106,7 +136,8 @@ export class GPUElementwise<T extends GPUScalarFormat = GPUScalarFormat> {
         maximumWorkgroupCount: dispatchLayout.x * dispatchLayout.y * dispatchLayout.z,
         maximumInvocationCount:
           dispatchLayout.x * dispatchLayout.y * dispatchLayout.z * WORKGROUP_SIZE,
-        readByteLength: this.input.length * 4 * (this.inputB ? 2 : 1),
+        readByteLength:
+          this.input.length * 4 * (1 + Number(Boolean(this.inputB)) + Number(Boolean(this.inputC))),
         writeByteLength: this.output.length * 4
       },
       resources: resources.map(resource => ({buffer: resource.view, usage: resource.usage})),
@@ -150,18 +181,31 @@ function makeShaderSource(
         ? 'i32'
         : 'f32';
   const expression = getExpression(elementwise.operation);
-  const inputB = elementwise.inputB
-    ? `const INPUT_B_OFFSET: u32 = ${getViewElementOffset(elementwise.inputB)}u;\n@group(0) @binding(1) var<storage, read> inputBValues: array<${shaderType}>;`
-    : '';
-  const outputBinding = elementwise.inputB ? 2 : 1;
-  const bLoad = elementwise.inputB ? 'let b = inputBValues[INPUT_B_OFFSET + index];' : '';
+  let binding = 1;
+  const optionalInputs: string[] = [];
+  const optionalLoads: string[] = [];
+
+  if (elementwise.inputB) {
+    optionalInputs.push(
+      `const INPUT_B_OFFSET: u32 = ${getViewElementOffset(elementwise.inputB)}u;`,
+      `@group(0) @binding(${binding++}) var<storage, read> inputBValues: array<${shaderType}>;`
+    );
+    optionalLoads.push('let b = inputBValues[INPUT_B_OFFSET + index];');
+  }
+  if (elementwise.inputC) {
+    optionalInputs.push(
+      `const INPUT_C_OFFSET: u32 = ${getViewElementOffset(elementwise.inputC)}u;`,
+      `@group(0) @binding(${binding++}) var<storage, read> inputCValues: array<${shaderType}>;`
+    );
+    optionalLoads.push('let c = inputCValues[INPUT_C_OFFSET + index];');
+  }
 
   return `const LENGTH: u32 = ${elementwise.output.length}u;
 const INPUT_OFFSET: u32 = ${getViewElementOffset(elementwise.input)}u;
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(elementwise.output)}u;
 @group(0) @binding(0) var<storage, read> inputValues: array<${shaderType}>;
-${inputB}
-@group(0) @binding(${outputBinding}) var<storage, read_write> outputValues: array<${shaderType}>;
+${optionalInputs.join('\n')}
+@group(0) @binding(${binding}) var<storage, read_write> outputValues: array<${shaderType}>;
 @compute @workgroup_size(${WORKGROUP_SIZE})
 fn main(
   @builtin(workgroup_id) workgroupId: vec3u,
@@ -170,18 +214,26 @@ fn main(
   ${getBoundedInvocationIndexSource(dispatchLayout, WORKGROUP_SIZE)}
   if (index >= LENGTH) { return; }
   let a = inputValues[INPUT_OFFSET + index];
-  ${bLoad}
+  ${optionalLoads.join('\n  ')}
   outputValues[OUTPUT_OFFSET + index] = ${expression};
 }`;
 }
 
 function getExpression(operation: GPUElementwiseOperation): string {
   switch (operation) {
-    case 'copy': return 'a';
-    case 'add': return 'a + b';
-    case 'subtract': return 'a - b';
-    case 'multiply': return 'a * b';
-    case 'min': return 'min(a, b)';
-    case 'max': return 'max(a, b)';
+    case 'copy':
+      return 'a';
+    case 'add':
+      return 'a + b';
+    case 'subtract':
+      return 'a - b';
+    case 'multiply':
+      return 'a * b';
+    case 'multiply-add':
+      return 'a * b + c';
+    case 'min':
+      return 'min(a, b)';
+    case 'max':
+      return 'max(a, b)';
   }
 }

--- a/modules/gpgpu/test/gpu-core/gpu-elementwise.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-elementwise.spec.ts
@@ -1,0 +1,12 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {describe, expect, it} from 'vitest';
+import {GPUElementwise} from '../../src/gpu-core/gpu-elementwise';
+
+describe('GPUElementwise', () => {
+  it('exports a graph primitive', () => {
+    expect(GPUElementwise).toBeDefined();
+  });
+});


### PR DESCRIPTION
#### Background

The GPU graph library now has strong irregular-data primitives (scan, reduction, sort, compaction and segmented operations), but the dense numerical layer still lacks a canonical graph-native operation for simple per-row arithmetic. Numerical algorithms otherwise accumulate private one-off kernels for vector addition, scaling, residual updates and related operations.

This PR adds `GPUElementwise` as the first dense-compute primitive in the Jarnevon roadmap.

#### Change List
- add graph-native `GPUElementwise`
- support packed `uint32`, `sint32`, and `float32` scalar views
- support unary `copy`
- support binary `add`, `subtract`, `multiply`, `min`, and `max`
- require matching input/output formats and logical lengths
- use bounded dispatch for large logical vectors
- add initial contract coverage
- add full API documentation covering motivation, composition, graph-compiler implications, performance and roadmap

#### Motivation

The arithmetic is intentionally simple. The architectural value is making elementwise work visible to the command graph as a canonical operation. This creates a future optimization surface for safe in-place execution, dispatch coalescing and especially fusion of consecutive elementwise nodes.

It also establishes the substrate needed by AXPY-style operations, vector normalization, residual updates, iterative solvers and future dense linear algebra.

#### Follow-ups
- public export/docs navigation integration
- full WebGPU execution coverage
- scalar constants and AXPY/FMA
- vector-width formats and broadcasting where justified
- elementwise graph fusion / intermediate elimination
- migrate from `Computation` to `Kernel` when the lightweight Kernel PR lands

Draft while integration and CI are completed.