### PR TITLE
feat(gpgpu): add adaptive reduction strategy planning

### DIFF
--- a/docs/api-reference/experimental/gpu-core/gpu-adaptive-reduction.md
+++ b/docs/api-reference/experimental/gpu-core/gpu-adaptive-reduction.md
@@ -1,0 +1,50 @@
+# Adaptive GPU reductions
+
+A reduction maps many values to fewer partial values until one result remains. There is no single best hierarchy shape for every input size or GPU.
+
+## Elements per thread
+
+A baseline reduction may assign one input element to each invocation:
+
+```text
+256 threads × 1 element = 256 values/workgroup
+```
+
+For large inputs, each invocation can accumulate several values before participating in the workgroup reduction:
+
+```text
+256 threads × 4 elements = 1024 values/workgroup
+```
+
+This reduces the number of first-level partials and therefore the number of hierarchy levels and dispatches. The tradeoff is less parallelism, so small inputs should not blindly maximize elements per thread.
+
+## Strategy
+
+The initial planner chooses among 64/128/256-thread workgroups according to device limits and 1/2/4/8 elements per thread according to workload size. Subgroup acceleration is selected independently when supported.
+
+```text
+input length + device limits/features
+                ↓
+       reduction strategy
+       ├─ workgroup size
+       ├─ elements/thread
+       ├─ hierarchy shape
+       └─ subgroup path
+```
+
+The policy is intentionally simple and deterministic. It establishes a common strategy object that can later be selected by benchmark-backed autotuning without changing reduction APIs.
+
+## Shared beneficiaries
+
+Adaptive reduction is infrastructure rather than a single algorithm optimization:
+
+```text
+adaptive reduction
+   ├─ sum / min / max
+   ├─ dot product
+   ├─ vector norms
+   ├─ solver residuals
+   └─ statistics / analytics
+```
+
+This is the compositional principle of the GPU core: improving one common execution substrate should improve many higher-level operations.

--- a/modules/gpgpu/src/gpu-core/gpu-reduction-strategy.ts
+++ b/modules/gpgpu/src/gpu-core/gpu-reduction-strategy.ts
@@ -1,0 +1,30 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Device} from '@luma.gl/core';
+import {getGPUShaderSubgroupStrategy} from './gpu-subgroup-utils';
+
+export type GPUReductionStrategy={workgroupSize:64|128|256;elementsPerThread:1|2|4|8;elementsPerWorkgroup:number;useSubgroups:boolean;firstLevelWorkgroups:number};
+
+/**
+ * Selects a reduction shape from workload size and device capabilities.
+ *
+ * More elements per thread amortize dispatch and hierarchy overhead on large inputs while smaller
+ * workloads retain enough workgroups for parallelism. Subgroups remain an orthogonal intra-group
+ * acceleration rather than changing public reduction semantics.
+ */
+export function getAdaptiveGPUReductionStrategy(device:Device,length:number):GPUReductionStrategy{
+  if(!Number.isSafeInteger(length)||length<1)throw new Error('reduction length must be positive');
+  const maxInvocations=device.limits.maxComputeInvocationsPerWorkgroup??256;
+  const workgroupSize=(maxInvocations>=256?256:maxInvocations>=128?128:64) as 64|128|256;
+  let elementsPerThread:1|2|4|8=1;
+  if(length>=workgroupSize*4096)elementsPerThread=8;else if(length>=workgroupSize*1024)elementsPerThread=4;else if(length>=workgroupSize*256)elementsPerThread=2;
+  const elementsPerWorkgroup=workgroupSize*elementsPerThread;
+  const firstLevelWorkgroups=Math.ceil(length/elementsPerWorkgroup);
+  const useSubgroups=getGPUShaderSubgroupStrategy(device,{requiresSubgroupId:true})==='subgroups';
+  return Object.freeze({workgroupSize,elementsPerThread,elementsPerWorkgroup,useSubgroups,firstLevelWorkgroups});
+}
+
+/** Returns hierarchy lengths using a selected adaptive reduction shape. */
+export function getAdaptiveGPUReductionLevels(length:number,strategy:GPUReductionStrategy):number[]{const levels:number[]=[];let current=length;do{current=Math.ceil(current/strategy.elementsPerWorkgroup);levels.push(current);}while(current>1);return levels;}


### PR DESCRIPTION
Superseded by consolidated Jarnevon numerics PR #3237. Adaptive reduction strategy planning is retained there.