### PR TITLE
feat(gpgpu): add GPU COO to CSR conversion

### DIFF
--- a/docs/api-reference/experimental/gpu-core/gpu-coo-to-csr.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-coo-to-csr.md
@@ -2,15 +2,19 @@
 
 ## Overview
 
-`GPUCOOToCSR` converts row-sorted coordinate-list sparse entries into compressed sparse row arrays entirely on the GPU.
+`GPUCOOToCSR` converts a sparse matrix from coordinate (COO) representation into compressed sparse row (CSR) representation entirely on the GPU.
 
-## Motivation
+## What changes during COO → CSR?
 
-COO is convenient while constructing sparse data because every entry carries an explicit row and column. CSR is better for row-oriented execution because rows become offset-delimited segments. A GPU-resident conversion lets construction flow directly into sparse numerical or graph execution without downloading row structure to JavaScript.
+Consider:
 
-## Contract
+```text
+A = [10  0 20]
+    [ 0 30  0]
+    [40  0 50]
+```
 
-The initial operation consumes row-sorted COO arrays:
+COO explicitly stores a row number for every nonzero:
 
 ```text
 rowIndices    = [0,0,1,2,2]
@@ -18,7 +22,7 @@ columnIndices = [0,2,1,0,2]
 values        = [10,20,30,40,50]
 ```
 
-and produces:
+CSR removes `rowIndices` and replaces them with N+1 row boundaries:
 
 ```text
 rowOffsets    = [0,2,3,5]
@@ -26,7 +30,55 @@ columnIndices = [0,2,1,0,2]
 values        = [10,20,30,40,50]
 ```
 
-Rows are described by offset-delimited ranges `[rowOffsets[r], rowOffsets[r + 1])`.
+Visually:
+
+```text
+COO rows:      [0,0 | 1 | 2,2]
+                    ↓ compress row identity
+CSR offsets:   [0,   2,  3,    5]
+```
+
+Nothing about the mathematical matrix changes. Only its indexing representation changes.
+
+## Why convert?
+
+COO is easy to construct because every entry is independent. CSR is efficient for row-oriented execution because all entries for row `r` are immediately available as:
+
+```text
+[rowOffsets[r], rowOffsets[r + 1])
+```
+
+This makes conversion a natural boundary between construction and execution:
+
+```text
+generate entries
+      ↓
+     COO
+      ↓
+sort/canonicalize
+      ↓
+ GPUCOOToCSR
+      ↓
+     CSR
+      ↓
+SpMV / graph / solver
+```
+
+## Empty rows
+
+Offset-delimited representation handles empty rows without special records. If row 1 contains no entries:
+
+```text
+rowOffsets = [0, 2, 2, 5]
+                       ↑
+               [2,2) is empty
+```
+
+Repeated offsets therefore have useful semantics and are not malformed data.
+
+## Contract
+
+The initial operation requires COO entries sorted nondecreasing by row:
 
 ```ts
 new GPUCOOToCSR({
@@ -40,48 +92,39 @@ new GPUCOOToCSR({
 }).addToGraph(graph);
 ```
 
-The initial primitive deliberately requires COO entries already sorted nondecreasing by row. Sorting and duplicate-coordinate canonicalization are separate concerns and can be composed before conversion.
+Sorting and duplicate-coordinate canonicalization are separate operations. Duplicate `(row,column)` entries are preserved by conversion.
 
 ## Execution strategy
 
-The conversion has two independent GPU stages. The entry arrays are copied into CSR entry order, which is already correct because the COO input is row-sorted. Row offsets are then generated in parallel: each output boundary computes the lower bound of its row number in the sorted COO row-index array.
-
-This produces correct offsets for empty rows as well as populated rows. For example, repeated equal offsets naturally represent empty rows.
-
-## Composition
-
-The intended sparse construction pipeline is:
+Because input is row-sorted, column/value arrays are already in CSR entry order and can be copied directly. Each CSR boundary independently finds the first COO entry whose row is at least that boundary's row number—a lower-bound search.
 
 ```text
-raw COO entries
-      ↓
-sort by row / column
-      ↓
-canonicalize duplicates if required
-      ↓
-GPUCOOToCSR
-      ↓
-GPUCSRMatrix
-      ↓
-GPUSpMV / graph / solver operations
+sorted COO row indices
+[0 0 0 2 2 4]
+ ↑     ↑   ↑ ↑
+row0  row1 row3 row5 boundaries
 ```
 
