### PR TITLE
feat(gpgpu): add dense matrix-vector primitive

### DIFF
--- a/docs/api-reference/experimental/gpu-core/gpu-matvec.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-matvec.md
@@ -4,19 +4,55 @@ import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
 
 <GPUCoreDocsTabs active="reduction" />
 
-## Overview
+## What is matrix-vector multiplication?
 
-`GPUMatVec` multiplies a dense row-major `float32` matrix by a packed `float32` vector entirely inside the GPU command graph.
+Matrix-vector multiplication applies a matrix `A` to a vector `x` to produce another vector `y`:
 
-## Motivation
+```text
+y = A x
+```
 
-Elementwise arithmetic provides the dense vector glue, but many numerical algorithms also need a linear operator. Matrix-vector multiplication is the smallest useful dense linear-algebra primitive that crosses that boundary: each output row computes a dot product between one matrix row and the input vector.
+For example:
 
-Making matvec graph-native provides a reusable building block for iterative solvers, transformations, numerical methods and dense reference implementations. It also establishes matrix layout conventions before introducing the substantially more performance-sensitive matrix-matrix multiply problem.
+```text
+A = [1 2 3]      x = [10]
+    [4 5 6]          [20]
+                       [30]
+```
+
+Each output is the dot product of one matrix row with `x`:
+
+```text
+y[0] = 1*10 + 2*20 + 3*30 = 140
+y[1] = 4*10 + 5*20 + 6*30 = 320
+
+A x = [140, 320]
+```
+
+So MatVec can be pictured as many row dot-products sharing the same vector:
+
+```text
+matrix row 0 ─┐
+              ├─ dot with x ─▶ y[0]
+matrix row 1 ─┤
+              ├─ dot with x ─▶ y[1]
+      ...     ─┘
+```
+
+Matrices often represent linear transformations, physical operators, graph-derived systems or discretized differential equations. Repeated `A*x` operations are central to iterative numerical methods.
+
+## Row-major storage
+
+The initial API stores the matrix flat in row-major order:
+
+```text
+matrix = [a00,a01,a02, a10,a11,a12]
+          └─ row 0 ─┘   └─ row 1 ─┘
+```
+
+For `rows × columns`, matrix element `(row,column)` is at `row * columns + column`.
 
 ## Contract
-
-The initial API deliberately avoids a general tensor abstraction. The matrix is one packed row-major `GraphDataView<'float32'>` with `rows * columns` values. The vector contains `columns` values and the output contains `rows` values.
 
 ```ts
 new GPUMatVec({
@@ -28,48 +64,39 @@ new GPUMatVec({
 }).addToGraph(graph);
 ```
 
-The mathematical operation is:
+The matrix contains `rows * columns` packed `float32` values, `x` contains `columns`, and `y` contains `rows`.
+
+## Dense vs sparse MatVec
+
+Dense MatVec stores every matrix value, including zeros. `GPUSpMV` performs the same mathematical `Ax` operation for a sparse representation that stores only nonzero entries:
 
 ```text
-y[row] = sum(matrix[row, column] * x[column])
+              y = A x
+             /       \
+      GPUMatVec     GPUSpMV
+        dense         sparse
 ```
 
-All resources remain caller-owned and GPU-resident. The primitive contributes compute work to the graph but performs no submission or readback.
+This shared linear-operator role is useful in solver design.
 
 ## Composition
 
-Matvec becomes especially useful together with the other numerical primitives:
-
 ```text
-          GPUMatVec
-              ↓
-        GPUElementwise
-       residual / MADD
-              ↓
-         GPUReduction
-          dot / norm
-              ↓
-       iterative solver
+GPUMatVec
+    ↓
+residual/vector update
+    ↓
+dot / norm
+    ↓
+iterative solver
 ```
 
-This is enough infrastructure to begin expressing algorithms such as conjugate gradient once dot-product and solver orchestration are added. A future sparse matrix-vector primitive can expose the same conceptual role while consuming an offset-delimited sparse representation instead of a dense row-major matrix.
+## Execution strategy
 
-## Why matvec before matmul?
+The baseline assigns one 256-thread workgroup to each matrix row. Lanes process columns in parallel and then reduce their partial products to one output value.
 
-Dense matrix multiplication is an important target but a poor place to establish basic API semantics: competitive GEMM requires tiling, shared-memory reuse, device specialization, vectorized loads and careful benchmarking. Matvec has a much smaller implementation surface while still forcing the library to define matrix shape, layout, dispatch and reduction behavior.
+MatVec is usually memory-bandwidth constrained because the matrix streams through memory while `x` is repeatedly reused. Future strategies may cache vector tiles, use subgroup reductions, or specialize for narrow/wide matrices.
 
