### PR TITLE
feat(gpgpu): add graph-native GPU scalar values

### DIFF
--- a/docs/api-reference/experimental/gpu-core/gpu-scalar.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-scalar.md
@@ -1,0 +1,154 @@
+# GPUScalar
+
+## Overview
+
+`GPUScalar<T>` is a first-class logical value produced and consumed by GPU graph operations. It represents one `float32`, `uint32`, or `sint32` value without implying that the value owns a storage buffer or consumes its own storage-buffer binding.
+
+`GPUScalar` is the semantic layer above the graph-owned `GPUValueArena`.
+
+## Why is a scalar different from a one-element vector?
+
+Numerical algorithms naturally distinguish vector state from scalar coefficients:
+
+```text
+vectors                         scalars
+-------                         -------
+x                               rr = r · r
+r                               pDotQ = p · q
+p                               alpha
+q                               beta
+```
+
+A dot product takes two vectors and produces one scalar. Scalar division can then produce another scalar, which may be broadcast back into a vector operation:
+
+```text
+r ─┐
+   ├── dot ──▶ rr ─┐
+r ─┘               │
+                   ├── divide ──▶ alpha
+p ─┐               │                 │
+   ├── dot ─▶ pDotQ┘                 │ broadcast
+q ─┘                                 ▼
+                               vector MADD
+```
+
+Treating these values as one-element vectors would work physically, but would erase useful semantic information from the graph/compiler. `GPUScalar` makes the mathematical role explicit while allowing the physical representation to evolve independently.
+
+## Physical representation
+
+A `GPUScalar` does **not** own a `Buffer`. Creating a scalar declares one typed slot in the graph's singleton `GPUValueArena`:
+
+```ts
+const alpha = createGPUScalar(graph, 'alpha', 'float32');
+const active = createGPUScalar(graph, 'active', 'uint32');
+```
+
+Conceptually:
+
+```text
+GPUScalar alpha ──┐
+GPUScalar beta  ──┤
+GPUScalar rr    ──┼──▶ graph-owned GPUValueArena ──▶ one storage buffer
+GPUScalar active──┘
+```
+
+The scalar carries logical identity, type and slot metadata. Once the arena is sealed, it can expose a one-row `GraphDataView` for existing graph resource tracking.
+
+## One binding, many values
+
+The initial WGSL representation binds the packed arena as words:
+
+```wgsl
+@group(0) @binding(0)
+var<storage, read_write> gpuValues: array<u32>;
+```
+
+A `float32` scalar at word offset 2 can be loaded as:
+
+```wgsl
+bitcast<f32>(gpuValues[2u])
+```
+
+while a `uint32` scalar uses the same word directly. Stores perform the inverse bitcast where required.
+
+The helper functions in this module generate these expressions so individual graph operations do not need to duplicate arena-layout knowledge.
+
+The important property is:
+
+```text
+100 logical GPUScalar values
+             │
+             ▼
+       one arena binding
+```
+
+rather than 100 storage-buffer bindings.
+
+## Scalar provenance
+
+`GPUScalar` specifically models a GPU-resident logical value. It should not force every scalar-like operand into the same physical mechanism:
+
+```text
+compile-time constant       WGSL literal / override
+CPU-updated parameter       uniform/parameter machinery
+GPU-produced scalar         GPUScalar → GPUValueArena
+```
+
+A future common scalar-operand API can allow operations such as MADD to accept any of these sources while the compiler chooses the appropriate representation.
+
+## Relationship to reductions
+
+Reductions are natural scalar producers:
+
+```text
+GPUVector ──▶ GPUReduction ──▶ GPUScalar
+
+GPUVector ─┐
+           ├─▶ GPUDotProduct ─▶ GPUScalar
+GPUVector ─┘
+
+GPUVector ──▶ GPUVectorNorm ──▶ GPUScalar
+```
+
+Today some primitives model scalar output as a one-row `GraphDataView`. Follow-up work can migrate them to accept `GPUScalar` while retaining arena-backed views internally for graph hazards.
+
+## Why this matters for iterative algorithms
+
+Conjugate gradient computes coefficients every iteration:
+
+```text
+rr = r · r
+pDotQ = p · A p
+alpha = rr / pDotQ
+beta = newRR / rr
+```
+
+Reading those values back to JavaScript would introduce GPU/CPU synchronization into the loop. Arena-backed `GPUScalar`s let the entire dependency chain remain GPU-resident.
+
+The same abstraction applies to convergence flags, counters, thresholds derived on GPU, adaptive algorithm state and indirect-dispatch metadata.
+
+## Scope of this PR
+
+This PR establishes only the logical scalar type and WGSL arena access machinery. It deliberately does not add arithmetic. Keeping representation separate lets the next PR define scalar operations cleanly:
+
+```text
+GPUValueArena
+      ↓
+ GPUScalar<T>        ← this PR
+      ↓
+scalar arithmetic
+      ↓
+scalar broadcast / MADD
+      ↓
+solver and GPU control flow
+```
+
+## Roadmap
+
+1. graph-owned packed `GPUValueArena`
+2. first-class `GPUScalar<T>` and WGSL access helpers
+3. scalar arithmetic and comparisons
+4. reduction outputs as `GPUScalar`
+5. scalar/constants/parameters as broadcast operands in `GPUElementwise`
+6. GPU-resident convergence and conjugate-gradient execution
+7. compiler-driven arena sealing and lifetime-based slot reuse