-The lower-bound baseline intentionally keeps this PR independent of the proposed RLE/segmented PRs. Once those primitives land, an alternative conversion strategy can be benchmarked using boundary detection, run-length encoding and scan. The public COO-to-CSR contract need not change.
+Rows missing from COO naturally map to repeated boundaries.
 
-## Semantics and validation
+## Alternative composition
 
-`rowIndices`, `columnIndices` and `values` must have equal logical length. `rowOffsets` must contain `rows + 1` entries. CSR column/value outputs must have capacity equal to the COO nonzero count.
+Once the general grouping primitives land, row offsets can also be viewed as a grouping problem:
 
-The primitive assumes GPU-resident row indices are sorted and in range. It does not read them back for host validation. Duplicate `(row,column)` entries are preserved; merging duplicates is a separate canonicalization operation.
+```text
+sorted row IDs
+      ↓
+run boundaries / RLE
+      ↓
+run lengths
+      ↓
+scan
+      ↓
+row offsets
+```
+
+The lower-bound implementation is a simple independent baseline. RLE/scan may reduce traffic for some shapes and should be benchmarked rather than assumed superior.
 
 ## Performance notes
 
-The initial row-offset implementation performs one binary lower-bound search per row, giving approximately `O(rows log nnz)` row-index reads. This is attractive as a simple parallel baseline and handles empty rows naturally.
-
-For very large row counts, a boundary/RLE/scan construction may reduce memory traffic. That alternative should be evaluated against the baseline rather than assumed faster: sparse shape, row distribution and GPU memory behavior all matter.
-
-## Roadmap
-
-The immediate consumer is `GPUSpMV`. Future work can add a canonicalization helper, benchmark lower-bound versus RLE/scan offset construction, and support additional sparse value formats where justified.
-
-Once the lightweight `Kernel` abstraction lands, this primitive should use it instead of `Computation`.
+The baseline performs one binary search per row, approximately `O(rows log nnz)` row-index reads. It remains entirely GPU-resident and handles populated and empty rows uniformly.

--- a/docs/api-reference/experimental/gpu-core/gpu-coo-to-csr.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-coo-to-csr.md
@@ -1,0 +1,87 @@
+# GPUCOOToCSR
+
+## Overview
+
+`GPUCOOToCSR` converts row-sorted coordinate-list sparse entries into compressed sparse row arrays entirely on the GPU.
+
+## Motivation
+
+COO is convenient while constructing sparse data because every entry carries an explicit row and column. CSR is better for row-oriented execution because rows become offset-delimited segments. A GPU-resident conversion lets construction flow directly into sparse numerical or graph execution without downloading row structure to JavaScript.
+
+## Contract
+
+The initial operation consumes row-sorted COO arrays:
+
+```text
+rowIndices    = [0,0,1,2,2]
+columnIndices = [0,2,1,0,2]
+values        = [10,20,30,40,50]
+```
+
+and produces:
+
+```text
+rowOffsets    = [0,2,3,5]
+columnIndices = [0,2,1,0,2]
+values        = [10,20,30,40,50]
+```
+
+Rows are described by offset-delimited ranges `[rowOffsets[r], rowOffsets[r + 1])`.
+
+```ts
+new GPUCOOToCSR({
+  rowIndices,
+  columnIndices,
+  values,
+  rows,
+  rowOffsets,
+  outputColumnIndices,
+  outputValues
+}).addToGraph(graph);
+```
+
+The initial primitive deliberately requires COO entries already sorted nondecreasing by row. Sorting and duplicate-coordinate canonicalization are separate concerns and can be composed before conversion.
+
+## Execution strategy
+
+The conversion has two independent GPU stages. The entry arrays are copied into CSR entry order, which is already correct because the COO input is row-sorted. Row offsets are then generated in parallel: each output boundary computes the lower bound of its row number in the sorted COO row-index array.
+
+This produces correct offsets for empty rows as well as populated rows. For example, repeated equal offsets naturally represent empty rows.
+
+## Composition
+
+The intended sparse construction pipeline is:
+
+```text
+raw COO entries
+      ↓
+sort by row / column
+      ↓
+canonicalize duplicates if required
+      ↓
+GPUCOOToCSR
+      ↓
+GPUCSRMatrix
+      ↓
+GPUSpMV / graph / solver operations
+```
+
+The lower-bound baseline intentionally keeps this PR independent of the proposed RLE/segmented PRs. Once those primitives land, an alternative conversion strategy can be benchmarked using boundary detection, run-length encoding and scan. The public COO-to-CSR contract need not change.
+
+## Semantics and validation
+
+`rowIndices`, `columnIndices` and `values` must have equal logical length. `rowOffsets` must contain `rows + 1` entries. CSR column/value outputs must have capacity equal to the COO nonzero count.
+
+The primitive assumes GPU-resident row indices are sorted and in range. It does not read them back for host validation. Duplicate `(row,column)` entries are preserved; merging duplicates is a separate canonicalization operation.
+
+## Performance notes
+
+The initial row-offset implementation performs one binary lower-bound search per row, giving approximately `O(rows log nnz)` row-index reads. This is attractive as a simple parallel baseline and handles empty rows naturally.
+
+For very large row counts, a boundary/RLE/scan construction may reduce memory traffic. That alternative should be evaluated against the baseline rather than assumed faster: sparse shape, row distribution and GPU memory behavior all matter.
+
+## Roadmap
+
+The immediate consumer is `GPUSpMV`. Future work can add a canonicalization helper, benchmark lower-bound versus RLE/scan offset construction, and support additional sparse value formats where justified.
+
+Once the lightweight `Kernel` abstraction lands, this primitive should use it instead of `Computation`.