-The initial row-major contract can therefore be validated independently before `GPUMatMul` introduces tiled execution and potentially richer layout metadata.
+## Why MatVec before MatMul?
 
-## Performance notes
-
-The first implementation assigns one 256-thread workgroup to each matrix row. Lanes stride across columns, multiply matrix/vector values, then perform a workgroup-tree reduction to one output value. This is a reasonable baseline for medium and wide rows and exposes straightforward future subgroup optimization.
-
-Matvec is typically memory-bandwidth constrained because the matrix is streamed once while the vector is repeatedly reused. Future implementations may cache vector tiles in workgroup memory, use subgroup reductions, specialize workgroup size, or choose alternate strategies for narrow matrices. Those optimizations need not change the API contract.
-
-## Limitations and roadmap
-
-The first API supports row-major packed `float32` only. It does not yet support transpose flags, batching, strided matrices, `float16`, mixed precision, bias/activation fusion or matrix views. Those should be introduced from demonstrated workloads rather than by prematurely creating a tensor framework.
-
-A future sparse `GPUSpMV` should share the same role in solver graphs. `GPUMatMul` is the next dense-linear-algebra step and will require a tiled implementation plus explicit performance benchmarks.
-
-Once the lightweight engine `Kernel` abstraction lands, this primitive should use it instead of `Computation`.
+MatVec establishes matrix shape, row-major layout and reduction semantics with a relatively simple kernel. Competitive matrix-matrix multiplication requires tiling and substantially more performance engineering, so it is treated separately by `GPUMatMul`.

--- a/docs/api-reference/experimental/gpu-core/gpu-matvec.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-matvec.md
@@ -1,0 +1,75 @@
+import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
+
+# GPUMatVec
+
+<GPUCoreDocsTabs active="reduction" />
+
+## Overview
+
+`GPUMatVec` multiplies a dense row-major `float32` matrix by a packed `float32` vector entirely inside the GPU command graph.
+
+## Motivation
+
+Elementwise arithmetic provides the dense vector glue, but many numerical algorithms also need a linear operator. Matrix-vector multiplication is the smallest useful dense linear-algebra primitive that crosses that boundary: each output row computes a dot product between one matrix row and the input vector.
+
+Making matvec graph-native provides a reusable building block for iterative solvers, transformations, numerical methods and dense reference implementations. It also establishes matrix layout conventions before introducing the substantially more performance-sensitive matrix-matrix multiply problem.
+
+## Contract
+
+The initial API deliberately avoids a general tensor abstraction. The matrix is one packed row-major `GraphDataView<'float32'>` with `rows * columns` values. The vector contains `columns` values and the output contains `rows` values.
+
+```ts
+new GPUMatVec({
+  matrix,
+  vector: x,
+  output: y,
+  rows: 1024,
+  columns: 1024
+}).addToGraph(graph);
+```
+
+The mathematical operation is:
+
+```text
+y[row] = sum(matrix[row, column] * x[column])
+```
+
+All resources remain caller-owned and GPU-resident. The primitive contributes compute work to the graph but performs no submission or readback.
+
+## Composition
+
+Matvec becomes especially useful together with the other numerical primitives:
+
+```text
+          GPUMatVec
+              ↓
+        GPUElementwise
+       residual / MADD
+              ↓
+         GPUReduction
+          dot / norm
+              ↓
+       iterative solver
+```
+
+This is enough infrastructure to begin expressing algorithms such as conjugate gradient once dot-product and solver orchestration are added. A future sparse matrix-vector primitive can expose the same conceptual role while consuming an offset-delimited sparse representation instead of a dense row-major matrix.
+
+## Why matvec before matmul?
+
+Dense matrix multiplication is an important target but a poor place to establish basic API semantics: competitive GEMM requires tiling, shared-memory reuse, device specialization, vectorized loads and careful benchmarking. Matvec has a much smaller implementation surface while still forcing the library to define matrix shape, layout, dispatch and reduction behavior.
+
+The initial row-major contract can therefore be validated independently before `GPUMatMul` introduces tiled execution and potentially richer layout metadata.
+
+## Performance notes
+
+The first implementation assigns one 256-thread workgroup to each matrix row. Lanes stride across columns, multiply matrix/vector values, then perform a workgroup-tree reduction to one output value. This is a reasonable baseline for medium and wide rows and exposes straightforward future subgroup optimization.
+
+Matvec is typically memory-bandwidth constrained because the matrix is streamed once while the vector is repeatedly reused. Future implementations may cache vector tiles in workgroup memory, use subgroup reductions, specialize workgroup size, or choose alternate strategies for narrow matrices. Those optimizations need not change the API contract.
+
+## Limitations and roadmap
+
+The first API supports row-major packed `float32` only. It does not yet support transpose flags, batching, strided matrices, `float16`, mixed precision, bias/activation fusion or matrix views. Those should be introduced from demonstrated workloads rather than by prematurely creating a tensor framework.
+
+A future sparse `GPUSpMV` should share the same role in solver graphs. `GPUMatMul` is the next dense-linear-algebra step and will require a tiled implementation plus explicit performance benchmarks.
+
+Once the lightweight engine `Kernel` abstraction lands, this primitive should use it instead of `Computation`.

