### PR TITLE
feat(gpgpu): add GPU dot product and vector norm primitives

### DIFF
--- a/docs/api-reference/experimental/gpu-core/gpu-dot-product.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-dot-product.md
@@ -4,59 +4,111 @@ import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
 
 <GPUCoreDocsTabs active="reduction" />
 
-## Overview
+## Dot product
 
-`GPUDotProduct` and `GPUVectorNorm` provide canonical scalar reductions for packed `float32` vectors. Dot product computes `sum(a[i] * b[i])`; vector norm computes the Euclidean/L2 norm `sqrt(sum(x[i] * x[i]))`.
+The dot product multiplies corresponding vector elements and sums the products:
 
-## Motivation
+```text
+a = [1, 2, 3]
+b = [4, 5, 6]
 
-General reduction can compute sums, but numerical algorithms repeatedly need these two compound reductions. Treating them as named graph operations makes intent visible to the command graph and avoids private multiply-then-reduce or square-then-reduce kernels with unnecessary intermediate buffers.
+       1*4 + 2*5 + 3*6
+              ↓
+a · b =       32
+```
 
-They complete the minimal vector algebra needed to begin composing iterative linear solvers with `GPUElementwise`, `GPUMatVec`, and `GPUSpMV`.
+Formally:
+
+```text
+a · b = Σ a[i] b[i]
+```
+
+It turns two vectors into one scalar. Geometrically it also measures directional alignment: orthogonal vectors have dot product zero. In numerical algorithms it appears constantly in projections, residual calculations and iterative solvers.
+
+A dot product can be viewed computationally as:
+
+```text
+a ─┐
+   × elementwise ─▶ [products] ─▶ sum reduction ─▶ scalar
+b ─┘
+```
+
+`GPUDotProduct` fuses those stages so the intermediate product vector need not be materialized.
+
+## Vector norm
+
+The Euclidean or L2 norm is the ordinary geometric length of a vector:
+
+```text
+x = [3, 4]
+
+||x||₂ = sqrt(3² + 4²) = 5
+```
+
+Formally:
+
+```text
+||x||₂ = sqrt(x · x)
+       = sqrt(Σ x[i]²)
+```
+
+For solver residuals, the norm answers a useful question: **how large is the remaining error vector?**
+
+```text
+residual r
+    ↓
+r · r
+    ↓
+sqrt
+    ↓
+||r||₂
+```
+
+## Why these are GPU scalars
+
+Both operations consume potentially huge vectors but produce exactly one value. That scalar should remain GPU-resident when it feeds later work:
+
+```text
+GPUVector r ─▶ GPUDotProduct ─▶ GPU scalar rr
+                                      │
+                                      ▼
+                              solver coefficient
+                                      │
+                                      ▼
+                                vector update
+```
+
+Reading the scalar to JavaScript between solver stages would introduce synchronization.
 
 ## Contract
-
-Both primitives consume packed `float32` views and write one caller-owned `float32` result row.
 
 ```ts
 new GPUDotProduct({left: x, right: y, output: dot}).addToGraph(graph);
 new GPUVectorNorm({input: residual, output: norm}).addToGraph(graph);
 ```
 
-Inputs remain GPU-resident; neither operation submits work or performs CPU readback.
+The initial contract uses packed `float32` vectors and writes one caller-owned `float32` result row.
 
-## Composition
+## Solver composition
 
-The important target is a solver graph:
+Conjugate gradient uses dot products directly:
 
 ```text
-GPUSpMV / GPUMatVec
-        ↓
-GPUElementwise residual update
-        ↓
-GPUDotProduct / GPUVectorNorm
-        ↓
-solver scalar state
-        ↓
-next vector update
+rr   = r · r
+pAp  = p · (A p)
+alpha = rr / pAp
 ```
 
-For conjugate gradient, dot products provide terms such as `r·r` and `p·Ap`; norm provides a natural convergence diagnostic. A solver should be able to keep these scalar values GPU-resident and feed them into later graph nodes rather than forcing a JavaScript synchronization point every iteration.
+and can use the residual norm as a convergence diagnostic:
 
-## Why named operations?
+```text
+||r||₂ < tolerance
+```
 