--- a/modules/gpgpu/src/gpu-core/gpu-coo-to-csr.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-coo-to-csr.ts
@@ -1,0 +1,81 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
+import {getViewBinding, getViewElementOffset, validatePackedUint32View, validatePackedView} from './graph-data-view-utils';
+
+const WORKGROUP_SIZE = 256;
+
+export type GPUCOOToCSRProps = {
+  id?: string;
+  /** COO row indices, sorted nondecreasing by row. */
+  rowIndices: GraphDataView<'uint32'>;
+  /** COO column indices in the same entry order. */
+  columnIndices: GraphDataView<'uint32'>;
+  /** COO values in the same entry order. */
+  values: GraphDataView<'float32'>;
+  /** Matrix row count. */
+  rows: number;
+  /** Caller-owned CSR row offsets, length rows + 1. */
+  rowOffsets: GraphDataView<'uint32'>;
+  /** Caller-owned CSR column indices, length nnz. */
+  outputColumnIndices: GraphDataView<'uint32'>;
+  /** Caller-owned CSR values, length nnz. */
+  outputValues: GraphDataView<'float32'>;
+};
+
+/** Converts row-sorted COO entries into CSR without CPU readback. */
+export class GPUCOOToCSR {
+  readonly id: string;
+  readonly props: GPUCOOToCSRProps;
+
+  constructor(props: GPUCOOToCSRProps) {
+    this.id = props.id ?? 'gpu-coo-to-csr';
+    this.props = props;
+    validatePackedUint32View(props.rowIndices, `${this.id} rowIndices`);
+    validatePackedUint32View(props.columnIndices, `${this.id} columnIndices`);
+    validatePackedView(props.values, ['float32'], `${this.id} values`);
+    validatePackedUint32View(props.rowOffsets, `${this.id} rowOffsets`);
+    validatePackedUint32View(props.outputColumnIndices, `${this.id} outputColumnIndices`);
+    validatePackedView(props.outputValues, ['float32'], `${this.id} outputValues`);
+    const nnz = props.rowIndices.length;
+    if (props.columnIndices.length !== nnz || props.values.length !== nnz) throw new Error(`${this.id} COO arrays must have equal length`);
+    if (!Number.isInteger(props.rows) || props.rows < 0) throw new Error(`${this.id} rows must be a non-negative integer`);
+    if (props.rowOffsets.length !== props.rows + 1) throw new Error(`${this.id} rowOffsets length must equal rows + 1`);
+    if (props.outputColumnIndices.length !== nnz || props.outputValues.length !== nnz) throw new Error(`${this.id} CSR entry outputs must have length nnz`);
+  }
+
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    const p = this.props;
+    const views = [p.rowIndices,p.columnIndices,p.values,p.rowOffsets,p.outputColumnIndices,p.outputValues];
+    if (views.some(view => view.buffer.graph !== graph)) throw new Error(`${this.id} views must belong to target graph`);
+    addCopyEntriesPass(graph, this);
+    addOffsetsPass(graph, this);
+  }
+}
+
+function addCopyEntriesPass<Parameters>(graph: GPUCommandGraph<Parameters>, conversion: GPUCOOToCSR): void {
+  const p=conversion.props; const nnz=p.rowIndices.length; if(nnz===0)return;
+  const groups=Math.ceil(nnz/WORKGROUP_SIZE);
+  const source=`const NNZ:u32=${nnz}u;const COL_IN:u32=${getViewElementOffset(p.columnIndices)}u;const VAL_IN:u32=${getViewElementOffset(p.values)}u;const COL_OUT:u32=${getViewElementOffset(p.outputColumnIndices)}u;const VAL_OUT:u32=${getViewElementOffset(p.outputValues)}u;
+@group(0) @binding(0) var<storage,read> columns:array<u32>;@group(0) @binding(1) var<storage,read> values:array<f32>;@group(0) @binding(2) var<storage,read_write> outColumns:array<u32>;@group(0) @binding(3) var<storage,read_write> outValues:array<f32>;
+@compute @workgroup_size(${WORKGROUP_SIZE}) fn main(@builtin(global_invocation_id) id:vec3u){let i=id.x;if(i>=NNZ){return;}outColumns[COL_OUT+i]=columns[COL_IN+i];outValues[VAL_OUT+i]=values[VAL_IN+i];}`;
+  addPass(graph,`${conversion.id}-copy`,source,groups,[{name:'columns',view:p.columnIndices,usage:'storage-read'},{name:'values',view:p.values,usage:'storage-read'},{name:'outColumns',view:p.outputColumnIndices,usage:'storage-write'},{name:'outValues',view:p.outputValues,usage:'storage-write'}]);
+}
+
+function addOffsetsPass<Parameters>(graph: GPUCommandGraph<Parameters>, conversion: GPUCOOToCSR): void {
+  const p=conversion.props; const nnz=p.rowIndices.length; const groups=Math.ceil((p.rows+1)/WORKGROUP_SIZE);
+  const source=`const ROWS:u32=${p.rows}u;const NNZ:u32=${nnz}u;const ROW_IN:u32=${getViewElementOffset(p.rowIndices)}u;const OFF_OUT:u32=${getViewElementOffset(p.rowOffsets)}u;
+@group(0) @binding(0) var<storage,read> rowsIn:array<u32>;@group(0) @binding(1) var<storage,read_write> offsets:array<u32>;
+fn lowerBound(target:u32)->u32{var lo=0u;var hi=NNZ;loop{if(lo>=hi){break;}let mid=lo+(hi-lo)/2u;if(rowsIn[ROW_IN+mid]<target){lo=mid+1u;}else{hi=mid;}}return lo;}
+@compute @workgroup_size(${WORKGROUP_SIZE}) fn main(@builtin(global_invocation_id) id:vec3u){let row=id.x;if(row>ROWS){return;}offsets[OFF_OUT+row]=lowerBound(row);}`;
+  addPass(graph,`${conversion.id}-offsets`,source,groups,[{name:'rowsIn',view:p.rowIndices,usage:'storage-read'},{name:'offsets',view:p.rowOffsets,usage:'storage-write'}]);
+}
+
+type Resource={name:string;view:GraphDataView;usage:'storage-read'|'storage-write'};
+function addPass<Parameters>(graph:GPUCommandGraph<Parameters>,id:string,source:string,groups:number,resources:Resource[]):void{
+  graph.addComputePass({id,workload:{operation:'GPUCOOToCSR',commandCount:1,maximumWorkgroupCount:groups,maximumInvocationCount:groups*WORKGROUP_SIZE,readByteLength:0,writeByteLength:0},resources:resources.map(r=>({buffer:r.view,usage:r.usage})),compile:({device})=>{const computation=new Computation(device,{id,source,shaderLayout:{bindings:resources.map((r,location)=>({name:r.name,type:r.usage==='storage-read'?'read-only-storage':'storage',group:0,location}))}});return{encode:({computePass,getBuffer})=>{const bindings:Record<string,Binding>={};for(const r of resources)bindings[r.name]=getViewBinding(r.view,getBuffer);computation.setBindings(bindings);computation.dispatch(computePass,groups,1,1);},destroy:()=>computation.destroy()};}});
+}

--- a/modules/gpgpu/test/gpu-core/gpu-coo-to-csr.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-coo-to-csr.spec.ts
@@ -1,0 +1,12 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {describe, expect, it} from 'vitest';
+import {GPUCOOToCSR} from '../../src/gpu-core/gpu-coo-to-csr';
+
+describe('GPUCOOToCSR', () => {
+  it('exports a graph primitive', () => {
+    expect(GPUCOOToCSR).toBeDefined();
+  });
+});


### PR DESCRIPTION
Superseded by consolidated Jarnevon numerics PR #3237. The GPU COO→CSR implementation and docs were explicitly folded into #3237; this PR remains as design/history context.