--- a/modules/gpgpu/src/gpu-core/gpu-matvec.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-matvec.ts
@@ -1,0 +1,109 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
+import {getViewBinding, getViewElementOffset, validatePackedView} from './graph-data-view-utils';
+
+const WORKGROUP_SIZE = 256;
+
+export type GPUMatVecProps = {
+  id?: string;
+  /** Row-major packed float32 matrix containing rows * columns values. */
+  matrix: GraphDataView<'float32'>;
+  /** Packed float32 vector containing columns values. */
+  vector: GraphDataView<'float32'>;
+  /** Packed float32 result containing rows values. */
+  output: GraphDataView<'float32'>;
+  /** Matrix row count. */
+  rows: number;
+  /** Matrix column count. */
+  columns: number;
+};
+
+/** Dense row-major float32 matrix-vector multiplication: `output = matrix * vector`. */
+export class GPUMatVec {
+  readonly id: string;
+  readonly matrix: GraphDataView<'float32'>;
+  readonly vector: GraphDataView<'float32'>;
+  readonly output: GraphDataView<'float32'>;
+  readonly rows: number;
+  readonly columns: number;
+
+  constructor(props: GPUMatVecProps) {
+    this.id = props.id ?? 'gpu-matvec';
+    this.matrix = props.matrix;
+    this.vector = props.vector;
+    this.output = props.output;
+    this.rows = props.rows;
+    this.columns = props.columns;
+
+    validatePackedView(this.matrix, ['float32'], `${this.id} matrix`);
+    validatePackedView(this.vector, ['float32'], `${this.id} vector`);
+    validatePackedView(this.output, ['float32'], `${this.id} output`);
+    if (!Number.isInteger(this.rows) || this.rows < 0) throw new Error(`${this.id} rows must be a non-negative integer`);
+    if (!Number.isInteger(this.columns) || this.columns < 0) throw new Error(`${this.id} columns must be a non-negative integer`);
+    if (this.matrix.length !== this.rows * this.columns) throw new Error(`${this.id} matrix length must equal rows * columns`);
+    if (this.vector.length !== this.columns) throw new Error(`${this.id} vector length must equal columns`);
+    if (this.output.length !== this.rows) throw new Error(`${this.id} output length must equal rows`);
+    if (this.output.buffer === this.matrix.buffer || this.output.buffer === this.vector.buffer) throw new Error(`${this.id} output must use a separate buffer`);
+  }
+
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    for (const view of [this.matrix, this.vector, this.output]) {
+      if (view.buffer.graph !== graph) throw new Error(`${this.id} views must belong to the target graph`);
+    }
+    if (this.rows === 0) return;
+
+    const source = makeShaderSource(this);
+    graph.addComputePass({
+      id: this.id,
+      workload: {
+        operation: 'GPUMatVec',
+        commandCount: 1,
+        maximumWorkgroupCount: this.rows,
+        maximumInvocationCount: this.rows * WORKGROUP_SIZE,
+        readByteLength: (this.matrix.length + this.vector.length) * 4,
+        writeByteLength: this.output.length * 4
+      },
+      resources: [
+        {buffer: this.matrix, usage: 'storage-read'},
+        {buffer: this.vector, usage: 'storage-read'},
+        {buffer: this.output, usage: 'storage-write'}
+      ],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: this.id,
+          source,
+          shaderLayout: {bindings: [
+            {name: 'matrixValues', type: 'read-only-storage', group: 0, location: 0},
+            {name: 'vectorValues', type: 'read-only-storage', group: 0, location: 1},
+            {name: 'outputValues', type: 'storage', group: 0, location: 2}
+          ]}
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            const bindings: Record<string, Binding> = {
+              matrixValues: getViewBinding(this.matrix, getBuffer),
+              vectorValues: getViewBinding(this.vector, getBuffer),
+              outputValues: getViewBinding(this.output, getBuffer)
+            };
+            computation.setBindings(bindings);
+            computation.dispatch(computePass, this.rows, 1, 1);
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+  }
+}
+
+function makeShaderSource(matvec: GPUMatVec): string {
+  return `const ROWS:u32=${matvec.rows}u; const COLUMNS:u32=${matvec.columns}u;
+const MATRIX_OFFSET:u32=${getViewElementOffset(matvec.matrix)}u; const VECTOR_OFFSET:u32=${getViewElementOffset(matvec.vector)}u; const OUTPUT_OFFSET:u32=${getViewElementOffset(matvec.output)}u;
+@group(0) @binding(0) var<storage,read> matrixValues:array<f32>; @group(0) @binding(1) var<storage,read> vectorValues:array<f32>; @group(0) @binding(2) var<storage,read_write> outputValues:array<f32>;
+var<workgroup> partials:array<f32,${WORKGROUP_SIZE}>;
+@compute @workgroup_size(${WORKGROUP_SIZE}) fn main(@builtin(workgroup_id) wg:vec3u,@builtin(local_invocation_index) lane:u32){let row=wg.x;if(row>=ROWS){return;}var sum=0.0;var column=lane;loop{if(column>=COLUMNS){break;}sum += matrixValues[MATRIX_OFFSET+row*COLUMNS+column]*vectorValues[VECTOR_OFFSET+column];column+=${WORKGROUP_SIZE}u;}partials[lane]=sum;workgroupBarrier();var stride=${WORKGROUP_SIZE / 2}u;loop{if(stride==0u){break;}if(lane<stride){partials[lane]+=partials[lane+stride];}workgroupBarrier();stride/=2u;}if(lane==0u){outputValues[OUTPUT_OFFSET+row]=partials[0];}}`;
+}

--- a/modules/gpgpu/test/gpu-core/gpu-matvec.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-matvec.spec.ts
@@ -1,0 +1,12 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {describe, expect, it} from 'vitest';
+import {GPUMatVec} from '../../src/gpu-core/gpu-matvec';
+
+describe('GPUMatVec', () => {
+  it('exports a graph primitive', () => {
+    expect(GPUMatVec).toBeDefined();
+  });
+});


### PR DESCRIPTION
#### Background

The Jarnevon roadmap has completed much of the irregular-data primitive vocabulary and introduced `GPUElementwise` as the first dense numerical primitive. The next missing building block is a graph-native linear operator.

This PR adds `GPUMatVec` as a deliberately narrow dense matrix-vector baseline before tackling the substantially more performance-sensitive GEMM problem.

#### Change List
- add graph-native `GPUMatVec`
- consume a packed row-major `float32` matrix plus packed `float32` vector
- produce one packed `float32` value per matrix row
- validate explicit `rows` and `columns` against resource lengths
- use one 256-thread workgroup per matrix row with a workgroup-tree dot-product reduction
- add initial contract coverage
- add full API documentation covering motivation, layout contract, composition, performance model and roadmap

#### Motivation

Matvec establishes the smallest useful dense linear-algebra operator and composes directly with `GPUElementwise` and `GPUReduction` in future solver graphs. It also lets the library establish matrix shape/layout semantics without prematurely introducing a tensor abstraction.

#### Performance model

The first implementation assigns one workgroup per matrix row. Lanes stride across columns and reduce partial dot products in workgroup memory. Future optimization can add subgroup reductions, vector/workgroup tiling and device-specific strategy selection without changing the row-major API contract.

#### Why before MatMul

Competitive matrix-matrix multiplication requires much more aggressive tiling, shared-memory reuse and benchmarking. Matvec lets us validate the dense matrix API boundary first, then tackle GEMM deliberately.

#### Follow-ups
- public export/docs navigation integration
- full WebGPU execution coverage and benchmarks
- subgroup reduction path
- `GPUMatMul` tiled implementation
- sparse `GPUSpMV`
- solver composition (dot/norm + conjugate gradient)
- migrate from `Computation` to `Kernel` when the lightweight Kernel PR lands

Draft while integration and CI are completed.