### PR TITLE
feat(gpgpu): add CSR sparse matrix-vector multiply

### DIFF
--- a/docs/api-reference/experimental/gpu-core/gpu-spmv.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-spmv.md
@@ -1,0 +1,102 @@
+import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
+
+# GPUSpMV
+
+<GPUCoreDocsTabs active="reduction" />
+
+## Overview
+
+`GPUSpMV` multiplies a sparse matrix in compressed sparse row (CSR) form by a dense `float32` vector entirely inside the GPU command graph.
+
+## Motivation
+
+Dense `GPUMatVec` establishes the linear-operator role for ordinary matrices. Sparse numerical methods need the same operation without storing or reading zeros. SpMV is the canonical CSR execution primitive and is central to iterative sparse solvers, graph-derived linear systems, discretized PDEs and many scientific workloads.
+
+Adding SpMV also connects two previously separate parts of the GPU roadmap: offset-delimited irregular data and numerical linear algebra.
+
+## Contract
+
+The matrix is supplied as three packed views:
+
+```text
+rowOffsets    uint32[rows + 1]
+columnIndices uint32[nnz]
+values        float32[nnz]
+```
+
+Matrix row `r` owns the offset-delimited range:
+
+```text
+[rowOffsets[r], rowOffsets[r + 1])
+```
+
+Each entry `i` contributes:
+
+```text
+values[i] * vector[columnIndices[i]]
+```
+
+to the output for that row.
+
+```ts
+new GPUSpMV({
+  rowOffsets,
+  columnIndices,
+  values,
+  vector: x,
+  output: y,
+  columns
+}).addToGraph(graph);
+```
+
+`output.length` defines the matrix row count. `vector.length` must equal `columns`. Empty matrix rows naturally produce zero.
+
+The primitive assumes GPU-resident CSR invariants such as monotonic offsets and valid terminal offsets. It bounds-checks column indices in the baseline kernel but does not force CPU readback to validate the representation.
+
+## Composition
+
+The sparse construction and execution path becomes:
+
+```text
+COO generation
+     ↓
+sort / canonicalize
+     ↓
+GPUCOOToCSR
+     ↓
+CSR matrix
+     ↓
+  GPUSpMV
+     ↓
+GPUElementwise / GPUReduction
+     ↓
+iterative solver
+```
+
+This is enough infrastructure to begin constructing conjugate-gradient and related solver graphs once dot products and scalar-coefficient updates are formalized.
+
+## Execution strategy
+
+The baseline assigns one 256-thread workgroup to each sparse row. Lanes stride through that row's nonzeros, compute `value * x[column]` partials, then reduce the partial sums in workgroup memory.
+
+This maps naturally to medium and wide rows and parallels the dense `GPUMatVec` reduction structure. Unlike dense matvec, however, sparse row lengths can vary dramatically.
+
+## Performance notes
+
+SpMV is generally memory-bandwidth and access-pattern limited. The matrix values and column indices are streamed, while accesses into the dense vector are indirect. Sparse row-length distributions strongly affect utilization.
+
+One-workgroup-per-row is therefore a portable baseline, not a universal optimum. Future strategy selection should consider short-row subgroup kernels, multiple rows per workgroup, very-long-row splitting, subgroup reductions and row-length bucketing. The command graph/autotuner can eventually choose among strategies using matrix statistics rather than exposing those choices in the public API.
+
+## Relationship to graph processing
+
+CSR matrices and graph adjacency structures share the same offset-delimited shape. A weighted graph adjacency list can often be interpreted directly as a sparse matrix: row offsets identify each vertex's outgoing edge segment, column indices identify neighboring vertices, and values provide edge weights.
+
+The sparse numerical layer should reuse that structural commonality without forcing graph algorithms and linear algebra into the same high-level API.
+
+## Limitations and roadmap
+
+The first implementation supports CSR `float32` values and a dense `float32` vector. It does not yet support transpose SpMV, multiple right-hand sides, alternative sparse layouts, `float16`, mixed precision or symmetric-matrix specialization.
+
+Next numerical steps include reusable dot/norm operations and a conjugate-gradient solver graph. Performance work should add representative sparse matrices and row-distribution benchmarks before proliferating alternative storage formats.
+
+Once the lightweight engine `Kernel` abstraction lands, this primitive should use it instead of `Computation`.

--- a/docs/api-reference/experimental/gpu-core/gpu-spmv.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-spmv.md
@@ -6,37 +6,80 @@ import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
 
 ## Overview
 
-`GPUSpMV` multiplies a sparse matrix in compressed sparse row (CSR) form by a dense `float32` vector entirely inside the GPU command graph.
+**SpMV** means sparse matrix-vector multiplication: `y = A x` where `A` stores only its nonzero entries. `GPUSpMV` performs this operation for a CSR matrix entirely inside the GPU command graph.
 