--- a/modules/gpgpu/src/gpu-core/gpu-scalar.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-scalar.ts
@@ -1,0 +1,93 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {GraphDataView} from './gpu-command-graph';
+import {getGPUValueArena, type GPUValueArena, type GPUValueFormat, type GPUValueSlot} from './gpu-value-arena';
+import type {GPUCommandGraph} from './gpu-command-graph';
+
+/** First-class logical scalar backed by one slot in a graph-owned GPUValueArena. */
+export class GPUScalar<T extends GPUValueFormat = GPUValueFormat> {
+  readonly id: string;
+  readonly format: T;
+  readonly arena: GPUValueArena;
+  /** @internal Physical slot metadata remains an implementation detail of the arena-backed scalar. */
+  readonly slot: GPUValueSlot<T>;
+
+  /** @internal Use {@link createGPUScalar}. */
+  constructor(arena: GPUValueArena, slot: GPUValueSlot<T>) {
+    this.id = slot.id;
+    this.format = slot.format;
+    this.arena = arena;
+    this.slot = slot;
+  }
+
+  /** Stable byte offset assigned during graph construction. */
+  get byteOffset(): number {
+    return this.slot.byteOffset;
+  }
+
+  /** 32-bit word index used by generated WGSL arena accessors. */
+  get wordOffset(): number {
+    return this.slot.byteOffset >>> 2;
+  }
+
+  /** Returns the typed one-row graph view after the owning arena has been sealed. */
+  get view(): GraphDataView<T> {
+    return this.arena.getView(this.slot);
+  }
+}
+
+/** Declares one logical GPU-produced scalar in the graph-owned packed value arena. */
+export function createGPUScalar<Parameters, T extends GPUValueFormat>(
+  graph: GPUCommandGraph<Parameters>,
+  id: string,
+  format: T
+): GPUScalar<T> {
+  const arena = getGPUValueArena(graph);
+  return new GPUScalar(arena, arena.allocate(id, format));
+}
+
+/** WGSL type corresponding to one arena scalar format. */
+export function getGPUScalarWGSLType(format: GPUValueFormat): 'f32' | 'u32' | 'i32' {
+  switch (format) {
+    case 'float32': return 'f32';
+    case 'uint32': return 'u32';
+    case 'sint32': return 'i32';
+  }
+}
+
+/**
+ * Generates one WGSL load expression for a scalar stored in an arena bound as `arenaExpression`.
+ * The arena is represented as `array<u32>` so all scalar formats share one physical binding.
+ */
+export function getGPUScalarWGSLLoad(
+  scalar: GPUScalar,
+  arenaExpression = 'gpuValues'
+): string {
+  const word = `${arenaExpression}[${scalar.wordOffset}u]`;
+  switch (scalar.format) {
+    case 'float32': return `bitcast<f32>(${word})`;
+    case 'uint32': return word;
+    case 'sint32': return `bitcast<i32>(${word})`;
+  }
+}
+
+/** Generates one WGSL statement that stores a typed expression into an arena-backed scalar. */
+export function getGPUScalarWGSLStore(
+  scalar: GPUScalar,
+  valueExpression: string,
+  arenaExpression = 'gpuValues'
+): string {
+  const target = `${arenaExpression}[${scalar.wordOffset}u]`;
+  switch (scalar.format) {
+    case 'float32': return `${target} = bitcast<u32>(${valueExpression});`;
+    case 'uint32': return `${target} = ${valueExpression};`;
+    case 'sint32': return `${target} = bitcast<u32>(${valueExpression});`;
+  }
+}
+
+/** Standard WGSL declaration for a read/write packed value arena binding. */
+export function getGPUValueArenaWGSLBinding(group: number, binding: number, name = 'gpuValues'): string {
+  return `@group(${group}) @binding(${binding}) var<storage, read_write> ${name}: array<u32>;`;
+}

--- a/modules/gpgpu/test/gpu-core/gpu-scalar.spec.ts
+++ b/modules/gpgpu/test/gpu-core/gpu-scalar.spec.ts
@@ -1,0 +1,20 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {describe, expect, it} from 'vitest';
+import {
+  GPUScalar,
+  getGPUScalarWGSLLoad,
+  getGPUScalarWGSLStore,
+  getGPUValueArenaWGSLBinding
+} from '../../src/gpu-core/gpu-scalar';
+
+describe('GPUScalar', () => {
+  it('exports the scalar abstraction and WGSL access helpers', () => {
+    expect(GPUScalar).toBeDefined();
+    expect(getGPUScalarWGSLLoad).toBeDefined();
+    expect(getGPUScalarWGSLStore).toBeDefined();
+    expect(getGPUValueArenaWGSLBinding(0, 3)).toContain('@binding(3)');
+  });
+});


### PR DESCRIPTION
Superseded by consolidated Jarnevon foundation PR #3233. GPUScalar is retained in that cumulative branch.