-A dot product is mathematically elementwise multiply followed by reduction, and an L2 norm is square, reduce, then square-root. Materializing those intermediate vectors is wasteful. Named operations allow a single kernel today and give a future graph compiler enough semantic information to recognize equivalent compositions and fuse them automatically.
+This is why dot/norm operations are more than convenience wrappers: they connect vector computation to GPU-resident scalar state and graph control.
 
 ## Performance notes
 
-The baseline uses one 256-thread workgroup. Lanes stride across the entire vector and then perform a workgroup-tree reduction. This avoids intermediate storage and is a useful baseline, but very large vectors will eventually require hierarchical reduction across multiple workgroups for greater parallelism.
+The baseline uses one 256-thread workgroup. Lanes stride across the vector and perform a workgroup-tree reduction. Very large vectors eventually need hierarchical multi-workgroup reduction and subgroup collectives.
 
-Future implementations should share reduction infrastructure with `GPUReduction`, use subgroup collectives when available, and choose strategies based on vector length. Numerically sensitive workloads may also require explicit accumulation-policy choices rather than silently changing precision or reduction order.
-
-## Limitations and roadmap
-
-The initial contract is `float32` only and defines L2 norm only. It does not expose normalization, cosine similarity, L1/L-infinity norms or mixed precision; several of those already overlap with vector-search functionality and should be unified rather than duplicated.
-
-The next roadmap milestone is a graph-native conjugate-gradient solver composed from sparse/dense matvec, elementwise updates and these scalar reductions. The critical architectural requirement is keeping iteration state GPU-resident.
-
-Once the lightweight engine `Kernel` abstraction lands, these primitives should use it instead of `Computation`.
+Floating-point addition is not associative, so parallel reduction order can produce small numerical differences. Tests should use tolerances rather than bitwise equality.

--- a/docs/api-reference/experimental/gpu-core/gpu-dot-product.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-dot-product.md
@@ -1,0 +1,62 @@
+import {GPUCoreDocsTabs} from '@site/src/components/docs/gpu-core-docs-tabs';
+
+# GPUDotProduct and GPUVectorNorm
+
+<GPUCoreDocsTabs active="reduction" />
+
+## Overview
+
+`GPUDotProduct` and `GPUVectorNorm` provide canonical scalar reductions for packed `float32` vectors. Dot product computes `sum(a[i] * b[i])`; vector norm computes the Euclidean/L2 norm `sqrt(sum(x[i] * x[i]))`.
+
+## Motivation
+
+General reduction can compute sums, but numerical algorithms repeatedly need these two compound reductions. Treating them as named graph operations makes intent visible to the command graph and avoids private multiply-then-reduce or square-then-reduce kernels with unnecessary intermediate buffers.
+
+They complete the minimal vector algebra needed to begin composing iterative linear solvers with `GPUElementwise`, `GPUMatVec`, and `GPUSpMV`.
+
+## Contract
+
+Both primitives consume packed `float32` views and write one caller-owned `float32` result row.
+
+```ts
+new GPUDotProduct({left: x, right: y, output: dot}).addToGraph(graph);
+new GPUVectorNorm({input: residual, output: norm}).addToGraph(graph);
+```
+
+Inputs remain GPU-resident; neither operation submits work or performs CPU readback.
+
+## Composition
+
+The important target is a solver graph:
+
+```text
+GPUSpMV / GPUMatVec
+        ↓
+GPUElementwise residual update
+        ↓
+GPUDotProduct / GPUVectorNorm
+        ↓
+solver scalar state
+        ↓
+next vector update
+```
+
+For conjugate gradient, dot products provide terms such as `r·r` and `p·Ap`; norm provides a natural convergence diagnostic. A solver should be able to keep these scalar values GPU-resident and feed them into later graph nodes rather than forcing a JavaScript synchronization point every iteration.
+
+## Why named operations?
+
+A dot product is mathematically elementwise multiply followed by reduction, and an L2 norm is square, reduce, then square-root. Materializing those intermediate vectors is wasteful. Named operations allow a single kernel today and give a future graph compiler enough semantic information to recognize equivalent compositions and fuse them automatically.
+
+## Performance notes
+
+The baseline uses one 256-thread workgroup. Lanes stride across the entire vector and then perform a workgroup-tree reduction. This avoids intermediate storage and is a useful baseline, but very large vectors will eventually require hierarchical reduction across multiple workgroups for greater parallelism.
+
+Future implementations should share reduction infrastructure with `GPUReduction`, use subgroup collectives when available, and choose strategies based on vector length. Numerically sensitive workloads may also require explicit accumulation-policy choices rather than silently changing precision or reduction order.
+
+## Limitations and roadmap
+
+The initial contract is `float32` only and defines L2 norm only. It does not expose normalization, cosine similarity, L1/L-infinity norms or mixed precision; several of those already overlap with vector-search functionality and should be unified rather than duplicated.
+
+The next roadmap milestone is a graph-native conjugate-gradient solver composed from sparse/dense matvec, elementwise updates and these scalar reductions. The critical architectural requirement is keeping iteration state GPU-resident.
+
+Once the lightweight engine `Kernel` abstraction lands, these primitives should use it instead of `Computation`.