-## Motivation
+## Dense MatVec vs sparse SpMV
 
-Dense `GPUMatVec` establishes the linear-operator role for ordinary matrices. Sparse numerical methods need the same operation without storing or reading zeros. SpMV is the canonical CSR execution primitive and is central to iterative sparse solvers, graph-derived linear systems, discretized PDEs and many scientific workloads.
+For a dense matrix:
 
-Adding SpMV also connects two previously separate parts of the GPU roadmap: offset-delimited irregular data and numerical linear algebra.
+```text
+A = [10  0 20]
+    [ 0 30  0]
+    [40  0 50]
+```
+
+ordinary matrix-vector multiplication conceptually evaluates every matrix position, including zeros. Sparse storage keeps only:
+
+```text
+rowOffsets    = [0,2,3,5]
+columnIndices = [0,2,1,0,2]
+values        = [10,20,30,40,50]
+```
+
+SpMV then visits only those five stored entries.
+
+For:
+
+```text
+x = [1, 2, 3]
+```
+
+we compute:
+
+```text
+y[0] = 10*x[0] + 20*x[2] = 70
+y[1] = 30*x[1]           = 60
+y[2] = 40*x[0] + 50*x[2] = 190
+
+result = [70, 60, 190]
+```
+
+So SpMV is not a different mathematical multiplication; it is a representation-aware way to compute the same `Ax` while avoiding explicit zeros.
+
+## How CSR maps to the operation
+
+Each CSR row is an offset-delimited segment:
+
+```text
+row 0 -> entries [0,2)
+row 1 -> entries [2,3)
+row 2 -> entries [3,5)
+```
+
+For each stored entry `i` in row `r`:
+
+```text
+column = columnIndices[i]
+contribution = values[i] * x[column]
+y[r] += contribution
+```
+
+This can be viewed as **indirect gather + multiply + segmented reduction**:
+
+```text
+columnIndices ──▶ gather x[column]
+                       │
+values ────────────────×
+                       │
+                 reduce by CSR row
+                       │
+                       ▼
+                       y
+```
+
+That connection is important: sparse numerical compute reuses the same irregular-data concepts as the rest of the GPU graph library.
 
 ## Contract
-
-The matrix is supplied as three packed views:
-
-```text
-rowOffsets    uint32[rows + 1]
-columnIndices uint32[nnz]
-values        float32[nnz]
-```
-
-Matrix row `r` owns the offset-delimited range:
-
-```text
-[rowOffsets[r], rowOffsets[r + 1])
-```
-
-Each entry `i` contributes:
-
-```text
-values[i] * vector[columnIndices[i]]
-```
-
-to the output for that row.
 
 ```ts
 new GPUSpMV({
@@ -49,54 +92,42 @@ new GPUSpMV({
 }).addToGraph(graph);
 ```
 
-`output.length` defines the matrix row count. `vector.length` must equal `columns`. Empty matrix rows naturally produce zero.
+`output.length` defines the row count; `vector.length` equals the matrix column count. Empty rows naturally produce zero. CSR offsets are assumed monotonic and valid without CPU readback.
 
-The primitive assumes GPU-resident CSR invariants such as monotonic offsets and valid terminal offsets. It bounds-checks column indices in the baseline kernel but does not force CPU readback to validate the representation.
+## Why SpMV matters
 
-## Composition
-
-The sparse construction and execution path becomes:
+Large sparse systems appear in graph-derived linear algebra, finite-element/finite-difference discretizations, optimization and iterative solvers. In algorithms such as conjugate gradient, the dominant operation each iteration is often:
 
 ```text
-COO generation
-     ↓
-sort / canonicalize
-     ↓
+p ──▶ A p
+```
+
+which is exactly SpMV.
+
+```text
+COO construction
+      ↓
 GPUCOOToCSR
-     ↓
+      ↓
 CSR matrix
-     ↓
-  GPUSpMV
-     ↓
-GPUElementwise / GPUReduction
-     ↓
+      ↓
+   GPUSpMV
+      ↓
+dot + vector updates
+      ↓
 iterative solver
 ```
 
-This is enough infrastructure to begin constructing conjugate-gradient and related solver graphs once dot products and scalar-coefficient updates are formalized.
-
 ## Execution strategy
 
-The baseline assigns one 256-thread workgroup to each sparse row. Lanes stride through that row's nonzeros, compute `value * x[column]` partials, then reduce the partial sums in workgroup memory.
-
-This maps naturally to medium and wide rows and parallels the dense `GPUMatVec` reduction structure. Unlike dense matvec, however, sparse row lengths can vary dramatically.
+The baseline assigns one 256-thread workgroup per sparse row. Lanes stride through the row's nonzeros, compute `value * x[column]` partials, then reduce them in workgroup memory.
 
 ## Performance notes
 
-SpMV is generally memory-bandwidth and access-pattern limited. The matrix values and column indices are streamed, while accesses into the dense vector are indirect. Sparse row-length distributions strongly affect utilization.
+SpMV is usually memory/access-pattern limited. Matrix values and column indices stream sequentially, while `x[column]` is an indirect access. Row lengths may vary from zero to thousands of entries, so no single scheduling strategy is optimal.
 
-One-workgroup-per-row is therefore a portable baseline, not a universal optimum. Future strategy selection should consider short-row subgroup kernels, multiple rows per workgroup, very-long-row splitting, subgroup reductions and row-length bucketing. The command graph/autotuner can eventually choose among strategies using matrix statistics rather than exposing those choices in the public API.
+Future strategies should include subgroup processing for short rows, multiple rows per workgroup, long-row splitting, row-length bucketing and autotuned selection. These strategies can preserve the CSR API.
 
-## Relationship to graph processing
+## Relationship to graphs
 
-CSR matrices and graph adjacency structures share the same offset-delimited shape. A weighted graph adjacency list can often be interpreted directly as a sparse matrix: row offsets identify each vertex's outgoing edge segment, column indices identify neighboring vertices, and values provide edge weights.
-
-The sparse numerical layer should reuse that structural commonality without forcing graph algorithms and linear algebra into the same high-level API.
-
-## Limitations and roadmap
-
-The first implementation supports CSR `float32` values and a dense `float32` vector. It does not yet support transpose SpMV, multiple right-hand sides, alternative sparse layouts, `float16`, mixed precision or symmetric-matrix specialization.
-
-Next numerical steps include reusable dot/norm operations and a conjugate-gradient solver graph. Performance work should add representative sparse matrices and row-distribution benchmarks before proliferating alternative storage formats.
-
-Once the lightweight engine `Kernel` abstraction lands, this primitive should use it instead of `Computation`.
+A weighted graph adjacency list has the same structural arrays: row offsets identify a vertex's edge segment, column indices identify neighbors, and values are edge weights. Sparse algebra and graph processing can therefore share low-level offset-delimited infrastructure while retaining distinct high-level APIs.