--- a/modules/gpgpu/src/gpu-core/gpu-dot-product.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-dot-product.ts
@@ -1,0 +1,57 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
+import {getViewBinding, getViewElementOffset, validatePackedView} from './graph-data-view-utils';
+
+const WORKGROUP_SIZE = 256;
+
+export type GPUDotProductProps = {
+  id?: string;
+  left: GraphDataView<'float32'>;
+  right: GraphDataView<'float32'>;
+  /** Single float32 output row. */
+  output: GraphDataView<'float32'>;
+};
+
+/** Computes the float32 dot product of two packed vectors. */
+export class GPUDotProduct {
+  readonly id: string;
+  readonly left: GraphDataView<'float32'>;
+  readonly right: GraphDataView<'float32'>;
+  readonly output: GraphDataView<'float32'>;
+
+  constructor(props: GPUDotProductProps) {
+    this.id = props.id ?? 'gpu-dot-product';
+    this.left = props.left;
+    this.right = props.right;
+    this.output = props.output;
+    validatePackedView(this.left, ['float32'], `${this.id} left`);
+    validatePackedView(this.right, ['float32'], `${this.id} right`);
+    validatePackedView(this.output, ['float32'], `${this.id} output`);
+    if (this.left.length !== this.right.length) throw new Error(`${this.id} inputs must have equal length`);
+    if (this.output.length < 1) throw new Error(`${this.id} output must contain one float32 row`);
+    if (this.output.buffer === this.left.buffer || this.output.buffer === this.right.buffer) throw new Error(`${this.id} output must use a separate buffer`);
+  }
+
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    for (const view of [this.left, this.right, this.output]) if (view.buffer.graph !== graph) throw new Error(`${this.id} views must belong to target graph`);
+    const source = makeDotSource(this);
+    graph.addComputePass({id:this.id,workload:{operation:'GPUDotProduct',commandCount:1,maximumWorkgroupCount:1,maximumInvocationCount:WORKGROUP_SIZE,readByteLength:(this.left.length+this.right.length)*4,writeByteLength:4},resources:[{buffer:this.left,usage:'storage-read'},{buffer:this.right,usage:'storage-read'},{buffer:this.output,usage:'storage-write'}],compile:({device})=>{const computation=new Computation(device,{id:this.id,source,shaderLayout:{bindings:[{name:'leftValues',type:'read-only-storage',group:0,location:0},{name:'rightValues',type:'read-only-storage',group:0,location:1},{name:'outputValues',type:'storage',group:0,location:2}]}});return{encode:({computePass,getBuffer})=>{const bindings:Record<string,Binding>={leftValues:getViewBinding(this.left,getBuffer),rightValues:getViewBinding(this.right,getBuffer),outputValues:getViewBinding(this.output,getBuffer)};computation.setBindings(bindings);computation.dispatch(computePass,1,1,1);},destroy:()=>computation.destroy()};}});
+  }
+}
+
+export type GPUVectorNormProps = {id?:string; input:GraphDataView<'float32'>; output:GraphDataView<'float32'>};
+
+/** Computes the Euclidean/L2 norm of a packed float32 vector. */
+export class GPUVectorNorm {
+  readonly id:string; readonly input:GraphDataView<'float32'>; readonly output:GraphDataView<'float32'>;
+  constructor(props:GPUVectorNormProps){this.id=props.id??'gpu-vector-norm';this.input=props.input;this.output=props.output;validatePackedView(this.input,['float32'],`${this.id} input`);validatePackedView(this.output,['float32'],`${this.id} output`);if(this.output.length<1)throw new Error(`${this.id} output must contain one float32 row`);if(this.output.buffer===this.input.buffer)throw new Error(`${this.id} output must use a separate buffer`);}
+  addToGraph<Parameters>(graph:GPUCommandGraph<Parameters>):void{for(const view of [this.input,this.output])if(view.buffer.graph!==graph)throw new Error(`${this.id} views must belong to target graph`);const source=makeNormSource(this);graph.addComputePass({id:this.id,workload:{operation:'GPUVectorNorm',commandCount:1,maximumWorkgroupCount:1,maximumInvocationCount:WORKGROUP_SIZE,readByteLength:this.input.length*4,writeByteLength:4},resources:[{buffer:this.input,usage:'storage-read'},{buffer:this.output,usage:'storage-write'}],compile:({device})=>{const computation=new Computation(device,{id:this.id,source,shaderLayout:{bindings:[{name:'inputValues',type:'read-only-storage',group:0,location:0},{name:'outputValues',type:'storage',group:0,location:1}]}});return{encode:({computePass,getBuffer})=>{computation.setBindings({inputValues:getViewBinding(this.input,getBuffer),outputValues:getViewBinding(this.output,getBuffer)});computation.dispatch(computePass,1,1,1);},destroy:()=>computation.destroy()};}});}
+}
+
+function makeDotSource(dot:GPUDotProduct):string{return `const LENGTH:u32=${dot.left.length}u;const L:u32=${getViewElementOffset(dot.left)}u;const R:u32=${getViewElementOffset(dot.right)}u;const O:u32=${getViewElementOffset(dot.output)}u;@group(0)@binding(0)var<storage,read>leftValues:array<f32>;@group(0)@binding(1)var<storage,read>rightValues:array<f32>;@group(0)@binding(2)var<storage,read_write>outputValues:array<f32>;var<workgroup>s:array<f32,${WORKGROUP_SIZE}>;@compute @workgroup_size(${WORKGROUP_SIZE})fn main(@builtin(local_invocation_index)lane:u32){var v=0.0;var i=lane;loop{if(i>=LENGTH){break;}v+=leftValues[L+i]*rightValues[R+i];i+=${WORKGROUP_SIZE}u;}s[lane]=v;workgroupBarrier();var stride=${WORKGROUP_SIZE/2}u;loop{if(stride==0u){break;}if(lane<stride){s[lane]+=s[lane+stride];}workgroupBarrier();stride/=2u;}if(lane==0u){outputValues[O]=s[0];}}`;}
+function makeNormSource(norm:GPUVectorNorm):string{return `const LENGTH:u32=${norm.input.length}u;const I:u32=${getViewElementOffset(norm.input)}u;const O:u32=${getViewElementOffset(norm.output)}u;@group(0)@binding(0)var<storage,read>inputValues:array<f32>;@group(0)@binding(1)var<storage,read_write>outputValues:array<f32>;var<workgroup>s:array<f32,${WORKGROUP_SIZE}>;@compute @workgroup_size(${WORKGROUP_SIZE})fn main(@builtin(local_invocation_index)lane:u32){var v=0.0;var i=lane;loop{if(i>=LENGTH){break;}let x=inputValues[I+i];v+=x*x;i+=${WORKGROUP_SIZE}u;}s[lane]=v;workgroupBarrier();var stride=${WORKGROUP_SIZE/2}u;loop{if(stride==0u){break;}if(lane<stride){s[lane]+=s[lane+stride];}workgroupBarrier();stride/=2u;}if(lane==0u){outputValues[O]=sqrt(s[0]);}}`;}

--- a/modules/gpgpu/test/gpu-core/gpu-dot-product.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-dot-product.spec.ts
@@ -1,0 +1,13 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {describe, expect, it} from 'vitest';
+import {GPUDotProduct, GPUVectorNorm} from '../../src/gpu-core/gpu-dot-product';
+
+describe('GPU vector reductions', () => {
+  it('exports dot product and L2 norm primitives', () => {
+    expect(GPUDotProduct).toBeDefined();
+    expect(GPUVectorNorm).toBeDefined();
+  });
+});


### PR DESCRIPTION
Superseded by consolidated Jarnevon foundation/numerics PRs #3233 and #3237. Hierarchical mapped reductions and GPUScalar outputs replace this standalone dot/norm baseline.