--- a/modules/gpgpu/src/gpu-core/gpu-spmv.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-spmv.ts
@@ -1,0 +1,79 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
+import {getViewBinding, getViewElementOffset, validatePackedUint32View, validatePackedView} from './graph-data-view-utils';
+
+const WORKGROUP_SIZE = 256;
+
+export type GPUSpMVProps = {
+  id?: string;
+  /** Offset-delimited CSR row boundaries. Length = rows + 1. */
+  rowOffsets: GraphDataView<'uint32'>;
+  /** CSR column index for each stored nonzero. */
+  columnIndices: GraphDataView<'uint32'>;
+  /** CSR float32 value for each stored nonzero. */
+  values: GraphDataView<'float32'>;
+  /** Dense input vector. */
+  vector: GraphDataView<'float32'>;
+  /** Dense output vector, one value per matrix row. */
+  output: GraphDataView<'float32'>;
+  /** Sparse matrix column count. */
+  columns: number;
+};
+
+/** CSR sparse matrix-vector multiplication: `output = matrix * vector`. */
+export class GPUSpMV {
+  readonly id: string;
+  readonly rowOffsets: GraphDataView<'uint32'>;
+  readonly columnIndices: GraphDataView<'uint32'>;
+  readonly values: GraphDataView<'float32'>;
+  readonly vector: GraphDataView<'float32'>;
+  readonly output: GraphDataView<'float32'>;
+  readonly columns: number;
+
+  constructor(props: GPUSpMVProps) {
+    this.id = props.id ?? 'gpu-spmv';
+    this.rowOffsets = props.rowOffsets;
+    this.columnIndices = props.columnIndices;
+    this.values = props.values;
+    this.vector = props.vector;
+    this.output = props.output;
+    this.columns = props.columns;
+
+    validatePackedUint32View(this.rowOffsets, `${this.id} rowOffsets`);
+    validatePackedUint32View(this.columnIndices, `${this.id} columnIndices`);
+    validatePackedView(this.values, ['float32'], `${this.id} values`);
+    validatePackedView(this.vector, ['float32'], `${this.id} vector`);
+    validatePackedView(this.output, ['float32'], `${this.id} output`);
+    if (this.rowOffsets.length !== this.output.length + 1) throw new Error(`${this.id} rowOffsets length must equal output.length + 1`);
+    if (this.columnIndices.length !== this.values.length) throw new Error(`${this.id} columnIndices and values must have equal length`);
+    if (!Number.isInteger(this.columns) || this.columns < 0) throw new Error(`${this.id} columns must be a non-negative integer`);
+    if (this.vector.length !== this.columns) throw new Error(`${this.id} vector length must equal columns`);
+    if ([this.rowOffsets.buffer, this.columnIndices.buffer, this.values.buffer, this.vector.buffer].includes(this.output.buffer)) throw new Error(`${this.id} output must use a separate buffer`);
+  }
+
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    for (const view of [this.rowOffsets, this.columnIndices, this.values, this.vector, this.output]) {
+      if (view.buffer.graph !== graph) throw new Error(`${this.id} views must belong to the target graph`);
+    }
+    const rows = this.output.length;
+    if (rows === 0) return;
+    const source = makeShaderSource(this);
+    graph.addComputePass({
+      id: this.id,
+      workload: {operation:'GPUSpMV',commandCount:1,maximumWorkgroupCount:rows,maximumInvocationCount:rows*WORKGROUP_SIZE,readByteLength:(this.rowOffsets.length+this.columnIndices.length)*4+(this.values.length+this.vector.length)*4,writeByteLength:this.output.length*4},
+      resources:[{buffer:this.rowOffsets,usage:'storage-read'},{buffer:this.columnIndices,usage:'storage-read'},{buffer:this.values,usage:'storage-read'},{buffer:this.vector,usage:'storage-read'},{buffer:this.output,usage:'storage-write'}],
+      compile:({device})=>{const computation=new Computation(device,{id:this.id,source,shaderLayout:{bindings:[{name:'rowOffsets',type:'read-only-storage',group:0,location:0},{name:'columnIndices',type:'read-only-storage',group:0,location:1},{name:'matrixValues',type:'read-only-storage',group:0,location:2},{name:'vectorValues',type:'read-only-storage',group:0,location:3},{name:'outputValues',type:'storage',group:0,location:4}]}});return{encode:({computePass,getBuffer})=>{const bindings:Record<string,Binding>={rowOffsets:getViewBinding(this.rowOffsets,getBuffer),columnIndices:getViewBinding(this.columnIndices,getBuffer),matrixValues:getViewBinding(this.values,getBuffer),vectorValues:getViewBinding(this.vector,getBuffer),outputValues:getViewBinding(this.output,getBuffer)};computation.setBindings(bindings);computation.dispatch(computePass,rows,1,1);},destroy:()=>computation.destroy()};}
+    });
+  }
+}
+
+function makeShaderSource(spmv: GPUSpMV): string {
+  return `const ROW_OFFSET:u32=${getViewElementOffset(spmv.rowOffsets)}u; const COLUMN_OFFSET:u32=${getViewElementOffset(spmv.columnIndices)}u; const VALUE_OFFSET:u32=${getViewElementOffset(spmv.values)}u; const VECTOR_OFFSET:u32=${getViewElementOffset(spmv.vector)}u; const OUTPUT_OFFSET:u32=${getViewElementOffset(spmv.output)}u; const COLUMNS:u32=${spmv.columns}u;
+@group(0) @binding(0) var<storage,read> rowOffsets:array<u32>; @group(0) @binding(1) var<storage,read> columnIndices:array<u32>; @group(0) @binding(2) var<storage,read> matrixValues:array<f32>; @group(0) @binding(3) var<storage,read> vectorValues:array<f32>; @group(0) @binding(4) var<storage,read_write> outputValues:array<f32>; var<workgroup> partials:array<f32,${WORKGROUP_SIZE}>;
+@compute @workgroup_size(${WORKGROUP_SIZE}) fn main(@builtin(workgroup_id) wg:vec3u,@builtin(local_invocation_index) lane:u32){let row=wg.x;let begin=rowOffsets[ROW_OFFSET+row];let end=rowOffsets[ROW_OFFSET+row+1u];var sum=0.0;var i=begin+lane;loop{if(i>=end){break;}let column=columnIndices[COLUMN_OFFSET+i];if(column<COLUMNS){sum += matrixValues[VALUE_OFFSET+i]*vectorValues[VECTOR_OFFSET+column];}i+=${WORKGROUP_SIZE}u;}partials[lane]=sum;workgroupBarrier();var stride=${WORKGROUP_SIZE / 2}u;loop{if(stride==0u){break;}if(lane<stride){partials[lane]+=partials[lane+stride];}workgroupBarrier();stride/=2u;}if(lane==0u){outputValues[OUTPUT_OFFSET+row]=partials[0];}}`;
+}

--- a/modules/gpgpu/test/gpu-core/gpu-spmv.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-spmv.spec.ts
@@ -1,0 +1,12 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {describe, expect, it} from 'vitest';
+import {GPUSpMV} from '../../src/gpu-core/gpu-spmv';
+
+describe('GPUSpMV', () => {
+  it('exports a graph primitive', () => {
+    expect(GPUSpMV).toBeDefined();
+  });
+});


### PR DESCRIPTION
Superseded by consolidated Jarnevon numerics PR #3237. Adaptive SpMV in #3237 replaces this baseline implementation while preserving the operation's purpose and documentation history.